### PR TITLE
[AsmParser] Faster location -> value lookups

### DIFF
--- a/llvm/include/llvm/AsmParser/AsmParserContext.h
+++ b/llvm/include/llvm/AsmParser/AsmParserContext.h
@@ -17,23 +17,6 @@
 #include <optional>
 
 namespace llvm {
-struct FileLocIntervalInfo {
-  // Overriding 'adjacent' to return false prevents the map
-  // from merging [10, 20] and [21, 30] even if values match.
-  static bool adjacent(const llvm::FileLoc &A, const llvm::FileLoc &B) {
-    return false;
-  }
-  static bool startLess(const llvm::FileLoc &X, const llvm::FileLoc &A) {
-    return X < A;
-  }
-  static bool stopLess(const llvm::FileLoc &B, const llvm::FileLoc &X) {
-    return B <= X;
-  }
-  static bool nonEmpty(const llvm::FileLoc &A, const llvm::FileLoc &B) {
-    return A < B;
-  }
-};
-
 /// Registry of file location information for LLVM IR constructs.
 ///
 /// This class provides access to the file location information
@@ -50,7 +33,7 @@ class AsmParserContext {
   using FMap =
       IntervalMap<FileLoc, Function *,
                   IntervalMapImpl::NodeSizer<FileLoc, Function *>::LeafSize,
-                  FileLocIntervalInfo>;
+                  IntervalMapHalfOpenInfo<FileLoc>>;
 
   DenseMap<Function *, FileLocRange> Functions;
   FMap::Allocator FAllocator;
@@ -59,14 +42,14 @@ class AsmParserContext {
   using BBMap =
       IntervalMap<FileLoc, BasicBlock *,
                   IntervalMapImpl::NodeSizer<FileLoc, BasicBlock *>::LeafSize,
-                  FileLocIntervalInfo>;
+                  IntervalMapHalfOpenInfo<FileLoc>>;
   BBMap::Allocator BBAllocator;
   BBMap BlocksInverse = BBMap(BBAllocator);
   DenseMap<Instruction *, FileLocRange> Instructions;
   using IMap =
       IntervalMap<FileLoc, Instruction *,
                   IntervalMapImpl::NodeSizer<FileLoc, Instruction *>::LeafSize,
-                  FileLocIntervalInfo>;
+                  IntervalMapHalfOpenInfo<FileLoc>>;
   IMap::Allocator IAllocator;
   IMap InstructionsInverse = IMap(IAllocator);
 

--- a/llvm/include/llvm/AsmParser/AsmParserContext.h
+++ b/llvm/include/llvm/AsmParser/AsmParserContext.h
@@ -12,11 +12,12 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/AsmParser/FileLoc.h"
-#include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Value.h"
 #include <optional>
 
 namespace llvm {
+class BasicBlock;
+
 /// Registry of file location information for LLVM IR constructs.
 ///
 /// This class provides access to the file location information

--- a/llvm/include/llvm/AsmParser/FileLoc.h
+++ b/llvm/include/llvm/AsmParser/FileLoc.h
@@ -21,6 +21,10 @@ struct FileLoc {
   /// 0-based column number
   unsigned Col;
 
+  bool operator==(const FileLoc &RHS) const {
+    return Line == RHS.Line && Col == RHS.Col;
+  }
+
   bool operator<=(const FileLoc &RHS) const {
     return Line < RHS.Line || (Line == RHS.Line && Col <= RHS.Col);
   }

--- a/llvm/include/llvm/AsmParser/FileLoc.h
+++ b/llvm/include/llvm/AsmParser/FileLoc.h
@@ -29,6 +29,7 @@ struct FileLoc {
     return Line < RHS.Line || (Line == RHS.Line && Col < RHS.Col);
   }
 
+  FileLoc() : Line(0), Col(0) {}
   FileLoc(unsigned L, unsigned C) : Line(L), Col(C) {}
   FileLoc(std::pair<unsigned, unsigned> LC) : Line(LC.first), Col(LC.second) {}
 };

--- a/llvm/unittests/AsmParser/AsmParserTest.cpp
+++ b/llvm/unittests/AsmParser/AsmParserTest.cpp
@@ -514,6 +514,8 @@ TEST(AsmParserTest, ParserObjectLocations) {
   auto MainLoc = MaybeMainLoc.value();
   auto ExpectedMainLoc = FileLocRange(FileLoc{0, 0}, FileLoc{4, 1});
   ASSERT_EQ_LOC(MainLoc, ExpectedMainLoc);
+  ASSERT_EQ(ParserContext.getFunctionAtLocation(MainLoc.Start),
+            ParserContext.getFunctionAtLocation(MainLoc));
 
   auto &EntryBB = MainFn->getEntryBlock();
   auto MaybeEntryBBLoc = ParserContext.getBlockLocation(&EntryBB);
@@ -521,6 +523,8 @@ TEST(AsmParserTest, ParserObjectLocations) {
   auto EntryBBLoc = MaybeEntryBBLoc.value();
   auto ExpectedEntryBBLoc = FileLocRange(FileLoc{1, 0}, FileLoc{3, 14});
   ASSERT_EQ_LOC(EntryBBLoc, ExpectedEntryBBLoc);
+  ASSERT_EQ(ParserContext.getBlockAtLocation(MaybeEntryBBLoc->Start),
+            ParserContext.getBlockAtLocation(*MaybeEntryBBLoc));
 
   SmallVector<FileLocRange> InstructionLocations = {
       FileLocRange(FileLoc{2, 4}, FileLoc{2, 21}),
@@ -531,6 +535,8 @@ TEST(AsmParserTest, ParserObjectLocations) {
     ASSERT_TRUE(MaybeMainLoc.has_value());
     auto InstLoc = MaybeInstLoc.value();
     ASSERT_EQ_LOC(InstLoc, ExpectedLoc);
+    ASSERT_EQ(ParserContext.getInstructionAtLocation(MaybeInstLoc->Start),
+              ParserContext.getInstructionAtLocation(*MaybeInstLoc));
   }
 }
 


### PR DESCRIPTION
Uses IntervalMap to make location -> value lookups faster.

Adds some tests with this feature.