### PR TITLE
[lldb] Change how Symbol stores symbol re-export info

### DIFF
--- a/lldb/include/lldb/Symbol/Symbol.h
+++ b/lldb/include/lldb/Symbol/Symbol.h
@@ -157,7 +157,7 @@ public:
 
   ConstString GetReExportedSymbolName() const { return m_reexport_name; }
 
-  FileSpec GetReExportedSymbolSharedLibrary() const {
+  const FileSpec &GetReExportedSymbolSharedLibrary() const {
     return m_reexport_library;
   }
 

--- a/lldb/include/lldb/Symbol/Symbol.h
+++ b/lldb/include/lldb/Symbol/Symbol.h
@@ -155,11 +155,9 @@ public:
     return m_mangled;
   }
 
-  ConstString GetReExportedSymbolName() const { return m_reexport_name; }
+  ConstString GetReExportedSymbolName() const;
 
-  const FileSpec &GetReExportedSymbolSharedLibrary() const {
-    return m_reexport_library;
-  }
+  FileSpec GetReExportedSymbolSharedLibrary() const;
 
   void SetReExportedSymbolName(ConstString name);
 
@@ -321,6 +319,11 @@ protected:
 
   void SynthesizeNameIfNeeded() const;
 
+  struct ReExportInfo {
+    ConstString name;
+    FileSpec library;
+  };
+
   uint32_t m_uid =
       UINT32_MAX;           // User ID (usually the original symbol table index)
   uint16_t m_type_data = 0; // data specific to m_type
@@ -350,12 +353,9 @@ protected:
   AddressRange m_addr_range; // Contains the value, or the section offset
                              // address when the value is an address in a
                              // section, and the size (if any)
-  /// Stores the re-exported name if this symbol is of type
+  /// Stores re-export information if this symbol is of type
   /// eSymbolTypeReExported.
-  ConstString m_reexport_name;
-  /// Stores the re-exported shared library if this symbol is of type
-  /// eSymbolTypeReExported.
-  FileSpec m_reexport_library;
+  std::unique_ptr<ReExportInfo> m_reexport_info;
   uint32_t m_flags = 0; // A copy of the flags from the original symbol table,
                         // the ObjectFile plug-in can interpret these
 };

--- a/lldb/include/lldb/Symbol/Symbol.h
+++ b/lldb/include/lldb/Symbol/Symbol.h
@@ -13,6 +13,7 @@
 #include "lldb/Core/Mangled.h"
 #include "lldb/Core/Section.h"
 #include "lldb/Symbol/SymbolContextScope.h"
+#include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/UserID.h"
 #include "lldb/lldb-enumerations.h"
@@ -154,9 +155,11 @@ public:
     return m_mangled;
   }
 
-  ConstString GetReExportedSymbolName() const;
+  ConstString GetReExportedSymbolName() const { return m_reexport_name; }
 
-  FileSpec GetReExportedSymbolSharedLibrary() const;
+  FileSpec GetReExportedSymbolSharedLibrary() const {
+    return m_reexport_library;
+  }
 
   void SetReExportedSymbolName(ConstString name);
 
@@ -312,7 +315,7 @@ protected:
   // modules we've already seen to make sure we don't get caught in a cycle.
 
   Symbol *ResolveReExportedSymbolInModuleSpec(
-      Target &target, ConstString &reexport_name,
+      Target &target, ConstString reexport_name,
       lldb_private::ModuleSpec &module_spec,
       lldb_private::ModuleList &seen_modules) const;
 
@@ -347,6 +350,12 @@ protected:
   AddressRange m_addr_range; // Contains the value, or the section offset
                              // address when the value is an address in a
                              // section, and the size (if any)
+  /// Stores the re-exported name if this symbol is of type
+  /// eSymbolTypeReExported.
+  ConstString m_reexport_name;
+  /// Stores the re-exported shared library if this symbol is of type
+  /// eSymbolTypeReExported.
+  FileSpec m_reexport_library;
   uint32_t m_flags = 0; // A copy of the flags from the original symbol table,
                         // the ObjectFile plug-in can interpret these
 };

--- a/lldb/source/Symbol/Symbol.cpp
+++ b/lldb/source/Symbol/Symbol.cpp
@@ -267,7 +267,8 @@ void Symbol::Dump(Stream *s, Target *target, uint32_t index,
 
     intptr_t shlib = m_addr_range.GetByteSize();
     if (shlib)
-      s->Printf(" -> %s`%s\n", (const char *)shlib, m_reexport_name.GetCString());
+      s->Printf(" -> %s`%s\n", (const char *)shlib,
+                m_reexport_name.GetCString());
     else
       s->Printf(" -> %s\n", m_reexport_name.GetCString());
   } else {

--- a/lldb/source/Symbol/Symbol.cpp
+++ b/lldb/source/Symbol/Symbol.cpp
@@ -265,12 +265,12 @@ void Symbol::Dump(Stream *s, Target *target, uint32_t index,
         "                                                         0x%8.8x %s",
         m_flags, name.AsCString(""));
 
-    intptr_t shlib = m_addr_range.GetByteSize();
+    const FileSpec &shlib = GetReExportedSymbolSharedLibrary();
     if (shlib)
-      s->Printf(" -> %s`%s\n", (const char *)shlib,
-                m_reexport_name.GetCString());
+      s->Printf(" -> %s`%s\n", shlib.GetPath().c_str(),
+                GetReExportedSymbolName().GetCString());
     else
-      s->Printf(" -> %s\n", m_reexport_name.GetCString());
+      s->Printf(" -> %s\n", GetReExportedSymbolName().GetCString());
   } else {
     const char *format =
         m_size_is_sibling
@@ -454,12 +454,13 @@ Symbol *Symbol::ResolveReExportedSymbolInModuleSpec(
 }
 
 Symbol *Symbol::ResolveReExportedSymbol(Target &target) const {
-  if (m_reexport_name) {
+  ConstString reexport_name(GetReExportedSymbolName());
+  if (reexport_name) {
     ModuleSpec module_spec;
     ModuleList seen_modules;
-    module_spec.GetFileSpec() = m_reexport_library;
+    module_spec.GetFileSpec() = GetReExportedSymbolSharedLibrary();
     if (module_spec.GetFileSpec()) {
-      return ResolveReExportedSymbolInModuleSpec(target, m_reexport_name,
+      return ResolveReExportedSymbolInModuleSpec(target, reexport_name,
                                                  module_spec, seen_modules);
     }
   }


### PR DESCRIPTION
This change is motivated by a recent crash report I received related to re-exported symbols and ConstStrings. I was unable to reproduce the crash so this fix is speculative.

Symbols of type eSymbolTypeReExported have metadata associated with them to resolve them to the correct place. The first is the re-exported name, in case the name differs between the library re-exporting it and the library defining it. The second is the library that actually defines the symbol being re-exported.

LLDB currently stores this metadata in an unsafe fashion. To store the re-export name, it takes the address of a ConstString's underlying storage and puts it in the Symbol's AddressRange's base Address. The same technique is applied for the library path except it is placed in the AddressRange's size member.

The intended way of preventing any potential memory corruption is to call `Symbol::ValueIsAddress` before accessing or modifying its AddressRange information. If done correctly, this allows you to save 2 pointer's worth of space per Symbol object. However, I do not believe that the saved space is worth the risk of getting this wrong.

rdar://166452748