### PR TITLE
[RISCV] Prefer li over pli in RISCVMatInt.

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMatInt.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMatInt.cpp
@@ -79,7 +79,7 @@ static void generateInstSeqImpl(int64_t Val, const MCSubtargetInfo &STI,
     }
   }
 
-  if (STI.hasFeature(RISCV::FeatureStdExtP)) {
+  if (STI.hasFeature(RISCV::FeatureStdExtP) && !isInt<12>(Val)) {
     // Check if the immediate is packed i8 or i10
     int32_t Bit63To32 = Val >> 32;
     int32_t Bit31To0 = Val;

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -25,3 +25,12 @@ define i64 @abs_i64(i64 %x) {
   %abs = tail call i64 @llvm.abs.i64(i64 %x, i1 true)
   ret i64 %abs
 }
+
+; FIXME: Prefer li over pli
+define i32 @li_imm() {
+; CHECK-LABEL: li_imm:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pli.h a0, -1
+; CHECK-NEXT:    ret
+  ret i32 -1
+}

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -30,7 +30,7 @@ define i64 @abs_i64(i64 %x) {
 define i32 @li_imm() {
 ; CHECK-LABEL: li_imm:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pli.h a0, -1
+; CHECK-NEXT:    li a0, -1
 ; CHECK-NEXT:    ret
   ret i32 -1
 }

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -26,7 +26,7 @@ define i64 @abs_i64(i64 %x) {
   ret i64 %abs
 }
 
-; FIXME: Prefer li over pli
+; Make sure we prefer li over pli
 define i32 @li_imm() {
 ; CHECK-LABEL: li_imm:
 ; CHECK:       # %bb.0:

--- a/llvm/test/CodeGen/RISCV/rv64p.ll
+++ b/llvm/test/CodeGen/RISCV/rv64p.ll
@@ -43,7 +43,7 @@ define i64 @pack_i64_imm() {
 define i64 @li_imm() {
 ; CHECK-LABEL: li_imm:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pli.w a0, -1
+; CHECK-NEXT:    li a0, -1
 ; CHECK-NEXT:    ret
   ret i64 -1
 }

--- a/llvm/test/CodeGen/RISCV/rv64p.ll
+++ b/llvm/test/CodeGen/RISCV/rv64p.ll
@@ -39,7 +39,7 @@ define i64 @pack_i64_imm() {
   ret i64 u0x0403020104030201
 }
 
-; FIXME: Prefer li over pli
+; Make sure we prefer li over pli
 define i64 @li_imm() {
 ; CHECK-LABEL: li_imm:
 ; CHECK:       # %bb.0:

--- a/llvm/test/CodeGen/RISCV/rv64p.ll
+++ b/llvm/test/CodeGen/RISCV/rv64p.ll
@@ -38,3 +38,12 @@ define i64 @pack_i64_imm() {
 ; CHECK-NEXT:    ret
   ret i64 u0x0403020104030201
 }
+
+; FIXME: Prefer li over pli
+define i64 @li_imm() {
+; CHECK-LABEL: li_imm:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    pli.w a0, -1
+; CHECK-NEXT:    ret
+  ret i64 -1
+}


### PR DESCRIPTION
li is compressible, pli is not.