### PR TITLE
[RISCV] Add Xqci feature flag

### DIFF
--- a/clang/test/Driver/print-supported-extensions-riscv.c
+++ b/clang/test/Driver/print-supported-extensions-riscv.c
@@ -230,6 +230,7 @@
 // CHECK-NEXT:     smpmpmt              0.6       'Smpmpmt' (PMP-based Memory Types Extension)
 // CHECK-NEXT:     svukte               0.3       'Svukte' (Address-Independent Latency of User-Mode Faults to Supervisor Addresses)
 // CHECK-NEXT:     xqccmp               0.3       'Xqccmp' (Qualcomm 16-bit Push/Pop and Double Moves)
+// CHECK-NEXT:     xqci                 0.13      'Xqci' (Qualcomm uC Extension)
 // CHECK-NEXT:     xqcia                0.7       'Xqcia' (Qualcomm uC Arithmetic Extension)
 // CHECK-NEXT:     xqciac               0.3       'Xqciac' (Qualcomm uC Load-Store Address Calculation Extension)
 // CHECK-NEXT:     xqcibi               0.2       'Xqcibi' (Qualcomm uC Branch Immediate Extension)

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -1651,10 +1651,6 @@ def FeatureVendorXqci
                                  FeatureVendorXqcilia, FeatureVendorXqcilo,
                                  FeatureVendorXqcilsm, FeatureVendorXqcisim,
                                  FeatureVendorXqcisls, FeatureVendorXqcisync]>;
-def HasVendorXqci
-    : Predicate<"Subtarget->hasVendorXqci()">,
-                AssemblerPredicate<(all_of FeatureVendorXqci),
-                "'Xqci' (Qualcomm uC Extension)">;
 
 // Rivos Extension(s)
 

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -1640,6 +1640,22 @@ def HasVendorXqcisync
       AssemblerPredicate<(all_of FeatureVendorXqcisync),
                          "'Xqcisync' (Qualcomm uC Sync Delay Extension)">;
 
+def FeatureVendorXqci
+    : RISCVExperimentalExtension<0, 13, "Qualcomm uC Extension",
+                                 [FeatureVendorXqcia, FeatureVendorXqciac,
+                                 FeatureVendorXqcibi, FeatureVendorXqcibm,
+                                 FeatureVendorXqcicli, FeatureVendorXqcicm,
+                                 FeatureVendorXqcics, FeatureVendorXqcicsr,
+                                 FeatureVendorXqciint, FeatureVendorXqciio,
+                                 FeatureVendorXqcilb, FeatureVendorXqcili,
+                                 FeatureVendorXqcilia, FeatureVendorXqcilo,
+                                 FeatureVendorXqcilsm, FeatureVendorXqcisim,
+                                 FeatureVendorXqcisls, FeatureVendorXqcisync]>;
+def HasVendorXqci
+    : Predicate<"Subtarget->hasVendorXqci()">,
+                AssemblerPredicate<(all_of FeatureVendorXqci),
+                "'Xqci' (Qualcomm uC Extension)">;
+
 // Rivos Extension(s)
 
 def FeatureVendorXRivosVisni

--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -748,10 +748,10 @@ Error RISCVISAInfo::checkDependency() {
   bool HasXqccmp = Exts.count("xqccmp") != 0;
 
   static constexpr StringLiteral XqciExts[] = {
-      {"xqcia"},   {"xqciac"},  {"xqcibi"},  {"xqcibm"},  {"xqcicli"},
-      {"xqcicm"},  {"xqcics"},  {"xqcicsr"}, {"xqciint"}, {"xqciio"},
-      {"xqcilb"},  {"xqcili"},  {"xqcilia"}, {"xqcilo"},  {"xqcilsm"},
-      {"xqcisim"}, {"xqcisls"}, {"xqcisync"}};
+      {"xqci"},    {"xqcia"},   {"xqciac"},  {"xqcibi"},  {"xqcibm"},
+      {"xqcicli"}, {"xqcicm"},  {"xqcics"},  {"xqcicsr"}, {"xqciint"},
+      {"xqciio"},  {"xqcilb"},  {"xqcili"},  {"xqcilia"}, {"xqcilo"},
+      {"xqcilsm"}, {"xqcisim"}, {"xqcisls"}, {"xqcisync"}};
   static constexpr StringLiteral ZcdOverlaps[] = {
       {"zcmt"}, {"zcmp"}, {"xqccmp"}, {"xqciac"}, {"xqcicm"}};
 

--- a/llvm/test/CodeGen/RISCV/features-info.ll
+++ b/llvm/test/CodeGen/RISCV/features-info.ll
@@ -30,6 +30,7 @@
 ; CHECK-NEXT:   experimental-smpmpmt             - 'Smpmpmt' (PMP-based Memory Types Extension).
 ; CHECK-NEXT:   experimental-svukte              - 'Svukte' (Address-Independent Latency of User-Mode Faults to Supervisor Addresses).
 ; CHECK-NEXT:   experimental-xqccmp              - 'Xqccmp' (Qualcomm 16-bit Push/Pop and Double Moves).
+; CHECK-NEXT:   experimental-xqci                - 'Xqci' (Qualcomm uC Extension).
 ; CHECK-NEXT:   experimental-xqcia               - 'Xqcia' (Qualcomm uC Arithmetic Extension).
 ; CHECK-NEXT:   experimental-xqciac              - 'Xqciac' (Qualcomm uC Load-Store Address Calculation Extension).
 ; CHECK-NEXT:   experimental-xqcibi              - 'Xqcibi' (Qualcomm uC Branch Immediate Extension).

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -687,7 +687,8 @@ TEST(ParseArchString, RejectsConflictingExtensions) {
         "rv64i_xqcics0p2", "rv64i_xqcicsr0p4", "rv64i_xqciint0p10",
         "rv64i_xqciio0p1", "rv64i_xqcilb0p2", "rv64i_xqcili0p2",
         "rv64i_xqcilia0p2", "rv64i_xqcilo0p3", "rv64i_xqcilsm0p6",
-        "rv64i_xqcisim0p2", "rv64i_xqcisls0p2", "rv64i_xqcisync0p3"}) {
+        "rv64i_xqcisim0p2", "rv64i_xqcisls0p2", "rv64i_xqcisync0p3",
+        "rv64i_xqci0p13"}) {
     EXPECT_THAT(
         toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
         ::testing::EndsWith(" is only supported for 'rv32'"));
@@ -695,7 +696,8 @@ TEST(ParseArchString, RejectsConflictingExtensions) {
 
   for (StringRef Input :
        {"rv32idc_xqciac0p3", "rv32i_zcd_xqciac0p3", "rv32idc_xqcicm0p2",
-        "rv32i_zcd_xqcicm0p2", "rv32idc_xqccmp0p3", "rv32i_zcd_xqccmp0p3"}) {
+        "rv32i_zcd_xqcicm0p2", "rv32idc_xqccmp0p3", "rv32i_zcd_xqccmp0p3",
+        "rv32idc_xqci0p13", "rv32i_zcd_xqci0p13"}) {
     EXPECT_THAT(
         toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
         ::testing::EndsWith("extension when 'd' extension is enabled"));
@@ -1207,6 +1209,7 @@ Experimental extensions
     smpmpmt              0.6
     svukte               0.3
     xqccmp               0.3
+    xqci                 0.13
     xqcia                0.7
     xqciac               0.3
     xqcibi               0.2


### PR DESCRIPTION
This patch adds an experimental Xqci feature flag that covers all the sub-extensions in the Qualcomm uC Extension.