### PR TITLE
[LV][doc] Update and extend the docs on floating-point reduction vectorization

### DIFF
--- a/llvm/docs/Vectorizers.rst
+++ b/llvm/docs/Vectorizers.rst
@@ -200,7 +200,22 @@ reduction operations, such as addition, multiplication, XOR, AND and OR.
     return sum;
   }
 
-We support floating point reduction operations when `-ffast-math` is used.
+The full vectorization of reductions inherently involves reordering operations,
+which is problematic for floating-point reductions. Since floating-point
+operations are not associative, the result may depend on the order of operations.
+Therefore, vectorizing floating-point reductions is implicitly prohibited by
+the C and C++ standards, unless the compiler can ensure that the result does
+not change.
+
+For this reason, on most targets we support floating point reduction operations
+only when `-ffast-math` (or at least the `-fassociative-math -fno-signed-zeros 
+-fno-trapping-math` subset of `-ffast-math`) is used. On select targets such as
+AArch64 and RISC-V we support generating ordered reductions which preserve the
+exact result, allowing a limited form of vectorization to take place while
+remaining standards-compliant. However, ordered reductions are typically less
+efficient than traditionally vectorized reductions, therefore enabling floating-
+point reordering may still result in more performant reductions on these
+targets.
 
 Inductions
 ^^^^^^^^^^

--- a/llvm/docs/Vectorizers.rst
+++ b/llvm/docs/Vectorizers.rst
@@ -208,10 +208,9 @@ operations.
 Changing floating-point results is implicitly prohibited by the C and C++
 standards, therefore LLVM supports vectorizing floating point reductions
 only when at least the `-fassociative-math -fno-signed-zeros 
--fno-trapping-math` subset of `-ffast-math` is used on most targets. On select
-targets such as AArch64 and RISC-V LLVM supports generating ordered reductions
-which preserve the exact result, allowing a limited form of vectorization to
-take place while remaining standards-compliant. However, ordered reductions
+-fno-trapping-math` subset of `-ffast-math` is used on most targets. On some
+targets, such as AArch64 and RISC-V, LLVM can generate ordered reductions
+that preserve the exact result, enabling limited, standards-compliant vectorization. However, ordered reductions
 are typically less efficient than traditionally vectorized reductions,
 therefore enabling floating-point reordering may still result in more
 performant reductions on these targets.

--- a/llvm/docs/Vectorizers.rst
+++ b/llvm/docs/Vectorizers.rst
@@ -200,20 +200,19 @@ reduction operations, such as addition, multiplication, XOR, AND and OR.
     return sum;
   }
 
-Fully vectorizing reductions requires reordering operations,
-which is problematic for floating-point arithmetic because it is
-not associative; therefore results may depend on the evaluation order.
+Fully vectorizing reductions requires reordering operations, which is
+problematic for floating-point arithmetic because it is not associative;
+therefore results may depend on the evaluation order.
 
 Changing floating-point results is implicitly prohibited by the C and C++
-standards, therefore LLVM supports vectorizing floating point reductions
-only when at least the `-fassociative-math -fno-signed-zeros 
--fno-trapping-math` subset of `-ffast-math` is used on most targets. On some
-targets, such as AArch64 and RISC-V, LLVM can generate ordered reductions
-that preserve the exact result, enabling limited, standards-compliant
-vectorization. However, ordered reductions
-are typically less efficient than traditionally vectorized reductions,
-therefore enabling floating-point reordering may still result in more
-performant reductions on these targets.
+standards, therefore LLVM supports vectorizing floating point reductions only
+when at least the `-fassociative-math -fno-signed-zeros -fno-trapping-math`
+subset of `-ffast-math` is used on most targets. On some targets, such as
+AArch64 and RISC-V, LLVM can generate ordered reductions that preserve the
+exact result, enabling limited, standards-compliant vectorization. However,
+ordered reductions are typically less efficient than traditionally vectorized
+reductions, therefore enabling floating-point reordering may still result in
+more performant reductions on these targets.
 
 Inductions
 ^^^^^^^^^^

--- a/llvm/docs/Vectorizers.rst
+++ b/llvm/docs/Vectorizers.rst
@@ -207,9 +207,9 @@ Therefore, vectorizing floating-point reductions is implicitly prohibited by
 the C and C++ standards, unless the compiler can ensure that the result does
 not change.
 
-For this reason, on most targets we support floating point reduction operations
-only when `-ffast-math` (or at least the `-fassociative-math -fno-signed-zeros 
--fno-trapping-math` subset of `-ffast-math`) is used. On select targets such as
+Therefore LLVM supports vectorizing floating point reductions
+only when at least the `-fassociative-math -fno-signed-zeros 
+-fno-trapping-math` subset of `-ffast-math` is used on most targets. On select targets such as
 AArch64 and RISC-V LLVM supports generating ordered reductions which preserve the
 exact result, allowing a limited form of vectorization to take place while
 remaining standards-compliant. However, ordered reductions are typically less

--- a/llvm/docs/Vectorizers.rst
+++ b/llvm/docs/Vectorizers.rst
@@ -200,17 +200,17 @@ reduction operations, such as addition, multiplication, XOR, AND and OR.
     return sum;
   }
 
-The full vectorization of reductions requires reordering operations,
-which is problematic for floating-point reductions. Since floating-point
-operations are not associative, the result may depend on the order of
-operations.
+Fully vectorizing reductions requires reordering operations,
+which is problematic for floating-point arithmetic because it is
+not associative; therefore results may depend on the evaluation order.
 
 Changing floating-point results is implicitly prohibited by the C and C++
 standards, therefore LLVM supports vectorizing floating point reductions
 only when at least the `-fassociative-math -fno-signed-zeros 
 -fno-trapping-math` subset of `-ffast-math` is used on most targets. On some
 targets, such as AArch64 and RISC-V, LLVM can generate ordered reductions
-that preserve the exact result, enabling limited, standards-compliant vectorization. However, ordered reductions
+that preserve the exact result, enabling limited, standards-compliant
+vectorization. However, ordered reductions
 are typically less efficient than traditionally vectorized reductions,
 therefore enabling floating-point reordering may still result in more
 performant reductions on these targets.

--- a/llvm/docs/Vectorizers.rst
+++ b/llvm/docs/Vectorizers.rst
@@ -210,7 +210,7 @@ not change.
 For this reason, on most targets we support floating point reduction operations
 only when `-ffast-math` (or at least the `-fassociative-math -fno-signed-zeros 
 -fno-trapping-math` subset of `-ffast-math`) is used. On select targets such as
-AArch64 and RISC-V we support generating ordered reductions which preserve the
+AArch64 and RISC-V LLVM supports generating ordered reductions which preserve the
 exact result, allowing a limited form of vectorization to take place while
 remaining standards-compliant. However, ordered reductions are typically less
 efficient than traditionally vectorized reductions, therefore enabling floating-

--- a/llvm/docs/Vectorizers.rst
+++ b/llvm/docs/Vectorizers.rst
@@ -200,7 +200,7 @@ reduction operations, such as addition, multiplication, XOR, AND and OR.
     return sum;
   }
 
-The full vectorization of reductions inherently involves reordering operations,
+The full vectorization of reductions requires reordering operations,
 which is problematic for floating-point reductions. Since floating-point
 operations are not associative, the result may depend on the order of operations.
 Therefore, vectorizing floating-point reductions is implicitly prohibited by

--- a/llvm/docs/Vectorizers.rst
+++ b/llvm/docs/Vectorizers.rst
@@ -202,18 +202,19 @@ reduction operations, such as addition, multiplication, XOR, AND and OR.
 
 The full vectorization of reductions requires reordering operations,
 which is problematic for floating-point reductions. Since floating-point
-operations are not associative, the result may depend on the order of operations.
+operations are not associative, the result may depend on the order of
+operations.
 
-Changing floating-point results is implicitly prohibited by the C and C++ standards,
-therefore LLVM supports vectorizing floating point reductions
+Changing floating-point results is implicitly prohibited by the C and C++
+standards, therefore LLVM supports vectorizing floating point reductions
 only when at least the `-fassociative-math -fno-signed-zeros 
--fno-trapping-math` subset of `-ffast-math` is used on most targets. On select targets such as
-AArch64 and RISC-V LLVM supports generating ordered reductions which preserve the
-exact result, allowing a limited form of vectorization to take place while
-remaining standards-compliant. However, ordered reductions are typically less
-efficient than traditionally vectorized reductions, therefore enabling floating-
-point reordering may still result in more performant reductions on these
-targets.
+-fno-trapping-math` subset of `-ffast-math` is used on most targets. On select
+targets such as AArch64 and RISC-V LLVM supports generating ordered reductions
+which preserve the exact result, allowing a limited form of vectorization to
+take place while remaining standards-compliant. However, ordered reductions
+are typically less efficient than traditionally vectorized reductions,
+therefore enabling floating-point reordering may still result in more
+performant reductions on these targets.
 
 Inductions
 ^^^^^^^^^^

--- a/llvm/docs/Vectorizers.rst
+++ b/llvm/docs/Vectorizers.rst
@@ -203,11 +203,9 @@ reduction operations, such as addition, multiplication, XOR, AND and OR.
 The full vectorization of reductions requires reordering operations,
 which is problematic for floating-point reductions. Since floating-point
 operations are not associative, the result may depend on the order of operations.
-Therefore, vectorizing floating-point reductions is implicitly prohibited by
-the C and C++ standards, unless the compiler can ensure that the result does
-not change.
 
-Therefore LLVM supports vectorizing floating point reductions
+Changing floating-point results is implicitly prohibited by the C and C++ standards,
+therefore LLVM supports vectorizing floating point reductions
 only when at least the `-fassociative-math -fno-signed-zeros 
 -fno-trapping-math` subset of `-ffast-math` is used on most targets. On select targets such as
 AArch64 and RISC-V LLVM supports generating ordered reductions which preserve the


### PR DESCRIPTION
The docs for reduction vectorization currently say that

> We support floating point reduction operations when -ffast-math is used.

This is outdated, as there are now cases where floating-point reductions are vectorized even without -ffast-math, through ordered reduction.
This PR updates the documentation for reduction vectorization, noting that that AArch64 and RISC-V default to ordered FP reductions being permitted. Furthermore, an explanation of why the vectorization of FP reduction is such a special case is added to the docs.