### PR TITLE
[llvm-objdump] Return non-zero exit code for invalid MachO files

### DIFF
--- a/llvm/test/Object/macho-invalid.test
+++ b/llvm/test/Object/macho-invalid.test
@@ -83,7 +83,7 @@ RUN: not llvm-objdump -t %p/Inputs/macho-invalid-section-index-getSectionRawName
 RUN:      | FileCheck -check-prefix INVALID-SECTION-IDX-SYMBOL-SEC-objdump %s
 INVALID-SECTION-IDX-SYMBOL-SEC-objdump: truncated or malformed object (bad section index: 66 for symbol at index 8)
 
-RUN: llvm-objdump --macho --private-headers %p/Inputs/macho-invalid-header 2>&1 | FileCheck --check-prefix=INVALID-HEADER %s
+RUN: not llvm-objdump --macho --private-headers %p/Inputs/macho-invalid-header 2>&1 | FileCheck --check-prefix=INVALID-HEADER %s
 INVALID-HEADER: is not an object file
 
 RUN: not llvm-objdump --macho --private-headers %p/Inputs/macho64-invalid-incomplete-segment-load-command 2>&1 | FileCheck --check-prefix=INCOMPLETE-SEGMENT-LOADC %s

--- a/llvm/test/tools/llvm-objdump/MachO/malformed.test
+++ b/llvm/test/tools/llvm-objdump/MachO/malformed.test
@@ -1,3 +1,3 @@
-RUN: llvm-objdump --macho --private-header %p/Inputs/malformed-macho.bin %p/Inputs/empty.macho-armv7 2>&1 | FileCheck %s --check-prefix=MALFORMED
+RUN: not llvm-objdump --macho --private-header %p/Inputs/malformed-macho.bin %p/Inputs/empty.macho-armv7 2>&1 | FileCheck %s --check-prefix=MALFORMED
 MALFORMED: is not an object file
 MALFORMED-NEXT: Mach header

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -2537,8 +2537,11 @@ void objdump::parseInputMachO(StringRef Filename) {
   if (!BinaryOrErr) {
     if (Error E = isNotObjectErrorInvalidFileType(BinaryOrErr.takeError()))
       reportError(std::move(E), Filename);
-    else
-      outs() << Filename << ": is not an object file\n";
+    else {
+      WithColor::error(errs(), "llvm-objdump")
+          << "'" << Filename << "': is not an object file\n";
+      HadError = true;
+    }
     return;
   }
   Binary &Bin = *BinaryOrErr.get().getBinary();

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -330,6 +330,7 @@ bool objdump::PrintImmHex;
 bool objdump::PrivateHeaders;
 std::vector<std::string> objdump::FilterSections;
 bool objdump::SectionHeaders;
+bool objdump::HadError;
 static bool ShowAllSymbols;
 static bool ShowLMA;
 bool objdump::PrintSource;
@@ -3911,5 +3912,5 @@ int llvm_objdump_main(int argc, char **argv, const llvm::ToolContext &) {
 
   warnOnNoMatchForSections();
 
-  return EXIT_SUCCESS;
+  return HadError ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/llvm/tools/llvm-objdump/llvm-objdump.h
+++ b/llvm/tools/llvm-objdump/llvm-objdump.h
@@ -72,6 +72,8 @@ extern bool SymbolTable;
 extern std::string TripleName;
 extern bool UnwindInfo;
 
+extern bool HadError;
+
 extern StringSet<> FoundSectionSet;
 
 class Dumper {


### PR DESCRIPTION
Fixes #84148