### PR TITLE
[NFC][Clang] Apply Rule of Three to BuildLockset

### DIFF
--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -1771,6 +1771,8 @@ public:
   }
 
   ~BuildLockset() { Analyzer->SxBuilder.setLookupLocalVarExpr(nullptr); }
+  BuildLockset(const BuildLockset &) = delete;
+  BuildLockset &operator=(const BuildLockset &) = delete;
 
   void VisitUnaryOperator(const UnaryOperator *UO);
   void VisitBinaryOperator(const BinaryOperator *BO);


### PR DESCRIPTION
Static analysis flagged BuildLockset as not following the Rule of Three, so I just added deleted copy ctor and copy assignment.