### PR TITLE
[LLDB] Run MSVC STL deque tests with PDB

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
@@ -133,6 +133,7 @@ lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::Update() {
 
   auto element_type = deque_type.GetTypeTemplateArgument(0);
   if (!element_type) {
+    // PDB doesn't have the template type, so use the type of _Map (T**).
     element_type = map_sp->GetCompilerType().GetPointeeType().GetPointeeType();
     if (!element_type)
       return lldb::eRefetch;

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
@@ -90,6 +90,38 @@ lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::GetChildAtIndex(
                                       m_element_type);
 }
 
+static std::optional<size_t>
+getBlockSize(const lldb_private::CompilerType &deque_type) {
+  auto block_size_decl = deque_type.GetStaticFieldWithName("_Block_size");
+  if (block_size_decl) {
+    auto block_size = block_size_decl.GetConstantValue();
+    if (block_size.IsValid())
+      return block_size.ULongLong();
+  }
+
+  // MSVC doesn't include static members like _Block_size. As a workaround, the
+  // STL has enum { _EEN_DS = _Block_size };
+  // This is named "<unnamed-enum-_EEN_DS>" in PDB.
+  auto enum_type =
+      deque_type.GetDirectNestedTypeWithName("<unnamed-enum-_EEN_DS>");
+  if (!enum_type)
+    return std::nullopt;
+
+  std::optional<size_t> value;
+  enum_type.ForEachEnumerator(
+      [&](const lldb_private::CompilerType &integer_type,
+          lldb_private::ConstString name, const llvm::APSInt &ap_value) {
+        if (name != "_EEN_DS")
+          return true; // keep iterating
+
+        int64_t signed_value = ap_value.getExtValue();
+        if (signed_value > 0)
+          value.emplace(static_cast<uint64_t>(signed_value));
+        return false;
+      });
+  return value;
+}
+
 lldb::ChildCacheState
 lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::Update() {
   m_size = 0;
@@ -104,18 +136,8 @@ lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::Update() {
   if (!deque_type)
     return lldb::eRefetch;
 
-  auto block_size_decl = deque_type.GetStaticFieldWithName("_Block_size");
-  if (!block_size_decl)
-    return lldb::eRefetch;
-  auto block_size = block_size_decl.GetConstantValue();
-  if (!block_size.IsValid())
-    return lldb::eRefetch;
-
-  auto element_type = deque_type.GetTypeTemplateArgument(0);
-  if (!element_type)
-    return lldb::eRefetch;
-  auto element_size = element_type.GetByteSize(nullptr);
-  if (!element_size)
+  auto block_size = getBlockSize(deque_type);
+  if (!block_size)
     return lldb::eRefetch;
 
   auto offset_sp = storage_sp->GetChildMemberWithName("_Myoff");
@@ -138,9 +160,19 @@ lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::Update() {
   if (!ok)
     return lldb::eRefetch;
 
+  auto element_type = deque_type.GetTypeTemplateArgument(0);
+  if (!element_type) {
+    element_type = map_sp->GetCompilerType().GetPointeeType().GetPointeeType();
+    if (!element_type)
+      return lldb::eRefetch;
+  }
+  auto element_size = element_type.GetByteSize(nullptr);
+  if (!element_size)
+    return lldb::eRefetch;
+
   m_map = map_sp.get();
   m_exe_ctx_ref = m_backend.GetExecutionContextRef();
-  m_block_size = block_size.ULongLong();
+  m_block_size = *block_size;
   m_offset = offset;
   m_map_size = map_size;
   m_element_size = *element_size;

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/deque/TestDataFormatterGenericDeque.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/deque/TestDataFormatterGenericDeque.py
@@ -5,6 +5,8 @@ from lldbsuite.test import lldbutil
 
 
 class GenericDequeDataFormatterTestCase(TestBase):
+    TEST_WITH_PDB_DEBUG_INFO = True
+
     def findVariable(self, name):
         var = self.frame().FindVariable(name)
         self.assertTrue(var.IsValid())


### PR DESCRIPTION
Similar to the other PRs, this looks up the type from a member variable. Here, we can use the type of `_Mapptr`. On its own, that's enough to pass the test with clang-cl.