### PR TITLE
[NFCI][lldb][test][asm] Enable AT&T syntax explicitly

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -180,21 +180,27 @@ else
 	# amd64, x86_64, x64 -> 64
 	ifeq "$(ARCH)" "amd64"
 		override ARCH := $(subst amd64,64,$(ARCH))
+		IS_X86 := 1
 	endif
 	ifeq "$(ARCH)" "x86_64"
 		override ARCH := $(subst x86_64,64,$(ARCH))
+		IS_X86 := 1
 	endif
 	ifeq "$(ARCH)" "x64"
 		override ARCH := $(subst x64,64,$(ARCH))
+		IS_X86 := 1
 	endif
 	ifeq "$(ARCH)" "x86"
 		override ARCH := $(subst x86,32,$(ARCH))
+		IS_X86 := 1
 	endif
 	ifeq "$(ARCH)" "i386"
 		override ARCH := $(subst i386,32,$(ARCH))
+		IS_X86 := 1
 	endif
 	ifeq "$(ARCH)" "i686"
 		override ARCH := $(subst i686,32,$(ARCH))
+		IS_X86 := 1
 	endif
 	ifeq "$(ARCH)" "powerpc"
 		override ARCH := $(subst powerpc,32,$(ARCH))
@@ -318,6 +324,15 @@ endif
 ifeq "$(MAKE_GMODULES)" "YES"
 	CFLAGS += $(MANDATORY_MODULE_BUILD_CFLAGS)
 	CXXFLAGS += $(MANDATORY_MODULE_BUILD_CFLAGS)
+endif
+
+# Our files use x86 AT&T assembly throughout.
+# Enable it explicitly so any local Clang preference for Intel syntax gets overriden.
+ifeq ($(CC_TYPE), clang)
+	ifeq ($(IS_X86), 1)
+		CFLAGS += -mllvm -x86-asm-syntax=att
+		CXXFLAGS += -mllvm -x86-asm-syntax=att
+	endif
 endif
 
 CFLAGS += $(CFLAGS_EXTRAS)

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -242,6 +242,11 @@ def use_support_substitutions(config):
     # The clang module cache is used for building inferiors.
     host_flags += ["-fmodules-cache-path={}".format(config.clang_module_cache)]
 
+    # Our files use x86 AT&T assembly throughout.
+    # Enable it explicitly so any local Clang preference for Intel syntax gets overriden.
+    if "x86-registered-target" in config.available_features:
+        host_flags += ["-mllvm", "-x86-asm-syntax=att"]
+
     if config.cmake_sysroot:
         host_flags += ["--sysroot={}".format(config.cmake_sysroot)]
 


### PR DESCRIPTION
Implementation files using the Intel syntax typically explicitly specify it. Do the same for the few files using AT&T syntax.
This enables building LLVM with `-mllvm -x86-asm-syntax=intel` in one's Clang config files (i.e. a global preference for Intel syntax).

Unreverts: 14c69497b31038b37c273417f43bd2cfe169c86f