### PR TITLE
[X86] combineConcatVectorOps - add handling for X86ISD::FMAX/FMIN vector ops

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -59652,6 +59652,8 @@ static SDValue combineConcatVectorOps(const SDLoc &DL, MVT VT,
     case ISD::FADD:
     case ISD::FSUB:
     case ISD::FMUL:
+    case X86ISD::FMAX:
+    case X86ISD::FMIN:
       if (!IsSplat && (VT.is256BitVector() ||
                        (VT.is512BitVector() && Subtarget.useAVX512Regs()))) {
         SDValue Concat0 = CombineSubOperand(VT, Ops, 0);

--- a/llvm/test/CodeGen/X86/combine-fmax.ll
+++ b/llvm/test/CodeGen/X86/combine-fmax.ll
@@ -14,10 +14,10 @@ define <4 x double> @concat_fmax_v4f64_v2f64(<2 x double> %a0, <2 x double> %a1)
 ;
 ; AVX-LABEL: concat_fmax_v4f64_v2f64:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    vxorpd %xmm2, %xmm2, %xmm2
-; AVX-NEXT:    vmaxpd %xmm2, %xmm0, %xmm0
-; AVX-NEXT:    vmaxpd %xmm2, %xmm1, %xmm1
+; AVX-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
 ; AVX-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
+; AVX-NEXT:    vxorpd %xmm1, %xmm1, %xmm1
+; AVX-NEXT:    vmaxpd %ymm1, %ymm0, %ymm0
 ; AVX-NEXT:    retq
   %v0 = call <2 x double> @llvm.x86.sse2.max.pd(<2 x double> %a0, <2 x double> zeroinitializer)
   %v1 = call <2 x double> @llvm.x86.sse2.max.pd(<2 x double> %a1, <2 x double> zeroinitializer)
@@ -35,10 +35,10 @@ define <8 x float> @concat_fmax_v8f32_v4f32(<4 x float> %a0, <4 x float> %a1) {
 ;
 ; AVX-LABEL: concat_fmax_v8f32_v4f32:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    vxorps %xmm2, %xmm2, %xmm2
-; AVX-NEXT:    vmaxps %xmm2, %xmm0, %xmm0
-; AVX-NEXT:    vmaxps %xmm2, %xmm1, %xmm1
+; AVX-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
 ; AVX-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
+; AVX-NEXT:    vxorps %xmm1, %xmm1, %xmm1
+; AVX-NEXT:    vmaxps %ymm1, %ymm0, %ymm0
 ; AVX-NEXT:    retq
   %v0 = call <4 x float> @llvm.x86.sse.max.ps(<4 x float> %a0, <4 x float> zeroinitializer)
   %v1 = call <4 x float> @llvm.x86.sse.max.ps(<4 x float> %a1, <4 x float> zeroinitializer)

--- a/llvm/test/CodeGen/X86/combine-fmin.ll
+++ b/llvm/test/CodeGen/X86/combine-fmin.ll
@@ -14,10 +14,10 @@ define <4 x double> @concat_fmin_v4f64_v2f64(<2 x double> %a0, <2 x double> %a1)
 ;
 ; AVX-LABEL: concat_fmin_v4f64_v2f64:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    vxorpd %xmm2, %xmm2, %xmm2
-; AVX-NEXT:    vminpd %xmm2, %xmm0, %xmm0
-; AVX-NEXT:    vminpd %xmm2, %xmm1, %xmm1
+; AVX-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
 ; AVX-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
+; AVX-NEXT:    vxorpd %xmm1, %xmm1, %xmm1
+; AVX-NEXT:    vminpd %ymm1, %ymm0, %ymm0
 ; AVX-NEXT:    retq
   %v0 = call <2 x double> @llvm.x86.sse2.min.pd(<2 x double> %a0, <2 x double> zeroinitializer)
   %v1 = call <2 x double> @llvm.x86.sse2.min.pd(<2 x double> %a1, <2 x double> zeroinitializer)
@@ -35,10 +35,10 @@ define <8 x float> @concat_fmin_v8f32_v4f32(<4 x float> %a0, <4 x float> %a1) {
 ;
 ; AVX-LABEL: concat_fmin_v8f32_v4f32:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    vxorps %xmm2, %xmm2, %xmm2
-; AVX-NEXT:    vminps %xmm2, %xmm0, %xmm0
-; AVX-NEXT:    vminps %xmm2, %xmm1, %xmm1
+; AVX-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
 ; AVX-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
+; AVX-NEXT:    vxorps %xmm1, %xmm1, %xmm1
+; AVX-NEXT:    vminps %ymm1, %ymm0, %ymm0
 ; AVX-NEXT:    retq
   %v0 = call <4 x float> @llvm.x86.sse.min.ps(<4 x float> %a0, <4 x float> zeroinitializer)
   %v1 = call <4 x float> @llvm.x86.sse.min.ps(<4 x float> %a1, <4 x float> zeroinitializer)


### PR DESCRIPTION
These are typically very similar to FADD/FSUB so we don't want to concat if it'd create additional VINSERT ops.