### PR TITLE
[lldb-dap][windows] deactivate TestDAP_attach.test_by_name_waitFor on Windows

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -59,6 +59,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         self.attach(program=program)
         self.continue_and_verify_pid()
 
+    @skipIfWindows
     def test_by_name_waitFor(self):
         """
         Tests waiting for, and attaching to a process by process name that

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -59,7 +59,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         self.attach(program=program)
         self.continue_and_verify_pid()
 
-    @skipIfWindows
+    @expectedFailureWindows
     def test_by_name_waitFor(self):
         """
         Tests waiting for, and attaching to a process by process name that


### PR DESCRIPTION
Attaching by name on Windows is not implemented yet.