### PR TITLE
[MLIR][Transform] Fix transform.smt.constrain_params's verifier

### DIFF
--- a/mlir/lib/Dialect/Transform/SMTExtension/SMTExtensionOps.cpp
+++ b/mlir/lib/Dialect/Transform/SMTExtension/SMTExtensionOps.cpp
@@ -121,9 +121,8 @@ LogicalResult transform::smt::ConstrainParamsOp::verify() {
   for (auto [idx, termOperandType, resultType] : llvm::enumerate(
            yieldTerminator->getOperands().getType(), getResultTypes())) {
     InFlightDiagnostic typeCheckResult =
-        checkTypes(idx, termOperandType, "terminator operand",
-                   cast<transform::ParamType>(resultType), "result",
-                   /*atOp=*/&yieldTerminator);
+        checkTypes(idx, termOperandType, "terminator operand", resultType,
+                   "result", /*atOp=*/&yieldTerminator);
     if (LogicalResult(typeCheckResult).failed())
       return typeCheckResult;
   }

--- a/mlir/test/python/dialects/transform_smt_ext.py
+++ b/mlir/test/python/dialects/transform_smt_ext.py
@@ -53,7 +53,7 @@ def testConstrainParamsOp(target):
 
     # CHECK: transform.smt.constrain_params(%[[PARAM_AS_PARAM]])
     compute_with_params = transform_smt.ConstrainParamsOp(
-        [transform.ParamType.get(ir.IntegerType.get_signless(32))],
+        [transform.AnyParamType.get()],
         [symbolic_value_as_param],
         [smt.IntType.get()],
     )


### PR DESCRIPTION
Verifier was insisting on `!transform.param<...>` too early and hence crashed on `!transform.any_param`.