### PR TITLE
[MemProf] Propagate size info used for hint reporting to duplicates

### DIFF
--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -1507,8 +1507,11 @@ CallsiteContextGraph<DerivedCCG, FuncTy, CallTy>::duplicateContextIds(
     NewContextIds.insert(++LastContextId);
     OldToNewContextIds[OldId].insert(LastContextId);
     assert(ContextIdToAllocationType.count(OldId));
-    // The new context has the same allocation type as original.
+    // The new context has the same allocation type and size info as original.
     ContextIdToAllocationType[LastContextId] = ContextIdToAllocationType[OldId];
+    auto CSI = ContextIdToContextSizeInfos.find(OldId);
+    if (CSI != ContextIdToContextSizeInfos.end())
+      ContextIdToContextSizeInfos[LastContextId] = CSI->second;
     if (DotAllocContextIds.contains(OldId))
       DotAllocContextIds.insert(LastContextId);
   }


### PR DESCRIPTION
When we duplicate contexts (due to clones e.g. matching different
inlined instances), we were propagating the allocation type but not the
ContextSizeInfo, which is used for -memprof-report-hinted-sizes.
This meant that we never reported hinting for any of the duplicated
contexts, which can result in conservative results as in some cases only
the duplicated contexts are able to be cloned and hinted. Note that this
change could result in overly optimistic reporting in some cases.
