### PR TITLE
[clang][NFC][diagnostics] Remove most usage of `getCustomDiagID()` from CodeGen

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -404,6 +404,69 @@ def warn_hlsl_langstd_minimal :
           "recommend using %1 instead">,
   InGroup<HLSLDXCCompat>;
 
+def err_data_layout_mismatch : Error<"backend data layout '%0' does not match "
+                                     "expected target description '%1'">;
+def err_failed_to_open_for_embedding
+    : Error<"could not open '%0' for embedding">;
+def err_unsupported_cxx_abi_feature
+    : Error<"cannot yet compile %0 in this ABI">;
+
+def err_target_region_offloading_entry_incorrect
+    : Error<"offloading entry for target region in %0 is incorrect: either the "
+            "address or the ID is invalid">;
+def err_target_var_offloading_entry_incorrect_with_parent
+    : Error<"offloading entry for declare target variable %0 is incorrect: the "
+            "address is invalid">;
+def err_target_var_offloading_entry_incorrect
+    : Error<"offloading entry for declare target variable is incorrect: the "
+            "address is invalid">;
+
+def err_missing_mandatory_offloading
+    : Error<"no offloading entry generated while offloading is mandatory">;
+
+def err_reading_profile : Error<"error in reading profile %0: %1">;
+def err_open_hotpatch_file_failed
+    : Error<"failed to open hotpatch functions file "
+            "(-fms-hotpatch-functions-file): %0 : %1">;
+
+def err_codegen_unsupported : Error<"cannot compile this %0 yet">;
+
+def warn_trivial_auto_var_limit
+    : Warning<"-ftrivial-auto-var-init-stop-after=%0 has been enabled to limit "
+              "the number of times ftrivial-auto-var-init=%1 gets applied">,
+      InGroup<TrivialAutoVarInit>;
+
+def warn_simdlen_1_no_effect
+    : Warning<"the clause simdlen(1) has no effect when targeting aarch64">,
+      InGroup<SIMDLen>;
+def warn_simdlen_requires_power_of_2
+    : Warning<"the value specified in simdlen must be a power of 2 when "
+              "targeting Advanced SIMD">,
+      InGroup<SIMDLen>;
+def warn_simdlen_must_fit_lanes
+    : Warning<"the clause simdlen must fit the %0-bit lanes in the "
+              "architectural constraints for SVE (min is 128-bit, max is "
+              "2048-bit, by steps of 128-bit)">,
+      InGroup<SIMDLen>;
+
+def warn_pgo_nested_boolean_expr
+    : Warning<
+          "unsupported MC/DC boolean expression; contains an operation with a "
+          "nested boolean expression. Expression will not be covered">,
+      InGroup<PGOCoverage>;
+def warn_pgo_condition_limit
+    : Warning<"unsupported MC/DC boolean expression; number of conditions (%0) "
+              "exceeds max (%1). Expression will not be covered">,
+      InGroup<PGOCoverage>;
+def warn_pgo_test_vector_limit
+    : Warning<"unsupported MC/DC boolean expression; number of test vectors "
+              "(%0) exceeds max (%1). Expression will not be covered">,
+      InGroup<PGOCoverage>;
+
+def err_member_ptr_requires_complete_type
+    : Error<"member pointer representation requires a complete class type for "
+            "%0 to perform this expression">;
+
 // ClangIR frontend errors
 def err_cir_to_cir_transform_failed : Error<
     "CIR-to-CIR transformation failed">, DefaultFatal;

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1780,5 +1780,14 @@ def ExtractAPIMisuse : DiagGroup<"extractapi-misuse">;
 // with a storage class specifier.
 def ExplicitSpecializationStorageClass : DiagGroup<"explicit-specialization-storage-class">;
 
+// Warnings related to the simdlen intrinsic
+def SIMDLen : DiagGroup<"simdlen">;
+
+// Warnings related to PGO coverage limitations
+def PGOCoverage : DiagGroup<"pgo-coverage">;
+
+// Warnings related to -ftrivial-auto-var-init
+def TrivialAutoVarInit : DiagGroup<"trivial-auto-var-init">;
+
 // A warning for options that enable a feature that is not yet complete
 def ExperimentalOption : DiagGroup<"experimental-option">;

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1511,10 +1511,7 @@ void clang::emitBackendOutput(CompilerInstance &CI, CodeGenOptions &CGOpts,
   if (AsmHelper.TM) {
     std::string DLDesc = M->getDataLayout().getStringRepresentation();
     if (DLDesc != TDesc) {
-      unsigned DiagID = Diags.getCustomDiagID(
-          DiagnosticsEngine::Error, "backend data layout '%0' does not match "
-                                    "expected target description '%1'");
-      Diags.Report(DiagID) << DLDesc << TDesc;
+      Diags.Report(diag::err_data_layout_mismatch) << DLDesc << TDesc;
     }
   }
 }
@@ -1540,9 +1537,7 @@ void clang::EmbedObject(llvm::Module *M, const CodeGenOptions &CGOpts,
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> ObjectOrErr =
         VFS.getBufferForFile(OffloadObject);
     if (ObjectOrErr.getError()) {
-      auto DiagID = Diags.getCustomDiagID(DiagnosticsEngine::Error,
-                                          "could not open '%0' for embedding");
-      Diags.Report(DiagID) << OffloadObject;
+      Diags.Report(diag::err_failed_to_open_for_embedding) << OffloadObject;
       return;
     }
 

--- a/clang/lib/CodeGen/CGCXXABI.cpp
+++ b/clang/lib/CodeGen/CGCXXABI.cpp
@@ -14,6 +14,7 @@
 #include "CGCXXABI.h"
 #include "CGCleanup.h"
 #include "clang/AST/Attr.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 
 using namespace clang;
 using namespace CodeGen;
@@ -28,11 +29,9 @@ Address CGCXXABI::getThisAddress(CodeGenFunction &CGF) {
 
 void CGCXXABI::ErrorUnsupportedABI(CodeGenFunction &CGF, StringRef S) {
   DiagnosticsEngine &Diags = CGF.CGM.getDiags();
-  unsigned DiagID = Diags.getCustomDiagID(DiagnosticsEngine::Error,
-                                          "cannot yet compile %0 in this ABI");
   Diags.Report(CGF.getContext().getFullLoc(CGF.CurCodeDecl->getLocation()),
-               DiagID)
-    << S;
+               diag::err_unsupported_cxx_abi_feature)
+      << S;
 }
 
 llvm::Constant *CGCXXABI::GetBogusMemberPointer(QualType T) {

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -24,6 +24,7 @@
 #include "clang/AST/OpenMPClause.h"
 #include "clang/AST/StmtOpenMP.h"
 #include "clang/AST/StmtVisitor.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Basic/OpenMPKinds.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/CodeGen/ConstantInitBuilder.h"
@@ -2832,25 +2833,17 @@ void CGOpenMPRuntime::createOffloadEntriesAndInfoMetadata() {
     }
     switch (Kind) {
     case llvm::OpenMPIRBuilder::EMIT_MD_TARGET_REGION_ERROR: {
-      unsigned DiagID = CGM.getDiags().getCustomDiagID(
-          DiagnosticsEngine::Error, "Offloading entry for target region in "
-                                    "%0 is incorrect: either the "
-                                    "address or the ID is invalid.");
-      CGM.getDiags().Report(Loc, DiagID) << EntryInfo.ParentName;
+      CGM.getDiags().Report(Loc,
+                            diag::err_target_region_offloading_entry_incorrect)
+          << EntryInfo.ParentName;
     } break;
     case llvm::OpenMPIRBuilder::EMIT_MD_DECLARE_TARGET_ERROR: {
-      unsigned DiagID = CGM.getDiags().getCustomDiagID(
-          DiagnosticsEngine::Error, "Offloading entry for declare target "
-                                    "variable %0 is incorrect: the "
-                                    "address is invalid.");
-      CGM.getDiags().Report(Loc, DiagID) << EntryInfo.ParentName;
+      CGM.getDiags().Report(
+          Loc, diag::err_target_var_offloading_entry_incorrect_with_parent)
+          << EntryInfo.ParentName;
     } break;
     case llvm::OpenMPIRBuilder::EMIT_MD_GLOBAL_VAR_LINK_ERROR: {
-      unsigned DiagID = CGM.getDiags().getCustomDiagID(
-          DiagnosticsEngine::Error,
-          "Offloading entry for declare target variable is incorrect: the "
-          "address is invalid.");
-      CGM.getDiags().Report(DiagID);
+      CGM.getDiags().Report(diag::err_target_var_offloading_entry_incorrect);
     } break;
     }
   };
@@ -11988,20 +11981,14 @@ static void emitAArch64DeclareSimdFunction(
   // Check the values provided via `simdlen` by the user.
   // 1. A `simdlen(1)` doesn't produce vector signatures,
   if (UserVLEN == 1) {
-    unsigned DiagID = CGM.getDiags().getCustomDiagID(
-        DiagnosticsEngine::Warning,
-        "The clause simdlen(1) has no effect when targeting aarch64.");
-    CGM.getDiags().Report(SLoc, DiagID);
+    CGM.getDiags().Report(SLoc, diag::warn_simdlen_1_no_effect);
     return;
   }
 
   // 2. Section 3.3.1, item 1: user input must be a power of 2 for
   // Advanced SIMD output.
   if (ISA == 'n' && UserVLEN && !llvm::isPowerOf2_32(UserVLEN)) {
-    unsigned DiagID = CGM.getDiags().getCustomDiagID(
-        DiagnosticsEngine::Warning, "The value specified in simdlen must be a "
-                                    "power of 2 when targeting Advanced SIMD.");
-    CGM.getDiags().Report(SLoc, DiagID);
+    CGM.getDiags().Report(SLoc, diag::warn_simdlen_requires_power_of_2);
     return;
   }
 
@@ -12009,12 +11996,7 @@ static void emitAArch64DeclareSimdFunction(
   // limits.
   if (ISA == 's' && UserVLEN != 0) {
     if ((UserVLEN * WDS > 2048) || (UserVLEN * WDS % 128 != 0)) {
-      unsigned DiagID = CGM.getDiags().getCustomDiagID(
-          DiagnosticsEngine::Warning, "The clause simdlen must fit the %0-bit "
-                                      "lanes in the architectural constraints "
-                                      "for SVE (min is 128-bit, max is "
-                                      "2048-bit, by steps of 128-bit)");
-      CGM.getDiags().Report(SLoc, DiagID) << WDS;
+      CGM.getDiags().Report(SLoc, diag::warn_simdlen_must_fit_lanes) << WDS;
       return;
     }
   }

--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -24,6 +24,7 @@
 #include "clang/AST/Stmt.h"
 #include "clang/AST/StmtOpenMP.h"
 #include "clang/AST/StmtVisitor.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Basic/OpenMPKinds.h"
 #include "clang/Basic/PrettyStackTrace.h"
 #include "clang/Basic/SourceManager.h"
@@ -6989,10 +6990,7 @@ static void emitCommonOMPTargetDirective(CodeGenFunction &CGF,
     IsOffloadEntry = false;
 
   if (CGM.getLangOpts().OpenMPOffloadMandatory && !IsOffloadEntry) {
-    unsigned DiagID = CGM.getDiags().getCustomDiagID(
-        DiagnosticsEngine::Error,
-        "No offloading entry generated while offloading is mandatory.");
-    CGM.getDiags().Report(DiagID);
+    CGM.getDiags().Report(diag::err_missing_mandatory_offloading);
   }
 
   assert(CGF.CurFuncDecl && "No parent declaration for target region!");

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -490,10 +490,8 @@ CodeGenModule::CodeGenModule(ASTContext &C,
         CodeGenOpts.ProfileInstrumentUsePath, *FS,
         CodeGenOpts.ProfileRemappingFile);
     if (auto E = ReaderOrErr.takeError()) {
-      unsigned DiagID = Diags.getCustomDiagID(
-          DiagnosticsEngine::Error, "Error in reading profile %0: %1");
       llvm::handleAllErrors(std::move(E), [&](const llvm::ErrorInfoBase &EI) {
-        Diags.Report(DiagID)
+        Diags.Report(diag::err_reading_profile)
             << CodeGenOpts.ProfileInstrumentUsePath << EI.message();
       });
       return;
@@ -537,12 +535,9 @@ CodeGenModule::CodeGenModule(ASTContext &C,
           this->MSHotPatchFunctions.push_back(std::string{*I});
       } else {
         auto &DE = Context.getDiagnostics();
-        unsigned DiagID =
-            DE.getCustomDiagID(DiagnosticsEngine::Error,
-                               "failed to open hotpatch functions file "
-                               "(-fms-hotpatch-functions-file): %0 : %1");
-        DE.Report(DiagID) << CGO.MSSecureHotPatchFunctionsFile
-                          << BufOrErr.getError().message();
+        DE.Report(diag::err_open_hotpatch_file_failed)
+            << CGO.MSSecureHotPatchFunctionsFile
+            << BufOrErr.getError().message();
       }
     }
 
@@ -1759,20 +1754,19 @@ void CodeGenModule::Error(SourceLocation loc, StringRef message) {
 /// ErrorUnsupported - Print out an error that codegen doesn't support the
 /// specified stmt yet.
 void CodeGenModule::ErrorUnsupported(const Stmt *S, const char *Type) {
-  unsigned DiagID = getDiags().getCustomDiagID(DiagnosticsEngine::Error,
-                                               "cannot compile this %0 yet");
   std::string Msg = Type;
-  getDiags().Report(Context.getFullLoc(S->getBeginLoc()), DiagID)
+  getDiags().Report(Context.getFullLoc(S->getBeginLoc()),
+                    diag::err_codegen_unsupported)
       << Msg << S->getSourceRange();
 }
 
 /// ErrorUnsupported - Print out an error that codegen doesn't support the
 /// specified decl yet.
 void CodeGenModule::ErrorUnsupported(const Decl *D, const char *Type) {
-  unsigned DiagID = getDiags().getCustomDiagID(DiagnosticsEngine::Error,
-                                               "cannot compile this %0 yet");
   std::string Msg = Type;
-  getDiags().Report(Context.getFullLoc(D->getLocation()), DiagID) << Msg;
+  getDiags().Report(Context.getFullLoc(D->getLocation()),
+                    diag::err_codegen_unsupported)
+      << Msg;
 }
 
 void CodeGenModule::runWithSufficientStackSpace(SourceLocation Loc,
@@ -8262,11 +8256,7 @@ bool CodeGenModule::stopAutoInit() {
       return true;
     }
     if (!NumAutoVarInit) {
-      unsigned DiagID = getDiags().getCustomDiagID(
-          DiagnosticsEngine::Warning,
-          "-ftrivial-auto-var-init-stop-after=%0 has been enabled to limit the "
-          "number of times ftrivial-auto-var-init=%1 gets applied.");
-      getDiags().Report(DiagID)
+      getDiags().Report(diag::warn_trivial_auto_var_limit)
           << StopAfter
           << (getContext().getLangOpts().getTrivialAutoVarInit() ==
                       LangOptions::TrivialAutoVarInitKind::Zero

--- a/clang/lib/CodeGen/CodeGenPGO.cpp
+++ b/clang/lib/CodeGen/CodeGenPGO.cpp
@@ -16,6 +16,7 @@
 #include "CoverageMappingGen.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/Support/CommandLine.h"
@@ -293,23 +294,14 @@ struct MapRegionCounters : public RecursiveASTVisitor<MapRegionCounters> {
         if (LogOpStack.empty()) {
           /// Was the "split-nested" logical operator case encountered?
           if (SplitNestedLogicalOp) {
-            unsigned DiagID = Diag.getCustomDiagID(
-                DiagnosticsEngine::Warning,
-                "unsupported MC/DC boolean expression; "
-                "contains an operation with a nested boolean expression. "
-                "Expression will not be covered");
-            Diag.Report(S->getBeginLoc(), DiagID);
+            Diag.Report(S->getBeginLoc(), diag::warn_pgo_nested_boolean_expr);
             return true;
           }
 
           /// Was the maximum number of conditions encountered?
           if (NumCond > MCDCMaxCond) {
-            unsigned DiagID = Diag.getCustomDiagID(
-                DiagnosticsEngine::Warning,
-                "unsupported MC/DC boolean expression; "
-                "number of conditions (%0) exceeds max (%1). "
-                "Expression will not be covered");
-            Diag.Report(S->getBeginLoc(), DiagID) << NumCond << MCDCMaxCond;
+            Diag.Report(S->getBeginLoc(), diag::warn_pgo_condition_limit)
+                << NumCond << MCDCMaxCond;
             return true;
           }
 

--- a/clang/lib/CodeGen/CoverageMappingGen.cpp
+++ b/clang/lib/CodeGen/CoverageMappingGen.cpp
@@ -15,6 +15,7 @@
 #include "CodeGenPGO.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Lex/Lexer.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallSet.h"
@@ -2223,12 +2224,8 @@ struct CounterCoverageMappingBuilder
   void cancelDecision(const BinaryOperator *E, unsigned Since, int NumTVs,
                       int MaxTVs) {
     auto &Diag = CVM.getCodeGenModule().getDiags();
-    unsigned DiagID =
-        Diag.getCustomDiagID(DiagnosticsEngine::Warning,
-                             "unsupported MC/DC boolean expression; "
-                             "number of test vectors (%0) exceeds max (%1). "
-                             "Expression will not be covered");
-    Diag.Report(E->getBeginLoc(), DiagID) << NumTVs << MaxTVs;
+    Diag.Report(E->getBeginLoc(), diag::warn_pgo_test_vector_limit)
+        << NumTVs << MaxTVs;
 
     // Restore MCDCBranch to Branch.
     for (auto &SR : MutableArrayRef(SourceRegions).slice(Since)) {

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -27,6 +27,7 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/StmtCXX.h"
 #include "clang/AST/VTableBuilder.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/CodeGen/ConstantInitBuilder.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSet.h"
@@ -3248,11 +3249,8 @@ llvm::Value *MicrosoftCXXABI::AdjustVirtualBase(
     CharUnits offs = CharUnits::Zero();
     if (!RD->hasDefinition()) {
       DiagnosticsEngine &Diags = CGF.CGM.getDiags();
-      unsigned DiagID = Diags.getCustomDiagID(
-          DiagnosticsEngine::Error,
-          "member pointer representation requires a "
-          "complete class type for %0 to perform this expression");
-      Diags.Report(E->getExprLoc(), DiagID) << RD << E->getSourceRange();
+      Diags.Report(E->getExprLoc(), diag::err_member_ptr_requires_complete_type)
+          << RD << E->getSourceRange();
     } else if (RD->getNumVBases())
       offs = getContext().getASTRecordLayout(RD).getVBPtrOffset();
     VBPtrOffset = llvm::ConstantInt::get(CGM.IntTy, offs.getQuantity());

--- a/clang/test/Frontend/custom-diag-werror-interaction.c
+++ b/clang/test/Frontend/custom-diag-werror-interaction.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -emit-llvm-only -fprofile-instrument=clang -fcoverage-mcdc -Werror -Wno-unused-value %s -verify
+// RUN: %clang_cc1 -emit-llvm-only -fprofile-instrument=clang -fcoverage-mcdc -Werror -Wno-error=pgo-coverage -Wno-unused-value %s -verify
 
 int foo(int x);
 

--- a/clang/test/OpenMP/declare_simd_aarch64_warning_advsimd.c
+++ b/clang/test/OpenMP/declare_simd_aarch64_warning_advsimd.c
@@ -4,10 +4,10 @@
 
 #pragma omp declare simd simdlen(6)
 double foo(float x);
-// expected-warning@-2{{The value specified in simdlen must be a power of 2 when targeting Advanced SIMD.}}
+// expected-warning@-2{{the value specified in simdlen must be a power of 2 when targeting Advanced SIMD}}
 #pragma omp declare simd simdlen(1)
 float bar(double x);
-// expected-warning@-2{{The clause simdlen(1) has no effect when targeting aarch64.}}
+// expected-warning@-2{{the clause simdlen(1) has no effect when targeting aarch64}}
 
 void foo_loop(double *x, float *y, int N) {
   for (int i = 0; i < N; ++i) {

--- a/clang/test/OpenMP/declare_simd_aarch64_warning_sve.c
+++ b/clang/test/OpenMP/declare_simd_aarch64_warning_sve.c
@@ -4,7 +4,7 @@
 
 #pragma omp declare simd simdlen(66)
 double foo(float x);
-//expected-warning@-2{{The clause simdlen must fit the 64-bit lanes in the architectural constraints for SVE (min is 128-bit, max is 2048-bit, by steps of 128-bit)}}
+//expected-warning@-2{{the clause simdlen must fit the 64-bit lanes in the architectural constraints for SVE (min is 128-bit, max is 2048-bit, by steps of 128-bit)}}
 
 void foo_loop(double *x, float *y, int N) {
   for (int i = 0; i < N; ++i) {

--- a/clang/test/Profile/profile-does-not-exist.c
+++ b/clang/test/Profile/profile-does-not-exist.c
@@ -1,6 +1,6 @@
 // RUN: not %clang_cc1 -emit-llvm %s -o - -fprofile-instrument-use=clang -fprofile-instrument-use-path=%t.nonexistent.profdata 2>&1 | FileCheck %s
 
-// CHECK: error: Error in reading profile {{.*}}.nonexistent.profdata:
+// CHECK: error: error in reading profile {{.*}}.nonexistent.profdata:
 // CHECK-NOT: Assertion failed
 
 int main() {


### PR DESCRIPTION
This change removes most of the usage of `getCustomDiagID()` from the CodeGen library, and replaces those uses with diagnostics defined in `DiagnosticFrontendKinds.td`. The warnings have been assigned new warning groups. The diagnostic text has been updated to match the casing and punctuation conventions that clang-tblgen enforces.

I had to update a few test expectations. Mostly this was to match the updated message text, but in one case, `-Werror` now affects one of the warnings, so I had to use `-Wno-error=` to turn off `-Werror` for that warning's group.