### PR TITLE
[bazel][libc] Remove unused dep in //libc:pkey_mprotect.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -7084,7 +7084,6 @@ libc_function(
         ":__support_common",
         ":__support_osutil_syscall",
         ":errno",
-        ":mprotect",
         ":mprotect_common",
         ":types_size_t",
     ],


### PR DESCRIPTION
Added in #162362 by mistake.