### PR TITLE
[lldb][test] Avoid out-of-bounds reads in TestConflictingSymbol.py

### DIFF
--- a/lldb/test/API/lang/c/conflicting-symbol/One/OneConstant.c
+++ b/lldb/test/API/lang/c/conflicting-symbol/One/OneConstant.c
@@ -1,1 +1,1 @@
-int __attribute__ ((visibility("hidden"))) conflicting_symbol = 11111;
+void *__attribute__((visibility("hidden"))) conflicting_symbol = (void *)0x1111;

--- a/lldb/test/API/lang/c/conflicting-symbol/TestConflictingSymbol.py
+++ b/lldb/test/API/lang/c/conflicting-symbol/TestConflictingSymbol.py
@@ -52,9 +52,10 @@ class TestConflictingSymbols(TestBase):
 
         # This should display correctly.
         self.expect(
-            "expr (unsigned long long)conflicting_symbol",
+            "expr conflicting_symbol",
             "Symbol from One should be found",
-            substrs=["11111"],
+            startstr="(void *)",
+            patterns=["0x0+1111$"],
         )
 
         self.runCmd("continue", RUN_SUCCEEDED)
@@ -69,9 +70,10 @@ class TestConflictingSymbols(TestBase):
         lldbutil.check_breakpoint(self, bpno=1, expected_hit_count=1)
 
         self.expect(
-            "expr (unsigned long long)conflicting_symbol",
+            "expr conflicting_symbol",
             "Symbol from Two should be found",
-            substrs=["22222"],
+            startstr="(void *)",
+            patterns=["0x0+2222$"],
         )
 
         self.runCmd("continue", RUN_SUCCEEDED)
@@ -86,7 +88,7 @@ class TestConflictingSymbols(TestBase):
         lldbutil.check_breakpoint(self, bpno=1, expected_hit_count=1)
 
         self.expect(
-            "expr (unsigned long long)conflicting_symbol",
+            "expr conflicting_symbol",
             "An error should be printed when symbols can't be ordered",
             error=True,
             substrs=["Multiple internal symbols"],

--- a/lldb/test/API/lang/c/conflicting-symbol/Two/TwoConstant.c
+++ b/lldb/test/API/lang/c/conflicting-symbol/Two/TwoConstant.c
@@ -1,1 +1,1 @@
-int __attribute__ ((visibility("hidden"))) conflicting_symbol = 22222;
+void *__attribute__((visibility("hidden"))) conflicting_symbol = (void *)0x2222;


### PR DESCRIPTION
Generic data variables are considered to be of the type `void *&`, see `ClangExpressionDeclMap::AddOneGenericVariable()`. On 64-bit platforms (e.g. AArch64), this type is 8 bytes long, while the `conflicting_symbol` variables are defined as `int`, which is typically 4 bytes. `test_conflicting_symbols` could fail if the next 4 bytes in memory after any of the variables are not zero. This can be reproduced by adding a variable with a non-zero value after `conflicting_symbol`:
```
--- a/lldb/test/API/lang/c/conflicting-symbol/One/OneConstant.c
+++ b/lldb/test/API/lang/c/conflicting-symbol/One/OneConstant.c
@@ -1 +1,2 @@
 int __attribute__ ((visibility("hidden"))) conflicting_symbol = 11111;
+int guard = 1;
```

In this case, the test fails with:
```
AssertionError: Ran command:
"expr (unsigned long long)conflicting_symbol"

Got output:
(unsigned long long) $0 = 4294978407

Expecting sub string: "11111" (was not found)
Symbol from One should be found
```

Note that 4294978407 = 0x100002B67 = 1 * 2^32 + 11111.