### PR TITLE
[ORC] Fix typo in method name. NFCI.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/ReOptimizeLayer.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ReOptimizeLayer.h
@@ -63,7 +63,7 @@ public:
   /// Registers reoptimize runtime dispatch handlers to given PlatformJD. The
   /// reoptimization request will not be handled if dispatch handler is not
   /// registered by using this function.
-  Error reigsterRuntimeFunctions(JITDylib &PlatformJD);
+  Error registerRuntimeFunctions(JITDylib &PlatformJD);
 
   /// Emits the given module. This should not be called by clients: it will be
   /// called by the JIT when a definition added via the add method is requested.

--- a/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
@@ -26,7 +26,7 @@ void ReOptimizeLayer::ReOptMaterializationUnitState::reoptimizeFailed() {
   Reoptimizing = false;
 }
 
-Error ReOptimizeLayer::reigsterRuntimeFunctions(JITDylib &PlatformJD) {
+Error ReOptimizeLayer::registerRuntimeFunctions(JITDylib &PlatformJD) {
   ExecutionSession::JITDispatchHandlerAssociationMap WFs;
   using ReoptimizeSPSSig = shared::SPSError(uint64_t, uint32_t);
   WFs[Mangle("__orc_rt_reoptimize_tag")] =

--- a/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
@@ -174,7 +174,7 @@ TEST_F(ReOptimizeLayerTest, BasicReOptimization) {
         });
         return Error::success();
       });
-  EXPECT_THAT_ERROR(ROLayer->reigsterRuntimeFunctions(*JD), Succeeded());
+  EXPECT_THAT_ERROR(ROLayer->registerRuntimeFunctions(*JD), Succeeded());
 
   auto Ctx = std::make_unique<LLVMContext>();
   auto M = std::make_unique<Module>("<main>", *Ctx);


### PR DESCRIPTION
"reigsterRuntimeFunctions" should be "registerRuntimeFunctions".