### PR TITLE
[clang][ssaf] Add SummaryName handle type

### DIFF
--- a/clang/include/clang/Analysis/Scalable/Model/SummaryName.h
+++ b/clang/include/clang/Analysis/Scalable/Model/SummaryName.h
@@ -1,0 +1,37 @@
+//===- SummaryName.h --------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_ANALYSIS_SCALABLE_MODEL_SUMMARYNAME_H
+#define LLVM_CLANG_ANALYSIS_SCALABLE_MODEL_SUMMARYNAME_H
+
+#include "llvm/ADT/StringRef.h"
+#include <string>
+
+namespace clang::ssaf {
+
+/// Uniquely identifies an analysis summary.
+///
+/// This is the key to refer to an analysis or to name a builder to build an analysis.
+class SummaryName {
+public:
+  explicit SummaryName(std::string Name) : Name(std::move(Name)) {}
+
+  bool operator==(const SummaryName &Other) const { return Name == Other.Name; }
+  bool operator!=(const SummaryName &Other) const { return !(*this == Other); }
+  bool operator<(const SummaryName &Other) const { return Name < Other.Name; }
+
+  /// Explicit conversion to the underlying string representation.
+  llvm::StringRef str() const { return Name; }
+
+private:
+  std::string Name;
+};
+
+} // namespace clang::ssaf
+
+#endif // LLVM_CLANG_ANALYSIS_SCALABLE_MODEL_SUMMARYNAME_H

--- a/clang/include/clang/Analysis/Scalable/Model/SummaryName.h
+++ b/clang/include/clang/Analysis/Scalable/Model/SummaryName.h
@@ -16,7 +16,8 @@ namespace clang::ssaf {
 
 /// Uniquely identifies an analysis summary.
 ///
-/// This is the key to refer to an analysis or to name a builder to build an analysis.
+/// This is the key to refer to an analysis or to name a builder to build an
+/// analysis.
 class SummaryName {
 public:
   explicit SummaryName(std::string Name) : Name(std::move(Name)) {}

--- a/clang/unittests/Analysis/Scalable/CMakeLists.txt
+++ b/clang/unittests/Analysis/Scalable/CMakeLists.txt
@@ -2,6 +2,7 @@ add_distinct_clang_unittest(ClangScalableAnalysisFrameworkTests
   ASTEntityMappingTest.cpp
   BuildNamespaceTest.cpp
   EntityNameTest.cpp
+  SummaryNameTest.cpp
 
   CLANG_LIBS
   clangAnalysisScalable

--- a/clang/unittests/Analysis/Scalable/SummaryNameTest.cpp
+++ b/clang/unittests/Analysis/Scalable/SummaryNameTest.cpp
@@ -1,0 +1,53 @@
+//===- unittests/Analysis/Scalable/SummaryNameTest.cpp --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Analysis/Scalable/Model/SummaryName.h"
+#include "gtest/gtest.h"
+
+using namespace clang;
+using namespace ssaf;
+
+namespace {
+
+TEST(SummaryNameTest, Equality) {
+  const auto TestAnalysis1 = SummaryName("TestAnalysis1");
+  const auto Alternative1 = SummaryName("TestAnalysis1");
+  const auto TestAnalysis2 = SummaryName("TestAnalysis2");
+
+  EXPECT_EQ(TestAnalysis1, Alternative1); // Idempotency.
+  EXPECT_NE(Alternative1, TestAnalysis2); // Inequality.
+}
+
+TEST(SummaryNameTest, LessThan) {
+  const auto TestAnalysis1 = SummaryName("TestAnalysis1");
+  const auto Alternative1 = SummaryName("TestAnalysis1");
+
+  const auto TestAnalysis2 = SummaryName("TestAnalysis2");
+  const auto TestAnalysis3 = SummaryName("TestAnalysis3");
+
+  // Equivalency.
+  EXPECT_FALSE(TestAnalysis1 < Alternative1);
+  EXPECT_FALSE(Alternative1 < TestAnalysis1);
+
+  // Transitivity.
+  EXPECT_LT(TestAnalysis1, TestAnalysis2);
+  EXPECT_LT(TestAnalysis2, TestAnalysis3);
+  EXPECT_LT(TestAnalysis1, TestAnalysis3);
+}
+
+TEST(SummaryNameTest, Str) {
+  const auto Handle1 = SummaryName("TestAnalysis1");
+  const auto Handle2 = SummaryName("TestAnalysis1");
+  const auto Handle3 = SummaryName("TestAnalysis2");
+
+  EXPECT_EQ(Handle1.str(), "TestAnalysis1");
+  EXPECT_EQ(Handle2.str(), "TestAnalysis1");
+  EXPECT_EQ(Handle3.str(), "TestAnalysis2");
+}
+
+} // namespace


### PR DESCRIPTION
This will be the type to connect different components, such as:
 - to refer to the data of some analysis
 - to name a builder to construct an analysis
 - to name an analysis to build from a command-line flag
 - to bind an analysis result to a TU summary, which will house multiple such analysis results

I don't expect to construct one of these too often. We would need one of these when actually building an analysis, or when an analysis wants to commit its results to the TU Summary.