### PR TITLE
[clang][NFC] In `CFGStmtMap`, remove mutable `getBlock` overload.

### DIFF
--- a/clang/include/clang/Analysis/CFGStmtMap.h
+++ b/clang/include/clang/Analysis/CFGStmtMap.h
@@ -40,7 +40,7 @@ public:
   /// are terminators, the CFGBlock is the block they appear as a terminator,
   /// and not the block they appear as a block-level expression (e.g, '&&').
   /// CaseStmts and LabelStmts map to the CFGBlock they label.
-  const CFGBlock *getBlock(const Stmt * S) const;
+  const CFGBlock *getBlock(const Stmt *S) const;
 };
 
 } // end clang namespace

--- a/clang/include/clang/Analysis/CFGStmtMap.h
+++ b/clang/include/clang/Analysis/CFGStmtMap.h
@@ -40,11 +40,7 @@ public:
   /// are terminators, the CFGBlock is the block they appear as a terminator,
   /// and not the block they appear as a block-level expression (e.g, '&&').
   /// CaseStmts and LabelStmts map to the CFGBlock they label.
-  CFGBlock *getBlock(Stmt * S);
-
-  const CFGBlock *getBlock(const Stmt * S) const {
-    return const_cast<CFGStmtMap*>(this)->getBlock(const_cast<Stmt*>(S));
-  }
+  const CFGBlock *getBlock(const Stmt * S) const;
 };
 
 } // end clang namespace

--- a/clang/lib/Analysis/CFGStmtMap.cpp
+++ b/clang/lib/Analysis/CFGStmtMap.cpp
@@ -24,9 +24,9 @@ static SMap *AsMap(void *m) { return (SMap*) m; }
 
 CFGStmtMap::~CFGStmtMap() { delete AsMap(M); }
 
-CFGBlock *CFGStmtMap::getBlock(Stmt *S) {
+const CFGBlock *CFGStmtMap::getBlock(const Stmt *S) const {
   SMap *SM = AsMap(M);
-  Stmt *X = S;
+  const Stmt *X = S;
 
   // If 'S' isn't in the map, walk the ParentMap to see if one of its ancestors
   // is in the map.


### PR DESCRIPTION
The mutable version of the overload is not used. The way we implemented code sharing in the const vs. mutable overloads had a const-correctness violation, anyway.