### PR TITLE
[PS5][Driver] forward -ffat-lto-objects to the linker

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -351,6 +351,10 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(D.getLTOMode() == LTOK_Thin ? "--lto=thin"
                                                   : "--lto=full");
 
+  if (Args.hasFlag(options::OPT_ffat_lto_objects,
+                   options::OPT_fno_fat_lto_objects, false))
+    CmdArgs.push_back("--fat-lto-objects");
+
   AddLTOFlag("-emit-jump-table-sizes-section");
 
   if (UseJMC)

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -207,3 +207,16 @@
 // CHECK-TARGETLIB-SAME: "-Luser"
 // CHECK-TARGETLIB-SAME: "-L{{.*}}myroot{{/|\\\\}}target{{/|\\\\}}lib"
 // CHECK-TARGETLIB-SAME: "-L."
+
+// Test that -ffat-lto-objects is forwarded to the linker.
+
+// RUN: %clang --target=x86_64-sie-ps5 -flto=full -ffat-lto-objects %s -### 2>&1 | FileCheck --check-prefixes=CHECK-FAT-LTO %s
+// RUN: %clang --target=x86_64-sie-ps5 -flto=full -funified-lto -ffat-lto-objects %s -### 2>&1 | FileCheck --check-prefixes=CHECK-FAT-LTO %s
+// RUN: %clang --target=x86_64-sie-ps5 -flto=full %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-FAT-LTO %s
+// RUN: %clang --target=x86_64-sie-ps5 -flto=full -funified-lto %s -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-FAT-LTO %s
+
+// CHECK-FAT-LTO: {{ld(\.exe)?}}"
+// CHECK-FAT-LTO-SAME: "--fat-lto-objects"
+// CHECK-NO-FAT-LTO: {{ld(\.exe)?}}"
+// CHECK-NO-FAT-LTO-NOT: "--fat-lto-objects"
+// CHECK-NO-FAT-LTO-SAME: {{$}}


### PR DESCRIPTION
When clang is driving the linker and is passed -ffat-lto-objects, pass it on to the linker as --fat-lto-objects.