### PR TITLE
[lldb-dap] Migrate restart request to structured types

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -87,7 +87,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         resp = self.attach(targetId=99999, expectFailure=True)
         self.assertFalse(resp["success"])
         self.assertIn(
-            "Both debuggerId and targetId must be specified together",
+            "Both 'debuggerId' and 'targetId' must be specified together",
             resp["body"]["error"]["format"],
         )
 

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -57,7 +57,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         )
         self.assertFalse(response["success"])
         self.assertTrue(self.get_dict_value(response, ["body", "error", "showUser"]))
-        self.assertEqual(
+        self.assertIn(
             "'launchCommands' and non-internal 'console' are mutually exclusive",
             self.get_dict_value(response, ["body", "error", "format"]),
         )

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -35,32 +35,10 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
   std::optional<int> debugger_id = args.debuggerId;
   std::optional<lldb::user_id_t> target_id = args.targetId;
 
-  // Validate that both debugger_id and target_id are provided together.
-  if (debugger_id.has_value() != target_id.has_value()) {
-    return llvm::createStringError(
-        "Both debuggerId and targetId must be specified together for debugger "
-        "reuse, or both must be omitted to create a new debugger");
-  }
-
   if (Error err = debugger_id && target_id
                       ? dap.InitializeDebugger(*debugger_id, *target_id)
                       : dap.InitializeDebugger())
     return err;
-
-  // Validate that we have a well formed attach request.
-  if (args.attachCommands.empty() && args.coreFile.empty() &&
-      args.configuration.program.empty() &&
-      args.pid == LLDB_INVALID_PROCESS_ID &&
-      args.gdbRemotePort == LLDB_DAP_INVALID_PORT && !target_id.has_value())
-    return make_error<DAPError>(
-        "expected one of 'pid', 'program', 'attachCommands', "
-        "'coreFile', 'gdb-remote-port', or target_id to be specified");
-
-  // Check if we have mutually exclusive arguments.
-  if ((args.pid != LLDB_INVALID_PROCESS_ID) &&
-      (args.gdbRemotePort != LLDB_DAP_INVALID_PORT))
-    return make_error<DAPError>(
-        "'pid' and 'gdb-remote-port' are mutually exclusive");
 
   dap.SetConfiguration(args.configuration, /*is_attach=*/true);
   if (!args.coreFile.empty())

--- a/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
@@ -26,12 +26,6 @@ Error LaunchRequestHandler::Run(const LaunchRequestArguments &arguments) const {
   if (Error err = dap.InitializeDebugger())
     return err;
 
-  // Validate that we have a well formed launch request.
-  if (!arguments.launchCommands.empty() &&
-      arguments.console != protocol::eConsoleInternal)
-    return make_error<DAPError>(
-        "'launchCommands' and non-internal 'console' are mutually exclusive");
-
   dap.SetConfiguration(arguments.configuration, /*is_attach=*/false);
   dap.last_launch_request = arguments;
 

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.h
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.h
@@ -340,11 +340,14 @@ public:
   void PostRun() const override;
 };
 
-class RestartRequestHandler : public LegacyRequestHandler {
+class RestartRequestHandler
+    : public RequestHandler<std::optional<protocol::RestartArguments>,
+                            protocol::RestartResponse> {
 public:
-  using LegacyRequestHandler::LegacyRequestHandler;
+  using RequestHandler::RequestHandler;
   static llvm::StringLiteral GetCommand() { return "restart"; }
-  void operator()(const llvm::json::Object &request) const override;
+  llvm::Error
+  Run(const std::optional<protocol::RestartArguments> &args) const override;
 };
 
 class NextRequestHandler

--- a/lldb/tools/lldb-dap/Handler/RestartRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RestartRequestHandler.cpp
@@ -64,7 +64,7 @@ RestartRequestHandler::Run(const std::optional<RestartArguments> &args) const {
   // FIXME: Should we run 'preRunCommands'?
   // FIXME: Should we add a 'preRestartCommands'?
   if (llvm::Error err = LaunchProcess(*dap.last_launch_request))
-    return llvm::make_error<DAPError>(llvm::toString(std::move(err)));
+    return err;
 
   SendProcessEvent(dap, Launch);
 
@@ -73,7 +73,7 @@ RestartRequestHandler::Run(const std::optional<RestartArguments> &args) const {
   // continue the process right away.
   if (dap.stop_at_entry) {
     if (llvm::Error err = SendThreadStoppedEvent(dap, /*on_entry=*/true))
-      return llvm::make_error<DAPError>(llvm::toString(std::move(err)));
+      return err;
   } else {
     dap.target.GetProcess().Continue();
   }

--- a/lldb/tools/lldb-dap/Handler/RestartRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RestartRequestHandler.cpp
@@ -12,7 +12,6 @@
 #include "LLDBUtils.h"
 #include "Protocol/ProtocolRequests.h"
 #include "RequestHandler.h"
-#include "lldb/API/SBError.h"
 
 using namespace lldb_dap;
 using namespace lldb_dap::protocol;
@@ -73,13 +72,8 @@ RestartRequestHandler::Run(const std::optional<RestartArguments> &args) const {
   // This is normally done after receiving a "configuration done" request.
   // Because we're restarting, configuration has already happened so we can
   // continue the process right away.
-  if (dap.stop_at_entry) {
-    if (llvm::Error error = SendThreadStoppedEvent(dap, /*on_entry=*/true))
-      return error;
-  } else {
-    if (lldb::SBError error = dap.target.GetProcess().Continue(); error.Fail())
-      return ToError(error);
-  }
+  if (dap.stop_at_entry)
+    return SendThreadStoppedEvent(dap, /*on_entry=*/true);
 
-  return llvm::Error::success();
+  return ToError(dap.target.GetProcess().Continue());
 }

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.cpp
@@ -296,31 +296,53 @@ bool fromJSON(const json::Value &Params, Console &C, json::Path P) {
 bool fromJSON(const json::Value &Params, LaunchRequestArguments &LRA,
               json::Path P) {
   json::ObjectMapper O(Params, P);
-  return O && fromJSON(Params, LRA.configuration, P) &&
-         O.mapOptional("noDebug", LRA.noDebug) &&
-         O.mapOptional("launchCommands", LRA.launchCommands) &&
-         O.mapOptional("cwd", LRA.cwd) && O.mapOptional("args", LRA.args) &&
-         O.mapOptional("detachOnError", LRA.detachOnError) &&
-         O.mapOptional("disableASLR", LRA.disableASLR) &&
-         O.mapOptional("disableSTDIO", LRA.disableSTDIO) &&
-         O.mapOptional("shellExpandArguments", LRA.shellExpandArguments) &&
-         O.mapOptional("runInTerminal", LRA.console) &&
-         O.mapOptional("console", LRA.console) &&
-         O.mapOptional("stdio", LRA.stdio) && parseEnv(Params, LRA.env, P);
+  bool success =
+      O && fromJSON(Params, LRA.configuration, P) &&
+      O.mapOptional("noDebug", LRA.noDebug) &&
+      O.mapOptional("launchCommands", LRA.launchCommands) &&
+      O.mapOptional("cwd", LRA.cwd) && O.mapOptional("args", LRA.args) &&
+      O.mapOptional("detachOnError", LRA.detachOnError) &&
+      O.mapOptional("disableASLR", LRA.disableASLR) &&
+      O.mapOptional("disableSTDIO", LRA.disableSTDIO) &&
+      O.mapOptional("shellExpandArguments", LRA.shellExpandArguments) &&
+      O.mapOptional("runInTerminal", LRA.console) &&
+      O.mapOptional("console", LRA.console) &&
+      O.mapOptional("stdio", LRA.stdio) && parseEnv(Params, LRA.env, P);
+  if (!success)
+    return false;
+  if (LRA.configuration.program.empty() && LRA.launchCommands.empty()) {
+    P.report("`program` or `launchCommands` should be provided");
+    return false;
+  }
+  return true;
 }
 
 bool fromJSON(const json::Value &Params, AttachRequestArguments &ARA,
               json::Path P) {
   json::ObjectMapper O(Params, P);
-  return O && fromJSON(Params, ARA.configuration, P) &&
-         O.mapOptional("attachCommands", ARA.attachCommands) &&
-         O.mapOptional("pid", ARA.pid) &&
-         O.mapOptional("waitFor", ARA.waitFor) &&
-         O.mapOptional("gdb-remote-port", ARA.gdbRemotePort) &&
-         O.mapOptional("gdb-remote-hostname", ARA.gdbRemoteHostname) &&
-         O.mapOptional("coreFile", ARA.coreFile) &&
-         O.mapOptional("targetId", ARA.targetId) &&
-         O.mapOptional("debuggerId", ARA.debuggerId);
+  bool success = O && fromJSON(Params, ARA.configuration, P) &&
+                 O.mapOptional("attachCommands", ARA.attachCommands) &&
+                 O.mapOptional("pid", ARA.pid) &&
+                 O.mapOptional("waitFor", ARA.waitFor) &&
+                 O.mapOptional("gdb-remote-port", ARA.gdbRemotePort) &&
+                 O.mapOptional("gdb-remote-hostname", ARA.gdbRemoteHostname) &&
+                 O.mapOptional("coreFile", ARA.coreFile) &&
+                 O.mapOptional("targetId", ARA.targetId) &&
+                 O.mapOptional("debuggerId", ARA.debuggerId);
+  if (!success)
+    return false;
+  if (ARA.debuggerId.has_value())
+    return true;
+  if (ARA.targetId.has_value())
+    return true;
+  if ((ARA.pid == LLDB_INVALID_PROCESS_ID) &&
+      ARA.configuration.program.empty() && ARA.attachCommands.empty() &&
+      ARA.coreFile.empty() && (ARA.gdbRemotePort == LLDB_DAP_INVALID_PORT)) {
+    P.report("`pid` or `program` or `attachCommands` or `coreFile` or "
+             "`gdbRemotePort` should be provided");
+    return false;
+  }
+  return true;
 }
 
 bool fromJSON(const json::Value &Params, ContinueArguments &CA, json::Path P) {
@@ -735,6 +757,32 @@ llvm::json::Value toJSON(const CompileUnitsResponseBody &Body) {
 llvm::json::Value toJSON(const TestGetTargetBreakpointsResponseBody &Body) {
   json::Object result{{"breakpoints", Body.breakpoints}};
   return result;
+}
+
+bool fromJSON(const llvm::json::Value &Params, RestartArguments &Args,
+              llvm::json::Path Path) {
+  const json::Object *O = Params.getAsObject();
+  if (!O) {
+    Path.report("expected object");
+    return false;
+  }
+  const json::Value *arguments = O->get("arguments");
+  if (arguments == nullptr)
+    return true;
+  LaunchRequestArguments launchArguments;
+  llvm::json::Path::Root root;
+  if (fromJSON(*arguments, launchArguments, root)) {
+    Args.arguments = std::move(launchArguments);
+    return true;
+  }
+  AttachRequestArguments attachArguments;
+  if (fromJSON(*arguments, attachArguments, root)) {
+    Args.arguments = std::move(attachArguments);
+    return true;
+  }
+  Path.report(
+      "failed to parse arguments, expected `launch` or `attach` arguments");
+  return false;
 }
 
 } // namespace lldb_dap::protocol

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace lldb_dap::protocol {
@@ -1254,6 +1255,18 @@ struct TestGetTargetBreakpointsResponseBody {
   std::vector<Breakpoint> breakpoints;
 };
 llvm::json::Value toJSON(const TestGetTargetBreakpointsResponseBody &);
+
+/// Arguments for `restart` request.
+struct RestartArguments {
+  /// The latest version of the `launch` or `attach` configuration.
+  std::variant<std::monostate, LaunchRequestArguments, AttachRequestArguments>
+      arguments = std::monostate{};
+};
+bool fromJSON(const llvm::json::Value &, RestartArguments &, llvm::json::Path);
+
+/// Response to `restart` request. This is just an acknowledgement, so no body
+/// field is required.
+using RestartResponse = VoidResponse;
 
 } // namespace lldb_dap::protocol
 

--- a/lldb/unittests/DAP/ProtocolRequestsTest.cpp
+++ b/lldb/unittests/DAP/ProtocolRequestsTest.cpp
@@ -304,3 +304,43 @@ TEST(ProtocolRequestsTest, TestGetTargetBreakpointsResponseBody) {
   ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
   EXPECT_EQ(PrettyPrint(*expected), PrettyPrint(body));
 }
+
+TEST(ProtocolRequestsTest, RestartArguments) {
+  llvm::Expected<RestartArguments> expected = parse<RestartArguments>(R"({})");
+  ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(expected->arguments));
+
+  // Check missed keys.
+  expected = parse<RestartArguments>(R"({
+    "arguments": {}
+  })");
+  EXPECT_THAT_EXPECTED(expected,
+                       FailedWithMessage("failed to parse arguments, expected "
+                                         "`launch` or `attach` arguments"));
+
+  // Check launch arguments.
+  expected = parse<RestartArguments>(R"({
+    "arguments": {
+      "program": "main.exe",
+      "cwd": "/home/root"
+    }
+  })");
+  ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
+  const LaunchRequestArguments *launch_args =
+      std::get_if<LaunchRequestArguments>(&expected->arguments);
+  EXPECT_NE(launch_args, nullptr);
+  EXPECT_EQ(launch_args->configuration.program, "main.exe");
+  EXPECT_EQ(launch_args->cwd, "/home/root");
+
+  // Check attach arguments.
+  expected = parse<RestartArguments>(R"({
+    "arguments": {
+      "pid": 123
+    }
+  })");
+  ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
+  const AttachRequestArguments *attach_args =
+      std::get_if<AttachRequestArguments>(&expected->arguments);
+  EXPECT_NE(attach_args, nullptr);
+  EXPECT_EQ(attach_args->pid, 123U);
+}


### PR DESCRIPTION
This patch migrates `restart` request to structured types. Also, I added some checks that at least one of the required fields was provided for `launch` and `attach` requests. Maybe I missed some possible configurations, so please double check.