### PR TITLE
[lldb][windows] only use a ConPTY if needed

### DIFF
--- a/lldb/source/Host/windows/ProcessLauncherWindows.cpp
+++ b/lldb/source/Host/windows/ProcessLauncherWindows.cpp
@@ -93,8 +93,9 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
   startupinfoex.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
 
   HPCON hPC = launch_info.GetPTY().GetPseudoTerminalHandle();
-  bool use_pty =
-      hPC != INVALID_HANDLE_VALUE && launch_info.GetNumFileActions() == 0;
+  bool use_pty = hPC != INVALID_HANDLE_VALUE &&
+                 launch_info.GetNumFileActions() == 0 &&
+                 launch_info.GetFlags().Test(lldb::eLaunchFlagLaunchInTTY);
 
   HANDLE stdin_handle = GetStdioHandle(launch_info, STDIN_FILENO);
   HANDLE stdout_handle = GetStdioHandle(launch_info, STDOUT_FILENO);


### PR DESCRIPTION
This patch fixes a regression caused by https://github.com/llvm/llvm-project/pull/168729.

The changes ensure that we only create the process with a ConPTY if we need to.