### PR TITLE
[InstCombine] Fold intrinsics over multi-use selects when the intrinsic is the only user

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1783,7 +1783,7 @@ Instruction *InstCombinerImpl::FoldOpIntoSelect(Instruction &Op, SelectInst *SI,
                                                 bool FoldWithMultiUse,
                                                 bool SimplifyBothArms) {
   // Don't modify shared select instructions unless set FoldWithMultiUse
-  if (!SI->hasOneUse() && !FoldWithMultiUse)
+  if (!SI->hasOneUser() && !FoldWithMultiUse)
     return nullptr;
 
   Value *TV = SI->getTrueValue();

--- a/llvm/test/Transforms/InstCombine/intrinsic-select.ll
+++ b/llvm/test/Transforms/InstCombine/intrinsic-select.ll
@@ -429,8 +429,7 @@ define { <4 x float>, <4 x float> } @test_select_of_sincos_intrinsic_operand(<4 
 
 define i8 @test_select_rotate_left(i1 %0) {
 ; CHECK-LABEL: @test_select_rotate_left(
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], i8 1, i8 -1
-; CHECK-NEXT:    [[RET:%.*]] = call i8 @llvm.fshl.i8(i8 [[S]], i8 [[S]], i8 1)
+; CHECK-NEXT:    [[RET:%.*]] = select i1 [[TMP0:%.*]], i8 2, i8 -1
 ; CHECK-NEXT:    ret i8 [[RET]]
 ;
   %s = select i1 %0, i8 1, i8 -1
@@ -462,8 +461,7 @@ define i8 @test_select_rotate_left_multiuser(i1 %0) {
 
 define <2 x i8> @test_select_rotate_left_splat(i1 %0) {
 ; CHECK-LABEL: @test_select_rotate_left_splat(
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> splat (i8 1), <2 x i8> splat (i8 -1)
-; CHECK-NEXT:    [[RET:%.*]] = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> [[S]], <2 x i8> [[S]], <2 x i8> splat (i8 1))
+; CHECK-NEXT:    [[RET:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> splat (i8 2), <2 x i8> splat (i8 -1)
 ; CHECK-NEXT:    ret <2 x i8> [[RET]]
 ;
   %s = select i1 %0, <2 x i8> <i8 1, i8 1>, <2 x i8> <i8 -1, i8 -1>
@@ -473,8 +471,7 @@ define <2 x i8> @test_select_rotate_left_splat(i1 %0) {
 
 define <2 x i8> @test_select_rotate_left_splat_poison(i1 %0) {
 ; CHECK-LABEL: @test_select_rotate_left_splat_poison(
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> <i8 1, i8 poison>, <2 x i8> splat (i8 -1)
-; CHECK-NEXT:    [[RET:%.*]] = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> [[S]], <2 x i8> [[S]], <2 x i8> splat (i8 1))
+; CHECK-NEXT:    [[RET:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> <i8 2, i8 poison>, <2 x i8> splat (i8 -1)
 ; CHECK-NEXT:    ret <2 x i8> [[RET]]
 ;
   %s = select i1 %0, <2 x i8> <i8 1, i8 poison>, <2 x i8> <i8 -1, i8 -1>
@@ -484,8 +481,7 @@ define <2 x i8> @test_select_rotate_left_splat_poison(i1 %0) {
 
 define <2 x i8> @test_select_rotate_left_non_splat(i1 %0) {
 ; CHECK-LABEL: @test_select_rotate_left_non_splat(
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> <i8 1, i8 2>, <2 x i8> <i8 -1, i8 -2>
-; CHECK-NEXT:    [[RET:%.*]] = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> [[S]], <2 x i8> [[S]], <2 x i8> splat (i8 1))
+; CHECK-NEXT:    [[RET:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> <i8 2, i8 4>, <2 x i8> <i8 -1, i8 -3>
 ; CHECK-NEXT:    ret <2 x i8> [[RET]]
 ;
   %s = select i1 %0, <2 x i8> <i8 1, i8 2>, <2 x i8> <i8 -1, i8 -2>
@@ -495,8 +491,7 @@ define <2 x i8> @test_select_rotate_left_non_splat(i1 %0) {
 
 define i8 @test_select_rotate_right(i1 %0) {
 ; CHECK-LABEL: @test_select_rotate_right(
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], i8 1, i8 -1
-; CHECK-NEXT:    [[RET:%.*]] = call i8 @llvm.fshl.i8(i8 [[S]], i8 [[S]], i8 1)
+; CHECK-NEXT:    [[RET:%.*]] = select i1 [[TMP0:%.*]], i8 2, i8 -1
 ; CHECK-NEXT:    ret i8 [[RET]]
 ;
   %s = select i1 %0, i8 1, i8 -1
@@ -528,8 +523,7 @@ define i8 @test_select_rotate_right_multiuser(i1 %0) {
 
 define <2 x i8> @test_select_rotate_right_splat(i1 %0) {
 ; CHECK-LABEL: @test_select_rotate_right_splat(
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> splat (i8 1), <2 x i8> splat (i8 -1)
-; CHECK-NEXT:    [[RET:%.*]] = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> [[S]], <2 x i8> [[S]], <2 x i8> splat (i8 1))
+; CHECK-NEXT:    [[RET:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> splat (i8 2), <2 x i8> splat (i8 -1)
 ; CHECK-NEXT:    ret <2 x i8> [[RET]]
 ;
   %s = select i1 %0, <2 x i8> <i8 1, i8 1>, <2 x i8> <i8 -1, i8 -1>
@@ -539,8 +533,7 @@ define <2 x i8> @test_select_rotate_right_splat(i1 %0) {
 
 define <2 x i8> @test_select_rotate_right_splat_poison(i1 %0) {
 ; CHECK-LABEL: @test_select_rotate_right_splat_poison(
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> <i8 1, i8 poison>, <2 x i8> splat (i8 -1)
-; CHECK-NEXT:    [[RET:%.*]] = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> [[S]], <2 x i8> [[S]], <2 x i8> splat (i8 1))
+; CHECK-NEXT:    [[RET:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> <i8 2, i8 poison>, <2 x i8> splat (i8 -1)
 ; CHECK-NEXT:    ret <2 x i8> [[RET]]
 ;
   %s = select i1 %0, <2 x i8> <i8 1, i8 poison>, <2 x i8> <i8 -1, i8 -1>
@@ -550,8 +543,7 @@ define <2 x i8> @test_select_rotate_right_splat_poison(i1 %0) {
 
 define <2 x i8> @test_select_rotate_right_non_splat(i1 %0) {
 ; CHECK-LABEL: @test_select_rotate_right_non_splat(
-; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> <i8 1, i8 2>, <2 x i8> <i8 -1, i8 -2>
-; CHECK-NEXT:    [[RET:%.*]] = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> [[S]], <2 x i8> [[S]], <2 x i8> splat (i8 1))
+; CHECK-NEXT:    [[RET:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> <i8 2, i8 4>, <2 x i8> <i8 -1, i8 -3>
 ; CHECK-NEXT:    ret <2 x i8> [[RET]]
 ;
   %s = select i1 %0, <2 x i8> <i8 1, i8 2>, <2 x i8> <i8 -1, i8 -2>

--- a/llvm/test/Transforms/InstCombine/intrinsic-select.ll
+++ b/llvm/test/Transforms/InstCombine/intrinsic-select.ll
@@ -426,3 +426,135 @@ define { <4 x float>, <4 x float> } @test_select_of_sincos_intrinsic_operand(<4 
   %result = call { <4 x float>, <4 x float> } @llvm.sincos.v4f32(<4 x float> %s)
   ret { <4 x float>, <4 x float> } %result
 }
+
+define i8 @test_select_rotate_left(i1 %0) {
+; CHECK-LABEL: @test_select_rotate_left(
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], i8 1, i8 -1
+; CHECK-NEXT:    [[RET:%.*]] = call i8 @llvm.fshl.i8(i8 [[S]], i8 [[S]], i8 1)
+; CHECK-NEXT:    ret i8 [[RET]]
+;
+  %s = select i1 %0, i8 1, i8 -1
+  %ret = call i8 @llvm.fshl.i8(i8 %s, i8 %s, i8 1)
+  ret i8 %ret
+}
+
+define i8 @test_select_rotate_left_poison(i1 %0) {
+; CHECK-LABEL: @test_select_rotate_left_poison(
+; CHECK-NEXT:    ret i8 -1
+;
+  %s = select i1 %0, i8 poison, i8 -1
+  %ret = call i8 @llvm.fshl.i8(i8 %s, i8 %s, i8 1)
+  ret i8 %ret
+}
+
+define i8 @test_select_rotate_left_multiuser(i1 %0) {
+; CHECK-LABEL: @test_select_rotate_left_multiuser(
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], i8 1, i8 -1
+; CHECK-NEXT:    [[RET:%.*]] = call i8 @llvm.fshl.i8(i8 [[S]], i8 [[S]], i8 1)
+; CHECK-NEXT:    call void @use(i8 [[S]])
+; CHECK-NEXT:    ret i8 [[RET]]
+;
+  %s = select i1 %0, i8 1, i8 -1
+  %ret = call i8 @llvm.fshl.i8(i8 %s, i8 %s, i8 1)
+  call void @use(i8 %s)
+  ret i8 %ret
+}
+
+define <2 x i8> @test_select_rotate_left_splat(i1 %0) {
+; CHECK-LABEL: @test_select_rotate_left_splat(
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> splat (i8 1), <2 x i8> splat (i8 -1)
+; CHECK-NEXT:    [[RET:%.*]] = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> [[S]], <2 x i8> [[S]], <2 x i8> splat (i8 1))
+; CHECK-NEXT:    ret <2 x i8> [[RET]]
+;
+  %s = select i1 %0, <2 x i8> <i8 1, i8 1>, <2 x i8> <i8 -1, i8 -1>
+  %ret = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> %s, <2 x i8> %s, <2 x i8> <i8 1, i8 1>)
+  ret <2 x i8> %ret
+}
+
+define <2 x i8> @test_select_rotate_left_splat_poison(i1 %0) {
+; CHECK-LABEL: @test_select_rotate_left_splat_poison(
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> <i8 1, i8 poison>, <2 x i8> splat (i8 -1)
+; CHECK-NEXT:    [[RET:%.*]] = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> [[S]], <2 x i8> [[S]], <2 x i8> splat (i8 1))
+; CHECK-NEXT:    ret <2 x i8> [[RET]]
+;
+  %s = select i1 %0, <2 x i8> <i8 1, i8 poison>, <2 x i8> <i8 -1, i8 -1>
+  %ret = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> %s, <2 x i8> %s, <2 x i8> <i8 1, i8 1>)
+  ret <2 x i8> %ret
+}
+
+define <2 x i8> @test_select_rotate_left_non_splat(i1 %0) {
+; CHECK-LABEL: @test_select_rotate_left_non_splat(
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> <i8 1, i8 2>, <2 x i8> <i8 -1, i8 -2>
+; CHECK-NEXT:    [[RET:%.*]] = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> [[S]], <2 x i8> [[S]], <2 x i8> splat (i8 1))
+; CHECK-NEXT:    ret <2 x i8> [[RET]]
+;
+  %s = select i1 %0, <2 x i8> <i8 1, i8 2>, <2 x i8> <i8 -1, i8 -2>
+  %ret = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> %s, <2 x i8> %s, <2 x i8> <i8 1, i8 1>)
+  ret <2 x i8> %ret
+}
+
+define i8 @test_select_rotate_right(i1 %0) {
+; CHECK-LABEL: @test_select_rotate_right(
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], i8 1, i8 -1
+; CHECK-NEXT:    [[RET:%.*]] = call i8 @llvm.fshl.i8(i8 [[S]], i8 [[S]], i8 1)
+; CHECK-NEXT:    ret i8 [[RET]]
+;
+  %s = select i1 %0, i8 1, i8 -1
+  %ret = call i8 @llvm.fshr.i8(i8 %s, i8 %s, i8 7)
+  ret i8 %ret
+}
+
+define i8 @test_select_rotate_right_poison_args(i1 %0) {
+; CHECK-LABEL: @test_select_rotate_right_poison_args(
+; CHECK-NEXT:    ret i8 -1
+;
+  %s = select i1 %0, i8 poison, i8 -1
+  %ret = call i8 @llvm.fshr.i8(i8 %s, i8 %s, i8 7)
+  ret i8 %ret
+}
+
+define i8 @test_select_rotate_right_multiuser(i1 %0) {
+; CHECK-LABEL: @test_select_rotate_right_multiuser(
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], i8 1, i8 -1
+; CHECK-NEXT:    [[RET:%.*]] = call i8 @llvm.fshl.i8(i8 [[S]], i8 [[S]], i8 1)
+; CHECK-NEXT:    call void @use(i8 [[S]])
+; CHECK-NEXT:    ret i8 [[RET]]
+;
+  %s = select i1 %0, i8 1, i8 -1
+  %ret = call i8 @llvm.fshr.i8(i8 %s, i8 %s, i8 7)
+  call void @use(i8 %s)
+  ret i8 %ret
+}
+
+define <2 x i8> @test_select_rotate_right_splat(i1 %0) {
+; CHECK-LABEL: @test_select_rotate_right_splat(
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> splat (i8 1), <2 x i8> splat (i8 -1)
+; CHECK-NEXT:    [[RET:%.*]] = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> [[S]], <2 x i8> [[S]], <2 x i8> splat (i8 1))
+; CHECK-NEXT:    ret <2 x i8> [[RET]]
+;
+  %s = select i1 %0, <2 x i8> <i8 1, i8 1>, <2 x i8> <i8 -1, i8 -1>
+  %ret = call <2 x i8> @llvm.fshr.v2i8(<2 x i8> %s, <2 x i8> %s, <2 x i8> <i8 7, i8 7>)
+  ret <2 x i8> %ret
+}
+
+define <2 x i8> @test_select_rotate_right_splat_poison(i1 %0) {
+; CHECK-LABEL: @test_select_rotate_right_splat_poison(
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> <i8 1, i8 poison>, <2 x i8> splat (i8 -1)
+; CHECK-NEXT:    [[RET:%.*]] = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> [[S]], <2 x i8> [[S]], <2 x i8> splat (i8 1))
+; CHECK-NEXT:    ret <2 x i8> [[RET]]
+;
+  %s = select i1 %0, <2 x i8> <i8 1, i8 poison>, <2 x i8> <i8 -1, i8 -1>
+  %ret = call <2 x i8> @llvm.fshr.v2i8(<2 x i8> %s, <2 x i8> %s, <2 x i8> <i8 7, i8 7>)
+  ret <2 x i8> %ret
+}
+
+define <2 x i8> @test_select_rotate_right_non_splat(i1 %0) {
+; CHECK-LABEL: @test_select_rotate_right_non_splat(
+; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], <2 x i8> <i8 1, i8 2>, <2 x i8> <i8 -1, i8 -2>
+; CHECK-NEXT:    [[RET:%.*]] = call <2 x i8> @llvm.fshl.v2i8(<2 x i8> [[S]], <2 x i8> [[S]], <2 x i8> splat (i8 1))
+; CHECK-NEXT:    ret <2 x i8> [[RET]]
+;
+  %s = select i1 %0, <2 x i8> <i8 1, i8 2>, <2 x i8> <i8 -1, i8 -2>
+  %ret = call <2 x i8> @llvm.fshr.v2i8(<2 x i8> %s, <2 x i8> %s, <2 x i8> <i8 7, i8 7>)
+  ret <2 x i8> %ret
+}

--- a/llvm/test/Transforms/InstCombine/intrinsic-select.ll
+++ b/llvm/test/Transforms/InstCombine/intrinsic-select.ll
@@ -437,15 +437,6 @@ define i8 @test_select_rotate_left(i1 %0) {
   ret i8 %ret
 }
 
-define i8 @test_select_rotate_left_poison(i1 %0) {
-; CHECK-LABEL: @test_select_rotate_left_poison(
-; CHECK-NEXT:    ret i8 -1
-;
-  %s = select i1 %0, i8 poison, i8 -1
-  %ret = call i8 @llvm.fshl.i8(i8 %s, i8 %s, i8 1)
-  ret i8 %ret
-}
-
 define i8 @test_select_rotate_left_multiuser(i1 %0) {
 ; CHECK-LABEL: @test_select_rotate_left_multiuser(
 ; CHECK-NEXT:    [[S:%.*]] = select i1 [[TMP0:%.*]], i8 1, i8 -1
@@ -495,15 +486,6 @@ define i8 @test_select_rotate_right(i1 %0) {
 ; CHECK-NEXT:    ret i8 [[RET]]
 ;
   %s = select i1 %0, i8 1, i8 -1
-  %ret = call i8 @llvm.fshr.i8(i8 %s, i8 %s, i8 7)
-  ret i8 %ret
-}
-
-define i8 @test_select_rotate_right_poison_args(i1 %0) {
-; CHECK-LABEL: @test_select_rotate_right_poison_args(
-; CHECK-NEXT:    ret i8 -1
-;
-  %s = select i1 %0, i8 poison, i8 -1
   %ret = call i8 @llvm.fshr.i8(i8 %s, i8 %s, i8 7)
   ret i8 %ret
 }


### PR DESCRIPTION
Closes #172176.

Previously, `FoldOpIntoSelect` wouldn't fold multi-use selects if `MultiUse` wasn't explicitly true. This prevents useful folding when the select is used multiple times in the same intrinsic call. Similar to what is done in `foldOpIntoPhi`, we'll now check that all of the uses come from a single user, rather than checking that there is only one use.