### PR TITLE
[RISCV] Extend selectSHXADDOp to handle an additional pattern

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -3729,6 +3729,24 @@ bool RISCVDAGToDAGISel::selectSHXADDOp(SDValue N, unsigned ShAmt,
   if (N.getOpcode() == ISD::AND && isa<ConstantSDNode>(N.getOperand(1))) {
     SDValue N0 = N.getOperand(0);
 
+    // Transform (and (shl x, c1), c2) -> (shl (and x, c2 >> c1), c1) as long
+    // as the shifted mask fits into a 12-bit immediate.
+    if (N0.getOpcode() == ISD::SHL && isa<ConstantSDNode>(N0.getOperand(1)) &&
+        N0.getConstantOperandVal(1) == ShAmt) {
+      uint64_t Mask = N.getConstantOperandVal(1);
+      uint64_t PreShiftMask = Mask >> ShAmt;
+
+      if (isInt<12>(PreShiftMask)) {
+        SDLoc DL(N);
+        EVT VT = N.getValueType();
+        Val = SDValue(CurDAG->getMachineNode(
+                          RISCV::ANDI, DL, VT, N0.getOperand(0),
+                          CurDAG->getTargetConstant(PreShiftMask, DL, VT)),
+                      0);
+        return true;
+      }
+    }
+
     if (bool LeftShift = N0.getOpcode() == ISD::SHL;
         (LeftShift || N0.getOpcode() == ISD::SRL) &&
         isa<ConstantSDNode>(N0.getOperand(1))) {

--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -3733,16 +3733,17 @@ bool RISCVDAGToDAGISel::selectSHXADDOp(SDValue N, unsigned ShAmt,
     // as the shifted mask fits into a 12-bit immediate.
     if (N0.getOpcode() == ISD::SHL && isa<ConstantSDNode>(N0.getOperand(1)) &&
         N0.getConstantOperandVal(1) == ShAmt) {
-      uint64_t Mask = N.getConstantOperandVal(1);
-      uint64_t PreShiftMask = Mask >> ShAmt;
+      int64_t Mask = N.getConstantOperandAPInt(1).getSExtValue();
+      int64_t PreShiftMask = Mask >> ShAmt;
 
       if (isInt<12>(PreShiftMask)) {
         SDLoc DL(N);
         EVT VT = N.getValueType();
-        Val = SDValue(CurDAG->getMachineNode(
-                          RISCV::ANDI, DL, VT, N0.getOperand(0),
-                          CurDAG->getTargetConstant(PreShiftMask, DL, VT)),
-                      0);
+        Val =
+            SDValue(CurDAG->getMachineNode(
+                        RISCV::ANDI, DL, VT, N0.getOperand(0),
+                        CurDAG->getSignedTargetConstant(PreShiftMask, DL, VT)),
+                    0);
         return true;
       }
     }

--- a/llvm/test/CodeGen/RISCV/rv32xtheadba.ll
+++ b/llvm/test/CodeGen/RISCV/rv32xtheadba.ll
@@ -723,8 +723,8 @@ define i32 @srli_1_sh2add(ptr %0, i32 %1) {
 ;
 ; RV32XTHEADBA-LABEL: srli_1_sh2add:
 ; RV32XTHEADBA:       # %bb.0:
-; RV32XTHEADBA-NEXT:    srli a1, a1, 1
-; RV32XTHEADBA-NEXT:    th.addsl a0, a0, a1, 2
+; RV32XTHEADBA-NEXT:    andi a1, a1, -2
+; RV32XTHEADBA-NEXT:    th.addsl a0, a0, a1, 1
 ; RV32XTHEADBA-NEXT:    lw a0, 0(a0)
 ; RV32XTHEADBA-NEXT:    ret
   %3 = lshr i32 %1, 1
@@ -745,8 +745,8 @@ define i64 @srli_2_sh3add(ptr %0, i32 %1) {
 ;
 ; RV32XTHEADBA-LABEL: srli_2_sh3add:
 ; RV32XTHEADBA:       # %bb.0:
-; RV32XTHEADBA-NEXT:    srli a1, a1, 2
-; RV32XTHEADBA-NEXT:    th.addsl a1, a0, a1, 3
+; RV32XTHEADBA-NEXT:    andi a1, a1, -4
+; RV32XTHEADBA-NEXT:    th.addsl a1, a0, a1, 1
 ; RV32XTHEADBA-NEXT:    lw a0, 0(a1)
 ; RV32XTHEADBA-NEXT:    lw a1, 4(a1)
 ; RV32XTHEADBA-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/rv32zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zba.ll
@@ -1305,7 +1305,6 @@ define ptr @shl_add_knownbits(ptr %p, i32 %i) {
 ;    (add (and (shl x, c1), c2), y)
 ; -> (shXadd (and x, c2 >> c1), y)
 ; i.e. shift left and then mask, so that shxadd can be selected.
-; TODO: This is not currently implemented.
 
 define i32 @sh1add_masked(i32 %a, i32 %b) nounwind {
 ; RV32I-LABEL: sh1add_masked:
@@ -1317,15 +1316,14 @@ define i32 @sh1add_masked(i32 %a, i32 %b) nounwind {
 ;
 ; RV32ZBA-LABEL: sh1add_masked:
 ; RV32ZBA:       # %bb.0:
-; RV32ZBA-NEXT:    slli a0, a0, 24
-; RV32ZBA-NEXT:    srli a0, a0, 23
-; RV32ZBA-NEXT:    add a0, a0, a1
+; RV32ZBA-NEXT:    zext.b a0, a0
+; RV32ZBA-NEXT:    sh1add a0, a0, a1
 ; RV32ZBA-NEXT:    ret
 ;
 ; RV32XANDESPERF-LABEL: sh1add_masked:
 ; RV32XANDESPERF:       # %bb.0:
-; RV32XANDESPERF-NEXT:    nds.bfoz a0, a0, 1, 8
-; RV32XANDESPERF-NEXT:    add a0, a0, a1
+; RV32XANDESPERF-NEXT:    zext.b a0, a0
+; RV32XANDESPERF-NEXT:    nds.lea.h a0, a1, a0
 ; RV32XANDESPERF-NEXT:    ret
   %shl = shl i32 %a, 1
   %and = and i32 %shl, 510
@@ -1343,15 +1341,14 @@ define i32 @sh2add_masked(i32 %a, i32 %b) nounwind {
 ;
 ; RV32ZBA-LABEL: sh2add_masked:
 ; RV32ZBA:       # %bb.0:
-; RV32ZBA-NEXT:    slli a0, a0, 22
-; RV32ZBA-NEXT:    srli a0, a0, 20
-; RV32ZBA-NEXT:    add a0, a0, a1
+; RV32ZBA-NEXT:    andi a0, a0, 1023
+; RV32ZBA-NEXT:    sh2add a0, a0, a1
 ; RV32ZBA-NEXT:    ret
 ;
 ; RV32XANDESPERF-LABEL: sh2add_masked:
 ; RV32XANDESPERF:       # %bb.0:
-; RV32XANDESPERF-NEXT:    nds.bfoz a0, a0, 2, 11
-; RV32XANDESPERF-NEXT:    add a0, a0, a1
+; RV32XANDESPERF-NEXT:    andi a0, a0, 1023
+; RV32XANDESPERF-NEXT:    nds.lea.w a0, a1, a0
 ; RV32XANDESPERF-NEXT:    ret
   %shl = shl i32 %a, 2
   %and = and i32 %shl, 4092
@@ -1360,12 +1357,24 @@ define i32 @sh2add_masked(i32 %a, i32 %b) nounwind {
 }
 
 define i32 @sh3add_masked(i32 %a, i32 %b) nounwind {
-; CHECK-LABEL: sh3add_masked:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a0, a0, 768
-; CHECK-NEXT:    slli a0, a0, 3
-; CHECK-NEXT:    add a0, a0, a1
-; CHECK-NEXT:    ret
+; RV32I-LABEL: sh3add_masked:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    andi a0, a0, 768
+; RV32I-NEXT:    slli a0, a0, 3
+; RV32I-NEXT:    add a0, a0, a1
+; RV32I-NEXT:    ret
+;
+; RV32ZBA-LABEL: sh3add_masked:
+; RV32ZBA:       # %bb.0:
+; RV32ZBA-NEXT:    andi a0, a0, 768
+; RV32ZBA-NEXT:    sh3add a0, a0, a1
+; RV32ZBA-NEXT:    ret
+;
+; RV32XANDESPERF-LABEL: sh3add_masked:
+; RV32XANDESPERF:       # %bb.0:
+; RV32XANDESPERF-NEXT:    andi a0, a0, 768
+; RV32XANDESPERF-NEXT:    nds.lea.d a0, a1, a0
+; RV32XANDESPERF-NEXT:    ret
   %shl = shl i32 %a, 3
   %and = and i32 %shl, 6144
   %add = add i32 %and, %b

--- a/llvm/test/CodeGen/RISCV/rv32zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zba.ll
@@ -897,15 +897,15 @@ define i32 @srli_1_sh2add(ptr %0, i32 %1) {
 ;
 ; RV32ZBA-LABEL: srli_1_sh2add:
 ; RV32ZBA:       # %bb.0:
-; RV32ZBA-NEXT:    srli a1, a1, 1
-; RV32ZBA-NEXT:    sh2add a0, a1, a0
+; RV32ZBA-NEXT:    andi a1, a1, -2
+; RV32ZBA-NEXT:    sh1add a0, a1, a0
 ; RV32ZBA-NEXT:    lw a0, 0(a0)
 ; RV32ZBA-NEXT:    ret
 ;
 ; RV32XANDESPERF-LABEL: srli_1_sh2add:
 ; RV32XANDESPERF:       # %bb.0:
-; RV32XANDESPERF-NEXT:    srli a1, a1, 1
-; RV32XANDESPERF-NEXT:    nds.lea.w a0, a0, a1
+; RV32XANDESPERF-NEXT:    andi a1, a1, -2
+; RV32XANDESPERF-NEXT:    nds.lea.h a0, a0, a1
 ; RV32XANDESPERF-NEXT:    lw a0, 0(a0)
 ; RV32XANDESPERF-NEXT:    ret
   %3 = lshr i32 %1, 1
@@ -926,16 +926,16 @@ define i64 @srli_2_sh3add(ptr %0, i32 %1) {
 ;
 ; RV32ZBA-LABEL: srli_2_sh3add:
 ; RV32ZBA:       # %bb.0:
-; RV32ZBA-NEXT:    srli a1, a1, 2
-; RV32ZBA-NEXT:    sh3add a1, a1, a0
+; RV32ZBA-NEXT:    andi a1, a1, -4
+; RV32ZBA-NEXT:    sh1add a1, a1, a0
 ; RV32ZBA-NEXT:    lw a0, 0(a1)
 ; RV32ZBA-NEXT:    lw a1, 4(a1)
 ; RV32ZBA-NEXT:    ret
 ;
 ; RV32XANDESPERF-LABEL: srli_2_sh3add:
 ; RV32XANDESPERF:       # %bb.0:
-; RV32XANDESPERF-NEXT:    srli a1, a1, 2
-; RV32XANDESPERF-NEXT:    nds.lea.d a1, a0, a1
+; RV32XANDESPERF-NEXT:    andi a1, a1, -4
+; RV32XANDESPERF-NEXT:    nds.lea.h a1, a0, a1
 ; RV32XANDESPERF-NEXT:    lw a0, 0(a1)
 ; RV32XANDESPERF-NEXT:    lw a1, 4(a1)
 ; RV32XANDESPERF-NEXT:    ret
@@ -1399,15 +1399,26 @@ define i32 @sh1add_large_mask(i32 %a, i32 %b) nounwind {
 
 ; Check that negative masks which fit into the andi 12-bit signed immediate
 ; are also supported.
-; TODO: Implement this.
 
 define i32 @sh1add_negative_mask(i32 %a, i32 %b) nounwind {
-; CHECK-LABEL: sh1add_negative_mask:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    andi a0, a0, -16
-; CHECK-NEXT:    add a0, a0, a1
-; CHECK-NEXT:    ret
+; RV32I-LABEL: sh1add_negative_mask:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    slli a0, a0, 1
+; RV32I-NEXT:    andi a0, a0, -16
+; RV32I-NEXT:    add a0, a0, a1
+; RV32I-NEXT:    ret
+;
+; RV32ZBA-LABEL: sh1add_negative_mask:
+; RV32ZBA:       # %bb.0:
+; RV32ZBA-NEXT:    andi a0, a0, -8
+; RV32ZBA-NEXT:    sh1add a0, a0, a1
+; RV32ZBA-NEXT:    ret
+;
+; RV32XANDESPERF-LABEL: sh1add_negative_mask:
+; RV32XANDESPERF:       # %bb.0:
+; RV32XANDESPERF-NEXT:    andi a0, a0, -8
+; RV32XANDESPERF-NEXT:    nds.lea.h a0, a1, a0
+; RV32XANDESPERF-NEXT:    ret
   %shl = shl i32 %a, 1
   %and = and i32 %shl, -16
   %add = add i32 %and, %b
@@ -1415,12 +1426,24 @@ define i32 @sh1add_negative_mask(i32 %a, i32 %b) nounwind {
 }
 
 define i32 @sh2add_negative_mask(i32 %a, i32 %b) nounwind {
-; CHECK-LABEL: sh2add_negative_mask:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a0, a0, 2
-; CHECK-NEXT:    andi a0, a0, -32
-; CHECK-NEXT:    add a0, a0, a1
-; CHECK-NEXT:    ret
+; RV32I-LABEL: sh2add_negative_mask:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    slli a0, a0, 2
+; RV32I-NEXT:    andi a0, a0, -32
+; RV32I-NEXT:    add a0, a0, a1
+; RV32I-NEXT:    ret
+;
+; RV32ZBA-LABEL: sh2add_negative_mask:
+; RV32ZBA:       # %bb.0:
+; RV32ZBA-NEXT:    andi a0, a0, -8
+; RV32ZBA-NEXT:    sh2add a0, a0, a1
+; RV32ZBA-NEXT:    ret
+;
+; RV32XANDESPERF-LABEL: sh2add_negative_mask:
+; RV32XANDESPERF:       # %bb.0:
+; RV32XANDESPERF-NEXT:    andi a0, a0, -8
+; RV32XANDESPERF-NEXT:    nds.lea.w a0, a1, a0
+; RV32XANDESPERF-NEXT:    ret
   %shl = shl i32 %a, 2
   %and = and i32 %shl, -32
   %add = add i32 %and, %b
@@ -1428,12 +1451,24 @@ define i32 @sh2add_negative_mask(i32 %a, i32 %b) nounwind {
 }
 
 define i32 @sh3add_negative_mask(i32 %a, i32 %b) nounwind {
-; CHECK-LABEL: sh3add_negative_mask:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    srli a0, a0, 3
-; CHECK-NEXT:    slli a0, a0, 6
-; CHECK-NEXT:    add a0, a0, a1
-; CHECK-NEXT:    ret
+; RV32I-LABEL: sh3add_negative_mask:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    srli a0, a0, 3
+; RV32I-NEXT:    slli a0, a0, 6
+; RV32I-NEXT:    add a0, a0, a1
+; RV32I-NEXT:    ret
+;
+; RV32ZBA-LABEL: sh3add_negative_mask:
+; RV32ZBA:       # %bb.0:
+; RV32ZBA-NEXT:    andi a0, a0, -8
+; RV32ZBA-NEXT:    sh3add a0, a0, a1
+; RV32ZBA-NEXT:    ret
+;
+; RV32XANDESPERF-LABEL: sh3add_negative_mask:
+; RV32XANDESPERF:       # %bb.0:
+; RV32XANDESPERF-NEXT:    andi a0, a0, -8
+; RV32XANDESPERF-NEXT:    nds.lea.d a0, a1, a0
+; RV32XANDESPERF-NEXT:    ret
   %shl = shl i32 %a, 3
   %and = and i32 %shl, -64
   %add = add i32 %and, %b

--- a/llvm/test/CodeGen/RISCV/rv32zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zba.ll
@@ -1396,3 +1396,46 @@ define i32 @sh1add_large_mask(i32 %a, i32 %b) nounwind {
   %add = add i32 %and, %b
   ret i32 %add
 }
+
+; Check that negative masks which fit into the andi 12-bit signed immediate
+; are also supported.
+; TODO: Implement this.
+
+define i32 @sh1add_negative_mask(i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: sh1add_negative_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 1
+; CHECK-NEXT:    andi a0, a0, -16
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %shl = shl i32 %a, 1
+  %and = and i32 %shl, -16
+  %add = add i32 %and, %b
+  ret i32 %add
+}
+
+define i32 @sh2add_negative_mask(i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: sh2add_negative_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 2
+; CHECK-NEXT:    andi a0, a0, -32
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %shl = shl i32 %a, 2
+  %and = and i32 %shl, -32
+  %add = add i32 %and, %b
+  ret i32 %add
+}
+
+define i32 @sh3add_negative_mask(i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: sh3add_negative_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    srli a0, a0, 3
+; CHECK-NEXT:    slli a0, a0, 6
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %shl = shl i32 %a, 3
+  %and = and i32 %shl, -64
+  %add = add i32 %and, %b
+  ret i32 %add
+}

--- a/llvm/test/CodeGen/RISCV/rv64xtheadba.ll
+++ b/llvm/test/CodeGen/RISCV/rv64xtheadba.ll
@@ -1503,8 +1503,8 @@ define signext i32 @srli_1_sh2add(ptr %0, i64 %1) {
 ;
 ; RV64XTHEADBA-LABEL: srli_1_sh2add:
 ; RV64XTHEADBA:       # %bb.0:
-; RV64XTHEADBA-NEXT:    srli a1, a1, 1
-; RV64XTHEADBA-NEXT:    th.addsl a0, a0, a1, 2
+; RV64XTHEADBA-NEXT:    andi a1, a1, -2
+; RV64XTHEADBA-NEXT:    th.addsl a0, a0, a1, 1
 ; RV64XTHEADBA-NEXT:    lw a0, 0(a0)
 ; RV64XTHEADBA-NEXT:    ret
   %3 = lshr i64 %1, 1
@@ -1524,8 +1524,8 @@ define i64 @srli_2_sh3add(ptr %0, i64 %1) {
 ;
 ; RV64XTHEADBA-LABEL: srli_2_sh3add:
 ; RV64XTHEADBA:       # %bb.0:
-; RV64XTHEADBA-NEXT:    srli a1, a1, 2
-; RV64XTHEADBA-NEXT:    th.addsl a0, a0, a1, 3
+; RV64XTHEADBA-NEXT:    andi a1, a1, -4
+; RV64XTHEADBA-NEXT:    th.addsl a0, a0, a1, 1
 ; RV64XTHEADBA-NEXT:    ld a0, 0(a0)
 ; RV64XTHEADBA-NEXT:    ret
   %3 = lshr i64 %1, 2

--- a/llvm/test/CodeGen/RISCV/rv64zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zba.ll
@@ -3229,15 +3229,15 @@ define signext i32 @srli_1_sh2add(ptr %0, i64 %1) {
 ;
 ; RV64ZBA-LABEL: srli_1_sh2add:
 ; RV64ZBA:       # %bb.0:
-; RV64ZBA-NEXT:    srli a1, a1, 1
-; RV64ZBA-NEXT:    sh2add a0, a1, a0
+; RV64ZBA-NEXT:    andi a1, a1, -2
+; RV64ZBA-NEXT:    sh1add a0, a1, a0
 ; RV64ZBA-NEXT:    lw a0, 0(a0)
 ; RV64ZBA-NEXT:    ret
 ;
 ; RV64XANDESPERF-LABEL: srli_1_sh2add:
 ; RV64XANDESPERF:       # %bb.0:
-; RV64XANDESPERF-NEXT:    srli a1, a1, 1
-; RV64XANDESPERF-NEXT:    nds.lea.w a0, a0, a1
+; RV64XANDESPERF-NEXT:    andi a1, a1, -2
+; RV64XANDESPERF-NEXT:    nds.lea.h a0, a0, a1
 ; RV64XANDESPERF-NEXT:    lw a0, 0(a0)
 ; RV64XANDESPERF-NEXT:    ret
   %3 = lshr i64 %1, 1
@@ -3257,15 +3257,15 @@ define i64 @srli_2_sh3add(ptr %0, i64 %1) {
 ;
 ; RV64ZBA-LABEL: srli_2_sh3add:
 ; RV64ZBA:       # %bb.0:
-; RV64ZBA-NEXT:    srli a1, a1, 2
-; RV64ZBA-NEXT:    sh3add a0, a1, a0
+; RV64ZBA-NEXT:    andi a1, a1, -4
+; RV64ZBA-NEXT:    sh1add a0, a1, a0
 ; RV64ZBA-NEXT:    ld a0, 0(a0)
 ; RV64ZBA-NEXT:    ret
 ;
 ; RV64XANDESPERF-LABEL: srli_2_sh3add:
 ; RV64XANDESPERF:       # %bb.0:
-; RV64XANDESPERF-NEXT:    srli a1, a1, 2
-; RV64XANDESPERF-NEXT:    nds.lea.d a0, a0, a1
+; RV64XANDESPERF-NEXT:    andi a1, a1, -4
+; RV64XANDESPERF-NEXT:    nds.lea.h a0, a0, a1
 ; RV64XANDESPERF-NEXT:    ld a0, 0(a0)
 ; RV64XANDESPERF-NEXT:    ret
   %3 = lshr i64 %1, 2
@@ -5186,15 +5186,26 @@ define i64 @sh1add_large_mask(i64 %a, i64 %b) nounwind {
 
 ; Check that negative masks which fit into the andi 12-bit signed immediate
 ; are also supported.
-; TODO: Implement this.
 
 define i64 @sh1add_negative_mask(i64 %a, i64 %b) nounwind {
-; CHECK-LABEL: sh1add_negative_mask:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a0, a0, 1
-; CHECK-NEXT:    andi a0, a0, -16
-; CHECK-NEXT:    add a0, a0, a1
-; CHECK-NEXT:    ret
+; RV64I-LABEL: sh1add_negative_mask:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    slli a0, a0, 1
+; RV64I-NEXT:    andi a0, a0, -16
+; RV64I-NEXT:    add a0, a0, a1
+; RV64I-NEXT:    ret
+;
+; RV64ZBA-LABEL: sh1add_negative_mask:
+; RV64ZBA:       # %bb.0:
+; RV64ZBA-NEXT:    andi a0, a0, -8
+; RV64ZBA-NEXT:    sh1add a0, a0, a1
+; RV64ZBA-NEXT:    ret
+;
+; RV64XANDESPERF-LABEL: sh1add_negative_mask:
+; RV64XANDESPERF:       # %bb.0:
+; RV64XANDESPERF-NEXT:    andi a0, a0, -8
+; RV64XANDESPERF-NEXT:    nds.lea.h a0, a1, a0
+; RV64XANDESPERF-NEXT:    ret
   %shl = shl i64 %a, 1
   %and = and i64 %shl, -16
   %add = add i64 %and, %b
@@ -5202,12 +5213,24 @@ define i64 @sh1add_negative_mask(i64 %a, i64 %b) nounwind {
 }
 
 define i64 @sh2add_negative_mask(i64 %a, i64 %b) nounwind {
-; CHECK-LABEL: sh2add_negative_mask:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a0, a0, 2
-; CHECK-NEXT:    andi a0, a0, -32
-; CHECK-NEXT:    add a0, a0, a1
-; CHECK-NEXT:    ret
+; RV64I-LABEL: sh2add_negative_mask:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    slli a0, a0, 2
+; RV64I-NEXT:    andi a0, a0, -32
+; RV64I-NEXT:    add a0, a0, a1
+; RV64I-NEXT:    ret
+;
+; RV64ZBA-LABEL: sh2add_negative_mask:
+; RV64ZBA:       # %bb.0:
+; RV64ZBA-NEXT:    andi a0, a0, -8
+; RV64ZBA-NEXT:    sh2add a0, a0, a1
+; RV64ZBA-NEXT:    ret
+;
+; RV64XANDESPERF-LABEL: sh2add_negative_mask:
+; RV64XANDESPERF:       # %bb.0:
+; RV64XANDESPERF-NEXT:    andi a0, a0, -8
+; RV64XANDESPERF-NEXT:    nds.lea.w a0, a1, a0
+; RV64XANDESPERF-NEXT:    ret
   %shl = shl i64 %a, 2
   %and = and i64 %shl, -32
   %add = add i64 %and, %b
@@ -5215,12 +5238,24 @@ define i64 @sh2add_negative_mask(i64 %a, i64 %b) nounwind {
 }
 
 define i64 @sh3add_negative_mask(i64 %a, i64 %b) nounwind {
-; CHECK-LABEL: sh3add_negative_mask:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    srli a0, a0, 3
-; CHECK-NEXT:    slli a0, a0, 6
-; CHECK-NEXT:    add a0, a0, a1
-; CHECK-NEXT:    ret
+; RV64I-LABEL: sh3add_negative_mask:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    srli a0, a0, 3
+; RV64I-NEXT:    slli a0, a0, 6
+; RV64I-NEXT:    add a0, a0, a1
+; RV64I-NEXT:    ret
+;
+; RV64ZBA-LABEL: sh3add_negative_mask:
+; RV64ZBA:       # %bb.0:
+; RV64ZBA-NEXT:    andi a0, a0, -8
+; RV64ZBA-NEXT:    sh3add a0, a0, a1
+; RV64ZBA-NEXT:    ret
+;
+; RV64XANDESPERF-LABEL: sh3add_negative_mask:
+; RV64XANDESPERF:       # %bb.0:
+; RV64XANDESPERF-NEXT:    andi a0, a0, -8
+; RV64XANDESPERF-NEXT:    nds.lea.d a0, a1, a0
+; RV64XANDESPERF-NEXT:    ret
   %shl = shl i64 %a, 3
   %and = and i64 %shl, -64
   %add = add i64 %and, %b

--- a/llvm/test/CodeGen/RISCV/rv64zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zba.ll
@@ -5183,3 +5183,46 @@ define i64 @sh1add_large_mask(i64 %a, i64 %b) nounwind {
   %add = add i64 %and, %b
   ret i64 %add
 }
+
+; Check that negative masks which fit into the andi 12-bit signed immediate
+; are also supported.
+; TODO: Implement this.
+
+define i64 @sh1add_negative_mask(i64 %a, i64 %b) nounwind {
+; CHECK-LABEL: sh1add_negative_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 1
+; CHECK-NEXT:    andi a0, a0, -16
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %shl = shl i64 %a, 1
+  %and = and i64 %shl, -16
+  %add = add i64 %and, %b
+  ret i64 %add
+}
+
+define i64 @sh2add_negative_mask(i64 %a, i64 %b) nounwind {
+; CHECK-LABEL: sh2add_negative_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 2
+; CHECK-NEXT:    andi a0, a0, -32
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %shl = shl i64 %a, 2
+  %and = and i64 %shl, -32
+  %add = add i64 %and, %b
+  ret i64 %add
+}
+
+define i64 @sh3add_negative_mask(i64 %a, i64 %b) nounwind {
+; CHECK-LABEL: sh3add_negative_mask:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    srli a0, a0, 3
+; CHECK-NEXT:    slli a0, a0, 6
+; CHECK-NEXT:    add a0, a0, a1
+; CHECK-NEXT:    ret
+  %shl = shl i64 %a, 3
+  %and = and i64 %shl, -64
+  %add = add i64 %and, %b
+  ret i64 %add
+}


### PR DESCRIPTION
 Transform (and (shl x, c1), c2) -> (shl (and x, c2 >> c1), c1) as long
 as the shifted mask fits into a 12-bit immediate. This allows a shxadd
 to be selected when it wasn't before.

 This was found in SPEC but I will note that the dynamic execution counts
 are not particularly high (the best we get is -0.04% on 531.deepsjeng_r.
 The diffstat on the generated assembly for an RVA22 SPEC build is 2086
 insertions, 2345 deletions.

 Although the impact is small on these benchmarks, I'm choosing to
 propose this because it _does_ represent a case where shxadd can
 'obviously' be selected without anything particularly heroic.
