### PR TITLE
Revert "[mlir][gpu] Use `SmallString`, `FailureOr` and `StringRef` in `module-to-binary` infra (NFC) (#172284)"

### DIFF
--- a/mlir/include/mlir/Target/LLVM/ModuleToObject.h
+++ b/mlir/include/mlir/Target/LLVM/ModuleToObject.h
@@ -45,7 +45,8 @@ public:
   virtual std::optional<SmallVector<char, 0>> run();
 
   /// Translate LLVM module to textual ISA.
-  static FailureOr<SmallString<0>>
+  /// TODO: switch to SmallString
+  static FailureOr<std::string>
   translateModuleToISA(llvm::Module &llvmModule,
                        llvm::TargetMachine &targetMachine,
                        function_ref<InFlightDiagnostic()> emitError);
@@ -75,13 +76,13 @@ protected:
 
   /// Serializes the LLVM IR bitcode to an object file, by default it serializes
   /// to LLVM bitcode.
-  virtual FailureOr<SmallVector<char, 0>>
+  virtual std::optional<SmallVector<char, 0>>
   moduleToObject(llvm::Module &llvmModule);
 
 protected:
   /// Create the target machine based on the target triple and chip.
   /// This can fail if the target is not available.
-  FailureOr<llvm::TargetMachine *> getOrCreateTargetMachine();
+  std::optional<llvm::TargetMachine *> getOrCreateTargetMachine();
 
   /// Loads a bitcode file from path.
   std::unique_ptr<llvm::Module> loadBitcodeFile(llvm::LLVMContext &context,

--- a/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
@@ -99,11 +99,11 @@ protected:
                            StringRef abiVer);
 
   /// Compiles assembly to a binary.
-  virtual FailureOr<SmallVector<char, 0>>
-  compileToBinary(StringRef serializedISA);
+  virtual std::optional<SmallVector<char, 0>>
+  compileToBinary(const std::string &serializedISA);
 
   /// Default implementation of `ModuleToObject::moduleToObject`.
-  FailureOr<SmallVector<char, 0>>
+  std::optional<SmallVector<char, 0>>
   moduleToObjectImpl(const gpu::TargetOptions &targetOptions,
                      llvm::Module &llvmModule);
 

--- a/mlir/include/mlir/Target/LLVM/XeVM/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/XeVM/Utils.h
@@ -40,8 +40,8 @@ public:
   gpu::GPUModuleOp getGPUModuleOp();
 
   /// Compiles to native code using `ocloc`.
-  FailureOr<SmallVector<char, 0>> compileToBinary(StringRef asmStr,
-                                                  StringRef inputFormat);
+  std::optional<SmallVector<char, 0>> compileToBinary(const std::string &asmStr,
+                                                      StringRef inputFormat);
 
 protected:
   /// XeVM Target attribute.

--- a/mlir/lib/Target/LLVM/XeVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/XeVM/Target.cpp
@@ -107,49 +107,51 @@ gpu::GPUModuleOp SerializeGPUModuleBase::getGPUModuleOp() {
 // There are 2 ways to access IGC: AOT (ocloc) and JIT (L0 runtime).
 // - L0 runtime consumes IL and is external to MLIR codebase (rt wrappers).
 // - `ocloc` tool can be "queried" from within MLIR.
-FailureOr<SmallVector<char, 0>>
-SerializeGPUModuleBase::compileToBinary(StringRef asmStr,
+std::optional<SmallVector<char, 0>>
+SerializeGPUModuleBase::compileToBinary(const std::string &asmStr,
                                         StringRef inputFormat) {
   using TmpFile = std::pair<llvm::SmallString<128>, llvm::FileRemover>;
   // Find the `ocloc` tool.
   std::optional<std::string> oclocCompiler = findTool("ocloc");
   if (!oclocCompiler)
-    return failure();
+    return std::nullopt;
   Location loc = getGPUModuleOp().getLoc();
   std::string basename = llvm::formatv(
       "mlir-{0}-{1}-{2}", getGPUModuleOp().getNameAttr().getValue(),
       getTarget().getTriple(), getTarget().getChip());
 
   auto createTemp = [&](StringRef name,
-                        StringRef suffix) -> FailureOr<TmpFile> {
+                        StringRef suffix) -> std::optional<TmpFile> {
     llvm::SmallString<128> filePath;
-    if (auto ec = llvm::sys::fs::createTemporaryFile(name, suffix, filePath))
-      return getGPUModuleOp().emitError()
-             << "Couldn't create the temp file: `" << filePath
-             << "`, error message: " << ec.message();
-
+    if (auto ec = llvm::sys::fs::createTemporaryFile(name, suffix, filePath)) {
+      getGPUModuleOp().emitError()
+          << "Couldn't create the temp file: `" << filePath
+          << "`, error message: " << ec.message();
+      return std::nullopt;
+    }
     return TmpFile(filePath, llvm::FileRemover(filePath.c_str()));
   };
   // Create temp file
-  FailureOr<TmpFile> asmFile = createTemp(basename, "asm");
-  FailureOr<TmpFile> binFile = createTemp(basename, "");
-  FailureOr<TmpFile> logFile = createTemp(basename, "log");
-  if (failed(logFile) || failed(asmFile) || failed(binFile))
-    return failure();
+  std::optional<TmpFile> asmFile = createTemp(basename, "asm");
+  std::optional<TmpFile> binFile = createTemp(basename, "");
+  std::optional<TmpFile> logFile = createTemp(basename, "log");
+  if (!logFile || !asmFile || !binFile)
+    return std::nullopt;
   // Dump the assembly to a temp file
   std::error_code ec;
   {
     llvm::raw_fd_ostream asmStream(asmFile->first, ec);
-    if (ec)
-      return emitError(loc) << "Couldn't open the file: `" << asmFile->first
-                            << "`, error message: " << ec.message();
-
+    if (ec) {
+      emitError(loc) << "Couldn't open the file: `" << asmFile->first
+                     << "`, error message: " << ec.message();
+      return std::nullopt;
+    }
     asmStream << asmStr;
-    if (asmStream.has_error())
-      return emitError(loc)
-             << "An error occurred while writing the assembly to: `"
-             << asmFile->first << "`.";
-
+    if (asmStream.has_error()) {
+      emitError(loc) << "An error occurred while writing the assembly to: `"
+                     << asmFile->first << "`.";
+      return std::nullopt;
+    }
     asmStream.flush();
   }
   // Set cmd options
@@ -174,18 +176,20 @@ SerializeGPUModuleBase::compileToBinary(StringRef asmStr,
   // Helper function for printing tool error logs.
   std::string message;
   auto emitLogError =
-      [&](StringRef toolName) -> FailureOr<SmallVector<char, 0>> {
+      [&](StringRef toolName) -> std::optional<SmallVector<char, 0>> {
     if (message.empty()) {
       llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> toolStderr =
           llvm::MemoryBuffer::getFile(logFile->first);
       if (toolStderr)
-        return emitError(loc) << toolName << " invocation failed. Log:\n"
-                              << toolStderr->get()->getBuffer();
+        emitError(loc) << toolName << " invocation failed. Log:\n"
+                       << toolStderr->get()->getBuffer();
       else
-        return emitError(loc) << toolName << " invocation failed.";
+        emitError(loc) << toolName << " invocation failed.";
+      return std::nullopt;
     }
-    return emitError(loc) << toolName
-                          << " invocation failed, error message: " << message;
+    emitError(loc) << toolName
+                   << " invocation failed, error message: " << message;
+    return std::nullopt;
   };
   std::optional<StringRef> redirects[] = {
       std::nullopt,
@@ -199,11 +203,11 @@ SerializeGPUModuleBase::compileToBinary(StringRef asmStr,
   binFile->first.append(".bin");
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> binaryBuffer =
       llvm::MemoryBuffer::getFile(binFile->first);
-  if (!binaryBuffer)
-    return emitError(loc) << "Couldn't open the file: `" << binFile->first
-                          << "`, error message: "
-                          << binaryBuffer.getError().message();
-
+  if (!binaryBuffer) {
+    emitError(loc) << "Couldn't open the file: `" << binFile->first
+                   << "`, error message: " << binaryBuffer.getError().message();
+    return std::nullopt;
+  }
   StringRef bin = (*binaryBuffer)->getBuffer();
   return SmallVector<char, 0>(bin.begin(), bin.end());
 }
@@ -241,7 +245,7 @@ public:
 
   /// Serializes the LLVM module to an object format, depending on the
   /// compilation target selected in target options.
-  FailureOr<SmallVector<char, 0>>
+  std::optional<SmallVector<char, 0>>
   moduleToObject(llvm::Module &llvmModule) override;
 
 private:
@@ -265,7 +269,7 @@ void SPIRVSerializer::init() {
   });
 }
 
-FailureOr<SmallVector<char, 0>>
+std::optional<SmallVector<char, 0>>
 SPIRVSerializer::moduleToObject(llvm::Module &llvmModule) {
 #define DEBUG_TYPE "serialize-to-llvm"
   LLVM_DEBUG({
@@ -281,27 +285,30 @@ SPIRVSerializer::moduleToObject(llvm::Module &llvmModule) {
     return SerializeGPUModuleBase::moduleToObject(llvmModule);
 
 #if !LLVM_HAS_SPIRV_TARGET
-  return getGPUModuleOp()->emitError(
-      "The `SPIRV` target was not built. Please enable "
-      "it when building LLVM.");
+  getGPUModuleOp()->emitError("The `SPIRV` target was not built. Please enable "
+                              "it when building LLVM.");
+  return std::nullopt;
 #endif // LLVM_HAS_SPIRV_TARGET
 
-  FailureOr<llvm::TargetMachine *> targetMachine = getOrCreateTargetMachine();
-  if (failed(targetMachine))
-    return getGPUModuleOp().emitError()
-           << "Target Machine unavailable for triple " << triple
-           << ", can't optimize with LLVM\n";
+  std::optional<llvm::TargetMachine *> targetMachine =
+      getOrCreateTargetMachine();
+  if (!targetMachine) {
+    getGPUModuleOp().emitError() << "Target Machine unavailable for triple "
+                                 << triple << ", can't optimize with LLVM\n";
+    return std::nullopt;
+  }
 
   // Return SPIRV if the compilation target is `assembly`.
   if (targetOptions.getCompilationTarget() ==
       gpu::CompilationTarget::Assembly) {
-    FailureOr<SmallString<0>> serializedISA =
+    FailureOr<std::string> serializedISA =
         translateModuleToISA(llvmModule, **targetMachine,
                              [&]() { return getGPUModuleOp().emitError(); });
-    if (failed(serializedISA))
-      return getGPUModuleOp().emitError()
-             << "Failed translating the module to ISA." << triple
-             << ", can't compile with LLVM\n";
+    if (failed(serializedISA)) {
+      getGPUModuleOp().emitError() << "Failed translating the module to ISA."
+                                   << triple << ", can't compile with LLVM\n";
+      return std::nullopt;
+    }
 
 #define DEBUG_TYPE "serialize-to-isa"
     LLVM_DEBUG({
@@ -324,14 +331,14 @@ SPIRVSerializer::moduleToObject(llvm::Module &llvmModule) {
   // implementation switches to native XeVM binary format.
   std::optional<std::string> serializedSPIRVBinary =
       translateToSPIRVBinary(llvmModule, **targetMachine);
-  if (!serializedSPIRVBinary)
-    return getGPUModuleOp().emitError()
-           << "Failed translating the module to Binary.";
-
-  if (serializedSPIRVBinary->size() % 4)
-    return getGPUModuleOp().emitError()
-           << "SPIRV code size must be a multiple of 4.";
-
+  if (!serializedSPIRVBinary) {
+    getGPUModuleOp().emitError() << "Failed translating the module to Binary.";
+    return std::nullopt;
+  }
+  if (serializedSPIRVBinary->size() % 4) {
+    getGPUModuleOp().emitError() << "SPIRV code size must be a multiple of 4.";
+    return std::nullopt;
+  }
   StringRef bin(serializedSPIRVBinary->c_str(), serializedSPIRVBinary->size());
   return SmallVector<char, 0>(bin.begin(), bin.end());
 }


### PR DESCRIPTION
This reverts commit c8b8b2f1f9ced8db1458dfdf1ea6a15152c695f0.

broke the bot