### PR TITLE
[CIR] Introduce syntax for scalable vectors

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -430,6 +430,7 @@ def CIR_VectorType : CIR_Type<"Vector", "vector", [
 
     ```mlir
     vector-type ::= !cir.vector<size x element-type>
+    size ::= (decimal-literal | `[` decimal-literal `]`)
     element-type ::= float-type | integer-type | pointer-type
     ```
 
@@ -442,6 +443,13 @@ def CIR_VectorType : CIR_Type<"Vector", "vector", [
     !cir.vector<4 x !cir.int<u, 8>>
     !cir.vector<2 x !cir.float>
     ```
+
+    Scalable vectors are indicated by enclosing size in square brackets.
+
+    Example:
+    ```mlir
+    !cir.vector<[4] x !cir.int<u, 8>>
+    ```
   }];
 
   let parameters = (ins
@@ -449,10 +457,6 @@ def CIR_VectorType : CIR_Type<"Vector", "vector", [
     "uint64_t":$size,
     OptionalParameter<"bool">:$is_scalable
   );
-
-  let assemblyFormat = [{
-    `<` $size `x` $element_type `>`
-  }];
 
   let builders = [
     TypeBuilderWithInferredContext<(ins
@@ -471,6 +475,7 @@ def CIR_VectorType : CIR_Type<"Vector", "vector", [
 
   let genVerifyDecl = 1;
   let skipDefaultBuilders = 1;
+  let hasCustomAssemblyFormat = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -828,6 +828,76 @@ mlir::LogicalResult cir::VectorType::verify(
   return success();
 }
 
+mlir::Type cir::VectorType::parse(::mlir::AsmParser &odsParser) {
+
+  llvm::SMLoc odsLoc = odsParser.getCurrentLocation();
+  mlir::Builder odsBuilder(odsParser.getContext());
+  mlir::FailureOr<::mlir::Type> elementType;
+  mlir::FailureOr<uint64_t> size;
+  bool isScalabe = false;
+
+  // Parse literal '<'
+  if (odsParser.parseLess())
+    return {};
+
+  // Parse literal '[', if present, and set the scalability flag accordingly
+  if (odsParser.parseOptionalLSquare().succeeded()) {
+    isScalabe = true;
+  }
+
+  // Parse variable 'size'
+  size = mlir::FieldParser<uint64_t>::parse(odsParser);
+  if (mlir::failed(size)) {
+    odsParser.emitError(odsParser.getCurrentLocation(),
+                        "failed to parse CIR_VectorType parameter 'size' which "
+                        "is to be a `uint64_t`");
+    return {};
+  }
+
+  // Parse literal ']', which is expected when dealing with scalable
+  // dim sizes
+  if (isScalabe && odsParser.parseRSquare().failed()) {
+    odsParser.emitError(odsParser.getCurrentLocation(),
+                        "missing closing `]` for scalable dim size");
+    return {};
+  }
+
+  // Parse literal 'x'
+  if (odsParser.parseKeyword("x"))
+    return {};
+
+  // Parse variable 'elementType'
+  elementType = mlir::FieldParser<::mlir::Type>::parse(odsParser);
+  if (mlir::failed(elementType)) {
+    odsParser.emitError(odsParser.getCurrentLocation(),
+                        "failed to parse CIR_VectorType parameter "
+                        "'elementType' which is to be a `mlir::Type`");
+    return {};
+  }
+
+  // Parse literal '>'
+  if (odsParser.parseGreater())
+    return {};
+  return odsParser.getChecked<VectorType>(odsLoc, odsParser.getContext(),
+                                          mlir::Type((*elementType)),
+                                          uint64_t((*size)), isScalabe);
+}
+
+void cir::VectorType::print(mlir::AsmPrinter &odsPrinter) const {
+  mlir::Builder odsBuilder(getContext());
+  odsPrinter << "<";
+  if (this->getIsScalable())
+    odsPrinter << "[";
+
+  odsPrinter.printStrippedAttrOrType(getSize());
+  if (this->getIsScalable())
+    odsPrinter << "]";
+  odsPrinter << ' ' << "x";
+  odsPrinter << ' ';
+  odsPrinter.printStrippedAttrOrType(getElementType());
+  odsPrinter << ">";
+}
+
 //===----------------------------------------------------------------------===//
 // TargetAddressSpace definitions
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -841,9 +841,8 @@ mlir::Type cir::VectorType::parse(::mlir::AsmParser &odsParser) {
     return {};
 
   // Parse literal '[', if present, and set the scalability flag accordingly
-  if (odsParser.parseOptionalLSquare().succeeded()) {
+  if (odsParser.parseOptionalLSquare().succeeded())
     isScalabe = true;
-  }
 
   // Parse variable 'size'
   size = mlir::FieldParser<uint64_t>::parse(odsParser);

--- a/clang/test/CIR/IR/invalid-vector.cir
+++ b/clang/test/CIR/IR/invalid-vector.cir
@@ -11,6 +11,16 @@ cir.global external @vec_b = #cir.zero : !cir.vector<4 x !cir.array<!s32i x 10>>
 
 // -----
 
+cir.func @invalid_scalable_vec_syntax() {
+  // expected-error@+2 {{missing closing `]` for scalable dim size}}
+  // expected-error @below {{expected ']'}}
+  %3 = cir.alloca !cir.vector<[1 x] !s32i>, !cir.ptr<!cir.vector<[1] x !s32i>>
+  cir.return
+
+}
+
+// -----
+
 !s32i = !cir.int<s, 32>
 !s64i = !cir.int<s, 64>
 

--- a/clang/test/CIR/IR/vector.cir
+++ b/clang/test/CIR/IR/vector.cir
@@ -23,6 +23,7 @@ cir.func @vec_int_test() {
   %0 = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["a"]
   %1 = cir.alloca !cir.vector<3 x !s32i>, !cir.ptr<!cir.vector<3 x !s32i>>, ["b"]
   %2 = cir.alloca !cir.vector<2 x !s32i>, !cir.ptr<!cir.vector<2 x !s32i>>, ["c"]
+  %3 = cir.alloca !cir.vector<[1] x !s32i>, !cir.ptr<!cir.vector<[1] x !s32i>>, ["d"]
   cir.return
 }
 
@@ -30,6 +31,7 @@ cir.func @vec_int_test() {
 // CHECK:  %0 = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["a"]
 // CHECK:  %1 = cir.alloca !cir.vector<3 x !s32i>, !cir.ptr<!cir.vector<3 x !s32i>>, ["b"]
 // CHECK:  %2 = cir.alloca !cir.vector<2 x !s32i>, !cir.ptr<!cir.vector<2 x !s32i>>, ["c"]
+// CHECK:  %3 = cir.alloca !cir.vector<[1] x !s32i>, !cir.ptr<!cir.vector<[1] x !s32i>>, ["d"]
 // CHECK:  cir.return
 // CHECK: }
 


### PR DESCRIPTION
As of #172346, CIR supports scalable vectors. This patch updates the
assembly format to introduce syntax for representing scalable
dimensions.

The proposed syntax follows the format used by the builtin vector type:
```mlir
  # Builtin scalable vector
  cir.vector<[16] x !cir.int<u, 8>>
  # CIR scalable vector
  !cir.vector<[16] x !cir.int<u, 8>>
```

This contrasts with LLVM IR, where scalable dimensions are modeled using
the `vscale` keyword:
```llvm
  ; LLVM scalable vector
  <vscale x 16 x i8>
```

To support this change, `cir::VectorType` gains a custom parser and
printer, which are small modifications of the auto-generated ones.
