### PR TITLE
[OpenMP][CIR] Implement 'barrier' lowering

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmtOpenMP.cpp
@@ -47,8 +47,9 @@ CIRGenFunction::emitOMPTaskyieldDirective(const OMPTaskyieldDirective &s) {
 }
 mlir::LogicalResult
 CIRGenFunction::emitOMPBarrierDirective(const OMPBarrierDirective &s) {
-  getCIRGenModule().errorNYI(s.getSourceRange(), "OpenMP OMPBarrierDirective");
-  return mlir::failure();
+  mlir::omp::BarrierOp::create(builder, getLoc(s.getBeginLoc()));
+  assert(s.clauses().empty() && "omp barrier doesn't support clauses");
+  return mlir::success();
 }
 mlir::LogicalResult
 CIRGenFunction::emitOMPMetaDirective(const OMPMetaDirective &s) {

--- a/clang/test/CIR/CodeGenOpenMP/barrier.c
+++ b/clang/test/CIR/CodeGenOpenMP/barrier.c
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -fopenmp -emit-cir -fclangir %s -o - | FileCheck %s
+
+void before(void);
+void after(void);
+
+void emit_simple_barrier() {
+  // CHECK: cir.func{{.*}}@emit_simple_barrier
+  before();
+  // CHECK-NEXT: cir.call @before
+#pragma omp barrier
+  // CHECK-NEXT: omp.barrier
+  after();
+  // CHECK-NEXT: cir.call @after
+}


### PR DESCRIPTION
As my next patch showing how OMP lowering should work, here is a simple construct implementation.  Best I can tell, the 'barrier' construct just results in a omp.barrier to be emitted into the IR.  This is our first use of the omp dialect, though the dialect was already added in my last patch.