### PR TITLE
[libc++] Optimize vector<bool>::resize()

### DIFF
--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -1050,25 +1050,16 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::swap(vector& __x)
 }
 
 template <class _Allocator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::resize(size_type __sz, value_type __x) {
-  size_type __cs = size();
-  if (__cs < __sz) {
-    iterator __r;
-    size_type __c = capacity();
-    size_type __n = __sz - __cs;
-    if (__n <= __c && __cs <= __c - __n) {
-      __r = end();
-      __size_ += __n;
-    } else {
-      vector __v(get_allocator());
-      __v.reserve(__recommend(__size_ + __n));
-      __v.__size_ = __size_ + __n;
-      __r         = std::copy(cbegin(), cend(), __v.begin());
-      swap(__v);
-    }
-    std::fill_n(__r, __n, __x);
-  } else
-    __size_ = __sz;
+_LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::resize(size_type __new_size, value_type __x) {
+  size_type __current_size = size();
+  if (__new_size < __current_size) {
+    __size_ = __new_size;
+    return;
+  }
+
+  reserve(__new_size);
+  std::fill_n(end(), __new_size - __current_size, __x);
+  __size_ = __new_size;
 }
 
 template <class _Allocator>

--- a/libcxx/test/benchmarks/containers/sequence/vector_bool.bench.cpp
+++ b/libcxx/test/benchmarks/containers/sequence/vector_bool.bench.cpp
@@ -68,4 +68,13 @@ static void BM_vector_bool_reserve(benchmark::State& state) {
 }
 BENCHMARK(BM_vector_bool_reserve)->Name("vector<bool>::reserve()");
 
+static void BM_vector_bool_resize(benchmark::State& state) {
+  for (auto _ : state) {
+    std::vector<bool> vec;
+    vec.resize(100);
+    benchmark::DoNotOptimize(vec);
+  }
+}
+BENCHMARK(BM_vector_bool_resize)->Name("vector<bool>::resize()");
+
 BENCHMARK_MAIN();


### PR DESCRIPTION
This both simplifies the implementation and improves the performance, since the compiler is better able to see through what's going on.

```
Benchmark                                                                              old             new    Difference    % Difference
--------------------------------------------------------------------------  --------------  --------------  ------------  --------------
vector<bool>(const_vector<bool>&)                                                    11.99           12.26          0.27           2.25%
vector<bool>(size_type,_const_value_type&)                                            9.24            9.29          0.05           0.54%
vector<bool>(vector<bool>&&,_const_allocator_type&)_(different_allocators)           14.26           14.35          0.09           0.65%
vector<bool>(vector<bool>&&,_const_allocator_type&)_(equal_allocators)                2.67            2.67         -0.01          -0.29%
vector<bool>::reserve()                                                               9.30            9.29         -0.01          -0.12%
vector<bool>::resize()                                                               15.14           13.43         -1.71         -11.28%
Geomean                                                                               9.17            9.03         -0.14          -1.48%
