### PR TITLE
[libc++] Remove [[nodiscard]] from map etc. operator[]

### DIFF
--- a/libcxx/include/__flat_map/flat_map.h
+++ b/libcxx/include/__flat_map/flat_map.h
@@ -465,13 +465,13 @@ public:
   }
 
   // [flat.map.access], element access
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 mapped_type& operator[](const key_type& __x)
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 mapped_type& operator[](const key_type& __x)
     requires is_constructible_v<mapped_type>
   {
     return try_emplace(__x).first->second;
   }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 mapped_type& operator[](key_type&& __x)
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 mapped_type& operator[](key_type&& __x)
     requires is_constructible_v<mapped_type>
   {
     return try_emplace(std::move(__x)).first->second;
@@ -480,7 +480,7 @@ public:
   template <class _Kp>
     requires(__is_compare_transparent && is_constructible_v<key_type, _Kp> && is_constructible_v<mapped_type> &&
              !is_convertible_v<_Kp &&, const_iterator> && !is_convertible_v<_Kp &&, iterator>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 mapped_type& operator[](_Kp&& __x) {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 mapped_type& operator[](_Kp&& __x) {
     return try_emplace(std::forward<_Kp>(__x)).first->second;
   }
 

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -1092,9 +1092,9 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type size() const _NOEXCEPT { return __tree_.size(); }
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type max_size() const _NOEXCEPT { return __tree_.max_size(); }
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI mapped_type& operator[](const key_type& __k);
+  _LIBCPP_HIDE_FROM_ABI mapped_type& operator[](const key_type& __k);
 #  ifndef _LIBCPP_CXX03_LANG
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI mapped_type& operator[](key_type&& __k);
+  _LIBCPP_HIDE_FROM_ABI mapped_type& operator[](key_type&& __k);
 #  endif
 
   template <class _Arg,

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -1262,9 +1262,9 @@ public:
   }
 #  endif // _LIBCPP_STD_VER >= 20
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI mapped_type& operator[](const key_type& __k);
+  _LIBCPP_HIDE_FROM_ABI mapped_type& operator[](const key_type& __k);
 #  ifndef _LIBCPP_CXX03_LANG
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI mapped_type& operator[](key_type&& __k);
+  _LIBCPP_HIDE_FROM_ABI mapped_type& operator[](key_type&& __k);
 #  endif
 
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI mapped_type& at(const key_type& __k);

--- a/libcxx/test/libcxx/diagnostics/flat_map.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/flat_map.nodiscard.verify.cpp
@@ -66,9 +66,9 @@ void test() {
   TransparentKey<int> tkey;
 
   std::flat_map<int, int> nfm;
-  nfm[key];            // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  fm[std::move(key)];  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  fm[std::move(tkey)]; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  nfm[key];            // no-warning
+  fm[std::move(key)];  // no-warning
+  fm[std::move(tkey)]; // no-warning
 
   fm.at(key);   // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
   cfm.at(key);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}

--- a/libcxx/test/libcxx/diagnostics/map.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/map.nodiscard.verify.cpp
@@ -55,8 +55,8 @@ void test() {
 
   int key = 0;
 
-  m[key];            // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  m[std::move(key)]; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  m[key];            // no-warning
+  m[std::move(key)]; // no-warning
 
 #if TEST_STD_VER >= 14
   std::map<std::string, int, std::less<>> strMap;

--- a/libcxx/test/libcxx/diagnostics/unordered_map.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/diagnostics/unordered_map.nodiscard.verify.cpp
@@ -81,8 +81,8 @@ void test() {
   ctm.equal_range(tkey); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
 #endif
 
-  m[key];            // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-  m[std::move(key)]; // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
+  m[key];            // no-warning
+  m[std::move(key)]; // no-warning
 
   m.at(key);  // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
   cm.at(key); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}


### PR DESCRIPTION
This was added in #169971 and related PRs. As commented there, discarding the return value on operator[] for these types does not typically indicate a bug since the operator can also be used to insert a default value.