### PR TITLE
[CodeGen][NPM] Support generic regalloc-npm option

### DIFF
--- a/llvm/docs/CommandGuide/llc.rst
+++ b/llvm/docs/CommandGuide/llc.rst
@@ -192,6 +192,41 @@ Tuning/Configuration Options
 
   Register allocator based on 'Partitioned Boolean Quadratic Programming'.
 
+.. option:: --regalloc-npm=<pipeline>
+
+ Specify a register allocator pipeline for the new pass manager. This option
+ requires ``-enable-new-pm``. The ``<pipeline>`` is a comma-separated list of
+ register allocator passes that must match the number of allocation phases
+ expected by the target. Cannot be used together with ``--passes``.
+
+ Valid passes are:
+
+ *regallocfast*
+
+  Fast register allocator. Only valid at ``-O0``.
+
+ *greedy<filter>*
+
+  Greedy register allocator. The optional ``<filter>`` restricts allocation
+  to specific register classes. Valid filters are target-dependent:
+  ``all`` (default), ``sgpr``/``vgpr``/``wwm`` (AMDGPU), ``tile-reg`` (X86).
+
+ *default*
+
+  Use the target's default allocator for this phase.
+
+ The number of passes should match the target's allocation phases. Most targets
+ use single-phase allocation. X86 with AMX uses two phases (tile, then general).
+ AMDGPU uses three phases (SGPR, WWM, VGPR). Specifying more passes than the
+ target expects results in an error. Specifying fewer is allowed; remaining
+ phases use target defaults.
+
+ .. code-block:: none
+
+   llc -enable-new-pm -regalloc-npm=greedy input.ll
+   llc -enable-new-pm -mtriple=x86_64 -regalloc-npm='greedy<tile-reg>,default' input.ll
+   llc -enable-new-pm -mtriple=amdgcn -regalloc-npm='greedy<sgpr>,greedy<wwm>,greedy<vgpr>' input.ll
+
 .. option:: --spiller=<spiller>
 
  Specify the spiller to use for register allocators that support it.  Currently

--- a/llvm/docs/CommandGuide/llc.rst
+++ b/llvm/docs/CommandGuide/llc.rst
@@ -194,16 +194,15 @@ Tuning/Configuration Options
 
 .. option:: --regalloc-npm=<pipeline>
 
- Specify a register allocator pipeline for the new pass manager. This option
- requires ``-enable-new-pm``. The ``<pipeline>`` is a comma-separated list of
- register allocator passes that must match the number of allocation phases
- expected by the target. Cannot be used together with ``--passes``.
+ Specify a custom pipeline for register allocation phases when using the new
+ pass manager. The ``<pipeline>`` is a comma-separated list of machine function
+ passes. Cannot be used together with ``--passes``.
 
- Valid passes are:
+ Common passes:
 
  *regallocfast*
 
-  Fast register allocator. Only valid at ``-O0``.
+  Fast register allocator.
 
  *greedy<filter>*
 
@@ -213,13 +212,13 @@ Tuning/Configuration Options
 
  *default*
 
-  Use the target's default allocator for this phase.
+  Use the target's or opt level's default allocator for this phase.
 
  The number of passes should match the target's allocation phases. Most targets
  use single-phase allocation. X86 with AMX uses two phases (tile, then general).
  AMDGPU uses three phases (SGPR, WWM, VGPR). Specifying more passes than the
  target expects results in an error. Specifying fewer is allowed; remaining
- phases use target defaults.
+ phases use target or opt level defaults.
 
  .. code-block:: none
 

--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -506,24 +506,26 @@ protected:
   void addTargetRegisterAllocator(PassManagerWrapper &PMW,
                                   bool Optimized) const;
 
-  /// addMachinePasses helper to create the target-selected or overriden
+  /// addMachinePasses helper to create the target-selected or overridden
   /// regalloc pass.
   Error addRegAllocPass(PassManagerWrapper &PMW, bool Optimized) const;
-  /// Read the --regalloc-npm-pipeline option to add the next pass in line.
+
+  /// Parse the next pass from the --regalloc-npm option and add it.
   /// If MatchPassTo is specified, ensures the pass matches the expected class.
   /// Returns an error if parsing fails or validation fails.
   Error addRegAllocPassFromOpt(PassManagerWrapper &PMW,
                                StringRef MatchPassTo = StringRef{}) const;
-  /// Add the next pass in the cli option or the pass specified if no pass is
-  /// left in the option.
+
+  /// Add the next pass from the --regalloc-npm option if available,
+  /// otherwise add the pass created by PassBuilder.
   template <typename RegAllocPassBuilderT>
   Error addRegAllocPassOrOpt(PassManagerWrapper &PMW,
                              RegAllocPassBuilderT PassBuilder) const;
 
-  /// Add core register alloator passes which do the actual register assignment
-  /// and rewriting. \returns true if any passes were added.
+  /// Add core register allocator passes which do the actual register assignment
+  /// and rewriting.
   Error addRegAssignmentFast(PassManagerWrapper &PMW) const;
-  Error addRegAssignmentOptimized(PassManagerWrapper &PMWM) const;
+  Error addRegAssignmentOptimized(PassManagerWrapper &PMW) const;
 
   /// Allow the target to disable a specific pass by default.
   /// Backend can declare unwanted passes in constructor.
@@ -1213,15 +1215,15 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAllocPassFromOpt(
 /// at the current optimization level.  Different register allocators are
 /// defined as separate passes because they may require different analysis.
 ///
-/// This helper ensures that the -regalloc-npm-pipeline= option is always
-/// available, even for targets that override the default allocator.
+/// This helper ensures that the --regalloc-npm option is always available,
+/// even for targets that override the default allocator.
 template <typename Derived, typename TargetMachineT>
 Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAllocPass(
     PassManagerWrapper &PMW, bool Optimized) const {
   // At O0 (not optimized), only regallocfast is allowed
   StringRef MatchPassTo = Optimized ? StringRef{} : "RegAllocFastPass";
 
-  // Use the specified -regalloc-npm-pipeline= option if provided
+  // Use the specified --regalloc-npm option if provided
   if (auto Err = addRegAllocPassFromOpt(PMW, MatchPassTo))
     return std::move(Err);
 

--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -103,11 +103,11 @@
 #include "llvm/IRPrinter/IRPrintingPasses.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCTargetOptions.h"
+#include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/Passes/PassBuilder.h"
 #include "llvm/Target/CGPassBuilderOption.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/ObjCARC.h"
@@ -1205,9 +1205,9 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAllocPassFromOpt(
 #include "llvm/Passes/MachinePassRegistry.def"
 
   if (!Matched)
-    return make_error<StringError>(
-        Twine("unknown register allocator pass: ") + PassOpt,
-        inconvertibleErrorCode());
+    return make_error<StringError>(Twine("unknown register allocator pass: ") +
+                                       PassOpt,
+                                   inconvertibleErrorCode());
 
   return Error::success();
 }

--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -1186,15 +1186,10 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAllocPassFromOpt(
     return Error::success();
 
   bool Matched = false;
-  // Reuse the registered parser to parse the pass name.
-#define RA_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)          \
+  // Parse any machine function pass with parameters.
+#define MACHINE_FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER,    \
+                                          PARAMS)                              \
   if (PassBuilder::checkParametrizedPassName(PassOpt, NAME)) {                 \
-    if (!MatchPassTo.empty() && MatchPassTo != CLASS) {                        \
-      return make_error<StringError>(                                          \
-          Twine("expected ") + PIC->getPassNameForClassName(MatchPassTo) +     \
-              " in option --regalloc-npm",                                     \
-          inconvertibleErrorCode());                                           \
-    }                                                                          \
     auto Params = PassBuilder::parsePassParameters(PARSER, PassOpt, NAME, PB); \
     if (!Params)                                                               \
       return Params.takeError();                                               \
@@ -1204,8 +1199,7 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAllocPassFromOpt(
 #include "llvm/Passes/MachinePassRegistry.def"
 
   if (!Matched)
-    return make_error<StringError>(Twine("unknown register allocator pass: ") +
-                                       PassOpt,
+    return make_error<StringError>(Twine("unknown machine pass: ") + PassOpt,
                                    inconvertibleErrorCode());
 
   return Error::success();

--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -511,10 +511,8 @@ protected:
   Error addRegAllocPass(PassManagerWrapper &PMW, bool Optimized) const;
 
   /// Parse the next pass from the --regalloc-npm option and add it.
-  /// If MatchPassTo is specified, ensures the pass matches the expected class.
-  /// Returns an error if parsing fails or validation fails.
-  Error addRegAllocPassFromOpt(PassManagerWrapper &PMW,
-                               StringRef MatchPassTo = StringRef{}) const;
+  /// Returns an error if parsing fails.
+  Error addRegAllocPassFromOpt(PassManagerWrapper &PMW) const;
 
   /// Add the next pass from the --regalloc-npm option if available,
   /// otherwise add the pass created by PassBuilder.
@@ -1174,7 +1172,7 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAllocPassOrOpt(
 
 template <typename Derived, typename TargetMachineT>
 Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAllocPassFromOpt(
-    PassManagerWrapper &PMW, StringRef MatchPassTo) const {
+    PassManagerWrapper &PMW) const {
   StringRef Pipeline = Opt.RegAllocPipeline;
   if (Pipeline.empty())
     return Error::success();
@@ -1214,11 +1212,8 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAllocPassFromOpt(
 template <typename Derived, typename TargetMachineT>
 Error CodeGenPassBuilder<Derived, TargetMachineT>::addRegAllocPass(
     PassManagerWrapper &PMW, bool Optimized) const {
-  // At O0 (not optimized), only regallocfast is allowed
-  StringRef MatchPassTo = Optimized ? StringRef{} : "RegAllocFastPass";
-
   // Use the specified --regalloc-npm option if provided
-  if (auto Err = addRegAllocPassFromOpt(PMW, MatchPassTo))
+  if (auto Err = addRegAllocPassFromOpt(PMW))
     return std::move(Err);
 
   // If no custom pipeline was specified, use the target's default allocator

--- a/llvm/include/llvm/Passes/MachinePassRegistry.def
+++ b/llvm/include/llvm/Passes/MachinePassRegistry.def
@@ -195,8 +195,8 @@ MACHINE_FUNCTION_PASS_WITH_PARAMS(
 MACHINE_FUNCTION_PASS_WITH_PARAMS(
     "branch-folder", "BranchFolderPass",
     [](bool EnableTailMerge) { return BranchFolderPass(EnableTailMerge); },
-    [](StringRef Params) {
-      return parseSinglePassOption(Params, "enable-tail-merge",
+    [](StringRef Params, const PassBuilder &) {
+      return PassBuilder::parseSinglePassOption(Params, "enable-tail-merge",
                                    "BranchFolderPass");
     },
     "enable-tail-merge")
@@ -206,8 +206,8 @@ MACHINE_FUNCTION_PASS_WITH_PARAMS(
     [](bool ShouldEmitDebugEntryValues) {
       return LiveDebugValuesPass(ShouldEmitDebugEntryValues);
     },
-    [](StringRef Params) {
-      return parseSinglePassOption(Params, "emit-debug-entry-values",
+    [](StringRef Params, const PassBuilder &) {
+      return PassBuilder::parseSinglePassOption(Params, "emit-debug-entry-values",
                                    "LiveDebugValuesPass");
     },
     "emit-debug-entry-values")
@@ -220,27 +220,36 @@ MACHINE_FUNCTION_PASS_WITH_PARAMS(
     parseMachineSinkingPassOptions, "enable-sink-fold")
 
 MACHINE_FUNCTION_PASS_WITH_PARAMS(
-    "regallocfast", "RegAllocFastPass",
-    [](RegAllocFastPass::Options Opts) { return RegAllocFastPass(Opts); },
-    [PB = this](StringRef Params) {
-      return parseRegAllocFastPassOptions(*PB, Params);
-    },
-    "filter=reg-filter;no-clear-vregs")
-
-// 'all' is the default filter.
-MACHINE_FUNCTION_PASS_WITH_PARAMS(
-    "greedy", "RAGreedyPass",
-    [](RAGreedyPass::Options Opts) { return RAGreedyPass(Opts); },
-    [PB = this](StringRef Params) {
-      return parseRegAllocGreedyFilterFunc(*PB, Params);
-    }, "reg-filter"
-)
-
-MACHINE_FUNCTION_PASS_WITH_PARAMS(
     "virt-reg-rewriter", "VirtRegRewriterPass",
     [](bool ClearVirtRegs) { return VirtRegRewriterPass(ClearVirtRegs); },
     parseVirtRegRewriterPassOptions, "no-clear-vregs;clear-vregs")
 
+#ifndef RA_PASS_WITH_PARAMS
+// Define MachineFunction passes that are register allocators.
+// This is to differentiate them from other MachineFunction passes
+// to be used in the --regalloc-npm option.
+#define RA_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)          \
+  MACHINE_FUNCTION_PASS_WITH_PARAMS(NAME, CLASS, CREATE_PASS, PARSER, PARAMS)
+#endif
+
+RA_PASS_WITH_PARAMS(
+    "regallocfast", "RegAllocFastPass",
+    [](RegAllocFastPass::Options Opts) { return RegAllocFastPass(Opts); },
+    [](StringRef Params, const PassBuilder &PB) {
+      return parseRegAllocFastPassOptions(PB, Params);
+    },
+    "filter=reg-filter;no-clear-vregs")
+
+// 'all' is the default filter.
+RA_PASS_WITH_PARAMS(
+    "greedy", "RAGreedyPass",
+    [](RAGreedyPass::Options Opts) { return RAGreedyPass(Opts); },
+    [](StringRef Params, const PassBuilder &PB) {
+      return parseRegAllocGreedyFilterFunc(PB, Params);
+    },
+    "reg-filter")
+
+#undef RA_PASS_WITH_PARAMS
 #undef MACHINE_FUNCTION_PASS_WITH_PARAMS
 
 // After a pass is converted to new pass manager, its entry should be moved from

--- a/llvm/include/llvm/Passes/PassBuilder.h
+++ b/llvm/include/llvm/Passes/PassBuilder.h
@@ -1005,18 +1005,18 @@ public:
 /// Common option used by multiple tools to print pipeline passes
 LLVM_ABI extern cl::opt<bool> PrintPipelinePasses;
 
-Expected<RAGreedyPass::Options>
+LLVM_ABI Expected<RAGreedyPass::Options>
 parseRegAllocGreedyFilterFunc(const PassBuilder &PB, StringRef Params);
 
-Expected<RegAllocFastPass::Options>
+LLVM_ABI Expected<RegAllocFastPass::Options>
 parseRegAllocFastPassOptions(const PassBuilder &PB, StringRef Params);
 
-Expected<bool> parseMachineSinkingPassOptions(StringRef Params,
-                                              const PassBuilder &);
-Expected<bool> parseMachineBlockPlacementPassOptions(StringRef Params,
-                                                     const PassBuilder &);
-Expected<bool> parseVirtRegRewriterPassOptions(StringRef Params,
-                                               const PassBuilder &);
+LLVM_ABI Expected<bool> parseMachineSinkingPassOptions(StringRef Params,
+                                                       const PassBuilder &);
+LLVM_ABI Expected<bool>
+parseMachineBlockPlacementPassOptions(StringRef Params, const PassBuilder &);
+LLVM_ABI Expected<bool> parseVirtRegRewriterPassOptions(StringRef Params,
+                                                        const PassBuilder &);
 }
 
 #endif

--- a/llvm/include/llvm/Passes/PassBuilder.h
+++ b/llvm/include/llvm/Passes/PassBuilder.h
@@ -18,6 +18,7 @@
 #include "llvm/Analysis/CGSCCPassManager.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/CodeGen/RegAllocCommon.h"
+#include "llvm/CodeGen/RegAllocGreedyPass.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Passes/OptimizationLevel.h"
 #include "llvm/Support/Compiler.h"
@@ -409,7 +410,7 @@ public:
 
   /// Parse RegAllocFilterName to get RegAllocFilterFunc.
   LLVM_ABI std::optional<RegAllocFilterFunc>
-  parseRegAllocFilter(StringRef RegAllocFilterName);
+  parseRegAllocFilter(StringRef RegAllocFilterName) const;
 
   /// Print pass names.
   LLVM_ABI void printPassNames(raw_ostream &OS);
@@ -708,11 +709,13 @@ public:
   /// parameter list in a form of a custom parameters type, all wrapped into
   /// Expected<> template class.
   ///
-  template <typename ParametersParseCallableT>
+  template <typename ParametersParseCallableT, typename... ExtraArgs>
   static auto parsePassParameters(ParametersParseCallableT &&Parser,
-                                  StringRef Name, StringRef PassName)
-      -> decltype(Parser(StringRef{})) {
-    using ParametersT = typename decltype(Parser(StringRef{}))::value_type;
+                                  StringRef Name, StringRef PassName,
+                                  ExtraArgs &&...Args)
+      -> decltype(Parser(StringRef{}, std::forward<ExtraArgs>(Args)...)) {
+    using ParametersT = typename decltype(Parser(
+        StringRef{}, std::forward<ExtraArgs>(Args)...))::value_type;
 
     StringRef Params = Name;
     if (!Params.consume_front(PassName)) {
@@ -724,7 +727,8 @@ public:
       llvm_unreachable("invalid format for parametrized pass name");
     }
 
-    Expected<ParametersT> Result = Parser(Params);
+    Expected<ParametersT> Result =
+        Parser(Params, std::forward<ExtraArgs>(Args)...);
     assert((Result || Result.template errorIsA<StringError>()) &&
            "Pass parameter parser can only return StringErrors.");
     return Result;
@@ -1000,6 +1004,19 @@ public:
 
 /// Common option used by multiple tools to print pipeline passes
 LLVM_ABI extern cl::opt<bool> PrintPipelinePasses;
+
+Expected<RAGreedyPass::Options>
+parseRegAllocGreedyFilterFunc(const PassBuilder &PB, StringRef Params);
+
+Expected<RegAllocFastPass::Options>
+parseRegAllocFastPassOptions(const PassBuilder &PB, StringRef Params);
+
+Expected<bool> parseMachineSinkingPassOptions(StringRef Params,
+                                              const PassBuilder &);
+Expected<bool> parseMachineBlockPlacementPassOptions(StringRef Params,
+                                                     const PassBuilder &);
+Expected<bool> parseVirtRegRewriterPassOptions(StringRef Params,
+                                               const PassBuilder &);
 }
 
 #endif

--- a/llvm/include/llvm/Passes/TargetPassRegistry.inc
+++ b/llvm/include/llvm/Passes/TargetPassRegistry.inc
@@ -83,7 +83,7 @@ if (PIC) {
 
 #define ADD_PASS_WITH_PARAMS(NAME, CREATE_PASS, PARSER)                        \
   if (PassBuilder::checkParametrizedPassName(Name, NAME)) {                    \
-    auto Params = PassBuilder::parsePassParameters(PARSER, Name, NAME);        \
+    auto Params = PassBuilder::parsePassParameters(PARSER, Name, NAME, PB);    \
     if (!Params) {                                                             \
       errs() << NAME ": " << toString(Params.takeError()) << '\n';             \
       return false;                                                            \

--- a/llvm/include/llvm/Target/CGPassBuilderOption.h
+++ b/llvm/include/llvm/Target/CGPassBuilderOption.h
@@ -80,7 +80,7 @@ struct CGPassBuilderOption {
   bool RequiresCodeGenSCCOrder = false;
 
   RunOutliner EnableMachineOutliner = RunOutliner::TargetDefault;
-  RegAllocType RegAlloc = RegAllocType::Unset;
+  mutable StringRef RegAllocPipeline;
   std::optional<GlobalISelAbortMode> EnableGlobalISelAbort;
   std::string FSProfileFile;
   std::string FSRemappingFile;

--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -487,8 +487,9 @@ public:
 
   virtual Error buildCodeGenPipeline(ModulePassManager &, raw_pwrite_stream &,
                                      raw_pwrite_stream *, CodeGenFileType,
-                                     const CGPassBuilderOption &,
-                                     PassInstrumentationCallbacks *) {
+                                     const CGPassBuilderOption &, MCContext &,
+                                     PassInstrumentationCallbacks *,
+                                     PassBuilder &) {
     return make_error<StringError>("buildCodeGenPipeline is not overridden",
                                    inconvertibleErrorCode());
   }

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -1622,20 +1622,6 @@ Expected<CodeGenOptLevel> parseExpandIRInstsOptions(StringRef Param) {
   return *Level;
 }
 
-Expected<RAGreedyPass::Options>
-parseRegAllocGreedyFilterFunc(PassBuilder &PB, StringRef Params) {
-  if (Params.empty() || Params == "all")
-    return RAGreedyPass::Options();
-
-  std::optional<RegAllocFilterFunc> Filter = PB.parseRegAllocFilter(Params);
-  if (Filter)
-    return RAGreedyPass::Options{*Filter, Params};
-
-  return make_error<StringError>(
-      formatv("invalid regallocgreedy register filter '{}'", Params).str(),
-      inconvertibleErrorCode());
-}
-
 Expected<bool> llvm::parseMachineSinkingPassOptions(StringRef Params,
                                               const PassBuilder &) {
   return PassBuilder::parseSinglePassOption(Params, "enable-sink-fold",

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -1668,8 +1668,7 @@ llvm::parseRegAllocFastPassOptions(const PassBuilder &PB, StringRef Params) {
           PB.parseRegAllocFilter(ParamName);
       if (!Filter) {
         return make_error<StringError>(
-            formatv("invalid regallocfast register filter '{0}' ", ParamName)
-                .str(),
+            formatv("invalid register filter '{0}'", ParamName).str(),
             inconvertibleErrorCode());
       }
       Opts.Filter = *Filter;
@@ -1683,7 +1682,7 @@ llvm::parseRegAllocFastPassOptions(const PassBuilder &PB, StringRef Params) {
     }
 
     return make_error<StringError>(
-        formatv("invalid regallocfast pass parameter '{0}' ", ParamName).str(),
+        formatv("invalid pass parameter '{0}'", ParamName).str(),
         inconvertibleErrorCode());
   }
   return Opts;
@@ -1699,7 +1698,7 @@ llvm::parseRegAllocGreedyFilterFunc(const PassBuilder &PB, StringRef Params) {
     return RAGreedyPass::Options{*Filter, Params};
 
   return make_error<StringError>(
-      formatv("invalid regallocgreedy register filter '{0}' ", Params).str(),
+      formatv("invalid register filter '{0}'", Params).str(),
       inconvertibleErrorCode());
 }
 

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -1623,7 +1623,7 @@ Expected<CodeGenOptLevel> parseExpandIRInstsOptions(StringRef Param) {
 }
 
 Expected<bool> llvm::parseMachineSinkingPassOptions(StringRef Params,
-                                              const PassBuilder &) {
+                                                    const PassBuilder &) {
   return PassBuilder::parseSinglePassOption(Params, "enable-sink-fold",
                                             "MachineSinkingPass");
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -141,8 +141,7 @@ class AMDGPUCodeGenPassBuilder
 public:
   AMDGPUCodeGenPassBuilder(GCNTargetMachine &TM,
                            const CGPassBuilderOption &Opts,
-                           PassInstrumentationCallbacks *PIC,
-                           PassBuilder &PB);
+                           PassInstrumentationCallbacks *PIC, PassBuilder &PB);
 
   void addIRPasses(PassManagerWrapper &PMW) const;
   void addCodeGenPrepare(PassManagerWrapper &PMW) const;
@@ -2400,7 +2399,7 @@ Error AMDGPUCodeGenPassBuilder::addRegAssignmentOptimized(
 
   addMachineFunctionPass(GCNPreRALongBranchRegPass(), PMW);
 
-addRegAllocPassOrOpt(
+  addRegAllocPassOrOpt(
       PMW, []() { return RAGreedyPass({onlyAllocateSGPRs, "sgpr"}); });
 
   // Commit allocated register changes. This is mostly necessary because too

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.h
@@ -100,8 +100,9 @@ public:
   Error buildCodeGenPipeline(ModulePassManager &MPM, raw_pwrite_stream &Out,
                              raw_pwrite_stream *DwoOut,
                              CodeGenFileType FileType,
-                             const CGPassBuilderOption &Opts,
-                             PassInstrumentationCallbacks *PIC) override;
+                             const CGPassBuilderOption &Opts, MCContext &Ctx,
+                             PassInstrumentationCallbacks *PIC,
+                             PassBuilder &) override;
 
   void registerMachineRegisterInfoCallback(MachineFunction &MF) const override;
 

--- a/llvm/lib/Target/AMDGPU/R600TargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/R600TargetMachine.cpp
@@ -55,7 +55,7 @@ class R600CodeGenPassBuilder
     : public CodeGenPassBuilder<R600CodeGenPassBuilder, R600TargetMachine> {
 public:
   R600CodeGenPassBuilder(R600TargetMachine &TM, const CGPassBuilderOption &Opts,
-                         PassInstrumentationCallbacks *PIC,  PassBuilder &PB);
+                         PassInstrumentationCallbacks *PIC, PassBuilder &PB);
 
   void addPreISel(PassManagerWrapper &PMW) const;
   void addAsmPrinter(PassManagerWrapper &PMW, CreateMCStreamer) const;

--- a/llvm/lib/Target/AMDGPU/R600TargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/R600TargetMachine.cpp
@@ -55,7 +55,7 @@ class R600CodeGenPassBuilder
     : public CodeGenPassBuilder<R600CodeGenPassBuilder, R600TargetMachine> {
 public:
   R600CodeGenPassBuilder(R600TargetMachine &TM, const CGPassBuilderOption &Opts,
-                         PassInstrumentationCallbacks *PIC);
+                         PassInstrumentationCallbacks *PIC,  PassBuilder &PB);
 
   void addPreISel(PassManagerWrapper &PMW) const;
   void addAsmPrinter(PassManagerWrapper &PMW, CreateMCStreamer) const;
@@ -164,10 +164,11 @@ TargetPassConfig *R600TargetMachine::createPassConfig(PassManagerBase &PM) {
 
 Error R600TargetMachine::buildCodeGenPipeline(
     ModulePassManager &MPM, raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
-    CodeGenFileType FileType, const CGPassBuilderOption &Opts,
-    PassInstrumentationCallbacks *PIC) {
-  R600CodeGenPassBuilder CGPB(*this, Opts, PIC);
-  return CGPB.buildPipeline(MPM, Out, DwoOut, FileType);
+    CodeGenFileType FileType, const CGPassBuilderOption &Opts, MCContext &Ctx,
+    PassInstrumentationCallbacks *PIC, PassBuilder &PB) {
+  R600CodeGenPassBuilder CGPB(*this, Opts, PIC, PB);
+  return CGPB.buildPipeline(MPM, Out, DwoOut, FileType, Ctx);
+}
 }
 
 MachineFunctionInfo *R600TargetMachine::createMachineFunctionInfo(
@@ -183,8 +184,8 @@ MachineFunctionInfo *R600TargetMachine::createMachineFunctionInfo(
 
 R600CodeGenPassBuilder::R600CodeGenPassBuilder(
     R600TargetMachine &TM, const CGPassBuilderOption &Opts,
-    PassInstrumentationCallbacks *PIC)
-    : CodeGenPassBuilder(TM, Opts, PIC) {
+    PassInstrumentationCallbacks *PIC, PassBuilder &PB)
+    : CodeGenPassBuilder(TM, Opts, PIC, PB) {
   Opt.RequiresCodeGenSCCOrder = true;
 }
 

--- a/llvm/lib/Target/AMDGPU/R600TargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/R600TargetMachine.cpp
@@ -169,7 +169,6 @@ Error R600TargetMachine::buildCodeGenPipeline(
   R600CodeGenPassBuilder CGPB(*this, Opts, PIC, PB);
   return CGPB.buildPipeline(MPM, Out, DwoOut, FileType, Ctx);
 }
-}
 
 MachineFunctionInfo *R600TargetMachine::createMachineFunctionInfo(
     BumpPtrAllocator &Allocator, const Function &F,

--- a/llvm/lib/Target/AMDGPU/R600TargetMachine.h
+++ b/llvm/lib/Target/AMDGPU/R600TargetMachine.h
@@ -41,8 +41,9 @@ public:
   Error buildCodeGenPipeline(ModulePassManager &MPM, raw_pwrite_stream &Out,
                              raw_pwrite_stream *DwoOut,
                              CodeGenFileType FileType,
-                             const CGPassBuilderOption &Opt,
-                             PassInstrumentationCallbacks *PIC) override;
+                             const CGPassBuilderOption &Opt, MCContext &Ctx,
+                             PassInstrumentationCallbacks *PIC,
+                             PassBuilder &) override;
 
   const TargetSubtargetInfo *getSubtargetImpl(const Function &) const override;
 

--- a/llvm/lib/Target/BPF/BPFTargetMachine.cpp
+++ b/llvm/lib/Target/BPF/BPFTargetMachine.cpp
@@ -114,7 +114,8 @@ TargetPassConfig *BPFTargetMachine::createPassConfig(PassManagerBase &PM) {
   return new BPFPassConfig(*this, PM);
 }
 
-static Expected<bool> parseBPFPreserveStaticOffsetOptions(StringRef Params) {
+static Expected<bool> parseBPFPreserveStaticOffsetOptions(StringRef Params,
+                                                          const PassBuilder &) {
   return PassBuilder::parseSinglePassOption(Params, "allow-partial",
                                             "BPFPreserveStaticOffsetPass");
 }

--- a/llvm/lib/Target/X86/CMakeLists.txt
+++ b/llvm/lib/Target/X86/CMakeLists.txt
@@ -106,6 +106,7 @@ add_llvm_target(X86CodeGen ${sources}
   Instrumentation
   MC
   ObjCARC
+  Passes
   ProfileData
   Scalar
   SelectionDAG

--- a/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
@@ -279,7 +279,7 @@ void X86TargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
 #define GET_PASS_REGISTRY "X86PassRegistry.def"
 #include "llvm/Passes/TargetPassRegistry.inc"
 
-PB.registerRegClassFilterParsingCallback(
+  PB.registerRegClassFilterParsingCallback(
       [](StringRef FilterName) -> RegAllocFilterFunc {
         if (FilterName == "tile-reg") {
           return onlyAllocateTileRegisters;

--- a/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
@@ -61,14 +61,15 @@ public:
 };
 
 Error X86CodeGenPassBuilder::addRegAssignmentOptimized(
-  PassManagerWrapper &PMW) const {
-if (EnableTileRAPass) {
-  addRegAllocPassOrOpt(PMW, []() {
-    return RAGreedyPass({onlyAllocateTileRegisters, "tile-reg"});
-  });
-  // TODO: addMachineFunctionPass(X86TileConfigPass(), PMW);
-}
-return Base::addRegAssignmentOptimized(PMW);
+    PassManagerWrapper &PMW) const {
+  if (EnableTileRAPass) {
+    if (auto Err = addRegAllocPassOrOpt(PMW, []() {
+          return RAGreedyPass({onlyAllocateTileRegisters, "tile-reg"});
+        }))
+      return Err;
+    // TODO: addMachineFunctionPass(X86TileConfigPass(), PMW);
+  }
+  return Base::addRegAssignmentOptimized(PMW);
 }
 
 void X86CodeGenPassBuilder::addIRPasses(PassManagerWrapper &PMW) const {

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -643,9 +643,9 @@ std::unique_ptr<CSEConfigBase> X86PassConfig::getCSEConfig() const {
   return getStandardCSEConfigForOpt(TM->getOptLevel());
 }
 
-static bool onlyAllocateTileRegisters(const TargetRegisterInfo &TRI,
-                                      const MachineRegisterInfo &MRI,
-                                      const Register Reg) {
+bool llvm::onlyAllocateTileRegisters(const TargetRegisterInfo &TRI,
+                                     const MachineRegisterInfo &MRI,
+                                     const Register Reg) {
   const TargetRegisterClass *RC = MRI.getRegClass(Reg);
   return static_cast<const X86RegisterInfo &>(TRI).isTileRegisterClass(RC);
 }

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -58,10 +58,10 @@ cl::opt<bool>
                                  cl::desc("Enable the machine combiner pass"),
                                  cl::init(true), cl::Hidden);
 
-static cl::opt<bool>
-    EnableTileRAPass("x86-tile-ra",
-                     cl::desc("Enable the tile register allocation pass"),
-                     cl::init(true), cl::Hidden);
+cl::opt<bool>
+    llvm::EnableTileRAPass("x86-tile-ra",
+                           cl::desc("Enable the tile register allocation pass"),
+                           cl::init(true), cl::Hidden);
 
 extern "C" LLVM_C_ABI void LLVMInitializeX86Target() {
   // Register the target.

--- a/llvm/lib/Target/X86/X86TargetMachine.h
+++ b/llvm/lib/Target/X86/X86TargetMachine.h
@@ -22,8 +22,14 @@
 
 namespace llvm {
 
+extern cl::opt<bool> EnableTileRAPass;
+
 class StringRef;
 class TargetTransformInfo;
+
+bool onlyAllocateTileRegisters(const TargetRegisterInfo &TRI,
+                               const MachineRegisterInfo &MRI,
+                               const Register Reg);
 
 class X86TargetMachine final : public CodeGenTargetMachineImpl {
   std::unique_ptr<TargetLoweringObjectFile> TLOF;
@@ -73,8 +79,9 @@ public:
 
   Error buildCodeGenPipeline(ModulePassManager &, raw_pwrite_stream &,
                              raw_pwrite_stream *, CodeGenFileType,
-                             const CGPassBuilderOption &,
-                             PassInstrumentationCallbacks *) override;
+                             const CGPassBuilderOption &, MCContext &,
+                             PassInstrumentationCallbacks *,
+                             PassBuilder &) override;
 
   bool isJIT() const { return IsJIT; }
 

--- a/llvm/test/CodeGen/X86/llc-pipeline-npm.ll
+++ b/llvm/test/CodeGen/X86/llc-pipeline-npm.ll
@@ -136,6 +136,7 @@
 ; O2-NEXT: register-coalescer
 ; O2-NEXT: rename-independent-subregs
 ; O2-NEXT: machine-scheduler
+; O2-NEXT: greedy<tile-reg>
 ; O2-NEXT: greedy<all>
 ; O2-NEXT: virt-reg-rewriter
 ; O2-NEXT: stack-slot-coloring
@@ -309,6 +310,7 @@
 ; O3-WINDOWS-NEXT: register-coalescer
 ; O3-WINDOWS-NEXT: rename-independent-subregs
 ; O3-WINDOWS-NEXT: machine-scheduler
+; O3-WINDOWS-NEXT: greedy<tile-reg>
 ; O3-WINDOWS-NEXT: greedy<all>
 ; O3-WINDOWS-NEXT: virt-reg-rewriter
 ; O3-WINDOWS-NEXT: stack-slot-coloring

--- a/llvm/test/tools/llc/new-pm/regalloc-amdgpu.mir
+++ b/llvm/test/tools/llc/new-pm/regalloc-amdgpu.mir
@@ -2,11 +2,16 @@
 # RUN: llc -mtriple=amdgcn --passes='regallocfast<filter=sgpr>,regallocfast<filter=wwm>,regallocfast<filter=vgpr>' --print-pipeline-passes --filetype=null %s | FileCheck %s --check-prefix=PASS
 # RUN: not llc -mtriple=amdgcn --passes='regallocfast<filter=bad-filter>' --print-pipeline-passes --filetype=null %s 2>&1 | FileCheck %s --check-prefix=BAD-FILTER
 
+# RUN: llc -mtriple=amdgcn -enable-new-pm --regalloc-npm="regallocfast<filter=sgpr;no-clear-vregs>,greedy<wwm>" --print-pipeline-passes --filetype=null %s | FileCheck %s --check-prefix=RA-NPM
+
 # PASS: regallocfast<filter=sgpr>
 # PASS: regallocfast<filter=wwm>
 # PASS: regallocfast<filter=vgpr>
 # BAD-FILTER: invalid regallocfast register filter 'bad-filter'
 
+# RA-NPM: regallocfast<filter=sgpr;no-clear-vregs>
+# RA-NPM: greedy<wwm>
+# RA-NPM: greedy<vgpr>
 ---
 name: f
 ...

--- a/llvm/test/tools/llc/new-pm/regalloc-amdgpu.mir
+++ b/llvm/test/tools/llc/new-pm/regalloc-amdgpu.mir
@@ -7,7 +7,7 @@
 # PASS: regallocfast<filter=sgpr>
 # PASS: regallocfast<filter=wwm>
 # PASS: regallocfast<filter=vgpr>
-# BAD-FILTER: invalid regallocfast register filter 'bad-filter'
+# BAD-FILTER: invalid register filter 'bad-filter'
 
 # RA-NPM: regallocfast<filter=sgpr;no-clear-vregs>
 # RA-NPM: greedy<wwm>

--- a/llvm/test/tools/llc/new-pm/x86_64-regalloc-pipeline.mir
+++ b/llvm/test/tools/llc/new-pm/x86_64-regalloc-pipeline.mir
@@ -1,28 +1,28 @@
 # REQUIRES: x86-registered-target
 # Test default pipeline
-# RUN: llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -print-pipeline-passes %s -o - 2>&1 | FileCheck %s
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -print-pipeline-passes -filetype=null %s 2>&1 | FileCheck %s
 
 # Test the -regalloc-npm option
-# RUN: llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm=regallocfast -print-pipeline-passes %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-FAST
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm=regallocfast -print-pipeline-passes -filetype=null %s 2>&1 | FileCheck %s --check-prefix=CHECK-FAST
 
-# RUN: llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm='greedy<tile-reg>' -print-pipeline-passes %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-GREEDY-FILTER
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm='greedy<tile-reg>' -print-pipeline-passes -filetype=null %s 2>&1 | FileCheck %s --check-prefix=CHECK-GREEDY-FILTER
 
 # This test attempts to bypass the tile register filter pass, inserts the default greedy<all> pass and then 
 # attempts to insert an extraneous pass.
 # RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm='default,default,basic' 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
-# RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm='machine-cp' -print-pipeline-passes %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-INVALID
-# RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -passes='machine-sink' -regalloc-npm='greedy' -print-pipeline-passes %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-BOTH-INVALID
+# RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm='machine-cp' -print-pipeline-passes -filetype=null %s 2>&1 | FileCheck %s --check-prefix=CHECK-INVALID
+# RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -passes='machine-sink' -regalloc-npm='greedy' -print-pipeline-passes -filetype=null %s 2>&1 | FileCheck %s --check-prefix=CHECK-BOTH-INVALID
 
-# RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O0 -regalloc-npm='greedy' -print-pipeline-passes %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ONLY-FAST
+# RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O0 -regalloc-npm='greedy' -print-pipeline-passes -filetype=null %s 2>&1 | FileCheck %s --check-prefix=CHECK-ONLY-FAST
 
 # CHECK: greedy<tile-reg>
 # CHECK: greedy<all>
 
-# CHECK-FAST: regallocfast
+# CHECK-FAST: regallocfast,greedy<tile-reg>,greedy<all>
 # CHECK-GREEDY: greedy<all>
 # CHECK-GREEDY-FILTER: greedy<tile-reg>
-# CHECK-ERROR: extra passes in regalloc pipeline: basic
-# CHECK-INVALID: unknown register allocator pass: machine-cp
-# CHECK-BOTH-INVALID: --passes and --regalloc-npm cannot be used together
-# CHECK-ONLY-FAST: expected regallocfast in option --regalloc-npm
+# CHECK-ERROR: {{.*}}: error: extra passes in regalloc pipeline: basic
+# CHECK-INVALID: {{.*}}: error: unknown register allocator pass: machine-cp
+# CHECK-BOTH-INVALID: {{.*}}: error: --passes and --regalloc-npm cannot be used together
+# CHECK-ONLY-FAST: {{.*}}: error: expected regallocfast in option --regalloc-npm

--- a/llvm/test/tools/llc/new-pm/x86_64-regalloc-pipeline.mir
+++ b/llvm/test/tools/llc/new-pm/x86_64-regalloc-pipeline.mir
@@ -1,6 +1,28 @@
 # REQUIRES: x86-registered-target
-# RUN: llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm=fast -print-pipeline-passes %s -o - 2>&1 | FileCheck %s
-# RUN: llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm=greedy -print-pipeline-passes %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-GREEDY
+# Test default pipeline
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -print-pipeline-passes %s -o - 2>&1 | FileCheck %s
 
-# CHECK: regallocfast
+# Test the -regalloc-npm option
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm=regallocfast -print-pipeline-passes %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-FAST
+
+# RUN: llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm='greedy<tile-reg>' -print-pipeline-passes %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-GREEDY-FILTER
+
+# This test attempts to bypass the tile register filter pass, inserts the default greedy<all> pass and then 
+# attempts to insert an extraneous pass.
+# RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm='default,default,basic' 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+
+# RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm='machine-cp' -print-pipeline-passes %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-INVALID
+# RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -passes='machine-sink' -regalloc-npm='greedy' -print-pipeline-passes %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-BOTH-INVALID
+
+# RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O0 -regalloc-npm='greedy' -print-pipeline-passes %s -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ONLY-FAST
+
+# CHECK: greedy<tile-reg>
+# CHECK: greedy<all>
+
+# CHECK-FAST: regallocfast
 # CHECK-GREEDY: greedy<all>
+# CHECK-GREEDY-FILTER: greedy<tile-reg>
+# CHECK-ERROR: extra passes in regalloc pipeline: basic
+# CHECK-INVALID: unknown register allocator pass: machine-cp
+# CHECK-BOTH-INVALID: --passes and --regalloc-npm cannot be used together
+# CHECK-ONLY-FAST: expected regallocfast in option --regalloc-npm

--- a/llvm/test/tools/llc/new-pm/x86_64-regalloc-pipeline.mir
+++ b/llvm/test/tools/llc/new-pm/x86_64-regalloc-pipeline.mir
@@ -14,8 +14,6 @@
 # RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O3 -regalloc-npm='machine-cp' -print-pipeline-passes -filetype=null %s 2>&1 | FileCheck %s --check-prefix=CHECK-INVALID
 # RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -passes='machine-sink' -regalloc-npm='greedy' -print-pipeline-passes -filetype=null %s 2>&1 | FileCheck %s --check-prefix=CHECK-BOTH-INVALID
 
-# RUN: not llc -mtriple=x86_64-unknown-linux-gnu -enable-new-pm -O0 -regalloc-npm='greedy' -print-pipeline-passes -filetype=null %s 2>&1 | FileCheck %s --check-prefix=CHECK-ONLY-FAST
-
 # CHECK: greedy<tile-reg>
 # CHECK: greedy<all>
 
@@ -23,6 +21,5 @@
 # CHECK-GREEDY: greedy<all>
 # CHECK-GREEDY-FILTER: greedy<tile-reg>
 # CHECK-ERROR: {{.*}}: error: extra passes in regalloc pipeline: basic
-# CHECK-INVALID: {{.*}}: error: unknown register allocator pass: machine-cp
+# CHECK-INVALID: {{.*}}: error: unknown machine pass: machine-cp
 # CHECK-BOTH-INVALID: {{.*}}: error: --passes and --regalloc-npm cannot be used together
-# CHECK-ONLY-FAST: {{.*}}: error: expected regallocfast in option --regalloc-npm

--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -94,6 +94,7 @@ int llvm::compileModuleWithNewPM(
     std::unique_ptr<ToolOutputFile> DwoOut, LLVMContext &Context,
     const TargetLibraryInfoImpl &TLII, VerifierKind VK, StringRef PassPipeline,
     CodeGenFileType FileType) {
+  ExitOnErr.setBanner(std::string(Arg0) + ": error: ");
 
   if (!PassPipeline.empty() && TargetPassConfig::hasLimitedCodeGenPipeline()) {
     WithColor::error(errs(), Arg0)

--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -179,9 +179,9 @@ int llvm::compileModuleWithNewPM(
     MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
 
   } else {
-    ExitOnErr(
-        Target->buildCodeGenPipeline(MPM, *OS, DwoOut ? &DwoOut->os() : nullptr,
-                                     FileType, Opt, MMI.getContext(), &PIC, PB));
+    ExitOnErr(Target->buildCodeGenPipeline(
+        MPM, *OS, DwoOut ? &DwoOut->os() : nullptr, FileType, Opt,
+        MMI.getContext(), &PIC, PB));
   }
 
   // If user only wants to print the pipeline, print it before parsing the MIR.


### PR DESCRIPTION
This work is a continuation of [PR#135149](https://github.com/llvm/llvm-project/pull/135149), co-authored by @optimisan.

The PR provides the `--regalloc-npm` option as an override to register allocation passes added in the New PM _CodeGen_ pipeline.

`--regalloc-npm` accepts a list of passes, reusing the normal **--passes** syntax, as opposed to [#129035](https://github.com/llvm/llvm-project/pull/129035)

Example: `llc --regalloc-npm='default,default,regallocfast<filter=vgpr>' -O3 -mtriple=amdgcn`
 will only replace the vgpr greedy (which is default) with RAFast.

Notes:
1. Number of passes in this options should match the number of RA passes the pipeline adds by default.
2. The special pass value "default" is to add the pipeline's default RAPass choice.
3. Only register allocator passes can be added here (introduced new macro RA_PASS_WITH_PARAMS for this)
4. If the option contains less passes, the rest will be decided according to the opt level.
5. It is an error to provide more passes than what the pipeline adds itself!

This patch also adds X86's tile-register filter support with the filter name tile-reg.