### PR TITLE
[llvm][AMDGPU] Fix signed/unsigned comparison warning in 32-bit builds

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -1084,19 +1084,19 @@ private:
       if (!SyncPipe.size())
         return false;
 
-      auto SuccSize = llvm::count_if(SU->Succs, [](const SDep &Succ) {
+      unsigned SuccSize = llvm::count_if(SU->Succs, [](const SDep &Succ) {
         return Succ.getKind() == SDep::Data;
       });
-      if (static_cast<unsigned>(SuccSize) >= Size)
+      if (SuccSize >= Size)
         return true;
 
       if (HasIntermediary) {
         for (auto Succ : SU->Succs) {
-          auto SuccSize =
+          unsigned SuccSize =
               llvm::count_if(Succ.getSUnit()->Succs, [](const SDep &SuccSucc) {
                 return SuccSucc.getKind() == SDep::Data;
               });
-          if (static_cast<unsigned>(SuccSize) >= Size)
+          if (SuccSize >= Size)
             return true;
         }
       }

--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -1047,7 +1047,7 @@ private:
       auto SuccSize = llvm::count_if(SU->Succs, [](const SDep &Succ) {
         return Succ.getKind() == SDep::Data;
       });
-      if (SuccSize >= Size)
+      if (static_cast<unsigned>(SuccSize) >= Size)
         return false;
 
       if (HasIntermediary) {
@@ -1056,7 +1056,7 @@ private:
               llvm::count_if(Succ.getSUnit()->Succs, [](const SDep &SuccSucc) {
                 return SuccSucc.getKind() == SDep::Data;
               });
-          if (SuccSize >= Size)
+          if (static_cast<unsigned>(SuccSize) >= Size)
             return false;
         }
       }
@@ -1087,7 +1087,7 @@ private:
       auto SuccSize = llvm::count_if(SU->Succs, [](const SDep &Succ) {
         return Succ.getKind() == SDep::Data;
       });
-      if (SuccSize >= Size)
+      if (static_cast<unsigned>(SuccSize) >= Size)
         return true;
 
       if (HasIntermediary) {
@@ -1096,7 +1096,7 @@ private:
               llvm::count_if(Succ.getSUnit()->Succs, [](const SDep &SuccSucc) {
                 return SuccSucc.getKind() == SDep::Data;
               });
-          if (SuccSize >= Size)
+          if (static_cast<unsigned>(SuccSize) >= Size)
             return true;
         }
       }

--- a/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUIGroupLP.cpp
@@ -1044,19 +1044,19 @@ private:
       if (!SyncPipe.size())
         return false;
 
-      auto SuccSize = llvm::count_if(SU->Succs, [](const SDep &Succ) {
+      unsigned SuccSize = llvm::count_if(SU->Succs, [](const SDep &Succ) {
         return Succ.getKind() == SDep::Data;
       });
-      if (static_cast<unsigned>(SuccSize) >= Size)
+      if (SuccSize >= Size)
         return false;
 
       if (HasIntermediary) {
         for (auto Succ : SU->Succs) {
-          auto SuccSize =
+          unsigned SuccSize =
               llvm::count_if(Succ.getSUnit()->Succs, [](const SDep &SuccSucc) {
                 return SuccSucc.getKind() == SDep::Data;
               });
-          if (static_cast<unsigned>(SuccSize) >= Size)
+          if (SuccSize >= Size)
             return false;
         }
       }


### PR DESCRIPTION
llvm::count_if calls std::count_if which returns a difference_type. difference_type is always signed but is never going to be a negative value when used as the result of count_if.

This resulted in warnings in our 32-bit Arm builds like: 
```
AMDGPUIGroupLP.cpp:1050:20: warning: comparison of integers of different signs: 
'typename iterator_traits<const SDep *>::difference_type' (aka 'int') and 'unsigned int' [-Wsign-compare]
 1050 |       if (SuccSize >= Size)
      |           ~~~~~~~~ ^  ~~~~
```

I presume these warnings are not generated in 64-bit builds because unsigned is 32-bit even for 64-bit platforms and there is no risk in extending 32-bit unsigned into 64-bit signed.

To fix the warning I've changed the type of SuccSize to unsigned, and the assignment acts like a static_cast into that type.