### PR TITLE
[MemProf] Update metadata verification for a single string tag

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5340,19 +5340,12 @@ void Verifier::visitMemProfMetadata(Instruction &I, MDNode *MD) {
     MDNode *StackMD = dyn_cast<MDNode>(MIB->getOperand(0));
     visitCallStackMetadata(StackMD);
 
-    // The next set of 1 or more operands should be MDString.
-    unsigned I = 1;
-    for (; I < MIB->getNumOperands(); ++I) {
-      if (!isa<MDString>(MIB->getOperand(I))) {
-        Check(I > 1,
-              "!memprof MemInfoBlock second operand should be an MDString",
-              MIB);
-        break;
-      }
-    }
+    // The second MIB operand should be MDString.
+    Check(isa<MDString>(MIB->getOperand(1)),
+          "!memprof MemInfoBlock second operand should be an MDString", MIB);
 
     // Any remaining should be MDNode that are pairs of integers
-    for (; I < MIB->getNumOperands(); ++I) {
+    for (unsigned I = 2; I < MIB->getNumOperands(); ++I) {
       MDNode *OpNode = dyn_cast<MDNode>(MIB->getOperand(I));
       Check(OpNode, "Not all !memprof MemInfoBlock operands 2 to N are MDNode",
             MIB);

--- a/llvm/test/Verifier/memprof-metadata-bad.ll
+++ b/llvm/test/Verifier/memprof-metadata-bad.ll
@@ -8,6 +8,8 @@ entry:
   %call3 = call noalias dereferenceable_or_null(40) ptr @malloc(i64 noundef 40), !memprof !3
   %call4 = call noalias dereferenceable_or_null(40) ptr @malloc(i64 noundef 40), !memprof !5
   %call5 = call noalias dereferenceable_or_null(40) ptr @malloc(i64 noundef 40), !memprof !7, !callsite !9
+  %call6 = call noalias dereferenceable_or_null(40) ptr @malloc(i64 noundef 40), !memprof !12
+  %call7 = call noalias dereferenceable_or_null(40) ptr @malloc(i64 noundef 40), !memprof !15
   ret ptr %call5
 }
 
@@ -45,10 +47,18 @@ declare dso_local noalias noundef ptr @malloc(i64 noundef)
 ; CHECK: call stack metadata should have at least 1 operand
 ; CHECK: Not all !memprof MemInfoBlock operands 2 to N are MDNode
 !8 = !{!0, !"default", i64 0, i64 5}
+!12 = !{!13}
+; CHECK: Not all !memprof MemInfoBlock operands 2 to N are MDNode
+!13 = !{!14, !"default", !"tag"}
+!15 = !{!16}
+; CHECK: Not all !memprof MemInfoBlock operands 2 to N are MDNode with 2 operands
+!16 = !{!14, !"default", !17}
+!17 = !{i64 789}
 !9 = !{i64 123}
 ; CHECK: call stack metadata operand should be constant integer
 !10 = !{!"wrongtype"}
 !11 = !{i64 789, i64 678}
+!14 = !{i64 234}
 
 ; Errors from annotating incorrect instruction type in @wronginsttype.
 ; CHECK: !memprof metadata should only exist on calls

--- a/llvm/test/Verifier/memprof-metadata-good.ll
+++ b/llvm/test/Verifier/memprof-metadata-good.ll
@@ -22,12 +22,16 @@ entry:
 declare dso_local noalias noundef ptr @malloc(i64 noundef)
 
 !0 = !{!1, !3}
-; !memprof metadata should be able to support an arbitrary list of string tags.
-!1 = !{!2, !"default", !"tag2"}
+; !memprof metadata can have a single string tag, followed by an arbitrary
+; list of MDNodes. The MDNodes should each be a pair
+!1 = !{!2, !"default", !8, !9}
 !2 = !{i64 123, i64 456}
-!3 = !{!4, !"cold", !"tag3", !"tag4"}
+!3 = !{!4, !"cold", !10}
 !4 = !{i64 123, i64 789, i64 678}
 !5 = !{i64 123}
 !6 = !{i64 456}
 ; Inlined callsites will have more than one call stack id.
 !7 = !{i64 789, i64 678}
+!8 = !{i64 891, i64 100}
+!9 = !{i64 912, i64 200}
+!10 = !{i64 1234, i64 300}


### PR DESCRIPTION
The memprof metadata verifier supported multiple string tags, but in
reality, the other code (e.g. addCallStack) only supports a single such
tag. Update the verifier to reflect that limitation, and the associated
tests.

Fixes #157217
