### PR TITLE
Thread Safety Analysis: Add more cast pointer-alias tests

### DIFF
--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -7325,6 +7325,15 @@ void testBasicPointerAlias(Foo *f) {
   ptr->mu.Unlock();       // unlock through alias
 }
 
+void testCastPointerAlias(Foo *f) {
+  // Cast to void* from unsigned long to test non-pointer cast indirection.
+  void *priv = (void *)(__UINTPTR_TYPE__)(&f->mu);
+  f->mu.Lock();
+  f->data = 42;
+  auto *mu = (Mutex *)priv;
+  mu->Unlock();
+}
+
 void testBasicPointerAliasNoInit(Foo *f) {
   Foo *ptr;
 


### PR DESCRIPTION
Add 2 tests for cast pointer aliases, with the cleanup pattern being a real pattern that is considered to be used in the Linux kernel: https://lore.kernel.org/all/aUGBff8Oko5O8EsP@elver.google.com/

This works today, but let's test it to make sure there are no regressions.

NFC.