### PR TITLE
[clang-tidy] Teach `misc-use-internal-linkage` to suggest giving classes internal linkage

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -517,6 +517,10 @@ Changes in existing checks
 - Improved :doc:`misc-header-include-cycle
   <clang-tidy/checks/misc/header-include-cycle>` check performance.
 
+- Improved :doc:`misc-use-internal-linkage
+  <clang-tidy/checks/misc/use-internal-linkage>` to suggest giving
+  structs, classes, unions, and enums internal linkage.
+
 - Improved :doc:`modernize-avoid-c-arrays
   <clang-tidy/checks/modernize/avoid-c-arrays>` to not diagnose array types
   which are part of an implicit instantiation of a template.

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/use-internal-linkage.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/use-internal-linkage.rst
@@ -3,12 +3,12 @@
 misc-use-internal-linkage
 =========================
 
-Detects variables and functions that can be marked as static or moved into
-an anonymous namespace to enforce internal linkage.
+Detects variables, functions, and classes that can be marked as static or
+moved into an anonymous namespace to enforce internal linkage.
 
-Static functions and variables are scoped to a single file. Marking functions
-and variables as static helps to better remove dead code. In addition, it gives
-the compiler more information and allows for more aggressive optimizations.
+Any entity that's only used within a single file should be given internal
+linkage. Doing so gives the compiler more information, allowing it to better
+remove dead code and perform more aggressive optimizations.
 
 Example:
 
@@ -17,11 +17,14 @@ Example:
   int v1; // can be marked as static
 
   void fn1() {} // can be marked as static
+  
+  struct S1 {}; // can be moved into anonymous namespace
 
   namespace {
     // already in anonymous namespace
     int v2;
     void fn2();
+    struct S2 {};
   }
   // already declared as extern
   extern int v2;
@@ -33,6 +36,7 @@ Example:
   export void fn4() {}
   export namespace t { void fn5() {} }
   export int v2;
+  export class C {};
 
 Options
 -------

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/Inputs/use-internal-linkage/tag.h
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/Inputs/use-internal-linkage/tag.h
@@ -7,3 +7,5 @@ class ClassDeclaredInHeader;
 
 template <typename>
 class TemplateDeclaredInHeader {};
+
+extern template class TemplateDeclaredInHeader<char>;

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/Inputs/use-internal-linkage/tag.h
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/Inputs/use-internal-linkage/tag.h
@@ -1,0 +1,9 @@
+#pragma once
+
+enum EnumDeclaredInHeader : int;
+struct StructDeclaredInHeader;
+union UnionDeclaredInHeader;
+class ClassDeclaredInHeader;
+
+template <typename>
+class TemplateDeclaredInHeader {};

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-func.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-func.cpp
@@ -57,6 +57,7 @@ NNDS void func_nnds() {}
 void func_h_inc() {}
 
 struct S {
+// CHECK-MESSAGES: :[[@LINE-1]]:8: warning: struct 'S' can be moved into an anonymous namespace to enforce internal linkage
   void method();
 };
 void S::method() {}

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-module.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-module.cpp
@@ -6,15 +6,19 @@ export module test;
 
 export void single_export_fn() {}
 export int single_export_var;
+export struct SingleExportStruct {};
 
 export {
   void group_export_fn1() {}
   void group_export_fn2() {}
   int group_export_var1;
   int group_export_var2;
+  struct GroupExportStruct1 {};
+  struct GroupExportStruct2 {};
 }
 
 export namespace aa {
 void namespace_export_fn() {}
 int namespace_export_var;
+struct NamespaceExportStruct {};
 } // namespace aa

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-tag.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-tag.cpp
@@ -81,6 +81,11 @@ struct {} VariableOfUnnamedType;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: variable 'VariableOfUnnamedType' can be made static or moved into an anonymous namespace to enforce internal linkage
 // CHECK-FIXES: static struct {} VariableOfUnnamedType;
 
+#define MACRO struct ClassDefinedInMacro {};
+
+MACRO
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: struct 'ClassDefinedInMacro' can be moved into an anonymous namespace to enforce internal linkage
+
 extern "C" struct MarkedExternC { int i; };
 
 extern "C" {

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-tag.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-tag.cpp
@@ -1,0 +1,90 @@
+// RUN: %check_clang_tidy %s misc-use-internal-linkage %t -- -- -I%S/Inputs/use-internal-linkage
+// RUN: %check_clang_tidy %s misc-use-internal-linkage %t -- \
+// RUN:   -config="{CheckOptions: {misc-use-internal-linkage.FixMode: 'UseStatic'}}"  -- -I%S/Inputs/use-internal-linkage
+
+#include "tag.h"
+
+struct StructDeclaredInHeader {};
+union UnionDeclaredInHeader {};
+class ClassDeclaredInHeader {};
+enum EnumDeclaredInHeader : int {};
+template <typename T> class TemplateDeclaredInHeader<T *> {};
+template <> class TemplateDeclaredInHeader<int> {};
+
+struct StructWithNoDefinition;
+union UnionWithNoDefinition;
+class ClassWithNoDefinition;
+enum EnumWithNoDefinition : int;
+
+namespace {
+
+struct StructAlreadyInAnonymousNamespace {};
+union UnionAlreadyInAnonymousNamespace {};
+class ClassAlreadyInAnonymousNamespace {};
+enum EnumAlreadyInAnonymousNamespace : int {};
+typedef struct {} TypedefedStructAlreadyInAnonymousNamespace;
+
+} // namespace
+
+struct S {};
+// CHECK-MESSAGES: :[[@LINE-1]]:8: warning: struct 'S' can be moved into an anonymous namespace to enforce internal linkage
+union U {};
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: union 'U' can be moved into an anonymous namespace to enforce internal linkage
+class C {};
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: class 'C' can be moved into an anonymous namespace to enforce internal linkage
+enum E {};
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: enum 'E' can be moved into an anonymous namespace to enforce internal linkage
+
+template <typename>
+class Template {};
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: class 'Template' can be moved into an anonymous namespace to enforce internal linkage
+
+struct OuterStruct {
+// CHECK-MESSAGES: :[[@LINE-1]]:8: warning: struct 'OuterStruct' can be moved into an anonymous namespace to enforce internal linkage
+
+  // No warnings for the inner members.
+  struct InnerStruct {};
+  union InnerUnion {};
+  class InnerClass {};
+  enum InnerEnum {};
+  struct InnerStructDefinedOutOfLine;
+};
+struct OuterStruct::InnerStructDefinedOutOfLine {};
+
+void f() {
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'f' can be made static or moved into an anonymous namespace to enforce internal linkage
+  struct StructInsideFunction {};
+}
+
+namespace ns {
+
+struct S {};
+// CHECK-MESSAGES: :[[@LINE-1]]:8: warning: struct 'S' can be moved into an anonymous namespace to enforce internal linkage
+union U {};
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: union 'U' can be moved into an anonymous namespace to enforce internal linkage
+class C {};
+// CHECK-MESSAGES: :[[@LINE-1]]:7: warning: class 'C' can be moved into an anonymous namespace to enforce internal linkage
+enum E {};
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: enum 'E' can be moved into an anonymous namespace to enforce internal linkage
+
+} // namespace ns
+
+typedef struct {} TypedefedStruct;
+// CHECK-MESSAGES: :[[@LINE-1]]:9: warning: struct 'TypedefedStruct' can be moved into an anonymous namespace to enforce internal linkage
+
+struct Named {} Variable;
+// CHECK-MESSAGES: :[[@LINE-1]]:8: warning: struct 'Named' can be moved into an anonymous namespace to enforce internal linkage
+// CHECK-MESSAGES: :[[@LINE-2]]:17: warning: variable 'Variable' can be made static or moved into an anonymous namespace to enforce internal linkage
+// CHECK-FIXES: static struct Named {} Variable;
+
+struct {} VariableOfUnnamedType;
+// CHECK-MESSAGES: :[[@LINE-1]]:11: warning: variable 'VariableOfUnnamedType' can be made static or moved into an anonymous namespace to enforce internal linkage
+// CHECK-FIXES: static struct {} VariableOfUnnamedType;
+
+extern "C" struct MarkedExternC { int i; };
+
+extern "C" {
+
+struct InExternCBlock { int i; };
+
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-tag.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-tag.cpp
@@ -10,6 +10,10 @@ class ClassDeclaredInHeader {};
 enum EnumDeclaredInHeader : int {};
 template <typename T> class TemplateDeclaredInHeader<T *> {};
 template <> class TemplateDeclaredInHeader<int> {};
+// This instantiation matches an 'extern template' declaration in the header.
+template class TemplateDeclaredInHeader<char>;
+// This instantiation has no associated 'extern template'.
+template class TemplateDeclaredInHeader<float>;
 
 struct StructWithNoDefinition;
 union UnionWithNoDefinition;

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-var.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-var.cpp
@@ -47,6 +47,7 @@ static void f(int para) {
 }
 
 struct S {
+// CHECK-MESSAGES: :[[@LINE-1]]:8: warning: struct 'S' can be moved into an anonymous namespace to enforce internal linkage
   int m1;
   static int m2;
 };


### PR DESCRIPTION
Currently, the check only supports variables and functions. This PR extends it to classes (and structs, unions, enums, etc.).