### PR TITLE
[ORC] Make WrapperFunctionResult constructor explicit.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h
@@ -47,7 +47,7 @@ public:
   ///
   /// Warning: This should only be used by clients writing wrapper-function
   /// caller utilities (like TargetProcessControl).
-  WrapperFunctionResult(CWrapperFunctionResult R) : R(R) {
+  explicit WrapperFunctionResult(CWrapperFunctionResult R) : R(R) {
     // Reset R.
     init(R);
   }

--- a/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
@@ -134,7 +134,8 @@ void SelfExecutorProcessControl::callWrapperAsync(ExecutorAddr WrapperFnAddr,
   using WrapperFnTy =
       shared::CWrapperFunctionResult (*)(const char *Data, size_t Size);
   auto *WrapperFn = WrapperFnAddr.toPtr<WrapperFnTy>();
-  SendResult(WrapperFn(ArgBuffer.data(), ArgBuffer.size()));
+  SendResult(shared::WrapperFunctionResult(
+      WrapperFn(ArgBuffer.data(), ArgBuffer.size())));
 }
 
 Error SelfExecutorProcessControl::disconnect() {


### PR DESCRIPTION
The WrapperFunctionBuffer(CWrapperFunctionBuffer) constructor takes ownership of the underlying buffer (if one exists). Making the constructor explicit makes this clearer at the call site.