### PR TITLE
[llvm-objdump] Fix mcpuHelp() memory leak

### DIFF
--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -3581,7 +3581,8 @@ static void mcpuHelp() {
   if (!DummyTarget)
     reportCmdLineError(ErrMessage);
   // We need to access the Help() through the corresponding MCSubtargetInfo.
-  DummyTarget->createMCSubtargetInfo(TheTriple, "help", "");
+  std::unique_ptr<MCSubtargetInfo> MSI(
+      DummyTarget->createMCSubtargetInfo(TheTriple.str(), "help", ""));
 }
 
 static void parseOtoolOptions(const llvm::opt::InputArgList &InputArgs) {

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -3582,7 +3582,7 @@ static void mcpuHelp() {
     reportCmdLineError(ErrMessage);
   // We need to access the Help() through the corresponding MCSubtargetInfo.
   std::unique_ptr<MCSubtargetInfo> MSI(
-      DummyTarget->createMCSubtargetInfo(TheTriple.str(), "help", ""));
+      DummyTarget->createMCSubtargetInfo(TheTriple, "help", ""));
 }
 
 static void parseOtoolOptions(const llvm::opt::InputArgList &InputArgs) {


### PR DESCRIPTION
The call to `DummyTarget->createMCSubtargetInfo` within `mcpuHelp()` returns a pointer that is not subsequently freed, leading to a memory leak.
Use std::unique_ptr to ensure the memory is released automatically.