### PR TITLE
[libunwind] Remove code related to dyld from libunwind

### DIFF
--- a/libunwind/src/Unwind-sjlj.c
+++ b/libunwind/src/Unwind-sjlj.c
@@ -74,8 +74,6 @@ struct _Unwind_FunctionContext {
 #endif
 
 
-#if !defined(FOR_DYLD)
-
 #if defined(__APPLE__)
 #include <System/pthread_machdep.h>
 #else
@@ -99,8 +97,6 @@ __Unwind_SjLj_SetTopOfFunctionStack(struct _Unwind_FunctionContext *fc) {
   stack = fc;
 #endif
 }
-
-#endif
 
 
 /// Called at start of each function that catches exceptions

--- a/libunwind/src/config.h
+++ b/libunwind/src/config.h
@@ -22,12 +22,8 @@
 
 // Platform specific configuration defines.
 #ifdef __APPLE__
-  #if defined(FOR_DYLD)
-    #define _LIBUNWIND_SUPPORT_COMPACT_UNWIND 1
-  #else
-    #define _LIBUNWIND_SUPPORT_COMPACT_UNWIND 1
-    #define _LIBUNWIND_SUPPORT_DWARF_UNWIND 1
-  #endif
+  #define _LIBUNWIND_SUPPORT_COMPACT_UNWIND 1
+  #define _LIBUNWIND_SUPPORT_DWARF_UNWIND   1
   #if defined(__aarch64__) || defined(__arm64__) || defined(__arm64e__)
     #define _LIBUNWIND_TRACE_RET_INJECT 1
   #endif


### PR DESCRIPTION
This hasn't been needed for many years, and in fact we've removed that code in Apple's fork of LLVM. This patch simply cleans up that code from upstream.