### PR TITLE
[DebugInfo] Drop stale entry value-limitation for call site values

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -614,11 +614,6 @@ static void finishCallSiteParams(ValT Val, const DIExpression *Expr,
   for (auto Param : DescribedParams) {
     bool ShouldCombineExpressions = Expr && Param.Expr->getNumElements() > 0;
 
-    // TODO: Entry value operations can currently not be combined with any
-    // other expressions, so we can't emit call site entries in those cases.
-    if (ShouldCombineExpressions && Expr->isEntryValue())
-      continue;
-
     // If a parameter's call site value is produced by a chain of
     // instructions we may have already created an expression for the
     // parameter when walking through the instructions. Append that to the

--- a/llvm/test/DebugInfo/MIR/AArch64/dbgcall-site-expr-entry-value.mir
+++ b/llvm/test/DebugInfo/MIR/AArch64/dbgcall-site-expr-entry-value.mir
@@ -81,12 +81,15 @@ body:             |
 
 ...
 
-# Verify that a call site parameter is emitted for the third parameter. There
-# should also be entries for the first and second parameter, but
-# DW_OP_LLVM_entry_value operations can currently not be emitted together with
-# any other expressions. Verify that nothing is emitted rather than an assert
-# being triggered, or broken expressions being emitted.
+# Verify that call site parameters are emitted for the three parameters.
+# FIXME: The parameters are ordered incorrectly (#43998).
 
+# CHECK: DW_TAG_GNU_call_site_parameter
+# CHECK-NEXT: DW_AT_location      (DW_OP_reg0 W0)
+# CHECK-NEXT: DW_AT_GNU_call_site_value   (DW_OP_GNU_entry_value(DW_OP_reg0 W0), DW_OP_plus_uconst 0xde)
 # CHECK: DW_TAG_GNU_call_site_parameter
 # CHECK-NEXT: DW_AT_location      (DW_OP_reg2 W2)
 # CHECK-NEXT: DW_AT_GNU_call_site_value   (DW_OP_GNU_entry_value(DW_OP_reg0 W0))
+# CHECK: DW_TAG_GNU_call_site_parameter
+# CHECK-NEXT: DW_AT_location      (DW_OP_reg1 W1)
+# CHECK-NEXT: DW_AT_GNU_call_site_value   (DW_OP_GNU_entry_value(DW_OP_reg0 W0), DW_OP_constu 0x1bc, DW_OP_minus)


### PR DESCRIPTION
Entry value operations could previously not be combined with other operations in debug expressions, meaning that we had to skip emitting call site values in such cases. This DIExpression limitation was removed in 57a371d7010802804343d17b85ac5e0d28d0f309, so we should be free to emit call site values for such cases now, for example:

    extern void call(int, int);
    void entry_value (int param) {
        call(param + 222, param - 444);
    }

This change exposed a call site parameter entry order issue in the dbgcall-site-expr-entry-value.mir test case. That ordering issue is tracked in #43998, and I don't think there is anything inherent in this patch that caused that.