### PR TITLE
[libclang/python] Remove unused exception variable

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3879,7 +3879,7 @@ class CompilationDatabase(ClangObject):
                     os.fspath(buildDir), byref(errorCode)
                 )
             )
-        except CompilationDatabaseError as e:
+        except CompilationDatabaseError:
             raise CompilationDatabaseError(
                 int(errorCode.value), "CompilationDatabase loading failed"
             )


### PR DESCRIPTION
Remove unused CompilationDatabaseError variable (fixes #172374)