### PR TITLE
Make STLExtras's (all|any|none)_of() Utility Functions Constexpr-Friendly

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1735,7 +1735,7 @@ UnaryFunction for_each(R &&Range, UnaryFunction F) {
 /// begin/end explicitly.
 template <typename R, typename UnaryPredicate>
 constexpr bool all_of(R &&Range, UnaryPredicate P) {
-  // TODO: switch back to std::all_of() after we bump to c++20.
+  // TODO: switch back to std::all_of() after it becomes constexpr in c++20.
   for (auto I = adl_begin(Range), E = adl_end(Range); I != E; ++I)
     if (!P(*I))
       return false;
@@ -1746,7 +1746,7 @@ constexpr bool all_of(R &&Range, UnaryPredicate P) {
 /// begin/end explicitly.
 template <typename R, typename UnaryPredicate>
 constexpr bool any_of(R &&Range, UnaryPredicate P) {
-  // TODO: switch back to std::any_of() after we bump to c++20.
+  // TODO: switch back to std::any_of() after it becomes constexpr in c++20.
   for (auto I = adl_begin(Range), E = adl_end(Range); I != E; ++I)
     if (P(*I))
       return true;
@@ -1757,11 +1757,8 @@ constexpr bool any_of(R &&Range, UnaryPredicate P) {
 /// begin/end explicitly.
 template <typename R, typename UnaryPredicate>
 constexpr bool none_of(R &&Range, UnaryPredicate P) {
-  // TODO: switch back to std::none_of() after we bump to c++20.
-  for (auto I = adl_begin(Range), E = adl_end(Range); I != E; ++I)
-    if (P(*I))
-      return false;
-  return true;
+  // TODO: switch back to std::none_of() after it becomes constexpr in c++20.
+  return !any_of(Range, P);
 }
 
 /// Provide wrappers to std::fill which take ranges instead of having to pass

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -638,10 +638,10 @@ make_early_inc_range(RangeT &&Range) {
 
 // Forward declarations required by zip_shortest/zip_equal/zip_first/zip_longest
 template <typename R, typename UnaryPredicate>
-bool all_of(R &&range, UnaryPredicate P);
+constexpr bool all_of(R &&range, UnaryPredicate P);
 
 template <typename R, typename UnaryPredicate>
-bool any_of(R &&range, UnaryPredicate P);
+constexpr bool any_of(R &&range, UnaryPredicate P);
 
 template <typename T> bool all_equal(std::initializer_list<T> Values);
 
@@ -1734,22 +1734,31 @@ UnaryFunction for_each(R &&Range, UnaryFunction F) {
 /// Provide wrappers to std::all_of which take ranges instead of having to pass
 /// begin/end explicitly.
 template <typename R, typename UnaryPredicate>
-bool all_of(R &&Range, UnaryPredicate P) {
-  return std::all_of(adl_begin(Range), adl_end(Range), P);
+constexpr bool all_of(R &&Range, UnaryPredicate P) {
+  for (auto I = adl_begin(Range), E = adl_end(Range); I != E; ++I)
+    if (!P(*I))
+      return false;
+  return true;
 }
 
 /// Provide wrappers to std::any_of which take ranges instead of having to pass
 /// begin/end explicitly.
 template <typename R, typename UnaryPredicate>
-bool any_of(R &&Range, UnaryPredicate P) {
-  return std::any_of(adl_begin(Range), adl_end(Range), P);
+constexpr bool any_of(R &&Range, UnaryPredicate P) {
+  for (auto I = adl_begin(Range), E = adl_end(Range); I != E; ++I)
+    if (P(*I))
+      return true;
+  return false;
 }
 
 /// Provide wrappers to std::none_of which take ranges instead of having to pass
 /// begin/end explicitly.
 template <typename R, typename UnaryPredicate>
-bool none_of(R &&Range, UnaryPredicate P) {
-  return std::none_of(adl_begin(Range), adl_end(Range), P);
+constexpr bool none_of(R &&Range, UnaryPredicate P) {
+  for (auto I = adl_begin(Range), E = adl_end(Range); I != E; ++I)
+    if (P(*I))
+      return false;
+  return true;
 }
 
 /// Provide wrappers to std::fill which take ranges instead of having to pass

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1735,6 +1735,7 @@ UnaryFunction for_each(R &&Range, UnaryFunction F) {
 /// begin/end explicitly.
 template <typename R, typename UnaryPredicate>
 constexpr bool all_of(R &&Range, UnaryPredicate P) {
+  // TODO: switch back to std::all_of() after we bump to c++20.
   for (auto I = adl_begin(Range), E = adl_end(Range); I != E; ++I)
     if (!P(*I))
       return false;
@@ -1745,6 +1746,7 @@ constexpr bool all_of(R &&Range, UnaryPredicate P) {
 /// begin/end explicitly.
 template <typename R, typename UnaryPredicate>
 constexpr bool any_of(R &&Range, UnaryPredicate P) {
+  // TODO: switch back to std::any_of() after we bump to c++20.
   for (auto I = adl_begin(Range), E = adl_end(Range); I != E; ++I)
     if (P(*I))
       return true;
@@ -1755,6 +1757,7 @@ constexpr bool any_of(R &&Range, UnaryPredicate P) {
 /// begin/end explicitly.
 template <typename R, typename UnaryPredicate>
 constexpr bool none_of(R &&Range, UnaryPredicate P) {
+  // TODO: switch back to std::none_of() after we bump to c++20.
   for (auto I = adl_begin(Range), E = adl_end(Range); I != E; ++I)
     if (P(*I))
       return false;

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1260,6 +1260,104 @@ TEST(STLExtras, MoveRange) {
   EXPECT_TRUE(llvm::all_of(V4, HasVal));
 }
 
+TEST(STLExtrasTest, AllOfAnyOfNoneOfConstexpr) {
+  // Test all_of with std::array.
+  constexpr std::array<int, 4> Arr1 = {2, 4, 6, 8};
+  static_assert(all_of(Arr1, [](int X) { return X % 2 == 0; }),
+                "all_of should return true for all even numbers");
+  static_assert(!all_of(Arr1, [](int X) { return X > 5; }),
+                "all_of should return false when not all elements satisfy");
+
+  // Test all_of with C-style array.
+  constexpr int CArr[] = {1, 3, 5, 7};
+  static_assert(all_of(CArr, [](int X) { return X % 2 == 1; }),
+                "all_of works with C-style array");
+  static_assert(!all_of(CArr, [](int X) { return X < 5; }),
+                "all_of should return false when some elements don't satisfy");
+
+  // Test with empty range.
+  constexpr std::array<int, 0> Empty = {};
+  static_assert(all_of(Empty, [](int) { return false; }),
+                "all_of should return true for empty range");
+
+  // Test any_of with std::string_view (testing with char type).
+  constexpr std::string_view Str1 = "hello";
+  static_assert(any_of(Str1, [](char C) { return C == 'e'; }),
+                "any_of finds character in string_view");
+  static_assert(any_of(Str1, [](char C) { return C > 'k'; }),
+                "any_of finds matching characters");
+  static_assert(!any_of(Str1, [](char C) { return C == 'x'; }),
+                "any_of returns false when no match");
+
+  // Test any_of with C-style array of different type.
+  constexpr bool BoolArr[] = {false, false, true, false};
+  static_assert(any_of(BoolArr, [](bool B) { return B; }),
+                "any_of finds true value");
+  static_assert(!any_of(BoolArr, [](bool B) { return !B; }) == false,
+                "any_of with negated predicate");
+
+  // Test any_of with empty range.
+  static_assert(!any_of(Empty, [](int) { return true; }),
+                "any_of should return false for empty range");
+
+  // Test none_of with std::array.
+  constexpr std::array<int, 5> Arr5 = {1, 3, 5, 7, 9};
+  static_assert(none_of(Arr5, [](int X) { return X % 2 == 0; }),
+                "none_of should return true when no elements are even");
+  static_assert(none_of(Arr5, [](int X) { return X > 10; }),
+                "none_of should return true when all elements don't satisfy");
+  static_assert(
+      !none_of(Arr5, [](int X) { return X == 5; }),
+      "none_of should return false when at least one element matches");
+
+  // Test none_of with std::string_view.
+  constexpr std::string_view Str2 = "WORLD";
+  static_assert(none_of(Str2, [](char C) { return C >= 'a' && C <= 'z'; }),
+                "none_of verifies no lowercase letters");
+  static_assert(!none_of(Str2, [](char C) { return C == 'R'; }),
+                "none_of returns false when element exists");
+
+  // Test none_of with empty range.
+  static_assert(none_of(Empty, [](int) { return true; }),
+                "none_of should return true for empty range");
+
+  // Test with single element C-style array.
+  constexpr int Single[] = {42};
+  static_assert(all_of(Single, [](int X) { return X == 42; }),
+                "all_of works with single element C-array");
+  static_assert(any_of(Single, [](int X) { return X == 42; }),
+                "any_of works with single element");
+  static_assert(none_of(Single, [](int X) { return X != 42; }),
+                "none_of works with single element");
+
+  // Test with const arrays.
+  constexpr const std::array<int, 3> ConstArr = {100, 200, 300};
+  static_assert(all_of(ConstArr, [](int X) { return X >= 100; }),
+                "all_of works with const std::array");
+  static_assert(any_of(ConstArr, [](int X) { return X == 200; }),
+                "any_of works with const std::array");
+  static_assert(none_of(ConstArr, [](int X) { return X < 100; }),
+                "none_of works with const std::array");
+
+  // Test logical relationships between all_of, any_of, and none_of.
+  constexpr std::array<int, 3> Arr8 = {5, 10, 15};
+  static_assert(all_of(Arr8, [](int X) { return X > 0; }) ==
+                    !any_of(Arr8, [](int X) { return X <= 0; }),
+                "all_of(P) should equal !any_of(!P)");
+  static_assert(none_of(Arr8, [](int X) { return X < 0; }) ==
+                    !any_of(Arr8, [](int X) { return X < 0; }),
+                "none_of(P) should equal !any_of(P)");
+
+  // Test with different element types in std::array.
+  constexpr std::array<char, 4> CharArr = {'a', 'b', 'c', 'd'};
+  static_assert(all_of(CharArr, [](char C) { return C >= 'a' && C <= 'z'; }),
+                "all_of works with char array");
+  static_assert(any_of(CharArr, [](char C) { return C == 'c'; }),
+                "any_of works with char array");
+  static_assert(none_of(CharArr, [](char C) { return C >= 'A' && C <= 'Z'; }),
+                "none_of works with char array");
+}
+
 TEST(STLExtras, Unique) {
   std::vector<int> V = {1, 5, 5, 4, 3, 3, 3};
 

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1261,101 +1261,22 @@ TEST(STLExtras, MoveRange) {
 }
 
 TEST(STLExtrasTest, AllOfAnyOfNoneOfConstexpr) {
-  // Test all_of with std::array.
-  constexpr std::array<int, 4> Arr1 = {2, 4, 6, 8};
-  static_assert(all_of(Arr1, [](int X) { return X % 2 == 0; }),
-                "all_of should return true for all even numbers");
-  static_assert(!all_of(Arr1, [](int X) { return X > 5; }),
-                "all_of should return false when not all elements satisfy");
+  // Verify constexpr evaluation works. Functional correctness is tested in
+  // runtime tests (e.g., MoveRange).
+  constexpr std::array<int, 3> Arr = {1, 2, 3};
+  static_assert(all_of(Arr, [](int X) { return X > 0; }));
+  static_assert(any_of(Arr, [](int X) { return X == 2; }));
+  static_assert(none_of(Arr, [](int X) { return X < 0; }));
 
-  // Test all_of with C-style array.
-  constexpr int CArr[] = {1, 3, 5, 7};
-  static_assert(all_of(CArr, [](int X) { return X % 2 == 1; }),
-                "all_of works with C-style array");
-  static_assert(!all_of(CArr, [](int X) { return X < 5; }),
-                "all_of should return false when some elements don't satisfy");
+  // Verify constexpr works with C-style arrays.
+  constexpr int CArr[] = {1, 2};
+  static_assert(all_of(CArr, [](int X) { return X > 0; }));
 
-  // Test with empty range.
+  // Verify empty range edge case.
   constexpr std::array<int, 0> Empty = {};
-  static_assert(all_of(Empty, [](int) { return false; }),
-                "all_of should return true for empty range");
-
-  // Test any_of with std::string_view (testing with char type).
-  constexpr std::string_view Str1 = "hello";
-  static_assert(any_of(Str1, [](char C) { return C == 'e'; }),
-                "any_of finds character in string_view");
-  static_assert(any_of(Str1, [](char C) { return C > 'k'; }),
-                "any_of finds matching characters");
-  static_assert(!any_of(Str1, [](char C) { return C == 'x'; }),
-                "any_of returns false when no match");
-
-  // Test any_of with C-style array of different type.
-  constexpr bool BoolArr[] = {false, false, true, false};
-  static_assert(any_of(BoolArr, [](bool B) { return B; }),
-                "any_of finds true value");
-  static_assert(!any_of(BoolArr, [](bool B) { return !B; }) == false,
-                "any_of with negated predicate");
-
-  // Test any_of with empty range.
-  static_assert(!any_of(Empty, [](int) { return true; }),
-                "any_of should return false for empty range");
-
-  // Test none_of with std::array.
-  constexpr std::array<int, 5> Arr5 = {1, 3, 5, 7, 9};
-  static_assert(none_of(Arr5, [](int X) { return X % 2 == 0; }),
-                "none_of should return true when no elements are even");
-  static_assert(none_of(Arr5, [](int X) { return X > 10; }),
-                "none_of should return true when all elements don't satisfy");
-  static_assert(
-      !none_of(Arr5, [](int X) { return X == 5; }),
-      "none_of should return false when at least one element matches");
-
-  // Test none_of with std::string_view.
-  constexpr std::string_view Str2 = "WORLD";
-  static_assert(none_of(Str2, [](char C) { return C >= 'a' && C <= 'z'; }),
-                "none_of verifies no lowercase letters");
-  static_assert(!none_of(Str2, [](char C) { return C == 'R'; }),
-                "none_of returns false when element exists");
-
-  // Test none_of with empty range.
-  static_assert(none_of(Empty, [](int) { return true; }),
-                "none_of should return true for empty range");
-
-  // Test with single element C-style array.
-  constexpr int Single[] = {42};
-  static_assert(all_of(Single, [](int X) { return X == 42; }),
-                "all_of works with single element C-array");
-  static_assert(any_of(Single, [](int X) { return X == 42; }),
-                "any_of works with single element");
-  static_assert(none_of(Single, [](int X) { return X != 42; }),
-                "none_of works with single element");
-
-  // Test with const arrays.
-  constexpr const std::array<int, 3> ConstArr = {100, 200, 300};
-  static_assert(all_of(ConstArr, [](int X) { return X >= 100; }),
-                "all_of works with const std::array");
-  static_assert(any_of(ConstArr, [](int X) { return X == 200; }),
-                "any_of works with const std::array");
-  static_assert(none_of(ConstArr, [](int X) { return X < 100; }),
-                "none_of works with const std::array");
-
-  // Test logical relationships between all_of, any_of, and none_of.
-  constexpr std::array<int, 3> Arr8 = {5, 10, 15};
-  static_assert(all_of(Arr8, [](int X) { return X > 0; }) ==
-                    !any_of(Arr8, [](int X) { return X <= 0; }),
-                "all_of(P) should equal !any_of(!P)");
-  static_assert(none_of(Arr8, [](int X) { return X < 0; }) ==
-                    !any_of(Arr8, [](int X) { return X < 0; }),
-                "none_of(P) should equal !any_of(P)");
-
-  // Test with different element types in std::array.
-  constexpr std::array<char, 4> CharArr = {'a', 'b', 'c', 'd'};
-  static_assert(all_of(CharArr, [](char C) { return C >= 'a' && C <= 'z'; }),
-                "all_of works with char array");
-  static_assert(any_of(CharArr, [](char C) { return C == 'c'; }),
-                "any_of works with char array");
-  static_assert(none_of(CharArr, [](char C) { return C >= 'A' && C <= 'Z'; }),
-                "none_of works with char array");
+  static_assert(all_of(Empty, [](int) { return false; }));
+  static_assert(!any_of(Empty, [](int) { return true; }));
+  static_assert(none_of(Empty, [](int) { return true; }));
 }
 
 TEST(STLExtras, Unique) {


### PR DESCRIPTION
This patch replaces the implementation of `llvm::all_of`, `llvm::any_of`, and `llvm::none_of` with simple loops instead of their corresponding `std` versions. This makes them possible to be evaluated at compile time for the time being. We can revisit once the C++ version of LLVM is promoted to C++20. https://en.cppreference.com/w/cpp/algorithm/all_any_none_of.html

This refactor was brought up in the context of this PR: https://github.com/llvm/llvm-project/pull/172062#discussion_r2615331513