### PR TITLE
[clang][deps] Extract `CompilerInvocation` creation

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
+++ b/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
@@ -124,9 +124,6 @@ std::optional<PrebuiltModulesAttrsMap>
 computePrebuiltModulesASTMap(CompilerInstance &ScanInstance,
                              SmallVector<StringRef> &StableDirs);
 
-std::unique_ptr<DependencyOutputOptions>
-takeAndUpdateDependencyOutputOptionsFrom(CompilerInstance &ScanInstance);
-
 /// Create the dependency collector that will collect the produced
 /// dependencies. May return the created ModuleDepCollector depending
 /// on the scanning format.

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -491,34 +491,10 @@ void dependencies::initializeScanCompilerInstance(
     DiagnosticConsumer *DiagConsumer, DependencyScanningService &Service,
     IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS) {
   ScanInstance.setBuildingModule(false);
-
   ScanInstance.createVirtualFileSystem(FS, DiagConsumer);
-
-  // Create the compiler's actual diagnostics engine.
-  sanitizeDiagOpts(ScanInstance.getDiagnosticOpts());
   ScanInstance.createDiagnostics(DiagConsumer, /*ShouldOwnClient=*/false);
-
-  ScanInstance.getPreprocessorOpts().AllowPCHWithDifferentModulesCachePath =
-      true;
-
-  if (ScanInstance.getHeaderSearchOpts().ModulesValidateOncePerBuildSession)
-    ScanInstance.getHeaderSearchOpts().BuildSessionTimestamp =
-        Service.getBuildSessionTimestamp();
-
-  ScanInstance.getFrontendOpts().DisableFree = false;
-  ScanInstance.getFrontendOpts().GenerateGlobalModuleIndex = false;
-  ScanInstance.getFrontendOpts().UseGlobalModuleIndex = false;
-  ScanInstance.getFrontendOpts().GenReducedBMI = false;
-  ScanInstance.getFrontendOpts().ModuleOutputPath.clear();
-  // This will prevent us compiling individual modules asynchronously since
-  // FileManager is not thread-safe, but it does improve performance for now.
-  ScanInstance.getFrontendOpts().ModulesShareFileManager = true;
-  ScanInstance.getHeaderSearchOpts().ModuleFormat = "raw";
-  ScanInstance.getHeaderSearchOpts().ModulesIncludeVFSUsage =
-      any(Service.getOptimizeArgs() & ScanningOptimizations::VFS);
-
-  // Create a new FileManager to match the invocation's FileSystemOptions.
   ScanInstance.createFileManager();
+  ScanInstance.createSourceManager();
 
   // Use DepFS for getting the dependency directives if requested to do so.
   if (Service.getMode() == ScanningMode::DependencyDirectivesScan) {
@@ -534,23 +510,56 @@ void dependencies::initializeScanCompilerInstance(
         std::make_unique<ScanningDependencyDirectivesGetter>(
             ScanInstance.getFileManager()));
   }
+}
 
-  ScanInstance.createSourceManager();
+/// Creates a CompilerInvocation suitable for the dependency scanner.
+static std::shared_ptr<CompilerInvocation>
+createScanCompilerInvocation(const CompilerInvocation &Invocation,
+                             const DependencyScanningService &Service) {
+  auto ScanInvocation = std::make_shared<CompilerInvocation>(Invocation);
+
+  sanitizeDiagOpts(ScanInvocation->getDiagnosticOpts());
+
+  ScanInvocation->getPreprocessorOpts().AllowPCHWithDifferentModulesCachePath =
+      true;
+
+  if (ScanInvocation->getHeaderSearchOpts().ModulesValidateOncePerBuildSession)
+    ScanInvocation->getHeaderSearchOpts().BuildSessionTimestamp =
+        Service.getBuildSessionTimestamp();
+
+  ScanInvocation->getFrontendOpts().DisableFree = false;
+  ScanInvocation->getFrontendOpts().GenerateGlobalModuleIndex = false;
+  ScanInvocation->getFrontendOpts().UseGlobalModuleIndex = false;
+  ScanInvocation->getFrontendOpts().GenReducedBMI = false;
+  ScanInvocation->getFrontendOpts().ModuleOutputPath.clear();
+  // This will prevent us compiling individual modules asynchronously since
+  // FileManager is not thread-safe, but it does improve performance for now.
+  ScanInvocation->getFrontendOpts().ModulesShareFileManager = true;
+  ScanInvocation->getHeaderSearchOpts().ModuleFormat = "raw";
+  ScanInvocation->getHeaderSearchOpts().ModulesIncludeVFSUsage =
+      any(Service.getOptimizeArgs() & ScanningOptimizations::VFS);
 
   // Consider different header search and diagnostic options to create
   // different modules. This avoids the unsound aliasing of module PCMs.
   //
   // TODO: Implement diagnostic bucketing to reduce the impact of strict
   // context hashing.
-  ScanInstance.getHeaderSearchOpts().ModulesStrictContextHash = true;
-  ScanInstance.getHeaderSearchOpts().ModulesSerializeOnlyPreprocessor = true;
-  ScanInstance.getHeaderSearchOpts().ModulesSkipDiagnosticOptions = true;
-  ScanInstance.getHeaderSearchOpts().ModulesSkipHeaderSearchPaths = true;
-  ScanInstance.getHeaderSearchOpts().ModulesSkipPragmaDiagnosticMappings = true;
-  ScanInstance.getHeaderSearchOpts().ModulesForceValidateUserHeaders = false;
+  ScanInvocation->getHeaderSearchOpts().ModulesStrictContextHash = true;
+  ScanInvocation->getHeaderSearchOpts().ModulesSerializeOnlyPreprocessor = true;
+  ScanInvocation->getHeaderSearchOpts().ModulesSkipDiagnosticOptions = true;
+  ScanInvocation->getHeaderSearchOpts().ModulesSkipHeaderSearchPaths = true;
+  ScanInvocation->getHeaderSearchOpts().ModulesSkipPragmaDiagnosticMappings =
+      true;
+  ScanInvocation->getHeaderSearchOpts().ModulesForceValidateUserHeaders = false;
 
   // Avoid some checks and module map parsing when loading PCM files.
-  ScanInstance.getPreprocessorOpts().ModulesCheckRelocated = false;
+  ScanInvocation->getPreprocessorOpts().ModulesCheckRelocated = false;
+
+  // Ensure that the scanner does not create new dependency collectors,
+  // and thus won't write out the extra '.d' files to disk.
+  ScanInvocation->getDependencyOutputOpts() = {};
+
+  return ScanInvocation;
 }
 
 llvm::SmallVector<StringRef>
@@ -584,20 +593,17 @@ dependencies::computePrebuiltModulesASTMap(
   return PrebuiltModulesASTMap;
 }
 
-std::unique_ptr<DependencyOutputOptions>
-dependencies::takeAndUpdateDependencyOutputOptionsFrom(
-    CompilerInstance &ScanInstance) {
-  // This function moves the existing dependency output options from the
-  // invocation to the collector. The options in the invocation are reset,
-  // which ensures that the compiler won't create new dependency collectors,
-  // and thus won't write out the extra '.d' files to disk.
-  auto Opts = std::make_unique<DependencyOutputOptions>();
-  std::swap(*Opts, ScanInstance.getInvocation().getDependencyOutputOpts());
+/// Creates dependency output options to be reported to the dependency consumer,
+/// deducing missing information if necessary.
+static std::unique_ptr<DependencyOutputOptions>
+createDependencyOutputOptions(const CompilerInvocation &Invocation) {
+  auto Opts = std::make_unique<DependencyOutputOptions>(
+      Invocation.getDependencyOutputOpts());
   // We need at least one -MT equivalent for the generator of make dependency
   // files to work.
   if (Opts->Targets.empty())
-    Opts->Targets = {deduceDepTarget(ScanInstance.getFrontendOpts().OutputFile,
-                                     ScanInstance.getFrontendOpts().Inputs)};
+    Opts->Targets = {deduceDepTarget(Invocation.getFrontendOpts().OutputFile,
+                                     Invocation.getFrontendOpts().Inputs)};
   Opts->IncludeSystemHeaders = true;
 
   return Opts;
@@ -632,18 +638,15 @@ dependencies::initializeScanInstanceDependencyCollector(
 }
 
 bool DependencyScanningAction::runInvocation(
-    std::string Executable, std::unique_ptr<CompilerInvocation> Invocation,
+    std::string Executable,
+    std::unique_ptr<CompilerInvocation> OriginalInvocation,
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS,
     std::shared_ptr<PCHContainerOperations> PCHContainerOps,
     DiagnosticConsumer *DiagConsumer) {
-  // Making sure that we canonicalize the defines before we create the deep
-  // copy to avoid unnecessary variants in the scanner and in the resulting
-  // explicit command lines.
+  // Making sure that we canonicalize the defines early to avoid unnecessary
+  // variants in both the scanner and in the resulting  explicit command lines.
   if (any(Service.getOptimizeArgs() & ScanningOptimizations::Macros))
-    canonicalizeDefines(Invocation->getPreprocessorOpts());
-
-  // Make a deep copy of the original Clang invocation.
-  CompilerInvocation OriginalInvocation(*Invocation);
+    canonicalizeDefines(OriginalInvocation->getPreprocessorOpts());
 
   if (Scanned) {
     // Scanning runs once for the first -cc1 invocation in a chain of driver
@@ -651,18 +654,20 @@ bool DependencyScanningAction::runInvocation(
     // update the new invocation.
     // FIXME: to support multi-arch builds, each arch requires a separate scan
     if (MDC)
-      MDC->applyDiscoveredDependencies(OriginalInvocation);
+      MDC->applyDiscoveredDependencies(*OriginalInvocation);
     Consumer.handleBuildCommand(
-        {Executable, OriginalInvocation.getCC1CommandLine()});
+        {Executable, OriginalInvocation->getCC1CommandLine()});
     return true;
   }
 
   Scanned = true;
 
   // Create a compiler instance to handle the actual work.
+  auto ScanInvocation =
+      createScanCompilerInvocation(*OriginalInvocation, Service);
   auto ModCache = makeInProcessModuleCache(Service.getModuleCacheEntries());
-  ScanInstanceStorage.emplace(std::move(Invocation), std::move(PCHContainerOps),
-                              ModCache.get());
+  ScanInstanceStorage.emplace(std::move(ScanInvocation),
+                              std::move(PCHContainerOps), ModCache.get());
   CompilerInstance &ScanInstance = *ScanInstanceStorage;
 
   assert(!DiagConsumerFinished && "attempt to reuse finished consumer");
@@ -675,11 +680,11 @@ bool DependencyScanningAction::runInvocation(
   if (!MaybePrebuiltModulesASTMap)
     return false;
 
-  auto DepOutputOpts = takeAndUpdateDependencyOutputOptionsFrom(ScanInstance);
+  auto DepOutputOpts = createDependencyOutputOptions(*OriginalInvocation);
 
   MDC = initializeScanInstanceDependencyCollector(
       ScanInstance, std::move(DepOutputOpts), WorkingDirectory, Consumer,
-      Service, OriginalInvocation, Controller, *MaybePrebuiltModulesASTMap,
+      Service, *OriginalInvocation, Controller, *MaybePrebuiltModulesASTMap,
       StableDirs);
 
   std::unique_ptr<FrontendAction> Action;
@@ -699,9 +704,9 @@ bool DependencyScanningAction::runInvocation(
 
   if (Result) {
     if (MDC)
-      MDC->applyDiscoveredDependencies(OriginalInvocation);
+      MDC->applyDiscoveredDependencies(*OriginalInvocation);
     Consumer.handleBuildCommand(
-        {Executable, OriginalInvocation.getCC1CommandLine()});
+        {Executable, OriginalInvocation->getCC1CommandLine()});
   }
 
   return Result;
@@ -739,7 +744,7 @@ bool CompilerInstanceWithContext::initialize(
   IntrusiveRefCntPtr<ModuleCache> ModCache =
       makeInProcessModuleCache(Worker.Service.getModuleCacheEntries());
   CIPtr = std::make_unique<CompilerInstance>(
-      std::make_shared<CompilerInvocation>(*OriginalInvocation),
+      createScanCompilerInvocation(*OriginalInvocation, Worker.Service),
       Worker.PCHContainerOps, ModCache.get());
   auto &CI = *CIPtr;
 
@@ -754,7 +759,7 @@ bool CompilerInstanceWithContext::initialize(
     return false;
 
   PrebuiltModuleASTMap = std::move(*MaybePrebuiltModulesASTMap);
-  OutputOpts = takeAndUpdateDependencyOutputOptionsFrom(CI);
+  OutputOpts = createDependencyOutputOptions(*OriginalInvocation);
 
   // We do not create the target in initializeScanCompilerInstance because
   // setting it here is unique for by-name lookups. We create the target only


### PR DESCRIPTION
This PR extracts the modifications we make to the scanner's `CompilerInvocation` from multiple spots into a single function.