### PR TITLE
[clang-tidy] Add ranges-style view for tokenizing source code

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.cpp
@@ -94,19 +94,8 @@ getCommentsInRange(ASTContext *Ctx, CharSourceRange Range) {
   if (Invalid)
     return Comments;
 
-  const char *StrData = Buffer.data() + BeginLoc.second;
-
-  Lexer TheLexer(SM.getLocForStartOfFile(BeginLoc.first), Ctx->getLangOpts(),
-                 Buffer.begin(), StrData, Buffer.end());
-  TheLexer.SetCommentRetentionState(true);
-
-  while (true) {
-    Token Tok;
-    if (TheLexer.LexFromRawLexer(Tok))
-      break;
-    if (Tok.getLocation() == Range.getEnd() || Tok.is(tok::eof))
-      break;
-
+  for (const Token Tok :
+       utils::lexer::tokensIncludingComments(Range, SM, Ctx->getLangOpts())) {
     if (Tok.is(tok::comment)) {
       const std::pair<FileID, unsigned> CommentLoc =
           SM.getDecomposedLoc(Tok.getLocation());

--- a/clang-tools-extra/clang-tidy/modernize/UseOverrideCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseOverrideCheck.cpp
@@ -54,20 +54,11 @@ void UseOverrideCheck::registerMatchers(MatchFinder *Finder) {
 static SmallVector<Token, 16>
 parseTokens(CharSourceRange Range, const MatchFinder::MatchResult &Result) {
   const SourceManager &Sources = *Result.SourceManager;
-  const std::pair<FileID, unsigned> LocInfo =
-      Sources.getDecomposedLoc(Range.getBegin());
-  const StringRef File = Sources.getBufferData(LocInfo.first);
-  const char *TokenBegin = File.data() + LocInfo.second;
-  Lexer RawLexer(Sources.getLocForStartOfFile(LocInfo.first),
-                 Result.Context->getLangOpts(), File.begin(), TokenBegin,
-                 File.end());
   SmallVector<Token, 16> Tokens;
-  Token Tok;
   int NestedParens = 0;
-  while (!RawLexer.LexFromRawLexer(Tok)) {
+  for (Token Tok :
+       utils::lexer::tokens(Range, Sources, Result.Context->getLangOpts())) {
     if ((Tok.is(tok::semi) || Tok.is(tok::l_brace)) && NestedParens == 0)
-      break;
-    if (Sources.isBeforeInTranslationUnit(Range.getEnd(), Tok.getLocation()))
       break;
     if (Tok.is(tok::l_paren))
       ++NestedParens;

--- a/clang-tools-extra/clang-tidy/utils/LexerUtils.h
+++ b/clang-tools-extra/clang-tidy/utils/LexerUtils.h
@@ -10,9 +10,9 @@
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_UTILS_LEXERUTILS_H
 
 #include "clang/AST/ASTContext.h"
+#include "clang/Basic/SourceManager.h"
 #include "clang/Basic/TokenKinds.h"
 #include "clang/Lex/Lexer.h"
-#include "clang/basic/SourceManager.h"
 #include <iterator>
 #include <optional>
 #include <utility>

--- a/clang-tools-extra/clang-tidy/utils/LexerUtils.h
+++ b/clang-tools-extra/clang-tidy/utils/LexerUtils.h
@@ -133,6 +133,9 @@ class TokenView {
 public:
   class iterator { // NOLINT(readability-identifier-naming)
   public:
+    using value_type = Token;
+    using pointer = const Token *;
+    using reference = const Token &;
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
     using iterator_category = std::input_iterator_tag;

--- a/clang-tools-extra/clang-tidy/utils/LexerUtils.h
+++ b/clang-tools-extra/clang-tidy/utils/LexerUtils.h
@@ -12,6 +12,8 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/TokenKinds.h"
 #include "clang/Lex/Lexer.h"
+#include "clang/basic/SourceManager.h"
+#include <iterator>
 #include <optional>
 #include <utility>
 
@@ -126,6 +128,78 @@ SourceLocation getUnifiedEndLoc(const Stmt &S, const SourceManager &SM,
 /// the noexcept specifier.
 SourceLocation getLocationForNoexceptSpecifier(const FunctionDecl *FuncDecl,
                                                const SourceManager &SM);
+
+class TokenView {
+public:
+  class iterator { // NOLINT(readability-identifier-naming)
+  public:
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using iterator_category = std::input_iterator_tag;
+
+    iterator &operator++() {
+      if (View->RawLexer.getBufferLocation() < View->EndOfLexedRange)
+        View->RawLexer.LexFromRawLexer(View->Tok);
+      else
+        View = nullptr; // No more tokens.
+      return *this;
+    }
+
+    void operator++(int) { operator++(); }
+
+    friend bool operator==(iterator LHS, iterator RHS) {
+      return LHS.View == RHS.View;
+    }
+
+    friend bool operator!=(iterator LHS, iterator RHS) { return !(LHS == RHS); }
+
+    const Token &operator*() const { return View->Tok; }
+    const Token *operator->() const { return &View->Tok; }
+
+  private:
+    friend class TokenView;
+    iterator(TokenView *V) : View(V) {}
+    TokenView *View;
+  };
+
+  iterator begin() {
+    iterator It(this);
+    ++It;
+    return It;
+  }
+  iterator end() { return {nullptr}; }
+
+  TokenView(CharSourceRange Range, const SourceManager &SM,
+            const LangOptions &LangOpts, bool RetainComments)
+      : RawLexer([&]() -> Lexer {
+          const auto [FID, BeginOffset] = SM.getDecomposedLoc(Range.getBegin());
+          const auto [_, EndOffset] = SM.getDecomposedLoc(Range.getEnd());
+          const StringRef FileContents = SM.getBufferData(FID);
+          const StringRef LexedRange = {FileContents.begin() + BeginOffset,
+                                        EndOffset - BeginOffset};
+          EndOfLexedRange = LexedRange.end();
+          return {Range.getBegin(), LangOpts, LexedRange.begin(),
+                  LexedRange.begin(), FileContents.end()};
+        }()) {
+    RawLexer.SetCommentRetentionState(RetainComments);
+  }
+
+private:
+  Lexer RawLexer;
+  const char *EndOfLexedRange;
+  Token Tok;
+};
+
+inline TokenView tokens(CharSourceRange Range, const SourceManager &SM,
+                        const LangOptions &LangOpts) {
+  return {Range, SM, LangOpts, false};
+}
+
+inline TokenView tokensIncludingComments(CharSourceRange Range,
+                                         const SourceManager &SM,
+                                         const LangOptions &LangOpts) {
+  return {Range, SM, LangOpts, true};
+}
 
 } // namespace tidy::utils::lexer
 } // namespace clang


### PR DESCRIPTION
We have several checks that want to relex source code, but right now, doing so is annoying; the `Lexer` API is difficult to use. This PR wraps it in a ranges-style view that produces a stream of `Token`s and converts some checks to use the new API.