### PR TITLE
[mlir][x86vector] Shuffle FMAs

### DIFF
--- a/mlir/include/mlir/Dialect/X86Vector/TransformOps/X86VectorTransformOps.td
+++ b/mlir/include/mlir/Dialect/X86Vector/TransformOps/X86VectorTransformOps.td
@@ -49,6 +49,17 @@ def ApplySinkVectorProducerOpsPatternsOp : Op<Transform_Dialect,
   let assemblyFormat = "attr-dict";
 }
 
+def ApplyShuffleVectorFMAOpsPatternsOp : Op<Transform_Dialect,
+    "apply_patterns.x86vector.shuffle_vector_fma_ops",
+    [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
+  let description = [{
+    Collect patterns to sink vector producer operations forward in a block to
+         place them immediately before their first use.
+  }];
+
+  let assemblyFormat = "attr-dict";
+}
+
 
 #endif // X86VECTOR_TRANSFORM_OPS
 

--- a/mlir/include/mlir/Dialect/X86Vector/TransformOps/X86VectorTransformOps.td
+++ b/mlir/include/mlir/Dialect/X86Vector/TransformOps/X86VectorTransformOps.td
@@ -53,8 +53,8 @@ def ApplyShuffleVectorFMAOpsPatternsOp : Op<Transform_Dialect,
     "apply_patterns.x86vector.shuffle_vector_fma_ops",
     [DeclareOpInterfaceMethods<PatternDescriptorOpInterface>]> {
   let description = [{
-    Collect patterns to sink vector producer operations forward in a block to
-         place them immediately before their first use.
+    Collect patterns to shuffle FMAs with x86vector operations as operands 
+    such that FMAs are grouped with respect to odd/even packed index.
   }];
 
   let assemblyFormat = "attr-dict";

--- a/mlir/include/mlir/Dialect/X86Vector/Transforms.h
+++ b/mlir/include/mlir/Dialect/X86Vector/Transforms.h
@@ -95,6 +95,8 @@ void populateVectorContractToPackedTypeDotProductPatterns(
 // range by placing them at their earliest legal use site
 void populateSinkVectorProducerOpsPatterns(RewritePatternSet &patterns);
 
+// Shuffles FMAs with x86vector operations as operands such that FMAs are
+// grouped with respect to odd/even packed index.
 void populateShuffleVectorFMAOpsPatterns(RewritePatternSet &patterns);
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/X86Vector/Transforms.h
+++ b/mlir/include/mlir/Dialect/X86Vector/Transforms.h
@@ -95,6 +95,8 @@ void populateVectorContractToPackedTypeDotProductPatterns(
 // range by placing them at their earliest legal use site
 void populateSinkVectorProducerOpsPatterns(RewritePatternSet &patterns);
 
+void populateShuffleVectorFMAOpsPatterns(RewritePatternSet &patterns);
+
 //===----------------------------------------------------------------------===//
 /// Helpers extracted from:
 ///   - clang/lib/Headers/avxintrin.h

--- a/mlir/lib/Dialect/X86Vector/TransformOps/X86VectorTransformOps.cpp
+++ b/mlir/lib/Dialect/X86Vector/TransformOps/X86VectorTransformOps.cpp
@@ -37,6 +37,11 @@ void mlir::transform::ApplySinkVectorProducerOpsPatternsOp::populatePatterns(
   x86vector::populateSinkVectorProducerOpsPatterns(patterns);
 }
 
+void mlir::transform::ApplyShuffleVectorFMAOpsPatternsOp::populatePatterns(
+    RewritePatternSet &patterns) {
+  x86vector::populateShuffleVectorFMAOpsPatterns(patterns);
+}
+
 //===----------------------------------------------------------------------===//
 // Transform op registration
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/X86Vector/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/X86Vector/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_dialect_library(MLIRX86VectorTransforms
   VectorContractToFMA.cpp
   VectorContractToPackedTypeDotProduct.cpp
   SinkVectorProducerOps.cpp
+  ShuffleVectorFMAOps.cpp
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/mlir/lib/Dialect/X86Vector/Transforms/ShuffleVectorFMAOps.cpp
+++ b/mlir/lib/Dialect/X86Vector/Transforms/ShuffleVectorFMAOps.cpp
@@ -36,8 +36,8 @@ static bool validateX86OpsHasOneUser(Value op) {
 // Validates the vector.fma operation on the following conditions:
 // (i) one of the lhs or rhs defining operation should be
 // CvtPackedEvenIndexedToF32Op, (ii) the lhs or rhs defining operation should be
-// an x86vector operation and has only one consumer, (iii) all oerations in same
-// block, and (iv) ths FMA has only one user.
+// an x86vector operation and has only one consumer, (iii) all operations
+// are in the same block, and (iv) ths FMA has only one user.
 static bool validateVectorFMAOp(vector::FMAOp fmaOp) {
   Value lhs = fmaOp.getLhs();
   Value rhs = fmaOp.getRhs();
@@ -65,7 +65,7 @@ static bool validateVectorFMAOp(vector::FMAOp fmaOp) {
   return true;
 }
 
-// Moves vector.fma along with the lhs and rhs defining operation before it's
+// Moves vector.fma along with the lhs and rhs defining operation before its
 // comsumer. If the consumer is vector.ShapeCastOp and has only one user then
 // move before the consumer of vector.ShapeCastOp.
 // TODO: Move before first consumer, if there are multiple.

--- a/mlir/lib/Dialect/X86Vector/Transforms/ShuffleVectorFMAOps.cpp
+++ b/mlir/lib/Dialect/X86Vector/Transforms/ShuffleVectorFMAOps.cpp
@@ -1,0 +1,127 @@
+//===- ShuffleVectorFMAOps.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Utils/VectorUtils.h"
+#include "mlir/Dialect/X86Vector/Transforms.h"
+#include "mlir/Dialect/X86Vector/X86VectorDialect.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/PatternMatch.h"
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+using namespace mlir::vector;
+using namespace mlir::x86vector;
+
+namespace {
+
+static bool validateX86OpsHasOneUser(Value op) {
+
+  if (auto x86Op = op.getDefiningOp<x86vector::CvtPackedEvenIndexedToF32Op>()) {
+    if (!x86Op.getResult().hasOneUse())
+      return false;
+  } else if (auto x86Op = op.getDefiningOp<x86vector::BcstToPackedF32Op>()) {
+    if (!x86Op.getResult().hasOneUse())
+      return false;
+  } else {
+    return false;
+  }
+  return true;
+}
+
+static bool validateVectorFMAOp(vector::FMAOp fmaOp) {
+
+  Value lhs = fmaOp.getLhs();
+  Value rhs = fmaOp.getRhs();
+
+  if (!isa<x86vector::CvtPackedEvenIndexedToF32Op>(lhs.getDefiningOp()) &&
+      !isa<x86vector::CvtPackedEvenIndexedToF32Op>(rhs.getDefiningOp()))
+    return false;
+
+  if (!validateX86OpsHasOneUser(fmaOp.getLhs()) ||
+      !validateX86OpsHasOneUser(fmaOp.getRhs()))
+    return false;
+
+  if (!fmaOp.getResult().hasOneUse())
+    return false;
+
+  return true;
+}
+
+static void moveFMA(vector::FMAOp fmaOp) {
+  Operation *onlyUser = *fmaOp.getResult().getUsers().begin();
+
+  if (auto shapeCastOp = dyn_cast<vector::ShapeCastOp>(onlyUser)) {
+    if (shapeCastOp.getResult().hasOneUse()) {
+      onlyUser = *shapeCastOp.getResult().getUsers().begin();
+      fmaOp.getLhs().getDefiningOp()->moveBefore(onlyUser);
+      fmaOp.getRhs().getDefiningOp()->moveBefore(onlyUser);
+      fmaOp->moveBefore(onlyUser);
+      shapeCastOp->moveBefore(onlyUser);
+      return;
+    }
+  }
+
+  fmaOp.getLhs().getDefiningOp()->moveBefore(onlyUser);
+  fmaOp.getRhs().getDefiningOp()->moveBefore(onlyUser);
+  fmaOp->moveBefore(onlyUser);
+  return;
+}
+
+struct ShuffleVectorFMAOps : public OpRewritePattern<vector::FMAOp> {
+  using OpRewritePattern<vector::FMAOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::FMAOp fmaOp,
+                                PatternRewriter &rewriter) const override {
+
+    if (!validateVectorFMAOp(fmaOp))
+      return failure();
+
+    llvm::SmallVector<vector::FMAOp> fmaOps;
+    Operation *nextOp = fmaOp;
+    bool loopBreak = true;
+
+    while ((nextOp = nextOp->getNextNode())) {
+      if (auto fma = dyn_cast<vector::FMAOp>(nextOp)) {
+        if (isa<x86vector::CvtPackedEvenIndexedToF32Op>(
+                fma.getLhs().getDefiningOp()) ||
+            isa<x86vector::CvtPackedEvenIndexedToF32Op>(
+                fma.getRhs().getDefiningOp())) {
+          if (loopBreak)
+            break;
+        }
+
+        if (validateVectorFMAOp(fma))
+          fmaOps.push_back(fma);
+
+        loopBreak = false;
+      }
+    }
+
+    if (fmaOps.empty())
+      return failure();
+
+    fmaOps.push_back(fmaOp);
+    for (size_t i = 0; i < fmaOps.size(); i++) {
+      moveFMA(fmaOps[i]);
+    }
+
+    return success();
+  }
+};
+
+} // namespace
+
+void x86vector::populateShuffleVectorFMAOpsPatterns(
+    RewritePatternSet &patterns) {
+  patterns.add<ShuffleVectorFMAOps>(patterns.getContext());
+}

--- a/mlir/test/Dialect/X86Vector/shuffle-vector-fmas.mlir
+++ b/mlir/test/Dialect/X86Vector/shuffle-vector-fmas.mlir
@@ -1,0 +1,51 @@
+// RUN: mlir-opt %s -transform-interpreter -cse -split-input-file | FileCheck %s
+
+!vec = vector<8xf32>
+!memrefA = memref<1x1x1xbf16>
+!memrefB = memref<1x8x2xbf16>
+
+func.func @shuffle_vector_fma(
+  %arg0: !memrefA, %arg1: !memrefA, %arg2: !memrefB, %arg3: !memrefA,
+  %arg4: !memrefA, %arg5: !memrefB, %arg6: !vec) -> !vec
+{
+  %0 = x86vector.avx.bcst_to_f32.packed %arg0 : !memrefA -> !vec
+  %1 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %2 = vector.fma %0, %1, %arg6 : !vec
+  %3 = x86vector.avx.bcst_to_f32.packed %arg1 : !memrefA -> !vec
+  %4 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %5 = vector.fma %3, %4, %2 : !vec
+  %55 = vector.shape_cast %5 : vector<8xf32> to vector<1x8xf32>
+  %6 = x86vector.avx.bcst_to_f32.packed %arg3 : !memrefA -> !vec
+  %7 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg5 : !memrefB -> !vec
+  %8 = vector.fma %6, %7, %arg6 : !vec
+  %9 = x86vector.avx.bcst_to_f32.packed %arg4 : !memrefA -> !vec
+  %10 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg5 : !memrefB -> !vec
+  %11 = vector.fma %9, %10, %8 : !vec
+  %13 = vector.shape_cast %55 : vector<1x8xf32> to vector<8xf32>
+  %12 = vector.fma %13, %11, %arg6 : !vec
+  return %12 : !vec
+}
+
+// CHECK-LABEL: @shuffle_vector_fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: vector.fma
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %0 {
+      transform.apply_patterns.x86vector.shuffle_vector_fma_ops
+    } : !transform.any_op
+    transform.yield
+  }
+}

--- a/mlir/test/Dialect/X86Vector/shuffle-vector-fmas.mlir
+++ b/mlir/test/Dialect/X86Vector/shuffle-vector-fmas.mlir
@@ -4,7 +4,7 @@
 !memrefA = memref<1x1x1xbf16>
 !memrefB = memref<1x8x2xbf16>
 
-func.func @shuffle_vector_fma(
+func.func @shuffle_fma_lhs_even_index(
   %arg0: !memrefA, %arg1: !memrefA, %arg2: !memrefB, %arg3: !memrefA,
   %arg4: !memrefA, %arg5: !memrefB, %arg6: !vec) -> !vec
 {
@@ -14,19 +14,17 @@ func.func @shuffle_vector_fma(
   %3 = x86vector.avx.bcst_to_f32.packed %arg1 : !memrefA -> !vec
   %4 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg2 : !memrefB -> !vec
   %5 = vector.fma %3, %4, %2 : !vec
-  %55 = vector.shape_cast %5 : vector<8xf32> to vector<1x8xf32>
   %6 = x86vector.avx.bcst_to_f32.packed %arg3 : !memrefA -> !vec
   %7 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg5 : !memrefB -> !vec
   %8 = vector.fma %6, %7, %arg6 : !vec
   %9 = x86vector.avx.bcst_to_f32.packed %arg4 : !memrefA -> !vec
   %10 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg5 : !memrefB -> !vec
   %11 = vector.fma %9, %10, %8 : !vec
-  %13 = vector.shape_cast %55 : vector<1x8xf32> to vector<8xf32>
-  %12 = vector.fma %13, %11, %arg6 : !vec
+  %12 = vector.fma %5, %11, %arg6 : !vec
   return %12 : !vec
 }
 
-// CHECK-LABEL: @shuffle_vector_fma
+// CHECK-LABEL: @shuffle_fma_lhs_even_index
 // CHECK: x86vector.avx.bcst_to_f32.packed
 // CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
 // CHECK: vector.fma
@@ -35,6 +33,266 @@ func.func @shuffle_vector_fma(
 // CHECK: vector.fma
 // CHECK: x86vector.avx.bcst_to_f32.packed
 // CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: vector.fma
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %0 {
+      transform.apply_patterns.x86vector.shuffle_vector_fma_ops
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+!vec = vector<8xf32>
+!memrefA = memref<1x1x1xbf16>
+!memrefB = memref<1x8x2xbf16>
+
+func.func @shuffle_fma_rhs_even_index(
+  %arg0: !memrefA, %arg1: !memrefA, %arg2: !memrefB, %arg3: !memrefA,
+  %arg4: !memrefA, %arg5: !memrefB, %arg6: !vec) -> !vec
+{
+  %0 = x86vector.avx.bcst_to_f32.packed %arg0 : !memrefA -> !vec
+  %1 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %2 = vector.fma %0, %1, %arg6 : !vec
+  %3 = x86vector.avx.bcst_to_f32.packed %arg1 : !memrefA -> !vec
+  %4 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %5 = vector.fma %4, %3, %2 : !vec
+  %6 = x86vector.avx.bcst_to_f32.packed %arg3 : !memrefA -> !vec
+  %7 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg5 : !memrefB -> !vec
+  %8 = vector.fma %6, %7, %arg6 : !vec
+  %9 = x86vector.avx.bcst_to_f32.packed %arg4 : !memrefA -> !vec
+  %10 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg5 : !memrefB -> !vec
+  %11 = vector.fma %9, %10, %8 : !vec
+  %12 = vector.fma %5, %11, %arg6 : !vec
+  return %12 : !vec
+}
+
+// CHECK-LABEL: @shuffle_fma_rhs_even_index
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: vector.fma
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %0 {
+      transform.apply_patterns.x86vector.shuffle_vector_fma_ops
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+!vec = vector<8xf32>
+!memrefA = memref<1x1x1xbf16>
+!memrefB = memref<1x8x2xbf16>
+
+func.func @negative_fma_lhs_multiple_consumer(
+  %arg0: !memrefA, %arg1: !memrefA, %arg2: !memrefB,
+  %arg3: !memrefA, %arg4: !memrefB, %arg5: !vec) -> !vec
+{
+  %0 = x86vector.avx.bcst_to_f32.packed %arg0 : !memrefA -> !vec
+  %1 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %2 = vector.fma %0, %1, %arg5 : !vec
+  %3 = x86vector.avx.bcst_to_f32.packed %arg1 : !memrefA -> !vec
+  %4 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %5 = vector.fma %3, %4, %2 : !vec
+  %7 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg4 : !memrefB -> !vec
+  %8 = vector.fma %3, %7, %arg5 : !vec
+  %9 = x86vector.avx.bcst_to_f32.packed %arg3 : !memrefA -> !vec
+  %10 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg4 : !memrefB -> !vec
+  %11 = vector.fma %9, %10, %8 : !vec
+  %12 = vector.fma %5, %11, %arg5 : !vec
+  return %12 : !vec
+}
+
+// CHECK-LABEL: @negative_fma_lhs_multiple_consumer
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: vector.fma
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %0 {
+      transform.apply_patterns.x86vector.shuffle_vector_fma_ops
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+!vec = vector<8xf32>
+!memrefA = memref<1x1x1xbf16>
+!memrefB = memref<1x8x2xbf16>
+
+func.func @negative_fma_rhs_multiple_consumer(
+  %arg0: !memrefA, %arg1: !memrefA, %arg2: !memrefB, %arg3: !memrefA,
+  %arg4: !memrefA, %arg5: !memrefB, %arg6: !vec) -> !vec
+{
+  %0 = x86vector.avx.bcst_to_f32.packed %arg0 : !memrefA -> !vec
+  %1 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %2 = vector.fma %0, %1, %arg6 : !vec
+  %3 = x86vector.avx.bcst_to_f32.packed %arg1 : !memrefA -> !vec
+  %4 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %5 = vector.fma %3, %4, %2 : !vec
+  %6 = x86vector.avx.bcst_to_f32.packed %arg3 : !memrefA -> !vec
+  %7 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg5 : !memrefB -> !vec
+  %8 = vector.fma %6, %7, %arg6 : !vec
+  %9 = x86vector.avx.bcst_to_f32.packed %arg4 : !memrefA -> !vec
+  %10 = vector.fma %9, %4, %8 : !vec
+  %11 = vector.fma %5, %10, %arg6 : !vec
+  return %11 : !vec
+}
+
+// CHECK-LABEL: @negative_fma_rhs_multiple_consumer
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: vector.fma
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %0 {
+      transform.apply_patterns.x86vector.shuffle_vector_fma_ops
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+!vec = vector<8xf32>
+!memrefA = memref<1x1x1xbf16>
+!memrefB = memref<1x8x2xbf16>
+
+func.func @negative_fma_multiple_consumer(
+  %arg0: !memrefA, %arg1: !memrefA, %arg2: !memrefB, %arg3: !memrefA,
+  %arg4: !memrefA, %arg5: !memrefB, %arg6: !vec) -> !vec
+{
+  %0 = x86vector.avx.bcst_to_f32.packed %arg0 : !memrefA -> !vec
+  %1 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %2 = vector.fma %0, %1, %arg6 : !vec
+  %3 = x86vector.avx.bcst_to_f32.packed %arg1 : !memrefA -> !vec
+  %4 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %5 = vector.fma %3, %4, %2 : !vec
+  %6 = x86vector.avx.bcst_to_f32.packed %arg3 : !memrefA -> !vec
+  %7 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg5 : !memrefB -> !vec
+  %8 = vector.fma %6, %7, %5 : !vec
+  %9 = x86vector.avx.bcst_to_f32.packed %arg4 : !memrefA -> !vec
+  %10 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg5 : !memrefB -> !vec
+  %11 = vector.fma %9, %10, %8 : !vec
+  %12 = vector.fma %5, %11, %arg6 : !vec
+  return %12 : !vec
+}
+
+// CHECK-LABEL: @negative_fma_multiple_consumer
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: vector.fma
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %0 {
+      transform.apply_patterns.x86vector.shuffle_vector_fma_ops
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+!vec = vector<8xf32>
+!memrefA = memref<1x1x1xbf16>
+!memrefB = memref<1x8x2xbf16>
+
+func.func @negative_no_shuffle_outside_block(
+  %arg0: !memrefA, %arg1: !memrefA, %arg2: !memrefB, %arg3: !memrefA,
+  %arg4: !memrefA, %arg5: !memrefB, %arg6: !vec, %arg7: i1) -> !vec
+{
+  %0 = x86vector.avx.bcst_to_f32.packed %arg0 : !memrefA -> !vec
+  %1 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %2 = vector.fma %0, %1, %arg6 : !vec
+  %3 = x86vector.avx.bcst_to_f32.packed %arg1 : !memrefA -> !vec
+  %4 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %5 = vector.fma %3, %4, %2 : !vec
+
+  %loop = scf.if %arg7 -> (vector<8xf32>) {
+    %6 = x86vector.avx.bcst_to_f32.packed %arg3 : !memrefA -> !vec
+    %7 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg5 : !memrefB -> !vec
+    %8 = vector.fma %6, %7, %arg6 : !vec
+    %9 = x86vector.avx.bcst_to_f32.packed %arg4 : !memrefA -> !vec
+    %10 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg5 : !memrefB -> !vec
+    %11 = vector.fma %9, %10, %8 : !vec
+    %12 = vector.fma %5, %11, %arg6 : !vec
+    scf.yield %12 : vector<8xf32>
+  } else {
+    %6 = x86vector.avx.bcst_to_f32.packed %arg3 : !memrefA -> !vec
+    %7 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg5 : !memrefB -> !vec
+    %8 = vector.fma %6, %7, %arg6 : !vec
+    %9 = x86vector.avx.bcst_to_f32.packed %arg4 : !memrefA -> !vec
+    %10 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg5 : !memrefB -> !vec
+    %11 = vector.fma %9, %10, %8 : !vec
+    %12 = vector.fma %5, %11, %arg6 : !vec
+    scf.yield %12 : vector<8xf32>
+  }
+
+  return %loop : !vec
+}
+
+// CHECK-LABEL: @negative_no_shuffle_outside_block
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32
+// CHECK: vector.fma
+// CHECK: scf.if
+// CHECK: x86vector.avx.bcst_to_f32.packed
+// CHECK: x86vector.avx.cvt.packed.odd.indexed_to_f32
 // CHECK: vector.fma
 // CHECK: x86vector.avx.bcst_to_f32.packed
 // CHECK: x86vector.avx.cvt.packed.even.indexed_to_f32

--- a/mlir/test/Dialect/X86Vector/shuffle-vector-fmas.mlir
+++ b/mlir/test/Dialect/X86Vector/shuffle-vector-fmas.mlir
@@ -108,6 +108,63 @@ module attributes {transform.with_named_sequence} {
 // -----
 
 !vec = vector<8xf32>
+!vecOut = vector<1x8xf32>
+!memrefA = memref<1x1x1xbf16>
+!memrefB = memref<1x8x2xbf16>
+
+func.func @shuffle_fma_with_shape_cast(
+  %arg0: !memrefA, %arg1: !memrefA, %arg2: !memrefB, %arg3: !memrefA,
+  %arg4: !memrefA, %arg5: !memrefB, %arg6: !vec) -> !vecOut
+{
+  %0 = x86vector.avx.bcst_to_f32.packed %arg0 : !memrefA -> !vec
+  %1 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %2 = vector.fma %0, %1, %arg6 : !vec
+  %3 = x86vector.avx.bcst_to_f32.packed %arg1 : !memrefA -> !vec
+  %4 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg2 : !memrefB -> !vec
+  %5 = vector.fma %3, %4, %2 : !vec
+  %res1 = vector.shape_cast %5 : !vec to !vecOut
+  %6 = x86vector.avx.bcst_to_f32.packed %arg3 : !memrefA -> !vec
+  %7 = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg5 : !memrefB -> !vec
+  %8 = vector.fma %6, %7, %arg6 : !vec
+  %9 = x86vector.avx.bcst_to_f32.packed %arg4 : !memrefA -> !vec
+  %10 = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg5 : !memrefB -> !vec
+  %11 = vector.fma %9, %10, %8 : !vec
+  %res2 = vector.shape_cast %11 : !vec to !vecOut
+  %12 = arith.addf %res1, %res2 : !vecOut
+  return %12 : !vecOut
+}
+
+// CHECK-LABEL: @shuffle_fma_with_shape_cast
+// Odd-Indexed FMAs
+// CHECK: %[[BCST0:.*]] = x86vector.avx.bcst_to_f32.packed %arg0
+// CHECK: %[[ODD0:.*]]  = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg2
+// CHECK: %[[FMA_ODD0:.*]] = vector.fma %[[BCST0]], %[[ODD0]], %arg6
+// CHECK: %[[BCST1:.*]] = x86vector.avx.bcst_to_f32.packed %arg3
+// CHECK: %[[ODD1:.*]]  = x86vector.avx.cvt.packed.odd.indexed_to_f32 %arg5
+// CHECK: %[[FMA_ODD1:.*]] = vector.fma %[[BCST1]], %[[ODD1]], %arg6
+// Even-Indexed FMAs
+// CHECK: %[[BCST3:.*]] = x86vector.avx.bcst_to_f32.packed %arg4
+// CHECK: %[[EVEN1:.*]] = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg5
+// CHECK: %[[FMA_EVEN1:.*]] = vector.fma %[[BCST3]], %[[EVEN1]], %[[FMA_ODD1]]
+// CHECK: vector.shape_cast
+// CHECK: %[[BCST2:.*]] = x86vector.avx.bcst_to_f32.packed %arg1
+// CHECK: %[[EVEN0:.*]] = x86vector.avx.cvt.packed.even.indexed_to_f32 %arg2
+// CHECK: %[[FMA_EVEN0:.*]] = vector.fma %[[BCST2]], %[[EVEN0]], %[[FMA_ODD0]]
+// CHECK: vector.shape_cast
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    transform.apply_patterns to %0 {
+      transform.apply_patterns.x86vector.shuffle_vector_fma_ops
+    } : !transform.any_op
+    transform.yield
+  }
+}
+
+// -----
+
+!vec = vector<8xf32>
 !memrefA = memref<1x1x1xbf16>
 !memrefB = memref<1x8x2xbf16>
 


### PR DESCRIPTION
This patch Shuffles FMAs with x86vector operations as operands such that FMAs are grouped with respect to odd/even packed index.
Continuation to PR: https://github.com/llvm/llvm-project/pull/170267 to manage register allocation efficiently.