### PR TITLE
[LoopInterchange] Add loop names to debug messages. NFC

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -642,8 +642,14 @@ struct LoopInterchange {
 
     unsigned LoopNestDepth = LoopList.size();
 
-    LLVM_DEBUG(dbgs() << "Processing LoopList of size = " << LoopNestDepth
-                      << "\n");
+    LLVM_DEBUG(
+      dbgs() << "Processing LoopList of size = " << LoopNestDepth
+             << " containing the following loops:\n";
+      for (auto *L : LoopList) {
+        dbgs() << "  - ";
+        L->print(dbgs());
+      }
+    );
 
     CharMatrix DependencyMatrix;
     Loop *OuterMostLoop = *(LoopList.begin());
@@ -659,7 +665,8 @@ struct LoopInterchange {
     // Get the Outermost loop exit.
     BasicBlock *LoopNestExit = OuterMostLoop->getExitBlock();
     if (!LoopNestExit) {
-      LLVM_DEBUG(dbgs() << "OuterMostLoop needs an unique exit block");
+      LLVM_DEBUG(dbgs() << "OuterMostLoop '" << OuterMostLoop->getName()
+                        << "' needs an unique exit block");
       return false;
     }
 
@@ -695,14 +702,19 @@ struct LoopInterchange {
                       << " and OuterLoopId = " << OuterLoopId << "\n");
     LoopInterchangeLegality LIL(OuterLoop, InnerLoop, SE, ORE);
     if (!LIL.canInterchangeLoops(InnerLoopId, OuterLoopId, DependencyMatrix)) {
-      LLVM_DEBUG(dbgs() << "Not interchanging loops. Cannot prove legality.\n");
+      LLVM_DEBUG(dbgs() << "Cannot prove legality, not interchanging loops '"
+                        << OuterLoop->getName() << "' and '"
+                        << InnerLoop->getName() << "'\n");
       return false;
     }
-    LLVM_DEBUG(dbgs() << "Loops are legal to interchange\n");
+    LLVM_DEBUG(dbgs() << "Loops '" << OuterLoop->getName() << "' and '"
+		      << InnerLoop->getName() << "' are legal to interchange\n");
     LoopInterchangeProfitability LIP(OuterLoop, InnerLoop, SE, ORE);
     if (!LIP.isProfitable(InnerLoop, OuterLoop, InnerLoopId, OuterLoopId,
                           DependencyMatrix, CCM)) {
-      LLVM_DEBUG(dbgs() << "Interchanging loops not profitable.\n");
+      LLVM_DEBUG(dbgs() << "Interchanging loops '" << OuterLoop->getName()
+                        << "' and '" << InnerLoop->getName()
+                        << "' not profitable.\n");
       return false;
     }
 
@@ -715,7 +727,9 @@ struct LoopInterchange {
 
     LoopInterchangeTransform LIT(OuterLoop, InnerLoop, SE, LI, DT, LIL);
     LIT.transform(LIL.getHasNoWrapReductions());
-    LLVM_DEBUG(dbgs() << "Loops interchanged.\n");
+    LLVM_DEBUG(dbgs() << "Loops interchanged: outer loop '"
+                      << OuterLoop->getName() << "' and inner loop '"
+                      << InnerLoop->getName() << "'\n");
     LoopsInterchanged++;
 
     llvm::formLCSSARecursively(*OuterLoop, *DT, LI, SE);
@@ -745,7 +759,9 @@ bool LoopInterchangeLegality::tightlyNested(Loop *OuterLoop, Loop *InnerLoop) {
   BasicBlock *InnerLoopPreHeader = InnerLoop->getLoopPreheader();
   BasicBlock *OuterLoopLatch = OuterLoop->getLoopLatch();
 
-  LLVM_DEBUG(dbgs() << "Checking if loops are tightly nested\n");
+  LLVM_DEBUG(dbgs() << "Checking if loops '" << OuterLoop->getName()
+                    << "' and '" << InnerLoop->getName()
+                    << "' are tightly nested\n");
 
   // A perfectly nested loop will not have any branch in between the outer and
   // inner block i.e. outer header will branch to either inner preheader and

--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -642,14 +642,14 @@ struct LoopInterchange {
 
     unsigned LoopNestDepth = LoopList.size();
 
-    LLVM_DEBUG(
+    LLVM_DEBUG({
       dbgs() << "Processing LoopList of size = " << LoopNestDepth
              << " containing the following loops:\n";
       for (auto *L : LoopList) {
         dbgs() << "  - ";
         L->print(dbgs());
       }
-    );
+    });
 
     CharMatrix DependencyMatrix;
     Loop *OuterMostLoop = *(LoopList.begin());

--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -708,7 +708,8 @@ struct LoopInterchange {
       return false;
     }
     LLVM_DEBUG(dbgs() << "Loops '" << OuterLoop->getName() << "' and '"
-		      << InnerLoop->getName() << "' are legal to interchange\n");
+                      << InnerLoop->getName()
+                      << "' are legal to interchange\n");
     LoopInterchangeProfitability LIP(OuterLoop, InnerLoop, SE, ORE);
     if (!LIP.isProfitable(InnerLoop, OuterLoop, InnerLoopId, OuterLoopId,
                           DependencyMatrix, CCM)) {

--- a/llvm/test/Transforms/LoopInterchange/delay-cachecost-calculation.ll
+++ b/llvm/test/Transforms/LoopInterchange/delay-cachecost-calculation.ll
@@ -11,7 +11,7 @@
 ;   for (j = 0; j < 16; j++)
 ;     A[j][i] += 1;
 
-; CHECK: Loops are legal to interchange
+; CHECK: Loops 'for.i.header' and 'for.j' are legal to interchange
 ; CHECK: Compute CacheCost
 define void @legal_to_interchange() {
 entry:

--- a/llvm/test/Transforms/LoopInterchange/inner-indvar-depend-on-outer-indvar-remark.ll
+++ b/llvm/test/Transforms/LoopInterchange/inner-indvar-depend-on-outer-indvar-remark.ll
@@ -12,7 +12,7 @@
 ; outer loop induction variable, i.e., triangular loops.
 ;
 ; CHECK: Loop structure not understood by pass
-; CHECK: Not interchanging loops. Cannot prove legality.
+; CHECK: Cannot prove legality, not interchanging loops 'for1.header' and 'for2'
 ;
 define void @interchange_01(i64 %k) {
 entry:
@@ -50,7 +50,7 @@ for.end12:
 ; outer loop induction variable, i.e., triangular loops.
 ;
 ; CHECK: Loop structure not understood by pass
-; CHECK: Not interchanging loops. Cannot prove legality.
+; CHECK: Cannot prove legality, not interchanging loops 'for1.header' and 'for2'
 ;
 define void @interchange_02(i64 %k) {
 entry:
@@ -87,7 +87,7 @@ for.end12:
 ; Inner loop induction variable exit condition depends on the
 ; outer loop induction variable, i.e., triangular loops.
 ; CHECK: Loop structure not understood by pass
-; CHECK: Not interchanging loops. Cannot prove legality.
+; CHECK: Cannot prove legality, not interchanging loops 'for1.header' and 'for2'
 ;
 define void @interchange_03(i64 %k) {
 entry:

--- a/llvm/test/Transforms/LoopInterchange/legality-check.ll
+++ b/llvm/test/Transforms/LoopInterchange/legality-check.ll
@@ -17,10 +17,10 @@
 ; CHECK-NEXT: * = <
 ; CHECK-NEXT: * = =
 ; CHECK-NEXT: Processing InnerLoopId = 2 and OuterLoopId = 1
-; CHECK-NEXT: Checking if loops are tightly nested
+; CHECK-NEXT: Checking if loops 'for.i.header' and 'for.j' are tightly nested
 ; CHECK-NEXT: Checking instructions in Loop header and Loop latch
 ; CHECK-NEXT: Loops are perfectly nested
-; CHECK-NEXT: Loops are legal to interchange
+; CHECK-NEXT: Loops 'for.i.header' and 'for.j' are legal to interchange
 
 define void @all_eq_lt() {
 entry:
@@ -72,7 +72,7 @@ exit:
 ; CHECK-NEXT: * <
 ; CHECK-NEXT: Processing InnerLoopId = 1 and OuterLoopId = 0
 ; CHECK-NEXT: Failed interchange InnerLoopId = 1 and OuterLoopId = 0 due to dependence
-; CHECK-NEXT: Not interchanging loops. Cannot prove legality.
+; CHECK-NEXT: Cannot prove legality, not interchanging loops 'for.i.header' and 'for.j'
 
 define void @all_lt() {
 entry:
@@ -114,7 +114,7 @@ exit:
 ; CHECK-NEXT: < >
 ; CHECK-NEXT: Processing InnerLoopId = 1 and OuterLoopId = 0
 ; CHECK-NEXT: Failed interchange InnerLoopId = 1 and OuterLoopId = 0 due to dependence
-; CHECK-NEXT: Not interchanging loops. Cannot prove legality.
+; CHECK-NEXT: Cannot prove legality, not interchanging loops 'for.i.header' and 'for.j'
 
 define void @lt_gt() {
 entry:
@@ -155,10 +155,10 @@ exit:
 ; CHECK-NEXT: = * *
 ; CHECK-NEXT: Processing InnerLoopId = 2 and OuterLoopId = 1
 ; CHECK-NEXT: Failed interchange InnerLoopId = 2 and OuterLoopId = 1 due to dependence
-; CHECK-NEXT: Not interchanging loops. Cannot prove legality.
+; CHECK-NEXT: Cannot prove legality, not interchanging loops 'for.j.header' and 'for.k'
 ; CHECK-NEXT: Processing InnerLoopId = 1 and OuterLoopId = 0
 ; CHECK-NEXT: Failed interchange InnerLoopId = 1 and OuterLoopId = 0 due to dependence
-; CHECK-NEXT: Not interchanging loops. Cannot prove legality.
+; CHECK-NEXT: Cannot prove legality, not interchanging loops 'for.i.header' and 'for.j.header'
 
 define void @eq_all_lt() {
 entry:


### PR DESCRIPTION
The debug messages are difficult to follow, because it is not printing which loops it is dealing with (or you would need to scroll up a lot and then it's still not very clear). Thus, this just adds loop names to various debug messages so it's easier to see which loops it is accepting, rejecting, etc.