### PR TITLE
[LLVM-Tablegen] Explicit Type Constraints for Overloaded LLVM Intrinsics

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -182,6 +182,7 @@ namespace Intrinsic {
       AArch64Svcount,
       ArgumentTypeConstraint, // For AnyTypeOf - marks constrained argument
                               // types.
+      ArgumentTypeExclusion,  // For NoneTypeOf - marks excluded argument types.
     } Kind;
 
     union {
@@ -235,6 +236,12 @@ namespace Intrinsic {
     // For ArgumentTypeConstraint: get number of allowed types.
     unsigned getArgumentNumConstraints() const {
       assert(Kind == ArgumentTypeConstraint);
+      return Argument_NumConstraints;
+    }
+
+    // For ArgumentTypeExclusion: get number of excluded types.
+    unsigned getArgumentNumExclusions() const {
+      assert(Kind == ArgumentTypeExclusion);
       return Argument_NumConstraints;
     }
 

--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -180,8 +180,6 @@ namespace Intrinsic {
       AMX,
       PPCQuad,
       AArch64Svcount,
-      ArgumentTypeConstraint, // For AnyTypeOf - marks constrained argument
-                              // types.
     } Kind;
 
     union {
@@ -190,7 +188,6 @@ namespace Intrinsic {
       unsigned Pointer_AddressSpace;
       unsigned Struct_NumElements;
       unsigned Argument_Info;
-      unsigned Argument_NumConstraints;
       ElementCount Vector_Width;
     };
 
@@ -205,7 +202,7 @@ namespace Intrinsic {
              Kind == TruncArgument || Kind == SameVecWidthArgument ||
              Kind == VecElementArgument || Kind == Subdivide2Argument ||
              Kind == Subdivide4Argument || Kind == VecOfBitcastsToInt);
-      return Argument_Info >> 3;
+      return (Argument_Info >> 3) & 0x1F;
     }
     ArgKind getArgumentKind() const {
       assert(Kind == Argument || Kind == ExtendArgument ||
@@ -232,10 +229,10 @@ namespace Intrinsic {
       return Argument_Info & 0xFFFF;
     }
 
-    // For ArgumentTypeConstraint: get number of allowed types.
-    unsigned getArgumentNumConstraints() const {
-      assert(Kind == ArgumentTypeConstraint);
-      return Argument_NumConstraints;
+    // For AnyOf: get number of allowed types.
+    unsigned getAnyOfCount() const {
+      assert(Kind == Argument && getArgumentKind() == AK_AnyOf);
+      return (Argument_Info >> 8) & 0xFF;
     }
 
     static IITDescriptor get(IITDescriptorKind K, unsigned Field) {

--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -180,6 +180,7 @@ namespace Intrinsic {
       AMX,
       PPCQuad,
       AArch64Svcount,
+      ArgumentTypeConstraint,  // For AnyTypeOf - marks constrained argument types.
     } Kind;
 
     union {
@@ -188,6 +189,7 @@ namespace Intrinsic {
       unsigned Pointer_AddressSpace;
       unsigned Struct_NumElements;
       unsigned Argument_Info;
+      unsigned Argument_NumConstraints;
       ElementCount Vector_Width;
     };
 
@@ -227,6 +229,12 @@ namespace Intrinsic {
     unsigned getRefArgNumber() const {
       assert(Kind == VecOfAnyPtrsToElt || Kind == OneNthEltsVecArgument);
       return Argument_Info & 0xFFFF;
+    }
+
+    // For ArgumentTypeConstraint: get number of allowed types.
+    unsigned getArgumentNumConstraints() const {
+      assert(Kind == ArgumentTypeConstraint);
+      return Argument_NumConstraints;
     }
 
     static IITDescriptor get(IITDescriptorKind K, unsigned Field) {
@@ -275,6 +283,10 @@ namespace Intrinsic {
   /// This method returns true on error.
   LLVM_ABI bool matchIntrinsicVarArg(bool isVarArg,
                                      ArrayRef<IITDescriptor> &Infos);
+
+  /// Verify type constraints for AnyTypeOf constrained intrinsics.
+  LLVM_ABI bool verifyIntrinsicTypeConstraints(ID id, FunctionType *FTy,
+                                               std::string &ErrMsg);
 
   /// Gets the type arguments of an intrinsic call by matching type contraints
   /// specified by the .td file. The overloaded types are pushed into the

--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -180,7 +180,8 @@ namespace Intrinsic {
       AMX,
       PPCQuad,
       AArch64Svcount,
-      ArgumentTypeConstraint,  // For AnyTypeOf - marks constrained argument types.
+      ArgumentTypeConstraint, // For AnyTypeOf - marks constrained argument
+                              // types.
     } Kind;
 
     union {

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -372,6 +372,8 @@ def IIT_V6 : IIT_Vec<6, 50>;
 def IIT_V10 : IIT_Vec<10, 51>;
 def IIT_V2048 : IIT_Vec<2048, 52>;
 def IIT_V4096 : IIT_Vec<4096, 53>;
+// Constrained type encoding for overloaded intrinsics.
+def IIT_ANYTYPE : IIT_Base<93>;
 }
 
 defvar IIT_all_FixedTypes = !filter(iit, IIT_all,
@@ -446,6 +448,23 @@ class LLVMQualPointerType<int addrspace>
 
 class LLVMAnyPointerType : LLVMAnyType<pAny> {
   assert isAny, "pAny should have isOverloaded";
+}
+
+// AnyTypeOf: Constrain overloaded type to specific set of allowed types.
+// Encoding follows the pattern: [IIT_ARG, EncAny, IIT_ANYTYPE, count, type_sigs...].
+class AnyTypeOf<list<LLVMType> allowed_types> : LLVMAnyType<Any> {
+  list<LLVMType> AllowedTypes = allowed_types;
+  
+  // Validation: specifying maximal 255 number of allowed types.
+  assert !le(!size(allowed_types), 255),
+         "AnyTypeOf cannot exceed 255 allowed types";
+  
+  let Sig = !listconcat(
+    [IIT_ARG.Number, EncAnyType<ArgCode>.ret],
+    [IIT_ANYTYPE.Number, !size(allowed_types)],
+    !foldl([]<int>, allowed_types, accum, ty,
+      !listconcat(accum, ty.Sig))
+  );
 }
 
 // Match the type of another intrinsic parameter.  Number is an index into the

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -374,6 +374,7 @@ def IIT_V2048 : IIT_Vec<2048, 52>;
 def IIT_V4096 : IIT_Vec<4096, 53>;
 // Constrained type encoding for overloaded intrinsics.
 def IIT_ANYTYPE : IIT_Base<93>;
+def IIT_NONETYPE : IIT_Base<94>;
 }
 
 defvar IIT_all_FixedTypes = !filter(iit, IIT_all,
@@ -463,6 +464,23 @@ class AnyTypeOf<list<LLVMType> allowed_types> : LLVMAnyType<Any> {
     [IIT_ARG.Number, EncAnyType<ArgCode>.ret],
     [IIT_ANYTYPE.Number, !size(allowed_types)],
     !foldl([]<int>, allowed_types, accum, ty,
+      !listconcat(accum, ty.Sig))
+  );
+}
+
+// NoneTypeOf: Exclude specific types from overloaded type (inverse of AnyTypeOf).
+// Encoding follows the pattern: [IIT_ARG, EncAny, IIT_NONETYPE, count, type_sigs...].
+class NoneTypeOf<list<LLVMType> excluded_types> : LLVMAnyType<Any> {
+  list<LLVMType> ExcludedTypes = excluded_types;
+  
+  // Validation: specifying maximal 255 number of excluded types.
+  assert !le(!size(excluded_types), 255),
+         "NoneTypeOf cannot exceed 255 excluded types";
+  
+  let Sig = !listconcat(
+    [IIT_ARG.Number, EncAnyType<ArgCode>.ret],
+    [IIT_NONETYPE.Number, !size(excluded_types)],
+    !foldl([]<int>, excluded_types, accum, ty,
       !listconcat(accum, ty.Sig))
   );
 }

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -239,6 +239,7 @@ def ArgKind {
   int AnyFloat   = 2;
   int AnyVector  = 3;
   int AnyPointer = 4;
+  int AnyOf      = 5;
 
   int MatchType  = 7;
 }
@@ -372,8 +373,6 @@ def IIT_V6 : IIT_Vec<6, 50>;
 def IIT_V10 : IIT_Vec<10, 51>;
 def IIT_V2048 : IIT_Vec<2048, 52>;
 def IIT_V4096 : IIT_Vec<4096, 53>;
-// Constrained type encoding for overloaded intrinsics.
-def IIT_ANYTYPE : IIT_Base<54>;
 }
 
 defvar IIT_all_FixedTypes = !filter(iit, IIT_all,
@@ -451,7 +450,7 @@ class LLVMAnyPointerType : LLVMAnyType<pAny> {
 }
 
 // AnyTypeOf: Constrain overloaded type to specific set of allowed types.
-// Encoding follows the pattern: [IIT_ARG, EncAny, IIT_ANYTYPE, count, type_sigs...].
+// Encoding follows the pattern: [IIT_ARG, EncAnyType<ArgKind.AnyOf>, count, type_sigs...].
 class AnyTypeOf<list<LLVMType> allowed_types> : LLVMAnyType<Any> {
   list<LLVMType> AllowedTypes = allowed_types;
   
@@ -460,8 +459,7 @@ class AnyTypeOf<list<LLVMType> allowed_types> : LLVMAnyType<Any> {
          "AnyTypeOf cannot exceed 255 allowed types";
   
   let Sig = !listconcat(
-    [IIT_ARG.Number, EncAnyType<ArgCode>.ret],
-    [IIT_ANYTYPE.Number, !size(allowed_types)],
+    [IIT_ARG.Number, EncAnyType<ArgKind.AnyOf>.ret, !size(allowed_types)],
     !foldl([]<int>, allowed_types, accum, ty,
       !listconcat(accum, ty.Sig))
   );

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -373,7 +373,7 @@ def IIT_V10 : IIT_Vec<10, 51>;
 def IIT_V2048 : IIT_Vec<2048, 52>;
 def IIT_V4096 : IIT_Vec<4096, 53>;
 // Constrained type encoding for overloaded intrinsics.
-def IIT_ANYTYPE : IIT_Base<93>;
+def IIT_ANYTYPE : IIT_Base<54>;
 }
 
 defvar IIT_all_FixedTypes = !filter(iit, IIT_all,
@@ -455,7 +455,7 @@ class LLVMAnyPointerType : LLVMAnyType<pAny> {
 class AnyTypeOf<list<LLVMType> allowed_types> : LLVMAnyType<Any> {
   list<LLVMType> AllowedTypes = allowed_types;
   
-  // Validation: specifying maximal 255 number of allowed types.
+  // Limit to 255 allowed types since it is encoded as a single byte.
   assert !le(!size(allowed_types), 255),
          "AnyTypeOf cannot exceed 255 allowed types";
   

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -374,7 +374,6 @@ def IIT_V2048 : IIT_Vec<2048, 52>;
 def IIT_V4096 : IIT_Vec<4096, 53>;
 // Constrained type encoding for overloaded intrinsics.
 def IIT_ANYTYPE : IIT_Base<93>;
-def IIT_NONETYPE : IIT_Base<94>;
 }
 
 defvar IIT_all_FixedTypes = !filter(iit, IIT_all,
@@ -464,23 +463,6 @@ class AnyTypeOf<list<LLVMType> allowed_types> : LLVMAnyType<Any> {
     [IIT_ARG.Number, EncAnyType<ArgCode>.ret],
     [IIT_ANYTYPE.Number, !size(allowed_types)],
     !foldl([]<int>, allowed_types, accum, ty,
-      !listconcat(accum, ty.Sig))
-  );
-}
-
-// NoneTypeOf: Exclude specific types from overloaded type (inverse of AnyTypeOf).
-// Encoding follows the pattern: [IIT_ARG, EncAny, IIT_NONETYPE, count, type_sigs...].
-class NoneTypeOf<list<LLVMType> excluded_types> : LLVMAnyType<Any> {
-  list<LLVMType> ExcludedTypes = excluded_types;
-  
-  // Validation: specifying maximal 255 number of excluded types.
-  assert !le(!size(excluded_types), 255),
-         "NoneTypeOf cannot exceed 255 excluded types";
-  
-  let Sig = !listconcat(
-    [IIT_ARG.Number, EncAnyType<ArgCode>.ret],
-    [IIT_NONETYPE.Number, !size(excluded_types)],
-    !foldl([]<int>, excluded_types, accum, ty,
       !listconcat(accum, ty.Sig))
   );
 }

--- a/llvm/include/llvm/IR/IntrinsicsNVVM.td
+++ b/llvm/include/llvm/IR/IntrinsicsNVVM.td
@@ -3421,11 +3421,10 @@ def int_nvvm_tensormap_replace_fill_mode :
                            ImmArgPrinter<"printTensormapFillMode">]>]>;
 
 // Test intrinsic - TODO: Add the feature to existing intrinsics and remove these test intrinsics.
-// IIT_LongEncodingTable entry:   /* 25339 */ 4, 15, 0, 93, 2, 3, 4, 15, 7, 15, 8, 93, 2, 15, 9, 7, 15, 16, 93, 2, 14, 24, 3, 15, 24, 93, 2, 5, 8, 15, 32, 93, 3, 3, 10, 4, 10, 7, 0,
-def int_nvvm_test_anytype : Intrinsic<[llvm_i32_ty],
-  [AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>, LLVMMatchType<0>, AnyTypeOf<[llvm_anyint_ty, llvm_float_ty]>, AnyTypeOf<[llvm_ptr_ty, llvm_shared_ptr_ty]>,
-   AnyTypeOf<[llvm_i64_ty, llvm_double_ty]>, AnyTypeOf<[llvm_i16_ty, llvm_v4i32_ty, llvm_v4f32_ty]>],
-  [IntrNoMem]>;
+// IIT_LongEncodingTable entry:  /* 16662 */ 4, 15, 0, 93, 2, 3, 4, 15, 7, 15, 8, 93, 2, 15, 9, 7, 15, 16, 93, 2, 14, 24, 3, 15, 24, 94, 2, 5, 8, 15, 32, 93, 3, 3, 10, 4, 10, 7, 0,
+def int_nvvm_test_type : Intrinsic<[llvm_i32_ty],
+   [AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>, LLVMMatchType<0>, AnyTypeOf<[llvm_anyint_ty, llvm_float_ty]>, AnyTypeOf<[llvm_ptr_ty, llvm_shared_ptr_ty]>, NoneTypeOf<[llvm_i64_ty, llvm_double_ty]>, AnyTypeOf<[llvm_i16_ty, llvm_v4i32_ty, llvm_v4f32_ty]>],
+   [IntrNoMem]>;
 
 // IIT_LongEncodingTable entry:  /* 15435 */ 21, 1, 4, 15, 0, 93, 2, 3, 4, 5, 4, 0,
 def int_nvvm_test_return_type : Intrinsic<[llvm_i32_ty, AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>, llvm_i64_ty],

--- a/llvm/include/llvm/IR/IntrinsicsNVVM.td
+++ b/llvm/include/llvm/IR/IntrinsicsNVVM.td
@@ -3420,4 +3420,16 @@ def int_nvvm_tensormap_replace_fill_mode :
      ArgInfo<ArgIndex<1>, [ArgName<"fill_mode">, 
                            ImmArgPrinter<"printTensormapFillMode">]>]>;
 
+// Test intrinsic - TODO: Add the feature to existing intrinsics and remove these test intrinsics.
+// IIT_LongEncodingTable entry:   /* 25339 */ 4, 15, 0, 93, 2, 3, 4, 15, 7, 15, 8, 93, 2, 15, 9, 7, 15, 16, 93, 2, 14, 24, 3, 15, 24, 93, 2, 5, 8, 15, 32, 93, 3, 3, 10, 4, 10, 7, 0,
+def int_nvvm_test_anytype : Intrinsic<[llvm_i32_ty],
+  [AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>, LLVMMatchType<0>, AnyTypeOf<[llvm_anyint_ty, llvm_float_ty]>, AnyTypeOf<[llvm_ptr_ty, llvm_shared_ptr_ty]>,
+   AnyTypeOf<[llvm_i64_ty, llvm_double_ty]>, AnyTypeOf<[llvm_i16_ty, llvm_v4i32_ty, llvm_v4f32_ty]>],
+  [IntrNoMem]>;
+
+// IIT_LongEncodingTable entry:  /* 15435 */ 21, 1, 4, 15, 0, 93, 2, 3, 4, 5, 4, 0,
+def int_nvvm_test_return_type : Intrinsic<[llvm_i32_ty, AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>, llvm_i64_ty],
+[llvm_i32_ty],
+[IntrNoMem]>;
+
 } // let TargetPrefix = "nvvm"

--- a/llvm/include/llvm/IR/IntrinsicsNVVM.td
+++ b/llvm/include/llvm/IR/IntrinsicsNVVM.td
@@ -3421,12 +3421,12 @@ def int_nvvm_tensormap_replace_fill_mode :
                            ImmArgPrinter<"printTensormapFillMode">]>]>;
 
 // Test intrinsic - TODO: Add the feature to existing intrinsics and remove these test intrinsics.
-// IIT_LongEncodingTable entry:  /* 16662 */ 4, 15, 0, 93, 2, 3, 4, 15, 7, 15, 8, 93, 2, 15, 9, 7, 15, 16, 93, 2, 14, 24, 3, 15, 24, 93, 2, 5, 8, 15, 32, 93, 2, 24, 1, 9, 5, 0,
+// IIT_LongEncodingTable entry:  /* 16662 */ 4, 15, 0, 54, 2, 3, 4, 15, 7, 15, 8, 54, 2, 15, 9, 7, 15, 16, 54, 2, 14, 24, 3, 15, 24, 54, 2, 5, 8, 15, 32, 54, 2, 24, 1, 9, 5, 0,
 def int_nvvm_test_anytype : Intrinsic<[llvm_i32_ty],
    [AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>, LLVMMatchType<0>, AnyTypeOf<[llvm_anyint_ty, llvm_float_ty]>, AnyTypeOf<[llvm_ptr_ty, llvm_shared_ptr_ty]>, AnyTypeOf<[llvm_i64_ty, llvm_double_ty]>, AnyTypeOf<[llvm_global_ptr_ty, llvm_v2i64_ty]>],
    [IntrNoMem]>;
 
-// IIT_LongEncodingTable entry:  /* 15435 */ 21, 1, 4, 15, 0, 93, 2, 3, 4, 5, 4, 0,
+// IIT_LongEncodingTable entry:  /* 15435 */ 21, 1, 4, 15, 0, 54, 2, 3, 4, 5, 4, 0,
 def int_nvvm_test_return_type : Intrinsic<[llvm_i32_ty, AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>, llvm_i64_ty],
 [llvm_i32_ty],
 [IntrNoMem]>;

--- a/llvm/include/llvm/IR/IntrinsicsNVVM.td
+++ b/llvm/include/llvm/IR/IntrinsicsNVVM.td
@@ -3421,12 +3421,12 @@ def int_nvvm_tensormap_replace_fill_mode :
                            ImmArgPrinter<"printTensormapFillMode">]>]>;
 
 // Test intrinsic - TODO: Add the feature to existing intrinsics and remove these test intrinsics.
-// IIT_LongEncodingTable entry:  /* 16662 */ 4, 15, 0, 54, 2, 3, 4, 15, 7, 15, 8, 54, 2, 15, 9, 7, 15, 16, 54, 2, 14, 24, 3, 15, 24, 54, 2, 5, 8, 15, 32, 54, 2, 24, 1, 9, 5, 0,
+// IIT_LongEncodingTable entry:    /* 15183 */ 4, 15, 5, 2, 3, 4, 15, 7, 15, 13, 2, 15, 9, 7, 15, 21, 2, 14, 24, 3, 15, 29, 2, 5, 8, 15, 37, 2, 24, 1, 9, 5, 0,
 def int_nvvm_test_anytype : Intrinsic<[llvm_i32_ty],
    [AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>, LLVMMatchType<0>, AnyTypeOf<[llvm_anyint_ty, llvm_float_ty]>, AnyTypeOf<[llvm_ptr_ty, llvm_shared_ptr_ty]>, AnyTypeOf<[llvm_i64_ty, llvm_double_ty]>, AnyTypeOf<[llvm_global_ptr_ty, llvm_v2i64_ty]>],
    [IntrNoMem]>;
 
-// IIT_LongEncodingTable entry:  /* 15435 */ 21, 1, 4, 15, 0, 54, 2, 3, 4, 5, 4, 0,
+// IIT_LongEncodingTable entry:  /* 11971 */ 21, 1, 4, 15, 5, 2, 3, 4, 5, 4, 0,
 def int_nvvm_test_return_type : Intrinsic<[llvm_i32_ty, AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>, llvm_i64_ty],
 [llvm_i32_ty],
 [IntrNoMem]>;

--- a/llvm/include/llvm/IR/IntrinsicsNVVM.td
+++ b/llvm/include/llvm/IR/IntrinsicsNVVM.td
@@ -3421,9 +3421,9 @@ def int_nvvm_tensormap_replace_fill_mode :
                            ImmArgPrinter<"printTensormapFillMode">]>]>;
 
 // Test intrinsic - TODO: Add the feature to existing intrinsics and remove these test intrinsics.
-// IIT_LongEncodingTable entry:  /* 16662 */ 4, 15, 0, 93, 2, 3, 4, 15, 7, 15, 8, 93, 2, 15, 9, 7, 15, 16, 93, 2, 14, 24, 3, 15, 24, 94, 2, 5, 8, 15, 32, 93, 3, 3, 10, 4, 10, 7, 0,
-def int_nvvm_test_type : Intrinsic<[llvm_i32_ty],
-   [AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>, LLVMMatchType<0>, AnyTypeOf<[llvm_anyint_ty, llvm_float_ty]>, AnyTypeOf<[llvm_ptr_ty, llvm_shared_ptr_ty]>, NoneTypeOf<[llvm_i64_ty, llvm_double_ty]>, AnyTypeOf<[llvm_i16_ty, llvm_v4i32_ty, llvm_v4f32_ty]>],
+// IIT_LongEncodingTable entry:  /* 16662 */ 4, 15, 0, 93, 2, 3, 4, 15, 7, 15, 8, 93, 2, 15, 9, 7, 15, 16, 93, 2, 14, 24, 3, 15, 24, 93, 2, 5, 8, 15, 32, 93, 2, 24, 1, 9, 5, 0,
+def int_nvvm_test_anytype : Intrinsic<[llvm_i32_ty],
+   [AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>, LLVMMatchType<0>, AnyTypeOf<[llvm_anyint_ty, llvm_float_ty]>, AnyTypeOf<[llvm_ptr_ty, llvm_shared_ptr_ty]>, AnyTypeOf<[llvm_i64_ty, llvm_double_ty]>, AnyTypeOf<[llvm_global_ptr_ty, llvm_v2i64_ty]>],
    [IntrNoMem]>;
 
 // IIT_LongEncodingTable entry:  /* 15435 */ 21, 1, 4, 15, 0, 93, 2, 3, 4, 5, 4, 0,

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -363,10 +363,24 @@ DecodeIITType(unsigned &NextElt, ArrayRef<unsigned char> Infos,
         DecodeIITType(NextElt, Infos, Info, OutputTable);
       return;
     }
+
+    if (NextElt < Infos.size() && Infos[NextElt] == IIT_NONETYPE) {
+      NextElt++;
+
+      unsigned NumTypes = Infos[NextElt++];
+      OutputTable.push_back(
+          IITDescriptor::get(IITDescriptor::ArgumentTypeExclusion, NumTypes));
+
+      for (unsigned i = 0; i < NumTypes; ++i)
+        DecodeIITType(NextElt, Infos, Info, OutputTable);
+      return;
+    }
     return;
   }
   case IIT_ANYTYPE:
     llvm_unreachable("IIT_ANYTYPE must follow IIT_ARG");
+  case IIT_NONETYPE:
+    llvm_unreachable("IIT_NONETYPE must follow IIT_ARG");
   case IIT_EXTEND_ARG: {
     unsigned ArgInfo = (NextElt == Infos.size() ? 0 : Infos[NextElt++]);
     OutputTable.push_back(
@@ -594,6 +608,9 @@ static Type *DecodeFixedType(ArrayRef<Intrinsic::IITDescriptor> &Infos,
   case IITDescriptor::ArgumentTypeConstraint:
     llvm_unreachable(
         "ArgumentTypeConstraint should not appear in DecodeFixedType");
+  case IITDescriptor::ArgumentTypeExclusion:
+    llvm_unreachable(
+        "ArgumentTypeExclusion should not appear in DecodeFixedType");
   }
   llvm_unreachable("unhandled");
 }
@@ -615,6 +632,15 @@ FunctionType *Intrinsic::getType(LLVMContext &Context, ID id,
       (void)DecodeFixedType(TableRef, Tys, Context);
   }
 
+  if (!TableRef.empty() &&
+      TableRef[0].Kind == IITDescriptor::ArgumentTypeExclusion) {
+    unsigned NumExclusions = TableRef[0].getArgumentNumExclusions();
+    TableRef = TableRef.slice(1);
+
+    for (unsigned i = 0; i < NumExclusions; ++i)
+      (void)DecodeFixedType(TableRef, Tys, Context);
+  }
+
   SmallVector<Type *, 8> ArgTys;
   while (!TableRef.empty()) {
     ArgTys.push_back(DecodeFixedType(TableRef, Tys, Context));
@@ -625,6 +651,15 @@ FunctionType *Intrinsic::getType(LLVMContext &Context, ID id,
       TableRef = TableRef.slice(1);
 
       for (unsigned i = 0; i < NumConstraints; ++i)
+        (void)DecodeFixedType(TableRef, Tys, Context);
+    }
+
+    if (!TableRef.empty() &&
+        TableRef[0].Kind == IITDescriptor::ArgumentTypeExclusion) {
+      unsigned NumExclusions = TableRef[0].getArgumentNumExclusions();
+      TableRef = TableRef.slice(1);
+
+      for (unsigned i = 0; i < NumExclusions; ++i)
         (void)DecodeFixedType(TableRef, Tys, Context);
     }
   }
@@ -909,6 +944,14 @@ skipDescriptorsForSingleType(ArrayRef<Intrinsic::IITDescriptor> &Infos) {
       for (unsigned i = 0; i < NumConstraints; ++i)
         Count += skipDescriptorsForSingleType(Infos);
     }
+    if (!Infos.empty() &&
+        Infos[0].Kind == IITDescriptor::ArgumentTypeExclusion) {
+      unsigned NumExclusions = Infos[0].getArgumentNumExclusions();
+      Count++;
+      Infos = Infos.slice(1);
+      for (unsigned i = 0; i < NumExclusions; ++i)
+        Count += skipDescriptorsForSingleType(Infos);
+    }
     break;
 
   default:
@@ -1046,6 +1089,17 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
       return false;
     }
 
+    if (!Infos.empty() &&
+        Infos[0].Kind == IITDescriptor::ArgumentTypeExclusion) {
+      unsigned NumExclusions = Infos[0].getArgumentNumExclusions();
+      Infos = Infos.slice(1);
+
+      for (unsigned i = 0; i < NumExclusions; ++i)
+        skipDescriptorsForSingleType(Infos);
+
+      return false;
+    }
+
     return false;
 
   case IITDescriptor::ExtendArgument: {
@@ -1169,6 +1223,9 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
   case IITDescriptor::ArgumentTypeConstraint:
     llvm_unreachable(
         "ArgumentTypeConstraint should be handled in Argument case");
+  case IITDescriptor::ArgumentTypeExclusion:
+    llvm_unreachable(
+        "ArgumentTypeExclusion should be handled in Argument case");
   }
   llvm_unreachable("unhandled");
 }
@@ -1199,7 +1256,7 @@ Intrinsic::matchIntrinsicSignature(FunctionType *FTy,
   return MatchIntrinsicTypes_Match;
 }
 
-// Helper: Check if a type matches AnyTypeOf constraints using
+// Check if a type matches AnyTypeOf constraints using
 // matchIntrinsicType.
 static bool
 verifyTypeAgainstConstraints(Type *Ty, unsigned NumConstraints,
@@ -1209,10 +1266,10 @@ verifyTypeAgainstConstraints(Type *Ty, unsigned NumConstraints,
   bool Matched = false;
   for (unsigned i = 0; i < NumConstraints && !Matched; ++i) {
     ArrayRef<IITDescriptor> TypeDesc = Infos;
-    SmallVector<Type *, 4> DummyArgTys;
-    SmallVector<DeferredIntrinsicMatchPair, 2> DummyDeferredChecks;
+    SmallVector<Type *, 4> TempArgTys;
+    SmallVector<DeferredIntrinsicMatchPair, 2> TempDeferredChecks;
 
-    if (!matchIntrinsicType(Ty, TypeDesc, DummyArgTys, DummyDeferredChecks,
+    if (!matchIntrinsicType(Ty, TypeDesc, TempArgTys, TempDeferredChecks,
                             false)) {
       Matched = true;
       for (unsigned j = 0; j < NumConstraints - i; ++j)
@@ -1225,7 +1282,7 @@ verifyTypeAgainstConstraints(Type *Ty, unsigned NumConstraints,
   return Matched;
 }
 
-// Helper: Format a type as string for error messages.
+// Format a type as string for error messages.
 static std::string typeToString(Type *Ty) {
   std::string Str;
   raw_string_ostream OS(Str);
@@ -1233,118 +1290,137 @@ static std::string typeToString(Type *Ty) {
   return Str;
 }
 
-bool Intrinsic::verifyIntrinsicTypeConstraints(ID id, FunctionType *FTy,
-                                               std::string &ErrMsg) {
+enum class ConstraintKind {
+  Allowed,
+  Excluded,
+};
 
-  if (id == 0 || id >= Intrinsic::num_intrinsics)
+static bool
+checkAndConsumeConstraintBlock(Type *Ty, ConstraintKind Kind,
+                               ArrayRef<Intrinsic::IITDescriptor> &Infos,
+                               const Twine &Constraint, std::string &ErrMsg) {
+  using namespace Intrinsic;
+
+  unsigned Count = Kind == ConstraintKind::Allowed
+                       ? Infos.front().getArgumentNumConstraints()
+                       : Infos.front().getArgumentNumExclusions();
+  Infos = Infos.slice(1);
+
+  bool Matches = verifyTypeAgainstConstraints(Ty, Count, Infos);
+  bool Violates = Kind == ConstraintKind::Allowed ? !Matches : Matches;
+  if (!Violates)
     return true;
 
-  SmallVector<IITDescriptor, 8> Table;
-  getIntrinsicInfoTableEntries(id, Table);
+  ErrMsg = (Constraint + " type '" + typeToString(Ty) + "'" +
+            (Kind == ConstraintKind::Allowed ? " not in allowed types"
+                                             : " is in excluded types"))
+               .str();
+  return false;
+}
 
-  if (Table.empty())
+// Verify the Struct return types.
+static bool
+verifyIntrinsicStructOutputTypes(Type *RetTy,
+                                 ArrayRef<Intrinsic::IITDescriptor> &Infos,
+                                 std::string &ErrMsg) {
+  using namespace Intrinsic;
+
+  auto *STy = dyn_cast<StructType>(RetTy);
+  if (!STy) {
+    skipDescriptorsForSingleType(Infos);
+    return false;
+  }
+
+  if (Infos.empty() || Infos[0].Kind != IITDescriptor::Struct) {
+    ErrMsg = "Return type struct encoding is malformed";
+    return false;
+  }
+
+  unsigned NumElements = Infos[0].Struct_NumElements;
+  Infos = Infos.slice(1);
+
+  for (unsigned ElemIdx = 0; ElemIdx < NumElements; ++ElemIdx) {
+    if (Infos.empty())
+      break;
+
+    if (Infos[0].Kind == IITDescriptor::Argument) {
+      Infos = Infos.slice(1);
+
+      Type *ElemTy = STy->getElementType(ElemIdx);
+
+      if (!Infos.empty() &&
+          Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+        if (!checkAndConsumeConstraintBlock(
+                ElemTy, ConstraintKind::Allowed, Infos,
+                Twine("Return type struct element ") + Twine(ElemIdx), ErrMsg))
+          return false;
+      } else if (!Infos.empty() &&
+                 Infos[0].Kind == IITDescriptor::ArgumentTypeExclusion) {
+        if (!checkAndConsumeConstraintBlock(
+                ElemTy, ConstraintKind::Excluded, Infos,
+                Twine("Return type struct element ") + Twine(ElemIdx), ErrMsg))
+          return false;
+      }
+    } else
+      skipDescriptorsForSingleType(Infos);
+  }
+
+  return true;
+}
+
+// Verify the non struct return types.
+static bool
+verifyIntrinsicNonStructOutputTypes(Type *RetTy,
+                                    ArrayRef<Intrinsic::IITDescriptor> &Infos,
+                                    std::string &ErrMsg) {
+  using namespace Intrinsic;
+
+  if (Infos.empty())
     return true;
 
-  ArrayRef<IITDescriptor> Infos = Table;
+  if (Infos[0].Kind != IITDescriptor::Argument) {
+    skipDescriptorsForSingleType(Infos);
+    return true;
+  }
+
+  Infos = Infos.slice(1);
+
+  if (!Infos.empty() &&
+      Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+    if (!checkAndConsumeConstraintBlock(RetTy, ConstraintKind::Allowed, Infos,
+                                        "Return type", ErrMsg))
+      return false;
+  } else if (!Infos.empty() &&
+             Infos[0].Kind == IITDescriptor::ArgumentTypeExclusion) {
+    if (!checkAndConsumeConstraintBlock(RetTy, ConstraintKind::Excluded, Infos,
+                                        "Return type", ErrMsg))
+      return false;
+  }
+
+  return true;
+}
+
+// Verify the return types.
+static bool
+verifyIntrinsicOutputTypes(Intrinsic::ID id, FunctionType *FTy,
+                           ArrayRef<Intrinsic::IITDescriptor> &Infos,
+                           std::string &ErrMsg) {
+
+  Type *RetTy = FTy->getReturnType();
+  if (RetTy->isStructTy())
+    return verifyIntrinsicStructOutputTypes(RetTy, Infos, ErrMsg);
+
+  return verifyIntrinsicNonStructOutputTypes(RetTy, Infos, ErrMsg);
+}
+
+// Verify the input parameters.
+static bool verifyIntrinsicInputTypes(Intrinsic::ID id, FunctionType *FTy,
+                                      ArrayRef<Intrinsic::IITDescriptor> &Infos,
+                                      std::string &ErrMsg) {
+  using namespace Intrinsic;
+
   SmallVector<Type *, 4> ArgTys;
 
-  // Processing return type.
-  Type *RetTy = FTy->getReturnType();
-  if (!Infos.empty() && Infos[0].Kind == IITDescriptor::Argument) {
-    Infos = Infos.slice(1);
-
-    if (!Infos.empty() &&
-        Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
-      unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
-      Infos = Infos.slice(1);
-
-      bool Matched = false;
-
-      // Check if a struct type's elements are all present in AnyTypeOf
-      // constraint list.
-      if (auto *STy = dyn_cast<StructType>(RetTy)) {
-        SmallVector<Type *, 8> AllowedTypes;
-        ArrayRef<IITDescriptor> TempInfos = Infos;
-        for (unsigned i = 0; i < NumConstraints; ++i) {
-          ArrayRef<IITDescriptor> TypeDesc = TempInfos;
-          SmallVector<Type *, 4> DummyTys;
-          Type *ConstraintTy =
-              DecodeFixedType(TypeDesc, DummyTys, FTy->getContext());
-          AllowedTypes.push_back(ConstraintTy);
-          TempInfos = TypeDesc;
-        }
-
-        Matched = llvm::all_of(STy->elements(), [&](Type *ElemTy) {
-          return llvm::is_contained(AllowedTypes, ElemTy);
-        });
-
-        if (Matched) {
-          for (unsigned i = 0; i < NumConstraints; ++i)
-            skipDescriptorsForSingleType(Infos);
-          Matched = true;
-        }
-      }
-
-      if (!Matched) {
-        for (unsigned i = 0; i < NumConstraints && !Matched; ++i) {
-          ArrayRef<IITDescriptor> TypeDesc = Infos;
-          SmallVector<Type *, 4> DummyArgTys;
-          SmallVector<DeferredIntrinsicMatchPair, 2> DummyDeferredChecks;
-
-          if (!matchIntrinsicType(RetTy, TypeDesc, DummyArgTys,
-                                  DummyDeferredChecks, false)) {
-            Matched = true;
-            for (unsigned j = 0; j < NumConstraints - i; ++j)
-              skipDescriptorsForSingleType(Infos);
-            break;
-          }
-          skipDescriptorsForSingleType(Infos);
-        }
-      }
-
-      if (!Matched) {
-        ErrMsg =
-            "Return type '" + typeToString(RetTy) + "' not in allowed types";
-        return false;
-      }
-    }
-  } else if (!Infos.empty() && Infos[0].Kind == IITDescriptor::Struct) {
-    // Handle struct return type with AnyTypeOf constrained elements.
-    auto *STy = dyn_cast<StructType>(RetTy);
-    if (!STy)
-      skipDescriptorsForSingleType(Infos);
-    else {
-      unsigned NumElements = Infos[0].Struct_NumElements;
-      Infos = Infos.slice(1);
-
-      for (unsigned ElemIdx = 0; ElemIdx < NumElements; ++ElemIdx) {
-        if (Infos.empty())
-          break;
-
-        if (Infos[0].Kind == IITDescriptor::Argument) {
-          Infos = Infos.slice(1);
-
-          if (!Infos.empty() &&
-              Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
-            unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
-            Infos = Infos.slice(1);
-
-            Type *ElemTy = STy->getElementType(ElemIdx);
-            if (!verifyTypeAgainstConstraints(ElemTy, NumConstraints, Infos)) {
-              ErrMsg = "Return type struct element " + std::to_string(ElemIdx) +
-                       " type '" + typeToString(ElemTy) +
-                       "' not in allowed types";
-              return false;
-            }
-          }
-        } else
-          skipDescriptorsForSingleType(Infos);
-      }
-    }
-  } else if (!Infos.empty())
-    skipDescriptorsForSingleType(Infos);
-
-  // Processing parameters.
   for (unsigned ParamIdx = 0; ParamIdx < FTy->getNumParams(); ++ParamIdx) {
     if (Infos.empty())
       break;
@@ -1357,21 +1433,61 @@ bool Intrinsic::verifyIntrinsicTypeConstraints(ID id, FunctionType *FTy,
 
       if (!Infos.empty() &&
           Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
-        unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
-        Infos = Infos.slice(1);
-
-        if (!verifyTypeAgainstConstraints(ParamTy, NumConstraints, Infos)) {
-          ErrMsg = "Parameter " + std::to_string(ParamIdx) + " type '" +
-                   typeToString(ParamTy) + "' not in allowed types";
+        if (!checkAndConsumeConstraintBlock(
+                ParamTy, ConstraintKind::Allowed, Infos,
+                Twine("Parameter ") + Twine(ParamIdx), ErrMsg))
           return false;
-        }
-
+        if (ArgNum == ArgTys.size())
+          ArgTys.push_back(ParamTy);
+      } else if (!Infos.empty() &&
+                 Infos[0].Kind == IITDescriptor::ArgumentTypeExclusion) {
+        if (!checkAndConsumeConstraintBlock(
+                ParamTy, ConstraintKind::Excluded, Infos,
+                Twine("Parameter ") + Twine(ParamIdx), ErrMsg))
+          return false;
         if (ArgNum == ArgTys.size())
           ArgTys.push_back(ParamTy);
       }
     } else
       skipDescriptorsForSingleType(Infos);
   }
+
+  return true;
+}
+
+bool Intrinsic::verifyIntrinsicTypeConstraints(ID id, FunctionType *FTy,
+                                               std::string &ErrMsg) {
+  if (id == 0 || id >= Intrinsic::num_intrinsics)
+    return true;
+
+  if (!isOverloaded(id))
+    return true;
+
+  SmallVector<IITDescriptor, 8> Table;
+  getIntrinsicInfoTableEntries(id, Table);
+  if (Table.empty())
+    return true;
+
+  ArrayRef<IITDescriptor> Infos = Table;
+
+  // if there are no constraint descriptors, skip verification.
+  bool HasConstraints = false;
+  for (const auto &D : Infos) {
+    if (D.Kind == IITDescriptor::ArgumentTypeConstraint ||
+        D.Kind == IITDescriptor::ArgumentTypeExclusion) {
+      HasConstraints = true;
+      break;
+    }
+  }
+  if (!HasConstraints)
+    return true;
+
+  if (!verifyIntrinsicOutputTypes(id, FTy, Infos, ErrMsg))
+    return false;
+
+  if (!verifyIntrinsicInputTypes(id, FTy, Infos, ErrMsg))
+    return false;
+
   return true;
 }
 

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -353,13 +353,14 @@ DecodeIITType(unsigned &NextElt, ArrayRef<unsigned char> Infos,
     if ((ArgInfo & 7) == IITDescriptor::AK_AnyOf) {
       unsigned NumTypes = Infos[NextElt++];
       ArgInfo |= (NumTypes << 8);
-      OutputTable.push_back(IITDescriptor::get(IITDescriptor::Argument, ArgInfo));
+      OutputTable.push_back(
+          IITDescriptor::get(IITDescriptor::Argument, ArgInfo));
 
       for (unsigned i = 0; i < NumTypes; ++i)
         DecodeIITType(NextElt, Infos, Info, OutputTable);
-    }
-    else
-      OutputTable.push_back(IITDescriptor::get(IITDescriptor::Argument, ArgInfo));
+    } else
+      OutputTable.push_back(
+          IITDescriptor::get(IITDescriptor::Argument, ArgInfo));
     return;
   }
   case IIT_EXTEND_ARG: {
@@ -896,10 +897,9 @@ static std::string typeToString(Type *Ty);
 static bool
 verifyTypeAgainstConstraints(Type *Ty, unsigned NumConstraints,
                              ArrayRef<Intrinsic::IITDescriptor> &Infos);
-static bool
-validateAndConsumeAnyOf(Type *Ty, unsigned NumConstraints,
-                             ArrayRef<Intrinsic::IITDescriptor> &Infos,
-                             const Twine &ArgDesc, std::string &ErrMsg);
+static bool validateAndConsumeAnyOf(Type *Ty, unsigned NumConstraints,
+                                    ArrayRef<Intrinsic::IITDescriptor> &Infos,
+                                    const Twine &ArgDesc, std::string &ErrMsg);
 
 using DeferredIntrinsicMatchPair =
     std::pair<Type *, ArrayRef<Intrinsic::IITDescriptor>>;
@@ -1023,13 +1023,14 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     if (D.getArgumentKind() == IITDescriptor::AK_AnyOf) {
       unsigned N = D.getAnyOfCount();
       if (ErrMsg) {
-        if (!validateAndConsumeAnyOf(
-                Ty, N, Infos,
-                Twine("Overloaded Argument ") + Twine(D.getArgumentNumber()),
-                *ErrMsg))
+        if (!validateAndConsumeAnyOf(Ty, N, Infos,
+                                     Twine("Overloaded Argument ") +
+                                         Twine(D.getArgumentNumber()),
+                                     *ErrMsg))
           return true;
       } else
-          for (unsigned i = 0; i < N; ++i) skipDescriptorsForSingleType(Infos);
+        for (unsigned i = 0; i < N; ++i)
+          skipDescriptorsForSingleType(Infos);
     }
 
     return false;
@@ -1193,12 +1194,13 @@ verifyTypeAgainstConstraints(Type *Ty, unsigned NumConstraints,
     SmallVector<Type *, 4> TempArgTys;
     SmallVector<DeferredIntrinsicMatchPair, 2> TempDeferredChecks;
 
-    if (!matchIntrinsicType(Ty, TypeDesc, TempArgTys, TempDeferredChecks, false)) {
+    if (!matchIntrinsicType(Ty, TypeDesc, TempArgTys, TempDeferredChecks,
+                            false)) {
       skipDescriptorsForSingleType(Infos);
       for (unsigned j = i + 1; j < NumConstraints; ++j)
         skipDescriptorsForSingleType(Infos);
       return true;
-     }
+    }
     skipDescriptorsForSingleType(Infos);
   }
 
@@ -1213,15 +1215,16 @@ static std::string typeToString(Type *Ty) {
   return Str;
 }
 
-// Verify Ty against NumConstraints allowed type descriptors at the front of Infos. 
-static bool
-validateAndConsumeAnyOf(Type *Ty, unsigned NumConstraints,
-                             ArrayRef<Intrinsic::IITDescriptor> &Infos,
-                             const Twine &ArgDesc, std::string &ErrMsg) {
+// Verify Ty against NumConstraints allowed type descriptors at the front of
+// Infos.
+static bool validateAndConsumeAnyOf(Type *Ty, unsigned NumConstraints,
+                                    ArrayRef<Intrinsic::IITDescriptor> &Infos,
+                                    const Twine &ArgDesc, std::string &ErrMsg) {
   if (verifyTypeAgainstConstraints(Ty, NumConstraints, Infos))
     return true;
 
-  ErrMsg = (ArgDesc + " type '" + typeToString(Ty) + "' not in allowed types").str();
+  ErrMsg =
+      (ArgDesc + " type '" + typeToString(Ty) + "' not in allowed types").str();
   return false;
 }
 

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -351,8 +351,21 @@ DecodeIITType(unsigned &NextElt, ArrayRef<unsigned char> Infos,
   case IIT_ARG: {
     unsigned ArgInfo = (NextElt == Infos.size() ? 0 : Infos[NextElt++]);
     OutputTable.push_back(IITDescriptor::get(IITDescriptor::Argument, ArgInfo));
+
+    if (NextElt < Infos.size() && Infos[NextElt] == IIT_ANYTYPE) {
+      NextElt++;
+
+      unsigned NumTypes = Infos[NextElt++];
+      OutputTable.push_back(IITDescriptor::get(IITDescriptor::ArgumentTypeConstraint, NumTypes));
+      
+      for (unsigned i = 0; i < NumTypes; ++i)
+        DecodeIITType(NextElt, Infos, Info, OutputTable);
+      return;
+    }
     return;
   }
+  case IIT_ANYTYPE:
+    llvm_unreachable("IIT_ANYTYPE must follow IIT_ARG");
   case IIT_EXTEND_ARG: {
     unsigned ArgInfo = (NextElt == Infos.size() ? 0 : Infos[NextElt++]);
     OutputTable.push_back(
@@ -577,6 +590,8 @@ static Type *DecodeFixedType(ArrayRef<Intrinsic::IITDescriptor> &Infos,
   case IITDescriptor::VecOfAnyPtrsToElt:
     // Return the overloaded type (which determines the pointers address space)
     return Tys[D.getOverloadArgNumber()];
+  case IITDescriptor::ArgumentTypeConstraint:
+    llvm_unreachable("ArgumentTypeConstraint should not appear in DecodeFixedType");
   }
   llvm_unreachable("unhandled");
 }
@@ -589,9 +604,26 @@ FunctionType *Intrinsic::getType(LLVMContext &Context, ID id,
   ArrayRef<IITDescriptor> TableRef = Table;
   Type *ResultTy = DecodeFixedType(TableRef, Tys, Context);
 
+  if (!TableRef.empty() && TableRef[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+    unsigned NumConstraints = TableRef[0].getArgumentNumConstraints();
+    TableRef = TableRef.slice(1);
+    
+    for (unsigned i = 0; i < NumConstraints; ++i)
+      (void)DecodeFixedType(TableRef, Tys, Context);
+  }
+
   SmallVector<Type *, 8> ArgTys;
-  while (!TableRef.empty())
+  while (!TableRef.empty()) {
     ArgTys.push_back(DecodeFixedType(TableRef, Tys, Context));
+    
+    if (!TableRef.empty() && TableRef[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+      unsigned NumConstraints = TableRef[0].getArgumentNumConstraints();
+      TableRef = TableRef.slice(1);
+      
+      for (unsigned i = 0; i < NumConstraints; ++i)
+        (void)DecodeFixedType(TableRef, Tys, Context);
+    }
+  }
 
   // DecodeFixedType returns Void for IITDescriptor::Void and
   // IITDescriptor::VarArg If we see void type as the type of the last argument,
@@ -834,6 +866,50 @@ bool Intrinsic::hasConstrainedFPRoundingModeOperand(Intrinsic::ID QID) {
   }
 }
 
+// Helper to skip past descriptors for one complete type in AnyTypeOf constraints.
+static unsigned skipDescriptorsForSingleType(ArrayRef<Intrinsic::IITDescriptor> &Infos) {
+  using namespace Intrinsic;
+  
+  if (Infos.empty())
+    return 0;
+  
+  IITDescriptor D = Infos[0];
+  unsigned Count = 1;
+  Infos = Infos.slice(1);
+  
+  switch (D.Kind) {
+  case IITDescriptor::Vector:
+    Count += skipDescriptorsForSingleType(Infos);
+    break;
+    
+  case IITDescriptor::Pointer:
+    break;
+    
+  case IITDescriptor::Struct:
+    for (unsigned i = 0, e = D.Struct_NumElements; i != e; ++i)
+      Count += skipDescriptorsForSingleType(Infos);
+    break;
+    
+  case IITDescriptor::SameVecWidthArgument:
+    Count += skipDescriptorsForSingleType(Infos);
+    break;
+    
+  case IITDescriptor::Argument:
+    if (!Infos.empty() && Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+      unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
+      Count++;
+      Infos = Infos.slice(1);
+      for (unsigned i = 0; i < NumConstraints; ++i)
+        Count += skipDescriptorsForSingleType(Infos);
+    }
+    break;
+
+  default:
+    break;
+  }
+  return Count;
+}
+
 using DeferredIntrinsicMatchPair =
     std::pair<Type *, ArrayRef<Intrinsic::IITDescriptor>>;
 
@@ -920,6 +996,29 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     // verify that the later instance matches the previous instance.
     if (D.getArgumentNumber() < ArgTys.size())
       return Ty != ArgTys[D.getArgumentNumber()];
+      
+    switch (D.getArgumentKind()) {
+    case IITDescriptor::AK_Any:
+      break;
+    case IITDescriptor::AK_AnyInteger:
+      if (!Ty->isIntOrIntVectorTy())
+        return true;
+      break;
+    case IITDescriptor::AK_AnyFloat:
+      if (!Ty->isFPOrFPVectorTy())
+        return true;
+      break;
+    case IITDescriptor::AK_AnyVector:
+      if (!isa<VectorType>(Ty))
+        return true;
+      break;
+    case IITDescriptor::AK_AnyPointer:
+      if (!isa<PointerType>(Ty))
+        return true;
+      break;
+    case IITDescriptor::AK_MatchType:
+      break;
+    }
 
     if (D.getArgumentNumber() > ArgTys.size() ||
         D.getArgumentKind() == IITDescriptor::AK_MatchType)
@@ -928,22 +1027,18 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     assert(D.getArgumentNumber() == ArgTys.size() && !IsDeferredCheck &&
            "Table consistency error");
     ArgTys.push_back(Ty);
+    
+    if (!Infos.empty() && Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+      unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
+      Infos = Infos.slice(1); 
 
-    switch (D.getArgumentKind()) {
-    case IITDescriptor::AK_Any:
-      return false; // Success
-    case IITDescriptor::AK_AnyInteger:
-      return !Ty->isIntOrIntVectorTy();
-    case IITDescriptor::AK_AnyFloat:
-      return !Ty->isFPOrFPVectorTy();
-    case IITDescriptor::AK_AnyVector:
-      return !isa<VectorType>(Ty);
-    case IITDescriptor::AK_AnyPointer:
-      return !isa<PointerType>(Ty);
-    default:
-      break;
+      for (unsigned i = 0; i < NumConstraints; ++i)
+        skipDescriptorsForSingleType(Infos);
+  
+      return false;
     }
-    llvm_unreachable("all argument kinds not covered");
+
+    return false;
 
   case IITDescriptor::ExtendArgument: {
     // If this is a forward reference, defer the check for later.
@@ -1063,6 +1158,8 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
       return true;
     return ThisArgVecTy != VectorType::getInteger(ReferenceType);
   }
+  case IITDescriptor::ArgumentTypeConstraint:
+    llvm_unreachable("ArgumentTypeConstraint should be handled in Argument case");
   }
   llvm_unreachable("unhandled");
 }
@@ -1091,6 +1188,174 @@ Intrinsic::matchIntrinsicSignature(FunctionType *FTy,
   }
 
   return MatchIntrinsicTypes_Match;
+}
+
+// Helper: Check if a type matches AnyTypeOf constraints using matchIntrinsicType.
+static bool verifyTypeAgainstConstraints(
+    Type *Ty, unsigned NumConstraints,
+    ArrayRef<Intrinsic::IITDescriptor> &Infos) {
+  using namespace Intrinsic;
+  
+  bool Matched = false;
+  for (unsigned i = 0; i < NumConstraints && !Matched; ++i) {
+    ArrayRef<IITDescriptor> TypeDesc = Infos;
+    SmallVector<Type *, 4> DummyArgTys;
+    SmallVector<DeferredIntrinsicMatchPair, 2> DummyDeferredChecks;
+    
+    if (!matchIntrinsicType(Ty, TypeDesc, DummyArgTys, DummyDeferredChecks, false)) {
+      Matched = true;
+      for (unsigned j = 0; j < NumConstraints - i; ++j)
+        skipDescriptorsForSingleType(Infos);
+      break;
+    }
+    skipDescriptorsForSingleType(Infos);
+  }
+  
+  return Matched;
+}
+
+// Helper: Format a type as string for error messages.
+static std::string typeToString(Type *Ty) {
+  std::string Str;
+  raw_string_ostream OS(Str);
+  Ty->print(OS);
+  return Str;
+}
+
+bool Intrinsic::verifyIntrinsicTypeConstraints(
+    ID id, FunctionType *FTy,
+    std::string &ErrMsg) {
+  
+  if (id == 0 || id >= Intrinsic::num_intrinsics)
+    return true;
+  
+  SmallVector<IITDescriptor, 8> Table;
+  getIntrinsicInfoTableEntries(id, Table);
+  
+  if (Table.empty())
+    return true;
+  
+  ArrayRef<IITDescriptor> Infos = Table;
+  SmallVector<Type *, 4> ArgTys;
+  
+  // Processing return type.
+  Type *RetTy = FTy->getReturnType();
+  if (!Infos.empty() && Infos[0].Kind == IITDescriptor::Argument) {
+    Infos = Infos.slice(1);
+    
+    if (!Infos.empty() && Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+      unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
+      Infos = Infos.slice(1);
+      
+      bool Matched = false;
+      
+      // Check if a struct type's elements are all present in AnyTypeOf constraint list. 
+      if (auto *STy = dyn_cast<StructType>(RetTy)) {
+        SmallVector<Type *, 8> AllowedTypes;
+        ArrayRef<IITDescriptor> TempInfos = Infos;
+        for (unsigned i = 0; i < NumConstraints; ++i) {
+          ArrayRef<IITDescriptor> TypeDesc = TempInfos;
+          SmallVector<Type *, 4> DummyTys;
+          Type *ConstraintTy = DecodeFixedType(TypeDesc, DummyTys, FTy->getContext());
+          AllowedTypes.push_back(ConstraintTy);
+          TempInfos = TypeDesc;
+        }
+        
+        Matched = llvm::all_of(STy->elements(), [&](Type *ElemTy) {
+              return llvm::is_contained(AllowedTypes, ElemTy);
+        });
+        
+        if (Matched) {
+          for (unsigned i = 0; i < NumConstraints; ++i)
+            skipDescriptorsForSingleType(Infos);
+          Matched = true;
+        }
+      }
+      
+      if (!Matched) {
+        for (unsigned i = 0; i < NumConstraints && !Matched; ++i) {
+          ArrayRef<IITDescriptor> TypeDesc = Infos;
+          SmallVector<Type *, 4> DummyArgTys;
+          SmallVector<DeferredIntrinsicMatchPair, 2> DummyDeferredChecks;
+          
+          if (!matchIntrinsicType(RetTy, TypeDesc, DummyArgTys, 
+                                  DummyDeferredChecks, false)) {
+            Matched = true;
+            for (unsigned j = 0; j < NumConstraints - i; ++j)
+              skipDescriptorsForSingleType(Infos);
+            break;
+          }
+          skipDescriptorsForSingleType(Infos);
+        }
+      }
+      
+      if (!Matched) {
+        ErrMsg = "Return type '" + typeToString(RetTy) + "' not in allowed types";
+        return false;
+      }
+    }
+  } else if (!Infos.empty() && Infos[0].Kind == IITDescriptor::Struct) {
+    // Handle struct return type with AnyTypeOf constrained elements.
+    auto *STy = dyn_cast<StructType>(RetTy);
+    if (!STy)
+      skipDescriptorsForSingleType(Infos);
+    else {
+      unsigned NumElements = Infos[0].Struct_NumElements;
+      Infos = Infos.slice(1);
+      
+      for (unsigned ElemIdx = 0; ElemIdx < NumElements; ++ElemIdx) {
+        if (Infos.empty())
+          break;
+        
+        if (Infos[0].Kind == IITDescriptor::Argument) {
+          Infos = Infos.slice(1);
+          
+          if (!Infos.empty() && Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+            unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
+            Infos = Infos.slice(1);
+            
+            Type *ElemTy = STy->getElementType(ElemIdx);
+            if (!verifyTypeAgainstConstraints(ElemTy, NumConstraints, Infos)) {
+              ErrMsg = "Return type struct element " + std::to_string(ElemIdx) + 
+                       " type '" + typeToString(ElemTy) + "' not in allowed types";
+              return false;
+            }
+          }
+        } else
+          skipDescriptorsForSingleType(Infos);
+      }
+    }
+  } else if (!Infos.empty())
+    skipDescriptorsForSingleType(Infos);
+
+  // Processing parameters.
+  for (unsigned ParamIdx = 0; ParamIdx < FTy->getNumParams(); ++ParamIdx) {
+    if (Infos.empty())
+      break;
+    
+    Type *ParamTy = FTy->getParamType(ParamIdx);
+    
+    if (Infos[0].Kind == IITDescriptor::Argument) {
+      unsigned ArgNum = Infos[0].getArgumentNumber();
+      Infos = Infos.slice(1);
+      
+      if (!Infos.empty() && Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+        unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
+        Infos = Infos.slice(1);
+        
+        if (!verifyTypeAgainstConstraints(ParamTy, NumConstraints, Infos)) {
+          ErrMsg = "Parameter " + std::to_string(ParamIdx) + " type '" + 
+                   typeToString(ParamTy) + "' not in allowed types";
+          return false;
+        }
+        
+        if (ArgNum == ArgTys.size())
+          ArgTys.push_back(ParamTy);
+      } 
+    } else
+      skipDescriptorsForSingleType(Infos);
+  }
+  return true;
 }
 
 bool Intrinsic::matchIntrinsicVarArg(

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -356,8 +356,9 @@ DecodeIITType(unsigned &NextElt, ArrayRef<unsigned char> Infos,
       NextElt++;
 
       unsigned NumTypes = Infos[NextElt++];
-      OutputTable.push_back(IITDescriptor::get(IITDescriptor::ArgumentTypeConstraint, NumTypes));
-      
+      OutputTable.push_back(
+          IITDescriptor::get(IITDescriptor::ArgumentTypeConstraint, NumTypes));
+
       for (unsigned i = 0; i < NumTypes; ++i)
         DecodeIITType(NextElt, Infos, Info, OutputTable);
       return;
@@ -591,7 +592,8 @@ static Type *DecodeFixedType(ArrayRef<Intrinsic::IITDescriptor> &Infos,
     // Return the overloaded type (which determines the pointers address space)
     return Tys[D.getOverloadArgNumber()];
   case IITDescriptor::ArgumentTypeConstraint:
-    llvm_unreachable("ArgumentTypeConstraint should not appear in DecodeFixedType");
+    llvm_unreachable(
+        "ArgumentTypeConstraint should not appear in DecodeFixedType");
   }
   llvm_unreachable("unhandled");
 }
@@ -604,10 +606,11 @@ FunctionType *Intrinsic::getType(LLVMContext &Context, ID id,
   ArrayRef<IITDescriptor> TableRef = Table;
   Type *ResultTy = DecodeFixedType(TableRef, Tys, Context);
 
-  if (!TableRef.empty() && TableRef[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+  if (!TableRef.empty() &&
+      TableRef[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
     unsigned NumConstraints = TableRef[0].getArgumentNumConstraints();
     TableRef = TableRef.slice(1);
-    
+
     for (unsigned i = 0; i < NumConstraints; ++i)
       (void)DecodeFixedType(TableRef, Tys, Context);
   }
@@ -615,11 +618,12 @@ FunctionType *Intrinsic::getType(LLVMContext &Context, ID id,
   SmallVector<Type *, 8> ArgTys;
   while (!TableRef.empty()) {
     ArgTys.push_back(DecodeFixedType(TableRef, Tys, Context));
-    
-    if (!TableRef.empty() && TableRef[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+
+    if (!TableRef.empty() &&
+        TableRef[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
       unsigned NumConstraints = TableRef[0].getArgumentNumConstraints();
       TableRef = TableRef.slice(1);
-      
+
       for (unsigned i = 0; i < NumConstraints; ++i)
         (void)DecodeFixedType(TableRef, Tys, Context);
     }
@@ -866,36 +870,39 @@ bool Intrinsic::hasConstrainedFPRoundingModeOperand(Intrinsic::ID QID) {
   }
 }
 
-// Helper to skip past descriptors for one complete type in AnyTypeOf constraints.
-static unsigned skipDescriptorsForSingleType(ArrayRef<Intrinsic::IITDescriptor> &Infos) {
+// Helper to skip past descriptors for one complete type in AnyTypeOf
+// constraints.
+static unsigned
+skipDescriptorsForSingleType(ArrayRef<Intrinsic::IITDescriptor> &Infos) {
   using namespace Intrinsic;
-  
+
   if (Infos.empty())
     return 0;
-  
+
   IITDescriptor D = Infos[0];
   unsigned Count = 1;
   Infos = Infos.slice(1);
-  
+
   switch (D.Kind) {
   case IITDescriptor::Vector:
     Count += skipDescriptorsForSingleType(Infos);
     break;
-    
+
   case IITDescriptor::Pointer:
     break;
-    
+
   case IITDescriptor::Struct:
     for (unsigned i = 0, e = D.Struct_NumElements; i != e; ++i)
       Count += skipDescriptorsForSingleType(Infos);
     break;
-    
+
   case IITDescriptor::SameVecWidthArgument:
     Count += skipDescriptorsForSingleType(Infos);
     break;
-    
+
   case IITDescriptor::Argument:
-    if (!Infos.empty() && Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+    if (!Infos.empty() &&
+        Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
       unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
       Count++;
       Infos = Infos.slice(1);
@@ -996,7 +1003,7 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     // verify that the later instance matches the previous instance.
     if (D.getArgumentNumber() < ArgTys.size())
       return Ty != ArgTys[D.getArgumentNumber()];
-      
+
     switch (D.getArgumentKind()) {
     case IITDescriptor::AK_Any:
       break;
@@ -1027,14 +1034,15 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     assert(D.getArgumentNumber() == ArgTys.size() && !IsDeferredCheck &&
            "Table consistency error");
     ArgTys.push_back(Ty);
-    
-    if (!Infos.empty() && Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+
+    if (!Infos.empty() &&
+        Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
       unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
-      Infos = Infos.slice(1); 
+      Infos = Infos.slice(1);
 
       for (unsigned i = 0; i < NumConstraints; ++i)
         skipDescriptorsForSingleType(Infos);
-  
+
       return false;
     }
 
@@ -1159,7 +1167,8 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     return ThisArgVecTy != VectorType::getInteger(ReferenceType);
   }
   case IITDescriptor::ArgumentTypeConstraint:
-    llvm_unreachable("ArgumentTypeConstraint should be handled in Argument case");
+    llvm_unreachable(
+        "ArgumentTypeConstraint should be handled in Argument case");
   }
   llvm_unreachable("unhandled");
 }
@@ -1190,19 +1199,21 @@ Intrinsic::matchIntrinsicSignature(FunctionType *FTy,
   return MatchIntrinsicTypes_Match;
 }
 
-// Helper: Check if a type matches AnyTypeOf constraints using matchIntrinsicType.
-static bool verifyTypeAgainstConstraints(
-    Type *Ty, unsigned NumConstraints,
-    ArrayRef<Intrinsic::IITDescriptor> &Infos) {
+// Helper: Check if a type matches AnyTypeOf constraints using
+// matchIntrinsicType.
+static bool
+verifyTypeAgainstConstraints(Type *Ty, unsigned NumConstraints,
+                             ArrayRef<Intrinsic::IITDescriptor> &Infos) {
   using namespace Intrinsic;
-  
+
   bool Matched = false;
   for (unsigned i = 0; i < NumConstraints && !Matched; ++i) {
     ArrayRef<IITDescriptor> TypeDesc = Infos;
     SmallVector<Type *, 4> DummyArgTys;
     SmallVector<DeferredIntrinsicMatchPair, 2> DummyDeferredChecks;
-    
-    if (!matchIntrinsicType(Ty, TypeDesc, DummyArgTys, DummyDeferredChecks, false)) {
+
+    if (!matchIntrinsicType(Ty, TypeDesc, DummyArgTys, DummyDeferredChecks,
+                            false)) {
       Matched = true;
       for (unsigned j = 0; j < NumConstraints - i; ++j)
         skipDescriptorsForSingleType(Infos);
@@ -1210,7 +1221,7 @@ static bool verifyTypeAgainstConstraints(
     }
     skipDescriptorsForSingleType(Infos);
   }
-  
+
   return Matched;
 }
 
@@ -1222,63 +1233,65 @@ static std::string typeToString(Type *Ty) {
   return Str;
 }
 
-bool Intrinsic::verifyIntrinsicTypeConstraints(
-    ID id, FunctionType *FTy,
-    std::string &ErrMsg) {
-  
+bool Intrinsic::verifyIntrinsicTypeConstraints(ID id, FunctionType *FTy,
+                                               std::string &ErrMsg) {
+
   if (id == 0 || id >= Intrinsic::num_intrinsics)
     return true;
-  
+
   SmallVector<IITDescriptor, 8> Table;
   getIntrinsicInfoTableEntries(id, Table);
-  
+
   if (Table.empty())
     return true;
-  
+
   ArrayRef<IITDescriptor> Infos = Table;
   SmallVector<Type *, 4> ArgTys;
-  
+
   // Processing return type.
   Type *RetTy = FTy->getReturnType();
   if (!Infos.empty() && Infos[0].Kind == IITDescriptor::Argument) {
     Infos = Infos.slice(1);
-    
-    if (!Infos.empty() && Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+
+    if (!Infos.empty() &&
+        Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
       unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
       Infos = Infos.slice(1);
-      
+
       bool Matched = false;
-      
-      // Check if a struct type's elements are all present in AnyTypeOf constraint list. 
+
+      // Check if a struct type's elements are all present in AnyTypeOf
+      // constraint list.
       if (auto *STy = dyn_cast<StructType>(RetTy)) {
         SmallVector<Type *, 8> AllowedTypes;
         ArrayRef<IITDescriptor> TempInfos = Infos;
         for (unsigned i = 0; i < NumConstraints; ++i) {
           ArrayRef<IITDescriptor> TypeDesc = TempInfos;
           SmallVector<Type *, 4> DummyTys;
-          Type *ConstraintTy = DecodeFixedType(TypeDesc, DummyTys, FTy->getContext());
+          Type *ConstraintTy =
+              DecodeFixedType(TypeDesc, DummyTys, FTy->getContext());
           AllowedTypes.push_back(ConstraintTy);
           TempInfos = TypeDesc;
         }
-        
+
         Matched = llvm::all_of(STy->elements(), [&](Type *ElemTy) {
-              return llvm::is_contained(AllowedTypes, ElemTy);
+          return llvm::is_contained(AllowedTypes, ElemTy);
         });
-        
+
         if (Matched) {
           for (unsigned i = 0; i < NumConstraints; ++i)
             skipDescriptorsForSingleType(Infos);
           Matched = true;
         }
       }
-      
+
       if (!Matched) {
         for (unsigned i = 0; i < NumConstraints && !Matched; ++i) {
           ArrayRef<IITDescriptor> TypeDesc = Infos;
           SmallVector<Type *, 4> DummyArgTys;
           SmallVector<DeferredIntrinsicMatchPair, 2> DummyDeferredChecks;
-          
-          if (!matchIntrinsicType(RetTy, TypeDesc, DummyArgTys, 
+
+          if (!matchIntrinsicType(RetTy, TypeDesc, DummyArgTys,
                                   DummyDeferredChecks, false)) {
             Matched = true;
             for (unsigned j = 0; j < NumConstraints - i; ++j)
@@ -1288,9 +1301,10 @@ bool Intrinsic::verifyIntrinsicTypeConstraints(
           skipDescriptorsForSingleType(Infos);
         }
       }
-      
+
       if (!Matched) {
-        ErrMsg = "Return type '" + typeToString(RetTy) + "' not in allowed types";
+        ErrMsg =
+            "Return type '" + typeToString(RetTy) + "' not in allowed types";
         return false;
       }
     }
@@ -1302,22 +1316,24 @@ bool Intrinsic::verifyIntrinsicTypeConstraints(
     else {
       unsigned NumElements = Infos[0].Struct_NumElements;
       Infos = Infos.slice(1);
-      
+
       for (unsigned ElemIdx = 0; ElemIdx < NumElements; ++ElemIdx) {
         if (Infos.empty())
           break;
-        
+
         if (Infos[0].Kind == IITDescriptor::Argument) {
           Infos = Infos.slice(1);
-          
-          if (!Infos.empty() && Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+
+          if (!Infos.empty() &&
+              Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
             unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
             Infos = Infos.slice(1);
-            
+
             Type *ElemTy = STy->getElementType(ElemIdx);
             if (!verifyTypeAgainstConstraints(ElemTy, NumConstraints, Infos)) {
-              ErrMsg = "Return type struct element " + std::to_string(ElemIdx) + 
-                       " type '" + typeToString(ElemTy) + "' not in allowed types";
+              ErrMsg = "Return type struct element " + std::to_string(ElemIdx) +
+                       " type '" + typeToString(ElemTy) +
+                       "' not in allowed types";
               return false;
             }
           }
@@ -1332,26 +1348,27 @@ bool Intrinsic::verifyIntrinsicTypeConstraints(
   for (unsigned ParamIdx = 0; ParamIdx < FTy->getNumParams(); ++ParamIdx) {
     if (Infos.empty())
       break;
-    
+
     Type *ParamTy = FTy->getParamType(ParamIdx);
-    
+
     if (Infos[0].Kind == IITDescriptor::Argument) {
       unsigned ArgNum = Infos[0].getArgumentNumber();
       Infos = Infos.slice(1);
-      
-      if (!Infos.empty() && Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
+
+      if (!Infos.empty() &&
+          Infos[0].Kind == IITDescriptor::ArgumentTypeConstraint) {
         unsigned NumConstraints = Infos[0].getArgumentNumConstraints();
         Infos = Infos.slice(1);
-        
+
         if (!verifyTypeAgainstConstraints(ParamTy, NumConstraints, Infos)) {
-          ErrMsg = "Parameter " + std::to_string(ParamIdx) + " type '" + 
+          ErrMsg = "Parameter " + std::to_string(ParamIdx) + " type '" +
                    typeToString(ParamTy) + "' not in allowed types";
           return false;
         }
-        
+
         if (ArgNum == ArgTys.size())
           ArgTys.push_back(ParamTy);
-      } 
+      }
     } else
       skipDescriptorsForSingleType(Infos);
   }

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3327,10 +3327,14 @@ void Verifier::visitFunction(const Function &F) {
   // Verify AnyTypeOf type constraints for intrinsic declarations.
   if (F.isIntrinsic()) {
     std::string ConstraintErrMsg;
-    if (!Intrinsic::verifyIntrinsicTypeConstraints(
-            F.getIntrinsicID(), F.getFunctionType(), ConstraintErrMsg))
-      CheckFailed("Intrinsic declaration '" + F.getName().str() +
-                  "' violates type constraint: " + ConstraintErrMsg);
+    SmallVector<Type *, 4> ArgTys;
+    if (!Intrinsic::getIntrinsicSignature(F.getIntrinsicID(),
+                                          F.getFunctionType(), ArgTys,
+                                          &ConstraintErrMsg)) {
+      if (!ConstraintErrMsg.empty())
+        CheckFailed("Intrinsic declaration '" + F.getName().str() +
+                    "' violates type constraint: " + ConstraintErrMsg);
+    }
   }
 
   auto *N = F.getSubprogram();

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3327,9 +3327,8 @@ void Verifier::visitFunction(const Function &F) {
   // Verify AnyTypeOf type constraints for intrinsic declarations.
   if (F.isIntrinsic()) {
     std::string ConstraintErrMsg;
-    if (!Intrinsic::verifyIntrinsicTypeConstraints(F.getIntrinsicID(),
-                                                   F.getFunctionType(),
-                                                   ConstraintErrMsg))
+    if (!Intrinsic::verifyIntrinsicTypeConstraints(
+            F.getIntrinsicID(), F.getFunctionType(), ConstraintErrMsg))
       CheckFailed("Intrinsic declaration '" + F.getName().str() +
                   "' violates type constraint: " + ConstraintErrMsg);
   }

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3324,6 +3324,16 @@ void Verifier::visitFunction(const Function &F) {
   }
   }
 
+  // Verify AnyTypeOf type constraints for intrinsic declarations.
+  if (F.isIntrinsic()) {
+    std::string ConstraintErrMsg;
+    if (!Intrinsic::verifyIntrinsicTypeConstraints(F.getIntrinsicID(),
+                                                   F.getFunctionType(),
+                                                   ConstraintErrMsg))
+      CheckFailed("Intrinsic declaration '" + F.getName().str() +
+                  "' violates type constraint: " + ConstraintErrMsg);
+  }
+
   auto *N = F.getSubprogram();
   HasDebugInfo = (N != nullptr);
   if (!HasDebugInfo)

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -3328,13 +3328,11 @@ void Verifier::visitFunction(const Function &F) {
   if (F.isIntrinsic()) {
     std::string ConstraintErrMsg;
     SmallVector<Type *, 4> ArgTys;
-    if (!Intrinsic::getIntrinsicSignature(F.getIntrinsicID(),
-                                          F.getFunctionType(), ArgTys,
-                                          &ConstraintErrMsg)) {
-      if (!ConstraintErrMsg.empty())
-        CheckFailed("Intrinsic declaration '" + F.getName().str() +
-                    "' violates type constraint: " + ConstraintErrMsg);
-    }
+    Intrinsic::getIntrinsicSignature(F.getIntrinsicID(), F.getFunctionType(),
+                                     ArgTys, &ConstraintErrMsg);
+    if (!ConstraintErrMsg.empty())
+      CheckFailed("Intrinsic declaration '" + F.getName().str() +
+                  "' violates AnyTypeOf constraint: " + ConstraintErrMsg);
   }
 
   auto *N = F.getSubprogram();

--- a/llvm/test/CodeGen/NVPTX/anytypeof_constraints_invalid.ll
+++ b/llvm/test/CodeGen/NVPTX/anytypeof_constraints_invalid.ll
@@ -1,0 +1,51 @@
+; RUN: not llvm-as < %s -o /dev/null
+; Test cases for int_nvvm_test_anytype intrinsic - INVALID combinations
+
+; arg0 must be i16 or i32, not i8
+define i32 @invalid_arg0_i8(i8 %a0, i8 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i8.i8.i32.p0.i64.i16(i8 %a0, i8 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5)
+  ret i32 %result
+}
+
+; arg1 must match arg0 (i16), not i32
+define i32 @invalid_arg1_mismatch_i16_i32(i16 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i16.i32.i32.p0.i64.i16(i16 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5)
+  ret i32 %result
+}
+
+; arg2 must be anyint or float, not double
+define i32 @invalid_arg2_double(i32 %a0, i32 %a1, double %a2, ptr %a3, i64 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.f64.p0.i64.i16(i32 %a0, i32 %a1, double %a2, ptr %a3, i64 %a4, i16 %a5)
+  ret i32 %result
+}
+
+; arg3 must be ptr or ptr addrspace(3), not ptr addrspace(1) (global)
+define i32 @invalid_arg3_ptr_as1_wrong(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(1) %a3, i64 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p1.i64.i16(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(1) %a3, i64 %a4, i16 %a5)
+  ret i32 %result
+}
+
+; arg4 must be i64 or double, not i32
+define i32 @invalid_arg4_i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i32.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5)
+  ret i32 %result
+}
+
+; arg5 must be i16, <4 x i32>, or <4 x f32>, not <2 x i32>
+define i32 @invalid_arg5_v2i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, <2 x i32> %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.v2i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, <2 x i32> %a5)
+  ret i32 %result
+}
+
+define {i32, i8, i64} @invalid_return_type_i8(i32 %arg) {
+  %result = call {i32, i8, i64} @llvm.nvvm.test.return.type.i8(i32 %arg)
+  ret {i32, i8, i64} %result
+}
+
+declare i32 @llvm.nvvm.test.anytype.i8.i8.i32.p0.i64.i16(i8, i8, i32, ptr, i64, i16)
+declare i32 @llvm.nvvm.test.anytype.i16.i32.i32.p0.i64.i16(i16, i32, i32, ptr, i64, i16)
+declare i32 @llvm.nvvm.test.anytype.i32.i32.f64.p0.i64.i16(i32, i32, double, ptr, i64, i16)
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p1.i64.i16(i32, i32, i32, ptr addrspace(1), i64, i16)
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i32.i16(i32, i32, i32, ptr, i32, i16)
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.v2i32(i32, i32, i32, ptr, i64, <2 x i32>)
+declare {i32, i8, i64} @llvm.nvvm.test.return.type.i8(i32)

--- a/llvm/test/CodeGen/NVPTX/anytypeof_constraints_invalid.ll
+++ b/llvm/test/CodeGen/NVPTX/anytypeof_constraints_invalid.ll
@@ -1,39 +1,39 @@
 ; RUN: not llvm-as < %s -o /dev/null
-; Test cases for int_nvvm_test_anytype intrinsic - INVALID combinations
+; Test cases for int_nvvm_test_type intrinsic - INVALID combinations
 
 ; arg0 must be i16 or i32, not i8
-define i32 @invalid_arg0_i8(i8 %a0, i8 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.anytype.i8.i8.i32.p0.i64.i16(i8 %a0, i8 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5)
+define i32 @invalid_arg0_i8(i8 %a0, i8 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.type.i8.i8.i32.p0.i32.i16(i8 %a0, i8 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5)
   ret i32 %result
 }
 
 ; arg1 must match arg0 (i16), not i32
-define i32 @invalid_arg1_mismatch_i16_i32(i16 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.anytype.i16.i32.i32.p0.i64.i16(i16 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5)
+define i32 @invalid_arg1_mismatch_i16_i32(i16 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.type.i16.i32.i32.p0.i32.i16(i16 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5)
   ret i32 %result
 }
 
 ; arg2 must be anyint or float, not double
-define i32 @invalid_arg2_double(i32 %a0, i32 %a1, double %a2, ptr %a3, i64 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.f64.p0.i64.i16(i32 %a0, i32 %a1, double %a2, ptr %a3, i64 %a4, i16 %a5)
+define i32 @invalid_arg2_double(i32 %a0, i32 %a1, double %a2, ptr %a3, i32 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.type.i32.i32.f64.p0.i32.i16(i32 %a0, i32 %a1, double %a2, ptr %a3, i32 %a4, i16 %a5)
   ret i32 %result
 }
 
 ; arg3 must be ptr or ptr addrspace(3), not ptr addrspace(1) (global)
-define i32 @invalid_arg3_ptr_as1_wrong(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(1) %a3, i64 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p1.i64.i16(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(1) %a3, i64 %a4, i16 %a5)
+define i32 @invalid_arg3_ptr_as1_wrong(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(1) %a3, i32 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p1.i32.i16(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(1) %a3, i32 %a4, i16 %a5)
   ret i32 %result
 }
 
-; arg4 must be i64 or double, not i32
-define i32 @invalid_arg4_i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i32.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5)
+; arg4 must not be i64 or double
+define i32 @test_arg4_double(i32 %a0, i32 %a1, i32 %a2, ptr %a3, double %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p0.f64.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, double %a4, i16 %a5)
   ret i32 %result
 }
 
 ; arg5 must be i16, <4 x i32>, or <4 x f32>, not <2 x i32>
-define i32 @invalid_arg5_v2i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, <2 x i32> %a5) {
-  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.v2i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, <2 x i32> %a5)
+define i32 @invalid_arg5_v2i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, <2 x i32> %a5) {
+  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.v2i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, <2 x i32> %a5)
   ret i32 %result
 }
 
@@ -42,10 +42,10 @@ define {i32, i8, i64} @invalid_return_type_i8(i32 %arg) {
   ret {i32, i8, i64} %result
 }
 
-declare i32 @llvm.nvvm.test.anytype.i8.i8.i32.p0.i64.i16(i8, i8, i32, ptr, i64, i16)
-declare i32 @llvm.nvvm.test.anytype.i16.i32.i32.p0.i64.i16(i16, i32, i32, ptr, i64, i16)
-declare i32 @llvm.nvvm.test.anytype.i32.i32.f64.p0.i64.i16(i32, i32, double, ptr, i64, i16)
-declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p1.i64.i16(i32, i32, i32, ptr addrspace(1), i64, i16)
-declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i32.i16(i32, i32, i32, ptr, i32, i16)
-declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.v2i32(i32, i32, i32, ptr, i64, <2 x i32>)
+declare i32 @llvm.nvvm.test.type.i8.i8.i32.p0.i32.i16(i8, i8, i32, ptr, i32, i16)
+declare i32 @llvm.nvvm.test.type.i16.i32.i32.p0.i32.i16(i16, i32, i32, ptr, i32, i16)
+declare i32 @llvm.nvvm.test.type.i32.i32.f64.p0.i32.i16(i32, i32, double, ptr, i32, i16)
+declare i32 @llvm.nvvm.test.type.i32.i32.i32.p1.i32.i16(i32, i32, i32, ptr addrspace(1), i32, i16)
+declare i32 @llvm.nvvm.test.type.i32.i32.i32.p0.f64.i16(i32, i32, i32, ptr, double, i16)
+declare i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.v2i32(i32, i32, i32, ptr, i32, <2 x i32>)
 declare {i32, i8, i64} @llvm.nvvm.test.return.type.i8(i32)

--- a/llvm/test/CodeGen/NVPTX/anytypeof_constraints_invalid.ll
+++ b/llvm/test/CodeGen/NVPTX/anytypeof_constraints_invalid.ll
@@ -1,39 +1,39 @@
 ; RUN: not llvm-as < %s -o /dev/null
-; Test cases for int_nvvm_test_type intrinsic - INVALID combinations
+; Test cases for int_nvvm_test_anytype intrinsic - INVALID combinations
 
 ; arg0 must be i16 or i32, not i8
-define i32 @invalid_arg0_i8(i8 %a0, i8 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.type.i8.i8.i32.p0.i32.i16(i8 %a0, i8 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5)
+define i32 @invalid_arg0_i8(i8 %a0, i8 %a1, i32 %a2, ptr %a3, i64 %a4, ptr addrspace(1) %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i8.i8.i32.p0.i64.p1(i8 %a0, i8 %a1, i32 %a2, ptr %a3, i64 %a4, ptr addrspace(1) %a5)
   ret i32 %result
 }
 
 ; arg1 must match arg0 (i16), not i32
-define i32 @invalid_arg1_mismatch_i16_i32(i16 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.type.i16.i32.i32.p0.i32.i16(i16 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5)
+define i32 @invalid_arg1_mismatch_i16_i32(i16 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, ptr addrspace(1) %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i16.i32.i32.p0.i64.p1(i16 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, ptr addrspace(1) %a5)
   ret i32 %result
 }
 
 ; arg2 must be anyint or float, not double
-define i32 @invalid_arg2_double(i32 %a0, i32 %a1, double %a2, ptr %a3, i32 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.type.i32.i32.f64.p0.i32.i16(i32 %a0, i32 %a1, double %a2, ptr %a3, i32 %a4, i16 %a5)
+define i32 @invalid_arg2_double(i32 %a0, i32 %a1, double %a2, ptr %a3, i64 %a4, ptr addrspace(1) %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.f64.p0.i64.p1(i32 %a0, i32 %a1, double %a2, ptr %a3, i64 %a4, ptr addrspace(1) %a5)
   ret i32 %result
 }
 
 ; arg3 must be ptr or ptr addrspace(3), not ptr addrspace(1) (global)
-define i32 @invalid_arg3_ptr_as1_wrong(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(1) %a3, i32 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p1.i32.i16(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(1) %a3, i32 %a4, i16 %a5)
+define i32 @invalid_arg3_ptr_as1_wrong(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(1) %a3, i64 %a4, <2 x i64> %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p1.i64.v2i64(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(1) %a3, i64 %a4, <2 x i64> %a5)
   ret i32 %result
 }
 
-; arg4 must not be i64 or double
-define i32 @test_arg4_double(i32 %a0, i32 %a1, i32 %a2, ptr %a3, double %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p0.f64.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, double %a4, i16 %a5)
+; arg4 must be i64 or double, not i32
+define i32 @invalid_arg4_i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, ptr addrspace(1) %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i32.p1(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, ptr addrspace(1) %a5)
   ret i32 %result
 }
 
-; arg5 must be i16, <4 x i32>, or <4 x f32>, not <2 x i32>
-define i32 @invalid_arg5_v2i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, <2 x i32> %a5) {
-  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.v2i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, <2 x i32> %a5)
+; arg5 must be ptr addrspace(1) or <2 x i64>, not <2 x i32>
+define i32 @invalid_arg5_v2i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, <2 x i32> %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.v2i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, <2 x i32> %a5)
   ret i32 %result
 }
 
@@ -42,10 +42,10 @@ define {i32, i8, i64} @invalid_return_type_i8(i32 %arg) {
   ret {i32, i8, i64} %result
 }
 
-declare i32 @llvm.nvvm.test.type.i8.i8.i32.p0.i32.i16(i8, i8, i32, ptr, i32, i16)
-declare i32 @llvm.nvvm.test.type.i16.i32.i32.p0.i32.i16(i16, i32, i32, ptr, i32, i16)
-declare i32 @llvm.nvvm.test.type.i32.i32.f64.p0.i32.i16(i32, i32, double, ptr, i32, i16)
-declare i32 @llvm.nvvm.test.type.i32.i32.i32.p1.i32.i16(i32, i32, i32, ptr addrspace(1), i32, i16)
-declare i32 @llvm.nvvm.test.type.i32.i32.i32.p0.f64.i16(i32, i32, i32, ptr, double, i16)
-declare i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.v2i32(i32, i32, i32, ptr, i32, <2 x i32>)
+declare i32 @llvm.nvvm.test.anytype.i8.i8.i32.p0.i64.p1(i8, i8, i32, ptr, i64, ptr addrspace(1))
+declare i32 @llvm.nvvm.test.anytype.i16.i32.i32.p0.i64.p1(i16, i32, i32, ptr, i64, ptr addrspace(1))
+declare i32 @llvm.nvvm.test.anytype.i32.i32.f64.p0.i64.p1(i32, i32, double, ptr, i64, ptr addrspace(1))
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p1.i64.v2i64(i32, i32, i32, ptr addrspace(1), i64, <2 x i64>)
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i32.p1(i32, i32, i32, ptr, i32, ptr addrspace(1))
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.v2i32(i32, i32, i32, ptr, i64, <2 x i32>)
 declare {i32, i8, i64} @llvm.nvvm.test.return.type.i8(i32)

--- a/llvm/test/CodeGen/NVPTX/anytypeof_constraints_valid.ll
+++ b/llvm/test/CodeGen/NVPTX/anytypeof_constraints_valid.ll
@@ -1,0 +1,45 @@
+; RUN: llvm-as < %s -o /dev/null
+; Test cases for int_nvvm_test_anytype intrinsic - VALID combinations
+
+define i32 @test_arg0_i16(i16 %a0, i16 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i16.i16.i32.p0.i64.i16(i16 %a0, i16 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5)
+  ret i32 %result
+}
+
+define i32 @test_arg0_i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5)
+  ret i32 %result
+}
+
+define i32 @test_arg2_anyint(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5)
+  ret i32 %result
+}
+
+define i32 @test_arg3_shared_ptr(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(3) %a3, i64 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p3.i64.i16(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(3) %a3, i64 %a4, i16 %a5)
+  ret i32 %result
+}
+
+define i32 @test_arg4_double(i32 %a0, i32 %a1, i32 %a2, ptr %a3, double %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.f64.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, double %a4, i16 %a5)
+  ret i32 %result
+}
+
+define i32 @test_arg5_v4i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, <4 x i32> %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.v4i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, <4 x i32> %a5)
+  ret i32 %result
+}
+
+define {i32, i32, i64} @test_return_type_valid(i32 %arg) {
+  %result = call {i32, i32, i64} @llvm.nvvm.test.return.type.i32(i32 %arg)
+  ret {i32, i32, i64} %result
+}
+
+declare i32 @llvm.nvvm.test.anytype.i16.i16.i32.p0.i64.i16(i16, i16, i32, ptr, i64, i16)
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.i16(i32, i32, i32, ptr, i64, i16)
+declare i32 @llvm.nvvm.test.anytype.i32.i32.f32.p0.i64.i16(i32, i32, i32, ptr, i64, i16)
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p3.i64.i16(i32, i32, i32, ptr addrspace(3), i64, i16)
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.f64.i16(i32, i32, i32, ptr, double, i16)
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.v4i32(i32, i32, i32, ptr, i64, <4 x i32>)
+declare {i32, i32, i64} @llvm.nvvm.test.return.type.i32(i32)

--- a/llvm/test/CodeGen/NVPTX/anytypeof_constraints_valid.ll
+++ b/llvm/test/CodeGen/NVPTX/anytypeof_constraints_valid.ll
@@ -1,33 +1,33 @@
 ; RUN: llvm-as < %s -o /dev/null
-; Test cases for int_nvvm_test_anytype intrinsic - VALID combinations
+; Test cases for int_nvvm_test_type intrinsic - VALID combinations
 
-define i32 @test_arg0_i16(i16 %a0, i16 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.anytype.i16.i16.i32.p0.i64.i16(i16 %a0, i16 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5)
+define i32 @test_arg0_i16(i16 %a0, i16 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.type.i16.i16.i32.p0.i32.i16(i16 %a0, i16 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5)
   ret i32 %result
 }
 
-define i32 @test_arg0_i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5)
+define i32 @test_arg0_i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5)
   ret i32 %result
 }
 
-define i32 @test_arg2_anyint(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, i16 %a5)
+define i32 @test_arg2_anyint(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5)
   ret i32 %result
 }
 
-define i32 @test_arg3_shared_ptr(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(3) %a3, i64 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p3.i64.i16(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(3) %a3, i64 %a4, i16 %a5)
+define i32 @test_arg3_shared_ptr(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(3) %a3, i32 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p3.i32.i16(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(3) %a3, i32 %a4, i16 %a5)
   ret i32 %result
 }
 
-define i32 @test_arg4_double(i32 %a0, i32 %a1, i32 %a2, ptr %a3, double %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.f64.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, double %a4, i16 %a5)
+define i32 @invalid_arg4_i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i16 %a4, i16 %a5) {
+  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i16.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i16 %a4, i16 %a5)
   ret i32 %result
 }
 
-define i32 @test_arg5_v4i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, <4 x i32> %a5) {
-  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.v4i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, <4 x i32> %a5)
+define i32 @test_arg5_v4i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, <4 x i32> %a5) {
+  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.v4i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, <4 x i32> %a5)
   ret i32 %result
 }
 
@@ -36,10 +36,10 @@ define {i32, i32, i64} @test_return_type_valid(i32 %arg) {
   ret {i32, i32, i64} %result
 }
 
-declare i32 @llvm.nvvm.test.anytype.i16.i16.i32.p0.i64.i16(i16, i16, i32, ptr, i64, i16)
-declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.i16(i32, i32, i32, ptr, i64, i16)
-declare i32 @llvm.nvvm.test.anytype.i32.i32.f32.p0.i64.i16(i32, i32, i32, ptr, i64, i16)
-declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p3.i64.i16(i32, i32, i32, ptr addrspace(3), i64, i16)
-declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.f64.i16(i32, i32, i32, ptr, double, i16)
-declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.v4i32(i32, i32, i32, ptr, i64, <4 x i32>)
+declare i32 @llvm.nvvm.test.type.i16.i16.i32.p0.i32.i16(i16, i16, i32, ptr, i32, i16)
+declare i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.i16(i32, i32, i32, ptr, i32, i16)
+declare i32 @llvm.nvvm.test.type.i32.i32.f32.p0.i32.i16(i32, i32, float, ptr, i32, i16)
+declare i32 @llvm.nvvm.test.type.i32.i32.i32.p3.i32.i16(i32, i32, i32, ptr addrspace(3), i32, i16)
+declare i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i16.i16(i32, i32, i32, ptr, i16, i16)
+declare i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.v4i32(i32, i32, i32, ptr, i32, <4 x i32>)
 declare {i32, i32, i64} @llvm.nvvm.test.return.type.i32(i32)

--- a/llvm/test/CodeGen/NVPTX/anytypeof_constraints_valid.ll
+++ b/llvm/test/CodeGen/NVPTX/anytypeof_constraints_valid.ll
@@ -1,33 +1,33 @@
 ; RUN: llvm-as < %s -o /dev/null
-; Test cases for int_nvvm_test_type intrinsic - VALID combinations
+; Test cases for int_nvvm_test_anytype intrinsic - VALID combinations
 
-define i32 @test_arg0_i16(i16 %a0, i16 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.type.i16.i16.i32.p0.i32.i16(i16 %a0, i16 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5)
+define i32 @test_arg0_i16(i16 %a0, i16 %a1, i32 %a2, ptr %a3, i64 %a4, ptr addrspace(1) %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i16.i16.i32.p0.i64.p1(i16 %a0, i16 %a1, i32 %a2, ptr %a3, i64 %a4, ptr addrspace(1) %a5)
   ret i32 %result
 }
 
-define i32 @test_arg0_i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5)
+define i32 @test_arg0_i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, ptr addrspace(1) %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.p1(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, ptr addrspace(1) %a5)
   ret i32 %result
 }
 
-define i32 @test_arg2_anyint(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, i16 %a5)
+define i32 @test_arg2_anyint(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, ptr addrspace(1) %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.p1(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, ptr addrspace(1) %a5)
   ret i32 %result
 }
 
-define i32 @test_arg3_shared_ptr(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(3) %a3, i32 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p3.i32.i16(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(3) %a3, i32 %a4, i16 %a5)
+define i32 @test_arg3_shared_ptr(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(3) %a3, i64 %a4, <2 x i64> %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p3.i64.v2i64(i32 %a0, i32 %a1, i32 %a2, ptr addrspace(3) %a3, i64 %a4, <2 x i64> %a5)
   ret i32 %result
 }
 
-define i32 @invalid_arg4_i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i16 %a4, i16 %a5) {
-  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i16.i16(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i16 %a4, i16 %a5)
+define i32 @test_arg4_double(i32 %a0, i32 %a1, i32 %a2, ptr %a3, double %a4, ptr addrspace(1) %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.f64.p1(i32 %a0, i32 %a1, i32 %a2, ptr %a3, double %a4, ptr addrspace(1) %a5)
   ret i32 %result
 }
 
-define i32 @test_arg5_v4i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, <4 x i32> %a5) {
-  %result = call i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.v4i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i32 %a4, <4 x i32> %a5)
+define i32 @test_arg5_v4i32(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, <2 x i64> %a5) {
+  %result = call i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.v2i64(i32 %a0, i32 %a1, i32 %a2, ptr %a3, i64 %a4, <2 x i64> %a5)
   ret i32 %result
 }
 
@@ -36,10 +36,10 @@ define {i32, i32, i64} @test_return_type_valid(i32 %arg) {
   ret {i32, i32, i64} %result
 }
 
-declare i32 @llvm.nvvm.test.type.i16.i16.i32.p0.i32.i16(i16, i16, i32, ptr, i32, i16)
-declare i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.i16(i32, i32, i32, ptr, i32, i16)
-declare i32 @llvm.nvvm.test.type.i32.i32.f32.p0.i32.i16(i32, i32, float, ptr, i32, i16)
-declare i32 @llvm.nvvm.test.type.i32.i32.i32.p3.i32.i16(i32, i32, i32, ptr addrspace(3), i32, i16)
-declare i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i16.i16(i32, i32, i32, ptr, i16, i16)
-declare i32 @llvm.nvvm.test.type.i32.i32.i32.p0.i32.v4i32(i32, i32, i32, ptr, i32, <4 x i32>)
+declare i32 @llvm.nvvm.test.anytype.i16.i16.i32.p0.i64.p1(i16, i16, i32, ptr, i64, ptr addrspace(1))
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.p1(i32, i32, i32, ptr, i64, ptr addrspace(1))
+declare i32 @llvm.nvvm.test.anytype.i32.i32.f32.p0.i64.p1(i32, i32, i32, ptr, i64, ptr addrspace(1))
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p3.i64.v2i64(i32, i32, i32, ptr addrspace(3), i64, <2 x i64>)
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.f64.p1(i32, i32, i32, ptr, double, ptr addrspace(1))
+declare i32 @llvm.nvvm.test.anytype.i32.i32.i32.p0.i64.v2i64(i32, i32, i32, ptr, i64, <2 x i64>)
 declare {i32, i32, i64} @llvm.nvvm.test.return.type.i32(i32)

--- a/llvm/test/TableGen/overloaded-intrinsic-constraints.td
+++ b/llvm/test/TableGen/overloaded-intrinsic-constraints.td
@@ -1,0 +1,43 @@
+// RUN: llvm-tblgen -gen-intrinsic-enums -I %p/../../include %s -DTEST_INTRINSICS_SUPPRESS_DEFS | FileCheck %s --check-prefix=CHECK-ENUM
+// RUN: llvm-tblgen -gen-intrinsic-impl -I %p/../../include %s -DTEST_INTRINSICS_SUPPRESS_DEFS | FileCheck %s --check-prefix=CHECK-IMPL
+
+include "llvm/IR/Intrinsics.td"
+
+// Test AnyTypeOf constraints for overloaded intrinsics.
+def int_anytypeof_multi : Intrinsic<
+  [llvm_i32_ty],
+  [
+    AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>,
+    AnyTypeOf<[llvm_anyint_ty, llvm_float_ty, llvm_double_ty]>
+  ],
+  [IntrNoMem]
+>;
+
+// Test mixed AnyTypeOf + NoneTypeOf.
+def int_mixed_constraints : Intrinsic<
+  [llvm_i32_ty],
+  [
+    AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>,
+    NoneTypeOf<[llvm_i8_ty]>
+  ],
+  [IntrNoMem]
+>;
+
+// Test NoneTypeOf on return type.
+def int_nonetypeof_return : Intrinsic<
+  [NoneTypeOf<[llvm_i8_ty, llvm_double_ty]>],
+  [llvm_i32_ty],
+  [IntrNoMem]
+>;
+
+// Verify enum generation.
+// CHECK-ENUM: anytypeof_multi = {{[0-9]+}}, // llvm.anytypeof.multi
+// CHECK-ENUM: mixed_constraints{{.*}}// llvm.mixed.constraints
+// CHECK-ENUM: nonetypeof_return{{.*}}// llvm.nonetypeof.return
+
+// Verify encoding table generation.
+// CHECK-IMPL: static constexpr unsigned char IIT_LongEncodingTable[] = {
+// CHECK-IMPL-NEXT: /* 0 */ 4, 15, 0, 93, 2, 3, 4, 15, 8, 94, 1, 2, 0,
+// CHECK-IMPL-NEXT: /* 13 */ 15, 0, 94, 2, 2, 8, 4, 0,
+// CHECK-IMPL-NEXT: /* 21 */ 4, 15, 0, 93, 2, 3, 4, 15, 8, 93, 3, 15, 9, 7, 8, 0,
+// CHECK-IMPL-NEXT: 255

--- a/llvm/test/TableGen/overloaded-intrinsic-constraints.td
+++ b/llvm/test/TableGen/overloaded-intrinsic-constraints.td
@@ -13,31 +13,10 @@ def int_anytypeof_multi : Intrinsic<
   [IntrNoMem]
 >;
 
-// Test mixed AnyTypeOf + NoneTypeOf.
-def int_mixed_constraints : Intrinsic<
-  [llvm_i32_ty],
-  [
-    AnyTypeOf<[llvm_i16_ty, llvm_i32_ty]>,
-    NoneTypeOf<[llvm_i8_ty]>
-  ],
-  [IntrNoMem]
->;
-
-// Test NoneTypeOf on return type.
-def int_nonetypeof_return : Intrinsic<
-  [NoneTypeOf<[llvm_i8_ty, llvm_double_ty]>],
-  [llvm_i32_ty],
-  [IntrNoMem]
->;
-
 // Verify enum generation.
 // CHECK-ENUM: anytypeof_multi = {{[0-9]+}}, // llvm.anytypeof.multi
-// CHECK-ENUM: mixed_constraints{{.*}}// llvm.mixed.constraints
-// CHECK-ENUM: nonetypeof_return{{.*}}// llvm.nonetypeof.return
 
 // Verify encoding table generation.
 // CHECK-IMPL: static constexpr unsigned char IIT_LongEncodingTable[] = {
-// CHECK-IMPL-NEXT: /* 0 */ 4, 15, 0, 93, 2, 3, 4, 15, 8, 94, 1, 2, 0,
-// CHECK-IMPL-NEXT: /* 13 */ 15, 0, 94, 2, 2, 8, 4, 0,
-// CHECK-IMPL-NEXT: /* 21 */ 4, 15, 0, 93, 2, 3, 4, 15, 8, 93, 3, 15, 9, 7, 8, 0,
+// CHECK-IMPL-NEXT: /* 0 */ 4, 15, 0, 93, 2, 3, 4, 15, 8, 93, 3, 15, 9, 7, 8, 0,
 // CHECK-IMPL-NEXT: 255

--- a/llvm/test/TableGen/overloaded-intrinsic-constraints.td
+++ b/llvm/test/TableGen/overloaded-intrinsic-constraints.td
@@ -18,5 +18,5 @@ def int_anytypeof_multi : Intrinsic<
 
 // Verify encoding table generation.
 // CHECK-IMPL: static constexpr unsigned char IIT_LongEncodingTable[] = {
-// CHECK-IMPL-NEXT: /* 0 */ 4, 15, 0, 93, 2, 3, 4, 15, 8, 93, 3, 15, 9, 7, 8, 0,
+// CHECK-IMPL-NEXT: /* 0 */ 4, 15, 0, 54, 2, 3, 4, 15, 8, 54, 3, 15, 9, 7, 8, 0,
 // CHECK-IMPL-NEXT: 255

--- a/llvm/test/TableGen/overloaded-intrinsic-constraints.td
+++ b/llvm/test/TableGen/overloaded-intrinsic-constraints.td
@@ -18,5 +18,5 @@ def int_anytypeof_multi : Intrinsic<
 
 // Verify encoding table generation.
 // CHECK-IMPL: static constexpr unsigned char IIT_LongEncodingTable[] = {
-// CHECK-IMPL-NEXT: /* 0 */ 4, 15, 0, 54, 2, 3, 4, 15, 8, 54, 3, 15, 9, 7, 8, 0,
+// CHECK-IMPL-NEXT: /* 0 */ 4, 15, 5, 2, 3, 4, 15, 13, 3, 15, 9, 7, 8, 0,
 // CHECK-IMPL-NEXT: 255


### PR DESCRIPTION
This patch adds LLVM TableGen infrastructure to support explicit type constraints for overloaded intrinsics. 
A new constrained type class, `AnyTypeOf<[list of LLVMType]>`, is added to express allowed type 
subsets directly in TableGen, enabling precise IR-level verification of intrinsic type usage. 

Type violations are now detected during the LLVM Verifier flow with clear, actionable diagnostics, 
improving error reporting and debuggability while keeping verification consistent with 
LLVM’s existing pipelines.

Link to the RFC, where this feature was discussed:
https://discourse.llvm.org/t/rfc-tablegen-explicit-type-constraints-for-overloaded-llvm-intrinsics/89142 

Version 1 of the `Except` predicates discussed in the RFC, built on top of this infrastructure,
is available in the draft PR #175445. 