### PR TITLE
[Github][CI] Bump Windows CI Container Python to v3.12.3

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -48,7 +48,7 @@ RUN regsvr32 /S "C:\BuildTools\DIA SDK\bin\amd64\msdia140.dll" & \
 RUN choco install -y ninja --version 1.13.1 && \
     choco install -y git --version 2.50.1 && \
     choco install -y sccache --version 0.10.0 && \
-    choco install -y python3 --version 3.9.7
+    choco install -y python3 --version 3.12.3
 
 # Testing requires psutil
 RUN pip install psutil

--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -39,9 +39,6 @@ RUN regsvr32 /S "C:\BuildTools\DIA SDK\bin\amd64\msdia140.dll" & \
 
 # install tools as described in https://llvm.org/docs/GettingStartedVS.html
 # and a few more that were not documented...
-# Pin an older version of Python; the current Python 3.10 fails when
-# doing "pip install" for the other dependencies, as it fails to find libxml
-# while compiling some package.
 # We version pin the other packages as well to ensure the container build is as
 # reproducible as possible to prevent issues when upgrading only part of the
 # container.


### PR DESCRIPTION
This is primarily intended to upgrade past python 3.9 so that we can continue building MLIR after https://discourse.llvm.org/t/rfc-adopt-regularly-scheduled-python-minimum-version-bumps/88841/9 lands. This also makes us consistent with the Linux container.

I tested this locally by building the container with this change applied and running the entire premerge pipeline within the freshly built container.