### PR TITLE
release/21.x: Build and ship OpenMP with LLVM releases (#160581)

### DIFF
--- a/clang/cmake/caches/Release.cmake
+++ b/clang/cmake/caches/Release.cmake
@@ -36,7 +36,7 @@ if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux")
   list(APPEND DEFAULT_PROJECTS "bolt")
 endif()
 
-set (DEFAULT_RUNTIMES "compiler-rt;libcxx")
+set (DEFAULT_RUNTIMES "compiler-rt;libcxx;openmp;flang-rt")
 if (NOT WIN32)
   list(APPEND DEFAULT_RUNTIMES "libcxxabi" "libunwind")
 endif()
@@ -158,6 +158,9 @@ endif()
 # Final Stage Config (stage2)
 set_final_stage_var(LLVM_ENABLE_RUNTIMES "${LLVM_RELEASE_ENABLE_RUNTIMES}" STRING)
 set_final_stage_var(LLVM_ENABLE_PROJECTS "${LLVM_RELEASE_ENABLE_PROJECTS}" STRING)
+# Don't build libarcher due to:
+# https://github.com/llvm/llvm-project/issues/170138
+set_final_stage_var(LIBOMP_ARCHER_SUPPORT "OFF" BOOL)
 if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux")
   set_final_stage_var(CLANG_BOLT "INSTRUMENT" STRING)
 endif()


### PR DESCRIPTION
Backport a93214c5828d64d699637221166870ae0a7e68ed

Fixes #135021

Suggested-by: Kawashima Takahiro <t-kawashima@fujitsu.com>
