### PR TITLE
[mlir][IR] Fix `RewriterBase::replaceUsesWithIf(ValueRange)` in dialect conversion

### DIFF
--- a/mlir/lib/IR/PatternMatch.cpp
+++ b/mlir/lib/IR/PatternMatch.cpp
@@ -276,16 +276,15 @@ void RewriterBase::replaceUsesWithIf(ValueRange from, ValueRange to,
                                      function_ref<bool(OpOperand &)> functor,
                                      bool *allUsesReplaced) {
   assert(from.size() == to.size() && "incorrect number of replacements");
-  for (auto [fromVal, toVal] : llvm::zip_equal(from, to)) {
-    if (allUsesReplaced) {
-      bool r;
-      replaceUsesWithIf(fromVal, toVal, functor,
-                        /*allUsesReplaced=*/&r);
-      *allUsesReplaced &= r;
-    } else {
-      replaceUsesWithIf(fromVal, toVal, functor);
-    }
+  bool allReplaced = true;
+  for (auto it : llvm::zip_equal(from, to)) {
+    bool r = true;
+    replaceUsesWithIf(std::get<0>(it), std::get<1>(it), functor,
+                      /*allUsesReplaced=*/allUsesReplaced ? &r : nullptr);
+    allReplaced &= r;
   }
+  if (allUsesReplaced)
+    *allUsesReplaced = allReplaced;
 }
 
 void RewriterBase::inlineBlockBefore(Block *source, Block *dest,

--- a/mlir/lib/IR/PatternMatch.cpp
+++ b/mlir/lib/IR/PatternMatch.cpp
@@ -276,15 +276,16 @@ void RewriterBase::replaceUsesWithIf(ValueRange from, ValueRange to,
                                      function_ref<bool(OpOperand &)> functor,
                                      bool *allUsesReplaced) {
   assert(from.size() == to.size() && "incorrect number of replacements");
-  bool allReplaced = true;
-  for (auto it : llvm::zip_equal(from, to)) {
-    bool r;
-    replaceUsesWithIf(std::get<0>(it), std::get<1>(it), functor,
-                      /*allUsesReplaced=*/&r);
-    allReplaced &= r;
+  for (auto [fromVal, toVal] : llvm::zip_equal(from, to)) {
+    if (allUsesReplaced) {
+      bool r;
+      replaceUsesWithIf(fromVal, toVal, functor,
+                        /*allUsesReplaced=*/&r);
+      *allUsesReplaced &= r;
+    } else {
+      replaceUsesWithIf(fromVal, toVal, functor);
+    }
   }
-  if (allUsesReplaced)
-    *allUsesReplaced = allReplaced;
 }
 
 void RewriterBase::inlineBlockBefore(Block *source, Block *dest,


### PR DESCRIPTION
`ConversionPatternRewriter::replaceUsesWithIf` does not support the `allUsesReplaced` flag and asserts that it's not set. However the `ValueRange` overload of  `RewriterBase::replaceUsesWithIf` always passes this flag when calling the virtual overload of `replaceUsesWithIf`. This means calls made to `RewriterBase::replaceUsesWithIf` from a `ConversionPattern`  crash, whether the `allUsesReplaced` flag is set or not.

This change tweaks `RewriterBase::replaceUsesWithIf` to only pass that flag if the callee has set it.