### PR TITLE
[clang][Frontend] Use move semantics when translating standalone diagnostics (NFC)

### DIFF
--- a/clang/include/clang/Frontend/StandaloneDiagnostic.h
+++ b/clang/include/clang/Frontend/StandaloneDiagnostic.h
@@ -74,7 +74,7 @@ struct StandaloneDiagnostic {
 /// StandaloneDiagnostics themselfs cannot be emitted directly.
 StoredDiagnostic
 translateStandaloneDiag(FileManager &FileMgr, SourceManager &SrcMgr,
-                        const StandaloneDiagnostic &StandaloneDiag,
+                        StandaloneDiagnostic StandaloneDiag,
                         llvm::StringMap<SourceLocation> &SrcLocCache);
 
 } // namespace clang

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -1225,13 +1225,11 @@ bool ASTUnit::Parse(std::shared_ptr<PCHContainerOperations> PCHContainerOps,
   if (SavedMainFileBuffer) {
     StoredDiagnostics.clear();
     StoredDiagnostics.reserve(PreambleDiagnostics.size());
-    llvm::transform(std::move(PreambleDiagnostics),
-                    std::back_inserter(StoredDiagnostics),
-                    [&](auto &&StandaloneDiag) {
-                      return translateStandaloneDiag(
-                          getFileManager(), getSourceManager(),
-                          std::move(StandaloneDiag), PreambleSrcLocCache);
-                    });
+    for (auto &PreambleDiag : PreambleDiagnostics) {
+      StoredDiagnostics.push_back(translateStandaloneDiag(
+          getFileManager(), getSourceManager(), std::move(PreambleDiag),
+          PreambleSrcLocCache));
+    }
   } else
     PreambleSrcLocCache.clear();
 


### PR DESCRIPTION
This optimizes translateStandaloneDiag to avoid copying strings in multiple places and cleans up a hard-to-read transform.