### PR TITLE
[LLDB][ELF CORE] Only display a stop reason when there is a valid signo

### DIFF
--- a/lldb/source/Plugins/Process/elf-core/ThreadElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ThreadElfCore.cpp
@@ -276,6 +276,15 @@ bool ThreadElfCore::CalculateStopInfo() {
     }
   }
 
+  // The above code references the siginfo_t bytes from the NT_SIGINFO note.
+  // This is not the only way to get a signo in an ELF core, and so
+  // ThreadELFCore has a m_signo variable for these cases, which is populated
+  // with a non-zero value when there is no NT_SIGINFO note. However if this is
+  // 0, it's the default value and we have no valid signal and should not report
+  // a stop info.
+  if (m_signo == 0)
+    return false;
+
   SetStopInfo(StopInfo::CreateStopReasonWithSignal(*this, m_signo));
   return true;
 }

--- a/lldb/source/Plugins/Process/elf-core/ThreadElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ThreadElfCore.cpp
@@ -282,7 +282,7 @@ bool ThreadElfCore::CalculateStopInfo() {
   // with a non-zero value when there is no NT_SIGINFO note. However if this is
   // 0, it's the default value and we have no valid signal and should not report
   // a stop info.
-  if (m_signo == 0)
+  if (m_signo == 0 && m_siginfo_bytes.empty())
     return false;
 
   SetStopInfo(StopInfo::CreateStopReasonWithSignal(*this, m_signo));

--- a/lldb/test/API/commands/target/stop-hooks/on-core-load/TestStopHookOnCoreLoad.py
+++ b/lldb/test/API/commands/target/stop-hooks/on-core-load/TestStopHookOnCoreLoad.py
@@ -50,6 +50,12 @@ class TestStopOnCoreLoad(TestBase):
         result = lldb.SBCommandReturnObject()
         self.dbg.GetCommandInterpreter().HandleCommand("report_command", result)
         print(f"Command Output: '{result.GetOutput}'")
-        self.assertIn(
-            f"Stop Threads: {stop_thread}", result.GetOutput(), "Ran the stop hook"
-        )
+
+        thread = target.process.GetThreadAtIndex(0)
+        # ELF Cores used to report stop reason 0 for all threads, but now that they're
+        # filtered we only want to check if the stop_hook was run on threads with
+        # stop reasons.
+        if thread.is_stopped:
+            self.assertIn(
+                f"Stop Threads: {stop_thread}", result.GetOutput(), "Ran the stop hook"
+            )

--- a/lldb/test/API/functionalities/postmortem/netbsd-core/TestNetBSDCore.py
+++ b/lldb/test/API/functionalities/postmortem/netbsd-core/TestNetBSDCore.py
@@ -172,9 +172,7 @@ class NetBSD2LWPT2CoreTestCase(NetBSDCoreCommonTestCase):
 
         # thread 1 should have no signal
         thread = process.GetThreadByID(1)
-        self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonSignal)
-        self.assertEqual(thread.GetStopReasonDataCount(), 1)
-        self.assertEqual(thread.GetStopReasonDataAtIndex(0), 0)
+        self.assertFalse(thread.is_stopped)
 
     @skipIfLLVMTargetMissing("AArch64")
     def test_aarch64_thread_signaled(self):

--- a/lldb/test/Shell/Register/Core/x86-32-linux-multithread.test
+++ b/lldb/test/Shell/Register/Core/x86-32-linux-multithread.test
@@ -2,9 +2,9 @@
 
 thread list
 # CHECK: * thread #1: tid = 330633, 0x080492d2, name = 'a.out', stop reason = SIGSEGV: address not mapped to object (fault address=0x0)
-# CHECK-NEXT:   thread #2: tid = 330634, 0x080492dd, stop reason = signal 0
-# CHECK-NEXT:   thread #3: tid = 330635, 0x080492dd, stop reason = signal 0
-# CHECK-NEXT:   thread #4: tid = 330632, 0xf7f59549, stop reason = signal 0
+# CHECK-NEXT:   thread #2: tid = 330634, 0x080492dd
+# CHECK-NEXT:   thread #3: tid = 330635, 0x080492dd
+# CHECK-NEXT:   thread #4: tid = 330632, 0xf7f59549
 
 register read --all
 # CHECK-DAG: ecx = 0x01010101

--- a/lldb/test/Shell/Register/Core/x86-32-netbsd-multithread.test
+++ b/lldb/test/Shell/Register/Core/x86-32-netbsd-multithread.test
@@ -1,10 +1,10 @@
 # RUN: %lldb -b -s %s -c %p/Inputs/x86-32-netbsd-multithread.core | FileCheck %s
 
 thread list
-# CHECK: * thread #1: tid = 2, 0x08048db9, stop reason = signal SIGSEGV 
-# CHECK-NEXT:   thread #2: tid = 4, 0x08048dbf, stop reason = signal 0 
-# CHECK-NEXT:   thread #3: tid = 3, 0x08048dbf, stop reason = signal 0 
-# CHECK-NEXT:   thread #4: tid = 1, 0xf876a147, stop reason = signal 0 
+# CHECK: * thread #1: tid = 2, 0x08048db9, stop reason = signal SIGSEGV
+# CHECK-NEXT:   thread #2: tid = 4, 0x08048dbf
+# CHECK-NEXT:   thread #3: tid = 3, 0x08048dbf
+# CHECK-NEXT:   thread #4: tid = 1, 0xf876a147
 
 
 register read --all

--- a/lldb/test/Shell/Register/Core/x86-64-linux-multithread.test
+++ b/lldb/test/Shell/Register/Core/x86-64-linux-multithread.test
@@ -2,9 +2,9 @@
 
 thread list
 # CHECK: * thread #1: tid = 329384, 0x0000000000401262, name = 'a.out', stop reason = SIGSEGV: address not mapped to object (fault address=0x0)
-# CHECK-NEXT:   thread #2: tid = 329385, 0x000000000040126d, stop reason = signal 0
-# CHECK-NEXT:   thread #3: tid = 329386, 0x000000000040126d, stop reason = signal 0
-# CHECK-NEXT:   thread #4: tid = 329383, 0x00007fcf5582f762, stop reason = signal 0
+# CHECK-NEXT:   thread #2: tid = 329385, 0x000000000040126d
+# CHECK-NEXT:   thread #3: tid = 329386, 0x000000000040126d
+# CHECK-NEXT:   thread #4: tid = 329383, 0x00007fcf5582f762
 
 register read --all
 # CHECK-DAG: ecx = 0x04040404

--- a/lldb/test/Shell/Register/Core/x86-64-netbsd-multithread.test
+++ b/lldb/test/Shell/Register/Core/x86-64-netbsd-multithread.test
@@ -1,10 +1,10 @@
 # RUN: %lldb -b -s %s -c %p/Inputs/x86-64-netbsd-multithread.core | FileCheck %s
 
 thread list
-# CHECK: * thread #1: tid = 2, 0x0000000000400f82, stop reason = signal SIGSEGV 
-# CHECK-NEXT:   thread #2: tid = 4, 0x0000000000400f88, stop reason = signal 0 
-# CHECK-NEXT:   thread #3: tid = 3, 0x0000000000400f88, stop reason = signal 0 
-# CHECK-NEXT:   thread #4: tid = 1, 0x0000791280ca1faa, stop reason = signal 0 
+# CHECK: * thread #1: tid = 2, 0x0000000000400f82, stop reason = signal SIGSEGV
+# CHECK-NEXT:   thread #2: tid = 4, 0x0000000000400f88
+# CHECK-NEXT:   thread #3: tid = 3, 0x0000000000400f88
+# CHECK-NEXT:   thread #4: tid = 1, 0x0000791280ca1faa
 
 register read --all
 # CHECK-DAG: ecx = 0x04040404

--- a/lldb/unittests/Process/elf-core/ThreadElfCoreTest.cpp
+++ b/lldb/unittests/Process/elf-core/ThreadElfCoreTest.cpp
@@ -181,3 +181,20 @@ TEST_F(ElfCoreTest, PopulatePrStatusTest) {
   ASSERT_EQ(prstatus_opt->pr_pgrp, static_cast<uint32_t>(getpgrp()));
   ASSERT_EQ(prstatus_opt->pr_sid, static_cast<uint32_t>(getsid(gettid())));
 }
+
+TEST_F(ElfCoreTest, NoStopReasonWhenNoPrStatus) {
+  ArchSpec arch{HostInfo::GetTargetTriple()};
+  lldb::DebuggerSP debugger_sp = Debugger::CreateInstance();
+  ASSERT_TRUE(debugger_sp);
+
+  lldb::TargetSP target_sp = CreateTarget(debugger_sp, arch);
+  ASSERT_TRUE(target_sp);
+
+  lldb::ListenerSP listener_sp(Listener::MakeListener("dummy"));
+  lldb::ProcessSP process_sp =
+      std::make_shared<DummyProcess>(target_sp, listener_sp);
+  ASSERT_TRUE(process_sp);
+  lldb::ThreadSP thread_sp = CreateThread(process_sp);
+  ASSERT_TRUE(thread_sp);
+  ASSERT_FALSE(thread_sp->ThreadStoppedForAReason());
+}


### PR DESCRIPTION
This patch fixes where ELF cores will report all threads as `STOP REASON 0`. 

This was/is a large personal annoyance of mine; added a test to verify a default elf core process/thread has no valid stop reason.