### PR TITLE
[BOLT][AArch64] Speed up ICF pass

### DIFF
--- a/bolt/lib/Core/HashUtilities.cpp
+++ b/bolt/lib/Core/HashUtilities.cpp
@@ -67,7 +67,11 @@ std::string hashExpr(BinaryContext &BC, const MCExpr &Expr) {
         .append(hashInteger(BinaryExpr.getOpcode()))
         .append(hashExpr(BC, *BinaryExpr.getRHS()));
   }
-  case MCExpr::Specifier:
+  case MCExpr::Specifier: {
+    const auto &SpecExpr = cast<MCSpecifierExpr>(Expr);
+    return hashInteger(SpecExpr.getSpecifier())
+        .append(hashExpr(BC, *SpecExpr.getSubExpr()));
+  }
   case MCExpr::Target:
     return std::string();
   }


### PR DESCRIPTION
Add hashing support for MCSpecifierExpr, which is frequently used as an operand in AArch64 instructions. Proper hashing reduces collisions when placing functions into buckets, resulting in shorter Identical Code Folding (ICF) pass runtime.

In one benchmark, the ICF wall time decreased from 272s to 124s.