### PR TITLE
Enable libarcher in LLVM releases

### DIFF
--- a/clang/cmake/caches/Release.cmake
+++ b/clang/cmake/caches/Release.cmake
@@ -165,9 +165,6 @@ endif()
 # Final Stage Config (stage2)
 set_final_stage_var(LLVM_ENABLE_RUNTIMES "${LLVM_RELEASE_ENABLE_RUNTIMES}" STRING)
 set_final_stage_var(LLVM_ENABLE_PROJECTS "${LLVM_RELEASE_ENABLE_PROJECTS}" STRING)
-# Don't build libarcher due to:
-# https://github.com/llvm/llvm-project/issues/170138
-set_final_stage_var(LIBOMP_ARCHER_SUPPORT "OFF" BOOL)
 if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux")
   set_final_stage_var(CLANG_BOLT "INSTRUMENT" STRING)
 endif()


### PR DESCRIPTION
It was disabled due to #170138, which is fixed now.
