### PR TITLE
[flang][NFC] Strip trailing whitespace from tests (13 of 14)

### DIFF
--- a/flang/test/Semantics/OpenMP/allocate06.f90
+++ b/flang/test/Semantics/OpenMP/allocate06.f90
@@ -2,7 +2,7 @@
 
 ! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags
 ! OpenMP Version 5.0
-! 2.11.3 allocate Directive 
+! 2.11.3 allocate Directive
 ! List items specified in the allocate directive must not have the ALLOCATABLE attribute unless the directive is associated with an
 ! allocate statement.
 

--- a/flang/test/Semantics/OpenMP/allocate07.f90
+++ b/flang/test/Semantics/OpenMP/allocate07.f90
@@ -2,7 +2,7 @@
 
 ! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags
 ! OpenMP Version 5.0
-! 2.11.3 allocate Directive 
+! 2.11.3 allocate Directive
 ! A type parameter inquiry cannot appear in an allocate directive.
 
 subroutine allocate()
@@ -17,21 +17,20 @@ use omp_lib
   INTEGER(KIND=4) :: x
   CHARACTER(LEN=32) :: w
   INTEGER, DIMENSION(:), ALLOCATABLE :: y
-  
+
   !ERROR: A type parameter inquiry cannot appear on the ALLOCATE directive
   !$omp allocate(x%KIND)
-  
+
   !ERROR: A type parameter inquiry cannot appear on the ALLOCATE directive
   !$omp allocate(w%LEN)
 
   !ERROR: A type parameter inquiry cannot appear on the ALLOCATE directive
   !$omp allocate(y%KIND)
-  
+
   !ERROR: A type parameter inquiry cannot appear on the ALLOCATE directive
   !$omp allocate(my_var%kind_param)
- 
+
   !ERROR: A type parameter inquiry cannot appear on the ALLOCATE directive
   !$omp allocate(my_var%len_param)
 
 end subroutine allocate
-

--- a/flang/test/Semantics/OpenMP/atomic-compare.f90
+++ b/flang/test/Semantics/OpenMP/atomic-compare.f90
@@ -5,7 +5,7 @@
   ! Check atomic compare. This combines elements from multiple other "atomic*.f90", as
   ! to avoid having several files with just a few lines in them. atomic compare needs
   ! higher openmp version than the others, so need a separate file.
-  
+
 
   real a, b, c
   a = 1.0

--- a/flang/test/Semantics/OpenMP/atomic-hint-clause.f90
+++ b/flang/test/Semantics/OpenMP/atomic-hint-clause.f90
@@ -12,29 +12,29 @@ program sample
     integer, parameter :: a = 1
     !$omp atomic hint(1) write
         y = 2
-    
+
     !$omp atomic read hint(2)
-        y = x    
-     
+        y = x
+
     !ERROR: The synchronization hint is not valid
     !$omp atomic hint(3)
         y = y + 10
-    
+
     !$omp atomic update hint(5)
         y = x + y
-    
+
     !ERROR: The synchronization hint is not valid
     !$omp atomic hint(7) capture
     !WARNING: In ATOMIC UPDATE operation with CAPTURE either statement could be the update and the capture, assuming the first one is the capture statement
         y = x
         x = y
     !$omp end atomic
-   
+
     !ERROR: Synchronization hint must be a constant integer value
     !ERROR: Must be a constant value
     !$omp atomic update hint(x)
         y = y * 1
-    
+
     !$omp atomic read hint(4)
         y = x
 
@@ -46,11 +46,11 @@ program sample
 
     !$omp atomic hint(omp_lock_hint_speculative)
         x = y + x
-    
+
     !ERROR: Synchronization hint must be a constant integer value
     !ERROR: Must be a constant value
     !$omp atomic hint(omp_sync_hint_uncontended + omp_sync_hint) read
-        y = x 
+        y = x
 
     !$omp atomic hint(omp_sync_hint_nonspeculative)
         y = y * 9
@@ -72,7 +72,7 @@ program sample
 
     !ERROR: The synchronization hint is not valid
     !$omp atomic hint(omp_sync_hint_uncontended + omp_sync_hint_contended) read
-        y = x 
+        y = x
 
     !ERROR: The synchronization hint is not valid
     !$omp atomic hint(omp_sync_hint_nonspeculative + omp_lock_hint_speculative)

--- a/flang/test/Semantics/OpenMP/atomic-update-overloaded-ops.f90
+++ b/flang/test/Semantics/OpenMP/atomic-update-overloaded-ops.f90
@@ -16,11 +16,11 @@ end module
 program sample
     use new_operator
     implicit none
-    integer :: x, y 
+    integer :: x, y
 
     !$omp atomic update
         x = x / y
-     
+
     !$omp atomic update
     !ERROR: A call to this function is not a valid ATOMIC UPDATE operation
         x = x .MYOPERATOR. y

--- a/flang/test/Semantics/OpenMP/atomic02.f90
+++ b/flang/test/Semantics/OpenMP/atomic02.f90
@@ -30,10 +30,10 @@ program OmpAtomic
    !$omp atomic
    !ERROR: The ** operator is not a valid ATOMIC UPDATE operation
    a = a**4
-   !$omp atomic 
+   !$omp atomic
    !ERROR: Atomic variable c cannot have CHARACTER type
    !ERROR: The atomic variable c should appear as an argument in the update operation
-   c = d 
+   c = d
    !$omp atomic
    !ERROR: The < operator is not a valid ATOMIC UPDATE operation
    l = a .LT. b

--- a/flang/test/Semantics/OpenMP/atomic03.f90
+++ b/flang/test/Semantics/OpenMP/atomic03.f90
@@ -60,7 +60,7 @@ program OmpAtomic
 !$omp atomic update
    !ERROR: The atomic variable z should appear as an argument of the top-level AND operator
    z = IAND(y, 4)
-!$omp atomic update 
+!$omp atomic update
    !ERROR: The atomic variable z should appear as an argument of the top-level OR operator
    z = IOR(y, 5)
 !$omp atomic update
@@ -101,11 +101,11 @@ subroutine more_invalid_atomic_update_stmts()
         integer :: m(10)
     end type
     type(some_type) :: s
- 
+
     !$omp atomic update
     !ERROR: The atomic variable a should be exactly one of the arguments of the top-level MIN operator
         a = min(a, a, b)
-     
+
     !$omp atomic
     !ERROR: The atomic variable a should be exactly one of the arguments of the top-level MAX operator
         a = max(b, a, b, a)
@@ -116,11 +116,11 @@ subroutine more_invalid_atomic_update_stmts()
     !$omp atomic
     !ERROR: The atomic variable a should be exactly one of the arguments of the top-level MAX operator
         a = max(b, a, b, a, b)
-    
+
     !$omp atomic update
     !ERROR: The atomic variable y should appear as an argument of the top-level MIN operator
         y = min(z, x)
-     
+
     !$omp atomic
         z = max(z, y)
 

--- a/flang/test/Semantics/OpenMP/atomic04.f90
+++ b/flang/test/Semantics/OpenMP/atomic04.f90
@@ -60,7 +60,7 @@ program OmpAtomic
    m = m .AND. n
 !$omp atomic
    m = n .AND. m
-!$omp atomic 
+!$omp atomic
    !ERROR: The atomic variable m should appear as an argument of the top-level AND operator
    m = n .AND. l
 
@@ -68,7 +68,7 @@ program OmpAtomic
    m = m .OR. n
 !$omp atomic
    m = n .OR. m
-!$omp atomic 
+!$omp atomic
    !ERROR: The atomic variable m should appear as an argument of the top-level OR operator
    m = n .OR. l
 
@@ -175,13 +175,13 @@ subroutine more_invalid_atomic_update_stmts()
         real :: n(10)
     end type
     type(some_type) p
-    
+
     !$omp atomic
         x = x
 
     !$omp atomic update
     !ERROR: This is not a valid ATOMIC UPDATE operation
-        x = 1    
+        x = 1
 
     !$omp atomic update
     !ERROR: The atomic variable a cannot be a proper subexpression of an argument (here: a*b) in the update operation

--- a/flang/test/Semantics/OpenMP/clause-validity01.f90
+++ b/flang/test/Semantics/OpenMP/clause-validity01.f90
@@ -426,7 +426,7 @@ use omp_lib
      enddo
   enddo
   !omp end do nowait
-  !$omp end parallel 
+  !$omp end parallel
 
 ! 2.11.4 parallel-do-simd-clause -> parallel-clause |
 !                                   do-simd-clause
@@ -591,7 +591,7 @@ use omp_lib
      allc = 3.14
   enddo
 
-  !$omp target enter data map(alloc:A) device(0) 
-  !$omp target exit data map(delete:A) device(0) 
+  !$omp target enter data map(alloc:A) device(0)
+  !$omp target exit data map(delete:A) device(0)
 
 end program

--- a/flang/test/Semantics/OpenMP/critical-empty.f90
+++ b/flang/test/Semantics/OpenMP/critical-empty.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp 
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
 ! Test that there are no errors for an empty critical construct
 
 !$omp critical

--- a/flang/test/Semantics/OpenMP/critical-hint-clause.f90
+++ b/flang/test/Semantics/OpenMP/critical-hint-clause.f90
@@ -1,6 +1,6 @@
 ! REQUIRES: openmp_runtime
 
-! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags 
+! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags
 ! Semantic checks on hint clauses, as they appear on critical construct
 
 program sample
@@ -9,35 +9,35 @@ program sample
     logical :: z
     real :: k
     integer :: p(1)
-    
+
     !$omp critical (name) hint(1)
         y = 2
     !$omp end critical (name)
-    
+
     !$omp critical (name) hint(2)
         y = 2
     !$omp end critical (name)
-     
+
     !ERROR: The synchronization hint is not valid
     !$omp critical (name) hint(3)
         y = 2
     !$omp end critical (name)
-    
+
     !$omp critical (name)  hint(5)
         y = 2
     !$omp end critical (name)
-    
+
     !ERROR: The synchronization hint is not valid
     !$omp critical (name) hint(7)
         y = 2
     !$omp end critical (name)
-   
+
     !ERROR: Synchronization hint must be a constant integer value
     !ERROR: Must be a constant value
     !$omp critical (name) hint(x)
         y = 2
     !$omp end critical (name)
-    
+
     !$omp critical (name) hint(4)
         y = 2
     !$omp end critical (name)
@@ -53,10 +53,10 @@ program sample
     !$omp critical (name) hint(omp_lock_hint_speculative)
         y = 2
     !$omp end critical (name)
-    
+
     !ERROR: Synchronization hint must be a constant integer value
     !ERROR: Must be a constant value
-    !$omp critical (name) hint(omp_sync_hint_uncontended + omp_sync_hint) 
+    !$omp critical (name) hint(omp_sync_hint_uncontended + omp_sync_hint)
         y = 2
     !$omp end critical (name)
 
@@ -96,7 +96,7 @@ program sample
 
     !ERROR: Synchronization hint must be a constant integer value
     !ERROR: Must have INTEGER type, but is REAL(4)
-    !$omp critical (name) hint(1.0) 
+    !$omp critical (name) hint(1.0)
         y = 2
     !$omp end critical (name)
 
@@ -118,4 +118,3 @@ program sample
         y = 2
     !$omp end critical (name)
 end program
-

--- a/flang/test/Semantics/OpenMP/critical_within_default.f90
+++ b/flang/test/Semantics/OpenMP/critical_within_default.f90
@@ -19,4 +19,4 @@ program mn
     j=200
     !$omp end critical(k2)
   !$omp end parallel
-end 
+end

--- a/flang/test/Semantics/OpenMP/declare-reduction-dupsym.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-dupsym.f90
@@ -6,10 +6,10 @@ subroutine dup_symbol()
      integer :: x
      integer :: y
   end type loc
- 
+
   integer :: my_red
 
 !CHECK: error: Duplicate definition of 'my_red' in DECLARE REDUCTION
   !$omp declare reduction(my_red : loc :  omp_out%x = omp_out%x + omp_in%x) initializer(omp_priv%x = 0)
-  
+
 end subroutine dup_symbol

--- a/flang/test/Semantics/OpenMP/declare-reduction-functions.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-functions.f90
@@ -23,7 +23,7 @@ contains
     x%a=n
     x%b=n
   end subroutine inittwo
-  
+
   subroutine initthree(x,n)
     integer :: n
     type(three) :: x
@@ -45,7 +45,7 @@ contains
     res%c = x%c + y%c
     add_three = res
   end function add_three
-  
+
 !CHECK-LABEL: Subprogram scope: functwo
   function functwo(x, n)
     type(two) functwo
@@ -61,8 +61,8 @@ contains
 !CHECK OtherConstruct scope
 !CHECK: omp_orig size=8 offset=0: ObjectEntity type: TYPE(two)
 !CHECK: omp_priv size=8 offset=8: ObjectEntity type: TYPE(two)
-    
-  
+
+
     !$omp simd reduction(adder:res)
     do i=1,n
        res=add_two(res,x(i))
@@ -78,14 +78,14 @@ contains
     integer :: i
     integer :: n
     !$omp declare reduction(adder:three:omp_out=add_three(omp_out,omp_in)) initializer(initthree(omp_priv,1))
-    
+
     !$omp simd reduction(adder:res)
     do i=1,n
        res=add_three(res,x(i))
     enddo
     functhree=res
   end function functhree
-  
+
   function functwothree(x, n)
     type(twothree) :: functwothree
     type(twothree) :: x(n)
@@ -96,9 +96,9 @@ contains
     integer :: i
 
     !$omp declare reduction(adder:two:omp_out=add_two(omp_out,omp_in)) initializer(inittwo(omp_priv,0))
-    
+
     !$omp declare reduction(adder:three:omp_out=add_three(omp_out,omp_in)) initializer(initthree(omp_priv,1))
-    
+
 !CHECK: adder: UserReductionDetails TYPE(two) TYPE(three)
 !CHECK OtherConstruct scope
 !CHECK: omp_in size=8 offset=0: ObjectEntity type: TYPE(two)
@@ -142,8 +142,8 @@ contains
 !CHECK OtherConstruct scope
 !CHECK: omp_orig size=8 offset=0: ObjectEntity type: TYPE(two)
 !CHECK: omp_priv size=8 offset=8: ObjectEntity type: TYPE(two)
-    
-  
+
+
     !$omp simd reduction(+:res)
     do i=1,n
        res=add_two(res,x(i))
@@ -161,9 +161,9 @@ contains
     integer :: i
 
     !$omp declare reduction(+:two:omp_out=add_two(omp_out,omp_in)) initializer(inittwo(omp_priv,0))
-    
+
     !$omp declare reduction(+:three:omp_out=add_three(omp_out,omp_in)) initializer(initthree(omp_priv,1))
-    
+
 !CHECK: op.+: UserReductionDetails TYPE(two) TYPE(three)
 !CHECK OtherConstruct scope
 !CHECK: omp_in size=8 offset=0: ObjectEntity type: TYPE(two)
@@ -207,5 +207,5 @@ contains
     !$omp declare reduction (rr : integer : omp_out = omp_out + omp_in) initializer (omp_priv = 0)
     reduction = .false.
   end function reduction
-  
+
 end module mm

--- a/flang/test/Semantics/OpenMP/declare-reduction-logical.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-logical.f90
@@ -22,12 +22,12 @@ contains
 !CHECK OtherConstruct scope
 !CHECK: omp_orig size=4 offset=0: ObjectEntity type: TYPE(logicalwrapper)
 !CHECK: omp_priv size=4 offset=4: ObjectEntity type: TYPE(logicalwrapper)
-  
+
     !$omp simd reduction(.AND.:res)
     do i=1,n
        res%b=res%b .and. x(i)%b
     enddo
-    
+
     func=res%b
   end function func
 end module mm

--- a/flang/test/Semantics/OpenMP/declare-reduction-mangled.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-mangled.f90
@@ -35,7 +35,7 @@ program omp_examples
   big%r = 0
   !$omp parallel do reduction(max:big)
 !CHECK: big (OmpReduction, OmpExplicit): HostAssoc
-!CHECK: max, INTRINSIC: ProcEntity  
+!CHECK: max, INTRINSIC: ProcEntity
   do i = 1, n
      big = mymax(values(i), big)
   end do
@@ -46,6 +46,6 @@ program omp_examples
   do i = 1, n
      small%r = min(values(i)%r, small%r)
   end do
-  
+
   print *, "small=", small%r, " big=", big%r
 end program omp_examples

--- a/flang/test/Semantics/OpenMP/declare-reduction-operators.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-operators.f90
@@ -34,7 +34,7 @@ module m1
 !$omp declare reduction(.mul.:t1:omp_out=omp_out.mul.omp_in)
 !$omp declare reduction(.fluffy.:t1:omp_out=omp_out.fluffy.omp_in)
 !CHECK: op.fluffy., PUBLIC: UserReductionDetails TYPE(t1)
-!CHECK: op.mul., PUBLIC: UserReductionDetails TYPE(t1)   
+!CHECK: op.mul., PUBLIC: UserReductionDetails TYPE(t1)
 contains
   function my_mul(x, y)
     type (t1), intent (in) :: x, y
@@ -80,6 +80,6 @@ program test_vector
   do i = 1, 100
      v2(i) = v2(i) + v1(i)  ! Invokes add_vectors
   end do
-  
+
   print *, 'v2 components:', v2%x, v2%y, v2%z
 end program test_vector

--- a/flang/test/Semantics/OpenMP/declare-reduction-typeerror.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction-typeerror.f90
@@ -23,7 +23,7 @@ contains
 
     !$omp declare reduction(dummy:kerflunk:omp_out=omp_out+omp_in)
 !CHECK: error: Derived type 'kerflunk' not found
-    
+
     !$omp declare reduction(adder:two:omp_out=add_two(omp_out,omp_in))
     !$omp simd reduction(adder:res3)
 !CHECK: error: The type of 'res3' is incompatible with the reduction operator.

--- a/flang/test/Semantics/OpenMP/declare-reduction.f90
+++ b/flang/test/Semantics/OpenMP/declare-reduction.f90
@@ -44,5 +44,5 @@ program main
 !CHECK: OtherConstruct scope:
 !CHECK: omp_orig size=4 offset=0: ObjectEntity type: INTEGER(4)
 !CHECK: omp_priv size=4 offset=4: ObjectEntity type: INTEGER(4)
-  
+
 end program main

--- a/flang/test/Semantics/OpenMP/declare-target01.f90
+++ b/flang/test/Semantics/OpenMP/declare-target01.f90
@@ -58,7 +58,7 @@ module declare_target01
 
   !WARNING: The usage of TO clause on DECLARE TARGET directive has been deprecated. Use ENTER clause instead. [-Wopen-mp-usage]
   !$omp declare target to (my_var) device_type(host)
-  
+
   !$omp declare target enter (my_var) device_type(host)
 
   !ERROR: A variable that is part of another variable (as an array or structure element) cannot appear on the DECLARE TARGET directive

--- a/flang/test/Semantics/OpenMP/declare-target02.f90
+++ b/flang/test/Semantics/OpenMP/declare-target02.f90
@@ -177,7 +177,7 @@ subroutine func5()
   !WARNING: The usage of TO clause on DECLARE TARGET directive has been deprecated. Use ENTER clause instead. [-Wopen-mp-usage]
   !ERROR: A variable that appears in a DECLARE TARGET directive must be declared in the scope of a module or have the SAVE attribute, either explicitly or implicitly
   !$omp declare target to (arr5_to)
-  
+
   !ERROR: A variable that appears in a DECLARE TARGET directive must be declared in the scope of a module or have the SAVE attribute, either explicitly or implicitly
   !$omp declare target enter (arr5_to)
 

--- a/flang/test/Semantics/OpenMP/declare-target07.f90
+++ b/flang/test/Semantics/OpenMP/declare-target07.f90
@@ -35,7 +35,7 @@ end module
 
 subroutine baz(x)
     real, intent(inout) :: x
-    real :: res 
+    real :: res
     stmtfunc(x) = 4.0 * (x**3)
     !ERROR: The procedure 'stmtfunc' in DECLARE TARGET construct cannot be a statement function.
     !$omp declare target (stmtfunc)

--- a/flang/test/Semantics/OpenMP/default-clause.f90
+++ b/flang/test/Semantics/OpenMP/default-clause.f90
@@ -1,6 +1,6 @@
 ! RUN: %flang_fc1 -fopenmp -fdebug-dump-symbols %s | FileCheck %s
 
-! Test symbols generated in block constructs in the 
+! Test symbols generated in block constructs in the
 ! presence of `default(...)` clause
 
 program sample
@@ -10,7 +10,7 @@ program sample
     !CHECK: x size=4 offset=0: ObjectEntity type: INTEGER(4)
     !CHECK: y size=4 offset=4: ObjectEntity type: INTEGER(4)
     !CHECK: z size=4 offset=8: ObjectEntity type: INTEGER(4)
-    integer x, y, z, w, k, a 
+    integer x, y, z, w, k, a
     !$omp parallel  firstprivate(x) private(y) shared(w) default(private)
         !CHECK: OtherConstruct scope: size=0 alignment=1
         !CHECK: a (OmpPrivate): HostAssoc
@@ -29,7 +29,7 @@ program sample
                 !CHECK: OtherConstruct scope: size=0 alignment=1
                 a = 10
            !$omp end parallel
-        !$omp end parallel 
+        !$omp end parallel
 
         !$omp parallel default(firstprivate) shared(y) private(w)
             !CHECK: OtherConstruct scope: size=0 alignment=1
@@ -37,9 +37,9 @@ program sample
             !CHECK: w (OmpPrivate, OmpExplicit): HostAssoc
             !CHECK: z (OmpFirstPrivate): HostAssoc
             y = 30
-            w = 40 
-            z = 50 
+            w = 40
+            z = 50
             k = 40
         !$omp end parallel
-    !$omp end parallel  
+    !$omp end parallel
 end program sample

--- a/flang/test/Semantics/OpenMP/deprecation.f90
+++ b/flang/test/Semantics/OpenMP/deprecation.f90
@@ -5,7 +5,7 @@
 subroutine test_master()
   integer :: c = 1
 !WARNING: OpenMP directive MASTER has been deprecated, please use MASKED instead. [-Wopen-mp-usage]
-  !$omp master 
+  !$omp master
   c = c + 1
   !$omp end master
 end subroutine
@@ -21,7 +21,7 @@ end subroutine
 subroutine test_master_taskloop_simd()
   integer :: i, j = 1
 !WARNING: OpenMP directive MASTER TASKLOOP SIMD has been deprecated, please use MASKED TASKLOOP SIMD instead. [-Wopen-mp-usage]
-  !$omp master taskloop simd 
+  !$omp master taskloop simd
   do i=1,10
    j = j + 1
   end do
@@ -35,13 +35,13 @@ subroutine test_master_taskloop
   do i=1,10
    j = j + 1
   end do
-  !$omp end master taskloop 
+  !$omp end master taskloop
 end subroutine
 
 subroutine test_parallel_master_taskloop_simd
   integer :: i, j = 1
 !WARNING: OpenMP directive PARALLEL MASTER TASKLOOP SIMD has been deprecated, please use PARALLEL_MASKED TASKLOOP SIMD instead. [-Wopen-mp-usage]
-  !$omp parallel master taskloop simd 
+  !$omp parallel master taskloop simd
   do i=1,10
    j = j + 1
   end do
@@ -55,5 +55,5 @@ subroutine test_parallel_master_taskloop
   do i=1,10
    j = j + 1
   end do
-  !$omp end parallel master taskloop 
+  !$omp end parallel master taskloop
 end subroutine

--- a/flang/test/Semantics/OpenMP/device-clause01.f90
+++ b/flang/test/Semantics/OpenMP/device-clause01.f90
@@ -10,14 +10,14 @@ subroutine foo
   !$omp end target
   !$omp target device(device_num:0)
   !$omp end target
-  
+
   !ERROR: The ANCESTOR device-modifier must not appear on the DEVICE clause on any directive other than the TARGET construct. Found on TARGET DATA construct.
   !$omp target data device(ancestor:0) map(tofrom:a)
   !$omp end target data
   !$omp target data device(device_num:0) map(tofrom:a)
   !$omp end target data
 
-  
+
   !ERROR: The ANCESTOR device-modifier must not appear on the DEVICE clause on any directive other than the TARGET construct. Found on TARGET ENTER DATA construct.
   !$omp target enter data device(ancestor:0) map(to:a)
   !$omp target exit data map(from:a)

--- a/flang/test/Semantics/OpenMP/do05-positivecase.f90
+++ b/flang/test/Semantics/OpenMP/do05-positivecase.f90
@@ -58,7 +58,7 @@ program OMP_DO
   end do
   !$omp end target teams distribute parallel do simd
 
-  !$omp target teams distribute 
+  !$omp target teams distribute
   !DEF: /OMP_DO/OtherConstruct6/i (OmpPrivate, OmpPreDetermined) HostAssoc INTEGER(4)
   do i=1,100
     !REF: /OMP_DO/OtherConstruct6/i

--- a/flang/test/Semantics/OpenMP/do05.f90
+++ b/flang/test/Semantics/OpenMP/do05.f90
@@ -80,7 +80,7 @@ program omp_do
   end do
   !$omp end distribute parallel do simd
 
-  !$omp target parallel do 
+  !$omp target parallel do
   do i=1,10
     !ERROR: A worksharing region may not be closely nested inside a worksharing, explicit task, taskloop, critical, ordered, atomic, or master region
     !$omp single

--- a/flang/test/Semantics/OpenMP/do18.f90
+++ b/flang/test/Semantics/OpenMP/do18.f90
@@ -8,7 +8,7 @@ integer OMP_GET_NUM_THREADS, OMP_GET_THREAD_NUM
 integer NUMTHRDS, TID
 integer N, CSZ, CNUM, I
 parameter (N=100)
-parameter (CSZ=10) 
+parameter (CSZ=10)
 real A(N), B(N), C(N)
 
 do 10 I = 1, N


### PR DESCRIPTION
Only some fortran source files in flang/test/Semantics/OpenMP have been modified. The remaining files will be cleaned up in subsequent commits.