### PR TITLE
[flang][runtime] Fix GPU output for multiple statements

### DIFF
--- a/flang-rt/lib/runtime/io-stmt.cpp
+++ b/flang-rt/lib/runtime/io-stmt.cpp
@@ -270,13 +270,11 @@ int ExternalIoStatementBase::EndIoStatement() {
     }
   }
 #else
-  // Fetch the unit pointer before *this disappears.
-  ExternalFileUnit *unitPtr{&unit_};
   // The pseudo file units are dynamically allocated
-  // and are not tracked in the unit map.
-  // They have to be destructed and deallocated here.
-  unitPtr->~ExternalFileUnit();
-  FreeMemory(unitPtr);
+  // and are not tracked in any unit map.
+  // They have to be destroyed and deallocated here.
+  unit_.~ExternalFileUnit();
+  FreeMemory(&unit_);
 #endif
   return result;
 }

--- a/flang-rt/lib/runtime/pseudo-unit.cpp
+++ b/flang-rt/lib/runtime/pseudo-unit.cpp
@@ -39,10 +39,9 @@ ExternalFileUnit *ExternalFileUnit::LookUpOrCreateAnonymous(int unit,
   if (direction != Direction::Output || unit != 6) {
     handler.Crash("ExternalFileUnit only supports output to unit 6");
   }
-  if (!defaultOutput) { // defer construction until/unless needed
-    defaultOutput = New<ExternalFileUnit>{handler}(unit).release();
-  }
-  return defaultOutput;
+  // The pseudo-unit allocated here will be released in
+  // ExternalIoStatementBase::EndIoStatement().
+  return New<ExternalFileUnit>{handler}(unit).release();
 }
 
 ExternalFileUnit *ExternalFileUnit::LookUp(const char *, std::size_t) {


### PR DESCRIPTION
I recently broke PRINT statements in GPU device code when multiple PRINTs occur in the same kernel by trying to preserve the allocated pseudo-unit.  This turned out to be a bad idea overall, and I'm reverting to the original protocol that minimizes allocated memory.