### PR TITLE
[libclang/python] Remove unused import in example

### DIFF
--- a/clang/bindings/python/examples/cindex/cindex-dump.py
+++ b/clang/bindings/python/examples/cindex/cindex-dump.py
@@ -63,7 +63,7 @@ def main():
     from clang.cindex import Index
     from pprint import pprint
 
-    from optparse import OptionParser, OptionGroup
+    from optparse import OptionParser
 
     global opts
 

--- a/clang/bindings/python/examples/cindex/cindex-includes.py
+++ b/clang/bindings/python/examples/cindex/cindex-includes.py
@@ -18,7 +18,7 @@ def main():
     import sys
     from clang.cindex import Index
 
-    from optparse import OptionParser, OptionGroup
+    from optparse import OptionParser
 
     parser = OptionParser("usage: %prog [options] {filename} [clang-args*]")
     parser.disable_interspersed_args()


### PR DESCRIPTION
Remove unused `OptionGroup` import in  some `cindex.py` example. 