### PR TITLE
[OpenMP][CIR] Implement basic 'parallel' lowering + some clause infra

### DIFF
--- a/clang/include/clang/AST/OpenMPClause.h
+++ b/clang/include/clang/AST/OpenMPClause.h
@@ -9527,7 +9527,9 @@ public:
 
 #define GEN_CLANG_CLAUSE_CLASS
 #define CLAUSE_CLASS(Enum, Str, Class)                                         \
-  RetTy Visit##Class(PTR(Class) S) { DISPATCH(Class); }
+  RetTy Visit##Class(PTR(Class) S) {                                           \
+    return static_cast<ImplClass *>(this)->VisitOMPClause(S);                  \
+  }
 #include "llvm/Frontend/OpenMP/OMP.inc"
 
   RetTy Visit(PTR(OMPClause) S) {
@@ -9536,7 +9538,7 @@ public:
 #define GEN_CLANG_CLAUSE_CLASS
 #define CLAUSE_CLASS(Enum, Str, Class)                                         \
   case llvm::omp::Clause::Enum:                                                \
-    return Visit##Class(static_cast<PTR(Class)>(S));
+    DISPATCH(Class);
 #define CLAUSE_NO_CLASS(Enum, Str)                                             \
   case llvm::omp::Clause::Enum:                                                \
     break;

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -2155,6 +2155,10 @@ public:
   void emitOMPDeclareMapper(const OMPDeclareMapperDecl &d);
   void emitOMPRequiresDecl(const OMPRequiresDecl &d);
 
+private:
+  template <typename Op>
+  void emitOpenMPClauses(Op &op, ArrayRef<const OMPClause *> clauses);
+
   //===--------------------------------------------------------------------===//
   //                         OpenACC Emission
   //===--------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenOpenMPClause.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenOpenMPClause.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Emit OpenMP clause nodes as CIR code.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CIRGenFunction.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+
+using namespace clang;
+using namespace clang::CIRGen;
+
+namespace {
+template <typename OpTy>
+class OpenMPClauseCIREmitter final
+    : public ConstOMPClauseVisitor<OpenMPClauseCIREmitter<OpTy>> {
+  OpTy &operation;
+  CIRGen::CIRGenFunction &cgf;
+  CIRGen::CIRGenBuilderTy &builder;
+
+public:
+  OpenMPClauseCIREmitter(OpTy &operation, CIRGen::CIRGenFunction &cgf,
+                         CIRGen::CIRGenBuilderTy &builder)
+      : operation(operation), cgf(cgf), builder(builder) {}
+
+  void VisitOMPClause(const OMPClause *clause) {
+    cgf.cgm.errorNYI(clause->getBeginLoc(), "OpenMPClause ",
+                     clause->getClauseKind());
+  }
+
+  void emitClauses(ArrayRef<const OMPClause *> clauses) {
+    for (const auto *c : clauses)
+      this->Visit(c);
+  }
+};
+template <typename OpTy>
+auto makeClauseEmitter(OpTy &op, CIRGen::CIRGenFunction &cgf,
+                       CIRGen::CIRGenBuilderTy &builder) {
+  return OpenMPClauseCIREmitter<OpTy>(op, cgf, builder);
+}
+} // namespace
+
+template <typename Op>
+void CIRGenFunction::emitOpenMPClauses(Op &op,
+                                       ArrayRef<const OMPClause *> clauses) {
+  mlir::OpBuilder::InsertionGuard guardCase(builder);
+  builder.setInsertionPoint(op);
+  makeClauseEmitter(op, *this, builder).emitClauses(clauses);
+}
+
+// We're defining the template for this in a .cpp file, so we have to explicitly
+// specialize the templates.
+#define EXPL_SPEC(N)                                                           \
+  template void CIRGenFunction::emitOpenMPClauses<N>(                          \
+      N &, ArrayRef<const OMPClause *>);
+EXPL_SPEC(mlir::omp::ParallelOp)
+#undef EXPL_SPEC

--- a/clang/lib/CIR/CodeGen/CMakeLists.txt
+++ b/clang/lib/CIR/CodeGen/CMakeLists.txt
@@ -37,6 +37,7 @@ add_clang_library(clangCIR
   CIRGenOpenACC.cpp
   CIRGenOpenACCClause.cpp
   CIRGenOpenACCRecipe.cpp
+  CIRGenOpenMPClause.cpp
   CIRGenPointerAuth.cpp
   CIRGenRecordLayoutBuilder.cpp
   CIRGenStmt.cpp

--- a/clang/test/CIR/CodeGenOpenMP/not-yet-implemented.c
+++ b/clang/test/CIR/CodeGenOpenMP/not-yet-implemented.c
@@ -10,7 +10,7 @@ void do_things() {
   {}
 
   int i;
-  // TODO(OMP): We might consider overloading operator<< for OMPClauseKind inx
+  // TODO(OMP): We might consider overloading operator<< for OMPClauseKind in
   // the future if we want to improve this.
   // expected-error@+2{{ClangIR code gen Not Yet Implemented: OpenMPClause : 50}}
   // expected-error@+2{{ClangIR code gen Not Yet Implemented: emitStmt: CapturedStmt}}

--- a/clang/test/CIR/CodeGenOpenMP/not-yet-implemented.c
+++ b/clang/test/CIR/CodeGenOpenMP/not-yet-implemented.c
@@ -10,7 +10,10 @@ void do_things() {
   {}
 
   int i;
-  // expected-error@+1{{ClangIR code gen Not Yet Implemented: OpenMP OMPParallelDirective}}
+  // TODO(OMP): We might consider overloading operator<< for OMPClauseKind inx
+  // the future if we want to improve this.
+  // expected-error@+2{{ClangIR code gen Not Yet Implemented: OpenMPClause : 50}}
+  // expected-error@+2{{ClangIR code gen Not Yet Implemented: emitStmt: CapturedStmt}}
 #pragma omp parallel if(i)
   {}
 }

--- a/clang/test/CIR/CodeGenOpenMP/parallel.c
+++ b/clang/test/CIR/CodeGenOpenMP/parallel.c
@@ -1,0 +1,32 @@
+// RUN: not %clang_cc1 -fopenmp -emit-cir -fclangir %s -o - | FileCheck %s
+
+void before(int);
+void during(int);
+void after(int);
+
+void emit_simple_parallel() {
+  // CHECK: cir.func{{.*}}@emit_simple_parallel
+  int i = 5;
+  before(i);
+  // CHECK: %[[I_LOAD:.*]] = cir.load{{.*}}
+  // CHECK-NEXT: cir.call @before(%[[I_LOAD]])
+
+#pragma omp parallel
+  {}
+  // CHECK-NEXT: omp.parallel {
+  // CHECK-NEXT: omp.terminator
+  // CHECK-NEXT: }
+#pragma omp parallel
+  {
+    // TODO(OMP): We don't yet emit captured stmt, so the body of this is lost,x
+    // thus we don't emit the 'during' call.
+    during(i);
+  }
+  // CHECK-NEXT: omp.parallel {
+  // CHECK-NEXT: omp.terminator
+  // CHECK-NEXT: }
+
+  after(i);
+  // CHECK: %[[I_LOAD:.*]] = cir.load{{.*}}
+  // CHECK-NEXT: cir.call @after(%[[I_LOAD]])
+}

--- a/clang/test/CIR/CodeGenOpenMP/parallel.c
+++ b/clang/test/CIR/CodeGenOpenMP/parallel.c
@@ -30,3 +30,21 @@ void emit_simple_parallel() {
   // CHECK: %[[I_LOAD:.*]] = cir.load{{.*}}
   // CHECK-NEXT: cir.call @after(%[[I_LOAD]])
 }
+
+void parallel_with_operations() {
+  // CHECK: cir.func{{.*}}@parallel_with_operations
+  int a, b;
+  // CHECK-NEXT: cir.alloca{{.*}}["a"]
+  // CHECK-NEXT: cir.alloca{{.*}}["b"]
+  // TODO(OMP): At the moment this results in 3 NYI diagnostics, 1 each for the
+  // clauses + 1 for the CapturedStmt. When those are implemented, the check
+  // lines will need updating.
+#pragma omp parallel shared(a) firstprivate(b)
+  {
+   ++a;
+   ++b;
+  }
+  // CHECK-NEXT: omp.parallel {
+  // CHECK-NEXT: omp.terminator
+  // CHECK-NEXT: }
+}


### PR DESCRIPTION
This patch adds some basic lowering for the OMP 'parallel' lowering, which adds an omp.parallel operation, plus tries to insert into its region, with a omp.terminator operation..  However, this patch doesn't implement CapturedStmt (and I don't intend to do so at all), so there is an NYI error when emitting a parallel region (plus it shows up in IR
    as 'empty'.

This patch also adds some infrastructure to 'lower' clauses, however no clauses are emitted, and this simply adds a 'not yet implemented' warning any time a clause is attempted. The OMP clause visitor seems to have had a bug with how it 'degraded' when a clause wasn't handled (it
  would result in an infinite recursion if it wasn't supplied), so this
fixes that as well.

A followup patch or two may use this infrastructure to demonstrate how to use it.