### PR TITLE
[SPIRV] Add support for non-interposable function aliases

### DIFF
--- a/llvm/test/CodeGen/SPIRV/ga-gv.ll
+++ b/llvm/test/CodeGen/SPIRV/ga-gv.ll
@@ -1,0 +1,24 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown < %s | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown -filetype=obj < %s  | spirv-val %}
+
+@glob = addrspace(1) global i32 0
+@glob_alias = alias i32, ptr addrspace(1) @glob
+
+define spir_kernel void @kernel() addrspace(4) {
+; CHECK: OpName %9 "kernel"
+; CHECK-NEXT: OpName %8 "glob"
+; CHECK-NEXT: OpName %2 "entry"
+; CHECK-NEXT: OpDecorate %8 LinkageAttributes "glob" Export
+; CHECK-NEXT: %3 = OpTypeVoid
+; CHECK-NEXT: %4 = OpTypeFunction %3
+; CHECK-NEXT: %5 = OpTypeInt 32 0
+; CHECK-NEXT: %6 = OpTypePointer CrossWorkgroup %5
+; CHECK-NEXT: %7 = OpConstantNull %5
+; CHECK-NEXT: %8 = OpVariable %6 CrossWorkgroup %7
+; CHECK-NEXT: %9 = OpFunction %3 None %4              ; -- Begin function kernel
+; CHECK-NEXT: %2 = OpLabel
+; CHECK-NEXT: OpStore %8 %7 Aligned 4
+entry:
+  store i32 0, ptr addrspace(1) @glob_alias
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/ga-interp-func-interp.ll
+++ b/llvm/test/CodeGen/SPIRV/ga-interp-func-interp.ll
@@ -1,0 +1,17 @@
+; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown < %s 2>&1 | FileCheck %s
+; CHECK: unable to translate instruction: call (in function: kernel)
+
+; Interposable aliases are not yet supported.
+@bar_alias = weak alias void (), ptr addrspace(4) @bar
+
+; Interposable functions are not yet supported for aliasing resolution.
+define weak spir_func void @bar() addrspace(4) {
+entry:
+  ret void
+}
+
+define spir_kernel void @kernel() addrspace(4) {
+entry:
+  call spir_func addrspace(4) void @bar_alias()
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/ga-interp-func-noninterp.ll
+++ b/llvm/test/CodeGen/SPIRV/ga-interp-func-noninterp.ll
@@ -1,0 +1,16 @@
+; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown < %s 2>&1 | FileCheck %s
+; CHECK: unable to translate instruction: call (in function: kernel)
+
+; Interposable aliases are not yet supported.
+@bar_alias = weak alias void (), ptr addrspace(4) @bar
+
+define spir_func void @bar() addrspace(4) {
+entry:
+  ret void
+}
+
+define spir_kernel void @kernel() addrspace(4) {
+entry:
+  call spir_func addrspace(4) void @bar_alias()
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/ga-inttoptr.ll
+++ b/llvm/test/CodeGen/SPIRV/ga-inttoptr.ll
@@ -1,0 +1,11 @@
+; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown < %s 2>&1 | FileCheck %s
+; CHECK: argument of incompatible type!
+
+; The BE does not support non-global-object aliases
+@glob.inttoptr = alias i32, inttoptr (i64 12345 to ptr)
+
+define spir_kernel void @kernel() addrspace(4) {
+entry:
+  store i32 0, ptr @glob.inttoptr
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/ga-noninterp-func-interp.ll
+++ b/llvm/test/CodeGen/SPIRV/ga-noninterp-func-interp.ll
@@ -1,0 +1,16 @@
+; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown < %s 2>&1 | FileCheck %s
+; CHECK: unable to translate instruction: call (in function: kernel)
+
+@bar_alias = alias void (), ptr addrspace(4) @bar
+
+; Interposable functions are not yet supported for aliasing resolution.
+define weak spir_func void @bar() addrspace(4) {
+entry:
+  ret void
+}
+
+define spir_kernel void @kernel() addrspace(4) {
+entry:
+  call spir_func addrspace(4) void @bar_alias()
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/ga-noninterp-func-noninterp.ll
+++ b/llvm/test/CodeGen/SPIRV/ga-noninterp-func-noninterp.ll
@@ -1,0 +1,22 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown < %s | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown -filetype=obj < %s  | spirv-val %}
+
+@bar_alias = alias void (), ptr addrspace(4) @bar
+
+define spir_func void @bar() addrspace(4) {
+; CHECK:         %6 = OpFunction %4 None %5 ; -- Begin function bar
+; CHECK-NEXT:    %2 = OpLabel
+; CHECK-NEXT:    OpReturn
+; CHECK-NEXT:    OpFunctionEnd
+entry:
+  ret void
+}
+
+define spir_kernel void @kernel() addrspace(4) {
+entry:
+; CHECK: %7 = OpFunction %4 None %5              ; -- Begin function kernel
+; CHECK-NEXT: %3 = OpLabel
+; CHECK-NEXT: %8 = OpFunctionCall %4 %6
+  call spir_func addrspace(4) void @bar_alias()
+  ret void
+}


### PR DESCRIPTION
The backend was not handling GlobalAliases such as in call targets. This patch pre-processes the aliases in the module and resolve them to their aliasee when possible. The patch also documents those cases that are not yet supported.

This LLVM defect was identified via the AMD Fuzzing project