### PR TITLE
[lldb] Recognize MTE faults with EXC_GUARD exception type

### DIFF
--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
@@ -77,19 +77,26 @@ static void DescribeAddressBriefly(Stream &strm, const Address &addr,
   strm.Printf(".\n");
 }
 
+std::optional<addr_t> StopInfoMachException::GetTagFaultAddress() const {
+  bool bad_access = (m_value == 1);              // EXC_BAD_ACCESS
+  bool tag_fault = (m_exc_code == 0x106);        // EXC_ARM_MTE_TAG_FAULT
+  bool has_fault_addr = (m_exc_data_count >= 2); // m_exc_subcode -> fault addr
+
+  if (bad_access && tag_fault && has_fault_addr)
+    return m_exc_subcode; // Fault address
+
+  return std::nullopt;
+}
+
 static constexpr uint8_t g_mte_tag_shift = 64 - 8;
 static constexpr addr_t g_mte_tag_mask = (addr_t)0x0f << g_mte_tag_shift;
 
-bool StopInfoMachException::DetermineTagMismatch(ExecutionContext &exe_ctx) {
-  const bool IsBadAccess = m_value == 1;            // EXC_BAD_ACCESS
-  const bool IsMTETagFault = (m_exc_code == 0x106); // EXC_ARM_MTE_TAG_FAULT
-  if (!IsBadAccess || !IsMTETagFault)
+bool StopInfoMachException::DetermineTagMismatch() {
+  auto fault_address = GetTagFaultAddress();
+  if (!fault_address)
     return false;
 
-  if (m_exc_data_count < 2)
-    return false;
-
-  const uint64_t bad_address = m_exc_subcode;
+  const uint64_t bad_address = *fault_address;
 
   StreamString strm;
   strm.Printf("EXC_ARM_MTE_TAG_FAULT (code=%" PRIu64 ", address=0x%" PRIx64
@@ -295,7 +302,7 @@ const char *StopInfoMachException::GetDescription() {
     case llvm::Triple::aarch64:
       if (DeterminePtrauthFailure(exe_ctx))
         return m_description.c_str();
-      if (DetermineTagMismatch(exe_ctx))
+      if (DetermineTagMismatch())
         return m_description.c_str();
       break;
 

--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
@@ -78,13 +78,14 @@ static void DescribeAddressBriefly(Stream &strm, const Address &addr,
 }
 
 std::optional<addr_t> StopInfoMachException::GetTagFaultAddress() const {
-  bool bad_access =
-      (m_value == 1 || m_value == 12);           // EXC_BAD_ACCESS or EXC_GUARD
-  bool tag_fault = (m_exc_code == 0x106);        // EXC_ARM_MTE_TAG_FAULT
-  bool has_fault_addr = (m_exc_data_count >= 2); // m_exc_subcode -> fault addr
+  const bool bad_access =
+      (m_value == 1 || m_value == 12);          // EXC_BAD_ACCESS or EXC_GUARD
+  const bool tag_fault = (m_exc_code == 0x106); // EXC_ARM_MTE_TAG_FAULT
+  // Whether the subcode (m_exc_subcode) holds the fault address.
+  const bool has_fault_addr = (m_exc_data_count >= 2);
 
   if (bad_access && tag_fault && has_fault_addr)
-    return m_exc_subcode; // Fault address
+    return m_exc_subcode; // The subcode is the fault address.
 
   return std::nullopt;
 }
@@ -93,7 +94,7 @@ static constexpr uint8_t g_mte_tag_shift = 64 - 8;
 static constexpr addr_t g_mte_tag_mask = (addr_t)0x0f << g_mte_tag_shift;
 
 bool StopInfoMachException::DetermineTagMismatch() {
-  auto fault_address = GetTagFaultAddress();
+  std::optional<addr_t> fault_address = GetTagFaultAddress();
   if (!fault_address)
     return false;
 

--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
@@ -78,7 +78,8 @@ static void DescribeAddressBriefly(Stream &strm, const Address &addr,
 }
 
 std::optional<addr_t> StopInfoMachException::GetTagFaultAddress() const {
-  bool bad_access = (m_value == 1);              // EXC_BAD_ACCESS
+  bool bad_access =
+      (m_value == 1 || m_value == 12);           // EXC_BAD_ACCESS or EXC_GUARD
   bool tag_fault = (m_exc_code == 0x106);        // EXC_ARM_MTE_TAG_FAULT
   bool has_fault_addr = (m_exc_data_count >= 2); // m_exc_subcode -> fault addr
 
@@ -497,6 +498,8 @@ const char *StopInfoMachException::GetDescription() {
 #endif
     break;
   case 12:
+    if (DetermineTagMismatch())
+      return m_description.c_str();
     exc_desc = "EXC_GUARD";
     break;
   }

--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.h
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.h
@@ -27,7 +27,7 @@ class StopInfoMachException : public StopInfo {
   /// is auth-related failure, and returns false otherwise.
   bool DeterminePtrauthFailure(ExecutionContext &exe_ctx);
 
-  bool DetermineTagMismatch(ExecutionContext &exe_ctx);
+  bool DetermineTagMismatch();
 
 public:
   // Constructors and Destructors
@@ -47,6 +47,9 @@ public:
   }
 
   const char *GetDescription() override;
+
+  // Returns the fault address, iff this is a EXC_ARM_MTE_TAG_FAULT.
+  std::optional<lldb::addr_t> GetTagFaultAddress() const;
 
 #if defined(__APPLE__)
   struct MachException {


### PR DESCRIPTION
**5a5a315c [lldb][NFC] Extract StopInfoMachException::GetTagFaultAddress() helper function**

**9a91ded9 [lldb] Recognize MTE faults with EXC_GUARD exception type**
Recognize the new `EXC_GUARD` mach exception type
for MTE faults.  We also keep supporting the old
`EXC_BAD_ACCESS` exception type for backward
compatibility (newer LLDB on older OS).

rdar://166415268