### PR TITLE
[OpenMP][CIR] Implement 'parallel's 'proc_bind' clause lowering

### DIFF
--- a/clang/test/CIR/CodeGenOpenMP/parallel.c
+++ b/clang/test/CIR/CodeGenOpenMP/parallel.c
@@ -48,3 +48,31 @@ void parallel_with_operations() {
   // CHECK-NEXT: omp.terminator
   // CHECK-NEXT: }
 }
+void proc_bind_parallel() {
+  // CHECK: cir.func{{.*}}@proc_bind_parallel
+#pragma omp parallel proc_bind(master)
+  {}
+  // CHECK-NEXT: omp.parallel proc_bind(master) {
+  // CHECK-NEXT: omp.terminator
+  // CHECK-NEXT: }
+#pragma omp parallel proc_bind(close)
+  {}
+  // CHECK-NEXT: omp.parallel proc_bind(close) {
+  // CHECK-NEXT: omp.terminator
+  // CHECK-NEXT: }
+#pragma omp parallel proc_bind(spread)
+  {}
+  // CHECK-NEXT: omp.parallel proc_bind(spread) {
+  // CHECK-NEXT: omp.terminator
+  // CHECK-NEXT: }
+#pragma omp parallel proc_bind(primary)
+  {}
+  // CHECK-NEXT: omp.parallel proc_bind(primary) {
+  // CHECK-NEXT: omp.terminator
+  // CHECK-NEXT: }
+#pragma omp parallel proc_bind(default)
+  {}
+  // CHECK-NEXT: omp.parallel {
+  // CHECK-NEXT: omp.terminator
+  // CHECK-NEXT: }
+}


### PR DESCRIPTION
This patch implements the 'first' clause for OMP, which is the 'proc_bind' clause. This clause takes one of a handful of values and just passes it onto the OMP dialect.

The 'default' value for this isn't present in the OMP dialect, however the classic-codegen doesn't generate the library call when this value is passed, so this is effectively a 'no-op'.