### PR TITLE
[MLIR][RemoveDeadValues] Fix affine.for induction variable incorrectly removed

### DIFF
--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -688,6 +688,25 @@ func.func @dead_value_loop_ivs_no_result(%lb: index, %ub: index, %step: index, %
 
 // -----
 
+// This test verifies that the induction variable in affine.for with constant
+// bounds is not deleted. This is a regression test for a bug where affine.for
+// with constant bounds (no operands for lb/ub/step) would have its IV deleted
+// because visitBranchOperand() was never called (no non-forwarded operands).
+
+// CHECK-LABEL: func @affine_for_iv_constant_bounds
+// CHECK: affine.for %{{.*}} = 0 to 1024 iter_args(%{{.*}} = %{{.*}}) -> (i32)
+func.func @affine_for_iv_constant_bounds() -> i32 {
+  %c1_i32 = arith.constant 1 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %0 = affine.for %iv = 0 to 1024 iter_args(%arg = %c0_i32) -> (i32) {
+    %1 = arith.addi %arg, %c1_i32 : i32
+    affine.yield %1 : i32
+  }
+  return %0 : i32
+}
+
+// -----
+
 // CHECK-LABEL: func @op_block_have_dead_arg
 func.func @op_block_have_dead_arg(%arg0: index, %arg1: index, %arg2: i1) {
   scf.execute_region {


### PR DESCRIPTION
## Summary

The fix in PR #161117 for issue #157934 addressed `scf.for` induction variable deletion by marking IVs as live in `visitBranchOperand()`. However, this fix doesn't cover `affine.for` with constant bounds because `visitBranchOperand()` is only called for non-forwarded operands.

For `affine.for` with constant bounds like `affine.for %iv = 0 to 1024`:
- Lower/upper bounds are encoded in affine maps (no operands)
- Step is a constant attribute (no operand)
- Inits are forwarded operands (not non-forwarded)

Since there are no non-forwarded operands, `visitBranchOperand()` is never called, and the IV is never marked live, leading to incorrect removal.

## The Fix

This patch fixes the issue by proactively marking non-successor-input block arguments (like IVs) as live during `RunLivenessAnalysis` initialization, rather than relying on `visitBranchOperand()` being called.

The fix walks all `RegionBranchOpInterface` ops and for each region successor from the parent, marks any block arguments that are NOT in the successor inputs as live. This covers IVs in both `scf.for` and `affine.for`, as well as similar patterns in other region branch ops.

## Test Plan

- Added regression test for `affine.for` with constant bounds and unused IV
- Verified existing `remove-dead-values.mlir` tests still pass
- Manually tested nested `affine.for` loops and `affine.for` without iter_args

Fixes #172610