### PR TITLE
[ORC] Rename WrapperFunctionResult to WrapperFunctionBuffer. NFCI.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/CallSPSViaEPC.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/CallSPSViaEPC.h
@@ -26,8 +26,8 @@ struct SPSCallSerializationImpl {
   using ArgSerialization = shared::SPSArgList<SPSArgTs...>;
 
   template <typename... ArgTs>
-  Expected<shared::WrapperFunctionResult> serialize(ArgTs &&...Args) {
-    auto Buffer = shared::WrapperFunctionResult::allocate(
+  Expected<shared::WrapperFunctionBuffer> serialize(ArgTs &&...Args) {
+    auto Buffer = shared::WrapperFunctionBuffer::allocate(
         ArgSerialization::size(Args...));
     shared::SPSOutputBuffer OB(Buffer.data(), Buffer.size());
     if (!ArgSerialization::serialize(OB, Args...))
@@ -48,7 +48,7 @@ template <typename SPSSig>
 struct SPSCallSerializer : public detail::SPSCallSerialization<SPSSig> {
 
   template <typename RetT>
-  Expected<RetT> deserialize(shared::WrapperFunctionResult ResultBytes) {
+  Expected<RetT> deserialize(shared::WrapperFunctionBuffer ResultBytes) {
     using RetDeserialization =
         typename detail::SPSCallSerialization<SPSSig>::RetSerialization;
     shared::SPSInputBuffer IB(ResultBytes.data(), ResultBytes.size());
@@ -66,7 +66,7 @@ struct SPSCallSerializer<void(SPSArgTs...)>
     : public detail::SPSCallSerialization<void(SPSArgTs...)> {
   template <typename RetT>
   std::enable_if_t<std::is_void_v<RetT>, Error>
-  deserialize(shared::WrapperFunctionResult ResultBytes) {
+  deserialize(shared::WrapperFunctionBuffer ResultBytes) {
     if (!ResultBytes.empty())
       return make_error<StringError>("Could not deserialize return value",
                                      inconvertibleErrorCode());

--- a/llvm/include/llvm/ExecutionEngine/Orc/CallViaEPC.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/CallViaEPC.h
@@ -67,7 +67,7 @@ callViaEPC(HandlerFn &&H, ExecutorProcessControl &EPC, Serializer S,
     EPC.callWrapperAsync(
         Fn.getAddress(),
         [S = std::move(S), H = std::forward<HandlerFn>(H)](
-            shared::WrapperFunctionResult R) mutable {
+            shared::WrapperFunctionBuffer R) mutable {
           if (const char *ErrMsg = R.getOutOfBandError())
             H(make_error<StringError>(ErrMsg, inconvertibleErrorCode()));
           else

--- a/llvm/include/llvm/ExecutionEngine/Orc/Core.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Core.h
@@ -1352,7 +1352,7 @@ public:
   using ErrorReporter = unique_function<void(Error)>;
 
   /// Send a result to the remote.
-  using SendResultFunction = unique_function<void(shared::WrapperFunctionResult)>;
+  using SendResultFunction = unique_function<void(shared::WrapperFunctionBuffer)>;
 
   /// An asynchronous wrapper-function callable from the executor via
   /// jit-dispatch.
@@ -1584,7 +1584,7 @@ public:
   /// The wrapper function should be callable as:
   ///
   /// \code{.cpp}
-  ///   CWrapperFunctionResult fn(uint8_t *Data, uint64_t Size);
+  ///   CWrapperFunctionBuffer fn(uint8_t *Data, uint64_t Size);
   /// \endcode{.cpp}
   void callWrapperAsync(ExecutorAddr WrapperFnAddr,
                         ExecutorProcessControl::IncomingWFRHandler OnComplete,
@@ -1614,9 +1614,9 @@ public:
   /// callable as:
   ///
   /// \code{.cpp}
-  ///   CWrapperFunctionResult fn(uint8_t *Data, uint64_t Size);
+  ///   CWrapperFunctionBuffer fn(uint8_t *Data, uint64_t Size);
   /// \endcode{.cpp}
-  shared::WrapperFunctionResult callWrapper(ExecutorAddr WrapperFnAddr,
+  shared::WrapperFunctionBuffer callWrapper(ExecutorAddr WrapperFnAddr,
                                             ArrayRef<char> ArgBuffer) {
     return EPC->callWrapper(WrapperFnAddr, ArgBuffer);
   }

--- a/llvm/include/llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SelfExecutorProcessControl.h
@@ -54,7 +54,7 @@ public:
   Error disconnect() override;
 
 private:
-  static shared::CWrapperFunctionResult
+  static shared::CWrapperFunctionBuffer
   jitDispatchViaWrapperFunctionManager(void *Ctx, const void *FnTag,
                                        const char *Data, size_t Size);
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.h
@@ -56,16 +56,16 @@ private:
   };
   using ReservationMap = DenseMap<void *, Reservation>;
 
-  static llvm::orc::shared::CWrapperFunctionResult
+  static llvm::orc::shared::CWrapperFunctionBuffer
   reserveWrapper(const char *ArgData, size_t ArgSize);
 
-  static llvm::orc::shared::CWrapperFunctionResult
+  static llvm::orc::shared::CWrapperFunctionBuffer
   initializeWrapper(const char *ArgData, size_t ArgSize);
 
-  static llvm::orc::shared::CWrapperFunctionResult
+  static llvm::orc::shared::CWrapperFunctionBuffer
   deinitializeWrapper(const char *ArgData, size_t ArgSize);
 
-  static llvm::orc::shared::CWrapperFunctionResult
+  static llvm::orc::shared::CWrapperFunctionBuffer
   releaseWrapper(const char *ArgData, size_t ArgSize);
 
 #if (defined(LLVM_ON_UNIX) && !defined(__ANDROID__)) || defined(_WIN32)

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.h
@@ -43,7 +43,7 @@ struct jit_descriptor {
 };
 }
 
-extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionResult
+extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerJITLoaderGDBAllocAction(const char *ArgData, size_t ArgSize);
 
 #endif // LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_JITLOADERGDB_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderPerf.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderPerf.h
@@ -17,13 +17,13 @@
 #include "llvm/Support/Compiler.h"
 #include <cstdint>
 
-extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionResult
+extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerJITLoaderPerfImpl(const char *ArgData, size_t ArgSize);
 
-extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionResult
+extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerJITLoaderPerfStart(const char *ArgData, size_t ArgSize);
 
-extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionResult
+extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerJITLoaderPerfEnd(const char *ArgData, size_t ArgSize);
 
 #endif // LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_JITLOADERPERF_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.h
@@ -17,13 +17,13 @@
 #include "llvm/Support/Compiler.h"
 #include <cstdint>
 
-extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionResult
+extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerVTuneImpl(const char *ArgData, size_t ArgSize);
 
-extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionResult
+extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_unregisterVTuneImpl(const char *ArgData, size_t ArgSize);
 
-extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionResult
+extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_test_registerVTuneImpl(const char *ArgData, size_t ArgSize);
 
 #endif // LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_JITLOADERVTUNE_H

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h
@@ -34,10 +34,10 @@ LLVM_ABI Error deregisterEHFrameSection(const void *EHFrameSectionAddr,
 } // end namespace orc
 } // end namespace llvm
 
-extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionResult
+extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerEHFrameSectionAllocAction(const char *ArgData, size_t ArgSize);
 
-extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionResult
+extern "C" LLVM_ABI llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_deregisterEHFrameSectionAllocAction(const char *ArgData,
                                              size_t ArgSize);
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.h
@@ -47,10 +47,10 @@ public:
 private:
   using DylibSet = DenseSet<void *>;
 
-  static llvm::orc::shared::CWrapperFunctionResult
+  static llvm::orc::shared::CWrapperFunctionBuffer
   openWrapper(const char *ArgData, size_t ArgSize);
 
-  static llvm::orc::shared::CWrapperFunctionResult
+  static llvm::orc::shared::CWrapperFunctionBuffer
   resolveWrapper(const char *ArgData, size_t ArgSize);
 
   std::mutex M;

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h
@@ -79,16 +79,16 @@ private:
   /// address must represent the start of an existing initialized region.
   Expected<RegionInfo &> getRegionInfo(ExecutorAddr A, StringRef Context);
 
-  static llvm::orc::shared::CWrapperFunctionResult
+  static llvm::orc::shared::CWrapperFunctionBuffer
   reserveWrapper(const char *ArgData, size_t ArgSize);
 
-  static llvm::orc::shared::CWrapperFunctionResult
+  static llvm::orc::shared::CWrapperFunctionBuffer
   initializeWrapper(const char *ArgData, size_t ArgSize);
 
-  static llvm::orc::shared::CWrapperFunctionResult
+  static llvm::orc::shared::CWrapperFunctionBuffer
   deinitializeWrapper(const char *ArgData, size_t ArgSize);
 
-  static llvm::orc::shared::CWrapperFunctionResult
+  static llvm::orc::shared::CWrapperFunctionBuffer
   releaseWrapper(const char *ArgData, size_t ArgSize);
 
   std::mutex M;

--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h
@@ -163,10 +163,10 @@ private:
   void handleCallWrapper(uint64_t RemoteSeqNo, ExecutorAddr TagAddr,
                          SimpleRemoteEPCArgBytesVector ArgBytes);
 
-  shared::WrapperFunctionResult
+  shared::WrapperFunctionBuffer
   doJITDispatch(const void *FnTag, const char *ArgData, size_t ArgSize);
 
-  static shared::CWrapperFunctionResult jitDispatchEntry(void *DispatchCtx,
+  static shared::CWrapperFunctionBuffer jitDispatchEntry(void *DispatchCtx,
                                                          const void *FnTag,
                                                          const char *ArgData,
                                                          size_t ArgSize);
@@ -175,7 +175,7 @@ private:
   void releaseSeqNo(uint64_t) {}
 
   using PendingJITDispatchResultsMap =
-      DenseMap<uint64_t, std::promise<shared::WrapperFunctionResult> *>;
+      DenseMap<uint64_t, std::promise<shared::WrapperFunctionBuffer> *>;
 
   std::mutex ServerStateMutex;
   std::condition_variable ShutdownCV;

--- a/llvm/lib/ExecutionEngine/Orc/Core.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Core.cpp
@@ -1912,7 +1912,7 @@ void ExecutionSession::runJITDispatchHandler(SendResultFunction SendResult,
   if (F)
     (*F)(std::move(SendResult), ArgBuffer.data(), ArgBuffer.size());
   else
-    SendResult(shared::WrapperFunctionResult::createOutOfBandError(
+    SendResult(shared::WrapperFunctionBuffer::createOutOfBandError(
         ("No function registered for tag " +
          formatv("{0:x16}", HandlerFnTagAddr))
             .str()));

--- a/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SelfExecutorProcessControl.cpp
@@ -132,9 +132,9 @@ void SelfExecutorProcessControl::callWrapperAsync(ExecutorAddr WrapperFnAddr,
                                                   IncomingWFRHandler SendResult,
                                                   ArrayRef<char> ArgBuffer) {
   using WrapperFnTy =
-      shared::CWrapperFunctionResult (*)(const char *Data, size_t Size);
+      shared::CWrapperFunctionBuffer (*)(const char *Data, size_t Size);
   auto *WrapperFn = WrapperFnAddr.toPtr<WrapperFnTy>();
-  SendResult(shared::WrapperFunctionResult(
+  SendResult(shared::WrapperFunctionBuffer(
       WrapperFn(ArgBuffer.data(), ArgBuffer.size())));
 }
 
@@ -143,7 +143,7 @@ Error SelfExecutorProcessControl::disconnect() {
   return Error::success();
 }
 
-shared::CWrapperFunctionResult
+shared::CWrapperFunctionBuffer
 SelfExecutorProcessControl::jitDispatchViaWrapperFunctionManager(
     void *Ctx, const void *FnTag, const char *Data, size_t Size) {
 
@@ -152,13 +152,13 @@ SelfExecutorProcessControl::jitDispatchViaWrapperFunctionManager(
            << " byte payload.\n";
   });
 
-  std::promise<shared::WrapperFunctionResult> ResultP;
+  std::promise<shared::WrapperFunctionBuffer> ResultP;
   auto ResultF = ResultP.get_future();
   static_cast<SelfExecutorProcessControl *>(Ctx)
       ->getExecutionSession()
       .runJITDispatchHandler(
           [ResultP = std::move(ResultP)](
-              shared::WrapperFunctionResult Result) mutable {
+              shared::WrapperFunctionBuffer Result) mutable {
             ResultP.set_value(std::move(Result));
           },
           ExecutorAddr::fromPtr(FnTag), {Data, Size});

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.cpp
@@ -321,7 +321,7 @@ void ExecutorSharedMemoryMapperService::addBootstrapSymbols(
       ExecutorAddr::fromPtr(&releaseWrapper);
 }
 
-llvm::orc::shared::CWrapperFunctionResult
+llvm::orc::shared::CWrapperFunctionBuffer
 ExecutorSharedMemoryMapperService::reserveWrapper(const char *ArgData,
                                                   size_t ArgSize) {
   return shared::WrapperFunction<
@@ -332,7 +332,7 @@ ExecutorSharedMemoryMapperService::reserveWrapper(const char *ArgData,
           .release();
 }
 
-llvm::orc::shared::CWrapperFunctionResult
+llvm::orc::shared::CWrapperFunctionBuffer
 ExecutorSharedMemoryMapperService::initializeWrapper(const char *ArgData,
                                                      size_t ArgSize) {
   return shared::WrapperFunction<
@@ -343,7 +343,7 @@ ExecutorSharedMemoryMapperService::initializeWrapper(const char *ArgData,
           .release();
 }
 
-llvm::orc::shared::CWrapperFunctionResult
+llvm::orc::shared::CWrapperFunctionBuffer
 ExecutorSharedMemoryMapperService::deinitializeWrapper(const char *ArgData,
                                                        size_t ArgSize) {
   return shared::WrapperFunction<
@@ -354,7 +354,7 @@ ExecutorSharedMemoryMapperService::deinitializeWrapper(const char *ArgData,
           .release();
 }
 
-llvm::orc::shared::CWrapperFunctionResult
+llvm::orc::shared::CWrapperFunctionBuffer
 ExecutorSharedMemoryMapperService::releaseWrapper(const char *ArgData,
                                                   size_t ArgSize) {
   return shared::WrapperFunction<

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderGDB.cpp
@@ -73,7 +73,7 @@ static void appendJITDebugDescriptor(const char *ObjAddr, size_t Size) {
   __jit_debug_descriptor.action_flag = JIT_REGISTER_FN;
 }
 
-extern "C" orc::shared::CWrapperFunctionResult
+extern "C" orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerJITLoaderGDBAllocAction(const char *ArgData, size_t ArgSize) {
   using namespace orc::shared;
   return WrapperFunction<SPSError(SPSExecutorAddrRange, bool)>::handle(

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderPerf.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderPerf.cpp
@@ -395,7 +395,7 @@ static Error registerJITLoaderPerfEndImpl() {
   return Error::success();
 }
 
-extern "C" llvm::orc::shared::CWrapperFunctionResult
+extern "C" llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerJITLoaderPerfImpl(const char *ArgData, size_t ArgSize) {
   using namespace orc::shared;
   return WrapperFunction<SPSError(SPSPerfJITRecordBatch)>::handle(
@@ -403,7 +403,7 @@ llvm_orc_registerJITLoaderPerfImpl(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-extern "C" llvm::orc::shared::CWrapperFunctionResult
+extern "C" llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerJITLoaderPerfStart(const char *ArgData, size_t ArgSize) {
   using namespace orc::shared;
   return WrapperFunction<SPSError()>::handle(ArgData, ArgSize,
@@ -411,7 +411,7 @@ llvm_orc_registerJITLoaderPerfStart(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-extern "C" llvm::orc::shared::CWrapperFunctionResult
+extern "C" llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerJITLoaderPerfEnd(const char *ArgData, size_t ArgSize) {
   using namespace orc::shared;
   return WrapperFunction<SPSError()>::handle(ArgData, ArgSize,
@@ -433,7 +433,7 @@ static Error badOS() {
 
 static Error badOSBatch(PerfJITRecordBatch &Batch) { return badOS(); }
 
-extern "C" llvm::orc::shared::CWrapperFunctionResult
+extern "C" llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerJITLoaderPerfImpl(const char *ArgData, size_t ArgSize) {
   using namespace shared;
   return WrapperFunction<SPSError(SPSPerfJITRecordBatch)>::handle(
@@ -441,13 +441,13 @@ llvm_orc_registerJITLoaderPerfImpl(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-extern "C" llvm::orc::shared::CWrapperFunctionResult
+extern "C" llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerJITLoaderPerfStart(const char *ArgData, size_t ArgSize) {
   using namespace shared;
   return WrapperFunction<SPSError()>::handle(ArgData, ArgSize, badOS).release();
 }
 
-extern "C" llvm::orc::shared::CWrapperFunctionResult
+extern "C" llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerJITLoaderPerfEnd(const char *ArgData, size_t ArgSize) {
   using namespace shared;
   return WrapperFunction<SPSError()>::handle(ArgData, ArgSize, badOS).release();

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
@@ -91,7 +91,7 @@ static void registerJITLoaderVTuneUnregisterImpl(
   }
 }
 
-extern "C" llvm::orc::shared::CWrapperFunctionResult
+extern "C" llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerVTuneImpl(const char *ArgData, size_t ArgSize) {
   using namespace orc::shared;
   if (!JITEventWrapper::Wrapper)
@@ -102,7 +102,7 @@ llvm_orc_registerVTuneImpl(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-extern "C" llvm::orc::shared::CWrapperFunctionResult
+extern "C" llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_unregisterVTuneImpl(const char *ArgData, size_t ArgSize) {
   using namespace orc::shared;
   return WrapperFunction<void(SPSVTuneUnloadedMethodIDs)>::handle(
@@ -173,7 +173,7 @@ static unsigned int GetNewMethodID(void) {
   return ++id;
 }
 
-extern "C" llvm::orc::shared::CWrapperFunctionResult
+extern "C" llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_test_registerVTuneImpl(const char *ArgData, size_t ArgSize) {
   using namespace orc::shared;
   JITEventWrapper::Wrapper.reset(new IntelJITEventsWrapper(
@@ -197,7 +197,7 @@ static void unsuppported(const std::vector<std::pair<uint64_t, uint64_t>> &UM) {
 
 }
 
-extern "C" llvm::orc::shared::CWrapperFunctionResult
+extern "C" llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerVTuneImpl(const char *ArgData, size_t ArgSize) {
   using namespace orc::shared;
   return WrapperFunction<SPSError(SPSVTuneMethodBatch)>::handle(
@@ -205,7 +205,7 @@ llvm_orc_registerVTuneImpl(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-extern "C" llvm::orc::shared::CWrapperFunctionResult
+extern "C" llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_unregisterVTuneImpl(const char *ArgData, size_t ArgSize) {
   using namespace orc::shared;
   return WrapperFunction<void(SPSVTuneUnloadedMethodIDs)>::handle(
@@ -213,7 +213,7 @@ llvm_orc_unregisterVTuneImpl(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-extern "C" llvm::orc::shared::CWrapperFunctionResult
+extern "C" llvm::orc::shared::CWrapperFunctionBuffer
 llvm_orc_test_registerVTuneImpl(const char *ArgData, size_t ArgSize) {
   using namespace orc::shared;
   return WrapperFunction<SPSError(SPSVTuneMethodBatch)>::handle(

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/OrcRTBootstrap.cpp
@@ -22,7 +22,7 @@ namespace orc {
 namespace rt_bootstrap {
 
 template <typename WriteT, typename SPSWriteT>
-static llvm::orc::shared::CWrapperFunctionResult
+static llvm::orc::shared::CWrapperFunctionBuffer
 writeUIntsWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<void(SPSSequence<SPSWriteT>)>::handle(
              ArgData, ArgSize,
@@ -33,7 +33,7 @@ writeUIntsWrapper(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-static llvm::orc::shared::CWrapperFunctionResult
+static llvm::orc::shared::CWrapperFunctionBuffer
 writePointersWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<void(SPSSequence<SPSMemoryAccessPointerWrite>)>::
       handle(ArgData, ArgSize,
@@ -45,7 +45,7 @@ writePointersWrapper(const char *ArgData, size_t ArgSize) {
           .release();
 }
 
-static llvm::orc::shared::CWrapperFunctionResult
+static llvm::orc::shared::CWrapperFunctionBuffer
 writeBuffersWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<void(SPSSequence<SPSMemoryAccessBufferWrite>)>::handle(
              ArgData, ArgSize,
@@ -58,7 +58,7 @@ writeBuffersWrapper(const char *ArgData, size_t ArgSize) {
 }
 
 template <typename ReadT>
-static llvm::orc::shared::CWrapperFunctionResult
+static llvm::orc::shared::CWrapperFunctionBuffer
 readUIntsWrapper(const char *ArgData, size_t ArgSize) {
   using SPSSig = SPSSequence<ReadT>(SPSSequence<SPSExecutorAddr>);
   return WrapperFunction<SPSSig>::handle(ArgData, ArgSize,
@@ -73,7 +73,7 @@ readUIntsWrapper(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-static llvm::orc::shared::CWrapperFunctionResult
+static llvm::orc::shared::CWrapperFunctionBuffer
 readPointersWrapper(const char *ArgData, size_t ArgSize) {
   using SPSSig = SPSSequence<SPSExecutorAddr>(SPSSequence<SPSExecutorAddr>);
   return WrapperFunction<SPSSig>::handle(
@@ -88,7 +88,7 @@ readPointersWrapper(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-static llvm::orc::shared::CWrapperFunctionResult
+static llvm::orc::shared::CWrapperFunctionBuffer
 readBuffersWrapper(const char *ArgData, size_t ArgSize) {
   using SPSSig =
       SPSSequence<SPSSequence<uint8_t>>(SPSSequence<SPSExecutorAddrRange>);
@@ -108,7 +108,7 @@ readBuffersWrapper(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-static llvm::orc::shared::CWrapperFunctionResult
+static llvm::orc::shared::CWrapperFunctionBuffer
 readStringsWrapper(const char *ArgData, size_t ArgSize) {
   using SPSSig = SPSSequence<SPSString>(SPSSequence<SPSExecutorAddr>);
   return WrapperFunction<SPSSig>::handle(ArgData, ArgSize,
@@ -123,7 +123,7 @@ readStringsWrapper(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-static llvm::orc::shared::CWrapperFunctionResult
+static llvm::orc::shared::CWrapperFunctionBuffer
 runAsMainWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<rt::SPSRunAsMainSignature>::handle(
              ArgData, ArgSize,
@@ -134,7 +134,7 @@ runAsMainWrapper(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-static llvm::orc::shared::CWrapperFunctionResult
+static llvm::orc::shared::CWrapperFunctionBuffer
 runAsVoidFunctionWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<rt::SPSRunAsVoidFunctionSignature>::handle(
              ArgData, ArgSize,
@@ -144,7 +144,7 @@ runAsVoidFunctionWrapper(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-static llvm::orc::shared::CWrapperFunctionResult
+static llvm::orc::shared::CWrapperFunctionBuffer
 runAsIntFunctionWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<rt::SPSRunAsIntFunctionSignature>::handle(
              ArgData, ArgSize,

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.cpp
@@ -163,7 +163,7 @@ static Error deregisterEHFrameWrapper(ExecutorAddrRange EHFrame) {
       EHFrame.Start.toPtr<const void *>(), EHFrame.size());
 }
 
-extern "C" orc::shared::CWrapperFunctionResult
+extern "C" orc::shared::CWrapperFunctionBuffer
 llvm_orc_registerEHFrameSectionAllocAction(const char *ArgData,
                                            size_t ArgSize) {
   return WrapperFunction<SPSError(SPSExecutorAddrRange)>::handle(
@@ -171,7 +171,7 @@ llvm_orc_registerEHFrameSectionAllocAction(const char *ArgData,
       .release();
 }
 
-extern "C" orc::shared::CWrapperFunctionResult
+extern "C" orc::shared::CWrapperFunctionBuffer
 llvm_orc_deregisterEHFrameSectionAllocAction(const char *ArgData,
                                              size_t ArgSize) {
   return WrapperFunction<SPSError(SPSExecutorAddrRange)>::handle(

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorDylibManager.cpp
@@ -65,7 +65,7 @@ void SimpleExecutorDylibManager::addBootstrapSymbols(
       ExecutorAddr::fromPtr(&resolveWrapper);
 }
 
-llvm::orc::shared::CWrapperFunctionResult
+llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorDylibManager::openWrapper(const char *ArgData, size_t ArgSize) {
   return shared::
       WrapperFunction<rt::SPSSimpleExecutorDylibManagerOpenSignature>::handle(
@@ -75,7 +75,7 @@ SimpleExecutorDylibManager::openWrapper(const char *ArgData, size_t ArgSize) {
           .release();
 }
 
-llvm::orc::shared::CWrapperFunctionResult
+llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorDylibManager::resolveWrapper(const char *ArgData,
                                            size_t ArgSize) {
   using ResolveResult = ExecutorResolver::ResolveResult;

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.cpp
@@ -306,7 +306,7 @@ SimpleExecutorMemoryManager::getRegionInfo(ExecutorAddr A, StringRef Context) {
   return getRegionInfo(*Slab, A, Context);
 }
 
-llvm::orc::shared::CWrapperFunctionResult
+llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorMemoryManager::reserveWrapper(const char *ArgData,
                                             size_t ArgSize) {
   return shared::WrapperFunction<rt::SPSSimpleRemoteMemoryMapReserveSignature>::
@@ -316,7 +316,7 @@ SimpleExecutorMemoryManager::reserveWrapper(const char *ArgData,
           .release();
 }
 
-llvm::orc::shared::CWrapperFunctionResult
+llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorMemoryManager::initializeWrapper(const char *ArgData,
                                                size_t ArgSize) {
   return shared::
@@ -327,7 +327,7 @@ SimpleExecutorMemoryManager::initializeWrapper(const char *ArgData,
           .release();
 }
 
-llvm::orc::shared::CWrapperFunctionResult
+llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorMemoryManager::deinitializeWrapper(const char *ArgData,
                                                  size_t ArgSize) {
   return shared::WrapperFunction<
@@ -338,7 +338,7 @@ SimpleExecutorMemoryManager::deinitializeWrapper(const char *ArgData,
           .release();
 }
 
-llvm::orc::shared::CWrapperFunctionResult
+llvm::orc::shared::CWrapperFunctionBuffer
 SimpleExecutorMemoryManager::releaseWrapper(const char *ArgData,
                                             size_t ArgSize) {
   return shared::WrapperFunction<rt::SPSSimpleRemoteMemoryMapReleaseSignature>::

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.cpp
@@ -131,7 +131,7 @@ void SimpleRemoteEPCServer::handleDisconnect(Error Err) {
   // Send out-of-band errors to any waiting threads.
   for (auto &KV : TmpPending)
     KV.second->set_value(
-        shared::WrapperFunctionResult::createOutOfBandError("disconnecting"));
+        shared::WrapperFunctionBuffer::createOutOfBandError("disconnecting"));
 
   // Wait for dispatcher to clear.
   D->shutdown();
@@ -212,7 +212,7 @@ Error SimpleRemoteEPCServer::sendSetupMessage(
   using SPSSerialize =
       shared::SPSArgList<shared::SPSSimpleRemoteEPCExecutorInfo>;
   auto SetupPacketBytes =
-      shared::WrapperFunctionResult::allocate(SPSSerialize::size(EI));
+      shared::WrapperFunctionBuffer::allocate(SPSSerialize::size(EI));
   shared::SPSOutputBuffer OB(SetupPacketBytes.data(), SetupPacketBytes.size());
   if (!SPSSerialize::serialize(OB, EI))
     return make_error<StringError>("Could not send setup packet",
@@ -225,7 +225,7 @@ Error SimpleRemoteEPCServer::sendSetupMessage(
 Error SimpleRemoteEPCServer::handleResult(
     uint64_t SeqNo, ExecutorAddr TagAddr,
     SimpleRemoteEPCArgBytesVector ArgBytes) {
-  std::promise<shared::WrapperFunctionResult> *P = nullptr;
+  std::promise<shared::WrapperFunctionBuffer> *P = nullptr;
   {
     std::lock_guard<std::mutex> Lock(ServerStateMutex);
     auto I = PendingJITDispatchResults.find(SeqNo);
@@ -237,7 +237,7 @@ Error SimpleRemoteEPCServer::handleResult(
     PendingJITDispatchResults.erase(I);
     releaseSeqNo(SeqNo);
   }
-  auto R = shared::WrapperFunctionResult::allocate(ArgBytes.size());
+  auto R = shared::WrapperFunctionBuffer::allocate(ArgBytes.size());
   memcpy(R.data(), ArgBytes.data(), ArgBytes.size());
   P->set_value(std::move(R));
   return Error::success();
@@ -248,9 +248,9 @@ void SimpleRemoteEPCServer::handleCallWrapper(
     SimpleRemoteEPCArgBytesVector ArgBytes) {
   D->dispatch([this, RemoteSeqNo, TagAddr, ArgBytes = std::move(ArgBytes)]() {
     using WrapperFnTy =
-        shared::CWrapperFunctionResult (*)(const char *, size_t);
+        shared::CWrapperFunctionBuffer (*)(const char *, size_t);
     auto *Fn = TagAddr.toPtr<WrapperFnTy>();
-    shared::WrapperFunctionResult ResultBytes(
+    shared::WrapperFunctionBuffer ResultBytes(
         Fn(ArgBytes.data(), ArgBytes.size()));
     if (auto Err = sendMessage(SimpleRemoteEPCOpcode::Result, RemoteSeqNo,
                                ExecutorAddr(),
@@ -259,16 +259,16 @@ void SimpleRemoteEPCServer::handleCallWrapper(
   });
 }
 
-shared::WrapperFunctionResult
+shared::WrapperFunctionBuffer
 SimpleRemoteEPCServer::doJITDispatch(const void *FnTag, const char *ArgData,
                                      size_t ArgSize) {
   uint64_t SeqNo;
-  std::promise<shared::WrapperFunctionResult> ResultP;
+  std::promise<shared::WrapperFunctionBuffer> ResultP;
   auto ResultF = ResultP.get_future();
   {
     std::lock_guard<std::mutex> Lock(ServerStateMutex);
     if (RunState != ServerRunning)
-      return shared::WrapperFunctionResult::createOutOfBandError(
+      return shared::WrapperFunctionBuffer::createOutOfBandError(
           "jit_dispatch not available (EPC server shut down)");
 
     SeqNo = getNextSeqNo();
@@ -283,7 +283,7 @@ SimpleRemoteEPCServer::doJITDispatch(const void *FnTag, const char *ArgData,
   return ResultF.get();
 }
 
-shared::CWrapperFunctionResult
+shared::CWrapperFunctionBuffer
 SimpleRemoteEPCServer::jitDispatchEntry(void *DispatchCtx, const void *FnTag,
                                         const char *ArgData, size_t ArgSize) {
   return reinterpret_cast<SimpleRemoteEPCServer *>(DispatchCtx)

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.cpp
@@ -20,7 +20,7 @@ using namespace llvm;
 using namespace llvm::orc;
 using namespace llvm::orc::shared;
 
-static orc::shared::CWrapperFunctionResult
+static orc::shared::CWrapperFunctionBuffer
 llvm_orc_rt_alt_UnwindInfoManager_register(const char *ArgData,
                                            size_t ArgSize) {
   using SPSSig = SPSError(SPSSequence<SPSExecutorAddrRange>, SPSExecutorAddr,
@@ -37,7 +37,7 @@ llvm_orc_rt_alt_UnwindInfoManager_register(const char *ArgData,
       .release();
 }
 
-static orc::shared::CWrapperFunctionResult
+static orc::shared::CWrapperFunctionBuffer
 llvm_orc_rt_alt_UnwindInfoManager_deregister(const char *ArgData,
                                              size_t ArgSize) {
   using SPSSig = SPSError(SPSSequence<SPSExecutorAddrRange>);

--- a/llvm/unittests/ExecutionEngine/Orc/CallSPSViaEPCTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/CallSPSViaEPCTest.cpp
@@ -19,11 +19,11 @@ using namespace llvm;
 using namespace llvm::orc;
 using namespace llvm::orc::shared;
 
-static CWrapperFunctionResult voidWrapper(const char *ArgData, size_t ArgSize) {
+static CWrapperFunctionBuffer voidWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<void()>::handle(ArgData, ArgSize, []() {}).release();
 }
 
-static CWrapperFunctionResult mainWrapper(const char *ArgData, size_t ArgSize) {
+static CWrapperFunctionBuffer mainWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<int32_t(SPSSequence<SPSString>)>::handle(
              ArgData, ArgSize,
              [](std::vector<std::string> Args) -> int32_t {

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericJITLinkMemoryManagerTest.cpp
@@ -82,14 +82,14 @@ private:
   DenseMap<void *, sys::OwningMemoryBlock> Blocks;
 };
 
-CWrapperFunctionResult testReserve(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer testReserve(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<rt::SPSSimpleExecutorMemoryManagerReserveSignature>::
       handle(ArgData, ArgSize,
              makeMethodWrapperHandler(&SimpleAllocator::reserve))
           .release();
 }
 
-CWrapperFunctionResult testInitialize(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer testInitialize(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<
              rt::SPSSimpleExecutorMemoryManagerInitializeSignature>::
       handle(ArgData, ArgSize,
@@ -97,7 +97,7 @@ CWrapperFunctionResult testInitialize(const char *ArgData, size_t ArgSize) {
           .release();
 }
 
-CWrapperFunctionResult testRelease(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer testRelease(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<rt::SPSSimpleExecutorMemoryManagerReleaseSignature>::
       handle(ArgData, ArgSize,
              makeMethodWrapperHandler(&SimpleAllocator::release))

--- a/llvm/unittests/ExecutionEngine/Orc/EPCGenericMemoryAccessTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/EPCGenericMemoryAccessTest.cpp
@@ -19,7 +19,7 @@ using namespace llvm::orc::shared;
 namespace {
 
 template <typename WriteT, typename SPSWriteT>
-CWrapperFunctionResult testWriteUInts(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer testWriteUInts(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<void(SPSSequence<SPSWriteT>)>::handle(
              ArgData, ArgSize,
              [](std::vector<WriteT> Ws) {
@@ -29,7 +29,7 @@ CWrapperFunctionResult testWriteUInts(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-CWrapperFunctionResult testWritePointers(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer testWritePointers(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<void(SPSSequence<SPSMemoryAccessPointerWrite>)>::
       handle(ArgData, ArgSize,
              [](std::vector<tpctypes::PointerWrite> Ws) {
@@ -39,7 +39,7 @@ CWrapperFunctionResult testWritePointers(const char *ArgData, size_t ArgSize) {
           .release();
 }
 
-CWrapperFunctionResult testWriteBuffers(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer testWriteBuffers(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<void(SPSSequence<SPSMemoryAccessBufferWrite>)>::handle(
              ArgData, ArgSize,
              [](std::vector<tpctypes::BufferWrite> Ws) {
@@ -51,7 +51,7 @@ CWrapperFunctionResult testWriteBuffers(const char *ArgData, size_t ArgSize) {
 }
 
 template <typename ReadT>
-CWrapperFunctionResult testReadUInts(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer testReadUInts(const char *ArgData, size_t ArgSize) {
   using SPSSig = SPSSequence<ReadT>(SPSSequence<SPSExecutorAddr>);
   return WrapperFunction<SPSSig>::handle(ArgData, ArgSize,
                                          [](std::vector<ExecutorAddr> Rs) {
@@ -65,7 +65,7 @@ CWrapperFunctionResult testReadUInts(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-CWrapperFunctionResult testReadPointers(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer testReadPointers(const char *ArgData, size_t ArgSize) {
   using SPSSig = SPSSequence<SPSExecutorAddr>(SPSSequence<SPSExecutorAddr>);
   return WrapperFunction<SPSSig>::handle(
              ArgData, ArgSize,
@@ -80,7 +80,7 @@ CWrapperFunctionResult testReadPointers(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-CWrapperFunctionResult testReadBuffers(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer testReadBuffers(const char *ArgData, size_t ArgSize) {
   using SPSSig =
       SPSSequence<SPSSequence<uint8_t>>(SPSSequence<SPSExecutorAddrRange>);
   return WrapperFunction<SPSSig>::handle(
@@ -99,7 +99,7 @@ CWrapperFunctionResult testReadBuffers(const char *ArgData, size_t ArgSize) {
       .release();
 }
 
-CWrapperFunctionResult testReadStrings(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer testReadStrings(const char *ArgData, size_t ArgSize) {
   using SPSSig = SPSSequence<SPSString>(SPSSequence<SPSExecutorAddr>);
   return WrapperFunction<SPSSig>::handle(
              ArgData, ArgSize,

--- a/llvm/unittests/ExecutionEngine/Orc/ExecutionSessionWrapperFunctionCallsTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ExecutionSessionWrapperFunctionCallsTest.cpp
@@ -20,7 +20,7 @@ using namespace llvm;
 using namespace llvm::orc;
 using namespace llvm::orc::shared;
 
-static CWrapperFunctionResult addWrapper(const char *ArgData, size_t ArgSize) {
+static CWrapperFunctionBuffer addWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<int32_t(int32_t, int32_t)>::handle(
              ArgData, ArgSize, [](int32_t X, int32_t Y) { return X + Y; })
       .release();
@@ -31,7 +31,7 @@ static void addAsyncWrapper(unique_function<void(int32_t)> SendResult,
   SendResult(X + Y);
 }
 
-static CWrapperFunctionResult voidWrapper(const char *ArgData, size_t ArgSize) {
+static CWrapperFunctionBuffer voidWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<void()>::handle(ArgData, ArgSize, []() {}).release();
 }
 
@@ -99,12 +99,12 @@ TEST(ExecutionSessionWrapperFunctionCalls, RegisterAsyncHandlerAndRun) {
 
   using ArgSerialization = SPSArgList<int32_t, int32_t>;
   size_t ArgBufferSize = ArgSerialization::size(1, 2);
-  auto ArgBuffer = WrapperFunctionResult::allocate(ArgBufferSize);
+  auto ArgBuffer = WrapperFunctionBuffer::allocate(ArgBufferSize);
   SPSOutputBuffer OB(ArgBuffer.data(), ArgBuffer.size());
   EXPECT_TRUE(ArgSerialization::serialize(OB, 1, 2));
 
   ES.runJITDispatchHandler(
-      [&](WrapperFunctionResult ResultBuffer) {
+      [&](WrapperFunctionBuffer ResultBuffer) {
         int32_t Result;
         SPSInputBuffer IB(ResultBuffer.data(), ResultBuffer.size());
         EXPECT_TRUE(SPSArgList<int32_t>::deserialize(IB, Result));

--- a/llvm/unittests/ExecutionEngine/Orc/MemoryMapperTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/MemoryMapperTest.cpp
@@ -49,7 +49,7 @@ Error release(MemoryMapper &M, const std::vector<ExecutorAddr> &Reservations) {
 }
 
 // A basic function to be used as both initializer/deinitializer
-CWrapperFunctionResult incrementWrapper(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer incrementWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<SPSError(SPSExecutorAddr)>::handle(
              ArgData, ArgSize,
              [](ExecutorAddr A) -> Error {

--- a/llvm/unittests/ExecutionEngine/Orc/SharedMemoryMapperTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/SharedMemoryMapperTest.cpp
@@ -23,7 +23,7 @@ using namespace llvm::orc::rt_bootstrap;
 #if (defined(LLVM_ON_UNIX) && !defined(__ANDROID__)) || defined(_WIN32)
 
 // A basic function to be used as both initializer/deinitializer
-CWrapperFunctionResult incrementWrapper(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer incrementWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<SPSError(SPSExecutorAddr)>::handle(
              ArgData, ArgSize,
              [](ExecutorAddr A) -> Error {

--- a/llvm/unittests/ExecutionEngine/Orc/SimpleExecutorMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/SimpleExecutorMemoryManagerTest.cpp
@@ -19,7 +19,7 @@ using namespace llvm::orc::rt_bootstrap;
 
 namespace {
 
-CWrapperFunctionResult incrementWrapper(const char *ArgData, size_t ArgSize) {
+CWrapperFunctionBuffer incrementWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<SPSError(SPSExecutorAddr)>::handle(
              ArgData, ArgSize,
              [](ExecutorAddr A) -> Error {

--- a/llvm/unittests/ExecutionEngine/Orc/WrapperFunctionUtilsTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/WrapperFunctionUtilsTest.cpp
@@ -21,39 +21,39 @@ namespace {
 constexpr const char *TestString = "test string";
 } // end anonymous namespace
 
-TEST(WrapperFunctionUtilsTest, DefaultWrapperFunctionResult) {
-  WrapperFunctionResult R;
+TEST(WrapperFunctionUtilsTest, DefaultWrapperFunctionBuffer) {
+  WrapperFunctionBuffer R;
   EXPECT_TRUE(R.empty());
   EXPECT_EQ(R.size(), 0U);
   EXPECT_EQ(R.getOutOfBandError(), nullptr);
 }
 
-TEST(WrapperFunctionUtilsTest, WrapperFunctionResultFromRange) {
-  auto R = WrapperFunctionResult::copyFrom(TestString, strlen(TestString) + 1);
+TEST(WrapperFunctionUtilsTest, WrapperFunctionBufferFromRange) {
+  auto R = WrapperFunctionBuffer::copyFrom(TestString, strlen(TestString) + 1);
   EXPECT_EQ(R.size(), strlen(TestString) + 1);
   EXPECT_TRUE(strcmp(R.data(), TestString) == 0);
   EXPECT_FALSE(R.empty());
   EXPECT_EQ(R.getOutOfBandError(), nullptr);
 }
 
-TEST(WrapperFunctionUtilsTest, WrapperFunctionResultFromCString) {
-  auto R = WrapperFunctionResult::copyFrom(TestString);
+TEST(WrapperFunctionUtilsTest, WrapperFunctionBufferFromCString) {
+  auto R = WrapperFunctionBuffer::copyFrom(TestString);
   EXPECT_EQ(R.size(), strlen(TestString) + 1);
   EXPECT_TRUE(strcmp(R.data(), TestString) == 0);
   EXPECT_FALSE(R.empty());
   EXPECT_EQ(R.getOutOfBandError(), nullptr);
 }
 
-TEST(WrapperFunctionUtilsTest, WrapperFunctionResultFromStdString) {
-  auto R = WrapperFunctionResult::copyFrom(std::string(TestString));
+TEST(WrapperFunctionUtilsTest, WrapperFunctionBufferFromStdString) {
+  auto R = WrapperFunctionBuffer::copyFrom(std::string(TestString));
   EXPECT_EQ(R.size(), strlen(TestString) + 1);
   EXPECT_TRUE(strcmp(R.data(), TestString) == 0);
   EXPECT_FALSE(R.empty());
   EXPECT_EQ(R.getOutOfBandError(), nullptr);
 }
 
-TEST(WrapperFunctionUtilsTest, WrapperFunctionResultFromOutOfBandError) {
-  auto R = WrapperFunctionResult::createOutOfBandError(TestString);
+TEST(WrapperFunctionUtilsTest, WrapperFunctionBufferFromOutOfBandError) {
+  auto R = WrapperFunctionBuffer::createOutOfBandError(TestString);
   EXPECT_FALSE(R.empty());
   EXPECT_TRUE(strcmp(R.getOutOfBandError(), TestString) == 0);
 }
@@ -73,17 +73,17 @@ private:
   int32_t X;
 };
 
-static WrapperFunctionResult voidNoopWrapper(const char *ArgData,
+static WrapperFunctionBuffer voidNoopWrapper(const char *ArgData,
                                              size_t ArgSize) {
   return WrapperFunction<void()>::handle(ArgData, ArgSize, voidNoop);
 }
 
-static WrapperFunctionResult addWrapper(const char *ArgData, size_t ArgSize) {
+static WrapperFunctionBuffer addWrapper(const char *ArgData, size_t ArgSize) {
   return WrapperFunction<int32_t(int32_t, int32_t)>::handle(
       ArgData, ArgSize, [](int32_t X, int32_t Y) -> int32_t { return X + Y; });
 }
 
-static WrapperFunctionResult addMethodWrapper(const char *ArgData,
+static WrapperFunctionBuffer addMethodWrapper(const char *ArgData,
                                               size_t ArgSize) {
   return WrapperFunction<int32_t(SPSExecutorAddr, int32_t)>::handle(
       ArgData, ArgSize, makeMethodWrapperHandler(&AddClass::addMethod));
@@ -112,27 +112,27 @@ static void voidNoopAsync(unique_function<void(SPSEmpty)> SendResult) {
   SendResult(SPSEmpty());
 }
 
-static WrapperFunctionResult voidNoopAsyncWrapper(const char *ArgData,
+static WrapperFunctionBuffer voidNoopAsyncWrapper(const char *ArgData,
                                                   size_t ArgSize) {
-  std::promise<WrapperFunctionResult> RP;
+  std::promise<WrapperFunctionBuffer> RP;
   auto RF = RP.get_future();
 
   WrapperFunction<void()>::handleAsync(
       ArgData, ArgSize,
-      [&](WrapperFunctionResult R) { RP.set_value(std::move(R)); },
+      [&](WrapperFunctionBuffer R) { RP.set_value(std::move(R)); },
       voidNoopAsync);
 
   return RF.get();
 }
 
-static WrapperFunctionResult addAsyncWrapper(const char *ArgData,
+static WrapperFunctionBuffer addAsyncWrapper(const char *ArgData,
                                              size_t ArgSize) {
-  std::promise<WrapperFunctionResult> RP;
+  std::promise<WrapperFunctionBuffer> RP;
   auto RF = RP.get_future();
 
   WrapperFunction<int32_t(int32_t, int32_t)>::handleAsync(
       ArgData, ArgSize,
-      [&](WrapperFunctionResult R) { RP.set_value(std::move(R)); },
+      [&](WrapperFunctionBuffer R) { RP.set_value(std::move(R)); },
       [](unique_function<void(int32_t)> SendResult, int32_t X, int32_t Y) {
         SendResult(X + Y);
       });
@@ -150,12 +150,12 @@ TEST(WrapperFunctionUtilsTest, WrapperFunctionCallAndHandleAsyncRet) {
   EXPECT_EQ(Result, (int32_t)3);
 }
 
-static WrapperFunctionResult failingWrapper(const char *ArgData,
+static WrapperFunctionBuffer failingWrapper(const char *ArgData,
                                             size_t ArgSize) {
-  return WrapperFunctionResult::createOutOfBandError("failed");
+  return WrapperFunctionBuffer::createOutOfBandError("failed");
 }
 
-void asyncFailingWrapperCaller(unique_function<void(WrapperFunctionResult)> F,
+void asyncFailingWrapperCaller(unique_function<void(WrapperFunctionBuffer)> F,
                                const char *ArgData, size_t ArgSize) {
   F(failingWrapper(ArgData, ArgSize));
 }


### PR DESCRIPTION
Also renames CWrapperFunctionResult to CWrapperFunctionBuffer.

These types are used as argument buffers, as well as result buffers. The new name better reflects their purpose, and is consistent with naming in the new ORC runtime (llvm-project/orc-rt).