### PR TITLE
[RISCV] Replace enablePExtCodeGen with hasStdExtP for scalar code in RISCVISelDAGToDAG.cpp

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -1049,7 +1049,7 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
     else if (!isInt<32>(Imm) && isUInt<32>(Imm) && hasAllWUsers(Node))
       Imm = SignExtend64<32>(Imm);
 
-    if (Subtarget->enablePExtCodeGen() && isApplicableToPLI(Imm) &&
+    if (Subtarget->hasStdExtP() && isApplicableToPLI(Imm) &&
         hasAllWUsers(Node)) {
       // If it's 4 packed 8-bit integers or 2 packed signed 16-bit integers, we
       // can simply copy lower 32 bits to higher 32 bits to make it able to

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -34,3 +34,14 @@ define i32 @li_imm() {
 ; CHECK-NEXT:    ret
   ret i32 -1
 }
+
+define void @pli_b_store_i32(ptr %p) {
+; CHECK-LABEL: pli_b_store_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lui a1, 267284
+; CHECK-NEXT:    addi a1, a1, 321
+; CHECK-NEXT:    sw a1, 0(a0)
+; CHECK-NEXT:    ret
+  store i32 u0x41414141, ptr %p
+  ret void
+}

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -38,8 +38,7 @@ define i32 @li_imm() {
 define void @pli_b_store_i32(ptr %p) {
 ; CHECK-LABEL: pli_b_store_i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lui a1, 267284
-; CHECK-NEXT:    addi a1, a1, 321
+; CHECK-NEXT:    pli.b a1, 65
 ; CHECK-NEXT:    sw a1, 0(a0)
 ; CHECK-NEXT:    ret
   store i32 u0x41414141, ptr %p

--- a/llvm/test/CodeGen/RISCV/rv64p.ll
+++ b/llvm/test/CodeGen/RISCV/rv64p.ll
@@ -51,8 +51,7 @@ define i64 @li_imm() {
 define void @pli_b_store_i32(ptr %p) {
 ; CHECK-LABEL: pli_b_store_i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lui a1, 267284
-; CHECK-NEXT:    addi a1, a1, 321
+; CHECK-NEXT:    pli.b a1, 65
 ; CHECK-NEXT:    sw a1, 0(a0)
 ; CHECK-NEXT:    ret
   store i32 u0x41414141, ptr %p

--- a/llvm/test/CodeGen/RISCV/rv64p.ll
+++ b/llvm/test/CodeGen/RISCV/rv64p.ll
@@ -47,3 +47,14 @@ define i64 @li_imm() {
 ; CHECK-NEXT:    ret
   ret i64 -1
 }
+
+define void @pli_b_store_i32(ptr %p) {
+; CHECK-LABEL: pli_b_store_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lui a1, 267284
+; CHECK-NEXT:    addi a1, a1, 321
+; CHECK-NEXT:    sw a1, 0(a0)
+; CHECK-NEXT:    ret
+  store i32 u0x41414141, ptr %p
+  ret void
+}


### PR DESCRIPTION
The enablePExtCodeGen was only intended to block vector code while
it is still in development. This code uses scalar types so we only
need to check for the extension.