### PR TITLE
[lldb][test] Xfail 3 backtrace related tests on Windows on Arm

### DIFF
--- a/lldb/test/API/functionalities/bt-interrupt/TestInterruptBacktrace.py
+++ b/lldb/test/API/functionalities/bt-interrupt/TestInterruptBacktrace.py
@@ -12,6 +12,7 @@ from lldbsuite.test.decorators import *
 class TestInterruptingBacktrace(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @expectedFailureAll(oslist=["windows"], archs=["aarch64"])
     @skipIf(oslist=["linux"], archs=["arm$"])
     def test_backtrace_interrupt(self):
         """Use RequestInterrupt followed by stack operations

--- a/lldb/test/API/python_api/hello_world/TestHelloWorld.py
+++ b/lldb/test/API/python_api/hello_world/TestHelloWorld.py
@@ -69,6 +69,7 @@ class HelloWorldTestCase(TestBase):
         # The breakpoint should have a hit count of 1.
         self.assertEqual(breakpoint.GetHitCount(), 1, BREAKPOINT_HIT_ONCE)
 
+    @expectedFailureAll(oslist=["windows"], archs=["aarch64"])
     @skipIfiOSSimulator
     def test_with_attach_to_process_with_id_api(self):
         """Create target, spawn a process, and attach to it with process id."""
@@ -99,6 +100,7 @@ class HelloWorldTestCase(TestBase):
             stacktraces, exe=False, substrs=["main.c:%d" % self.line2, "(int)argc=2"]
         )
 
+    @expectedFailureAll(oslist=["windows"], archs=["aarch64"])
     @skipIfiOSSimulator
     @skipIfAsan  # FIXME: Hangs indefinitely.
     def test_with_attach_to_process_with_name_api(self):


### PR DESCRIPTION
Since we updated our buildbot setup, these have been failing. Ignore them until we have time to find the real problem, which is something to do with failing to backtrace, or missing debug info when we do.