### PR TITLE
[libc] Add `IN6_IS_ADDR_MC*`

### DIFF
--- a/libc/include/llvm-libc-macros/netinet-in-macros.h
+++ b/libc/include/llvm-libc-macros/netinet-in-macros.h
@@ -38,6 +38,12 @@
 // int and takes a single argument of type const struct in6_addr *:
 // https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/netinet_in.h.html
 
+#define IN6_IS_ADDR_UNSPECIFIED(a)                                             \
+  ((__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[0]) == 0 &&              \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[1]) == 0 &&              \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[2]) == 0 &&              \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[3]) == 0)
+
 #define IN6_IS_ADDR_LINKLOCAL(a)                                               \
   ((__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[0]) == 0xfe &&            \
    (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xc0) == 0x80)

--- a/libc/include/llvm-libc-macros/netinet-in-macros.h
+++ b/libc/include/llvm-libc-macros/netinet-in-macros.h
@@ -44,6 +44,15 @@
    (__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[2]) == 0 &&              \
    (__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[3]) == 0)
 
+#define IN6_IS_ADDR_LOOPBACK(a)                                                \
+  ((__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[0]) == 0 &&              \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[1]) == 0 &&              \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint32_t *, a)[2]) == 0 &&              \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[12]) == 0 &&              \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[13]) == 0 &&              \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[14]) == 0 &&              \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[15]) == 1)
+
 #define IN6_IS_ADDR_LINKLOCAL(a)                                               \
   ((__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[0]) == 0xfe &&            \
    (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xc0) == 0x80)

--- a/libc/include/llvm-libc-macros/netinet-in-macros.h
+++ b/libc/include/llvm-libc-macros/netinet-in-macros.h
@@ -64,4 +64,24 @@
   ((__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[0]) == 0xfe &&            \
    (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xc0) == 0xc0)
 
+#define IN6_IS_ADDR_MC_NODELOCAL(a)                                            \
+  (IN6_IS_ADDR_MULTICAST(a) &&                                                 \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xf) == 0x1)
+
+#define IN6_IS_ADDR_MC_LINKLOCAL(a)                                            \
+  (IN6_IS_ADDR_MULTICAST(a) &&                                                 \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xf) == 0x2)
+
+#define IN6_IS_ADDR_MC_SITELOCAL(a)                                            \
+  (IN6_IS_ADDR_MULTICAST(a) &&                                                 \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xf) == 0x5)
+
+#define IN6_IS_ADDR_MC_ORGLOCAL(a)                                             \
+  (IN6_IS_ADDR_MULTICAST(a) &&                                                 \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xf) == 0x8)
+
+#define IN6_IS_ADDR_MC_GLOBAL(a)                                               \
+  (IN6_IS_ADDR_MULTICAST(a) &&                                                 \
+   (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xf) == 0xe)
+
 #endif // LLVM_LIBC_MACROS_NETINET_IN_MACROS_H

--- a/libc/include/llvm-libc-macros/netinet-in-macros.h
+++ b/libc/include/llvm-libc-macros/netinet-in-macros.h
@@ -53,6 +53,9 @@
    (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[14]) == 0 &&              \
    (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[15]) == 1)
 
+#define IN6_IS_ADDR_MULTICAST(a)                                               \
+  (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[0]) == 0xff
+
 #define IN6_IS_ADDR_LINKLOCAL(a)                                               \
   ((__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[0]) == 0xfe &&            \
    (__LLVM_LIBC_CAST(reinterpret_cast, uint8_t *, a)[1] & 0xc0) == 0x80)

--- a/libc/test/include/netinet_in_test.cpp
+++ b/libc/test/include/netinet_in_test.cpp
@@ -42,4 +42,18 @@ TEST(LlvmLibcNetinetInTest, IN6Macro) {
   buff[0] = 0xff;
   buff[1] = 0x80;
   EXPECT_FALSE(IN6_IS_ADDR_SITELOCAL(buff));
+
+  buff[0] = 0xff;
+  buff[1] = 0x1;
+  EXPECT_TRUE(IN6_IS_ADDR_MC_NODELOCAL(buff));
+  buff[1] = 0x2;
+  EXPECT_TRUE(IN6_IS_ADDR_MC_LINKLOCAL(buff));
+  buff[1] = 0x5;
+  EXPECT_TRUE(IN6_IS_ADDR_MC_SITELOCAL(buff));
+  buff[1] = 0x8;
+  EXPECT_TRUE(IN6_IS_ADDR_MC_ORGLOCAL(buff));
+  buff[1] = 0xe;
+  EXPECT_TRUE(IN6_IS_ADDR_MC_GLOBAL(buff));
+  buff[1] = 0;
+  buff[0] = 0;
 }

--- a/libc/test/include/netinet_in_test.cpp
+++ b/libc/test/include/netinet_in_test.cpp
@@ -12,6 +12,13 @@
 TEST(LlvmLibcNetinetInTest, IN6Macro) {
   char buff[16] = {};
 
+  EXPECT_TRUE(IN6_IS_ADDR_UNSPECIFIED(buff));
+  for (int i = 0; i < 16; ++i) {
+    buff[i] = 1;
+    EXPECT_FALSE(IN6_IS_ADDR_UNSPECIFIED(buff));
+    buff[i] = 0;
+  }
+
   buff[0] = 0xfe;
   buff[1] = 0x80;
   EXPECT_TRUE(IN6_IS_ADDR_LINKLOCAL(buff));

--- a/libc/test/include/netinet_in_test.cpp
+++ b/libc/test/include/netinet_in_test.cpp
@@ -24,6 +24,11 @@ TEST(LlvmLibcNetinetInTest, IN6Macro) {
   EXPECT_TRUE(IN6_IS_ADDR_LOOPBACK(buff));
   buff[15] = 0;
 
+  EXPECT_FALSE(IN6_IS_ADDR_MULTICAST(buff));
+  buff[0] = 0xff;
+  EXPECT_TRUE(IN6_IS_ADDR_MULTICAST(buff));
+  buff[0] = 0;
+
   buff[0] = 0xfe;
   buff[1] = 0x80;
   EXPECT_TRUE(IN6_IS_ADDR_LINKLOCAL(buff));

--- a/libc/test/include/netinet_in_test.cpp
+++ b/libc/test/include/netinet_in_test.cpp
@@ -19,6 +19,11 @@ TEST(LlvmLibcNetinetInTest, IN6Macro) {
     buff[i] = 0;
   }
 
+  EXPECT_FALSE(IN6_IS_ADDR_LOOPBACK(buff));
+  buff[15] = 1;
+  EXPECT_TRUE(IN6_IS_ADDR_LOOPBACK(buff));
+  buff[15] = 0;
+
   buff[0] = 0xfe;
   buff[1] = 0x80;
   EXPECT_TRUE(IN6_IS_ADDR_LINKLOCAL(buff));


### PR DESCRIPTION
This patch adds the `IN6_IS_ADDR_MC*` macro, which checks whether an address is multicast node-local address, multicast link-local address, multicast site-local address, multicast organization-local address and multicast global address.