### PR TITLE
[clang-format] Fix comparison warning in 32-bit builds

### DIFF
--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -644,7 +644,7 @@ private:
       // Check if there is even a line after the inner result.
       if (auto Distance = std::distance(I, E);
           static_cast<decltype(N)>(Distance) <= N) {
-         return 0;
+        return 0;
       }
       // Check that the line after the inner result starts with a closing brace
       // which we are permitted to merge into one line.

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -604,7 +604,7 @@ private:
     if (BraceOpenLine[0]->Last->isNot(TT_NamespaceLBrace))
       return 0;
 
-    if (std::distance(BraceOpenLine, E) <= 2)
+    if ((BraceOpenLine, E) <= 2)
       return 0;
 
     if (BraceOpenLine[0]->Last->is(tok::comment))
@@ -642,8 +642,10 @@ private:
         return 0;
       const auto N = MergedLines + LinesToBeMerged;
       // Check if there is even a line after the inner result.
-      if (auto Distance = std::distance(I, E); static_cast<decltype(N)>(Distance) <= N)
-        return 0;
+      if (auto Distance = std::distance(I, E);
+          static_cast<decltype(N)>(Distance) <= N) {
+         return 0;
+      }
       // Check that the line after the inner result starts with a closing brace
       // which we are permitted to merge into one line.
       if (I[N]->First->is(TT_NamespaceRBrace) &&

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -642,7 +642,9 @@ private:
         return 0;
       const auto N = MergedLines + LinesToBeMerged;
       // Check if there is even a line after the inner result.
-      if (std::distance(I, E) <= N)
+      auto Distance = std::distance(I, E);
+      assert(Distance >= 0);
+      if (static_cast<decltype(N)>(Distance) <= N)
         return 0;
       // Check that the line after the inner result starts with a closing brace
       // which we are permitted to merge into one line.

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -642,9 +642,7 @@ private:
         return 0;
       const auto N = MergedLines + LinesToBeMerged;
       // Check if there is even a line after the inner result.
-      auto Distance = std::distance(I, E);
-      assert(Distance >= 0);
-      if (static_cast<decltype(N)>(Distance) <= N)
+      if (auto Distance = std::distance(I, E); static_cast<decltype(N)>(Distance) <= N)
         return 0;
       // Check that the line after the inner result starts with a closing brace
       // which we are permitted to merge into one line.

--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -604,7 +604,7 @@ private:
     if (BraceOpenLine[0]->Last->isNot(TT_NamespaceLBrace))
       return 0;
 
-    if ((BraceOpenLine, E) <= 2)
+    if (std::distance(BraceOpenLine, E) <= 2)
       return 0;
 
     if (BraceOpenLine[0]->Last->is(tok::comment))


### PR DESCRIPTION
In our 32-bit Arm builds we see:
```
UnwrappedLineFormatter.cpp:645:31: warning: comparison of integers of different signs: 'typename iterator_traits<AnnotatedLine *const *>::difference_type' (aka 'int') and 'const unsigned int' [-Wsign-compare]
  645 |       if (std::distance(I, E) <= N)
      |           ~~~~~~~~~~~~~~~~~~~ ^  ~
```

The existing comparison seems to assume that the distance will not be negative. So to fix this warning I've cast the distance to the unsigned type.

I think this warning does not occur in 64-bit builds because there it is safe to extend the unsigned 32-bit integer to the 64-bit signed distance type.