### PR TITLE
[lldb-dap] Do not show memory address on types with no summary

### DIFF
--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -168,11 +168,7 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         else:
             self.assertEvaluate(
                 "struct1",
-                (
-                    re.escape("{foo:15}")
-                    if enableAutoVariableSummaries
-                    else "my_struct @ 0x"
-                ),
+                (re.escape("{foo:15}") if enableAutoVariableSummaries else "my_struct"),
                 want_varref=True,
             )
             self.assertEvaluate(
@@ -243,11 +239,7 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         else:
             self.assertEvaluate(
                 "struct1",
-                (
-                    re.escape("{foo:15}")
-                    if enableAutoVariableSummaries
-                    else "my_struct @ 0x"
-                ),
+                (re.escape("{foo:15}") if enableAutoVariableSummaries else "my_struct"),
                 want_type="my_struct",
                 want_varref=True,
             )

--- a/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
+++ b/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
@@ -255,7 +255,7 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
                     "result": (
                         "{x:11, y:22, buffer:{...}}"
                         if enableAutoVariableSummaries
-                        else "PointType @ 0x"
+                        else "PointType"
                     )
                 },
                 "hasVariablesReference": True,
@@ -266,7 +266,7 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
                     "result": (
                         "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...}"
                         if enableAutoVariableSummaries
-                        else "int[16] @ 0x"
+                        else "int[16]"
                     )
                 },
                 "hasVariablesReference": True,
@@ -502,7 +502,7 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
                         "result": (
                             "{x:11, y:22, buffer:{...}}"
                             if enableAutoVariableSummaries
-                            else "PointType @ 0x"
+                            else "PointType"
                         )
                     },
                     "missing": ["indexedVariables"],
@@ -514,7 +514,7 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
                         "result": (
                             "{x:11, y:22, buffer:{...}}"
                             if enableAutoVariableSummaries
-                            else "PointType @ 0x"
+                            else "PointType"
                         )
                     },
                     "missing": ["indexedVariables"],
@@ -526,7 +526,7 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
                         "result": (
                             "{x:11, y:22, buffer:{...}}"
                             if enableAutoVariableSummaries
-                            else "PointType @ 0x"
+                            else "PointType"
                         )
                     },
                     "missing": ["indexedVariables"],

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -814,13 +814,8 @@ VariableDescription::VariableDescription(lldb::SBValue v,
       os_display_value << *effective_summary;
 
       // As last resort, we print its type and address if available.
-    } else {
-      if (!raw_display_type_name.empty()) {
-        os_display_value << raw_display_type_name;
-        lldb::addr_t address = v.GetLoadAddress();
-        if (address != LLDB_INVALID_ADDRESS)
-          os_display_value << " @ " << llvm::format_hex(address, 0);
-      }
+    } else if (!raw_display_type_name.empty()) {
+      os_display_value << raw_display_type_name;
     }
   }
 


### PR DESCRIPTION
Majority of the time users are less interested on the memory address of a type. It is mostly useful for pointer types (the memory address is shown). 
It makes the view more bloated without adding useful information.

can always fall back to the debug console or watch pane to view the information if necessary.

Memory Address            |  No Memory Address
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/8347dfef-4982-43cf-bc72-c1e60fd54724) | ![](https://github.com/user-attachments/assets/85bc3eec-b057-47e0-a231-1d1a5ebf0e7a)