### PR TITLE
[lldb][ClangASTSource][NFC] Clean up RegisterNamespaceMap

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -969,10 +969,10 @@ void ClangASTImporter::SetDeclOrigin(const clang::Decl *decl,
 }
 
 void ClangASTImporter::RegisterNamespaceMap(const clang::NamespaceDecl *decl,
-                                            NamespaceMapSP &namespace_map) {
+                                            NamespaceMapSP namespace_map) {
   ASTContextMetadataSP context_md = GetContextMetadata(&decl->getASTContext());
 
-  context_md->m_namespace_maps[decl] = namespace_map;
+  context_md->m_namespace_maps[decl] = std::move(namespace_map);
 }
 
 ClangASTImporter::NamespaceMapSP

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.h
@@ -202,7 +202,7 @@ public:
   typedef std::shared_ptr<NamespaceMap> NamespaceMapSP;
 
   void RegisterNamespaceMap(const clang::NamespaceDecl *decl,
-                            NamespaceMapSP &namespace_map);
+                            NamespaceMapSP namespace_map);
 
   NamespaceMapSP GetNamespaceMap(const clang::NamespaceDecl *decl);
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
@@ -1431,12 +1431,12 @@ void ClangASTSource::CompleteNamespaceMap(
   }
 }
 
-NamespaceDecl *ClangASTSource::AddNamespace(
-    NameSearchContext &context) {
+NamespaceDecl *ClangASTSource::AddNamespace(NameSearchContext &context) {
   if (!context.m_namespace_map)
     return nullptr;
 
-  const CompilerDeclContext &namespace_decl = context.m_namespace_map->begin()->second;
+  const CompilerDeclContext &namespace_decl =
+      context.m_namespace_map->begin()->second;
 
   clang::ASTContext *src_ast =
       TypeSystemClang::DeclContextGetTypeSystemClang(namespace_decl);

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
@@ -545,8 +545,7 @@ void ClangASTSource::FindExternalVisibleDecls(NameSearchContext &context) {
       LLDB_LOG(log, "  CAS::FEVD Registering namespace map {0:x} ({1} entries)",
                context.m_namespace_map.get(), context.m_namespace_map->size());
 
-    NamespaceDecl *clang_namespace_decl =
-        AddNamespace(context, context.m_namespace_map);
+    NamespaceDecl *clang_namespace_decl = AddNamespace(context);
 
     if (clang_namespace_decl)
       clang_namespace_decl->setHasExternalVisibleStorage();
@@ -1433,12 +1432,11 @@ void ClangASTSource::CompleteNamespaceMap(
 }
 
 NamespaceDecl *ClangASTSource::AddNamespace(
-    NameSearchContext &context,
-    ClangASTImporter::NamespaceMapSP &namespace_decls) {
-  if (!namespace_decls)
+    NameSearchContext &context) {
+  if (!context.m_namespace_map)
     return nullptr;
 
-  const CompilerDeclContext &namespace_decl = namespace_decls->begin()->second;
+  const CompilerDeclContext &namespace_decl = context.m_namespace_map->begin()->second;
 
   clang::ASTContext *src_ast =
       TypeSystemClang::DeclContextGetTypeSystemClang(namespace_decl);
@@ -1463,7 +1461,7 @@ NamespaceDecl *ClangASTSource::AddNamespace(
   context.m_decls.push_back(copied_namespace_decl);
 
   m_ast_importer_sp->RegisterNamespaceMap(copied_namespace_decl,
-                                          namespace_decls);
+                                          context.m_namespace_map);
 
   return dyn_cast<NamespaceDecl>(copied_decl);
 }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.h
@@ -188,8 +188,7 @@ public:
   //
 
   clang::NamespaceDecl *
-  AddNamespace(NameSearchContext &context,
-               ClangASTImporter::NamespaceMapSP &namespace_decls);
+  AddNamespace(NameSearchContext &context);
 
   /// The worker function for FindExternalVisibleDeclsByName.
   ///

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.h
@@ -187,8 +187,7 @@ public:
   // Helper APIs
   //
 
-  clang::NamespaceDecl *
-  AddNamespace(NameSearchContext &context);
+  clang::NamespaceDecl *AddNamespace(NameSearchContext &context);
 
   /// The worker function for FindExternalVisibleDeclsByName.
   ///


### PR DESCRIPTION
I've been trying to wrap my head around this code but there's a lot of action-at-a-distance going on which I'm having trouble following. This patch cleans up a small part of it.

We were passing the `context`s namespace map as a separate mutable argument. But nothing in this function requires it to be mutable (and separate from the owning structure). This patch drops the redundant argument and passes the shared_ptr by value.