### PR TITLE
[libcxx][ci] Remove myself as a contact for Linaro bots

### DIFF
--- a/libcxx/utils/ci/BOT_OWNERS.txt
+++ b/libcxx/utils/ci/BOT_OWNERS.txt
@@ -11,7 +11,7 @@ Each entry should contain at least the (N), (E) and (D) fields.
 N: Linaro Toolchain Working Group
 E: linaro-toolchain@lists.linaro.org
 D: Arm platforms and picolibc
-G: DavidSpickett, omjavaid, ceseo
+G: omjavaid, ceseo, antmox
 
 N: LLVM on Power
 E: powerllvm@ca.ibm.com


### PR DESCRIPTION
Next year I will no longer be an assignee to Linaro. Still available for questions about the Arm architecture.

Adding Antoine who is another member of the LLVM team at Linaro.