### PR TITLE
[CI] Use the exit code from the premerge advisor

### DIFF
--- a/.ci/premerge_advisor_explain.py
+++ b/.ci/premerge_advisor_explain.py
@@ -7,7 +7,6 @@ import argparse
 import platform
 import sys
 import json
-import os
 
 # TODO(boomanaiden154): Remove the optional call once we can require Python
 # 3.10.

--- a/.ci/premerge_advisor_explain.py
+++ b/.ci/premerge_advisor_explain.py
@@ -7,6 +7,7 @@ import argparse
 import platform
 import sys
 import json
+import os
 
 # TODO(boomanaiden154): Remove the optional call once we can require Python
 # 3.10.
@@ -158,3 +159,5 @@ if __name__ == "__main__":
         args.pr_number,
         args.return_code,
     )
+
+    sys.exit(args.return_code)

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -41,6 +41,7 @@ function at-exit {
       $(git rev-parse HEAD~1) $retcode "${GITHUB_TOKEN}" \
       $GITHUB_PR_NUMBER "${BUILD_DIR}"/test-results.*.xml \
       "${MONOREPO_ROOT}"/ninja*.log)
+    advisor_retcode=$?
   fi
 
   if [[ "$retcode" != "0" ]]; then

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -37,10 +37,10 @@ function at-exit {
     python "${MONOREPO_ROOT}"/.ci/generate_test_report_github.py \
       $retcode "${BUILD_DIR}"/test-results.*.xml "${MONOREPO_ROOT}"/ninja*.log \
       >> $GITHUB_STEP_SUMMARY
-    python "${MONOREPO_ROOT}"/.ci/premerge_advisor_explain.py \
+    (python "${MONOREPO_ROOT}"/.ci/premerge_advisor_explain.py \
       $(git rev-parse HEAD~1) $retcode "${GITHUB_TOKEN}" \
       $GITHUB_PR_NUMBER "${BUILD_DIR}"/test-results.*.xml \
-      "${MONOREPO_ROOT}"/ninja*.log
+      "${MONOREPO_ROOT}"/ninja*.log)
   fi
 
   if [[ "$retcode" != "0" ]]; then
@@ -53,6 +53,10 @@ function at-exit {
         $(git rev-parse HEAD) $BUILDBOT_BUILDNUMBER \
         "${BUILD_DIR}"/test-results.*.xml "${MONOREPO_ROOT}"/ninja*.log
     fi
+  fi
+
+  if [[ -n "$GITHUB_ACTIONS" ]]; then
+    exit $advisor_retcode
   fi
 }
 trap at-exit EXIT


### PR DESCRIPTION
This patch makes it so that we use an exit code determined by the
premerge advisor rather than whatever exit code was returned by the
failing command. This is intended for making it so that we can mark the
CI as green if all of the failures are explained as either flaky or
already failing at HEAD. For now we just propagate whatever the last
command returned.
