### PR TITLE
[mlir] Use SymbolOpInterface to implement operateOnSymbol in test-symbol-uses pass

### DIFF
--- a/mlir/test/lib/IR/TestSymbolUses.cpp
+++ b/mlir/test/lib/IR/TestSymbolUses.cpp
@@ -59,7 +59,7 @@ struct SymbolUsesPass
               symbolUse.getUser()->getParentOp(), symbolUse.getSymbolRef())) {
         symbolUse.getUser()->emitRemark()
             << "found use of symbol : " << symbolUse.getSymbolRef() << " : "
-            << *symbol->getInherentAttr(SymbolTable::getSymbolAttrName());
+            << symbol->getAttr(SymbolTable::getSymbolAttrName());
       }
     }
     symbol->emitRemark() << "symbol has " << llvm::size(*symbolUses) << " uses";

--- a/mlir/test/lib/IR/TestSymbolUses.cpp
+++ b/mlir/test/lib/IR/TestSymbolUses.cpp
@@ -73,7 +73,6 @@ struct SymbolUsesPass
     SmallVector<func::FuncOp, 4> deadFunctions;
     module.getBodyRegion().walk([&](SymbolOpInterface nestedOp) {
       return operateOnSymbol(nestedOp, module, deadFunctions);
-      return WalkResult::advance();
     });
 
     SymbolTable table(module);


### PR DESCRIPTION
Fix https://github.com/llvm/llvm-project/issues/172603 by using SymbolOpInterface to implement operateOnSymbol.