### PR TITLE
[flang] Allow extended char set in `BIND(C, name="...")`

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -3476,6 +3476,12 @@ void CheckHelper::CheckBindC(const Symbol &symbol) {
   if (const std::string * bindName{symbol.GetBindName()};
       bindName) { // has a binding name
     if (!bindName->empty()) {
+      bool toolchain_error{bindName->front() == '.'};
+      if (toolchain_error) {
+        messages_.Say(symbol.name(),
+            "Symbol has a BIND(C) name with leading dot that may have special meaning to the toolchain"_err_en_US);
+        context_.SetError(symbol);
+      }
       bool visible_ascii{true};
       for (char ch : *bindName) {
         visible_ascii &= parser::IsPrintable(ch);

--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -3476,8 +3476,7 @@ void CheckHelper::CheckBindC(const Symbol &symbol) {
   if (const std::string * bindName{symbol.GetBindName()};
       bindName) { // has a binding name
     if (!bindName->empty()) {
-      bool toolchain_error{bindName->front() == '.'};
-      if (toolchain_error) {
+      if (bindName->front() == '.') {
         messages_.Say(symbol.name(),
             "Symbol has a BIND(C) name with leading dot that may have special meaning to the toolchain"_err_en_US);
         context_.SetError(symbol);

--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -3481,11 +3481,11 @@ void CheckHelper::CheckBindC(const Symbol &symbol) {
             "Symbol has a BIND(C) name with leading dot that may have special meaning to the toolchain"_err_en_US);
         context_.SetError(symbol);
       }
-      bool visible_ascii{true};
+      bool visibleAscii{true};
       for (char ch : *bindName) {
-        visible_ascii &= parser::IsPrintable(ch);
+        visibleAscii &= parser::IsPrintable(ch);
       }
-      if (!visible_ascii) {
+      if (!visibleAscii) {
         messages_.Say(symbol.name(),
             "Symbol has a BIND(C) name containing non-visible ASCII character(s)"_err_en_US);
         context_.SetError(symbol);

--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -3476,13 +3476,13 @@ void CheckHelper::CheckBindC(const Symbol &symbol) {
   if (const std::string * bindName{symbol.GetBindName()};
       bindName) { // has a binding name
     if (!bindName->empty()) {
-      bool ok{bindName->front() == '_' || parser::IsLetter(bindName->front())};
+      bool visible_ascii{true};
       for (char ch : *bindName) {
-        ok &= ch == '_' || parser::IsLetter(ch) || parser::IsDecimalDigit(ch);
+        visible_ascii &= parser::IsPrintable(ch);
       }
-      if (!ok) {
+      if (!visible_ascii) {
         messages_.Say(symbol.name(),
-            "Symbol has a BIND(C) name that is not a valid C language identifier"_err_en_US);
+            "Symbol has a BIND(C) name containing non-visible ASCII character(s)"_err_en_US);
         context_.SetError(symbol);
       }
     }

--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -3476,11 +3476,6 @@ void CheckHelper::CheckBindC(const Symbol &symbol) {
   if (const std::string * bindName{symbol.GetBindName()};
       bindName) { // has a binding name
     if (!bindName->empty()) {
-      if (bindName->front() == '.') {
-        messages_.Say(symbol.name(),
-            "Symbol has a BIND(C) name with leading dot that may have special meaning to the toolchain"_err_en_US);
-        context_.SetError(symbol);
-      }
       bool visibleAscii{true};
       for (char ch : *bindName) {
         visibleAscii &= parser::IsPrintable(ch);

--- a/flang/test/Semantics/bind-c10.f90
+++ b/flang/test/Semantics/bind-c10.f90
@@ -1,10 +1,14 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
-!ERROR: Symbol has a BIND(C) name that is not a valid C language identifier
 subroutine bang() bind(C,name='!')
 end
-!ERROR: Symbol has a BIND(C) name that is not a valid C language identifier
+!ERROR: Symbol has a BIND(C) name containing non-visible ASCII character(s)
 subroutine cr() bind(C,name=achar(13))
 end
-!ERROR: Symbol has a BIND(C) name that is not a valid C language identifier
 subroutine beast() bind(C,name="666")
+end
+!ERROR: Symbol has a BIND(C) name with leading dot that may have special meaning to the toolchain
+subroutine llvm() bind(C,name=".L1")
+end
+!ERROR: Symbol has a BIND(C) name with leading dot that may have special meaning to the toolchain
+subroutine ld() bind(C,name=".text")
 end

--- a/flang/test/Semantics/bind-c10.f90
+++ b/flang/test/Semantics/bind-c10.f90
@@ -1,4 +1,6 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
+subroutine foo() bind(C,name='bar')
+end
 subroutine currency() bind(C,name='$')
 end
 !ERROR: Symbol has a BIND(C) name containing non-visible ASCII character(s)

--- a/flang/test/Semantics/bind-c10.f90
+++ b/flang/test/Semantics/bind-c10.f90
@@ -1,18 +1,9 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
-subroutine bang() bind(C,name='!')
+subroutine currency() bind(C,name='$')
 end
 !ERROR: Symbol has a BIND(C) name containing non-visible ASCII character(s)
 subroutine cr() bind(C,name=achar(13))
 end
-!! depending on used assembler it can be threated as error or not
-subroutine beast() bind(C,name="666")
-end
-!! depending on used assembler it can be threated as error or not
-subroutine llvm() bind(C,name=".L1")
-end
-!! depending on used assembler it can be threated as error or not
-subroutine as() bind(C,name=".text")
-end
-!! depending on used assembler it can be threated as error or not
-subroutine printable_ascii() bind(C,name="! ""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~'")
+!ERROR: Symbol has a BIND(C) name containing non-visible ASCII character(s)
+subroutine null_terminator() bind(C,name="null_terminator" // achar(0))
 end

--- a/flang/test/Semantics/bind-c10.f90
+++ b/flang/test/Semantics/bind-c10.f90
@@ -6,9 +6,7 @@ subroutine cr() bind(C,name=achar(13))
 end
 subroutine beast() bind(C,name="666")
 end
-!ERROR: Symbol has a BIND(C) name with leading dot that may have special meaning to the toolchain
 subroutine llvm() bind(C,name=".L1")
 end
-!ERROR: Symbol has a BIND(C) name with leading dot that may have special meaning to the toolchain
 subroutine ld() bind(C,name=".text")
 end

--- a/flang/test/Semantics/bind-c10.f90
+++ b/flang/test/Semantics/bind-c10.f90
@@ -4,9 +4,15 @@ end
 !ERROR: Symbol has a BIND(C) name containing non-visible ASCII character(s)
 subroutine cr() bind(C,name=achar(13))
 end
+!! depending on used assembler it can be threated as error or not
 subroutine beast() bind(C,name="666")
 end
+!! depending on used assembler it can be threated as error or not
 subroutine llvm() bind(C,name=".L1")
 end
-subroutine ld() bind(C,name=".text")
+!! depending on used assembler it can be threated as error or not
+subroutine as() bind(C,name=".text")
+end
+!! depending on used assembler it can be threated as error or not
+subroutine printable_ascii() bind(C,name="! ""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~'")
 end


### PR DESCRIPTION
Fixes #172456 

The char set was expanded to all printable ASCII characters. To avoid any issues with LLVM, linker, and other toolchain tools, leading dot is prohibited.