### PR TITLE
[lldb] Fix TestIvarProtocols to use +new instead of +alloc (NFC)

### DIFF
--- a/lldb/test/API/lang/objc/objc-ivar-protocols/main.m
+++ b/lldb/test/API/lang/objc/objc-ivar-protocols/main.m
@@ -27,7 +27,7 @@ int main ()
 {
   @autoreleasepool
   {
-    MyClass *c = [MyClass alloc];
+    MyClass *c = [MyClass new];
     [c doSomething];
   }
 }


### PR DESCRIPTION
A test failure on green dragon shows the ivars with unexpected values. This makes the test us an explicit `+new` instead of `+alloc` (which is missing an `-init` call).