### PR TITLE
[ConstantInt] Add ImplicitTrunc parameter to getSigned() (NFC)

### DIFF
--- a/llvm/include/llvm/IR/Constants.h
+++ b/llvm/include/llvm/IR/Constants.h
@@ -133,11 +133,14 @@ public:
   /// either getSExtValue() or getZExtValue() will yield a correctly sized and
   /// signed value for the type Ty.
   /// Get a ConstantInt for a specific signed value.
-  static ConstantInt *getSigned(IntegerType *Ty, int64_t V) {
-    return get(Ty, V, true);
+  /// \param ImplicitTrunc Whether to allow implicit truncation of the value.
+  // TODO: Make ImplicitTrunc default to false.
+  static ConstantInt *getSigned(IntegerType *Ty, int64_t V,
+                                bool ImplicitTrunc = true) {
+    return get(Ty, V, /*IsSigned=*/true, ImplicitTrunc);
   }
-  static Constant *getSigned(Type *Ty, int64_t V) {
-    return get(Ty, V, true);
+  static Constant *getSigned(Type *Ty, int64_t V, bool ImplicitTrunc = true) {
+    return get(Ty, V, /*IsSigned=*/true, ImplicitTrunc);
   }
 
   /// Return a ConstantInt with the specified value and an implied Type. The

--- a/llvm/lib/Transforms/Scalar/StraightLineStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/StraightLineStrengthReduce.cpp
@@ -1105,8 +1105,8 @@ void StraightLineStrengthReduce::allocateCandidatesAndFindBasisForGEP(
     uint64_t ElementSize = GTI.getSequentialElementStride(*DL);
     IntegerType *PtrIdxTy = cast<IntegerType>(DL->getIndexType(GEP->getType()));
     // If the element size overflows the type, truncate.
-    ConstantInt *ElementSizeIdx = ConstantInt::get(
-        PtrIdxTy, ElementSize, /*IsSigned=*/true, /*ImplicitTrunc=*/true);
+    ConstantInt *ElementSizeIdx =
+        ConstantInt::getSigned(PtrIdxTy, ElementSize, /*ImplicitTrunc=*/true);
     if (ArrayIdx->getType()->getIntegerBitWidth() <=
         DL->getIndexSizeInBits(GEP->getAddressSpace())) {
       // Skip factoring if ArrayIdx is wider than the index size, because


### PR DESCRIPTION
For consistency with `ConstantInt::get()`, add an ImplicitTrunc parameter to `ConstantInt::getSigned()` as well. It currently defaults to true and will be flipped to false in the future (by https://github.com/llvm/llvm-project/pull/171456).