### PR TITLE
[clang] Fix TemplateInstantiator crash transforming loop hint argument

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -134,6 +134,8 @@ Miscellaneous Clang Crashes Fixed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Fixed a crash when attempting to jump over initialization of a variable with variably modified type. (#GH175540)
+- Fixed a crash when using loop hint with a value dependent argument inside a
+  generic lambda. (#GH172289)
 
 OpenACC Specific Changes
 ------------------------

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -2204,6 +2204,11 @@ TemplateInstantiator::TransformLoopHintAttr(const LoopHintAttr *LH) {
   LoopHintAttr::OptionType Option = LH->getOption();
   LoopHintAttr::LoopHintState State = LH->getState();
 
+  // Since C++ does not have partial instantiation, we would expect a
+  // transformed loop hint expression to not be value dependent.  However, at
+  // the time of writing, the use of a generic lambda inside a template
+  // triggers a double instantiation, so we must protect against this event.
+  // This provision may become unneeded in the future.
   if (Option == LoopHintAttr::UnrollCount &&
       !TransformedExpr->isValueDependent()) {
     llvm::APSInt ValueAPS =

--- a/clang/test/CodeGenCXX/pragma-unroll.cpp
+++ b/clang/test/CodeGenCXX/pragma-unroll.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-apple-darwin -std=c++11 -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -std=c++11 -emit-llvm -o - %s | FileCheck --check-prefixes=CHECK,OTHER %s
 
 // Check that passing -fno-unroll-loops does not impact the decision made using pragmas.
 // RUN: %clang_cc1 -triple x86_64-apple-darwin -std=c++11 -emit-llvm -o - -O1 -disable-llvm-optzns -fno-unroll-loops %s | FileCheck %s
@@ -144,12 +144,40 @@ void test_value_dependent(int n) {
   value_dependent<true>(n);
 }
 
+// Verify that the special treatment of #pragma unroll 0|1 does not affect
+// other loop pragmas with an integer argument, such as vectorize_width or
+// interleave_count.
+
+void for_vectorize_one_test(int *List, int Length) {
+  // OTHER: define {{.*}} @_Z22for_vectorize_one_testPii
+  #pragma clang loop vectorize_width(1)
+  for (int i = 0; i < Length; i++) {
+    // OTHER: br label {{.*}}, !llvm.loop ![[LOOP_18:.*]]
+    List[i] = i * 2;
+  }
+}
+
+template <int V>
+void for_vectorize_value_dependent(int *List, int Length) {
+  // OTHER: define {{.*}} @_Z29for_vectorize_value_dependentILi1EEvPii
+  #pragma clang loop vectorize_width(V)
+  for (int i = 0; i < Length; i++) {
+    // OTHER: br label {{.*}}, !llvm.loop ![[LOOP_19:.*]]
+    List[i] = i * 2;
+  }
+}
+
+template void for_vectorize_value_dependent<1>(int *List, int Length);
+
 // CHECK-DAG: ![[MP:[0-9]+]] = !{!"llvm.loop.mustprogress"}
 //
 // CHECK-DAG: ![[UNROLL_ENABLE:[0-9]+]] = !{!"llvm.loop.unroll.enable"}
 // CHECK-DAG: ![[UNROLL_DISABLE:[0-9]+]] = !{!"llvm.loop.unroll.disable"}
 // CHECK-DAG: ![[UNROLL_4:[0-9]+]] = !{!"llvm.loop.unroll.count", i32 4}
 // CHECK-DAG: ![[UNROLL_8:[0-9]+]] = !{!"llvm.loop.unroll.count", i32 8}
+//
+// OTHER-DAG: ![[VEC_1:[0-9]+]] = !{!"llvm.loop.vectorize.width", i32 1}
+// OTHER-DAG: ![[VEC_FIXED:[0-9]+]] = !{!"llvm.loop.vectorize.scalable.enable", i1 false}
 //
 // CHECK-DAG: ![[LOOP_1]] = distinct !{![[LOOP_1]], ![[MP]], ![[UNROLL_ENABLE]]}
 // CHECK-DAG: ![[LOOP_2]] = distinct !{![[LOOP_2]], ![[MP]], ![[UNROLL_DISABLE]]}
@@ -162,3 +190,5 @@ void test_value_dependent(int n) {
 // CHECK-DAG: ![[LOOP_15]] = distinct !{![[LOOP_15]], ![[MP]], ![[UNROLL_DISABLE]]}
 // CHECK-DAG: ![[LOOP_16]] = distinct !{![[LOOP_16]], ![[MP]], ![[UNROLL_DISABLE]]}
 // CHECK-DAG: ![[LOOP_17]] = distinct !{![[LOOP_17]], ![[MP]], ![[UNROLL_DISABLE]]}
+// OTHER-DAG: ![[LOOP_18]] = distinct !{![[LOOP_18]], ![[MP]], ![[VEC_1]], ![[VEC_FIXED]]}
+// OTHER-DAG: ![[LOOP_19]] = distinct !{![[LOOP_19]], ![[MP]], ![[VEC_1]], ![[VEC_FIXED]]}

--- a/clang/test/Sema/unroll-template-value-crash.cpp
+++ b/clang/test/Sema/unroll-template-value-crash.cpp
@@ -8,3 +8,28 @@ template <int Unroll> void foo() {
   #pragma GCC unroll Unroll
   for (int i = 0; i < Unroll; ++i);
 }
+
+struct val {
+  constexpr operator int() const { return 1; }
+};
+
+// generic lambda (using double template instantiation)
+
+template<typename T>
+void use(T t) {
+  auto lam = [](auto N) {
+    #pragma clang loop unroll_count(N+1)
+    for (int i = 0; i < 10; ++i);
+
+    #pragma unroll N+1
+    for (int i = 0; i < 10; ++i);
+
+    #pragma GCC unroll N+1
+    for (int i = 0; i < 10; ++i);
+  };
+  lam(t);
+}
+
+void test() {
+  use(val());
+}


### PR DESCRIPTION
In cases where multiple template instations occur (e.g. with a generic lambda), the loop hint argument expression may still be value dependent. (It is also not needed to do the constant evaluation when the loop hint is not an unroll count anyway.)