### PR TITLE
[NFC][CodeGen][Clang] Apply Rule of Three to DisableDebugLocationUpdates

### DIFF
--- a/clang/lib/CodeGen/CGCall.h
+++ b/clang/lib/CodeGen/CGCall.h
@@ -457,6 +457,9 @@ struct DisableDebugLocationUpdates {
   CodeGenFunction &CGF;
   DisableDebugLocationUpdates(CodeGenFunction &CGF);
   ~DisableDebugLocationUpdates();
+  DisableDebugLocationUpdates(const DisableDebugLocationUpdates &) = delete;
+  DisableDebugLocationUpdates &
+  operator=(const DisableDebugLocationUpdates &) = delete;
 };
 
 } // end namespace CodeGen


### PR DESCRIPTION
Static analysis flagged that DisableDebugLocationUpdates has a user defined destructor but not copy ctor and copy assignment as per rule of three. We can define them as deleted if they are not needed.