### PR TITLE
[BOLT][AArch64] Treat undefined symbols as errors in tests

### DIFF
--- a/bolt/test/AArch64/bf_min_alignment.s
+++ b/bolt/test/AArch64/bf_min_alignment.s
@@ -20,7 +20,7 @@
   .type _start, %function
 _start:
 # FDATA: 0 [unknown] 0 1 _start 0 0 1
-   bl dymmy
+   bl dummy
    ret
   .size _start, .-_start
 

--- a/bolt/test/AArch64/epilogue-determination.s
+++ b/bolt/test/AArch64/epilogue-determination.s
@@ -2,7 +2,7 @@
 # `_foo` or the second basic block in function `_goo` as epilogue, and will
 # recognize epilogues in the other cases.
 
-# RUN: %clang %cflags %s -o %t.so -Wl,-q
+# RUN: %clang %cflags %s -o %t.so -Wl,-q,-z,undefs
 # RUN: llvm-bolt %t.so -o %t.bolt --print-cfg | FileCheck %s
 
   .text

--- a/bolt/test/AArch64/exceptions-plt.cpp
+++ b/bolt/test/AArch64/exceptions-plt.cpp
@@ -4,7 +4,7 @@
 
 // RUN: %clang %cflags -fpic -shared -xc /dev/null -o %t.so
 // Link against a DSO to ensure PLT entries.
-// RUN: %clangxx %cxxflags -O1 -Wl,-q,-znow %s %t.so -o %t.exe
+// RUN: %clangxx %cxxflags -O1 -Wl,-z,undefs,-q,-znow %s %t.so -o %t.exe
 // RUN: llvm-bolt %t.exe -o %t.bolt.exe --plt=all --print-only=.*main.* \
 // RUN:   --print-finalized 2>&1 | FileCheck %s
 

--- a/bolt/test/AArch64/ifunc.test
+++ b/bolt/test/AArch64/ifunc.test
@@ -1,6 +1,6 @@
 // With -O0 indirect call is performed on IPLT trampoline. IPLT trampoline
 // has IFUNC symbol.
-// RUN: %clang %cflags -nostdlib -O0 -no-pie %p/../Inputs/ifunc.c -fuse-ld=lld \
+// RUN: %clang %cflags -Wl,-z,undefs -nostdlib -O0 -no-pie %p/../Inputs/ifunc.c -fuse-ld=lld \
 // RUN:    -o %t.O0.exe -Wl,-q
 // RUN: llvm-bolt %t.O0.exe -o %t.O0.bolt.exe \
 // RUN:   --print-disasm --print-only=_start | \
@@ -10,7 +10,7 @@
 
 // Non-pie static executable doesn't generate PT_DYNAMIC, check relocation
 // is read successfully and IPLT trampoline has been identified by bolt.
-// RUN: %clang %cflags -nostdlib -O3 %p/../Inputs/ifunc.c -fuse-ld=lld -no-pie \
+// RUN: %clang %cflags -Wl,-z,undefs -nostdlib -O3 %p/../Inputs/ifunc.c -fuse-ld=lld -no-pie \
 // RUN:   -o %t.O3_nopie.exe -Wl,-q
 // RUN: llvm-readelf -l %t.O3_nopie.exe | \
 // RUN:   FileCheck --check-prefix=NON_DYN_CHECK %s
@@ -23,7 +23,7 @@
 // With -O3 direct call is performed on IPLT trampoline. IPLT trampoline
 // doesn't have associated symbol. The ifunc symbol has the same address as
 // IFUNC resolver function.
-// RUN: %clang %cflags -nostdlib -O3 %p/../Inputs/ifunc.c -fuse-ld=lld -fPIC -pie \
+// RUN: %clang %cflags -Wl,-z,undefs -nostdlib -O3 %p/../Inputs/ifunc.c -fuse-ld=lld -fPIC -pie \
 // RUN:   -o %t.O3_pie.exe -Wl,-q
 // RUN: llvm-bolt %t.O3_pie.exe -o %t.O3_pie.bolt.exe  \
 // RUN:   --print-disasm --print-only=_start | \
@@ -33,7 +33,7 @@
 
 // Check that IPLT trampoline located in .plt section are normally handled by
 // BOLT. The gnu-ld linker doesn't use separate .iplt section.
-// RUN: %clang %cflags -nostdlib -O3 %p/../Inputs/ifunc.c -fuse-ld=lld -fPIC -pie \
+// RUN: %clang %cflags -Wl,-z,undefs -nostdlib -O3 %p/../Inputs/ifunc.c -fuse-ld=lld -fPIC -pie \
 // RUN:   -T %p/../Inputs/iplt.ld -o %t.iplt_O3_pie.exe -Wl,-q
 // RUN: llvm-bolt %t.iplt_O3_pie.exe -o %t.iplt_O3_pie.bolt.exe  \
 // RUN:   --print-disasm --print-only=_start  | \

--- a/bolt/test/AArch64/lit.local.cfg
+++ b/bolt/test/AArch64/lit.local.cfg
@@ -1,7 +1,7 @@
 if "AArch64" not in config.root.targets:
     config.unsupported = True
 
-flags = "--target=aarch64-unknown-linux-gnu -nostartfiles -nostdlib -ffreestanding"
+flags = "--target=aarch64-unknown-linux-gnu -nostartfiles -nostdlib -ffreestanding -Wl,-z,defs"
 
 config.substitutions.insert(0, ("%cflags", f"%cflags {flags}"))
 config.substitutions.insert(0, ("%cxxflags", f"%cxxflags {flags}"))

--- a/bolt/test/AArch64/plt-call.test
+++ b/bolt/test/AArch64/plt-call.test
@@ -2,7 +2,7 @@
 
 RUN: %clang %cflags -fpic -shared -xc /dev/null -o %t.so
 // Link against a DSO to ensure PLT entries.
-RUN: %clang %cflags %p/../Inputs/plt-tailcall.c %t.so \
+RUN: %clang %cflags -Wl,-z,undefs %p/../Inputs/plt-tailcall.c %t.so \
 RUN:    -o %t -Wl,-q
 RUN: llvm-bolt %t -o %t.bolt --plt=all --print-plt  --print-only=foo | FileCheck %s
 

--- a/bolt/test/AArch64/text-data.c
+++ b/bolt/test/AArch64/text-data.c
@@ -1,7 +1,7 @@
 // This test checks that the data object located in text section
 // is properly emitted in the new section.
 
-// RUN: %clang %cflags %s -o %t.exe -Wl,-q
+// RUN: %clang %cflags %s -o %t.exe -Wl,-q,-z,undefs
 // RUN: llvm-bolt %t.exe -o %t.bolt --lite=0 --use-old-text=0
 // RUN: llvm-objdump -j .text -d --disassemble-symbols=arr %t.bolt | \
 // RUN:   FileCheck %s

--- a/bolt/test/AArch64/tls.c
+++ b/bolt/test/AArch64/tls.c
@@ -35,7 +35,8 @@ int main() {
 // RUN:   -nostdlib
 // RUN: llvm-bolt %t_pie.exe -o %t.bolt
 
-// RUN: %clang %cflags -fPIC -shared %s -o %t.so -Wl,-q -fuse-ld=lld
+// RUN: %clang %cflags -Wl,--unresolved-symbols=ignore-all -fPIC -shared %s -o \
+// RUN:   %t.so -Wl,-q -fuse-ld=lld
 // RUN: llvm-objdump -d -r --disassemble-symbols=main %t.so | FileCheck %s
 // RUN: llvm-bolt %t.so -o %t.bolt.so
 

--- a/bolt/test/AArch64/unsupported-passes.test
+++ b/bolt/test/AArch64/unsupported-passes.test
@@ -2,7 +2,7 @@
 
 // REQUIRES: system-linux,asserts,target=aarch64{{.*}}
 
-RUN: %clang %cflags %p/../Inputs/hello.c -o %t -Wl,-q
+RUN: %clang %cflags %p/../Inputs/hello.c -o %t -Wl,-q,-z,undefs
 RUN: not llvm-bolt %t -o %t.bolt --frame-opt=all 2>&1 | FileCheck %s --check-prefix=CHECK-FRAME-OPT
 
 CHECK-FRAME-OPT: BOLT-ERROR: frame-optimizer is supported only on X86


### PR DESCRIPTION
Add `-Wl,-z,defs` in `%cflags`  to make linking more consistent across distros. Aims to catch typos in handwritten assembly tests. If intentional, individual tests can override this with: `-Wl,-z,undefs`

Tests changed:
- bolt/test/AArch64/bf_min_alignment.s: fixed a typo
- bolt/test/AArch64/tls.c: overriding behaviour in all clang invocations, making the test more consistent.
- Overrides to allow undefined symbols in:
  - bolt/test/AArch64/epilogue-determination.s
  - bolt/test/AArch64/exceptions-plt.cpp
  - bolt/test/AArch64/ifunc.test
  - bolt/test/AArch64/plt-call.test
  - bolt/test/AArch64/text-data.c
  - bolt/test/AArch64/unsupported-passes.test
  - bolt/test/AArch64/unsupported-passes.test