### PR TITLE
Fix typo in readability-identifier-naming docs

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/identifier-naming.rst
@@ -231,7 +231,7 @@ A detailed description of each option is presented below:
 .. option:: AbstractClassPrefix
 
     When defined, the check will ensure abstract class names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: AbstractClassIgnoredRegexp
 
@@ -368,7 +368,7 @@ and thus no warnings will be emitted.
 .. option:: ClassPrefix
 
     When defined, the check will ensure class names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ClassIgnoredRegexp
 
@@ -422,7 +422,7 @@ After:
 .. option:: ClassConstexprPrefix
 
     When defined, the check will ensure class ``constexpr`` names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ClassConstexprIgnoredRegexp
 
@@ -474,7 +474,7 @@ After:
 .. option:: ClassConstantPrefix
 
     When defined, the check will ensure class constant names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ClassConstantIgnoredRegexp
 
@@ -526,7 +526,7 @@ After:
 .. option:: ClassMemberPrefix
 
     When defined, the check will ensure class member names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ClassMemberIgnoredRegexp
 
@@ -578,7 +578,7 @@ After:
 .. option:: ClassMethodPrefix
 
     When defined, the check will ensure class method names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ClassMethodIgnoredRegexp
 
@@ -624,7 +624,7 @@ After:
 .. option:: ConceptPrefix
 
     When defined, the check will ensure concept names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ConceptIgnoredRegexp
 
@@ -664,7 +664,7 @@ After:
 .. option:: ConstantPrefix
 
     When defined, the check will ensure constant names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ConstantIgnoredRegexp
 
@@ -710,7 +710,7 @@ After:
 .. option:: ConstantMemberPrefix
 
     When defined, the check will ensure constant member names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ConstantMemberIgnoredRegexp
 
@@ -760,7 +760,7 @@ After:
 .. option:: ConstantParameterPrefix
 
     When defined, the check will ensure constant parameter names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ConstantParameterIgnoredRegexp
 
@@ -806,7 +806,7 @@ After:
 .. option:: ConstantPointerParameterPrefix
 
     When defined, the check will ensure constant pointer parameter names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ConstantPointerParameterIgnoredRegexp
 
@@ -852,7 +852,7 @@ After:
 .. option:: ConstexprFunctionPrefix
 
     When defined, the check will ensure constexpr function names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ConstexprFunctionIgnoredRegexp
 
@@ -892,7 +892,7 @@ After:
 .. option:: ConstexprMethodPrefix
 
     When defined, the check will ensure constexpr method names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ConstexprMethodIgnoredRegexp
 
@@ -938,7 +938,7 @@ After:
 .. option:: ConstexprVariablePrefix
 
     When defined, the check will ensure constexpr variable names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ConstexprVariableIgnoredRegexp
 
@@ -984,7 +984,7 @@ After:
 .. option:: EnumPrefix
 
     When defined, the check will ensure enumeration names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: EnumIgnoredRegexp
 
@@ -1024,7 +1024,7 @@ After:
 .. option:: EnumConstantPrefix
 
     When defined, the check will ensure enumeration constant names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: EnumConstantIgnoredRegexp
 
@@ -1070,7 +1070,7 @@ After:
 .. option:: FunctionPrefix
 
     When defined, the check will ensure function names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: FunctionIgnoredRegexp
 
@@ -1163,7 +1163,7 @@ After:
 .. option:: GlobalConstantPrefix
 
     When defined, the check will ensure global constant names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: GlobalConstantIgnoredRegexp
 
@@ -1209,7 +1209,7 @@ After:
 .. option:: GlobalConstantPointerPrefix
 
     When defined, the check will ensure global constant pointer names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: GlobalConstantPointerIgnoredRegexp
 
@@ -1255,7 +1255,7 @@ After:
 .. option:: GlobalFunctionPrefix
 
     When defined, the check will ensure global function names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: GlobalFunctionIgnoredRegexp
 
@@ -1295,7 +1295,7 @@ After:
 .. option:: GlobalPointerPrefix
 
     When defined, the check will ensure global pointer names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: GlobalPointerIgnoredRegexp
 
@@ -1341,7 +1341,7 @@ After:
 .. option:: GlobalVariablePrefix
 
     When defined, the check will ensure global variable names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: GlobalVariableIgnoredRegexp
 
@@ -1393,7 +1393,7 @@ After:
 .. option:: InlineNamespacePrefix
 
     When defined, the check will ensure inline namespaces names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: InlineNamespaceIgnoredRegexp
 
@@ -1487,7 +1487,7 @@ After:
 .. option:: LocalConstantPrefix
 
     When defined, the check will ensure local constant names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: LocalConstantIgnoredRegexp
 
@@ -1533,7 +1533,7 @@ After:
 .. option:: LocalConstantPointerPrefix
 
     When defined, the check will ensure local constant pointer names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: LocalConstantPointerIgnoredRegexp
 
@@ -1579,7 +1579,7 @@ After:
 .. option:: LocalPointerPrefix
 
     When defined, the check will ensure local pointer names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: LocalPointerIgnoredRegexp
 
@@ -1625,7 +1625,7 @@ After:
 .. option:: LocalVariablePrefix
 
     When defined, the check will ensure local variable names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: LocalVariableIgnoredRegexp
 
@@ -1679,7 +1679,7 @@ After:
 .. option:: MacroDefinitionPrefix
 
     When defined, the check will ensure macro definitions will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: MacroDefinitionIgnoredRegexp
 
@@ -1722,7 +1722,7 @@ command line using the ``-D`` flag.
 .. option:: MemberPrefix
 
     When defined, the check will ensure member names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: MemberIgnoredRegexp
 
@@ -1772,7 +1772,7 @@ After:
 .. option:: MethodPrefix
 
     When defined, the check will ensure method names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: MethodIgnoredRegexp
 
@@ -1816,7 +1816,7 @@ After:
 .. option:: NamespacePrefix
 
     When defined, the check will ensure namespace names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: NamespaceIgnoredRegexp
 
@@ -1860,7 +1860,7 @@ After:
 .. option:: ParameterPrefix
 
     When defined, the check will ensure parameter names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ParameterIgnoredRegexp
 
@@ -1906,7 +1906,7 @@ After:
 .. option:: ParameterPackPrefix
 
     When defined, the check will ensure parameter pack names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ParameterPackIgnoredRegexp
 
@@ -1950,7 +1950,7 @@ After:
 .. option:: PointerParameterPrefix
 
     When defined, the check will ensure pointer parameter names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: PointerParameterIgnoredRegexp
 
@@ -1996,7 +1996,7 @@ After:
 .. option:: PrivateMemberPrefix
 
     When defined, the check will ensure private member names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: PrivateMemberIgnoredRegexp
 
@@ -2048,7 +2048,7 @@ After:
 .. option:: PrivateMethodPrefix
 
     When defined, the check will ensure private method names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: PrivateMethodIgnoredRegexp
 
@@ -2094,7 +2094,7 @@ After:
 .. option:: ProtectedMemberPrefix
 
     When defined, the check will ensure protected member names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ProtectedMemberIgnoredRegexp
 
@@ -2146,7 +2146,7 @@ After:
 .. option:: ProtectedMethodPrefix
 
     When defined, the check will ensure protected method names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ProtectedMethodIgnoredRegexp
 
@@ -2192,7 +2192,7 @@ After:
 .. option:: PublicMemberPrefix
 
     When defined, the check will ensure public member names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: PublicMemberIgnoredRegexp
 
@@ -2244,7 +2244,7 @@ After:
 .. option:: PublicMethodPrefix
 
     When defined, the check will ensure public method names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: PublicMethodIgnoredRegexp
 
@@ -2290,7 +2290,7 @@ After:
 .. option:: ScopedEnumConstantPrefix
 
     When defined, the check will ensure scoped enum constant names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ScopedEnumConstantIgnoredRegexp
 
@@ -2382,7 +2382,7 @@ After:
 .. option:: StaticConstantPrefix
 
     When defined, the check will ensure static constant names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: StaticConstantIgnoredRegexp
 
@@ -2428,7 +2428,7 @@ After:
 .. option:: StaticVariablePrefix
 
     When defined, the check will ensure static variable names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: StaticVariableIgnoredRegexp
 
@@ -2474,7 +2474,7 @@ After:
 .. option:: StructPrefix
 
     When defined, the check will ensure struct names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: StructIgnoredRegexp
 
@@ -2520,7 +2520,7 @@ After:
 .. option:: TemplateParameterPrefix
 
     When defined, the check will ensure template parameter names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: TemplateParameterIgnoredRegexp
 
@@ -2560,7 +2560,7 @@ After:
 .. option:: TemplateTemplateParameterPrefix
 
     When defined, the check will ensure template template parameter names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: TemplateTemplateParameterIgnoredRegexp
 
@@ -2602,7 +2602,7 @@ After:
 .. option:: TypeAliasPrefix
 
     When defined, the check will ensure type alias names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: TypeAliasIgnoredRegexp
 
@@ -2642,7 +2642,7 @@ After:
 .. option:: TypedefPrefix
 
     When defined, the check will ensure typedef names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: TypedefIgnoredRegexp
 
@@ -2682,7 +2682,7 @@ After:
 .. option:: TypeTemplateParameterPrefix
 
     When defined, the check will ensure type template parameter names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: TypeTemplateParameterIgnoredRegexp
 
@@ -2724,7 +2724,7 @@ After:
 .. option:: UnionPrefix
 
     When defined, the check will ensure union names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: UnionIgnoredRegexp
 
@@ -2770,7 +2770,7 @@ After:
 .. option:: ValueTemplateParameterPrefix
 
     When defined, the check will ensure value template parameter names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: ValueTemplateParameterIgnoredRegexp
 
@@ -2812,7 +2812,7 @@ After:
 .. option:: VariablePrefix
 
     When defined, the check will ensure variable names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: VariableIgnoredRegexp
 
@@ -2858,7 +2858,7 @@ After:
 .. option:: VirtualMethodPrefix
 
     When defined, the check will ensure virtual method names will add the
-    prefixed with the given value (regardless of casing).
+    prefix with the given value (regardless of casing).
 
 .. option:: VirtualMethodIgnoredRegexp
 


### PR DESCRIPTION
Found in #171686 , can be merged first