### PR TITLE
[libc] Add `IN6_IS_ADDR_UNSPECIFIED`

### DIFF
--- a/libc/include/llvm-libc-macros/netinet-in-macros.h
+++ b/libc/include/llvm-libc-macros/netinet-in-macros.h
@@ -38,6 +38,12 @@
 // int and takes a single argument of type const struct in6_addr *:
 // https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/netinet_in.h.html
 
+#define IN6_IS_ADDR_UNSPECIFIED(a)                                             \
+  ((__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[0]) == 0 &&              \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[1]) == 0 &&              \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[2]) == 0 &&              \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[3]) == 0)
+
 #define IN6_IS_ADDR_LINKLOCAL(a)                                               \
   ((__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[0]) == 0xfe &&            \
    (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xc0) == 0x80)

--- a/libc/test/include/netinet_in_test.cpp
+++ b/libc/test/include/netinet_in_test.cpp
@@ -12,6 +12,13 @@
 TEST(LlvmLibcNetinetInTest, IN6Macro) {
   char buff[16] = {};
 
+  EXPECT_TRUE(IN6_IS_ADDR_UNSPECIFIED(buff));
+  for (int i = 0; i < 16; ++i) {
+    buff[i] = 1;
+    EXPECT_FALSE(IN6_IS_ADDR_UNSPECIFIED(buff));
+    buff[i] = 0;
+  }
+
   buff[0] = 0xfe;
   buff[1] = 0x80;
   EXPECT_TRUE(IN6_IS_ADDR_LINKLOCAL(buff));


### PR DESCRIPTION
This patch adds the `IN6_IS_ADDR_UNSPECIFIED` macro, which checks whether an address is unspecified address.