### PR TITLE
[compiler-rt][sanitizer] some additional Haiku build fixes

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -1287,7 +1287,7 @@ uptr GetPageSize() {
 
 uptr ReadBinaryName(/*out*/ char *buf, uptr buf_len) {
 #  if SANITIZER_HAIKU
-  int32_t cookie = 0;
+  int32 cookie = 0;
   image_info info;
   const char *argv0 = "<UNKNOWN>";
   while (get_next_image_info(B_CURRENT_TEAM, &cookie, &info) == B_OK) {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
@@ -32,6 +32,8 @@
 #  elif SANITIZER_GLIBC || SANITIZER_ANDROID
 #    define SANITIZER_HAS_STAT64 1
 #    define SANITIZER_HAS_STATFS64 1
+#  elif SANITIZER_HAIKU
+#    include <stdint.h>
 #  endif
 
 #  if defined(__sparc__)
@@ -629,7 +631,7 @@ typedef unsigned long __sanitizer_sigset_t;
 #  elif SANITIZER_APPLE
 typedef unsigned __sanitizer_sigset_t;
 #  elif SANITIZER_HAIKU
-typedef unsigned long long __sanitizer_sigset_t;
+typedef uint64_t __sanitizer_sigset_t;
 #  elif SANITIZER_LINUX
 struct __sanitizer_sigset_t {
   // The size is determined by looking at sizeof of real sigset_t on linux.


### PR DESCRIPTION
- Correct field type for cookie variable
- Use proper type for __sanitizer_sigset_t on 64-bit archs