### PR TITLE
[Clang] [Headers] Actually install the stddefer.h header

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -24,6 +24,7 @@ set(core_files
   stdcountof.h
   stdckdint.h
   stddef.h
+  stddefer.h
   __stddef_header_macro.h
   __stddef_max_align_t.h
   __stddef_null.h


### PR DESCRIPTION
I forgot to add the `stddefer.h` header to this list, which causes it to not be found at the moment: (see https://godbolt.org/z/arc18rhrK).