### PR TITLE
[clang-tidy] Add support for use-after-suspend to bugprone-use-after-move

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/UseAfterMoveCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/UseAfterMoveCheck.h
@@ -31,6 +31,8 @@ public:
 private:
   std::vector<StringRef> InvalidationFunctions;
   std::vector<StringRef> ReinitializationFunctions;
+  std::vector<StringRef> Awaitables;
+  std::vector<StringRef> NonlocalAccessors;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -491,6 +491,9 @@ Changes in existing checks
   - Added `ReinitializationFunctions` option to support custom reinitialization
     functions.
 
+  - Added `Awaitables` and `NonlocalAccessors` options to detect uses of
+    thread-locals after suspension points (which may cause thread migrations).
+
 - Improved :doc:`cppcoreguidelines-avoid-non-const-global-variables
   <clang-tidy/checks/cppcoreguidelines/avoid-non-const-global-variables>` check
   by adding a new option `AllowThreadLocal` that suppresses warnings on

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/use-after-move-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/use-after-move-cxx20.cpp
@@ -1,0 +1,144 @@
+// RUN: %check_clang_tidy -std=c++20-or-later %s bugprone-use-after-move %t -- \
+// RUN:   -config='{CheckOptions: { \
+// RUN:     bugprone-use-after-move.Awaitables: "::std::suspend_always;::CustomAwaitable", \
+// RUN:     bugprone-use-after-move.NonlocalAccessors: "::GetNonlocalState" \
+// RUN:   }}' -- \
+// RUN:   -fno-delayed-template-parsing
+
+namespace std {
+template <typename R, typename...>
+struct coroutine_traits {
+  using promise_type = typename R::promise_type;
+};
+
+template <typename Promise = void>
+struct coroutine_handle;
+
+template <>
+struct coroutine_handle<void> {
+  static coroutine_handle from_address(void *addr) noexcept;
+  void operator()();
+  void *address() const noexcept;
+  void resume() const;
+  void destroy() const;
+  bool done() const;
+  coroutine_handle &operator=(decltype(nullptr));
+  coroutine_handle(decltype(nullptr));
+  coroutine_handle();
+  explicit operator bool() const;
+};
+
+template <typename Promise>
+struct coroutine_handle : coroutine_handle<> {
+  using coroutine_handle<>::operator=;
+  static coroutine_handle from_address(void *addr) noexcept;
+  Promise &promise() const;
+  static coroutine_handle from_promise(Promise &promise);
+};
+
+struct suspend_always {
+  bool await_ready() noexcept;
+  void await_suspend(coroutine_handle<>) noexcept;
+  void await_resume() noexcept;
+};
+
+} // namespace std
+
+struct CustomAwaitable {
+  bool await_ready() noexcept;
+  void await_suspend(std::coroutine_handle<>) noexcept;
+  void await_resume() noexcept;
+};
+
+class A {
+public:
+  A();
+  A(const A &);
+  A(A &&);
+
+  A &operator=(const A &);
+  A &operator=(A &&);
+
+  void foo() const;
+  void bar(int i) const;
+  int getInt() const;
+
+  operator bool() const;
+
+  int i;
+};
+
+template <class Elem, class Final>
+class Coroutine final {
+ public:
+  struct promise_type;
+  explicit Coroutine(std::coroutine_handle<promise_type> h);
+  ~Coroutine();
+  struct promise_type {
+    std::suspend_always final_suspend() noexcept;
+    Coroutine get_return_object() noexcept;
+    std::suspend_always initial_suspend() noexcept;
+    void return_void();
+    void unhandled_exception();
+    std::suspend_always yield_value(const Elem &);
+  };
+};
+
+struct GlobalState {
+  int val() const;
+  const int &ref() const;
+  const void *ptr() const;
+};
+const GlobalState &GetNonlocalState();
+
+template <class T>
+void use(const T &);
+
+namespace coroutines {
+
+Coroutine<int, void> simpleSuspension() {
+  {
+    A a;
+    a.foo();
+    auto &&ctx = GetNonlocalState();
+    use(ctx);
+    co_yield 0;
+    a.foo();
+    use(ctx);
+    // CHECK-NOTES: [[@LINE-1]]:9: warning: 'ctx' used after a suspension point [bugprone-use-after-move]
+    // CHECK-NOTES: [[@LINE-4]]:5: note: suspension occurred here
+  }
+  {
+    A a;
+    a.foo();
+    auto &ctx = GetNonlocalState().ref();
+    use(ctx);
+    co_await CustomAwaitable();
+    a.foo();
+    use(ctx);
+    // CHECK-NOTES: [[@LINE-1]]:9: warning: 'ctx' used after a suspension point [bugprone-use-after-move]
+    // CHECK-NOTES: [[@LINE-4]]:5: note: suspension occurred here
+  }
+  {
+    A a;
+    a.foo();
+    auto *ctx = GetNonlocalState().ptr();
+    use(ctx);
+    co_yield 0;
+    a.foo();
+    use(ctx);
+    // CHECK-NOTES: [[@LINE-1]]:9: warning: 'ctx' used after a suspension point [bugprone-use-after-move]
+    // CHECK-NOTES: [[@LINE-4]]:5: note: suspension occurred here
+  }
+  {
+    A a;
+    a.foo();
+    auto &&ctx = GetNonlocalState().val();
+    use(ctx);
+    co_yield 0;
+    a.foo();
+    use(ctx);  // No error
+  }
+}
+
+} // namespace coroutines

--- a/clang/docs/LibASTMatchersReference.html
+++ b/clang/docs/LibASTMatchersReference.html
@@ -4145,6 +4145,12 @@ functionDecl(templateArgumentCountIs(1))
 </pre></td></tr>
 
 
+<tr><td>Matcher&lt;<a href="https://clang.llvm.org/doxygen/classclang_1_1CoawaitExpr.html">CoawaitExpr</a>&gt;</td><td class="name" onclick="toggle('isImplicit3')"><a name="isImplicit3Anchor">isImplicit</a></td><td></td></tr>
+<tr><td colspan="4" class="doc" id="isImplicit3"><pre>Matches an entity that has been implicitly added by the compiler (e.g.
+implicit default/copy constructors).
+</pre></td></tr>
+
+
 <tr><td>Matcher&lt;<a href="https://clang.llvm.org/doxygen/classclang_1_1CompoundStmt.html">CompoundStmt</a>&gt;</td><td class="name" onclick="toggle('statementCountIs0')"><a name="statementCountIs0Anchor">statementCountIs</a></td><td>unsigned N</td></tr>
 <tr><td colspan="4" class="doc" id="statementCountIs0"><pre>Checks that a compound statement contains a specific number of
 child statements.

--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -775,7 +775,8 @@ AST_MATCHER_P(ClassTemplateSpecializationDecl, hasSpecializedTemplate,
 /// implicit default/copy constructors).
 AST_POLYMORPHIC_MATCHER(isImplicit,
                         AST_POLYMORPHIC_SUPPORTED_TYPES(Decl, Attr,
-                                                        LambdaCapture)) {
+                                                        LambdaCapture,
+                                                        CoawaitExpr)) {
   return Node.isImplicit();
 }
 


### PR DESCRIPTION
This adds support for broken patterns such as:

```
ThreadContext* thread_context = GetThreadLocalContext();
co_await SwitchToAnotherThread();
Use(*thread_context);  // error! accessing wrong thread's TLS data
```

It's a rudimentary opt-in check and has room for improvement, but it's still better than nothing.