### PR TITLE
[clang] Properly check for -mms-bitfields in Sema/struct-packed-align.c

### DIFF
--- a/clang/test/Sema/struct-packed-align.c
+++ b/clang/test/Sema/struct-packed-align.c
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 %s -fsyntax-only -verify
 // RUN: %clang_cc1 %s -fsyntax-only -triple=x86_64-windows-coff -verify
+// RUN: %clang_cc1 %s -fsyntax-only -triple=x86_64-windows-gnu -verify
 // RUN: %clang_cc1 %s -fsyntax-only -triple=x86_64-scei-ps4 -verify
 // RUN: %clang_cc1 %s -fsyntax-only -triple=x86_64-sie-ps5 -verify
 
@@ -131,7 +132,7 @@ struct nS {
   nt start_lba;
 };
 
-#if defined(_WIN32) && !defined(__declspec) // _MSC_VER is unavailable in cc1.
+#if defined(_WIN32)
 // Alignment doesn't affect packing in MS mode.
 extern int n1[sizeof(struct nS) == 16 ? 1 : -1];
 extern int n2[__alignof(struct nS) == 8 ? 1 : -1];
@@ -159,7 +160,7 @@ struct packed_chars {
   char f : 4, g : 8, h : 8, i : 8;
 };
 
-#if (defined(_WIN32) || defined(__SCE__)) && !defined(__declspec) // _MSC_VER is unavailable in cc1.
+#if defined(_WIN32) || defined(__SCE__)
 // On Windows clang uses MSVC compatible layout in this case.
 //
 // Additionally, test for pre-r254596 clang behavior on the PS4/PS5 targets.


### PR DESCRIPTION
Before #71148, providing only `-triple=x86_64-windows-gnu` to cc1 did not set `-mms-bitfields` (`-fms-layout-compatibility=microsoft`). Therefore, MS-compatible layout was only triggered in true MSVC targets. This is not the case now, so we should only check if we are compiling for Windows to test to determine if MS layout will be used.

The change of behavior is harmless as it only affects direct invocations of cc1.