### PR TITLE
[NFC][LLVM] Adopt ListSeparator/interleaved in more places

### DIFF
--- a/llvm/include/llvm/ADT/GenericCycleInfo.h
+++ b/llvm/include/llvm/ADT/GenericCycleInfo.h
@@ -32,6 +32,7 @@
 #include "llvm/ADT/GenericSSAContext.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -230,13 +231,9 @@ public:
 
   Printable printEntries(const ContextT &Ctx) const {
     return Printable([this, &Ctx](raw_ostream &Out) {
-      bool First = true;
-      for (auto *Entry : Entries) {
-        if (!First)
-          Out << ' ';
-        First = false;
-        Out << Ctx.print(Entry);
-      }
+      ListSeparator LS(" ");
+      for (auto *Entry : Entries)
+        Out << LS << Ctx.print(Entry);
     });
   }
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFTypePrinter.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFTypePrinter.h
@@ -709,7 +709,7 @@ void DWARFTypePrinter<DieType>::appendSubroutineNameAfter(
   DieType FirstParamIfArtificial;
   OS << '(';
   EndedWithTemplate = false;
-  bool First = true;
+  ListSeparator LS;
   bool RealFirst = true;
   for (DieType P : D) {
     if (P.getTag() != dwarf::DW_TAG_formal_parameter &&
@@ -722,10 +722,7 @@ void DWARFTypePrinter<DieType>::appendSubroutineNameAfter(
       RealFirst = false;
       continue;
     }
-    if (!First) {
-      OS << ", ";
-    }
-    First = false;
+    OS << LS;
     if (P.getTag() == dwarf::DW_TAG_unspecified_parameters)
       OS << "...";
     else

--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -455,9 +455,8 @@ struct AllocInfo {
 
 inline raw_ostream &operator<<(raw_ostream &OS, const AllocInfo &AE) {
   ListSeparator LS;
-  OS << "Versions: ";
-  for (auto V : AE.Versions)
-    OS << LS << (unsigned)V;
+  OS << "Versions: "
+     << interleaved(map_range(AE.Versions, StaticCastTo<unsigned>));
 
   OS << " MIB:\n";
   for (auto &M : AE.MIBs)

--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -454,29 +454,21 @@ struct AllocInfo {
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const AllocInfo &AE) {
-  bool First = true;
+  ListSeparator LS;
   OS << "Versions: ";
-  for (auto V : AE.Versions) {
-    if (!First)
-      OS << ", ";
-    First = false;
-    OS << (unsigned)V;
-  }
+  for (auto V : AE.Versions)
+    OS << LS << (unsigned)V;
+
   OS << " MIB:\n";
-  for (auto &M : AE.MIBs) {
+  for (auto &M : AE.MIBs)
     OS << "\t\t" << M << "\n";
-  }
   if (!AE.ContextSizeInfos.empty()) {
     OS << "\tContextSizeInfo per MIB:\n";
     for (auto Infos : AE.ContextSizeInfos) {
       OS << "\t\t";
-      bool FirstInfo = true;
-      for (auto [FullStackId, TotalSize] : Infos) {
-        if (!FirstInfo)
-          OS << ", ";
-        FirstInfo = false;
-        OS << "{ " << FullStackId << ", " << TotalSize << " }";
-      }
+      ListSeparator InfoLS;
+      for (auto [FullStackId, TotalSize] : Infos)
+        OS << InfoLS << "{ " << FullStackId << ", " << TotalSize << " }";
       OS << "\n";
     }
   }

--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -454,7 +454,6 @@ struct AllocInfo {
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const AllocInfo &AE) {
-  ListSeparator LS;
   OS << "Versions: "
      << interleaved(map_range(AE.Versions, StaticCastTo<unsigned>));
 

--- a/llvm/lib/Analysis/CFGSCCPrinter.cpp
+++ b/llvm/lib/Analysis/CFGSCCPrinter.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/Analysis/CFGSCCPrinter.h"
 #include "llvm/ADT/SCCIterator.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/CFG.h"
 
 using namespace llvm;
@@ -19,12 +20,9 @@ PreservedAnalyses CFGSCCPrinterPass::run(Function &F,
   for (scc_iterator<Function *> SCCI = scc_begin(&F); !SCCI.isAtEnd(); ++SCCI) {
     const std::vector<BasicBlock *> &NextSCC = *SCCI;
     OS << "\nSCC #" << ++SccNum << ": ";
-    bool First = true;
+    ListSeparator LS;
     for (BasicBlock *BB : NextSCC) {
-      if (First)
-        First = false;
-      else
-        OS << ", ";
+      OS << LS;
       BB->printAsOperand(OS, false);
     }
     if (NextSCC.size() == 1 && SCCI.hasCycle())

--- a/llvm/lib/Analysis/CallGraph.cpp
+++ b/llvm/lib/Analysis/CallGraph.cpp
@@ -10,6 +10,7 @@
 #include "llvm/ADT/SCCIterator.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/AbstractCallSite.h"
 #include "llvm/IR/Function.h"
@@ -273,16 +274,11 @@ PreservedAnalyses CallGraphSCCsPrinterPass::run(Module &M,
        ++SCCI) {
     const std::vector<CallGraphNode *> &nextSCC = *SCCI;
     OS << "\nSCC #" << ++sccNum << ": ";
-    bool First = true;
-    for (CallGraphNode *CGN : nextSCC) {
-      if (First)
-        First = false;
-      else
-        OS << ", ";
-      OS << (CGN->getFunction() ? CGN->getFunction()->getName()
+    ListSeparator LS;
+    for (CallGraphNode *CGN : nextSCC)
+      OS << LS
+         << (CGN->getFunction() ? CGN->getFunction()->getName()
                                 : "external node");
-    }
-
     if (nextSCC.size() == 1 && SCCI.hasCycle())
       OS << " (Has self-loop).";
   }

--- a/llvm/lib/Analysis/InlineAdvisor.cpp
+++ b/llvm/lib/Analysis/InlineAdvisor.cpp
@@ -473,10 +473,9 @@ std::string llvm::formatCallSiteLocation(DebugLoc DLoc,
                                          const CallSiteFormat &Format) {
   std::string Buffer;
   raw_string_ostream CallSiteLoc(Buffer);
-  bool First = true;
+  ListSeparator LS(" @ ");
   for (DILocation *DIL = DLoc.get(); DIL; DIL = DIL->getInlinedAt()) {
-    if (!First)
-      CallSiteLoc << " @ ";
+    CallSiteLoc << LS;
     // Note that negative line offset is actually possible, but we use
     // unsigned int to match line offset representation in remarks so
     // it's directly consumable by relay advisor.
@@ -491,16 +490,14 @@ std::string llvm::formatCallSiteLocation(DebugLoc DLoc,
       CallSiteLoc << ":" << llvm::utostr(DIL->getColumn());
     if (Format.outputDiscriminator() && Discriminator)
       CallSiteLoc << "." << llvm::utostr(Discriminator);
-    First = false;
   }
 
   return CallSiteLoc.str();
 }
 
 void llvm::addLocationToRemarks(OptimizationRemark &Remark, DebugLoc DLoc) {
-  if (!DLoc) {
+  if (!DLoc)
     return;
-  }
 
   bool First = true;
   Remark << " at callsite ";

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -14085,15 +14085,9 @@ void ScalarEvolution::print(raw_ostream &OS) const {
             OS << *ExitValue;
           }
 
-          bool First = true;
+          ListSeparator LS(", ", "\t\tLoopDispositions: { ");
           for (const auto *Iter = L; Iter; Iter = Iter->getParentLoop()) {
-            if (First) {
-              OS << "\t\t" "LoopDispositions: { ";
-              First = false;
-            } else {
-              OS << ", ";
-            }
-
+            OS << LS;
             Iter->getHeader()->printAsOperand(OS, /*PrintType=*/false);
             OS << ": " << SE.getLoopDisposition(SV, Iter);
           }
@@ -14101,13 +14095,7 @@ void ScalarEvolution::print(raw_ostream &OS) const {
           for (const auto *InnerL : depth_first(L)) {
             if (InnerL == L)
               continue;
-            if (First) {
-              OS << "\t\t" "LoopDispositions: { ";
-              First = false;
-            } else {
-              OS << ", ";
-            }
-
+            OS << LS;
             InnerL->getHeader()->printAsOperand(OS, /*PrintType=*/false);
             OS << ": " << SE.getLoopDisposition(SV, InnerL);
           }

--- a/llvm/lib/CodeGen/TargetInstrInfo.cpp
+++ b/llvm/lib/CodeGen/TargetInstrInfo.cpp
@@ -34,6 +34,7 @@
 #include "llvm/MC/MCInstrItineraries.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/InterleavedRange.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetMachine.h"
 
@@ -2048,9 +2049,7 @@ std::string TargetInstrInfo::createMIROperandComment(
   if (OpIdx == InlineAsm::MIOp_ExtraInfo) {
     // Print HasSideEffects, MayLoad, MayStore, IsAlignStack
     unsigned ExtraInfo = Op.getImm();
-    ListSeparator LS(" ");
-    for (StringRef Info : InlineAsm::getExtraInfoNames(ExtraInfo))
-      OS << LS << Info;
+    OS << interleaved(InlineAsm::getExtraInfoNames(ExtraInfo), " ");
     return Flags;
   }
 

--- a/llvm/lib/CodeGen/TargetInstrInfo.cpp
+++ b/llvm/lib/CodeGen/TargetInstrInfo.cpp
@@ -2048,14 +2048,9 @@ std::string TargetInstrInfo::createMIROperandComment(
   if (OpIdx == InlineAsm::MIOp_ExtraInfo) {
     // Print HasSideEffects, MayLoad, MayStore, IsAlignStack
     unsigned ExtraInfo = Op.getImm();
-    bool First = true;
-    for (StringRef Info : InlineAsm::getExtraInfoNames(ExtraInfo)) {
-      if (!First)
-        OS << " ";
-      First = false;
-      OS << Info;
-    }
-
+    ListSeparator LS(" ");
+    for (StringRef Info : InlineAsm::getExtraInfoNames(ExtraInfo))
+      OS << LS << Info;
     return Flags;
   }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -9,6 +9,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFDebugLine.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
@@ -1219,15 +1220,10 @@ Error DWARFDebugLine::LineTable::parse(
           }
           if (Verbose && !Operands.empty()) {
             *OS << " (operands: ";
-            bool First = true;
-            for (uint64_t Value : Operands) {
-              if (!First)
-                *OS << ", ";
-              First = false;
-              *OS << format("0x%16.16" PRIx64, Value);
-            }
-            if (Verbose)
-              *OS << ')';
+            ListSeparator LS;
+            for (uint64_t Value : Operands)
+              *OS << LS << format("0x%16.16" PRIx64, Value);
+            *OS << ')';
           }
         }
         break;

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnwindTablePrinter.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnwindTablePrinter.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/DebugInfo/DWARF/DWARFUnwindTablePrinter.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/DebugInfo/DIContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFExpressionPrinter.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -115,13 +116,10 @@ raw_ostream &llvm::dwarf::operator<<(raw_ostream &OS,
 /// for certain architectures like x86.
 static void printRegisterLocations(const RegisterLocations &RL, raw_ostream &OS,
                                    DIDumpOptions DumpOpts) {
-  bool First = true;
+  ListSeparator LS;
   for (uint32_t Reg : RL.getRegisters()) {
     auto Loc = *RL.getRegisterLocation(Reg);
-    if (First)
-      First = false;
-    else
-      OS << ", ";
+    OS << LS;
     printRegister(OS, DumpOpts, Reg);
     OS << '=';
     printUnwindLocation(Loc, OS, DumpOpts);

--- a/llvm/lib/DebugInfo/GSYM/InlineInfo.cpp
+++ b/llvm/lib/DebugInfo/GSYM/InlineInfo.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/DebugInfo/GSYM/InlineInfo.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/DebugInfo/GSYM/FileEntry.h"
 #include "llvm/DebugInfo/GSYM/FileWriter.h"
 #include "llvm/DebugInfo/GSYM/GsymReader.h"
@@ -20,14 +21,9 @@ using namespace gsym;
 raw_ostream &llvm::gsym::operator<<(raw_ostream &OS, const InlineInfo &II) {
   if (!II.isValid())
     return OS;
-  bool First = true;
-  for (auto Range : II.Ranges) {
-    if (First)
-      First = false;
-    else
-      OS << ' ';
-    OS << Range;
-  }
+  ListSeparator LS(" ");
+  for (auto Range : II.Ranges)
+    OS << LS << Range;
   OS << " Name = " << HEX32(II.Name) << ", CallFile = " << II.CallFile
      << ", CallLine = " << II.CallFile << '\n';
   for (const auto &Child : II.Children)

--- a/llvm/lib/DebugInfo/GSYM/InlineInfo.cpp
+++ b/llvm/lib/DebugInfo/GSYM/InlineInfo.cpp
@@ -12,6 +12,7 @@
 #include "llvm/DebugInfo/GSYM/FileWriter.h"
 #include "llvm/DebugInfo/GSYM/GsymReader.h"
 #include "llvm/Support/DataExtractor.h"
+#include "llvm/Support/InterleavedRange.h"
 #include <inttypes.h>
 
 using namespace llvm;
@@ -21,9 +22,7 @@ using namespace gsym;
 raw_ostream &llvm::gsym::operator<<(raw_ostream &OS, const InlineInfo &II) {
   if (!II.isValid())
     return OS;
-  ListSeparator LS(" ");
-  for (auto Range : II.Ranges)
-    OS << LS << Range;
+  OS << interleaved(II.Ranges, " ");
   OS << " Name = " << HEX32(II.Name) << ", CallFile = " << II.CallFile
      << ", CallLine = " << II.CallFile << '\n';
   for (const auto &Child : II.Children)

--- a/llvm/lib/DebugInfo/GSYM/LineTable.cpp
+++ b/llvm/lib/DebugInfo/GSYM/LineTable.cpp
@@ -137,9 +137,9 @@ llvm::Error LineTable::encode(FileWriter &Out, uint64_t BaseAddr) const {
     int64_t PrevLine = 1;
     bool First = true;
     for (const auto &line_entry : Lines) {
-      if (First)
+      if (First) {
         First = false;
-      else {
+      } else {
         int64_t LineDelta = (int64_t)line_entry.Line - PrevLine;
         auto End = DeltaInfos.end();
         auto Pos = std::lower_bound(DeltaInfos.begin(), End, LineDelta);

--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -1999,13 +1999,9 @@ bool FileCheck::readCheckFile(
       (ImplicitNegativeChecks.empty() || !Req.IsDefaultCheckPrefix)) {
     errs() << "error: no check strings found with prefix"
            << (PrefixesNotFound.size() > 1 ? "es " : " ");
-    bool First = true;
-    for (StringRef MissingPrefix : PrefixesNotFound) {
-      if (!First)
-        errs() << ", ";
-      errs() << "\'" << MissingPrefix << ":'";
-      First = false;
-    }
+    ListSeparator LS;
+    for (StringRef MissingPrefix : PrefixesNotFound)
+      errs() << LS << "\'" << MissingPrefix << ":'";
     errs() << '\n';
     return true;
   }

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -12,6 +12,7 @@
 
 #include "llvm/Frontend/HLSL/HLSLRootSignature.h"
 #include "llvm/Support/DXILABI.h"
+#include "llvm/Support/InterleavedRange.h"
 #include "llvm/Support/ScopedPrinter.h"
 
 namespace llvm {
@@ -208,11 +209,7 @@ raw_ostream &operator<<(raw_ostream &OS, const RootElement &Element) {
 }
 
 void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
-  OS << " RootElements{";
-  ListSeparator LS;
-  for (const RootElement &Element : Elements)
-    OS << LS << Element;
-  OS << "}";
+  OS << " RootElements" << interleaved(Elements, ", ", "{", "}");
 }
 
 } // namespace rootsig

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -209,13 +209,9 @@ raw_ostream &operator<<(raw_ostream &OS, const RootElement &Element) {
 
 void dumpRootElements(raw_ostream &OS, ArrayRef<RootElement> Elements) {
   OS << " RootElements{";
-  bool First = true;
-  for (const RootElement &Element : Elements) {
-    if (!First)
-      OS << ",";
-    OS << " " << Element;
-    First = false;
-  }
+  ListSeparator LS;
+  for (const RootElement &Element : Elements)
+    OS << LS << Element;
   OS << "}";
 }
 

--- a/llvm/lib/MC/MCInstPrinter.cpp
+++ b/llvm/lib/MC/MCInstPrinter.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/MC/MCInstPrinter.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCInst.h"
@@ -24,15 +25,9 @@ using namespace llvm;
 
 void llvm::dumpBytes(ArrayRef<uint8_t> bytes, raw_ostream &OS) {
   static const char hex_rep[] = "0123456789abcdef";
-  bool First = true;
-  for (char i: bytes) {
-    if (First)
-      First = false;
-    else
-      OS << ' ';
-    OS << hex_rep[(i & 0xF0) >> 4];
-    OS << hex_rep[i & 0xF];
-  }
+  ListSeparator LS(" ");
+  for (char i : bytes)
+    OS << LS << hex_rep[(i & 0xF0) >> 4] << hex_rep[i & 0xF];
 }
 
 MCInstPrinter::~MCInstPrinter() = default;

--- a/llvm/lib/MC/MCInstPrinter.cpp
+++ b/llvm/lib/MC/MCInstPrinter.cpp
@@ -23,11 +23,11 @@
 
 using namespace llvm;
 
-void llvm::dumpBytes(ArrayRef<uint8_t> bytes, raw_ostream &OS) {
-  static const char hex_rep[] = "0123456789abcdef";
+void llvm::dumpBytes(ArrayRef<uint8_t> Bytes, raw_ostream &OS) {
+  static const char HexRep[] = "0123456789abcdef";
   ListSeparator LS(" ");
-  for (char i : bytes)
-    OS << LS << hex_rep[(i & 0xF0) >> 4] << hex_rep[i & 0xF];
+  for (char Byte : Bytes)
+    OS << LS << HexRep[(Byte & 0xF0) >> 4] << HexRep[Byte & 0xF];
 }
 
 MCInstPrinter::~MCInstPrinter() = default;

--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -3240,13 +3240,9 @@ void CallsiteContextGraph<DerivedCCG, FuncTy, CallTy>::ContextNode::print(
        << ")\n";
   if (!Clones.empty()) {
     OS << "\tClones: ";
-    bool First = true;
-    for (auto *C : Clones) {
-      if (!First)
-        OS << ", ";
-      First = false;
-      OS << C << " NodeId: " << C->NodeId;
-    }
+    ListSeparator LS;
+    for (auto *C : Clones)
+      OS << LS << C << " NodeId: " << C->NodeId;
     OS << "\n";
   } else if (CloneOf) {
     OS << "\tClone of " << CloneOf << " NodeId: " << CloneOf->NodeId << "\n";

--- a/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -760,39 +760,32 @@ bool Formula::hasRegsUsedByUsesOtherThan(size_t LUIdx,
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void Formula::print(raw_ostream &OS) const {
-  bool First = true;
+  ListSeparator Plus(" + ");
   if (BaseGV) {
-    if (!First) OS << " + "; else First = false;
+    OS << Plus;
     BaseGV->printAsOperand(OS, /*PrintType=*/false);
   }
-  if (BaseOffset.isNonZero()) {
-    if (!First) OS << " + "; else First = false;
-    OS << BaseOffset;
-  }
-  for (const SCEV *BaseReg : BaseRegs) {
-    if (!First) OS << " + "; else First = false;
-    OS << "reg(" << *BaseReg << ')';
-  }
-  if (HasBaseReg && BaseRegs.empty()) {
-    if (!First) OS << " + "; else First = false;
-    OS << "**error: HasBaseReg**";
-  } else if (!HasBaseReg && !BaseRegs.empty()) {
-    if (!First) OS << " + "; else First = false;
-    OS << "**error: !HasBaseReg**";
-  }
+  if (BaseOffset.isNonZero())
+    OS << Plus << BaseOffset;
+
+  for (const SCEV *BaseReg : BaseRegs)
+    OS << Plus << "reg(" << *BaseReg << ')';
+
+  if (HasBaseReg && BaseRegs.empty())
+    OS << Plus << "**error: HasBaseReg**";
+  else if (!HasBaseReg && !BaseRegs.empty())
+    OS << Plus << "**error: !HasBaseReg**";
+
   if (Scale != 0) {
-    if (!First) OS << " + "; else First = false;
-    OS << Scale << "*reg(";
+    OS << Plus << Scale << "*reg(";
     if (ScaledReg)
       OS << *ScaledReg;
     else
       OS << "<unknown>";
     OS << ')';
   }
-  if (UnfoldedOffset.isNonZero()) {
-    if (!First) OS << " + ";
-    OS << "imm(" << UnfoldedOffset << ')';
-  }
+  if (UnfoldedOffset.isNonZero())
+    OS << Plus << "imm(" << UnfoldedOffset << ')';
 }
 
 LLVM_DUMP_METHOD void Formula::dump() const {
@@ -6286,19 +6279,13 @@ void LSRInstance::print_factors_and_types(raw_ostream &OS) const {
   if (Factors.empty() && Types.empty()) return;
 
   OS << "LSR has identified the following interesting factors and types: ";
-  bool First = true;
+  ListSeparator LS;
 
-  for (int64_t Factor : Factors) {
-    if (!First) OS << ", ";
-    First = false;
-    OS << '*' << Factor;
-  }
+  for (int64_t Factor : Factors)
+    OS << LS << '*' << Factor;
 
-  for (Type *Ty : Types) {
-    if (!First) OS << ", ";
-    First = false;
-    OS << '(' << *Ty << ')';
-  }
+  for (Type *Ty : Types)
+    OS << LS << '(' << *Ty << ')';
   OS << '\n';
 }
 

--- a/llvm/tools/llvm-config/llvm-config.cpp
+++ b/llvm/tools/llvm-config/llvm-config.cpp
@@ -18,6 +18,7 @@
 
 #include "llvm/Config/llvm-config.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
@@ -520,13 +521,11 @@ int main(int argc, char **argv) {
 
   // Render include paths and associated flags
   auto RenderFlags = [&](StringRef Flags) {
-    bool First = true;
+    ListSeparator LS(" ");
     for (auto &Include : ActiveIncludeOptions) {
-      if (!First)
-        OS << ' ';
+      OS << LS;
       std::string FlagsStr = "-I" + Include;
       MaybePrintQuoted(FlagsStr);
-      First = false;
     }
     OS << ' ' << Flags << '\n';
   };

--- a/llvm/tools/llvm-exegesis/lib/Analysis.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Analysis.cpp
@@ -244,12 +244,9 @@ static void writeParallelSnippetHtml(raw_ostream &OS,
 static void writeLatencySnippetHtml(raw_ostream &OS,
                                     const std::vector<MCInst> &Instructions,
                                     const MCInstrInfo &InstrInfo) {
-  bool First = true;
+  ListSeparator LS(" &rarr; ");
   for (const MCInst &Instr : Instructions) {
-    if (First)
-      First = false;
-    else
-      OS << " &rarr; ";
+    OS << LS;
     writeEscaped<kEscapeHtml>(OS, InstrInfo.getName(Instr.getOpcode()));
   }
 }

--- a/llvm/utils/TableGen/Common/PredicateExpander.cpp
+++ b/llvm/utils/TableGen/Common/PredicateExpander.cpp
@@ -177,18 +177,15 @@ void PredicateExpander::expandPredicateSequence(
     return expandPredicate(OS, Sequence[0]);
 
   // Okay, there is more than one predicate in the set.
-  bool First = true;
+  ListSeparator LS(IsCheckAll ? "&& " : "|| ");
   OS << (shouldNegate() ? "!(" : "(");
   ++Indent;
 
   bool OldValue = shouldNegate();
   setNegatePredicate(false);
   for (const Record *Rec : Sequence) {
-    OS << '\n' << Indent;
-    if (!First)
-      OS << (IsCheckAll ? "&& " : "|| ");
+    OS << '\n' << Indent << LS;
     expandPredicate(OS, Rec);
-    First = false;
   }
   --Indent;
   OS << '\n' << Indent << ')';


### PR DESCRIPTION
Adopt `ListSeparator` and `interleaved` in various places instead of manual code to print separators between loop iterations.