### PR TITLE
[orc-rt] Add CooperativeFuture/Promise.

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -6,6 +6,7 @@ set(ORC_RT_HEADERS
     orc-rt/AllocAction.h
     orc-rt/BitmaskEnum.h
     orc-rt/Compiler.h
+    orc-rt/CooperativeFuture.h
     orc-rt/Error.h
     orc-rt/ExecutorAddress.h
     orc-rt/IntervalMap.h

--- a/orc-rt/include/orc-rt/CooperativeFuture.h
+++ b/orc-rt/include/orc-rt/CooperativeFuture.h
@@ -1,0 +1,270 @@
+//===--------------------- CooperativeFuture.h ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines a "cooperative" promise/future implementation.
+//
+// CooperativeFuture::get() runs tasks from a CooperativeFutureWorkQueue until
+// the corresponding result is ready. This allows clients to block on a *result*
+// without blocking the underlying thread (which will continue to perform work).
+//
+// Cooperative futures are intended for ORC runtime API clients who want to use
+// blocking patterns with a single thread or fixed-sized thread pool.
+//
+// The CooperativeFuture and CooperativePromise APIs are deliberately similar to
+// std::future and std::promise, but there are some differences. In particular:
+//   1. Constructing a CooperativePromise requires a
+//      CooperativeFutureTaskRunner.
+//   2. When building with exceptions turned off, CooperativePromise and
+//      CooperativeFuture can only be instantiated with types constructible
+//      from Error. This is because CooperativeFutureTaskRunner may return an
+//      Error, and CooperativeFuture::get needs a way to return in this case.
+//      When exceptions are enabled, CooperativeFuture::get will throw any
+//      Error received as an Exception (making its behavior more like
+//      std::future).
+//
+// Blocking patterns should never be used inside the ORC runtime itself.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_COOPERATIVEFUTURE_H
+#define ORC_RT_COOPERATIVEFUTURE_H
+
+#include "orc-rt/BitmaskEnum.h"
+#include "orc-rt/Error.h"
+
+#include <atomic>
+#include <cassert>
+#include <utility>
+
+namespace orc_rt {
+
+/// CooperativeFutureTaskRunner provides an interface for CooperativeFuture to
+/// run tasks.
+class CooperativeFutureTaskRunner {
+public:
+  CooperativeFutureTaskRunner() = default;
+  CooperativeFutureTaskRunner(const CooperativeFutureTaskRunner &) = delete;
+  CooperativeFutureTaskRunner(CooperativeFutureTaskRunner &&) = delete;
+  CooperativeFutureTaskRunner &
+  operator=(const CooperativeFutureTaskRunner &) = delete;
+  CooperativeFutureTaskRunner &
+  operator=(CooperativeFutureTaskRunner &&) = delete;
+
+  virtual ~CooperativeFutureTaskRunner();
+
+  // Run the next available task. Should return Error::success if the task was
+  // run, or an Error if no further tasks can be run (since in this case the
+  // future that requested the work will be left without a value, and we want
+  // to report why).
+  virtual Error runNextItem() = 0;
+};
+
+template <typename T> class CooperativeFuture;
+template <typename T> class CooperativePromise;
+
+namespace detail {
+
+// Storage for the value being communicated from promise to future.
+class CooperativeFutureStorageBase {
+  template <typename T> friend class orc_rt::CooperativeFuture;
+  template <typename T> friend class orc_rt::CooperativePromise;
+
+public:
+  enum State : int {
+    HasValue = 1 << 0,
+    PromiseAttached = 1 << 1,
+    FutureAttached = 1 << 2,
+    LargestValue = FutureAttached,
+    ORC_RT_MARK_AS_BITMASK_ENUM(LargestValue)
+  };
+
+protected:
+  CooperativeFutureStorageBase(CooperativeFutureTaskRunner &WQ) : WQ(WQ) {}
+
+  CooperativeFutureStorageBase(const CooperativeFutureStorageBase &) = delete;
+  CooperativeFutureStorageBase &
+  operator=(const CooperativeFutureStorageBase &) = delete;
+  CooperativeFutureStorageBase(CooperativeFutureStorageBase &&) = delete;
+  CooperativeFutureStorageBase &
+  operator=(CooperativeFutureStorageBase &&) = delete;
+
+  bool hasValue() { return (S & State::HasValue) == State::HasValue; }
+
+  void setHasValue() {
+    assert(!hasValue());
+    S.fetch_or(State::HasValue);
+  }
+  void setHasNoValue() { S.fetch_and(~State::HasValue); }
+  Error workUntilHasValue() {
+    while (!hasValue())
+      if (auto Err = WQ.runNextItem())
+        return Err;
+    return Error::success();
+  }
+
+private:
+  void attachPromise() {
+    assert((S & State::PromiseAttached) != State::PromiseAttached);
+    S |= State::PromiseAttached;
+  }
+
+  bool detachPromise() {
+    return (S.fetch_and(~State::PromiseAttached) & State::FutureAttached) !=
+           State::FutureAttached;
+  }
+
+  void attachFuture() {
+    assert((S & State::FutureAttached) != State::FutureAttached);
+    S |= State::FutureAttached;
+  }
+
+  bool detachFuture() {
+    return (S.fetch_and(~State::FutureAttached) & State::PromiseAttached) !=
+           State::PromiseAttached;
+  }
+
+  CooperativeFutureTaskRunner &WQ;
+  std::atomic<int> S = 0;
+};
+
+template <typename T>
+class CooperativeFutureStorage : public CooperativeFutureStorageBase {
+public:
+  CooperativeFutureStorage(CooperativeFutureTaskRunner &WQ)
+      : CooperativeFutureStorageBase(WQ) {}
+  ~CooperativeFutureStorage() {
+    if (hasValue())
+      Storage.Value.~T();
+  }
+
+  void setValue(T &&Val) {
+    new (&Storage.Value) T(std::move(Val));
+    setHasValue();
+  }
+
+  T getValue() {
+    if (auto Err = workUntilHasValue()) {
+#if ORC_RT_ENABLE_EXCEPTIONS
+      Err.throwOnFailure();
+#else
+      return Err;
+#endif // ORC_RT_ENABLE_EXCEPTIONS
+    }
+    setHasNoValue();
+    return std::move(Storage.Value);
+  }
+
+private:
+  union ValueStorage {
+    ValueStorage() {}
+    ~ValueStorage() {}
+    T Value;
+  } Storage;
+};
+}; // namespace detail
+
+/// Cooperative future.
+///
+/// Similar to std::future, but performs work-stealing while waiting for
+/// its result. This allows it to work in contexts where there are no
+/// other worker threads running.
+///
+/// Note that if exceptions are disabled (ORC_RT_ENABLE_EXCEPTIONS=Off) then T
+/// must be constructible from orc_rt::Error (so must be Error or Expected<U>).
+/// This allows errors such as unfulfilled promises to be reported via Error
+/// (since exceptions are not available). When exceptions are enabled
+/// (ORC_RT_ENABLE_EXCEPTIONS=On) T may be any type.
+template <typename T> class CooperativeFuture {
+  template <typename U> friend class CooperativePromise;
+
+public:
+  CooperativeFuture() = default;
+  CooperativeFuture(CooperativeFuture &&Other) : Storage(Other.Storage) {
+    Other.Storage = nullptr;
+  }
+  CooperativeFuture &operator=(CooperativeFuture &&Other) {
+    releaseStorage();
+    Storage = Other.Storage;
+    Other.Storage = nullptr;
+    return *this;
+  }
+  ~CooperativeFuture() { releaseStorage(); }
+
+  T get() {
+    assert(Storage);
+    return Storage->getValue();
+  }
+
+private:
+  CooperativeFuture(detail::CooperativeFutureStorage<T> *Storage)
+      : Storage(Storage) {
+    Storage->attachFuture();
+  }
+
+  void releaseStorage() {
+    if (Storage && Storage->detachFuture())
+      delete Storage;
+  }
+
+  detail::CooperativeFutureStorage<T> *Storage = nullptr;
+};
+
+/// Cooperative promise.
+///
+/// Similar to std::promise, but performs work-stealing while waiting for
+/// its result. This allows it to work in contexts where there are no
+/// other worker threads running.
+///
+/// Note that if exceptions are disabled (ORC_RT_ENABLE_EXCEPTIONS=Off) then T
+/// must be constructible from orc_rt::Error (so must be Error or Expected<U>).
+/// This allows errors such as unfulfilled promises to be reported via Error
+/// (since exceptions are not available). When exceptions are enabled
+/// (ORC_RT_ENABLE_EXCEPTIONS=On) T may be any type.
+template <typename T> class CooperativePromise {
+public:
+  CooperativePromise() = default;
+  CooperativePromise(CooperativeFutureTaskRunner &WQ)
+      : Storage(new detail::CooperativeFutureStorage<T>(WQ)) {
+    Storage->attachPromise();
+  }
+  CooperativePromise(CooperativePromise &&Other) : Storage(Other.Storage) {
+    Other.Storage = nullptr;
+  }
+  CooperativePromise &operator=(CooperativePromise &&Other) {
+    releaseStorage();
+    Storage = Other.Storage;
+    Other.Storage = nullptr;
+    return *this;
+  }
+  ~CooperativePromise() { releaseStorage(); }
+
+  CooperativeFuture<T> get_future() { return CooperativeFuture<T>(Storage); }
+
+  template <typename U = T>
+  std::enable_if_t<!std::is_void_v<U>> set_value(T &&Value) {
+    assert(Storage);
+    Storage->setValue(std::move(Value));
+  }
+
+  template <typename U = T> std::enable_if_t<std::is_void_v<U>> set_value() {
+    assert(Storage);
+    Storage->setValue();
+  }
+
+private:
+  void releaseStorage() {
+    if (Storage && Storage->detachPromise())
+      delete Storage;
+  }
+
+  detail::CooperativeFutureStorage<T> *Storage = nullptr;
+};
+
+} // namespace orc_rt
+
+#endif // ORC_RT_COOPERATIVEFUTURE_H

--- a/orc-rt/include/orc-rt/CooperativeFuture.h
+++ b/orc-rt/include/orc-rt/CooperativeFuture.h
@@ -61,7 +61,7 @@ public:
   // run, or an Error if no further tasks can be run (since in this case the
   // future that requested the work will be left without a value, and we want
   // to report why).
-  virtual Error runNextItem() = 0;
+  virtual Error runNextTask() = 0;
 };
 
 template <typename T> class CooperativeFuture;
@@ -102,7 +102,7 @@ protected:
   void setHasNoValue() { S.fetch_and(~State::HasValue); }
   Error workUntilHasValue() {
     while (!hasValue())
-      if (auto Err = WQ.runNextItem())
+      if (auto Err = WQ.runNextTask())
         return Err;
     return Error::success();
   }

--- a/orc-rt/lib/executor/CMakeLists.txt
+++ b/orc-rt/lib/executor/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(files
   AllocAction.cpp
+  CooperativeFuture.cpp
   Error.cpp
   QueueingTaskDispatcher.cpp
   ResourceManager.cpp

--- a/orc-rt/lib/executor/CooperativeFuture.cpp
+++ b/orc-rt/lib/executor/CooperativeFuture.cpp
@@ -1,0 +1,19 @@
+//===- CooperativeFuture.cpp ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the implementation of APIs in the orc-rt/CooperativeFuture.h header.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/CooperativeFuture.h"
+
+namespace orc_rt {
+
+CooperativeFutureTaskRunner::~CooperativeFutureTaskRunner() = default;
+
+} // namespace orc_rt

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_orc_rt_unittest(CoreTests
   AllocActionTest.cpp
   BitmaskEnumTest.cpp
   CallableTraitsHelperTest.cpp
+  CooperativeFutureTest.cpp
   EndianTest.cpp
   ErrorTest.cpp
   ErrorExceptionInteropTest.cpp

--- a/orc-rt/unittests/CooperativeFutureTest.cpp
+++ b/orc-rt/unittests/CooperativeFutureTest.cpp
@@ -1,0 +1,257 @@
+//===- CooperativeFutureTest.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for orc-rt/CooperativeFuture.h APIs.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/CooperativeFuture.h"
+#include "orc-rt/QueueingTaskDispatcher.h"
+#include "gtest/gtest.h"
+
+#include <memory>
+
+using namespace orc_rt;
+
+namespace {
+
+class QueueingTaskDispatchRunner : public CooperativeFutureTaskRunner {
+public:
+  QueueingTaskDispatchRunner(QueueingTaskDispatcher &QTD) : QTD(QTD) {}
+
+  Error runNextItem() override {
+    ++RunNextItemCalls;
+    if (auto T = QTD.pop_back()) {
+      T->run();
+      return Error::success();
+    }
+    return make_error<StringError>("No tasks left");
+  }
+  size_t getRunNextItemCalls() const { return RunNextItemCalls; }
+
+private:
+  QueueingTaskDispatcher &QTD;
+  size_t RunNextItemCalls = 0;
+};
+
+} // anonymous namespace
+
+using namespace orc_rt;
+
+TEST(CooperativeFutureTest, PromiseDefaultConstructionAndDestruction) {
+  QueueingTaskDispatcher QTD;
+  QueueingTaskDispatchRunner QTDRunner(QTD);
+
+  // Test that promise can be created and destroyed without issues
+  CooperativePromise<Expected<int>> P(QTDRunner);
+}
+
+TEST(CooperativeFutureTest, FutureDefaultConstructionAndDestruction) {
+  // Test that future can be created and destroyed without issues
+  CooperativeFuture<Expected<int>> F;
+}
+
+TEST(CooperativeFutureTest, BasicPromiseFuturePairValue) {
+  QueueingTaskDispatcher QTD;
+  QueueingTaskDispatchRunner QTDRunner(QTD);
+
+  // Create promise and get future
+  CooperativePromise<Expected<int>> P(QTDRunner);
+  auto F = P.get_future();
+
+  // Set value on promise
+  P.set_value(Expected<int>(42));
+
+  // Get value from future
+  auto Result = F.get();
+  EXPECT_TRUE(!!Result);
+  EXPECT_EQ(*Result, 42);
+}
+
+TEST(CooperativeFutureTest, BasicPromiseFuturePairError) {
+  QueueingTaskDispatcher QTD;
+  QueueingTaskDispatchRunner QTDRunner(QTD);
+
+  CooperativePromise<Expected<int>> P(QTDRunner);
+  auto F = P.get_future();
+
+  // Set error value
+  P.set_value(make_error<StringError>("Test error"));
+
+  // Get error from future
+  auto Result = F.get();
+  EXPECT_FALSE(!!Result);
+  EXPECT_EQ(toString(Result.takeError()), "Test error");
+}
+
+TEST(CooperativeFutureTest, WorkStealingDuringWait) {
+  QueueingTaskDispatcher QTD;
+  QueueingTaskDispatchRunner QTDRunner(QTD);
+
+  CooperativePromise<Expected<int>> P(QTDRunner);
+  auto F = P.get_future();
+
+  // Dispatch a task that will set the promise value
+  QTD.dispatch(makeGenericTask([&]() { P.set_value(Expected<int>(42)); }));
+
+  // Getting the value should cause the task to be run
+  auto Result = F.get();
+
+  // Verify task ran and value was set
+  EXPECT_TRUE(!!Result);
+  EXPECT_EQ(*Result, 42);
+}
+
+TEST(CooperativeFutureTest, MultipleTasksBeforeValue) {
+  QueueingTaskDispatcher QTD;
+  QueueingTaskDispatchRunner QTDRunner(QTD);
+
+  int TasksRun = 0;
+
+  CooperativePromise<Expected<int>> P(QTDRunner);
+  auto F = P.get_future();
+
+  // Dispatch a task to set the promise. TaskWorkQueue runs tasks in LIFO
+  // order, so this will run last.
+  QTD.dispatch(makeGenericTask([&P]() { P.set_value(Expected<int>(42)); }));
+
+  // Dispatch several other tasks to run before the one that sets the promise.
+  for (int I = 0; I < 3; ++I)
+    QTD.dispatch(makeGenericTask([&TasksRun]() { ++TasksRun; }));
+
+  // Could get should run all tasks until value is set
+  auto Result = F.get();
+
+  EXPECT_EQ(TasksRun, 3);
+  EXPECT_TRUE(!!Result);
+  EXPECT_EQ(*Result, 42);
+}
+
+TEST(CooperativeFutureTest, PromiseMoveConstruction) {
+  QueueingTaskDispatcher QTD;
+  QueueingTaskDispatchRunner QTDRunner(QTD);
+
+  CooperativePromise<Expected<int>> P1(QTDRunner);
+  auto F = P1.get_future();
+
+  // Move promise
+  CooperativePromise<Expected<int>> P2 = std::move(P1);
+
+  // Set value on moved promise
+  P2.set_value(Expected<int>(42));
+
+  auto Result = F.get();
+  EXPECT_TRUE(!!Result);
+  EXPECT_EQ(*Result, 42);
+}
+
+TEST(CooperativeFutureTest, FutureMoveConstruction) {
+  QueueingTaskDispatcher QTD;
+  QueueingTaskDispatchRunner QTDRunner(QTD);
+
+  CooperativePromise<Expected<int>> P(QTDRunner);
+  auto F1 = P.get_future();
+
+  // Move future
+  CooperativeFuture<Expected<int>> F2 = std::move(F1);
+
+  P.set_value(Expected<int>(42));
+
+  auto Result = F2.get();
+  EXPECT_TRUE(!!Result);
+  EXPECT_EQ(*Result, 42);
+}
+
+TEST(CooperativeFutureTest, PromiseAssignment) {
+  QueueingTaskDispatcher QTD;
+  QueueingTaskDispatchRunner QTDRunner(QTD);
+
+  CooperativePromise<Expected<int>> P1(QTDRunner);
+  CooperativePromise<Expected<int>> P2;
+  auto F = P1.get_future();
+
+  // Move-assign promise
+  P2 = std::move(P1);
+
+  P2.set_value(Expected<int>(42));
+
+  auto Result = F.get();
+  EXPECT_TRUE(!!Result);
+  EXPECT_EQ(*Result, 42);
+}
+
+TEST(CooperativeFutureTest, FutureAssignment) {
+  QueueingTaskDispatcher QTD;
+  QueueingTaskDispatchRunner QTDRunner(QTD);
+
+  CooperativePromise<Expected<int>> P(QTDRunner);
+  CooperativeFuture<Expected<int>> F1 = P.get_future();
+  CooperativeFuture<Expected<int>> F2;
+
+  // Move-assign future
+  F2 = std::move(F1);
+
+  P.set_value(Expected<int>(42));
+
+  auto Result = F2.get();
+  EXPECT_TRUE(!!Result);
+  EXPECT_EQ(*Result, 42);
+}
+
+TEST(CooperativeFutureTest, ErrorTypeValue) {
+  QueueingTaskDispatcher QTD;
+  QueueingTaskDispatchRunner QTDRunner(QTD);
+
+  // Test with Error as the future type
+  CooperativePromise<Error> P(QTDRunner);
+  auto F = P.get_future();
+
+  P.set_value(Error::success());
+
+  auto Result = F.get();
+  EXPECT_FALSE(!!Result); // Error::success() evaluates to false
+}
+
+TEST(CooperativeFutureTest, ErrorTypeError) {
+  QueueingTaskDispatcher QTD;
+  QueueingTaskDispatchRunner QTDRunner(QTD);
+
+  CooperativePromise<Error> P(QTDRunner);
+  auto F = P.get_future();
+
+  P.set_value(make_error<StringError>("Error type test"));
+
+  auto Result = F.get();
+  EXPECT_TRUE(!!Result); // Error with content evaluates to true
+  EXPECT_EQ(toString(std::move(Result)), "Error type test");
+}
+
+TEST(CooperativeFutureTest, WorkQueueFailure) {
+  QueueingTaskDispatcher QTD;
+  QueueingTaskDispatchRunner QTDRunner(QTD);
+
+  CooperativePromise<Expected<int>> P(QTDRunner);
+  auto F = P.get_future();
+
+  // With no value set and no tasks to run available this should return / throw
+  // an error.
+#if ORC_RT_ENABLE_EXCEPTIONS
+  try {
+    auto Result = F.get();
+    ADD_FAILURE() << "CooperativeFuture::get() did not throw on empty queue";
+  } catch (ErrorInfoBase &EIB) {
+    SUCCEED();
+  }
+#else
+  auto Result = F.get();
+
+  EXPECT_FALSE(!!Result);
+  consumeError(Result.takeError());
+  EXPECT_GT(QTDRunner.getRunNextItemCalls(), 0u);
+#endif // ORC_RT_ENABLE_EXCEPTIONS
+}

--- a/orc-rt/unittests/CooperativeFutureTest.cpp
+++ b/orc-rt/unittests/CooperativeFutureTest.cpp
@@ -24,19 +24,19 @@ class QueueingTaskDispatchRunner : public CooperativeFutureTaskRunner {
 public:
   QueueingTaskDispatchRunner(QueueingTaskDispatcher &QTD) : QTD(QTD) {}
 
-  Error runNextItem() override {
-    ++RunNextItemCalls;
+  Error runNextTask() override {
+    ++RunNextTaskCalls;
     if (auto T = QTD.pop_back()) {
       T->run();
       return Error::success();
     }
     return make_error<StringError>("No tasks left");
   }
-  size_t getRunNextItemCalls() const { return RunNextItemCalls; }
+  size_t getRunNextTaskCalls() const { return RunNextTaskCalls; }
 
 private:
   QueueingTaskDispatcher &QTD;
-  size_t RunNextItemCalls = 0;
+  size_t RunNextTaskCalls = 0;
 };
 
 } // anonymous namespace
@@ -252,6 +252,6 @@ TEST(CooperativeFutureTest, WorkQueueFailure) {
 
   EXPECT_FALSE(!!Result);
   consumeError(Result.takeError());
-  EXPECT_GT(QTDRunner.getRunNextItemCalls(), 0u);
+  EXPECT_GT(QTDRunner.getRunNextTaskCalls(), 0u);
 #endif // ORC_RT_ENABLE_EXCEPTIONS
 }


### PR DESCRIPTION
CooperativePromise and CooperativeFuture provide a promise/future implementation that's largely compatible with std::promise/future, but which uses a work stealing pattern inside CooperativeFuture::get to enable progress on the current thread while waiting for a result. This allows CooperativeFuture::get to return a result even if the current thread is the only one in the program (e.g. if this program is running on a single-threaded system).

This idea was respectfully inspired by (/shamelessly stolen from) @vtjnash's cowait draft: https://github.com/vtjnash/llvm-project/pull/1.