### PR TITLE
[AutoUpgrade]: Fixed assertion by considering number of args

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -4996,12 +4996,13 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
 
   case Intrinsic::ctlz:
   case Intrinsic::cttz: {
-    assert((CI->arg_size() <= 2) &&
-           "Mismatch between function args and call args");
+    if (CI->arg_size() != 1) {
+      DefaultCase();
+      return;
+    }
 
-    Value *IsZeroPoison =
-        CI->arg_size() == 1 ? Builder.getFalse() : CI->getArgOperand(1);
-    NewCall = Builder.CreateCall(NewFn, {CI->getArgOperand(0), IsZeroPoison});
+    NewCall =
+        Builder.CreateCall(NewFn, {CI->getArgOperand(0), Builder.getFalse()});
 
     break;
   }

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -4995,12 +4995,16 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
     break;
 
   case Intrinsic::ctlz:
-  case Intrinsic::cttz:
-    assert(CI->arg_size() == 1 &&
+  case Intrinsic::cttz: {
+    assert((CI->arg_size() <= 2) &&
            "Mismatch between function args and call args");
-    NewCall =
-        Builder.CreateCall(NewFn, {CI->getArgOperand(0), Builder.getFalse()});
+
+    Value *IsZeroPoison =
+        CI->arg_size() == 1 ? Builder.getFalse() : CI->getArgOperand(1);
+    NewCall = Builder.CreateCall(NewFn, {CI->getArgOperand(0), IsZeroPoison});
+
     break;
+  }
 
   case Intrinsic::objectsize: {
     Value *NullIsUnknownSize =

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -5003,7 +5003,6 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
 
     NewCall =
         Builder.CreateCall(NewFn, {CI->getArgOperand(0), Builder.getFalse()});
-
     break;
   }
 

--- a/llvm/test/Assembler/auto_upgrade_intrinsics.ll
+++ b/llvm/test/Assembler/auto_upgrade_intrinsics.ll
@@ -8,7 +8,8 @@ declare i8 @llvm.ctlz.i8(i8)
 declare i16 @llvm.ctlz.i16(i16)
 declare i32 @llvm.ctlz.i32(i32)
 declare i42 @llvm.ctlz.i42(i42)  ; Not a power-of-2
-
+declare i32 @llvm.ctlz.i32.p0(i32, i1 immarg)
+declare i32 @llvm.cttz.i32.p0(i32, i1 immarg)
 
 define void @test.ctlz(i8 %a, i16 %b, i32 %c, i42 %d) {
 ; CHECK: @test.ctlz
@@ -214,6 +215,30 @@ define void @test.prefetch.unnamed(ptr %ptr) {
 ; CHECK: @llvm.prefetch.p0(ptr %ptr, i32 0, i32 3, i32 1)
   call void @llvm.prefetch.unnamed(ptr %ptr, i32 0, i32 3, i32 1)
   ret void
+}
+
+define i32 @ctlz(i32 %A) {
+; CHECK: %for.body.i = call i32 @llvm.ctlz.i32(i32 %A, i1 false)
+  %for.body.i = call i32 @llvm.ctlz.i32.p0(i32 %A)
+  ret i32 %for.body.i
+}
+
+define i32 @ctlz_with_isZeroPoison(i32 %A) {
+; CHECK: %for.body.i = call i32 @llvm.ctlz.i32(i32 %A, i1 false)
+  %for.body.i = call i32 @llvm.ctlz.i32.p0(i32 %A, i1 false)
+  ret i32 %for.body.i
+}
+
+define i32 @cttz(i32 %A) {
+; CHECK: %for.body.i = call i32 @llvm.cttz.i32(i32 %A, i1 false)
+  %for.body.i = call i32 @llvm.cttz.i32.p0(i32 %A)
+  ret i32 %for.body.i
+}
+
+define i32 @cttz_with_isZeroPoison(i32 %A) {
+; CHECK: %for.body.i = call i32 @llvm.cttz.i32(i32 %A, i1 false)
+  %for.body.i = call i32 @llvm.cttz.i32.p0(i32 %A, i1 false)
+  ret i32 %for.body.i
 }
 
 ; This is part of @test.objectsize(), since llvm.objectsize declaration gets

--- a/llvm/test/CodeGen/Generic/overloaded-intrinsic-name.ll
+++ b/llvm/test/CodeGen/Generic/overloaded-intrinsic-name.ll
@@ -73,6 +73,31 @@ entry:
       %v-new = call ptr addrspace(1) @llvm.experimental.gc.relocate.beefdead(token %tok,  i32 0, i32 0)
       ret ptr addrspace(1) %v-new
 }
+
+define i32 @ctlz(i32 %A) {
+; CHECK: %for.body.i = call i32 @llvm.ctlz.i32(i32 %A, i1 false)
+  %for.body.i = call i32 @llvm.ctlz.i32.p0(i32 %A)
+  ret i32 %for.body.i
+}
+
+define i32 @ctlz_with_isZeroPoison(i32 %A) {
+; CHECK: %for.body.i = call i32 @llvm.ctlz.i32(i32 %A, i1 false)
+  %for.body.i = call i32 @llvm.ctlz.i32.p0(i32 %A, i1 false)
+  ret i32 %for.body.i
+}
+
+define i32 @cttz(i32 %A) {
+; CHECK: %for.body.i = call i32 @llvm.cttz.i32(i32 %A, i1 false)
+  %for.body.i = call i32 @llvm.cttz.i32.p0(i32 %A)
+  ret i32 %for.body.i
+}
+
+define i32 @cttz_with_isZeroPoison(i32 %A) {
+; CHECK: %for.body.i = call i32 @llvm.cttz.i32(i32 %A, i1 false)
+  %for.body.i = call i32 @llvm.cttz.i32.p0(i32 %A, i1 false)
+  ret i32 %for.body.i
+}
+
 declare zeroext i1 @return_i1()
 declare token @llvm.experimental.gc.statepoint.p0(i64, i32, ptr, i32, i32, ...)
 declare ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token, i32, i32)
@@ -80,3 +105,5 @@ declare ptr addrspace(1) @llvm.experimental.gc.relocate.p1.tests(token, i32, i32
 declare ptr addrspace(1) @llvm.experimental.gc.relocate.p1.test(token, i32, i32)
 declare ptr addrspace(1) @llvm.experimental.gc.relocate.beefdead(token, i32, i32)
 declare token @llvm.experimental.gc.statepoint.deadbeef(i64, i32, ptr, i32, i32, ...)
+declare i32 @llvm.ctlz.i32.p0(i32, i1 immarg)
+declare i32 @llvm.cttz.i32.p0(i32, i1 immarg)

--- a/llvm/test/CodeGen/Generic/overloaded-intrinsic-name.ll
+++ b/llvm/test/CodeGen/Generic/overloaded-intrinsic-name.ll
@@ -73,31 +73,6 @@ entry:
       %v-new = call ptr addrspace(1) @llvm.experimental.gc.relocate.beefdead(token %tok,  i32 0, i32 0)
       ret ptr addrspace(1) %v-new
 }
-
-define i32 @ctlz(i32 %A) {
-; CHECK: %for.body.i = call i32 @llvm.ctlz.i32(i32 %A, i1 false)
-  %for.body.i = call i32 @llvm.ctlz.i32.p0(i32 %A)
-  ret i32 %for.body.i
-}
-
-define i32 @ctlz_with_isZeroPoison(i32 %A) {
-; CHECK: %for.body.i = call i32 @llvm.ctlz.i32(i32 %A, i1 false)
-  %for.body.i = call i32 @llvm.ctlz.i32.p0(i32 %A, i1 false)
-  ret i32 %for.body.i
-}
-
-define i32 @cttz(i32 %A) {
-; CHECK: %for.body.i = call i32 @llvm.cttz.i32(i32 %A, i1 false)
-  %for.body.i = call i32 @llvm.cttz.i32.p0(i32 %A)
-  ret i32 %for.body.i
-}
-
-define i32 @cttz_with_isZeroPoison(i32 %A) {
-; CHECK: %for.body.i = call i32 @llvm.cttz.i32(i32 %A, i1 false)
-  %for.body.i = call i32 @llvm.cttz.i32.p0(i32 %A, i1 false)
-  ret i32 %for.body.i
-}
-
 declare zeroext i1 @return_i1()
 declare token @llvm.experimental.gc.statepoint.p0(i64, i32, ptr, i32, i32, ...)
 declare ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token, i32, i32)
@@ -105,5 +80,3 @@ declare ptr addrspace(1) @llvm.experimental.gc.relocate.p1.tests(token, i32, i32
 declare ptr addrspace(1) @llvm.experimental.gc.relocate.p1.test(token, i32, i32)
 declare ptr addrspace(1) @llvm.experimental.gc.relocate.beefdead(token, i32, i32)
 declare token @llvm.experimental.gc.statepoint.deadbeef(i64, i32, ptr, i32, i32, ...)
-declare i32 @llvm.ctlz.i32.p0(i32, i1 immarg)
-declare i32 @llvm.cttz.i32.p0(i32, i1 immarg)


### PR DESCRIPTION
The assertion was violated because the intrinsic had too many arguments. This PR allows the intrinsic to have the second parameter and overwrites the default value in that case.

Closes https://github.com/llvm/llvm-project/issues/172817