### PR TITLE
[RISCV] P extension should not call hasAllWUsers or create non-simm32 constants on RV32.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -1049,7 +1049,7 @@ void RISCVDAGToDAGISel::Select(SDNode *Node) {
     else if (!isInt<32>(Imm) && isUInt<32>(Imm) && hasAllWUsers(Node))
       Imm = SignExtend64<32>(Imm);
 
-    if (Subtarget->hasStdExtP() && isApplicableToPLI(Imm) &&
+    if (VT == MVT::i64 && Subtarget->hasStdExtP() && isApplicableToPLI(Imm) &&
         hasAllWUsers(Node)) {
       // If it's 4 packed 8-bit integers or 2 packed signed 16-bit integers, we
       // can simply copy lower 32 bits to higher 32 bits to make it able to

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -38,7 +38,8 @@ define i32 @li_imm() {
 define void @pli_b_store_i32(ptr %p) {
 ; CHECK-LABEL: pli_b_store_i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pli.b a1, 65
+; CHECK-NEXT:    lui a1, 267284
+; CHECK-NEXT:    addi a1, a1, 321
 ; CHECK-NEXT:    sw a1, 0(a0)
 ; CHECK-NEXT:    ret
   store i32 u0x41414141, ptr %p


### PR DESCRIPTION
This causes a regression due to incomplete handling of RV32 for the P extension in RISCVMatInt. I'll fix that in a follow up.