### PR TITLE
[clang][NFC] Remove useless `const_cast` in `CFGWalker`

### DIFF
--- a/clang/include/clang/Analysis/Analyses/ThreadSafetyCommon.h
+++ b/clang/include/clang/Analysis/Analyses/ThreadSafetyCommon.h
@@ -213,10 +213,8 @@ public:
 
         case CFGElement::AutomaticObjectDtor: {
           CFGAutomaticObjDtor AD = BI.castAs<CFGAutomaticObjDtor>();
-          auto *DD = const_cast<CXXDestructorDecl *>(
-              AD.getDestructorDecl(ACtx->getASTContext()));
-          auto *VD = const_cast<VarDecl *>(AD.getVarDecl());
-          V.handleDestructorCall(VD, DD);
+          V.handleDestructorCall(AD.getVarDecl(),
+                                 AD.getDestructorDecl(ACtx->getASTContext()));
           break;
         }
         default:


### PR DESCRIPTION
We have two `const_cast`, but the function those pointers are passed to accept pointers to `const`.