### PR TITLE
libc: Prefix Rounding Control Error enum to avoid conflict in windows build

### DIFF
--- a/libc/src/__support/FPUtil/x86_64/FEnvImpl.h
+++ b/libc/src/__support/FPUtil/x86_64/FEnvImpl.h
@@ -120,7 +120,7 @@ LIBC_INLINE static int get_round() {
 
 LIBC_INLINE static int set_round(int rounding_mode) {
   uint16_t rounding = internal::get_rounding_control_from_macro(rounding_mode);
-  if (LIBC_UNLIKELY(rounding == internal::RoundingControl::ERROR))
+  if (LIBC_UNLIKELY(rounding == internal::RoundingControl::RC_ERROR))
     return -1;
   sse::set_round(rounding);
 

--- a/libc/src/__support/FPUtil/x86_64/fenv_x86_common.h
+++ b/libc/src/__support/FPUtil/x86_64/fenv_x86_common.h
@@ -75,7 +75,7 @@ struct RoundingControl {
                                                 << X87_BIT_POSITION;
   static constexpr uint16_t MXCSR_ROUNDING_MASK = ROUNDING_MASK
                                                   << MXCSR_BIT_POSITION;
-  static constexpr uint16_t ERROR = 0xFFFF;
+  static constexpr uint16_t RC_ERROR = 0xFFFF;
 };
 
 // Exception flags are individual bits in the corresponding registers.
@@ -127,7 +127,7 @@ LIBC_INLINE static uint16_t get_rounding_control_from_macro(int rounding) {
   case FE_TOWARDZERO:
     return RoundingControl::TOWARD_ZERO;
   default:
-    return RoundingControl::ERROR;
+    return RoundingControl::RC_ERROR;
   }
 }
 

--- a/libc/src/__support/FPUtil/x86_64/fenv_x87_only.h
+++ b/libc/src/__support/FPUtil/x86_64/fenv_x87_only.h
@@ -76,7 +76,7 @@ LIBC_INLINE static int get_round() {
 
 LIBC_INLINE static int set_round(int rounding_mode) {
   uint16_t rounding = internal::get_rounding_control_from_macro(rounding_mode);
-  if (LIBC_UNLIKELY(rounding == internal::RoundingControl::ERROR))
+  if (LIBC_UNLIKELY(rounding == internal::RoundingControl::RC_ERROR))
     return -1;
   x87::set_round(rounding);
   return 0;


### PR DESCRIPTION
Similar to e85a9f5540f5

Somehow conflict with define in wingdi.h.

Fix build failures:
...FPUtil\x86_64\fenv_x86_common.h(78,29): error: expected member name or
';' after declaration specifiers

78 |   static constexpr uint16_t ERROR = 0xFFFF;
         |   ~~~~~~~~~~~~~~~~~~~~~~~~~ ^
c:\Program files (x86)\Windows Kits\10\include\10.0.22000.0\um\wingdi.h(118,29):
note: expanded from macro 'ERROR'
      118 | #define ERROR               0
          |
