### PR TITLE
[libclang/python] Fix cindex test for cpp lang

### DIFF
--- a/clang/bindings/python/tests/cindex/test_cursor_language.py
+++ b/clang/bindings/python/tests/cindex/test_cursor_language.py
@@ -16,7 +16,7 @@ class TestCursorLanguage(unittest.TestCase):
         main_func = get_cursor(tu.cursor, "a")
         self.assertEqual(main_func.language, LanguageKind.C)
 
-    def test_c(self):
+    def test_cpp(self):
         tu = get_tu("class Cls {};", lang="cpp")
         main_func = get_cursor(tu.cursor, "Cls")
         self.assertEqual(main_func.language, LanguageKind.C_PLUS_PLUS)


### PR DESCRIPTION
Fix typo in cindex.py where the C++ support test was incorrectly named test_c instead of test_cpp