### PR TITLE
[Clang][NFC] remove getUnqualifiedType() when it's already unqualified

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
+++ b/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
@@ -26,18 +26,14 @@ using ast_matchers::returns;
 
 CanQualType getLikeReturnType(QualType RT) {
   if (!RT.isNull() && RT->isPointerType()) {
-    return RT->getPointeeType()
-        ->getCanonicalTypeUnqualified()
-        .getUnqualifiedType();
+    return RT->getPointeeType()->getCanonicalTypeUnqualified();
   }
   return {};
 }
 
 CanQualType valueLikeReturnType(QualType RT) {
   if (!RT.isNull() && RT->isReferenceType()) {
-    return RT.getNonReferenceType()
-        ->getCanonicalTypeUnqualified()
-        .getUnqualifiedType();
+    return RT.getNonReferenceType()->getCanonicalTypeUnqualified();
   }
   return {};
 }

--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -317,9 +317,7 @@ arrangeFreeFunctionLikeCall(CIRGenTypes &cgt, CIRGenModule &cgm,
   for (const CallArg &arg : args)
     argTypes.push_back(cgt.getASTContext().getCanonicalParamType(arg.ty));
 
-  CanQualType retType = fnType->getReturnType()
-                            ->getCanonicalTypeUnqualified()
-                            .getUnqualifiedType();
+  CanQualType retType = fnType->getReturnType()->getCanonicalTypeUnqualified();
 
   assert(!cir::MissingFeatures::opCallFnInfoOpts());
   return cgt.arrangeCIRFunctionInfo(retType, argTypes, required);
@@ -381,10 +379,9 @@ const CIRGenFunctionInfo &CIRGenTypes::arrangeCXXMethodCall(
     argTypes.push_back(astContext.getCanonicalParamType(arg.ty));
 
   assert(!cir::MissingFeatures::opCallFnInfoOpts());
-  return arrangeCIRFunctionInfo(proto->getReturnType()
-                                    ->getCanonicalTypeUnqualified()
-                                    .getUnqualifiedType(),
-                                argTypes, required);
+  return arrangeCIRFunctionInfo(
+      proto->getReturnType()->getCanonicalTypeUnqualified(), argTypes,
+      required);
 }
 
 const CIRGenFunctionInfo &

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -150,7 +150,7 @@ static CanQual<FunctionProtoType> GetFormalType(const CXXMethodDecl *MD) {
 /// and it makes ABI code a little easier to be able to assume that
 /// all parameter and return types are top-level unqualified.
 static CanQualType GetReturnType(QualType RetTy) {
-  return RetTy->getCanonicalTypeUnqualified().getUnqualifiedType();
+  return RetTy->getCanonicalTypeUnqualified();
 }
 
 /// Arrange the argument and result information for a value of the given

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -6170,7 +6170,7 @@ struct CheckAbstractUsage {
       Sel = Sema::AbstractArrayType;
       T = Info.S.Context.getBaseElementType(T);
     }
-    CanQualType CT = T->getCanonicalTypeUnqualified().getUnqualifiedType();
+    CanQualType CT = T->getCanonicalTypeUnqualified();
     if (CT != Info.AbstractType) return;
 
     // It matched; do some magic.
@@ -13008,8 +13008,7 @@ static CXXBaseSpecifier *findDirectBaseWithType(CXXRecordDecl *Derived,
                                                 QualType DesiredBase,
                                                 bool &AnyDependentBases) {
   // Check whether the named type is a direct base class.
-  CanQualType CanonicalDesiredBase = DesiredBase->getCanonicalTypeUnqualified()
-    .getUnqualifiedType();
+  CanQualType CanonicalDesiredBase = DesiredBase->getCanonicalTypeUnqualified();
   for (auto &Base : Derived->bases()) {
     CanQualType BaseType = Base.getType()->getCanonicalTypeUnqualified();
     if (CanonicalDesiredBase == BaseType)


### PR DESCRIPTION
Since 8c4950951269ec58296afbeba14e99aef467f84d, getCanonicalTypeUnqualified() calls getUnqualifiedType(), so there's no point in calling that again on its return value.