### PR TITLE
[clang] Make error for [[clang::coro_wrapper]] be downgradable to a warning

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12743,10 +12743,10 @@ def err_conflicting_aligned_options : Error <
 def err_coro_invalid_addr_of_label : Error<
   "the GNU address of label extension is not allowed in coroutines"
 >;
-def err_coroutine_return_type : Error<
+def warn_coroutine_return_type : Warning<
   "function returns a type %0 marked with [[clang::coro_return_type]] but is neither a coroutine nor a coroutine wrapper; "
-  "non-coroutines should be marked with [[clang::coro_wrapper]] to allow returning coroutine return type"
->;
+  "non-coroutines should be marked with [[clang::coro_wrapper]] to allow returning coroutine return type">,
+  DefaultError;
 def warn_coroutine_type_aware_allocator_ignored : Warning <
   "type aware %0 will not be used for coroutine allocation">,
   InGroup<CoroTypeAwareAllocationFunction>;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16440,7 +16440,7 @@ void Sema::CheckCoroutineWrapper(FunctionDecl *FD) {
   if (CanBeGetReturnObject(FD) || CanBeGetReturnTypeOnAllocFailure(FD))
     return;
   if (!FD->hasAttr<CoroWrapperAttr>())
-    Diag(FD->getLocation(), diag::err_coroutine_return_type) << RD;
+    Diag(FD->getLocation(), diag::warn_coroutine_return_type) << RD;
 }
 
 Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body, bool IsInstantiation,

--- a/clang/test/SemaCXX/coro-return-type-and-wrapper.cpp
+++ b/clang/test/SemaCXX/coro-return-type-and-wrapper.cpp
@@ -59,16 +59,17 @@ Co<int> non_marked_wrapper(int b) { return foo_coro(b); }
 namespace lambdas {
 
 void foo() {
-  auto coro_lambda = []() -> Gen<int> {
+  auto coro_lambda [[maybe_unused]] = []() -> Gen<int> {
     co_return 1;
   };
   // expected-error@+1 {{neither a coroutine nor a coroutine wrapper}}
-  auto not_allowed_wrapper = []() -> Gen<int> {
+  auto not_allowed_wrapper [[maybe_unused]] = []() -> Gen<int> {
     return foo_coro(1);
   };
-  auto allowed_wrapper = [] [[clang::coro_wrapper]] () -> Gen<int> {
-    return foo_coro(1);
-  };
+  auto allowed_wrapper [[maybe_unused]] =
+      [] [[clang::coro_wrapper]] () -> Gen<int> {
+        return foo_coro(1);
+      };
 }
 
 Gen<int> coro_containing_lambda() {


### PR DESCRIPTION
Given that both `-Wreturn-type` and `-Wdangling` are already warnings and not hard errors, it makes sense for this diagnostic to behave similarly.

This allows suppressing benign occurrences of the error in external headers whose source code is not in the user's direct control.