### PR TITLE
Revert "[clang][analyzer] Format macro expansions"

### DIFF
--- a/clang/include/clang/Analysis/MacroExpansionContext.h
+++ b/clang/include/clang/Analysis/MacroExpansionContext.h
@@ -96,13 +96,6 @@ public:
   std::optional<StringRef>
   getOriginalText(SourceLocation MacroExpansionLoc) const;
 
-  /// \param MacroExpansionLoc Must be the expansion location of a macro.
-  /// \return A formatted representation of the textual representation of the
-  ///         token sequence which was substituted in place of the macro.
-  ///         If no macro was expanded at that location, returns std::nullopt.
-  std::optional<StringRef>
-  getFormattedExpandedText(SourceLocation MacroExpansionLoc) const;
-
   LLVM_DUMP_METHOD void dumpExpansionRangesToStream(raw_ostream &OS) const;
   LLVM_DUMP_METHOD void dumpExpandedTextsToStream(raw_ostream &OS) const;
   LLVM_DUMP_METHOD void dumpExpansionRanges() const;
@@ -113,7 +106,6 @@ private:
   using MacroExpansionText = SmallString<40>;
   using ExpansionMap = llvm::DenseMap<SourceLocation, MacroExpansionText>;
   using ExpansionRangeMap = llvm::DenseMap<SourceLocation, SourceLocation>;
-  using FormattedExpansionMap = llvm::DenseMap<SourceLocation, std::string>;
 
   /// Associates the textual representation of the expanded tokens at the given
   /// macro expansion location.
@@ -122,9 +114,6 @@ private:
   /// Tracks which source location was the last affected by any macro
   /// substitution starting from a given macro expansion location.
   ExpansionRangeMap ExpansionRanges;
-
-  /// Caches formatted macro expansions keyed by expansion location.
-  mutable FormattedExpansionMap FormattedExpandedTokens;
 
   Preprocessor *PP = nullptr;
   SourceManager *SM = nullptr;

--- a/clang/lib/Analysis/CMakeLists.txt
+++ b/clang/lib/Analysis/CMakeLists.txt
@@ -40,7 +40,6 @@ add_clang_library(clangAnalysis
   clangAST
   clangASTMatchers
   clangBasic
-  clangFormat
   clangLex
 
   DEPENDS

--- a/clang/lib/StaticAnalyzer/Core/PlistDiagnostics.cpp
+++ b/clang/lib/StaticAnalyzer/Core/PlistDiagnostics.cpp
@@ -835,7 +835,7 @@ getExpandedMacro(SourceLocation MacroExpansionLoc,
                  const SourceManager &SM) {
   if (auto CTUMacroExpCtx =
           CTU.getMacroExpansionContextForSourceLocation(MacroExpansionLoc)) {
-    return CTUMacroExpCtx->getFormattedExpandedText(MacroExpansionLoc);
+    return CTUMacroExpCtx->getExpandedText(MacroExpansionLoc);
   }
-  return MacroExpansions.getFormattedExpandedText(MacroExpansionLoc);
+  return MacroExpansions.getExpandedText(MacroExpansionLoc);
 }

--- a/clang/test/Analysis/plist-macros-with-expansion-ctu.c
+++ b/clang/test/Analysis/plist-macros-with-expansion-ctu.c
@@ -66,7 +66,7 @@ void test3(void) {
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>M</string>
-// CHECK-NEXT:   <key>expansion</key><string>F1
+// CHECK-NEXT:   <key>expansion</key><string>F1 (&amp;X )</string>
 // CHECK-NEXT:  </dict>
 // CHECK-NEXT: </array>
 
@@ -89,7 +89,7 @@ void test4(void) {
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>M</string>
-// CHECK-NEXT:   <key>expansion</key><string>F2
+// CHECK-NEXT:   <key>expansion</key><string>F2 (&amp;X )</string>
 // CHECK-NEXT:  </dict>
 // CHECK-NEXT: </array>
 

--- a/clang/test/Analysis/plist-macros-with-expansion.c
+++ b/clang/test/Analysis/plist-macros-with-expansion.c
@@ -22,7 +22,7 @@ void test_strange_macro_expansion(void) {
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>STRANGE_FN(path)</string>
-// CHECK-NEXT:   <key>expansion</key><string>STRANGE_FN
+// CHECK-NEXT:   <key>expansion</key><string>STRANGE_FN (path ,0)</string>
 // CHECK-NEXT:  </dict>
 // CHECK-NEXT: </array>
 

--- a/clang/test/Analysis/plist-macros-with-expansion.cpp
+++ b/clang/test/Analysis/plist-macros-with-expansion.cpp
@@ -29,7 +29,7 @@ void nonFunctionLikeMacroTest() {
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>SET_PTR_VAR_TO_NULL</string>
-// CHECK-NEXT:   <key>expansion</key><string>ptr
+// CHECK-NEXT:   <key>expansion</key><string>ptr =0</string>
 // CHECK-NEXT:  </dict>
 // CHECK-NEXT: </array>
 
@@ -53,7 +53,7 @@ void nonFunctionLikeNestedMacroTest() {
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:  <key>name</key><string>SET_PTR_VAR_TO_NULL_WITH_NESTED_MACRO</string>
-// CHECK-NEXT:  <key>expansion</key><string>ptr
+// CHECK-NEXT:  <key>expansion</key><string>ptr =0</string>
 // CHECK-NEXT:  </dict>
 // CHECK-NEXT: </array>
 
@@ -84,7 +84,7 @@ void functionLikeMacroTest() {
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:  <key>name</key><string>TO_NULL(&amp;ptr)</string>
-// CHECK-NEXT:  <key>expansion</key><string>setToNull
+// CHECK-NEXT:  <key>expansion</key><string>setToNull (&amp;ptr )</string>
 // CHECK-NEXT:  </dict>
 // CHECK-NEXT: </array>
 
@@ -115,7 +115,7 @@ void functionLikeNestedMacroTest() {
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>TO_NULL(&amp;a)</string>
-// CHECK-NEXT:   <key>expansion</key><string>setToNull
+// CHECK-NEXT:   <key>expansion</key><string>setToNull (&amp;a )</string>
 // CHECK-NEXT:  </dict>
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
@@ -125,7 +125,9 @@ void functionLikeNestedMacroTest() {
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>DEREF(a)</string>
-// CHECK-NEXT:   <key>expansion</key><string>{
+// CHECK-NEXT:   <key>expansion</key><string>{int b ;b =5;}print (a );*a </string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 //===----------------------------------------------------------------------===//
 // Tests for undefining and/or redifining macros.
@@ -147,12 +149,14 @@ void undefinedMacroByTheEndOfParsingTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>139</integer>
+// CHECK-NEXT:    <key>line</key><integer>141</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>WILL_UNDEF_SET_NULL_TO_PTR(ptr)</string>
-// CHECK-NEXT:   <key>expansion</key><string>ptr
+// CHECK-NEXT:   <key>expansion</key><string>ptr =nullptr ;</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define WILL_REDIFINE_MULTIPLE_TIMES_SET_TO_NULL(ptr) \
   /* Nothing */
@@ -176,12 +180,14 @@ void macroRedefinedMultipleTimesTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>165</integer>
+// CHECK-NEXT:    <key>line</key><integer>169</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>WILL_REDIFINE_MULTIPLE_TIMES_SET_TO_NULL(ptr)</string>
-// CHECK-NEXT:   <key>expansion</key><string>ptr
+// CHECK-NEXT:   <key>expansion</key><string>ptr =nullptr ;</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define WILL_UNDEF_SET_NULL_TO_PTR_2(ptr) \
   ptr = nullptr;
@@ -200,12 +206,14 @@ void undefinedMacroInsideAnotherMacroTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>194</integer>
+// CHECK-NEXT:    <key>line</key><integer>200</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>PASS_PTR_TO_MACRO_THAT_WILL_BE_UNDEFD(ptr)</string>
-// CHECK-NEXT:   <key>expansion</key><string>ptr
+// CHECK-NEXT:   <key>expansion</key><string>ptr =nullptr ;</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #undef WILL_UNDEF_SET_NULL_TO_PTR_2
 
@@ -235,12 +243,14 @@ void macroArgContainsCommaInStringTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>229</integer>
+// CHECK-NEXT:    <key>line</key><integer>237</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>TO_NULL_AND_PRINT(a, &quot;Will this , cause a crash?&quot;)</string>
-// CHECK-NEXT:   <key>expansion</key><string>a
+// CHECK-NEXT:   <key>expansion</key><string>a =0;print (&quot;Will this , cause a crash?&quot;)</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 void macroArgContainsLParenInStringTest() {
   int *a;
@@ -253,12 +263,14 @@ void macroArgContainsLParenInStringTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>247</integer>
+// CHECK-NEXT:    <key>line</key><integer>257</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>TO_NULL_AND_PRINT(a, &quot;Will this ( cause a crash?&quot;)</string>
-// CHECK-NEXT:   <key>expansion</key><string>a
+// CHECK-NEXT:   <key>expansion</key><string>a =0;print (&quot;Will this ( cause a crash?&quot;)</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 void macroArgContainsRParenInStringTest() {
   int *a;
@@ -271,12 +283,14 @@ void macroArgContainsRParenInStringTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>265</integer>
+// CHECK-NEXT:    <key>line</key><integer>277</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>TO_NULL_AND_PRINT(a, &quot;Will this ) cause a crash?&quot;)</string>
-// CHECK-NEXT:   <key>expansion</key><string>a
+// CHECK-NEXT:   <key>expansion</key><string>a =0;print (&quot;Will this ) cause a crash?&quot;)</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define CALL_FUNCTION(funcCall)   \
   funcCall
@@ -294,12 +308,14 @@ void macroArgContainsLParenRParenTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>288</integer>
+// CHECK-NEXT:    <key>line</key><integer>302</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>CALL_FUNCTION(setToNull(&amp;a))</string>
-// CHECK-NEXT:   <key>expansion</key><string>setToNull
+// CHECK-NEXT:   <key>expansion</key><string>setToNull (&amp;a )</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 void setToNullAndPrint(int **vptr, const char *str) {
   setToNull(vptr);
@@ -317,12 +333,14 @@ void macroArgContainsCommaLParenRParenTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>311</integer>
+// CHECK-NEXT:    <key>line</key><integer>327</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>CALL_FUNCTION(setToNullAndPrint(&amp;a, &quot;Hello!&quot;))</string>
-// CHECK-NEXT:   <key>expansion</key><string>setToNullAndPrint
+// CHECK-NEXT:   <key>expansion</key><string>setToNullAndPrint (&amp;a ,&quot;Hello!&quot;)</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define CALL_FUNCTION_WITH_TWO_PARAMS(funcCall, param1, param2) \
   funcCall(param1, param2)
@@ -338,12 +356,14 @@ void macroArgContainsCommaLParenRParenTest2() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>332</integer>
+// CHECK-NEXT:    <key>line</key><integer>350</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>CALL_FUNCTION_WITH_TWO_PARAMS(setToNullAndPrint, &amp;a, &quot;Hello!&quot;)</string>
-// CHECK-NEXT:   <key>expansion</key><string>setToNullAndPrint
+// CHECK-NEXT:   <key>expansion</key><string>setToNullAndPrint (&amp;a ,&quot;Hello!&quot;)</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define CALL_LAMBDA(l) \
   l()
@@ -362,22 +382,24 @@ void commaInBracketsTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>356</integer>
+// CHECK-NEXT:    <key>line</key><integer>376</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>CALL_LAMBDA(([&amp;ptr, str] () mutable { TO_NULL(&amp;ptr); }))</string>
-// CHECK-NEXT:   <key>expansion</key><string>(
-// CHECK:  </dict>
+// CHECK-NEXT:   <key>expansion</key><string>([&amp;ptr ,str ]()mutable {setToNull (&amp;ptr );})()</string>
+// CHECK-NEXT:  </dict>
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>356</integer>
+// CHECK-NEXT:    <key>line</key><integer>376</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>CALL_LAMBDA(([&amp;ptr, str] () mutable { TO_NULL(&amp;ptr); }))</string>
-// CHECK-NEXT:   <key>expansion</key><string>(
+// CHECK-NEXT:   <key>expansion</key><string>([&amp;ptr ,str ]()mutable {setToNull (&amp;ptr );})()</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define PASTE_CODE(code) \
   code
@@ -399,7 +421,7 @@ void commaInBracesTest() {
 // CHECK-NEXT:    <dict>
 // CHECK-NEXT:     <key>location</key>
 // CHECK-NEXT:     <dict>
-// CHECK-NEXT:      <key>line</key><integer>386</integer>
+// CHECK-NEXT:      <key>line</key><integer>408</integer>
 // CHECK-NEXT:      <key>col</key><integer>3</integer>
 // CHECK-NEXT:      <key>file</key><integer>0</integer>
 // CHECK-NEXT:     </dict>
@@ -412,7 +434,9 @@ void commaInBracesTest() {
 // CHECK-NEXT:    int *ptr = nullptr;
 // CHECK-NEXT:    *ptr = 5;
 // CHECK-NEXT:  })</string>
-// CHECK-NEXT:     <key>expansion</key><string>{
+// CHECK-NEXT:     <key>expansion</key><string>{int *ptr =nullptr ;*ptr =5;}</string>
+// CHECK-NEXT:    </dict>
+// CHECK-NEXT:   </array>
 
 // Example taken from
 // https://gcc.gnu.org/onlinedocs/cpp/Macro-Arguments.html#Macro-Arguments.
@@ -433,12 +457,14 @@ void emptyParamTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>427</integer>
+// CHECK-NEXT:    <key>line</key><integer>451</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>POTENTIALLY_EMPTY_PARAM(,ptr)</string>
-// CHECK-NEXT:   <key>expansion</key><string>;
+// CHECK-NEXT:   <key>expansion</key><string>;ptr =nullptr </string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define NESTED_EMPTY_PARAM(a, b) \
   POTENTIALLY_EMPTY_PARAM(a, b);
@@ -456,12 +482,14 @@ void nestedEmptyParamTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>450</integer>
+// CHECK-NEXT:    <key>line</key><integer>476</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>NESTED_EMPTY_PARAM(, ptr)</string>
-// CHECK-NEXT:   <key>expansion</key><string>;
+// CHECK-NEXT:   <key>expansion</key><string>;ptr =nullptr ;</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define CALL_FUNCTION_WITH_ONE_PARAM_THROUGH_MACRO(func, param) \
   CALL_FUNCTION(func(param))
@@ -477,12 +505,14 @@ void lParenRParenInNestedMacro() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>471</integer>
+// CHECK-NEXT:    <key>line</key><integer>499</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>CALL_FUNCTION_WITH_ONE_PARAM_THROUGH_MACRO(setToNull, &amp;ptr)</string>
-// CHECK-NEXT:   <key>expansion</key><string>setToNull
+// CHECK-NEXT:   <key>expansion</key><string>setToNull (&amp;ptr )</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 //===----------------------------------------------------------------------===//
 // Tests for variadic macro arguments.
@@ -506,12 +536,14 @@ void variadicMacroArgumentTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>500</integer>
+// CHECK-NEXT:    <key>line</key><integer>530</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>VARIADIC_SET_TO_NULL(ptr, 1, 5, &quot;haha!&quot;)</string>
-// CHECK-NEXT:   <key>expansion</key><string>ptr
+// CHECK-NEXT:   <key>expansion</key><string>ptr =nullptr ;variadicFunc (1,5,&quot;haha!&quot;)</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 void variadicMacroArgumentWithoutAnyArgumentTest() {
   int *ptr;
@@ -526,12 +558,14 @@ void variadicMacroArgumentWithoutAnyArgumentTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>520</integer>
+// CHECK-NEXT:    <key>line</key><integer>552</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>VARIADIC_SET_TO_NULL(ptr)</string>
-// CHECK-NEXT:   <key>expansion</key><string>ptr
+// CHECK-NEXT:   <key>expansion</key><string>ptr =nullptr ;variadicFunc ()</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 //===----------------------------------------------------------------------===//
 // Tests for # and ##.
@@ -552,12 +586,14 @@ void hashHashOperatorTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>546</integer>
+// CHECK-NEXT:    <key>line</key><integer>580</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>DECLARE_FUNC_AND_SET_TO_NULL(whatever, ptr)</string>
-// CHECK-NEXT:   <key>expansion</key><string>void generated_whatever
+// CHECK-NEXT:   <key>expansion</key><string>void generated_whatever ();ptr =nullptr ;</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 void macroArgContainsHashHashInStringTest() {
   int *a;
@@ -570,12 +606,14 @@ void macroArgContainsHashHashInStringTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>564</integer>
+// CHECK-NEXT:    <key>line</key><integer>600</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>TO_NULL_AND_PRINT(a, &quot;Will this ## cause a crash?&quot;)</string>
-// CHECK-NEXT:   <key>expansion</key><string>a
+// CHECK-NEXT:   <key>expansion</key><string>a =0;print (&quot;Will this ## cause a crash?&quot;)</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define PRINT_STR(str, ptr) \
   print(#str);              \
@@ -592,12 +630,14 @@ void hashOperatorTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>586</integer>
+// CHECK-NEXT:    <key>line</key><integer>624</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>PRINT_STR(Hello, ptr)</string>
-// CHECK-NEXT:   <key>expansion</key><string>print
+// CHECK-NEXT:   <key>expansion</key><string>print (&quot;Hello&quot;);ptr =nullptr </string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 void macroArgContainsHashInStringTest() {
   int *a;
@@ -610,12 +650,14 @@ void macroArgContainsHashInStringTest() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>604</integer>
+// CHECK-NEXT:    <key>line</key><integer>644</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>TO_NULL_AND_PRINT(a, &quot;Will this # cause a crash?&quot;)</string>
-// CHECK-NEXT:   <key>expansion</key><string>a
+// CHECK-NEXT:   <key>expansion</key><string>a =0;print (&quot;Will this # cause a crash?&quot;)</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 //===----------------------------------------------------------------------===//
 // Tests for more complex macro expansions.
@@ -666,12 +708,14 @@ void testVeryComplexAlgorithm() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>656</integer>
+// CHECK-NEXT:    <key>line</key><integer>698</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>EUCLIDEAN_ALGORITHM(A, B)</string>
-// CHECK-NEXT:   <key>expansion</key><string>if
+// CHECK-NEXT:   <key>expansion</key><string>if (A &lt;0){A =-A ;}if (B &lt;0){B =-B ;}return B /(B -B );</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define YET_ANOTHER_SET_TO_NULL(x, y, z)   \
   print((void *) x);                       \
@@ -692,12 +736,14 @@ void test() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>686</integer>
+// CHECK-NEXT:    <key>line</key><integer>730</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>YET_ANOTHER_SET_TO_NULL(5, DO_NOTHING2(&quot;Remember the Vasa&quot;), ptr)</string>
-// CHECK-NEXT:   <key>expansion</key><string>print
+// CHECK-NEXT:   <key>expansion</key><string>print ((void *)5);print ((void *)&quot;Remember the Vasa&quot;);ptr =nullptr ;</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 int garbage_value;
 
@@ -715,12 +761,14 @@ void recursiveMacroUser() {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>708</integer>
+// CHECK-NEXT:    <key>line</key><integer>754</integer>
 // CHECK-NEXT:    <key>col</key><integer>7</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>value</string>
-// CHECK-NEXT:   <key>expansion</key><string>garbage_value
+// CHECK-NEXT:   <key>expansion</key><string>garbage_value </string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define FOO(x) int foo() { return x; }
 #define APPLY_ZERO1(function) function(0)
@@ -733,12 +781,14 @@ void useZeroApplier1() { (void)(1 / foo()); } // expected-warning{{Division by z
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>728</integer>
+// CHECK-NEXT:    <key>line</key><integer>776</integer>
 // CHECK-NEXT:    <key>col</key><integer>1</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>APPLY_ZERO1(FOO)</string>
-// CHECK-NEXT:   <key>expansion</key><string>int foo
+// CHECK-NEXT:   <key>expansion</key><string>int foo (){return 0;}</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define BAR(x) int bar() { return x; }
 #define APPLY_ZERO2 BAR(0)
@@ -751,12 +801,14 @@ void useZeroApplier2() { (void)(1 / bar()); } // expected-warning{{Division by z
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>746</integer>
+// CHECK-NEXT:    <key>line</key><integer>796</integer>
 // CHECK-NEXT:    <key>col</key><integer>1</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>APPLY_ZERO2</string>
-// CHECK-NEXT:   <key>expansion</key><string>int
+// CHECK-NEXT:   <key>expansion</key><string>int bar (){return 0;}</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 void foo(int &x, const char *str);
 
@@ -775,12 +827,14 @@ void mulitpleParamsResolveToVA_ARGS(void) {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>769</integer>
+// CHECK-NEXT:    <key>line</key><integer>821</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>DISPATCH(x, &quot;LF1M healer&quot;)</string>
-// CHECK-NEXT:   <key>expansion</key><string>foo
+// CHECK-NEXT:   <key>expansion</key><string>foo (x ,&quot;LF1M healer&quot;);x =0;;</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 void variadicCFunction(int &x, const char *str, ...);
 
@@ -798,12 +852,14 @@ void concatVA_ARGS(void) {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>792</integer>
+// CHECK-NEXT:    <key>line</key><integer>846</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>CONCAT_VA_ARGS(x, &quot;You need to construct additional pylons.&quot;, &apos;c&apos;, 9)</string>
-// CHECK-NEXT:   <key>expansion</key><string>variadicCFunction
+// CHECK-NEXT:   <key>expansion</key><string>variadicCFunction (x ,&quot;You need to construct additional pylons.&quot;,&apos;c&apos;,9);x =0;</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 void concatVA_ARGSEmpty(void) {
   int x = 1;
@@ -816,12 +872,14 @@ void concatVA_ARGSEmpty(void) {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>810</integer>
+// CHECK-NEXT:    <key>line</key><integer>866</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>CONCAT_VA_ARGS(x, &quot;You need to construct&quot;)</string>
-// CHECK-NEXT:   <key>expansion</key><string>variadicCFunction
+// CHECK-NEXT:   <key>expansion</key><string>variadicCFunction (x ,&quot;You need to construct&quot;);x =0;</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 #define STRINGIFIED_VA_ARGS(i, fmt, ...) variadicCFunction(i, fmt, #__VA_ARGS__); \
   i = 0;
@@ -837,12 +895,14 @@ void stringifyVA_ARGS(void) {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>831</integer>
+// CHECK-NEXT:    <key>line</key><integer>889</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>STRINGIFIED_VA_ARGS(x, &quot;Additional supply depots required.&quot;, &apos;a&apos;, 10)</string>
-// CHECK-NEXT:   <key>expansion</key><string>variadicCFunction
+// CHECK-NEXT:   <key>expansion</key><string>variadicCFunction (x ,&quot;Additional supply depots required.&quot;,&quot;&apos;a&apos;, 10&quot;);x =0;</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 void stringifyVA_ARGSEmpty(void) {
   int x = 1;
@@ -855,12 +915,14 @@ void stringifyVA_ARGSEmpty(void) {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>849</integer>
+// CHECK-NEXT:    <key>line</key><integer>909</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>STRINGIFIED_VA_ARGS(x, &quot;Additional supply depots required.&quot;)</string>
-// CHECK-NEXT:   <key>expansion</key><string>variadicCFunction
+// CHECK-NEXT:   <key>expansion</key><string>variadicCFunction (x ,&quot;Additional supply depots required.&quot;,&quot;&quot;);x =0;</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>
 
 // bz44493: Support GNU-style named variadic arguments in plister
 #define BZ44493_GNUVA(i, args...)  --(i);
@@ -878,9 +940,11 @@ int bz44493(void) {
 // CHECK-NEXT:  <dict>
 // CHECK-NEXT:   <key>location</key>
 // CHECK-NEXT:   <dict>
-// CHECK-NEXT:    <key>line</key><integer>871</integer>
+// CHECK-NEXT:    <key>line</key><integer>933</integer>
 // CHECK-NEXT:    <key>col</key><integer>3</integer>
 // CHECK-NEXT:    <key>file</key><integer>0</integer>
 // CHECK-NEXT:   </dict>
 // CHECK-NEXT:   <key>name</key><string>BZ44493_GNUVA(a, &quot;arg2&quot;)</string>
-// CHECK-NEXT:   <key>expansion</key><string>--(a
+// CHECK-NEXT:   <key>expansion</key><string>--(a );</string>
+// CHECK-NEXT:  </dict>
+// CHECK-NEXT: </array>

--- a/clang/unittests/Analysis/MacroExpansionContextTest.cpp
+++ b/clang/unittests/Analysis/MacroExpansionContextTest.cpp
@@ -405,43 +405,6 @@ TEST_F(MacroExpansionContextTest, UnbalacedParenthesis) {
   EXPECT_EQ("f(f(1))", *Ctx->getOriginalText(at(13, 12)));
 }
 
-TEST_F(MacroExpansionContextTest, FormattedExpandedTextNoneWhenNoExpansion) {
-  const auto Ctx = getMacroExpansionContextFor(R"code(
-  #define UNUSED 1
-  int value = 0;
-      )code");
-  EXPECT_FALSE(Ctx->getFormattedExpandedText(at(3, 3)).has_value());
-}
-
-TEST_F(MacroExpansionContextTest,
-       FormattedExpandedTextKeepsOriginalWhenStable) {
-  const auto Ctx = getMacroExpansionContextFor(R"code(
-  #define ANSWER 42
-  int life = ANSWER;
-      )code");
-
-  const auto Expanded = Ctx->getExpandedText(at(3, 14));
-  ASSERT_TRUE(Expanded.has_value());
-
-  EXPECT_EQ(*Expanded, *Ctx->getFormattedExpandedText(at(3, 14)));
-}
-
-TEST_F(MacroExpansionContextTest, FormattedExpandedTextChangesWhenFormatting) {
-  const auto Ctx = getMacroExpansionContextFor(R"code(
-  #define ADD(x, y) (x+y* x)
-  int result = ADD(1,2);
-      )code");
-
-  const auto Expanded = Ctx->getExpandedText(at(3, 16));
-  ASSERT_TRUE(Expanded.has_value());
-
-  const auto Formatted = Ctx->getFormattedExpandedText(at(3, 16));
-  ASSERT_TRUE(Formatted.has_value());
-
-  EXPECT_EQ(*Formatted, *Ctx->getFormattedExpandedText(at(3, 16)));
-  EXPECT_NE(*Expanded, *Formatted);
-}
-
 } // namespace
 } // namespace analysis
 } // namespace clang


### PR DESCRIPTION
Reverts llvm/llvm-project#156046

See https://github.com/llvm/llvm-project/pull/156046#issuecomment-3660172948

```
11.210 [660/22/4115] Linking CXX shared library lib/libclangAnalysis.so.22.0git
FAILED: lib/libclangAnalysis.so.22.0git 
: && /usr/bin/c++ -fPIC -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-uninitialized -Wno-nonnull -Wno-class-memaccess -Wno-redundant-move -Wno-pessimizing-move -Wno-array-bounds -Wno-stringop-overread -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-comment -Wno-misleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -fno-common -Woverloaded-virtual -O3 -DNDEBUG  -Wl,-z,defs -Wl,-z,nodelete   -Wl,-rpath-link,/home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.build/./lib  -Wl,--gc-sections -shared -Wl,-soname,libclangAnalysis.so.22.0git -o lib/libclangAnalysis.so.22.0git tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/AnalysisDeclContext.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/BodyFarm.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/CalledOnceCheck.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/CFG.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/CFGReachabilityAnalysis.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/CFGStmtMap.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/CallGraph.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/CloneDetection.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/CocoaConventions.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/ConstructionContext.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/Consumed.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/CodeInjector.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/Dominators.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/ExprMutationAnalyzer.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/FixitUtil.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/IntervalPartition.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/IssueHash.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/LiveVariables.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/MacroExpansionContext.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/ObjCNoReturn.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/PathDiagnostic.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/PostOrderCFGView.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/ProgramPoint.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/ReachableCode.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/RetainSummaryManager.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/ThreadSafety.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/ThreadSafetyCommon.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/ThreadSafetyLogical.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/ThreadSafetyTIL.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/UninitializedValues.cpp.o tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/UnsafeBufferUsage.cpp.o  -Wl,-rpath,"\$ORIGIN/../lib:/home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.build/lib:"  lib/libclangASTMatchers.so.22.0git  lib/libclangFormat.so.22.0git  lib/libclangAST.so.22.0git  lib/libclangLex.so.22.0git  lib/libclangBasic.so.22.0git  lib/libLLVMFrontendOpenMP.so.22.0git  lib/libLLVMSupport.so.22.0git  -Wl,-rpath-link,/home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.build/lib && :
/usr/bin/ld: tools/clang/lib/Analysis/CMakeFiles/obj.clangAnalysis.dir/MacroExpansionContext.cpp.o: in function `clang::MacroExpansionContext::getFormattedExpandedText(clang::SourceLocation) const':
MacroExpansionContext.cpp:(.text._ZNK5clang21MacroExpansionContext24getFormattedExpandedTextENS_14SourceLocationE+0x274): undefined reference to `clang::tooling::applyAllReplacements[abi:cxx11](llvm::StringRef, clang::tooling::Replacements const&)'
collect2: error: ld returned 1 exit status
```