### PR TITLE
[MLIR] Fix AsmPrinter alias uniqueness check

### DIFF
--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -1090,9 +1090,12 @@ unsigned AliasInitializer::uniqueAliasNameIndex(
   }
   // Otherwise, we had a conflict - probe until we find a unique name.
   SmallString<64> probeAlias(alias);
+  size_t probeSize = probeAlias.size();
   // alias with trailing digit will be printed as _N
-  if (isdigit(alias.back()))
+  if (isdigit(alias.back())) {
     probeAlias.push_back('_');
+    probeSize++;
+  }
   // nameCounts start from 1 because 0 is not printed in SymbolAlias.
   if (nameCounts[probeAlias] == 0)
     nameCounts[probeAlias] = 1;
@@ -1106,7 +1109,7 @@ unsigned AliasInitializer::uniqueAliasNameIndex(
       return nameIndex;
     }
     // Reset probeAlias to the original alias for the next iteration.
-    probeAlias.resize(alias.size() + isdigit(alias.back()) ? 1 : 0);
+    probeAlias.resize(probeSize);
   }
 }
 

--- a/mlir/test/IR/print-attr-type-aliases.mlir
+++ b/mlir/test/IR/print-attr-type-aliases.mlir
@@ -90,3 +90,16 @@
 // CHECK: fused<#test.conditional_alias<#[[TEST_ALIAS]]>
 // CHECK: "test.op"
 "test.op"() {attr = #no_alias} : () -> () loc(fused<#no_alias>["test.mlir":0:0])
+
+// -----
+
+// Check that conflicting aliases are printed correctly in the presence of different nesting levels.
+
+// CHECK: #unique_base = #test.nested_alias<"alias_test:trailing_digit_conflict_base">
+// CHECK: #unique_base1 = #test.nested_alias<"alias_test:trailing_digit_conflict_base1">
+// CHECK: #unique_base2 = #test.nested_alias<"alias_test:trailing_digit_conflict_base_conflict", #unique_base1>
+
+// CHECK: alias_test = #test.nested_alias<"alias_test:trailing_digit_conflict_other", #unique_base>
+// CHECK-NEXT: alias_test = #unique_base2
+"test.op"() {alias_test = #test.nested_alias<"alias_test:trailing_digit_conflict_other", #test.nested_alias<"alias_test:trailing_digit_conflict_base">>} : () -> ()
+"test.op"() {alias_test = #test.nested_alias<"alias_test:trailing_digit_conflict_base_conflict", #test.nested_alias<"alias_test:trailing_digit_conflict_base1">>} : () -> ()

--- a/mlir/test/lib/Dialect/Test/TestAttrDefs.td
+++ b/mlir/test/lib/Dialect/Test/TestAttrDefs.td
@@ -360,6 +360,14 @@ def TestConditionalAliasAttr : Test_Attr<"TestConditionalAlias"> {
   }];
 }
 
+def TestNestedAliasAttr : Test_Attr<"TestNestedAlias"> {
+  let mnemonic = "nested_alias";
+  let parameters = (ins "mlir::StringAttr":$value, OptionalParameter<"TestNestedAliasAttr">:$nested);
+  let assemblyFormat = [{
+    `<` $value (`,` $nested^)? `>`
+  }];
+}
+
 // Test AsmParser::parseFloat(const fltSemnatics&, APFloat&) API through the
 // custom parser and printer.
 def TestCustomFloatAttr : Test_Attr<"TestCustomFloat"> {

--- a/mlir/test/lib/Dialect/Test/TestDialectInterfaces.cpp
+++ b/mlir/test/lib/Dialect/Test/TestDialectInterfaces.cpp
@@ -177,6 +177,22 @@ struct TestOpAsmInterface : public OpAsmDialectInterface {
   //===------------------------------------------------------------------===//
 
   AliasResult getAlias(Attribute attr, raw_ostream &os) const final {
+    if (auto nestedAttr = dyn_cast<TestNestedAliasAttr>(attr)) {
+      std::optional<StringRef> aliasName =
+          StringSwitch<std::optional<StringRef>>(nestedAttr.getValue())
+              .Case("alias_test:trailing_digit_conflict_base",
+                    StringRef("unique_base"))
+              .Case("alias_test:trailing_digit_conflict_base_conflict",
+                    StringRef("unique_base"))
+              .Case("alias_test:trailing_digit_conflict_base1",
+                    StringRef("unique_base1"))
+              .Default(std::nullopt);
+      if (!aliasName)
+        return AliasResult::NoAlias;
+      os << *aliasName;
+      return AliasResult::FinalAlias;
+    }
+
     StringAttr strAttr = dyn_cast<StringAttr>(attr);
     if (!strAttr)
       return AliasResult::NoAlias;


### PR DESCRIPTION
A sneaky operator precedence bug caused this resize operation to always truncate to size 0 or 1:
```
probeAlias.resize(alias.size() + isdigit(alias.back()) ? 1 : 0);
```
Because `+` is associated more strongly than the ternary operator. This eventually led to the asm printer repeating an alias name, generating illegal IR.

It wasn't a problem in most cases because it required two things to trigger:
- Two naturally generated aliases, one "xxx" the other "xxx1" (note the trailing "1").
- A unique processing order such that we process "xxx", then "xxx1", then "xxx" again. This can only happen if they happen to be at different "alias depths", since otherwise the pre-sorting will make sure this ordering never happens. See the added test case for how this works in practice (I will also attach what the current code generates).

This PR fixes the operator precedence, but also moves the calculation outside the loop since it never changes.