### PR TITLE
[InstCombine] Limit (icmp eq/ne (and (add A, Addend), Msk), C) fold to one use of and

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -2005,8 +2005,8 @@ Instruction *InstCombinerImpl::foldICmpAndConstant(ICmpInst &Cmp,
   {
     Value *A;
     const APInt *Addend, *Msk;
-    if (match(And, m_And(m_OneUse(m_Add(m_Value(A), m_APInt(Addend))),
-                         m_LowBitMask(Msk))) &&
+    if (match(And, m_OneUse(m_And(m_OneUse(m_Add(m_Value(A), m_APInt(Addend))),
+                                  m_LowBitMask(Msk)))) &&
         C.ule(*Msk)) {
       APInt NewComperand = (C - *Addend) & *Msk;
       Value *MaskA = Builder.CreateAnd(A, ConstantInt::get(A->getType(), *Msk));

--- a/llvm/test/Transforms/InstCombine/and-compare.ll
+++ b/llvm/test/Transforms/InstCombine/and-compare.ll
@@ -280,3 +280,21 @@ entry:
   %cmp = icmp ne i8 %and, 16
   ret i1 %cmp
 }
+
+define i1 @test_ne_11_and_15_add_10_multiuse(i8 %a) {
+; CHECK-LABEL: @test_ne_11_and_15_add_10_multiuse(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[A:%.*]], 10
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[ADD]], 15
+; CHECK-NEXT:    call void @use.i8(i8 [[AND]])
+; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[A]], 15
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i8 [[TMP0]], 1
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+entry:
+  %add = add i8 %a, 10
+  %and = and i8 %add, 15
+  call void @use.i8(i8 %and)
+  %cmp = icmp ne i8 %and, 11
+  ret i1 %cmp
+}

--- a/llvm/test/Transforms/InstCombine/and-compare.ll
+++ b/llvm/test/Transforms/InstCombine/and-compare.ll
@@ -287,8 +287,7 @@ define i1 @test_ne_11_and_15_add_10_multiuse(i8 %a) {
 ; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[A:%.*]], 10
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[ADD]], 15
 ; CHECK-NEXT:    call void @use.i8(i8 [[AND]])
-; CHECK-NEXT:    [[TMP0:%.*]] = and i8 [[A]], 15
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i8 [[TMP0]], 1
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i8 [[AND]], 11
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
 entry:


### PR DESCRIPTION
If the and has multiple uses, the fold can increase the instruction count.