### PR TITLE
[clang-tidy][NFC] Remove redundant braces with clang-format 'RemoveBracesLLVM' (1/N)

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -108,9 +108,8 @@ public:
     DiagOpts.ShowColors = Context.getOptions().UseColor.value_or(
         llvm::sys::Process::StandardOutHasColors());
     DiagPrinter->BeginSourceFile(LangOpts);
-    if (DiagOpts.ShowColors && !llvm::sys::Process::StandardOutIsDisplayed()) {
+    if (DiagOpts.ShowColors && !llvm::sys::Process::StandardOutIsDisplayed())
       llvm::sys::Process::UseANSIEscapeCodes(true);
-    }
   }
 
   SourceManager &getSourceManager() { return SourceMgr; }
@@ -234,9 +233,8 @@ public:
           llvm::errs() << llvm::toString(FormattedReplacements.takeError())
                        << ". Skipping formatting.\n";
         }
-        if (!tooling::applyAllReplacements(Replacements.get(), Rewrite)) {
+        if (!tooling::applyAllReplacements(Replacements.get(), Rewrite))
           llvm::errs() << "Can't apply replacements for file " << File << "\n";
-        }
         AnyNotWritten |= Rewrite.overwriteChangedFiles();
       }
 
@@ -491,10 +489,9 @@ ClangTidyASTConsumerFactory::createASTConsumer(
 
 std::vector<std::string> ClangTidyASTConsumerFactory::getCheckNames() {
   std::vector<std::string> CheckNames;
-  for (const auto &CheckFactory : *CheckFactories) {
+  for (const auto &CheckFactory : *CheckFactories)
     if (Context.isCheckEnabled(CheckFactory.getKey()))
       CheckNames.emplace_back(CheckFactory.getKey());
-  }
 
 #if CLANG_TIDY_ENABLE_STATIC_ANALYZER
   for (const auto &AnalyzerCheck : getAnalyzerCheckersAndPackages(
@@ -749,9 +746,8 @@ ChecksAndOptions getAllChecksAndOptions(bool AllowEnablingAnalyzerAlphaCheckers,
 #endif // CLANG_TIDY_ENABLE_STATIC_ANALYZER
 
   Context.setOptionsCollector(&Result.Options);
-  for (const auto &Factory : Factories) {
+  for (const auto &Factory : Factories)
     Factory.getValue()(Factory.getKey(), &Context);
-  }
 
   return Result;
 }

--- a/clang-tools-extra/clang-tidy/ClangTidyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyCheck.cpp
@@ -165,9 +165,8 @@ ClangTidyCheck::OptionsView::getEnumInt(StringRef LocalName,
   StringRef Closest;
   unsigned EditDistance = 3;
   for (const auto &NameAndEnum : Mapping) {
-    if (Value == NameAndEnum.second) {
+    if (Value == NameAndEnum.second)
       return NameAndEnum.first;
-    }
     if (Value.equals_insensitive(NameAndEnum.second)) {
       Closest = NameAndEnum.second;
       EditDistance = 0;

--- a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
@@ -690,17 +690,15 @@ void ClangTidyDiagnosticConsumer::removeIncompatibleErrors() {
   std::vector<
       std::pair<ClangTidyError *, llvm::StringMap<tooling::Replacements> *>>
       ErrorFixes;
-  for (auto &Error : Errors) {
+  for (auto &Error : Errors)
     if (const auto *Fix = getFixIt(Error, GetFixesFromNotes))
       ErrorFixes.emplace_back(
           &Error, const_cast<llvm::StringMap<tooling::Replacements> *>(Fix));
-  }
   for (const auto &ErrorAndFix : ErrorFixes) {
     int Size = 0;
-    for (const auto &FileAndReplaces : *ErrorAndFix.second) {
+    for (const auto &FileAndReplaces : *ErrorAndFix.second)
       for (const auto &Replace : FileAndReplaces.second)
         Size += Replace.getLength();
-    }
     Sizes.push_back(Size);
   }
 

--- a/clang-tools-extra/clang-tidy/ClangTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyModule.cpp
@@ -23,10 +23,9 @@ void ClangTidyCheckFactories::registerCheckFactory(StringRef Name,
 std::vector<std::unique_ptr<ClangTidyCheck>>
 ClangTidyCheckFactories::createChecks(ClangTidyContext *Context) const {
   std::vector<std::unique_ptr<ClangTidyCheck>> Checks;
-  for (const auto &[CheckName, Factory] : Factories) {
+  for (const auto &[CheckName, Factory] : Factories)
     if (Context->isCheckEnabled(CheckName))
       Checks.emplace_back(Factory(CheckName, Context));
-  }
   return Checks;
 }
 

--- a/clang-tools-extra/clang-tidy/ClangTidyOptions.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyOptions.cpp
@@ -52,10 +52,9 @@ template <> struct MappingTraits<FileFilter> {
   static std::string validate(IO &Io, FileFilter &File) {
     if (File.Name.empty())
       return "No file name specified";
-    for (const FileFilter::LineRange &Range : File.LineRanges) {
+    for (const FileFilter::LineRange &Range : File.LineRanges)
       if (Range.first <= 0 || Range.second <= 0)
         return "Invalid line range";
-    }
     return "";
   }
 };
@@ -91,9 +90,8 @@ void yamlize(IO &IO, ClangTidyOptions::OptionMap &Val, bool,
     // Ensure check options are sorted
     std::vector<std::pair<StringRef, StringRef>> SortedOptions;
     SortedOptions.reserve(Val.size());
-    for (auto &Key : Val) {
+    for (auto &Key : Val)
       SortedOptions.emplace_back(Key.getKey(), Key.getValue().Value);
-    }
     std::sort(SortedOptions.begin(), SortedOptions.end());
 
     IO.beginMapping();
@@ -361,9 +359,8 @@ ConfigOptionsProvider::getRawOptions(llvm::StringRef FileName) {
 
     llvm::ErrorOr<llvm::SmallString<128>> AbsoluteFilePath =
         getNormalizedAbsolutePath(FileName);
-    if (AbsoluteFilePath) {
+    if (AbsoluteFilePath)
       addRawFileOptions(AbsoluteFilePath->str(), RawOptions);
-    }
   }
   RawOptions.emplace_back(ConfigOptions,
                           OptionsSourceTypeConfigCommandLineOption);

--- a/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.cpp
+++ b/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.cpp
@@ -129,13 +129,11 @@ void ExpandModularHeadersPPCallbacks::handleModuleFile(
 
 void ExpandModularHeadersPPCallbacks::parseToLocation(SourceLocation Loc) {
   // Load all source locations present in the external sources.
-  for (unsigned I = 0, N = Sources.loaded_sloc_entry_size(); I != N; ++I) {
+  for (unsigned I = 0, N = Sources.loaded_sloc_entry_size(); I != N; ++I)
     Sources.getLoadedSLocEntry(I, nullptr);
-  }
   // Record contents of files we are interested in and add to the FileSystem.
-  for (auto It = Sources.fileinfo_begin(); It != Sources.fileinfo_end(); ++It) {
+  for (auto It = Sources.fileinfo_begin(); It != Sources.fileinfo_end(); ++It)
     Recorder->recordFileContent(It->getFirst(), *It->getSecond(), *InMemoryFs);
-  }
   Recorder->checkAllFilesRecorded();
 
   if (!StartedLexing) {

--- a/clang-tools-extra/clang-tidy/GlobList.cpp
+++ b/clang-tools-extra/clang-tidy/GlobList.cpp
@@ -59,10 +59,9 @@ GlobList::GlobList(StringRef Globs, bool KeepNegativeGlobs /* =true */) {
 bool GlobList::contains(StringRef S) const {
   // Iterating the container backwards as the last match determins if S is in
   // the list.
-  for (const GlobListItem &Item : llvm::reverse(Items)) {
+  for (const GlobListItem &Item : llvm::reverse(Items))
     if (Item.Regex.match(S))
       return Item.IsPositive;
-  }
   return false;
 }
 

--- a/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ArgumentCommentCheck.cpp
@@ -234,9 +234,8 @@ static const FunctionDecl *resolveMocks(const FunctionDecl *Func) {
     if (const auto *MockedMethod = findMockedMethod(Method)) {
       // If mocked method overrides the real one, we can use its parameter
       // names, otherwise we're out of luck.
-      if (MockedMethod->size_overridden_methods() > 0) {
+      if (MockedMethod->size_overridden_methods() > 0)
         return *MockedMethod->begin_overridden_methods();
-      }
       return nullptr;
     }
   }

--- a/clang-tools-extra/clang-tidy/bugprone/AssertSideEffectCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/AssertSideEffectCheck.cpp
@@ -34,9 +34,8 @@ AST_MATCHER_P2(Expr, hasSideEffect, bool, CheckFunctionCalls,
            OC == UO_PreDec;
   }
 
-  if (const auto *Op = dyn_cast<BinaryOperator>(E)) {
+  if (const auto *Op = dyn_cast<BinaryOperator>(E))
     return Op->isAssignmentOp();
-  }
 
   if (const auto *OpCallExpr = dyn_cast<CXXOperatorCallExpr>(E)) {
     if (const auto *MethodDecl =

--- a/clang-tools-extra/clang-tidy/bugprone/BranchCloneCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/BranchCloneCheck.cpp
@@ -74,10 +74,9 @@ static bool isFallthroughSwitchBranch(const SwitchBranch &Branch) {
     }
   } Visitor;
 
-  for (const Stmt *Elem : Branch) {
+  for (const Stmt *Elem : Branch)
     if (!Visitor.TraverseStmt(const_cast<Stmt *>(Elem)))
       return true;
-  }
   return false;
 }
 
@@ -352,9 +351,8 @@ void BranchCloneCheck::check(const MatchFinder::MatchResult &Result) {
           const SourceLocation End =
               Lexer::getLocForEndOfToken(Branches[I]->getEndLoc(), 0,
                                          *Result.SourceManager, getLangOpts());
-          if (End.isValid()) {
+          if (End.isValid())
             diag(End, "end of the original", DiagnosticIDs::Note);
-          }
         }
 
         diag(Branches[J]->getBeginLoc(), "clone %0 starts here",
@@ -441,9 +439,8 @@ void BranchCloneCheck::check(const MatchFinder::MatchResult &Result) {
         EndLoc = Context.getSourceManager().getExpansionLoc(EndLoc);
       EndLoc = Lexer::getLocForEndOfToken(EndLoc, 0, *Result.SourceManager,
                                           getLangOpts());
-      if (EndLoc.isValid()) {
+      if (EndLoc.isValid())
         diag(EndLoc, "last of these clones ends here", DiagnosticIDs::Note);
-      }
       BeginCurrent = EndCurrent;
     }
     return;

--- a/clang-tools-extra/clang-tidy/bugprone/ComparePointerToMemberVirtualFunctionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ComparePointerToMemberVirtualFunctionCheck.cpp
@@ -85,9 +85,8 @@ void ComparePointerToMemberVirtualFunctionCheck::check(
     return Ret;
   };
 
-  if (StopVisit != VisitSameSignatureVirtualMethods(RD)) {
+  if (StopVisit != VisitSameSignatureVirtualMethods(RD))
     RD->forallBases(VisitSameSignatureVirtualMethods);
-  }
 
   if (!SameSignatureVirtualMethods.empty()) {
     diag(BO->getOperatorLoc(), ErrorMsg);

--- a/clang-tools-extra/clang-tidy/bugprone/CrtpConstructorAccessibilityCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/CrtpConstructorAccessibilityCheck.cpp
@@ -24,9 +24,8 @@ static bool isDerivedParameterBefriended(const CXXRecordDecl *CRTP,
                                          const NamedDecl *Param) {
   return llvm::any_of(CRTP->friends(), [&](const FriendDecl *Friend) {
     const TypeSourceInfo *const FriendType = Friend->getFriendType();
-    if (!FriendType) {
+    if (!FriendType)
       return false;
-    }
 
     const auto *const TTPT =
         dyn_cast<TemplateTypeParmType>(FriendType->getType());
@@ -39,9 +38,8 @@ static bool isDerivedClassBefriended(const CXXRecordDecl *CRTP,
                                      const CXXRecordDecl *Derived) {
   return llvm::any_of(CRTP->friends(), [&](const FriendDecl *Friend) {
     const TypeSourceInfo *const FriendType = Friend->getFriendType();
-    if (!FriendType) {
+    if (!FriendType)
       return false;
-    }
 
     return declaresSameEntity(FriendType->getType()->getAsCXXRecordDecl(),
                               Derived);
@@ -106,9 +104,8 @@ void CrtpConstructorAccessibilityCheck::check(
   const CXXRecordDecl *CRTPDeclaration =
       CRTPInstantiation->getSpecializedTemplate()->getTemplatedDecl();
 
-  if (!CRTPDeclaration->hasDefinition()) {
+  if (!CRTPDeclaration->hasDefinition())
     return;
-  }
 
   const auto *DerivedTemplateParameter =
       getDerivedParameter(CRTPInstantiation, DerivedRecord);

--- a/clang-tools-extra/clang-tidy/bugprone/ForwardDeclarationNamespaceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ForwardDeclarationNamespaceCheck.cpp
@@ -98,9 +98,8 @@ static bool haveSameNamespaceOrTranslationUnit(const CXXRecordDecl *Decl1,
 
 static std::string getNameOfNamespace(const CXXRecordDecl *Decl) {
   const auto *ParentDecl = Decl->getLexicalParent();
-  if (ParentDecl->getDeclKind() == Decl::TranslationUnit) {
+  if (ParentDecl->getDeclKind() == Decl::TranslationUnit)
     return "(global)";
-  }
   const auto *NsDecl = cast<NamespaceDecl>(ParentDecl);
   std::string Ns;
   llvm::raw_string_ostream OStream(Ns);
@@ -115,9 +114,8 @@ void ForwardDeclarationNamespaceCheck::onEndOfTranslationUnit() {
     // If more than 1 declaration exists, we check if all are in the same
     // namespace.
     for (const auto *CurDecl : Declarations) {
-      if (CurDecl->hasDefinition() || CurDecl->isReferenced()) {
+      if (CurDecl->hasDefinition() || CurDecl->isReferenced())
         continue; // Skip forward declarations that are used/referenced.
-      }
       if (FriendTypes.contains(CurDecl->getASTContext()
                                    .getCanonicalTagType(CurDecl)
                                    ->getTypePtr())) {
@@ -129,9 +127,8 @@ void ForwardDeclarationNamespaceCheck::onEndOfTranslationUnit() {
       }
       // Compare with all other declarations with the same name.
       for (const auto *Decl : Declarations) {
-        if (Decl == CurDecl) {
+        if (Decl == CurDecl)
           continue; // Don't compare with self.
-        }
         if (!CurDecl->hasDefinition() &&
             !haveSameNamespaceOrTranslationUnit(CurDecl, Decl)) {
           diag(CurDecl->getLocation(),
@@ -147,9 +144,8 @@ void ForwardDeclarationNamespaceCheck::onEndOfTranslationUnit() {
       // Check if a definition in another namespace exists.
       const auto DeclName = CurDecl->getName();
       auto It = DeclNameToDefinitions.find(DeclName);
-      if (It == DeclNameToDefinitions.end()) {
+      if (It == DeclNameToDefinitions.end())
         continue; // No definition in this translation unit, we can skip it.
-      }
       // Make a warning for each definition with the same name (in other
       // namespaces).
       const auto &Definitions = It->second;

--- a/clang-tools-extra/clang-tidy/bugprone/ForwardingReferenceOverloadCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ForwardingReferenceOverloadCheck.cpp
@@ -29,9 +29,8 @@ AST_MATCHER(QualType, isEnableIf) {
   };
   const Type *BaseType = Node.getTypePtr();
   // Case: pointer or reference to enable_if.
-  while (BaseType->isPointerType() || BaseType->isReferenceType()) {
+  while (BaseType->isPointerType() || BaseType->isReferenceType())
     BaseType = BaseType->getPointeeType().getTypePtr();
-  }
   // Case: type parameter dependent (enable_if<is_integral<T>>).
   if (const auto *Dependent = BaseType->getAs<DependentNameType>())
     BaseType = Dependent->getQualifier().getAsType();
@@ -114,10 +113,9 @@ void ForwardingReferenceOverloadCheck::check(
 
   // Every parameter after the first must have a default value.
   const auto *Ctor = Result.Nodes.getNodeAs<CXXConstructorDecl>("ctor");
-  for (const auto *Param : llvm::drop_begin(Ctor->parameters())) {
+  for (const auto *Param : llvm::drop_begin(Ctor->parameters()))
     if (!Param->hasDefaultArg())
       return;
-  }
   bool EnabledCopy = false, DisabledCopy = false, EnabledMove = false,
        DisabledMove = false;
   for (const auto *OtherCtor : Ctor->getParent()->ctors()) {

--- a/clang-tools-extra/clang-tidy/bugprone/InfiniteLoopCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/InfiniteLoopCheck.cpp
@@ -130,9 +130,8 @@ static std::string getCondVarNames(const Stmt *Cond) {
     if (const auto *Var = dyn_cast<VarDecl>(DRE->getDecl()))
       return std::string(Var->getName());
 
-    if (const auto *BD = dyn_cast<BindingDecl>(DRE->getDecl())) {
+    if (const auto *BD = dyn_cast<BindingDecl>(DRE->getDecl()))
       return std::string(BD->getName());
-    }
   }
 
   std::string Result;

--- a/clang-tools-extra/clang-tidy/bugprone/LambdaFunctionNameCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/LambdaFunctionNameCheck.cpp
@@ -41,16 +41,14 @@ public:
     for (const Token &T : MD.getMacroInfo()->tokens()) {
       if (T.is(tok::identifier)) {
         const StringRef IdentName = T.getIdentifierInfo()->getName();
-        if (IdentName == "__FILE__") {
+        if (IdentName == "__FILE__")
           HasFile = true;
-        } else if (IdentName == "__LINE__") {
+        else if (IdentName == "__LINE__")
           HasLine = true;
-        }
       }
     }
-    if (HasFile && HasLine) {
+    if (HasFile && HasLine)
       SuppressMacroExpansions->insert(Range);
-    }
   }
 
 private:

--- a/clang-tools-extra/clang-tidy/bugprone/LambdaFunctionNameCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/LambdaFunctionNameCheck.h
@@ -23,9 +23,8 @@ class LambdaFunctionNameCheck : public ClangTidyCheck {
 public:
   struct SourceRangeLessThan {
     bool operator()(const SourceRange &L, const SourceRange &R) const {
-      if (L.getBegin() == R.getBegin()) {
+      if (L.getBegin() == R.getBegin())
         return L.getEnd() < R.getEnd();
-      }
       return L.getBegin() < R.getBegin();
     }
   };

--- a/clang-tools-extra/clang-tidy/bugprone/MacroRepeatedSideEffectsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MacroRepeatedSideEffectsCheck.cpp
@@ -161,10 +161,9 @@ unsigned MacroRepeatedPPCallbacks::countArgumentExpansions(
 
 bool MacroRepeatedPPCallbacks::hasSideEffects(
     const Token *ResultArgToks) const {
-  for (; ResultArgToks->isNot(tok::eof); ++ResultArgToks) {
+  for (; ResultArgToks->isNot(tok::eof); ++ResultArgToks)
     if (ResultArgToks->isOneOf(tok::plusplus, tok::minusminus))
       return true;
-  }
   return false;
 }
 

--- a/clang-tools-extra/clang-tidy/bugprone/MisplacedPointerArithmeticInAllocCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MisplacedPointerArithmeticInAllocCheck.cpp
@@ -65,9 +65,8 @@ void MisplacedPointerArithmeticInAllocCheck::check(
 
   if (const auto *Call = dyn_cast<CallExpr>(AllocExpr)) {
     const NamedDecl *Func = Call->getDirectCallee();
-    if (!Func) {
+    if (!Func)
       Func = cast<NamedDecl>(Call->getCalleeDecl());
-    }
     CallName = Func->getName().str();
   } else {
     const auto *New = cast<CXXNewExpr>(AllocExpr);

--- a/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.cpp
@@ -323,9 +323,8 @@ bool NarrowingConversionsCheck::isWarningInhibitedByEquivalentSize(
   if (!WarnOnEquivalentBitWidth) {
     const uint64_t FromTypeSize = Context.getTypeSize(&FromType);
     const uint64_t ToTypeSize = Context.getTypeSize(&ToType);
-    if (FromTypeSize == ToTypeSize) {
+    if (FromTypeSize == ToTypeSize)
       return true;
-    }
   }
   return false;
 }

--- a/clang-tools-extra/clang-tidy/bugprone/ReturnConstRefFromParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ReturnConstRefFromParameterCheck.cpp
@@ -85,9 +85,8 @@ static const Decl *findRVRefOverload(const FunctionDecl &FD,
   // 2. forward reference
   const DeclContext::lookup_result LookupResult =
       FD.getParent()->lookup(FD.getNameInfo().getName());
-  if (LookupResult.isSingleResult()) {
+  if (LookupResult.isSingleResult())
     return nullptr;
-  }
   for (const Decl *Overload : LookupResult) {
     if (Overload == &FD)
       continue;

--- a/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp
@@ -50,9 +50,8 @@ AST_MATCHER_P2(RecordDecl, fieldCountOfKindIsOne,
   const FieldDecl *FirstMatch = nullptr;
   for (const FieldDecl *Field : Node.fields()) {
     if (InnerMatcher.matches(*Field, Finder, &TempBuilder)) {
-      if (FirstMatch) {
+      if (FirstMatch)
         return false;
-      }
       FirstMatch = Field;
     }
   }

--- a/clang-tools-extra/clang-tidy/bugprone/UncheckedStringToNumberConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UncheckedStringToNumberConversionCheck.cpp
@@ -204,9 +204,8 @@ void UncheckedStringToNumberConversionCheck::check(
       return;
 
     if (const Expr *Arg = Call->getArg(Idx)->IgnoreParenImpCasts()) {
-      if (const auto *SL = dyn_cast<StringLiteral>(Arg)) {
+      if (const auto *SL = dyn_cast<StringLiteral>(Arg))
         FmtStr = SL->getString();
-      }
     }
 
     // If we could not get the format string, bail out.

--- a/clang-tools-extra/clang-tidy/bugprone/UnsafeFunctionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnsafeFunctionsCheck.cpp
@@ -169,13 +169,12 @@ static std::string serializeCheckedFunctions(
   std::vector<std::string> Result;
   Result.reserve(Functions.size());
 
-  for (const auto &Entry : Functions) {
+  for (const auto &Entry : Functions)
     if (Entry.Reason.empty())
       Result.push_back(Entry.Name + "," + Entry.Replacement);
     else
       Result.push_back(Entry.Name + "," + Entry.Replacement + "," +
                        Entry.Reason);
-  }
 
   return llvm::join(Result, ";");
 }

--- a/clang-tools-extra/clang-tidy/bugprone/UseAfterMoveCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UseAfterMoveCheck.cpp
@@ -175,14 +175,12 @@ UseAfterMoveFinder::findInternal(const CFGBlock *Block, const Expr *MovingCall,
   // If `Reinit` is identical to `MovingCall`, we're looking at a move-to-self
   // (e.g. `a = std::move(a)`). Count these as reinitializations.
   llvm::SmallVector<const Stmt *, 1> ReinitsToDelete;
-  for (const Stmt *Reinit : Reinits) {
+  for (const Stmt *Reinit : Reinits)
     if (MovingCall && Reinit != MovingCall &&
         Sequence->potentiallyAfter(MovingCall, Reinit))
       ReinitsToDelete.push_back(Reinit);
-  }
-  for (const Stmt *Reinit : ReinitsToDelete) {
+  for (const Stmt *Reinit : ReinitsToDelete)
     Reinits.erase(Reinit);
-  }
 
   // Find all uses that potentially come after the move.
   for (const DeclRefExpr *Use : Uses) {
@@ -191,10 +189,9 @@ UseAfterMoveFinder::findInternal(const CFGBlock *Block, const Expr *MovingCall,
       // comes before the use, i.e. if there's no potential that the reinit is
       // after the use.
       bool HaveSavingReinit = false;
-      for (const Stmt *Reinit : Reinits) {
+      for (const Stmt *Reinit : Reinits)
         if (!Sequence->potentiallyAfter(Reinit, Use))
           HaveSavingReinit = true;
-      }
 
       if (!HaveSavingReinit) {
         UseAfterMove TheUseAfterMove;
@@ -218,9 +215,8 @@ UseAfterMoveFinder::findInternal(const CFGBlock *Block, const Expr *MovingCall,
   if (Reinits.empty()) {
     for (const auto &Succ : Block->succs()) {
       if (Succ) {
-        if (auto Found = findInternal(Succ, nullptr, MovedVariable)) {
+        if (auto Found = findInternal(Succ, nullptr, MovedVariable))
           return Found;
-        }
       }
     }
   }
@@ -240,10 +236,9 @@ void UseAfterMoveFinder::getUsesAndReinits(
 
   // All references to the variable that aren't reinitializations are uses.
   Uses->clear();
-  for (const DeclRefExpr *DeclRef : DeclRefs) {
+  for (const DeclRefExpr *DeclRef : DeclRefs)
     if (!ReinitDeclRefs.contains(DeclRef))
       Uses->push_back(DeclRef);
-  }
 
   // Sort the uses by their occurrence in the source code.
   llvm::sort(*Uses, [](const DeclRefExpr *D1, const DeclRefExpr *D2) {
@@ -288,9 +283,8 @@ void UseAfterMoveFinder::getDeclRefs(
         if (DeclRef && BlockMap->blockContainingStmt(DeclRef) == Block) {
           // Ignore uses of a standard smart pointer that don't dereference the
           // pointer.
-          if (Operator || !isStandardSmartPointer(DeclRef->getDecl())) {
+          if (Operator || !isStandardSmartPointer(DeclRef->getDecl()))
             DeclRefs->insert(DeclRef);
-          }
         }
       }
     };

--- a/clang-tools-extra/clang-tidy/bugprone/VirtualNearMissCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/VirtualNearMissCheck.cpp
@@ -97,10 +97,9 @@ static bool checkOverridingFunctionReturnType(const ASTContext *Context,
     const bool IsItself =
         DRD->getCanonicalDecl() == DerivedMD->getParent()->getCanonicalDecl();
     bool HasPublicAccess = false;
-    for (const auto &Path : Paths) {
+    for (const auto &Path : Paths)
       if (Path.Access == AS_public)
         HasPublicAccess = true;
-    }
     if (!HasPublicAccess && !IsItself)
       return false;
     // End checking conversion from D to B.
@@ -134,12 +133,11 @@ static bool checkParamTypes(const CXXMethodDecl *BaseMD,
   if (NumParamA != NumParamB)
     return false;
 
-  for (unsigned I = 0; I < NumParamA; I++) {
+  for (unsigned I = 0; I < NumParamA; I++)
     if (getDecayedType(BaseMD->getParamDecl(I)->getType().getCanonicalType()) !=
         getDecayedType(
             DerivedMD->getParamDecl(I)->getType().getCanonicalType()))
       return false;
-  }
   return true;
 }
 


### PR DESCRIPTION
Prepare codebase to enable https://clang.llvm.org/docs/ClangFormatStyleOptions.html#removebracesllvm.