### PR TITLE
[llvm][ADT] Add llvm::StringRef::consume_front(char) overload

### DIFF
--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -639,7 +639,6 @@ namespace llvm {
         return false;
 
       *this = drop_front();
-
       return true;
     }
 

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -634,6 +634,17 @@ namespace llvm {
 
     /// Returns true if this StringRef has the given prefix and removes that
     /// prefix.
+    bool consume_front(char Prefix) {
+      if (!starts_with(Prefix))
+        return false;
+
+      *this = drop_front();
+
+      return true;
+    }
+
+    /// Returns true if this StringRef has the given prefix and removes that
+    /// prefix.
     bool consume_front(StringRef Prefix) {
       if (!starts_with(Prefix))
         return false;

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -402,6 +402,14 @@ TEST(StringRefTest, ConsumeFrontChar) {
   }
 
   {
+    StringRef Str("\0");
+    EXPECT_FALSE(Str.consume_front('\0'));
+    EXPECT_EQ("", Str);
+    EXPECT_FALSE(Str.consume_front('\0'));
+    EXPECT_EQ("", Str);
+  }
+
+  {
     char Prefix = 'h';
     StringRef Str("h");
     EXPECT_TRUE(Str.consume_front(Prefix));

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -391,6 +391,26 @@ TEST(StringRefTest, ConsumeFront) {
   EXPECT_TRUE(Str.consume_front(""));
 }
 
+TEST(StringRefTest, ConsumeFrontChar) {
+  {
+    StringRef Str("hello");
+    EXPECT_EQ("hello", Str);
+    EXPECT_TRUE(Str.consume_front('h'));
+    EXPECT_EQ("ello", Str);
+    EXPECT_FALSE(Str.consume_front('h'));
+    EXPECT_EQ("ello", Str);
+  }
+
+  {
+    char Prefix = 'h';
+    StringRef Str("h");
+    EXPECT_TRUE(Str.consume_front(Prefix));
+    EXPECT_EQ("", Str);
+    EXPECT_FALSE(Str.consume_front('\0'));
+    EXPECT_EQ("", Str);
+  }
+}
+
 TEST(StringRefTest, ConsumeFrontInsensitive) {
   StringRef Str("heLLo");
   EXPECT_TRUE(Str.consume_front_insensitive(""));


### PR DESCRIPTION
This patch adds support for consuming a `char` from the front of a `StringRef`. Most of the time a user wanting to consume a single character off the front can just wrap the character in a string literal (i.e., `consume_front("a")`). But this doesn't work if we don't have a `char` literal, but instead a variable of type `char`. I.e., `char c = 'a'; str.consume_front(c)`. There's at least one helper in LLDB that does this. Also there's plenty of example of `consume_front` being passed a single character via string literal. This patch adds the `char` overload. We already have a `starts_with(char)` overload, so there's at least some related precedent.