### PR TITLE
[clang] Avoid invalid iterator in `MergeDefinitionData`

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -2107,8 +2107,9 @@ void ASTDeclMerger::MergeDefinitionData(
     auto *Def = DD.Definition;
     DD = std::move(MergeDD);
     DD.Definition = Def;
-    for (auto *D : Def->redecls())
-      cast<CXXRecordDecl>(D)->DefinitionData = &DD;
+    for (auto *R = Reader.getMostRecentExistingDecl(Def); R;
+         R = R->getPreviousDecl())
+      cast<CXXRecordDecl>(R)->DefinitionData = &DD;
     return;
   }
 


### PR DESCRIPTION
Change the code added in commit 0d490ae55f and modified in commit 5ee6cff90b to the pattern found in `ASTReader::finishPendingActions()` that avoids the iterator returned from `redecls()`, which may become invalid during iteration.