### PR TITLE
[InstCombine] Enable folding of (select C, (x bin_op a), x) bin_op b -> x bin_op select C, (a bin_op b), b

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1835,10 +1835,11 @@ Instruction *InstCombinerImpl::FoldOpIntoSelect(Instruction &Op, SelectInst *SI,
   //   %3 = or i8 %2, C2
   Value *Input;
   if (!NewTV && !NewFV &&
-      (!Op.isBinaryOp() || !match(&Op, m_c_BinOp(m_Value(), m_ConstantInt())) ||
-       !(match(SI, m_c_Select(m_Value(Input),
-                              m_c_BinOp(Op.getOpcode(), m_Deferred(Input),
-                                        m_ConstantInt()))))))
+      (!match(&Op,
+              m_c_BinOp(m_c_Select(m_Value(Input),
+                                   m_c_BinOp(Op.getOpcode(), m_Deferred(Input),
+                                             m_ConstantInt())),
+                        m_ConstantInt()))))
     return nullptr;
 
   // Create an instruction for the arm that did not fold.

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1835,7 +1835,7 @@ Instruction *InstCombinerImpl::FoldOpIntoSelect(Instruction &Op, SelectInst *SI,
   //   %3 = or i8 %2, C2
   Value *Input;
   if (!NewTV && !NewFV &&
-      (Op.isIntDivRem() || Op.isFPDivRem() ||
+      (Op.isIntDivRem() ||
        !match(&Op, m_BinOp(m_c_Select(m_Value(Input),
                                       m_BinOp(Op.getOpcode(), m_Deferred(Input),
                                               m_ConstantInt())),

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1835,7 +1835,8 @@ Instruction *InstCombinerImpl::FoldOpIntoSelect(Instruction &Op, SelectInst *SI,
   //   %3 = or i8 %2, C2
   Value *Input;
   if (!NewTV && !NewFV &&
-      (!match(&Op, m_BinOp(m_c_Select(m_Value(Input),
+      (Op.isIntDivRem() || Op.isFPDivRem() ||
+       !match(&Op, m_BinOp(m_c_Select(m_Value(Input),
                                       m_BinOp(Op.getOpcode(), m_Deferred(Input),
                                               m_ConstantInt())),
                            m_ConstantInt()))))

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1835,11 +1835,10 @@ Instruction *InstCombinerImpl::FoldOpIntoSelect(Instruction &Op, SelectInst *SI,
   //   %3 = or i8 %2, C2
   Value *Input;
   if (!NewTV && !NewFV &&
-      (!match(&Op,
-              m_c_BinOp(m_c_Select(m_Value(Input),
-                                   m_c_BinOp(Op.getOpcode(), m_Deferred(Input),
-                                             m_ConstantInt())),
-                        m_ConstantInt()))))
+      (!match(&Op, m_BinOp(m_c_Select(m_Value(Input),
+                                      m_BinOp(Op.getOpcode(), m_Deferred(Input),
+                                              m_ConstantInt())),
+                           m_ConstantInt()))))
     return nullptr;
 
   // Create an instruction for the arm that did not fold.

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -575,9 +575,8 @@ define i32 @OrSelectIcmpNonZero(i32 %a, i32 %b) {
 define i8 @orSelectOrNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -605,9 +604,8 @@ define i8 @orSelectOrNoCommonBits2(i8 %arg0, i8 %arg1) {
 define i8 @orSelectOrSubset1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrSubset1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 2
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 13
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 15, i8 13
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -620,9 +618,8 @@ define i8 @orSelectOrSubset1(i8 %arg0, i8 %arg1) {
 define i8 @orSelectOrSubset2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrSubset2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 11
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 15, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -635,9 +632,8 @@ define i8 @orSelectOrSubset2(i8 %arg0, i8 %arg1) {
 define i8 @orSelectOrSomeCommon1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrSomeCommon1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 10
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 5
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 15, i8 5
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -650,9 +646,8 @@ define i8 @orSelectOrSomeCommon1(i8 %arg0, i8 %arg1) {
 define i8 @orSelectOrSomeCommon2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrSomeCommon2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 11
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 15, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -774,9 +769,8 @@ define i8 @andSelectandSame(i8 %arg0, i8 %arg1) {
 define i8 @xorSelectxorNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @xorSelectxorNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 4
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -804,9 +798,8 @@ define i8 @xorSelectxorNoCommonBits2(i8 %arg0, i8 %arg1) {
 define i8 @xorSelectxorSubset1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @xorSelectxorSubset1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 13
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 6, i8 13
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -819,9 +812,8 @@ define i8 @xorSelectxorSubset1(i8 %arg0, i8 %arg1) {
 define i8 @xorSelectxorSubset2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @xorSelectxorSubset2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 13
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 11
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 6, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -834,9 +826,8 @@ define i8 @xorSelectxorSubset2(i8 %arg0, i8 %arg1) {
 define i8 @xorSelectxorSomeCommon1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @xorSelectxorSomeCommon1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 5
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 14, i8 5
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -849,9 +840,8 @@ define i8 @xorSelectxorSomeCommon1(i8 %arg0, i8 %arg1) {
 define i8 @xorSelectxorSomeCommon2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @xorSelectxorSomeCommon2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 5
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 11
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 14, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -879,9 +869,8 @@ define i8 @xorSelectxorSame(i8 %arg0, i8 %arg1) {
 define i8 @addSelectaddNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 4
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -909,9 +898,8 @@ define i8 @addSelectaddNoCommonBits2(i8 %arg0, i8 %arg1) {
 define i8 @addSelectaddSubset1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddSubset1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 13
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 24, i8 13
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -924,9 +912,8 @@ define i8 @addSelectaddSubset1(i8 %arg0, i8 %arg1) {
 define i8 @addSelectaddSubset2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddSubset2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 13
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 11
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 24, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -939,9 +926,8 @@ define i8 @addSelectaddSubset2(i8 %arg0, i8 %arg1) {
 define i8 @addSelectaddSomeCommon1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddSomeCommon1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 5
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 16, i8 5
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -954,9 +940,8 @@ define i8 @addSelectaddSomeCommon1(i8 %arg0, i8 %arg1) {
 define i8 @addSelectaddSomeCommon2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddSomeCommon2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 5
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 11
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 16, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -969,9 +954,8 @@ define i8 @addSelectaddSomeCommon2(i8 %arg0, i8 %arg1) {
 define i8 @addSelectaddSame(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddSame(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 42
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 42
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 84, i8 42
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -985,9 +969,8 @@ define i8 @addSelectaddSame(i8 %arg0, i8 %arg1) {
 define i8 @subSelectsubNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -4
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 -5, i8 -1
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1015,9 +998,8 @@ define i8 @subSelectsubNoCommonBits2(i8 %arg0, i8 %arg1) {
 define i8 @subSelectsubSubset1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubSubset1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -13
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 -24, i8 -13
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1030,9 +1012,8 @@ define i8 @subSelectsubSubset1(i8 %arg0, i8 %arg1) {
 define i8 @subSelectsubSubset2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubSubset2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -13
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -11
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 -24, i8 -11
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1045,9 +1026,8 @@ define i8 @subSelectsubSubset2(i8 %arg0, i8 %arg1) {
 define i8 @subSelectsubSomeCommon1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubSomeCommon1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -5
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 -16, i8 -5
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1060,9 +1040,8 @@ define i8 @subSelectsubSomeCommon1(i8 %arg0, i8 %arg1) {
 define i8 @subSelectsubSomeCommon2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubSomeCommon2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -5
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -11
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 -16, i8 -11
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1075,9 +1054,8 @@ define i8 @subSelectsubSomeCommon2(i8 %arg0, i8 %arg1) {
 define i8 @subSelectsubSame(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubSame(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -42
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -42
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 -84, i8 -42
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1117,9 +1095,8 @@ define i8 @mulSelectmulNoCommonBits2(i8 %arg0, i8 %arg1) {
 define i8 @mulSelectmulmulset1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulmulset1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 13
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 -113, i8 13
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1132,9 +1109,8 @@ define i8 @mulSelectmulmulset1(i8 %arg0, i8 %arg1) {
 define i8 @mulSelectmulmulset2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulmulset2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 13
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 11
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 -113, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1147,9 +1123,8 @@ define i8 @mulSelectmulmulset2(i8 %arg0, i8 %arg1) {
 define i8 @mulSelectmulSomeCommon1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulSomeCommon1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 5
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 55, i8 5
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1162,9 +1137,8 @@ define i8 @mulSelectmulSomeCommon1(i8 %arg0, i8 %arg1) {
 define i8 @mulSelectmulSomeCommon2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulSomeCommon2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 5
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 11
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 55, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1177,9 +1151,8 @@ define i8 @mulSelectmulSomeCommon2(i8 %arg0, i8 %arg1) {
 define i8 @mulSelectmulSame(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulSame(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 42
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 42
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 -28, i8 42
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1219,9 +1192,10 @@ define i8 @udivSelectudivNoCommonBits2(i8 %arg0, i8 %arg1) {
 define i8 @udivSelectudivudivset1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @udivSelectudivudivset1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = udiv i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 13
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ugt i8 [[V4:%.*]], -114
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i8
+; CHECK-NEXT:    [[V5:%.*]] = udiv i8 [[V4]], 13
+; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i8 [[TMP2]], i8 [[V5]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1234,9 +1208,10 @@ define i8 @udivSelectudivudivset1(i8 %arg0, i8 %arg1) {
 define i8 @udivSelectudivudivset2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @udivSelectudivudivset2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = udiv i8 [[ARG0:%.*]], 13
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 11
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp ugt i8 [[V4:%.*]], -114
+; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i8
+; CHECK-NEXT:    [[V5:%.*]] = udiv i8 [[V4]], 11
+; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i8 [[TMP2]], i8 [[V5]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1248,10 +1223,10 @@ define i8 @udivSelectudivudivset2(i8 %arg0, i8 %arg1) {
 
 define i8 @udivSelectudivSomeCommon1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @udivSelectudivSomeCommon1(
-; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = udiv i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 5
+; CHECK-NEXT:    [[ARG1:%.*]] = freeze i8 [[ARG2:%.*]]
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 55, i8 5
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1263,10 +1238,10 @@ define i8 @udivSelectudivSomeCommon1(i8 %arg0, i8 %arg1) {
 
 define i8 @udivSelectudivSomeCommon2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @udivSelectudivSomeCommon2(
-; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = udiv i8 [[ARG0:%.*]], 5
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 11
+; CHECK-NEXT:    [[ARG1:%.*]] = freeze i8 [[ARG2:%.*]]
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 55, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1288,4 +1263,22 @@ define i8 @udivSelectudivSame(i8 %arg0, i8 %arg1) {
   %v2 = select i1 %v0, i8 %v1, i8 %arg0
   %v3 = udiv i8 %v2, 42
   ret i8 %v3
+}
+
+
+define i8 @orSelectOrUses(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrUses(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0]], [[V3_V]]
+; CHECK-NEXT:    [[RES:%.*]] = add i8 [[V1]], [[V3]]
+; CHECK-NEXT:    ret i8 [[RES]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 1
+  %res = add i8 %v1, %v3
+  ret i8 %res
 }

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -571,3 +571,721 @@ define i32 @OrSelectIcmpNonZero(i32 %a, i32 %b) {
   %or = or i32 %sel, %a
   ret i32 %or
 }
+
+define i8 @orSelectOrNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 1
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @orSelectOrNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = zext i1 [[V0]] to i8
+; CHECK-NEXT:    [[V2:%.*]] = or i8 [[ARG0:%.*]], [[V1]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 4
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @orSelectOrSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrSubset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 2
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 13
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @orSelectOrSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrSubset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @orSelectOrSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 10
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @orSelectOrSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @orSelectOrSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrSame(
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 42
+; CHECK-NEXT:    ret i8 [[V1]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 42
+  ret i8 %v3
+}
+
+define i8 @andSelectandNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[ARG0:%.*]], 1
+; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i8 0, i8 [[TMP1]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @andSelectandNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3:%.*]] = and i8 [[V2:%.*]], 4
+; CHECK-NEXT:    [[V4:%.*]] = select i1 [[V0]], i8 0, i8 [[V3]]
+; CHECK-NEXT:    ret i8 [[V4]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @andSelectandSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandSubset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 9, i8 13
+; CHECK-NEXT:    [[V3:%.*]] = and i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @andSelectandSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandSubset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 9, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = and i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @andSelectandSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 1, i8 5
+; CHECK-NEXT:    [[V3:%.*]] = and i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @andSelectandSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 1, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = and i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @andSelectandSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandSame(
+; CHECK-NEXT:    [[V1:%.*]] = and i8 [[ARG0:%.*]], 42
+; CHECK-NEXT:    ret i8 [[V1]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 42
+  ret i8 %v3
+}
+
+
+define i8 @xorSelectxorNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 1
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @xorSelectxorNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = zext i1 [[V0]] to i8
+; CHECK-NEXT:    [[V2:%.*]] = xor i8 [[ARG0:%.*]], [[V1]]
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 4
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @xorSelectxorSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorSubset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 13
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @xorSelectxorSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorSubset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 13
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @xorSelectxorSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @xorSelectxorSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 5
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @xorSelectxorSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorSame(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 42
+; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i8 [[ARG0]], i8 [[V1]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 42
+  ret i8 %v3
+}
+
+
+define i8 @addSelectaddNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 1
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @addSelectaddNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = zext i1 [[V0]] to i8
+; CHECK-NEXT:    [[V2:%.*]] = add i8 [[ARG0:%.*]], [[V1]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 4
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @addSelectaddSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddSubset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 13
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @addSelectaddSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddSubset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 13
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @addSelectaddSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @addSelectaddSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 5
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @addSelectaddSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddSame(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 42
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 42
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 42
+  ret i8 %v3
+}
+
+
+define i8 @subSelectsubNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -1
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @subSelectsubNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = sext i1 [[V0]] to i8
+; CHECK-NEXT:    [[V2:%.*]] = add i8 [[ARG0:%.*]], [[V1]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -4
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @subSelectsubSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubSubset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -13
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @subSelectsubSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubSubset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -13
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @subSelectsubSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @subSelectsubSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -5
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @subSelectsubSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubSame(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -42
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -42
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 42
+  ret i8 %v3
+}
+
+
+define i8 @mulSelectmulNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = shl i8 [[ARG0:%.*]], 2
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    ret i8 [[V2]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @mulSelectmulNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulNoCommonBits2(
+; CHECK-NEXT:    [[V3:%.*]] = shl i8 [[ARG0:%.*]], 2
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @mulSelectmulmulset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulmulset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 13
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @mulSelectmulmulset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulmulset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 13
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @mulSelectmulSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @mulSelectmulSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 5
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @mulSelectmulSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulSame(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 42
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 42
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 42
+  ret i8 %v3
+}
+
+
+define i8 @udivSelectudivNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @udivSelectudivNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = lshr i8 [[ARG0:%.*]], 2
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    ret i8 [[V2]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = udiv i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = udiv i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @udivSelectudivNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @udivSelectudivNoCommonBits2(
+; CHECK-NEXT:    [[V3:%.*]] = lshr i8 [[ARG0:%.*]], 2
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = udiv i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = udiv i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @udivSelectudivudivset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @udivSelectudivudivset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = udiv i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 13
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = udiv i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = udiv i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @udivSelectudivudivset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @udivSelectudivudivset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = udiv i8 [[ARG0:%.*]], 13
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = udiv i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = udiv i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @udivSelectudivSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @udivSelectudivSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = udiv i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = udiv i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = udiv i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @udivSelectudivSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @udivSelectudivSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = udiv i8 [[ARG0:%.*]], 5
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = udiv i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = udiv i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @udivSelectudivSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @udivSelectudivSame(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2:%.*]], 42
+; CHECK-NEXT:    [[V4:%.*]] = select i1 [[V0]], i8 0, i8 [[V3]]
+; CHECK-NEXT:    ret i8 [[V4]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = udiv i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = udiv i8 %v2, 42
+  ret i8 %v3
+}

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -616,6 +616,79 @@ define i8 @comBinOpSelectComBinOpRev3(i8 %arg0, i8 %arg1) {
   ret i8 %v3
 }
 
+define i8 @BinOpSelectBinOpMultiUseRegsWithSelect1(i8 %arg0, i8 %arg1, i1 %whatToReturn) {
+; CHECK-LABEL: @BinOpSelectBinOpMultiUseRegsWithSelect1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0]], [[V3_V]]
+; CHECK-NEXT:    [[USE:%.*]] = add i8 [[V1]], 42
+; CHECK-NEXT:    [[RETVAL:%.*]] = select i1 [[WHATTORETURN:%.*]], i8 [[USE]], i8 [[V3]]
+; CHECK-NEXT:    ret i8 [[RETVAL]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 1, %v2
+  %use = add i8 %v1, 42
+  %retVal = select i1 %whatToReturn, i8 %use, i8 %v3
+  ret i8 %retVal
+}
+
+
+define i8 @BinOpSelectBinOpMultiUseRegsWithSelect2(i8 %arg0, i8 %arg1, i1 %whatToReturn) {
+; CHECK-LABEL: @BinOpSelectBinOpMultiUseRegsWithSelect2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 1
+; CHECK-NEXT:    [[USE:%.*]] = add i8 [[V2]], 42
+; CHECK-NEXT:    [[RETVAL:%.*]] = select i1 [[WHATTORETURN:%.*]], i8 [[USE]], i8 [[V3]]
+; CHECK-NEXT:    ret i8 [[RETVAL]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 1, %v2
+  %use = add i8 %v2, 42
+  %retVal = select i1 %whatToReturn, i8 %use, i8 %v3
+  ret i8 %retVal
+}
+
+define i8 @BinOpSelectBinOpMultiUseRegsWithSelect3(i8 %arg0, i8 %arg1, i1 %whatToReturn) {
+; CHECK-LABEL: @BinOpSelectBinOpMultiUseRegsWithSelect3(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[RETVAL_V:%.*]] = select i1 [[WHATTORETURN:%.*]], i8 4, i8 [[V3_V]]
+; CHECK-NEXT:    [[RETVAL:%.*]] = or i8 [[ARG0:%.*]], [[RETVAL_V]]
+; CHECK-NEXT:    ret i8 [[RETVAL]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 1, %v2
+  %retVal = select i1 %whatToReturn, i8 %v1, i8 %v3
+  ret i8 %retVal
+}
+
+define i8 @BinOpSelectBinOpMultiUseRegsWithSelect4(i8 %arg0, i8 %arg1, i1 %whatToReturn) {
+; CHECK-LABEL: @BinOpSelectBinOpMultiUseRegsWithSelect4(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[NOT_WHATTORETURN:%.*]] = xor i1 [[WHATTORETURN:%.*]], true
+; CHECK-NEXT:    [[V3:%.*]] = zext i1 [[NOT_WHATTORETURN]] to i8
+; CHECK-NEXT:    [[RETVAL:%.*]] = or i8 [[V2]], [[V3]]
+; CHECK-NEXT:    ret i8 [[RETVAL]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 1, %v2
+  %retVal = select i1 %whatToReturn, i8 %v2, i8 %v3
+  ret i8 %retVal
+}
+
 define i8 @orSelectOrNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -572,6 +572,50 @@ define i32 @OrSelectIcmpNonZero(i32 %a, i32 %b) {
   ret i32 %or
 }
 
+define i8 @comBinOpSelectComBinOpRev1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @comBinOpSelectComBinOpRev1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 1, %v2
+  ret i8 %v3
+}
+
+
+define i8 @comBinOpSelectComBinOpRev2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @comBinOpSelectComBinOpRev2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 1
+  ret i8 %v3
+}
+
+
+define i8 @comBinOpSelectComBinOpRev3(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @comBinOpSelectComBinOpRev3(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 1, %v2
+  ret i8 %v3
+}
+
 define i8 @orSelectOrNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
@@ -965,6 +1009,52 @@ define i8 @addSelectaddSame(i8 %arg0, i8 %arg1) {
   ret i8 %v3
 }
 
+define i8 @subSelectsubNoCommonBitsConstOnLeft1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubNoCommonBitsConstOnLeft1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = sub i8 4, [[ARG0:%.*]]
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -1
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 1
+  ret i8 %v3
+}
+
+
+define i8 @subSelectsubNoCommonBitsConstOnLeft2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubNoCommonBitsConstOnLeft2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = sub i8 1, [[V2]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 1, %v2
+  ret i8 %v3
+}
+
+
+define i8 @subSelectsubNoCommonBitsConstOnLeft3(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubNoCommonBitsConstOnLeft3(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i8 4, [[TMP2:%.*]]
+; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i8 [[TMP1]], i8 [[TMP2]]
+; CHECK-NEXT:    [[V4:%.*]] = sub i8 1, [[V3]]
+; CHECK-NEXT:    ret i8 [[V4]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 1, %v2
+  ret i8 %v3
+}
 
 define i8 @subSelectsubNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubNoCommonBits1(
@@ -1165,6 +1255,50 @@ define i8 @mulSelectmulSame(i8 %arg0, i8 %arg1) {
   ret i8 %v3
 }
 
+define i8 @udivSelectudivNoCommonBitsConstOnLeft1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @udivSelectudivNoCommonBitsConstOnLeft1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = udiv i8 4, [[ARG0:%.*]]
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 3
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = udiv i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = udiv i8 %v2, 3
+  ret i8 %v3
+}
+
+define i8 @udivSelectudivNoCommonBitsConstOnLeft2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @udivSelectudivNoCommonBitsConstOnLeft2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V11:%.*]] = lshr i8 [[ARG0:%.*]], 2
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V11]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 3, [[V2]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = udiv i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = udiv i8 3, %v2
+  ret i8 %v3
+}
+
+define i8 @udivSelectudivNoCommonBitsConstOnLeft3(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @udivSelectudivNoCommonBitsConstOnLeft3(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = udiv i8 4, [[ARG0:%.*]]
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 3, [[V2]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = udiv i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = udiv i8 3, %v2
+  ret i8 %v3
+}
 
 define i8 @udivSelectudivNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @udivSelectudivNoCommonBits1(

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -1069,24 +1069,27 @@ define i8 @subSelectsubSame(i8 %arg0, i8 %arg1) {
 define i8 @mulSelectmulNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = shl i8 [[ARG0:%.*]], 2
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 3, i8 1
+; CHECK-NEXT:    [[V2:%.*]] = shl i8 [[ARG0:%.*]], [[V3_V]]
 ; CHECK-NEXT:    ret i8 [[V2]]
 ;
   %v0 = icmp eq i8 %arg1, -1
   %v1 = mul i8 %arg0, 4
   %v2 = select i1 %v0, i8 %v1, i8 %arg0
-  %v3 = mul i8 %v2, 1
+  %v3 = mul i8 %v2, 2
   ret i8 %v3
 }
 
 define i8 @mulSelectmulNoCommonBits2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulNoCommonBits2(
-; CHECK-NEXT:    [[V3:%.*]] = shl i8 [[ARG0:%.*]], 2
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG2:%.*]], 3
+; CHECK-NEXT:    [[ARG0:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG2]]
+; CHECK-NEXT:    [[V3:%.*]] = shl i8 [[ARG0]], 2
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
-  %v1 = mul i8 %arg0, 1
+  %v1 = mul i8 %arg0, 3
   %v2 = select i1 %v0, i8 %v1, i8 %arg0
   %v3 = mul i8 %v2, 4
   ret i8 %v3
@@ -1168,22 +1171,26 @@ define i8 @udivSelectudivNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
 ; CHECK-NEXT:    [[V1:%.*]] = lshr i8 [[ARG0:%.*]], 2
 ; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    ret i8 [[V2]]
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 3
+; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
   %v1 = udiv i8 %arg0, 4
   %v2 = select i1 %v0, i8 %v1, i8 %arg0
-  %v3 = udiv i8 %v2, 1
+  %v3 = udiv i8 %v2, 3
   ret i8 %v3
 }
 
 define i8 @udivSelectudivNoCommonBits2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @udivSelectudivNoCommonBits2(
-; CHECK-NEXT:    [[V3:%.*]] = lshr i8 [[ARG0:%.*]], 2
-; CHECK-NEXT:    ret i8 [[V3]]
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[TMP1:%.*]] = udiv i8 [[ARG0:%.*]], 28
+; CHECK-NEXT:    [[V3:%.*]] = lshr i8 [[ARG0]], 2
+; CHECK-NEXT:    [[V4:%.*]] = select i1 [[V0]], i8 [[TMP1]], i8 [[V3]]
+; CHECK-NEXT:    ret i8 [[V4]]
 ;
   %v0 = icmp eq i8 %arg1, -1
-  %v1 = udiv i8 %arg0, 1
+  %v1 = udiv i8 %arg0, 7
   %v2 = select i1 %v0, i8 %v1, i8 %arg0
   %v3 = udiv i8 %v2, 4
   ret i8 %v3

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -1423,3 +1423,17 @@ define i8 @orSelectOrUses(i8 %arg0, i8 %arg1) {
   %res = add i8 %v1, %v3
   ret i8 %res
 }
+
+define i8 @udivSelectudivSomeCommon1InfLoopRep(i8 %arg0, i8 %arg1, i1 %v0) {
+; CHECK-LABEL: @udivSelectudivSomeCommon1InfLoopRep(
+; CHECK-NEXT:    [[V1:%.*]] = udiv i8 11, [[ARG0:%.*]]
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0:%.*]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v01 = icmp sgt i8 %arg0, 0
+  %v1 = udiv i8 11, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = udiv i8 %v2, 5
+  ret i8 %v3
+}

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -689,6 +689,7 @@ define i8 @BinOpSelectBinOpMultiUseRegsWithSelect4(i8 %arg0, i8 %arg1, i1 %whatT
   ret i8 %retVal
 }
 
+; or tests
 define i8 @orSelectOrNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
@@ -786,6 +787,7 @@ define i8 @orSelectOrSame(i8 %arg0, i8 %arg1) {
   ret i8 %v3
 }
 
+; and tests
 define i8 @andSelectandNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @andSelectandNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
@@ -882,7 +884,7 @@ define i8 @andSelectandSame(i8 %arg0, i8 %arg1) {
   ret i8 %v3
 }
 
-
+; xor tests
 define i8 @xorSelectxorNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @xorSelectxorNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
@@ -982,7 +984,7 @@ define i8 @xorSelectxorSame(i8 %arg0, i8 %arg1) {
   ret i8 %v3
 }
 
-
+; add tests
 define i8 @addSelectaddNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
@@ -1082,6 +1084,7 @@ define i8 @addSelectaddSame(i8 %arg0, i8 %arg1) {
   ret i8 %v3
 }
 
+; sub tests
 define i8 @subSelectsubNoCommonBitsConstOnLeft1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubNoCommonBitsConstOnLeft1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
@@ -1097,7 +1100,6 @@ define i8 @subSelectsubNoCommonBitsConstOnLeft1(i8 %arg0, i8 %arg1) {
   ret i8 %v3
 }
 
-
 define i8 @subSelectsubNoCommonBitsConstOnLeft2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubNoCommonBitsConstOnLeft2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
@@ -1112,7 +1114,6 @@ define i8 @subSelectsubNoCommonBitsConstOnLeft2(i8 %arg0, i8 %arg1) {
   %v3 = sub i8 1, %v2
   ret i8 %v3
 }
-
 
 define i8 @subSelectsubNoCommonBitsConstOnLeft3(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubNoCommonBitsConstOnLeft3(
@@ -1228,7 +1229,7 @@ define i8 @subSelectsubSame(i8 %arg0, i8 %arg1) {
   ret i8 %v3
 }
 
-
+; mul tests
 define i8 @mulSelectmulNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
@@ -1328,6 +1329,7 @@ define i8 @mulSelectmulSame(i8 %arg0, i8 %arg1) {
   ret i8 %v3
 }
 
+; udiv tests
 define i8 @udivSelectudivNoCommonBitsConstOnLeft1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @udivSelectudivNoCommonBitsConstOnLeft1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
@@ -1391,10 +1393,10 @@ define i8 @udivSelectudivNoCommonBits1(i8 %arg0, i8 %arg1) {
 define i8 @udivSelectudivNoCommonBits2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @udivSelectudivNoCommonBits2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[TMP1:%.*]] = udiv i8 [[ARG0:%.*]], 28
-; CHECK-NEXT:    [[V3:%.*]] = lshr i8 [[ARG0]], 2
+; CHECK-NEXT:    [[TMP1:%.*]] = udiv i8 [[V3:%.*]], 7
 ; CHECK-NEXT:    [[V4:%.*]] = select i1 [[V0]], i8 [[TMP1]], i8 [[V3]]
-; CHECK-NEXT:    ret i8 [[V4]]
+; CHECK-NEXT:    [[V31:%.*]] = lshr i8 [[V4]], 2
+; CHECK-NEXT:    ret i8 [[V31]]
 ;
   %v0 = icmp eq i8 %arg1, -1
   %v1 = udiv i8 %arg0, 7
@@ -1406,11 +1408,10 @@ define i8 @udivSelectudivNoCommonBits2(i8 %arg0, i8 %arg1) {
 define i8 @udivSelectudivudivset1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @udivSelectudivudivset1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ugt i8 [[V4:%.*]], -114
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i8
-; CHECK-NEXT:    [[V5:%.*]] = udiv i8 [[V4]], 13
+; CHECK-NEXT:    [[TMP2:%.*]] = udiv i8 [[V5:%.*]], 11
 ; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i8 [[TMP2]], i8 [[V5]]
-; CHECK-NEXT:    ret i8 [[V3]]
+; CHECK-NEXT:    [[V4:%.*]] = udiv i8 [[V3]], 13
+; CHECK-NEXT:    ret i8 [[V4]]
 ;
   %v0 = icmp eq i8 %arg1, -1
   %v1 = udiv i8 %arg0, 11
@@ -1422,11 +1423,10 @@ define i8 @udivSelectudivudivset1(i8 %arg0, i8 %arg1) {
 define i8 @udivSelectudivudivset2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @udivSelectudivudivset2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp ugt i8 [[V4:%.*]], -114
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[TMP1]] to i8
-; CHECK-NEXT:    [[V5:%.*]] = udiv i8 [[V4]], 11
+; CHECK-NEXT:    [[TMP2:%.*]] = udiv i8 [[V5:%.*]], 13
 ; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i8 [[TMP2]], i8 [[V5]]
-; CHECK-NEXT:    ret i8 [[V3]]
+; CHECK-NEXT:    [[V4:%.*]] = udiv i8 [[V3]], 11
+; CHECK-NEXT:    ret i8 [[V4]]
 ;
   %v0 = icmp eq i8 %arg1, -1
   %v1 = udiv i8 %arg0, 13
@@ -1437,10 +1437,10 @@ define i8 @udivSelectudivudivset2(i8 %arg0, i8 %arg1) {
 
 define i8 @udivSelectudivSomeCommon1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @udivSelectudivSomeCommon1(
-; CHECK-NEXT:    [[ARG1:%.*]] = freeze i8 [[ARG2:%.*]]
-; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1]], -1
-; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 55, i8 5
-; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = udiv i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 5
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1452,10 +1452,10 @@ define i8 @udivSelectudivSomeCommon1(i8 %arg0, i8 %arg1) {
 
 define i8 @udivSelectudivSomeCommon2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @udivSelectudivSomeCommon2(
-; CHECK-NEXT:    [[ARG1:%.*]] = freeze i8 [[ARG2:%.*]]
-; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1]], -1
-; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 55, i8 11
-; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = udiv i8 [[ARG0:%.*]], 5
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 11
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1476,6 +1476,154 @@ define i8 @udivSelectudivSame(i8 %arg0, i8 %arg1) {
   %v1 = udiv i8 %arg0, 42
   %v2 = select i1 %v0, i8 %v1, i8 %arg0
   %v3 = udiv i8 %v2, 42
+  ret i8 %v3
+}
+
+; sdiv tests
+define i8 @sdivSelectsdivNoCommonBitsConstOnLeft1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sdivSelectsdivNoCommonBitsConstOnLeft1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = sdiv i8 4, [[ARG0:%.*]]
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = sdiv i8 [[V2]], 3
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sdiv i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sdiv i8 %v2, 3
+  ret i8 %v3
+}
+
+define i8 @sdivSelectsdivNoCommonBitsConstOnLeft2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sdivSelectsdivNoCommonBitsConstOnLeft2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V11:%.*]] = sdiv i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V11]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = sdiv i8 3, [[V2]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sdiv i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sdiv i8 3, %v2
+  ret i8 %v3
+}
+
+define i8 @sdivSelectsdivNoCommonBitsConstOnLeft3(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sdivSelectsdivNoCommonBitsConstOnLeft3(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = sdiv i8 4, [[ARG0:%.*]]
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = sdiv i8 3, [[V2]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sdiv i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sdiv i8 3, %v2
+  ret i8 %v3
+}
+
+define i8 @sdivSelectsdivNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sdivSelectsdivNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = sdiv i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = sdiv i8 [[V2]], 3
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sdiv i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sdiv i8 %v2, 3
+  ret i8 %v3
+}
+
+define i8 @sdivSelectsdivNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sdivSelectsdivNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[TMP1:%.*]] = sdiv i8 [[V3:%.*]], 7
+; CHECK-NEXT:    [[V4:%.*]] = select i1 [[V0]], i8 [[TMP1]], i8 [[V3]]
+; CHECK-NEXT:    [[V31:%.*]] = sdiv i8 [[V4]], 4
+; CHECK-NEXT:    ret i8 [[V31]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sdiv i8 %arg0, 7
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sdiv i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @sdivSelectsdivsdivset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sdivSelectsdivsdivset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V4:%.*]] = sdiv i8 [[V3:%.*]], 13
+; CHECK-NEXT:    [[V5:%.*]] = select i1 [[V0]], i8 0, i8 [[V4]]
+; CHECK-NEXT:    ret i8 [[V5]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sdiv i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sdiv i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @sdivSelectsdivsdivset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sdivSelectsdivsdivset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V4:%.*]] = sdiv i8 [[V3:%.*]], 11
+; CHECK-NEXT:    [[V5:%.*]] = select i1 [[V0]], i8 0, i8 [[V4]]
+; CHECK-NEXT:    ret i8 [[V5]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sdiv i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sdiv i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @sdivSelectsdivSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sdivSelectsdivSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = sdiv i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = sdiv i8 [[V2]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sdiv i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sdiv i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @sdivSelectsdivSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sdivSelectsdivSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = sdiv i8 [[ARG0:%.*]], 5
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = sdiv i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sdiv i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sdiv i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @sdivSelectsdivSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sdivSelectsdivSame(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3:%.*]] = sdiv i8 [[V2:%.*]], 42
+; CHECK-NEXT:    [[V4:%.*]] = select i1 [[V0]], i8 0, i8 [[V3]]
+; CHECK-NEXT:    ret i8 [[V4]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sdiv i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sdiv i8 %v2, 42
   ret i8 %v3
 }
 
@@ -1510,3 +1658,297 @@ define i8 @udivSelectudivSomeCommon1InfLoopRep(i8 %arg0, i8 %arg1, i1 %v0) {
   %v3 = udiv i8 %v2, 5
   ret i8 %v3
 }
+
+; shl tests
+define i8 @shlSelectshlNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @shlSelectshlNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V3:%.*]] = shl i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = shl i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = shl i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @shlSelectshlNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @shlSelectshlNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = zext i1 [[V0]] to i8
+; CHECK-NEXT:    [[V2:%.*]] = shl i8 [[ARG0:%.*]], [[V1]]
+; CHECK-NEXT:    [[V3:%.*]] = shl i8 [[V2]], 4
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = shl i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = shl i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @shlSelectshlSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @shlSelectshlSubset1(
+; CHECK-NEXT:    ret i8 poison
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = shl i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = shl i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @shlSelectshlSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @shlSelectshlSubset2(
+; CHECK-NEXT:    ret i8 poison
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = shl i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = shl i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @shlSelectshlSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @shlSelectshlSomeCommon1(
+; CHECK-NEXT:    [[V3:%.*]] = shl i8 [[ARG0:%.*]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = shl i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = shl i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @shlSelectshlSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @shlSelectshlSomeCommon2(
+; CHECK-NEXT:    ret i8 poison
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = shl i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = shl i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @shlSelectshlSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @shlSelectshlSame(
+; CHECK-NEXT:    ret i8 poison
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = shl i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = shl i8 %v2, 42
+  ret i8 %v3
+}
+
+
+; urem tests
+define i8 @uremSelecturemNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @uremSelecturemNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = and i8 [[ARG0:%.*]], 3
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = urem i8 [[V2]], 3
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = urem i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = urem i8 %v2, 3
+  ret i8 %v3
+}
+
+define i8 @uremSelecturemNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @uremSelecturemNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = urem i8 [[ARG0:%.*]], 3
+; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[ARG0]], 3
+; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[TMP1]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = urem i8 %arg0, 3
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = urem i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @uremSelecturemSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @uremSelecturemSubset1(
+; CHECK-NEXT:    [[ARG1_FR:%.*]] = freeze i8 [[ARG1:%.*]]
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1_FR]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 11, i8 13
+; CHECK-NEXT:    [[V3:%.*]] = urem i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = urem i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = urem i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @uremSelecturemSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @uremSelecturemSubset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = urem i8 [[ARG0:%.*]], 13
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = urem i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = urem i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = urem i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @uremSelecturemSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @uremSelecturemSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = urem i8 [[ARG2:%.*]], 11
+; CHECK-NEXT:    [[ARG0:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG2]]
+; CHECK-NEXT:    [[V3:%.*]] = urem i8 [[ARG0]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = urem i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = urem i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @uremSelecturemSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @uremSelecturemSomeCommon2(
+; CHECK-NEXT:    [[ARG1_FR:%.*]] = freeze i8 [[ARG1:%.*]]
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1_FR]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = urem i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = urem i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = urem i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @uremSelecturemSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @uremSelecturemSame(
+; CHECK-NEXT:    [[V1:%.*]] = urem i8 [[ARG0:%.*]], 42
+; CHECK-NEXT:    ret i8 [[V1]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = urem i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = urem i8 %v2, 42
+  ret i8 %v3
+}
+
+; srem tests
+define i8 @sremSelectsremNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sremSelectsremNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = srem i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = srem i8 [[V2]], 3
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = srem i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = srem i8 %v2, 3
+  ret i8 %v3
+}
+
+define i8 @sremSelectsremNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sremSelectsremNoCommonBits2(
+; CHECK-NEXT:    [[ARG1:%.*]] = freeze i8 [[ARG2:%.*]]
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 3, i8 4
+; CHECK-NEXT:    [[V3:%.*]] = srem i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = srem i8 %arg0, 3
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = srem i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @sremSelectsremSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sremSelectsremSubset1(
+; CHECK-NEXT:    [[ARG1_FR:%.*]] = freeze i8 [[ARG1:%.*]]
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1_FR]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 11, i8 13
+; CHECK-NEXT:    [[V3:%.*]] = srem i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = srem i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = srem i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @sremSelectsremSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sremSelectsremSubset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = srem i8 [[ARG0:%.*]], 13
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = srem i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = srem i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = srem i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @sremSelectsremSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sremSelectsremSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = srem i8 [[ARG2:%.*]], 11
+; CHECK-NEXT:    [[ARG0:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG2]]
+; CHECK-NEXT:    [[V3:%.*]] = srem i8 [[ARG0]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = srem i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = srem i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @sremSelectsremSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sremSelectsremSomeCommon2(
+; CHECK-NEXT:    [[ARG1_FR:%.*]] = freeze i8 [[ARG1:%.*]]
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1_FR]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = srem i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = srem i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = srem i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @sremSelectsremSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @sremSelectsremSame(
+; CHECK-NEXT:    [[V1:%.*]] = srem i8 [[ARG0:%.*]], 42
+; CHECK-NEXT:    ret i8 [[V1]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = srem i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = srem i8 %v2, 42
+  ret i8 %v3
+}
+

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -572,50 +572,6 @@ define i32 @OrSelectIcmpNonZero(i32 %a, i32 %b) {
   ret i32 %or
 }
 
-define i8 @comBinOpSelectComBinOpRev1(i8 %arg0, i8 %arg1) {
-; CHECK-LABEL: @comBinOpSelectComBinOpRev1(
-; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0:%.*]], [[V3_V]]
-; CHECK-NEXT:    ret i8 [[V3]]
-;
-  %v0 = icmp eq i8 %arg1, -1
-  %v1 = or i8 %arg0, 4
-  %v2 = select i1 %v0, i8 %v1, i8 %arg0
-  %v3 = or i8 1, %v2
-  ret i8 %v3
-}
-
-
-define i8 @comBinOpSelectComBinOpRev2(i8 %arg0, i8 %arg1) {
-; CHECK-LABEL: @comBinOpSelectComBinOpRev2(
-; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0:%.*]], [[V3_V]]
-; CHECK-NEXT:    ret i8 [[V3]]
-;
-  %v0 = icmp eq i8 %arg1, -1
-  %v1 = or i8 4, %arg0
-  %v2 = select i1 %v0, i8 %v1, i8 %arg0
-  %v3 = or i8 %v2, 1
-  ret i8 %v3
-}
-
-
-define i8 @comBinOpSelectComBinOpRev3(i8 %arg0, i8 %arg1) {
-; CHECK-LABEL: @comBinOpSelectComBinOpRev3(
-; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 5, i8 1
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[ARG0:%.*]], [[V3_V]]
-; CHECK-NEXT:    ret i8 [[V3]]
-;
-  %v0 = icmp eq i8 %arg1, -1
-  %v1 = or i8 4, %arg0
-  %v2 = select i1 %v0, i8 %v1, i8 %arg0
-  %v3 = or i8 1, %v2
-  ret i8 %v3
-}
-
 define i8 @BinOpSelectBinOpMultiUseRegsWithSelect1(i8 %arg0, i8 %arg1, i1 %whatToReturn) {
 ; CHECK-LABEL: @BinOpSelectBinOpMultiUseRegsWithSelect1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1

--- a/llvm/test/Transforms/PGOProfile/chr.ll
+++ b/llvm/test/Transforms/PGOProfile/chr.ll
@@ -478,7 +478,7 @@ define i32 @test_chr_5(ptr %i, i32 %sum0) !prof !14 {
 ; CHECK-NEXT:    [[TMP12:%.*]] = icmp eq i32 [[TMP11]], 0
 ; CHECK-NEXT:    [[TMP13:%.*]] = and i32 [[DOTFR1]], 8
 ; CHECK-NEXT:    [[TMP14:%.*]] = icmp eq i32 [[TMP13]], 0
-; CHECK-NEXT:    [[SUM4_NONCHR_V:%.*]] = select i1 [[TMP14]], i32 44, i32 88
+; CHECK-NEXT:    [[SUM4_NONCHR_V:%.*]] = select i1 [[TMP14]], i32 44, i32 88, !prof [[PROF16]]
 ; CHECK-NEXT:    [[SUM4_NONCHR:%.*]] = add i32 [[SUM2_NONCHR]], [[SUM4_NONCHR_V]]
 ; CHECK-NEXT:    [[SUM5_NONCHR:%.*]] = select i1 [[TMP12]], i32 [[SUM2_NONCHR]], i32 [[SUM4_NONCHR]], !prof [[PROF16]]
 ; CHECK-NEXT:    br label [[BB3]]
@@ -579,7 +579,7 @@ define i32 @test_chr_5_1(ptr %i, i32 %sum0) !prof !14 {
 ; CHECK-NEXT:    [[TMP15:%.*]] = icmp eq i32 [[TMP14]], 0
 ; CHECK-NEXT:    [[TMP16:%.*]] = and i32 [[DOTFR1]], 8
 ; CHECK-NEXT:    [[TMP17:%.*]] = icmp eq i32 [[TMP16]], 0
-; CHECK-NEXT:    [[SUM4_NONCHR_V:%.*]] = select i1 [[TMP17]], i32 44, i32 88
+; CHECK-NEXT:    [[SUM4_NONCHR_V:%.*]] = select i1 [[TMP17]], i32 44, i32 88, !prof [[PROF16]]
 ; CHECK-NEXT:    [[SUM4_NONCHR:%.*]] = add i32 [[SUM2_NONCHR]], [[SUM4_NONCHR_V]]
 ; CHECK-NEXT:    [[SUM5_NONCHR:%.*]] = select i1 [[TMP15]], i32 [[SUM2_NONCHR]], i32 [[SUM4_NONCHR]], !prof [[PROF16]]
 ; CHECK-NEXT:    br label [[BB3]]
@@ -677,7 +677,7 @@ define i32 @test_chr_6(ptr %i, ptr %j, i32 %sum0) !prof !14 {
 ; CHECK-NEXT:    [[V10_NONCHR:%.*]] = icmp eq i32 [[V9_NONCHR]], 0
 ; CHECK-NEXT:    [[V11_NONCHR:%.*]] = and i32 [[I0_FR]], 8
 ; CHECK-NEXT:    [[V12_NONCHR:%.*]] = icmp eq i32 [[V11_NONCHR]], 0
-; CHECK-NEXT:    [[SUM4_NONCHR_V:%.*]] = select i1 [[V12_NONCHR]], i32 44, i32 88
+; CHECK-NEXT:    [[SUM4_NONCHR_V:%.*]] = select i1 [[V12_NONCHR]], i32 44, i32 88, !prof [[PROF16]]
 ; CHECK-NEXT:    [[SUM4_NONCHR:%.*]] = add i32 [[SUM2_NONCHR]], [[SUM4_NONCHR_V]]
 ; CHECK-NEXT:    [[SUM5_NONCHR:%.*]] = select i1 [[V10_NONCHR]], i32 [[SUM2_NONCHR]], i32 [[SUM4_NONCHR]], !prof [[PROF16]]
 ; CHECK-NEXT:    br label [[BB3]]
@@ -1392,7 +1392,7 @@ define i32 @test_chr_15(ptr %i, ptr %j, i32 %sum0, i1 %pred, i32 %z) !prof !14 {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[I0:%.*]] = load i32, ptr [[I:%.*]], align 4
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i32 [[Z:%.*]], 0
-; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i1 [[PRED:%.*]], i1 false
+; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i1 [[PRED:%.*]], i1 false, !prof [[PROF19:![0-9]+]]
 ; CHECK-NEXT:    br i1 [[V3]], label [[BB0:%.*]], label [[BB1:%.*]], !prof [[PROF16]]
 ; CHECK:       bb0:
 ; CHECK-NEXT:    call void @foo()
@@ -1670,15 +1670,15 @@ define i32 @test_chr_18(ptr %i, i32 %sum0) !prof !14 {
 ; CHECK-NEXT:    [[INC1:%.*]] = phi i32 [ [[TMP2:%.*]], [[BB2:%.*]] ], [ 0, [[ENTRY:%.*]] ]
 ; CHECK-NEXT:    [[LI:%.*]] = load i32, ptr [[I:%.*]], align 4
 ; CHECK-NEXT:    [[LI_FR:%.*]] = freeze i32 [[LI]]
-; CHECK-NEXT:    [[SUM1:%.*]] = add i32 [[SUM0:%.*]], 42
 ; CHECK-NEXT:    [[TMP0:%.*]] = and i32 [[LI_FR]], 5
 ; CHECK-NEXT:    [[TMP1:%.*]] = icmp eq i32 [[TMP0]], 5
 ; CHECK-NEXT:    br i1 [[TMP1]], label [[BB1:%.*]], label [[BB0_SPLIT_NONCHR:%.*]], !prof [[PROF15]]
 ; CHECK:       bb1:
 ; CHECK-NEXT:    [[INC2:%.*]] = add i32 [[INC1]], 1
-; CHECK-NEXT:    [[SUM3:%.*]] = add i32 [[SUM0]], 86
+; CHECK-NEXT:    [[SUM3:%.*]] = add i32 [[SUM0:%.*]], 86
 ; CHECK-NEXT:    br label [[BB2]]
 ; CHECK:       bb0.split.nonchr:
+; CHECK-NEXT:    [[SUM1:%.*]] = add i32 [[SUM0]], 42
 ; CHECK-NEXT:    [[A4_NONCHR:%.*]] = and i32 [[LI_FR]], 4
 ; CHECK-NEXT:    [[CMP4_NONCHR:%.*]] = icmp eq i32 [[A4_NONCHR]], 0
 ; CHECK-NEXT:    [[INC2_NONCHR:%.*]] = add i32 [[INC1]], 1
@@ -1686,8 +1686,8 @@ define i32 @test_chr_18(ptr %i, i32 %sum0) !prof !14 {
 ; CHECK:       bb1.nonchr:
 ; CHECK-NEXT:    [[A1:%.*]] = and i32 [[LI_FR]], 1
 ; CHECK-NEXT:    [[CMP1_NOT:%.*]] = icmp eq i32 [[A1]], 0
-; CHECK-NEXT:    [[SUM2_NONCHR:%.*]] = select i1 [[CMP1_NOT]], i32 [[SUM0]], i32 [[SUM1]], !prof [[PROF16]]
-; CHECK-NEXT:    [[SUM3_NONCHR:%.*]] = add i32 [[SUM2_NONCHR]], 44
+; CHECK-NEXT:    [[SUM3_NONCHR_V:%.*]] = select i1 [[CMP1_NOT]], i32 44, i32 86, !prof [[PROF16]]
+; CHECK-NEXT:    [[SUM3_NONCHR:%.*]] = add i32 [[SUM0]], [[SUM3_NONCHR_V]]
 ; CHECK-NEXT:    br label [[BB2]]
 ; CHECK:       bb2:
 ; CHECK-NEXT:    [[TMP2]] = phi i32 [ [[INC2]], [[BB1]] ], [ [[INC2_NONCHR]], [[BB0_SPLIT_NONCHR]] ], [ [[INC2_NONCHR]], [[BB1_NONCHR]] ]
@@ -1777,7 +1777,7 @@ define i32 @test_chr_19(ptr %i, i32 %sum0) !prof !14 {
 ; CHECK-NEXT:    [[SUM2_NONCHR:%.*]] = select i1 [[TMP6]], i32 [[SUM0]], i32 [[TMP7]], !prof [[PROF16]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = and i32 [[DOTFR1]], 8
 ; CHECK-NEXT:    [[TMP9:%.*]] = icmp eq i32 [[TMP8]], 0
-; CHECK-NEXT:    [[SUM4_NONCHR_V:%.*]] = select i1 [[TMP9]], i32 44, i32 88
+; CHECK-NEXT:    [[SUM4_NONCHR_V:%.*]] = select i1 [[TMP9]], i32 44, i32 88, !prof [[PROF16]]
 ; CHECK-NEXT:    [[SUM4_NONCHR:%.*]] = add i32 [[SUM2_NONCHR]], [[SUM4_NONCHR_V]]
 ; CHECK-NEXT:    [[SUM5_NONCHR:%.*]] = select i1 [[TMP6]], i32 [[SUM2_NONCHR]], i32 [[SUM4_NONCHR]], !prof [[PROF16]]
 ; CHECK-NEXT:    br label [[BB3]]
@@ -1945,7 +1945,7 @@ define i32 @test_chr_21(i64 %i, i64 %k, i64 %j) "instcombine-no-verify-fixpoint"
 ; CHECK-NEXT:    switch i64 [[I_FR]], label [[BB2:%.*]] [
 ; CHECK-NEXT:      i64 2, label [[BB3_NONCHR2:%.*]]
 ; CHECK-NEXT:      i64 86, label [[BB2_NONCHR1:%.*]]
-; CHECK-NEXT:    ], !prof [[PROF19:![0-9]+]]
+; CHECK-NEXT:    ], !prof [[PROF20:![0-9]+]]
 ; CHECK:       bb2:
 ; CHECK-NEXT:    call void @foo()
 ; CHECK-NEXT:    call void @foo()
@@ -2527,14 +2527,14 @@ define void @test_chr_24(ptr %i) !prof !14 {
 ; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[I:%.*]], align 4
 ; CHECK-NEXT:    [[TMP1:%.*]] = and i32 [[TMP0]], 1
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i32 [[TMP1]], 0
-; CHECK-NEXT:    br i1 [[TMP2]], label [[BB1:%.*]], label [[BB0:%.*]], !prof [[PROF20:![0-9]+]]
+; CHECK-NEXT:    br i1 [[TMP2]], label [[BB1:%.*]], label [[BB0:%.*]], !prof [[PROF21:![0-9]+]]
 ; CHECK:       bb0:
 ; CHECK-NEXT:    call void @foo()
 ; CHECK-NEXT:    br label [[BB1]]
 ; CHECK:       bb1:
 ; CHECK-NEXT:    [[TMP3:%.*]] = and i32 [[TMP0]], 2
 ; CHECK-NEXT:    [[TMP4:%.*]] = icmp eq i32 [[TMP3]], 0
-; CHECK-NEXT:    br i1 [[TMP4]], label [[BB3:%.*]], label [[BB2:%.*]], !prof [[PROF20]]
+; CHECK-NEXT:    br i1 [[TMP4]], label [[BB3:%.*]], label [[BB2:%.*]], !prof [[PROF21]]
 ; CHECK:       bb2:
 ; CHECK-NEXT:    call void @foo()
 ; CHECK-NEXT:    br label [[BB3]]


### PR DESCRIPTION
Fixes #154246.

The original pattern in the issue was the following.

```llvm
define i8 @src(i8 %arg0, i8 %arg1) {
  %v0 = icmp eq i8 %arg1, -1
  %v1 = or i8 %arg0, 4
  %v2 = select i1 %v0, i8 %v1, i8 %arg0
  %v3 = or i8 %v2, 1
  ret i8 %v3
}
```
to
```llvm
define i8 @tgt(i8 %arg0, i8 %arg1) {
  %v0 = icmp eq i8 %arg1, -1
  %v3.v = select i1 %v0, i8 5, i8 1
  %v3 = or i8 %arg0, %v3.v
  ret i8 %v3
}
```
(Alive2: https://alive2.llvm.org/ce/z/Nq6b4)

After some investigation I have found out, that if we were to replace `or` with `and`, then this optimization already works.

The reason for this is that, `SimplifyDemandedUseBits`'s `ShrinkDemandedConstant` shrinks the constants that way, that the one of the `and`'s constnat is always a subset of the other `and`'s constant. For example:
```llvm
define i8 @and(i8 %arg0, i8 %arg1) {
  %v0 = icmp eq i8 %arg1, -1
  %v1 = and i8 %arg0, 13
  %v2 = select i1 %v0, i8 %v1, i8 %arg0
  %v3 = and i8 %v2, 11
  ret i8 %v3
}
```
will become
```llvm
define i8 @and(i8 %arg0, i8 %arg1) {
  %v0 = icmp eq i8 %arg1, -1
  %v1 = and i8 %arg0, 13
  %v2 = select i1 %v0, i8 %v1, i8 %arg0
  %v3 = and i8 %v2, 9
  ret i8 %v3
}
```
After this `foldBinOpIntoSelect` will call `InstSimplify`, where `simplifyAssociativeBinOp` will succeed.

This would not work for the `or` case. At least as long as we have a `ShrinkDemandedConstant` call. `ShrinkDemandedConstant` for `or` and `xor` results in less ones set in the constant. For example:
```llvm
define i8 @src(i8 %arg0, i8 %arg1) {
  %v0 = icmp eq i8 %arg1, -1
  %v1 = or i8 %arg0, 11
  %v2 = select i1 %v0, i8 %v1, i8 %arg0
  %v3 = or i8 %v2, 13
  ret i8 %v3
}
```
will become
```llvm
define i8 @src(i8 %arg0, i8 %arg1) {
  %v0 = icmp eq i8 %arg1, -1
  %v1 = or i8 %arg0, 2
  %v2 = select i1 %v0, i8 %v1, i8 %arg0
  %v3 = or i8 %v2, 13
  ret i8 %v3
}
```
So instead of going to a direction, where the first constant would "absorb" the second one it make one of the constant into more narrow "set" (Less ones in the number). (Obviously, since the goal at this point of the code is to only have the later relevant bits set, and if a later `or` sets those bit to one either way why would the be already one.)

My current solution adresses the issue in `foldBinOpIntoSelect`. It recognizes the pattern, and folds both arms of the select even without any simplification. So if I understand the code correctly we get from
```llvm
define i8 @src(i8 %arg0, i8 %arg1) {
  %v0 = icmp eq i8 %arg1, -1
  %v1 = or i8 %arg0, 4
  %v2 = select i1 %v0, i8 %v1, i8 %arg0
  %v3 = or i8 %v2, 1
  ret i8 %v3
}
```
to
```llvm
define i8 @src-after-fold-bin-op-into-sel(i8 %arg0, i8 %arg1) {
  %v0 = icmp eq i8 %arg1, -1
  %v1 = or i8 %arg0, 4
  %vE = or i8 %v1, 1
  %arg1E = or i8 %arg0, 1
  %v2 = select i1 %v0, i8 %vE, i8 %arg1E
  ret i8 %v2
}
```
which is later transformed into our target:
```llvm
define i8 @src(i8 %arg0, i8 %arg1) {
  %v0 = icmp eq i8 %arg1, -1
  %v3.v = select i1 %v0, i8 5, i8 1
  %v3 = or i8 %arg0, %v3.v
  ret i8 %v3
}
```

Another possible solution would maybe be thinkering around with `SimplifyAssociativeOrCommutative`. It would be more expensive and make things a bit more complex. We could maybe account for abstracting selects in the function or we could make it work similar to `simplifyInstructionWithOperands` in that regard, it would get the operands in an array and would work with that, and there would be a wrapper function creating that array. That function could address these `select`s. This is arther just an intuiton of mine, I don't have a concrete plan and maybe it is impossible.
