### PR TITLE
[clang-tidy][NFC] Add option 'RemoveBracesLLVM' to clang-format config

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-format
+++ b/clang-tools-extra/clang-tidy/.clang-format
@@ -6,3 +6,4 @@ KeepEmptyLines:
   AtStartOfFile: false
 LineEnding: LF
 QualifierAlignment: Left
+RemoveBracesLLVM: true


### PR DESCRIPTION
We successfully cleared codebase (https://github.com/llvm/llvm-project/pull/172748, https://github.com/llvm/llvm-project/pull/172751, https://github.com/llvm/llvm-project/pull/172752, https://github.com/llvm/llvm-project/pull/172754) without any significant issues encountered.

I propose we add `RemoveBracesLLVM: true` which should _drastically_ reduce churn on code reviews.