### PR TITLE
[mlir][gpu] Use `SmallString`, `FailureOr` and `StringRef` in `module-to-binary` infra (NFC)

### DIFF
--- a/mlir/include/mlir/Target/LLVM/ModuleToObject.h
+++ b/mlir/include/mlir/Target/LLVM/ModuleToObject.h
@@ -81,7 +81,7 @@ protected:
 protected:
   /// Create the target machine based on the target triple and chip.
   /// This can fail if the target is not available.
-  std::optional<llvm::TargetMachine *> getOrCreateTargetMachine();
+  FailureOr<llvm::TargetMachine *> getOrCreateTargetMachine();
 
   /// Loads a bitcode file from path.
   std::unique_ptr<llvm::Module> loadBitcodeFile(llvm::LLVMContext &context,

--- a/mlir/include/mlir/Target/LLVM/ModuleToObject.h
+++ b/mlir/include/mlir/Target/LLVM/ModuleToObject.h
@@ -75,7 +75,7 @@ protected:
 
   /// Serializes the LLVM IR bitcode to an object file, by default it serializes
   /// to LLVM bitcode.
-  virtual std::optional<SmallVector<char, 0>>
+  virtual FailureOr<SmallVector<char, 0>>
   moduleToObject(llvm::Module &llvmModule);
 
 protected:

--- a/mlir/include/mlir/Target/LLVM/ModuleToObject.h
+++ b/mlir/include/mlir/Target/LLVM/ModuleToObject.h
@@ -45,8 +45,7 @@ public:
   virtual std::optional<SmallVector<char, 0>> run();
 
   /// Translate LLVM module to textual ISA.
-  /// TODO: switch to SmallString
-  static FailureOr<std::string>
+  static FailureOr<SmallString<0>>
   translateModuleToISA(llvm::Module &llvmModule,
                        llvm::TargetMachine &targetMachine,
                        function_ref<InFlightDiagnostic()> emitError);

--- a/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
@@ -100,7 +100,7 @@ protected:
 
   /// Compiles assembly to a binary.
   virtual std::optional<SmallVector<char, 0>>
-  compileToBinary(const std::string &serializedISA);
+  compileToBinary(StringRef serializedISA);
 
   /// Default implementation of `ModuleToObject::moduleToObject`.
   std::optional<SmallVector<char, 0>>

--- a/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
@@ -99,11 +99,11 @@ protected:
                            StringRef abiVer);
 
   /// Compiles assembly to a binary.
-  virtual std::optional<SmallVector<char, 0>>
+  virtual FailureOr<SmallVector<char, 0>>
   compileToBinary(StringRef serializedISA);
 
   /// Default implementation of `ModuleToObject::moduleToObject`.
-  std::optional<SmallVector<char, 0>>
+  FailureOr<SmallVector<char, 0>>
   moduleToObjectImpl(const gpu::TargetOptions &targetOptions,
                      llvm::Module &llvmModule);
 

--- a/mlir/include/mlir/Target/LLVM/XeVM/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/XeVM/Utils.h
@@ -40,8 +40,8 @@ public:
   gpu::GPUModuleOp getGPUModuleOp();
 
   /// Compiles to native code using `ocloc`.
-  std::optional<SmallVector<char, 0>> compileToBinary(StringRef asmStr,
-                                                      StringRef inputFormat);
+  FailureOr<SmallVector<char, 0>> compileToBinary(StringRef asmStr,
+                                                  StringRef inputFormat);
 
 protected:
   /// XeVM Target attribute.

--- a/mlir/include/mlir/Target/LLVM/XeVM/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/XeVM/Utils.h
@@ -40,7 +40,7 @@ public:
   gpu::GPUModuleOp getGPUModuleOp();
 
   /// Compiles to native code using `ocloc`.
-  std::optional<SmallVector<char, 0>> compileToBinary(const std::string &asmStr,
+  std::optional<SmallVector<char, 0>> compileToBinary(StringRef asmStr,
                                                       StringRef inputFormat);
 
 protected:

--- a/mlir/lib/Target/LLVM/ModuleToObject.cpp
+++ b/mlir/lib/Target/LLVM/ModuleToObject.cpp
@@ -233,7 +233,7 @@ void ModuleToObject::setDataLayoutAndTriple(llvm::Module &module) {
   module.setTargetTriple((*targetMachine)->getTargetTriple());
 }
 
-std::optional<SmallVector<char, 0>>
+FailureOr<SmallVector<char, 0>>
 ModuleToObject::moduleToObject(llvm::Module &llvmModule) {
   SmallVector<char, 0> binaryData;
   // Write the LLVM module bitcode to a buffer.

--- a/mlir/lib/Target/LLVM/ModuleToObject.cpp
+++ b/mlir/lib/Target/LLVM/ModuleToObject.cpp
@@ -205,11 +205,11 @@ LogicalResult ModuleToObject::optimizeModule(llvm::Module &module,
   return success();
 }
 
-FailureOr<std::string> ModuleToObject::translateModuleToISA(
+FailureOr<SmallString<0>> ModuleToObject::translateModuleToISA(
     llvm::Module &llvmModule, llvm::TargetMachine &targetMachine,
     function_ref<InFlightDiagnostic()> emitError) {
-  std::string targetISA;
-  llvm::raw_string_ostream stream(targetISA);
+  SmallString<0> targetISA;
+  llvm::raw_svector_ostream stream(targetISA);
 
   { // Drop pstream after this to prevent the ISA from being stuck buffering
     llvm::buffer_ostream pstream(stream);

--- a/mlir/lib/Target/LLVM/ModuleToObject.cpp
+++ b/mlir/lib/Target/LLVM/ModuleToObject.cpp
@@ -50,8 +50,7 @@ ModuleToObject::~ModuleToObject() = default;
 
 Operation &ModuleToObject::getOperation() { return module; }
 
-std::optional<llvm::TargetMachine *>
-ModuleToObject::getOrCreateTargetMachine() {
+FailureOr<llvm::TargetMachine *> ModuleToObject::getOrCreateTargetMachine() {
   if (targetMachine)
     return targetMachine.get();
   // Load the target.
@@ -59,17 +58,17 @@ ModuleToObject::getOrCreateTargetMachine() {
   llvm::Triple parsedTriple(triple);
   const llvm::Target *target =
       llvm::TargetRegistry::lookupTarget(parsedTriple, error);
-  if (!target) {
-    getOperation().emitError()
-        << "Failed to lookup target for triple '" << triple << "' " << error;
-    return std::nullopt;
-  }
+  if (!target)
+    return getOperation().emitError()
+           << "Failed to lookup target for triple '" << triple << "' " << error;
 
   // Create the target machine using the target.
   targetMachine.reset(
       target->createTargetMachine(parsedTriple, chip, features, {}, {}));
   if (!targetMachine)
-    return std::nullopt;
+    return getOperation().emitError()
+           << "Failed to create target machine for triple '" << triple << "'";
+
   return targetMachine.get();
 }
 
@@ -183,9 +182,8 @@ LogicalResult ModuleToObject::optimizeModule(llvm::Module &module,
     return getOperation().emitError()
            << "Invalid optimization level: " << optLevel << ".";
 
-  std::optional<llvm::TargetMachine *> targetMachine =
-      getOrCreateTargetMachine();
-  if (!targetMachine)
+  FailureOr<llvm::TargetMachine *> targetMachine = getOrCreateTargetMachine();
+  if (failed(targetMachine))
     return getOperation().emitError()
            << "Target Machine unavailable for triple " << triple
            << ", can't optimize with LLVM\n";
@@ -226,13 +224,13 @@ FailureOr<SmallString<0>> ModuleToObject::translateModuleToISA(
 
 void ModuleToObject::setDataLayoutAndTriple(llvm::Module &module) {
   // Create the target machine.
-  std::optional<llvm::TargetMachine *> targetMachine =
-      getOrCreateTargetMachine();
-  if (targetMachine) {
-    // Set the data layout and target triple of the module.
-    module.setDataLayout((*targetMachine)->createDataLayout());
-    module.setTargetTriple((*targetMachine)->getTargetTriple());
-  }
+  FailureOr<llvm::TargetMachine *> targetMachine = getOrCreateTargetMachine();
+  if (failed(targetMachine))
+    return;
+
+  // Set the data layout and target triple of the module.
+  module.setDataLayout((*targetMachine)->createDataLayout());
+  module.setTargetTriple((*targetMachine)->getTargetTriple());
 }
 
 std::optional<SmallVector<char, 0>>

--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -687,9 +687,8 @@ NVPTXSerializer::moduleToObject(llvm::Module &llvmModule) {
 #endif // LLVM_HAS_NVPTX_TARGET
 
   // Emit PTX code.
-  std::optional<llvm::TargetMachine *> targetMachine =
-      getOrCreateTargetMachine();
-  if (!targetMachine) {
+  FailureOr<llvm::TargetMachine *> targetMachine = getOrCreateTargetMachine();
+  if (failed(targetMachine)) {
     getOperation().emitError() << "Target Machine unavailable for triple "
                                << triple << ", can't optimize with LLVM\n";
     return std::nullopt;

--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -212,12 +212,10 @@ public:
   gpu::GPUModuleOp getOperation();
 
   /// Compiles PTX to cubin using `ptxas`.
-  std::optional<SmallVector<char, 0>>
-  compileToBinary(const std::string &ptxCode);
+  std::optional<SmallVector<char, 0>> compileToBinary(StringRef ptxCode);
 
   /// Compiles PTX to cubin using the `nvptxcompiler` library.
-  std::optional<SmallVector<char, 0>>
-  compileToBinaryNVPTX(const std::string &ptxCode);
+  std::optional<SmallVector<char, 0>> compileToBinaryNVPTX(StringRef ptxCode);
 
   /// Serializes the LLVM module to an object format, depending on the
   /// compilation target selected in target options.
@@ -347,7 +345,7 @@ static void setOptionalCommandlineArguments(NVVMTargetAttr target,
 // TODO: clean this method & have a generic tool driver or never emit binaries
 // with this mechanism and let another stage take care of it.
 std::optional<SmallVector<char, 0>>
-NVPTXSerializer::compileToBinary(const std::string &ptxCode) {
+NVPTXSerializer::compileToBinary(StringRef ptxCode) {
   // Determine if the serializer should create a fatbinary with the PTX embeded
   // or a simple CUBIN binary.
   const bool createFatbin =
@@ -570,7 +568,7 @@ NVPTXSerializer::compileToBinary(const std::string &ptxCode) {
   } while (false)
 
 std::optional<SmallVector<char, 0>>
-NVPTXSerializer::compileToBinaryNVPTX(const std::string &ptxCode) {
+NVPTXSerializer::compileToBinaryNVPTX(StringRef ptxCode) {
   Location loc = getOperation().getLoc();
   nvPTXCompilerHandle compiler = nullptr;
   nvPTXCompileResult status;
@@ -697,7 +695,7 @@ NVPTXSerializer::moduleToObject(llvm::Module &llvmModule) {
     return std::nullopt;
   }
   moduleToObjectTimer.startTimer();
-  FailureOr<std::string> serializedISA =
+  FailureOr<SmallString<0>> serializedISA =
       translateModuleToISA(llvmModule, **targetMachine,
                            [&]() { return getOperation().emitError(); });
   moduleToObjectTimer.stopTimer();

--- a/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+++ b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
@@ -412,9 +412,8 @@ std::optional<SmallVector<char, 0>> SerializeGPUModuleBase::moduleToObjectImpl(
   if (targetOptions.getCompilationTarget() == gpu::CompilationTarget::Offload)
     return SerializeGPUModuleBase::moduleToObject(llvmModule);
 
-  std::optional<llvm::TargetMachine *> targetMachine =
-      getOrCreateTargetMachine();
-  if (!targetMachine) {
+  FailureOr<llvm::TargetMachine *> targetMachine = getOrCreateTargetMachine();
+  if (failed(targetMachine)) {
     getOperation().emitError() << "target Machine unavailable for triple "
                                << triple << ", can't compile with LLVM";
     return std::nullopt;

--- a/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+++ b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
@@ -380,7 +380,7 @@ mlir::ROCDL::linkObjectCode(ArrayRef<char> objectCode, StringRef toolkitPath,
   return SmallVector<char, 0>(buffer.begin(), buffer.end());
 }
 
-std::optional<SmallVector<char, 0>>
+FailureOr<SmallVector<char, 0>>
 SerializeGPUModuleBase::compileToBinary(StringRef serializedISA) {
   auto errCallback = [&]() { return getOperation().emitError(); };
   // Assemble the ISA.
@@ -388,18 +388,18 @@ SerializeGPUModuleBase::compileToBinary(StringRef serializedISA) {
       serializedISA, this->triple, this->chip, this->features, errCallback);
 
   if (failed(isaBinary))
-    return std::nullopt;
+    return failure();
 
   // Link the object code.
   FailureOr<SmallVector<char, 0>> linkedCode =
       ROCDL::linkObjectCode(*isaBinary, toolkitPath, errCallback);
   if (failed(linkedCode))
-    return std::nullopt;
+    return failure();
 
   return linkedCode;
 }
 
-std::optional<SmallVector<char, 0>> SerializeGPUModuleBase::moduleToObjectImpl(
+FailureOr<SmallVector<char, 0>> SerializeGPUModuleBase::moduleToObjectImpl(
     const gpu::TargetOptions &targetOptions, llvm::Module &llvmModule) {
   // Return LLVM IR if the compilation target is offload.
 #define DEBUG_TYPE "serialize-to-llvm"
@@ -413,20 +413,18 @@ std::optional<SmallVector<char, 0>> SerializeGPUModuleBase::moduleToObjectImpl(
     return SerializeGPUModuleBase::moduleToObject(llvmModule);
 
   FailureOr<llvm::TargetMachine *> targetMachine = getOrCreateTargetMachine();
-  if (failed(targetMachine)) {
-    getOperation().emitError() << "target Machine unavailable for triple "
-                               << triple << ", can't compile with LLVM";
-    return std::nullopt;
-  }
+  if (failed(targetMachine))
+    return getOperation().emitError()
+           << "target Machine unavailable for triple " << triple
+           << ", can't compile with LLVM";
 
   // Translate the Module to ISA.
   FailureOr<SmallString<0>> serializedISA =
       translateModuleToISA(llvmModule, **targetMachine,
                            [&]() { return getOperation().emitError(); });
-  if (failed(serializedISA)) {
-    getOperation().emitError() << "failed translating the module to ISA";
-    return std::nullopt;
-  }
+  if (failed(serializedISA))
+    return getOperation().emitError() << "failed translating the module to ISA";
+
 #define DEBUG_TYPE "serialize-to-isa"
   LLVM_DEBUG({
     llvm::dbgs() << "ISA for module: "
@@ -439,10 +437,9 @@ std::optional<SmallVector<char, 0>> SerializeGPUModuleBase::moduleToObjectImpl(
     return SmallVector<char, 0>(serializedISA->begin(), serializedISA->end());
 
   // Compiling to binary requires a valid ROCm path, fail if it's not found.
-  if (getToolkitPath().empty()) {
-    getOperation().emitError() << "invalid ROCm path, please set a valid path";
-    return std::nullopt;
-  }
+  if (getToolkitPath().empty())
+    return getOperation().emitError()
+           << "invalid ROCm path, please set a valid path";
 
   // Compile to binary.
   return compileToBinary(*serializedISA);
@@ -455,7 +452,7 @@ public:
   AMDGPUSerializer(Operation &module, ROCDLTargetAttr target,
                    const gpu::TargetOptions &targetOptions);
 
-  std::optional<SmallVector<char, 0>>
+  FailureOr<SmallVector<char, 0>>
   moduleToObject(llvm::Module &llvmModule) override;
 
 private:
@@ -469,7 +466,7 @@ AMDGPUSerializer::AMDGPUSerializer(Operation &module, ROCDLTargetAttr target,
     : SerializeGPUModuleBase(module, target, targetOptions),
       targetOptions(targetOptions) {}
 
-std::optional<SmallVector<char, 0>>
+FailureOr<SmallVector<char, 0>>
 AMDGPUSerializer::moduleToObject(llvm::Module &llvmModule) {
   return moduleToObjectImpl(targetOptions, llvmModule);
 }

--- a/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+++ b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
@@ -381,7 +381,7 @@ mlir::ROCDL::linkObjectCode(ArrayRef<char> objectCode, StringRef toolkitPath,
 }
 
 std::optional<SmallVector<char, 0>>
-SerializeGPUModuleBase::compileToBinary(const std::string &serializedISA) {
+SerializeGPUModuleBase::compileToBinary(StringRef serializedISA) {
   auto errCallback = [&]() { return getOperation().emitError(); };
   // Assemble the ISA.
   FailureOr<SmallVector<char, 0>> isaBinary = ROCDL::assembleIsa(
@@ -421,7 +421,7 @@ std::optional<SmallVector<char, 0>> SerializeGPUModuleBase::moduleToObjectImpl(
   }
 
   // Translate the Module to ISA.
-  FailureOr<std::string> serializedISA =
+  FailureOr<SmallString<0>> serializedISA =
       translateModuleToISA(llvmModule, **targetMachine,
                            [&]() { return getOperation().emitError(); });
   if (failed(serializedISA)) {

--- a/mlir/lib/Target/LLVM/XeVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/XeVM/Target.cpp
@@ -108,7 +108,7 @@ gpu::GPUModuleOp SerializeGPUModuleBase::getGPUModuleOp() {
 // - L0 runtime consumes IL and is external to MLIR codebase (rt wrappers).
 // - `ocloc` tool can be "queried" from within MLIR.
 std::optional<SmallVector<char, 0>>
-SerializeGPUModuleBase::compileToBinary(const std::string &asmStr,
+SerializeGPUModuleBase::compileToBinary(StringRef asmStr,
                                         StringRef inputFormat) {
   using TmpFile = std::pair<llvm::SmallString<128>, llvm::FileRemover>;
   // Find the `ocloc` tool.
@@ -301,7 +301,7 @@ SPIRVSerializer::moduleToObject(llvm::Module &llvmModule) {
   // Return SPIRV if the compilation target is `assembly`.
   if (targetOptions.getCompilationTarget() ==
       gpu::CompilationTarget::Assembly) {
-    FailureOr<std::string> serializedISA =
+    FailureOr<SmallString<0>> serializedISA =
         translateModuleToISA(llvmModule, **targetMachine,
                              [&]() { return getGPUModuleOp().emitError(); });
     if (failed(serializedISA)) {

--- a/mlir/lib/Target/LLVM/XeVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/XeVM/Target.cpp
@@ -290,9 +290,8 @@ SPIRVSerializer::moduleToObject(llvm::Module &llvmModule) {
   return std::nullopt;
 #endif // LLVM_HAS_SPIRV_TARGET
 
-  std::optional<llvm::TargetMachine *> targetMachine =
-      getOrCreateTargetMachine();
-  if (!targetMachine) {
+  FailureOr<llvm::TargetMachine *> targetMachine = getOrCreateTargetMachine();
+  if (failed(targetMachine)) {
     getGPUModuleOp().emitError() << "Target Machine unavailable for triple "
                                  << triple << ", can't optimize with LLVM\n";
     return std::nullopt;

--- a/mlir/lib/Target/LLVM/XeVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/XeVM/Target.cpp
@@ -107,51 +107,49 @@ gpu::GPUModuleOp SerializeGPUModuleBase::getGPUModuleOp() {
 // There are 2 ways to access IGC: AOT (ocloc) and JIT (L0 runtime).
 // - L0 runtime consumes IL and is external to MLIR codebase (rt wrappers).
 // - `ocloc` tool can be "queried" from within MLIR.
-std::optional<SmallVector<char, 0>>
+FailureOr<SmallVector<char, 0>>
 SerializeGPUModuleBase::compileToBinary(StringRef asmStr,
                                         StringRef inputFormat) {
   using TmpFile = std::pair<llvm::SmallString<128>, llvm::FileRemover>;
   // Find the `ocloc` tool.
   std::optional<std::string> oclocCompiler = findTool("ocloc");
   if (!oclocCompiler)
-    return std::nullopt;
+    return failure();
   Location loc = getGPUModuleOp().getLoc();
   std::string basename = llvm::formatv(
       "mlir-{0}-{1}-{2}", getGPUModuleOp().getNameAttr().getValue(),
       getTarget().getTriple(), getTarget().getChip());
 
   auto createTemp = [&](StringRef name,
-                        StringRef suffix) -> std::optional<TmpFile> {
+                        StringRef suffix) -> FailureOr<TmpFile> {
     llvm::SmallString<128> filePath;
-    if (auto ec = llvm::sys::fs::createTemporaryFile(name, suffix, filePath)) {
-      getGPUModuleOp().emitError()
-          << "Couldn't create the temp file: `" << filePath
-          << "`, error message: " << ec.message();
-      return std::nullopt;
-    }
+    if (auto ec = llvm::sys::fs::createTemporaryFile(name, suffix, filePath))
+      return getGPUModuleOp().emitError()
+             << "Couldn't create the temp file: `" << filePath
+             << "`, error message: " << ec.message();
+
     return TmpFile(filePath, llvm::FileRemover(filePath.c_str()));
   };
   // Create temp file
-  std::optional<TmpFile> asmFile = createTemp(basename, "asm");
-  std::optional<TmpFile> binFile = createTemp(basename, "");
-  std::optional<TmpFile> logFile = createTemp(basename, "log");
-  if (!logFile || !asmFile || !binFile)
-    return std::nullopt;
+  FailureOr<TmpFile> asmFile = createTemp(basename, "asm");
+  FailureOr<TmpFile> binFile = createTemp(basename, "");
+  FailureOr<TmpFile> logFile = createTemp(basename, "log");
+  if (failed(logFile) || failed(asmFile) || failed(binFile))
+    return failure();
   // Dump the assembly to a temp file
   std::error_code ec;
   {
     llvm::raw_fd_ostream asmStream(asmFile->first, ec);
-    if (ec) {
-      emitError(loc) << "Couldn't open the file: `" << asmFile->first
-                     << "`, error message: " << ec.message();
-      return std::nullopt;
-    }
+    if (ec)
+      return emitError(loc) << "Couldn't open the file: `" << asmFile->first
+                            << "`, error message: " << ec.message();
+
     asmStream << asmStr;
-    if (asmStream.has_error()) {
-      emitError(loc) << "An error occurred while writing the assembly to: `"
-                     << asmFile->first << "`.";
-      return std::nullopt;
-    }
+    if (asmStream.has_error())
+      return emitError(loc)
+             << "An error occurred while writing the assembly to: `"
+             << asmFile->first << "`.";
+
     asmStream.flush();
   }
   // Set cmd options
@@ -176,20 +174,18 @@ SerializeGPUModuleBase::compileToBinary(StringRef asmStr,
   // Helper function for printing tool error logs.
   std::string message;
   auto emitLogError =
-      [&](StringRef toolName) -> std::optional<SmallVector<char, 0>> {
+      [&](StringRef toolName) -> FailureOr<SmallVector<char, 0>> {
     if (message.empty()) {
       llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> toolStderr =
           llvm::MemoryBuffer::getFile(logFile->first);
       if (toolStderr)
-        emitError(loc) << toolName << " invocation failed. Log:\n"
-                       << toolStderr->get()->getBuffer();
+        return emitError(loc) << toolName << " invocation failed. Log:\n"
+                              << toolStderr->get()->getBuffer();
       else
-        emitError(loc) << toolName << " invocation failed.";
-      return std::nullopt;
+        return emitError(loc) << toolName << " invocation failed.";
     }
-    emitError(loc) << toolName
-                   << " invocation failed, error message: " << message;
-    return std::nullopt;
+    return emitError(loc) << toolName
+                          << " invocation failed, error message: " << message;
   };
   std::optional<StringRef> redirects[] = {
       std::nullopt,
@@ -203,11 +199,11 @@ SerializeGPUModuleBase::compileToBinary(StringRef asmStr,
   binFile->first.append(".bin");
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> binaryBuffer =
       llvm::MemoryBuffer::getFile(binFile->first);
-  if (!binaryBuffer) {
-    emitError(loc) << "Couldn't open the file: `" << binFile->first
-                   << "`, error message: " << binaryBuffer.getError().message();
-    return std::nullopt;
-  }
+  if (!binaryBuffer)
+    return emitError(loc) << "Couldn't open the file: `" << binFile->first
+                          << "`, error message: "
+                          << binaryBuffer.getError().message();
+
   StringRef bin = (*binaryBuffer)->getBuffer();
   return SmallVector<char, 0>(bin.begin(), bin.end());
 }
@@ -245,7 +241,7 @@ public:
 
   /// Serializes the LLVM module to an object format, depending on the
   /// compilation target selected in target options.
-  std::optional<SmallVector<char, 0>>
+  FailureOr<SmallVector<char, 0>>
   moduleToObject(llvm::Module &llvmModule) override;
 
 private:
@@ -269,7 +265,7 @@ void SPIRVSerializer::init() {
   });
 }
 
-std::optional<SmallVector<char, 0>>
+FailureOr<SmallVector<char, 0>>
 SPIRVSerializer::moduleToObject(llvm::Module &llvmModule) {
 #define DEBUG_TYPE "serialize-to-llvm"
   LLVM_DEBUG({
@@ -285,17 +281,16 @@ SPIRVSerializer::moduleToObject(llvm::Module &llvmModule) {
     return SerializeGPUModuleBase::moduleToObject(llvmModule);
 
 #if !LLVM_HAS_SPIRV_TARGET
-  getGPUModuleOp()->emitError("The `SPIRV` target was not built. Please enable "
-                              "it when building LLVM.");
-  return std::nullopt;
+  return getGPUModuleOp()->emitError(
+      "The `SPIRV` target was not built. Please enable "
+      "it when building LLVM.");
 #endif // LLVM_HAS_SPIRV_TARGET
 
   FailureOr<llvm::TargetMachine *> targetMachine = getOrCreateTargetMachine();
-  if (failed(targetMachine)) {
-    getGPUModuleOp().emitError() << "Target Machine unavailable for triple "
-                                 << triple << ", can't optimize with LLVM\n";
-    return std::nullopt;
-  }
+  if (failed(targetMachine))
+    return getGPUModuleOp().emitError()
+           << "Target Machine unavailable for triple " << triple
+           << ", can't optimize with LLVM\n";
 
   // Return SPIRV if the compilation target is `assembly`.
   if (targetOptions.getCompilationTarget() ==
@@ -303,11 +298,10 @@ SPIRVSerializer::moduleToObject(llvm::Module &llvmModule) {
     FailureOr<SmallString<0>> serializedISA =
         translateModuleToISA(llvmModule, **targetMachine,
                              [&]() { return getGPUModuleOp().emitError(); });
-    if (failed(serializedISA)) {
-      getGPUModuleOp().emitError() << "Failed translating the module to ISA."
-                                   << triple << ", can't compile with LLVM\n";
-      return std::nullopt;
-    }
+    if (failed(serializedISA))
+      return getGPUModuleOp().emitError()
+             << "Failed translating the module to ISA." << triple
+             << ", can't compile with LLVM\n";
 
 #define DEBUG_TYPE "serialize-to-isa"
     LLVM_DEBUG({
@@ -330,14 +324,14 @@ SPIRVSerializer::moduleToObject(llvm::Module &llvmModule) {
   // implementation switches to native XeVM binary format.
   std::optional<std::string> serializedSPIRVBinary =
       translateToSPIRVBinary(llvmModule, **targetMachine);
-  if (!serializedSPIRVBinary) {
-    getGPUModuleOp().emitError() << "Failed translating the module to Binary.";
-    return std::nullopt;
-  }
-  if (serializedSPIRVBinary->size() % 4) {
-    getGPUModuleOp().emitError() << "SPIRV code size must be a multiple of 4.";
-    return std::nullopt;
-  }
+  if (!serializedSPIRVBinary)
+    return getGPUModuleOp().emitError()
+           << "Failed translating the module to Binary.";
+
+  if (serializedSPIRVBinary->size() % 4)
+    return getGPUModuleOp().emitError()
+           << "SPIRV code size must be a multiple of 4.";
+
   StringRef bin(serializedSPIRVBinary->c_str(), serializedSPIRVBinary->size());
   return SmallVector<char, 0>(bin.begin(), bin.end());
 }


### PR DESCRIPTION
Instead of `std::string`, `std::optional` and `const std::string&`.