### PR TITLE
[NFCI][bolt][test] Enable AT&T syntax generally

### DIFF
--- a/bolt/test/X86/lit.local.cfg
+++ b/bolt/test/X86/lit.local.cfg
@@ -1,7 +1,7 @@
 if not "X86" in config.root.targets:
     config.unsupported = True
 
-flags = "--target=x86_64-unknown-linux-gnu -nostdlib -mllvm -x86-asm-syntax=att"
+flags = "--target=x86_64-unknown-linux-gnu -nostdlib"
 
 config.substitutions.insert(0, ("%cflags", f"%cflags {flags}"))
 config.substitutions.insert(0, ("%cxxflags", f"%cxxflags {flags}"))

--- a/bolt/test/lit.local.cfg
+++ b/bolt/test/lit.local.cfg
@@ -7,5 +7,10 @@ if not "linux" in host_triple:
 common_linker_flags = "-fuse-ld=lld -Wl,--unresolved-symbols=ignore-all -Wl,--build-id=none -pie"
 flags = f"--target={host_triple} -fPIE {common_linker_flags}"
 
+# Our files use x86 AT&T assembly throughout.
+# Enable it explicitly so any local Clang preference for Intel syntax gets overriden.
+if "x86-registered-target" in config.available_features:
+  flags += " -mllvm -x86-asm-syntax=att"
+
 config.substitutions.insert(0, ("%cflags", f"%cflags {flags}"))
 config.substitutions.insert(0, ("%cxxflags", f"%cxxflags {flags}"))


### PR DESCRIPTION
Having it in the X86 subdirectory only affects tests in that directory. That's however not sufficient as for example `runtime/X86/pie-exceptions-split.test` is affected but isn't located in the X86 directory.
This essentially fixes the fix for the original commit by guarding it properly for when the X86 target has been built, i.e. the flag is recognized.

Fixes: 6c48fbc1dcfbd44a47f126f21e575340b67aac06