### PR TITLE
[X86][APX] Check APXSave before enabling APX features

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/x86.c
+++ b/compiler-rt/lib/builtins/cpu_model/x86.c
@@ -926,6 +926,7 @@ static void getAvailableFeatures(unsigned ECX, unsigned EDX, unsigned MaxLeaf,
   const unsigned AMXBits = (1 << 17) | (1 << 18);
   bool HasXSave = ((ECX >> 27) & 1) && !getX86XCR0(&EAX, &EDX);
   bool HasAMXSave = HasXSave && ((EAX & AMXBits) == AMXBits);
+  bool HasAPXSave = HasXSave && ((EAX >> 19) & 1);
 
   if (HasAVXSave)
     setFeature(FEATURE_AVX);
@@ -1065,7 +1066,7 @@ static void getAvailableFeatures(unsigned ECX, unsigned EDX, unsigned MaxLeaf,
     setFeature(FEATURE_PREFETCHI);
   if (HasLeaf7Subleaf1 && ((EDX >> 15) & 1))
     setFeature(FEATURE_USERMSR);
-  if (HasLeaf7Subleaf1 && ((EDX >> 21) & 1))
+  if (HasLeaf7Subleaf1 && ((EDX >> 21) & 1) && HasAPXSave)
     setFeature(FEATURE_APXF);
 
   unsigned MaxLevel = 0;

--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -2040,6 +2040,8 @@ StringMap<bool> sys::getHostCPUFeatures() {
   // AMX requires additional context to be saved by the OS.
   const unsigned AMXBits = (1 << 17) | (1 << 18);
   bool HasAMXSave = HasXSave && ((EAX & AMXBits) == AMXBits);
+  // APX requires additional context to be saved by the OS.
+  bool HasAPXSave = HasXSave && ((EAX >> 19) & 1);
 
   Features["avx"]   = HasAVXSave;
   Features["fma"]   = ((ECX >> 12) & 1) && HasAVXSave;
@@ -2162,7 +2164,7 @@ StringMap<bool> sys::getHostCPUFeatures() {
   Features["prefetchi"] |= HasLeaf7Subleaf1 && ((EDX >> 14) & 1);
   Features["usermsr"]  = HasLeaf7Subleaf1 && ((EDX >> 15) & 1);
   bool HasAVX10 = HasLeaf7Subleaf1 && ((EDX >> 19) & 1);
-  bool HasAPXF = HasLeaf7Subleaf1 && ((EDX >> 21) & 1);
+  bool HasAPXF = HasLeaf7Subleaf1 && ((EDX >> 21) & 1) && HasAPXSave;
   Features["egpr"] = HasAPXF;
   Features["push2pop2"] = HasAPXF;
   Features["ppx"] = HasAPXF;


### PR DESCRIPTION
According to APX spec 3.1.4.2, APX instructions can normally execute only when XCR0[APX_F]=1, where APX_F=19.