### PR TITLE
[clang-tidy][NFC] Prefer `isa<T>` over `T::classof`

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/SwitchMissingDefaultCaseCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SwitchMissingDefaultCaseCheck.cpp
@@ -17,7 +17,7 @@ namespace {
 AST_MATCHER(SwitchStmt, hasDefaultCase) {
   const SwitchCase *Case = Node.getSwitchCaseList();
   while (Case) {
-    if (DefaultStmt::classof(Case))
+    if (isa<DefaultStmt>(Case))
       return true;
 
     Case = Case->getNextSwitchCase();

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/AvoidCapturingLambdaCoroutinesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/AvoidCapturingLambdaCoroutinesCheck.cpp
@@ -17,7 +17,7 @@ namespace clang::tidy::cppcoreguidelines {
 namespace {
 AST_MATCHER(LambdaExpr, hasCoroutineBody) {
   const Stmt *Body = Node.getBody();
-  return Body != nullptr && CoroutineBodyStmt::classof(Body);
+  return Body != nullptr && isa<CoroutineBodyStmt>(Body);
 }
 
 AST_MATCHER(LambdaExpr, hasCaptures) { return Node.capture_size() != 0U; }

--- a/clang-tools-extra/clang-tidy/performance/NoexceptMoveConstructorCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/NoexceptMoveConstructorCheck.cpp
@@ -30,7 +30,7 @@ DiagnosticBuilder NoexceptMoveConstructorCheck::reportMissingNoexcept(
   return diag(FuncDecl->getLocation(),
               "move %select{assignment operator|constructor}0s should "
               "be marked noexcept")
-         << CXXConstructorDecl::classof(FuncDecl);
+         << isa<CXXConstructorDecl>(FuncDecl);
 }
 
 void NoexceptMoveConstructorCheck::reportNoexceptEvaluatedToFalse(
@@ -38,7 +38,7 @@ void NoexceptMoveConstructorCheck::reportNoexceptEvaluatedToFalse(
   diag(NoexceptExpr->getExprLoc(),
        "noexcept specifier on the move %select{assignment "
        "operator|constructor}0 evaluates to 'false'")
-      << CXXConstructorDecl::classof(FuncDecl);
+      << isa<CXXConstructorDecl>(FuncDecl);
 }
 
 } // namespace clang::tidy::performance


### PR DESCRIPTION
We overwhelmingly prefer `isa` already, and I would argue it's more readable.