### PR TITLE
[LLDB] Run MSVC STL atomic tests with PDB

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/atomic/TestDataFormatterStdAtomic.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/atomic/TestDataFormatterStdAtomic.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdAtomicTestCase(TestBase):
+    TEST_WITH_PDB_DEBUG_INFO = True
+
     def get_variable(self, name):
         var = self.frame().FindVariable(name)
         var.SetPreferDynamicValue(lldb.eDynamicCanRunTarget)


### PR DESCRIPTION
Because PDB doesn't know about templates, we need to get to `T` of `std::atomic<T>` differently. The type includes the `value_type` typedef, which is always equal to `T`. The native PDB plugin includes this since #169248.

Then we can run the `std::atomic` test with (native) PDB.