### PR TITLE
[CodeGenPrepare][NPM] Remove incorrect LoopAnalysis preservation in CodeGenPrepare

### DIFF
--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -556,7 +556,6 @@ PreservedAnalyses CodeGenPreparePass::run(Function &F,
   PreservedAnalyses PA;
   PA.preserve<TargetLibraryAnalysis>();
   PA.preserve<TargetIRAnalysis>();
-  PA.preserve<LoopAnalysis>();
   return PA;
 }
 


### PR DESCRIPTION
CodeGenPrepare modifies and restructures loops & control flow. So, it shouldn't preserve LoopAnalysis.

The test `llvm/test/CodeGen/AMDGPU/cf-loop-on-constant.ll` shows CodeGenPrepare modifying loop structure, hence we cannot preserve LoopAnalysis.