### PR TITLE
[WinEH] Fix crash, object unwinding in the except block

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -286,6 +286,8 @@ def err_seh___except_filter : Error<
   "%0 only allowed in __except filter expression">;
 def err_seh___finally_block : Error<
   "%0 only allowed in __finally block">;
+def err_seh_object_unwinding : Error<
+  "'__try' is not permitted in functions that require object unwinding">;
 
 // Sema && AST
 def note_invalid_subexpr_in_const_expr : Note<

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -2212,8 +2212,13 @@ void CodeGenFunction::EmitAutoVarCleanups(const AutoVarEmission &emission) {
   const VarDecl &D = *emission.Variable;
 
   // Check the type for a cleanup.
-  if (QualType::DestructionKind dtorKind = D.needsDestruction(getContext()))
+  if (QualType::DestructionKind dtorKind = D.needsDestruction(getContext())) {
+    // Check if we're in a SEH block, prevent it
+    if (currentFunctionUsesSEHTry())
+      getContext().getDiagnostics().Report(D.getLocation(),
+                                           diag::err_seh_object_unwinding);
     emitAutoVarTypeCleanup(emission, dtorKind);
+  }
 
   // In GC mode, honor objc_precise_lifetime.
   if (getLangOpts().getGC() != LangOptions::NonGC &&

--- a/clang/test/CodeGenCXX/exceptions-seh.cpp
+++ b/clang/test/CodeGenCXX/exceptions-seh.cpp
@@ -4,6 +4,12 @@
 // RUN: %clang_cc1 -std=c++11 -fblocks -fms-extensions %s -triple=x86_64-windows-msvc -emit-llvm \
 // RUN:         -o - -mconstructor-aliases -O1 -disable-llvm-passes | \
 // RUN:         FileCheck %s --check-prefix=CHECK --check-prefix=NOCXX
+// RUN: %clang_cc1 -triple x86_64-windows -fasync-exceptions -fcxx-exceptions -fexceptions \
+// RUN:         -fms-extensions -x c++ -emit-llvm -verify %s -DERR1
+// RUN: %clang_cc1 -triple x86_64-windows -fasync-exceptions -fcxx-exceptions -fexceptions \
+// RUN:         -fms-extensions -x c++ -emit-llvm -verify %s -DERR2
+// RUN: %clang_cc1 -triple x86_64-windows -fasync-exceptions -fcxx-exceptions -fexceptions \
+// RUN:         -fms-extensions -x c++ -emit-llvm -verify %s -DERR3
 
 extern "C" unsigned long _exception_code();
 extern "C" void might_throw();
@@ -175,3 +181,26 @@ void use_inline() {
 // CHECK: attributes #[[NOINLINE]] = { {{.*noinline.*}} }
 
 void seh_in_noexcept() noexcept { __try {} __finally {} }
+
+#if defined(ERR1)
+void seh_unwinding() {
+  __try {
+    HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
+  } __except (1) {
+  }
+}
+#elif defined(ERR2)
+void seh_unwinding() {
+  __try {
+  } __except (1) {
+    HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
+  }
+}
+#elif defined(ERR3)
+void seh_unwinding() {
+  HasCleanup x; // expected-error{{'__try' is not permitted in functions that require object unwinding}}
+  __try {
+  } __except (1) {
+  }
+}
+#endif


### PR DESCRIPTION
Consider the following code:
```
class CheckError {
 public:
  static CheckError Check();

  ~CheckError();
};

void Foo(const int* p) {
  int d = 0;
  __try {
    d = *p;
  } __except (EXCEPTION_EXECUTE_HANDLER) {
    ::CheckError::Check();
  }
}

```

The following error will occur in mscv.
```
error C2712: Cannot use __try in functions that require object unwinding
```

However, using LLVM /EHa will cause it to crash.
```
llvm::SmallVectorTemplateCommon<llvm::SEHUnwindMapEntry,void>::operator[](unsigned __int64 idx) Line 295	C++
llvm::calculateSEHStateForAsynchEH(const llvm::BasicBlock * BB, int State, llvm::WinEHFuncInfo & EHInfo) Line 346	C++
llvm::calculateSEHStateNumbers(const llvm::Function * Fn, llvm::WinEHFuncInfo & FuncInfo) Line 612	C++
llvm::FunctionLoweringInfo::set(const llvm::Function & fn, llvm::MachineFunction & mf, llvm::SelectionDAG * DAG) Line 114	C++
llvm::SelectionDAGISel::runOnMachineFunction(llvm::MachineFunction & mf) Line 588	C++
```

This patch is compatible with the crash(Unexpected state == -1)