### PR TITLE
[CGExprScalar] Fix inc/dec of vector larger than 64-bit

### DIFF
--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -3335,7 +3335,7 @@ ScalarExprEmitter::EmitScalarPrePostIncDec(const UnaryOperator *E, LValue LV,
   // Vector increment/decrement.
   } else if (type->isVectorType()) {
     if (type->hasIntegerRepresentation()) {
-      llvm::Value *amt = llvm::ConstantInt::get(value->getType(), amount);
+      llvm::Value *amt = llvm::ConstantInt::getSigned(value->getType(), amount);
 
       value = Builder.CreateAdd(value, amt, isInc ? "inc" : "dec");
     } else {

--- a/clang/test/CodeGen/SystemZ/zvector.c
+++ b/clang/test/CodeGen/SystemZ/zvector.c
@@ -298,10 +298,10 @@ void test_postinc(void) {
 // CHECK-NEXT:    [[DEC7:%.*]] = add <2 x i64> [[TMP7]], splat (i64 -1)
 // CHECK-NEXT:    store volatile <2 x i64> [[DEC7]], ptr @ul2, align 8
 // CHECK-NEXT:    [[TMP8:%.*]] = load volatile <1 x i128>, ptr @slll2, align 8
-// CHECK-NEXT:    [[DEC8:%.*]] = add <1 x i128> [[TMP8]], splat (i128 18446744073709551615)
+// CHECK-NEXT:    [[DEC8:%.*]] = add <1 x i128> [[TMP8]], splat (i128 -1)
 // CHECK-NEXT:    store volatile <1 x i128> [[DEC8]], ptr @slll2, align 8
 // CHECK-NEXT:    [[TMP9:%.*]] = load volatile <1 x i128>, ptr @ulll2, align 8
-// CHECK-NEXT:    [[DEC9:%.*]] = add <1 x i128> [[TMP9]], splat (i128 18446744073709551615)
+// CHECK-NEXT:    [[DEC9:%.*]] = add <1 x i128> [[TMP9]], splat (i128 -1)
 // CHECK-NEXT:    store volatile <1 x i128> [[DEC9]], ptr @ulll2, align 8
 // CHECK-NEXT:    [[TMP10:%.*]] = load volatile <2 x double>, ptr @fd2, align 8
 // CHECK-NEXT:    [[DEC10:%.*]] = fadd <2 x double> [[TMP10]], splat (double -1.000000e+00)
@@ -356,10 +356,10 @@ void test_predec(void) {
 // CHECK-NEXT:    [[DEC7:%.*]] = add <2 x i64> [[TMP7]], splat (i64 -1)
 // CHECK-NEXT:    store volatile <2 x i64> [[DEC7]], ptr @ul2, align 8
 // CHECK-NEXT:    [[TMP8:%.*]] = load volatile <1 x i128>, ptr @slll2, align 8
-// CHECK-NEXT:    [[DEC8:%.*]] = add <1 x i128> [[TMP8]], splat (i128 18446744073709551615)
+// CHECK-NEXT:    [[DEC8:%.*]] = add <1 x i128> [[TMP8]], splat (i128 -1)
 // CHECK-NEXT:    store volatile <1 x i128> [[DEC8]], ptr @slll2, align 8
 // CHECK-NEXT:    [[TMP9:%.*]] = load volatile <1 x i128>, ptr @ulll2, align 8
-// CHECK-NEXT:    [[DEC9:%.*]] = add <1 x i128> [[TMP9]], splat (i128 18446744073709551615)
+// CHECK-NEXT:    [[DEC9:%.*]] = add <1 x i128> [[TMP9]], splat (i128 -1)
 // CHECK-NEXT:    store volatile <1 x i128> [[DEC9]], ptr @ulll2, align 8
 // CHECK-NEXT:    [[TMP10:%.*]] = load volatile <2 x double>, ptr @fd2, align 8
 // CHECK-NEXT:    [[DEC10:%.*]] = fadd <2 x double> [[TMP10]], splat (double -1.000000e+00)


### PR DESCRIPTION
Use getSigned() to create the 1 or -1 constant, so it gets properly sign extended.

This miscompile was found while working on https://github.com/llvm/llvm-project/pull/171456.