### PR TITLE
[lldb] Restrict JITLoaderGDB test to native Linux environments

### DIFF
--- a/lldb/test/Shell/Breakpoint/jit-loader_jitlink_elf.test
+++ b/lldb/test/Shell/Breakpoint/jit-loader_jitlink_elf.test
@@ -2,8 +2,7 @@
 
 # JITLink is the Orc-specific JIT linker implementation.
 #
-# RUN: %clangxx -g -S -emit-llvm -fPIC \
-# RUN:          -o %t.ll %p/Inputs/jitbp.cpp
+# RUN: %clangxx_host -g -S -emit-llvm -o %t.ll %p/Inputs/jitbp.cpp
 # RUN: %lldb -b -o 'settings set plugin.jit-loader.gdb.enable on' -o 'b jitbp' \
 # RUN:          -o 'run --jit-linker=jitlink %t.ll' lli | FileCheck %s
 

--- a/lldb/test/Shell/Breakpoint/jit-loader_jitlink_elf.test
+++ b/lldb/test/Shell/Breakpoint/jit-loader_jitlink_elf.test
@@ -1,9 +1,8 @@
-# REQUIRES: target-x86_64
-# XFAIL: system-windows
+# REQUIRES: target-x86_64, system-linux, native
 
 # JITLink is the Orc-specific JIT linker implementation.
 #
-# RUN: %clangxx -g -S -emit-llvm -fPIC --target=x86_64-unknown-unknown-elf \
+# RUN: %clangxx -g -S -emit-llvm -fPIC \
 # RUN:          -o %t.ll %p/Inputs/jitbp.cpp
 # RUN: %lldb -b -o 'settings set plugin.jit-loader.gdb.enable on' -o 'b jitbp' \
 # RUN:          -o 'run --jit-linker=jitlink %t.ll' lli | FileCheck %s


### PR DESCRIPTION
This test used to work on non-Linux platforms that could run simple ELF objects in a JIT session. However, there is a risk that this will become too unstable for CI, so let's limit it to what we actually need.