### PR TITLE
[MLIR] Add DefaultValuedEnumAttr decorator

### DIFF
--- a/mlir/docs/DefiningDialects/Operations.md
+++ b/mlir/docs/DefiningDialects/Operations.md
@@ -287,6 +287,11 @@ like `"0.5f"`, and an integer array default value should be specified as like
 The generated operation printing function will not print default-valued
 attributes when the attribute value is equal to the default.
 
+For enum attributes, you can use `DefaultValuedEnumAttr<EnumAttr, EnumCase>`
+instead of `DefaultValuedAttr`. This allows specifying the default value using a
+TableGen `EnumCase` variable instead of a raw string. For example 
+`DefaultValuedEnumAttr<SomeI64Enum, I64Case5>`.
+
 #### Confining attributes
 
 `ConfinedAttr` is provided as a general mechanism to help modelling further

--- a/mlir/include/mlir/IR/EnumAttr.td
+++ b/mlir/include/mlir/IR/EnumAttr.td
@@ -278,6 +278,12 @@ class EnumAttrInfo<
   string parameterPrinter = ?;
 }
 
+// Decorates an enum attribute to have a default (unvalidated) default value
+// from a specific enum case if not present. The default value is constructed as
+// the fully-qualified enum case symbol.
+class DefaultValuedEnumAttr<EnumAttrInfo attr, EnumCase case>
+    : DefaultValuedAttr<attr, attr.cppType # "::" # case.symbol>;
+
 // An attribute holding a single integer value.
 class IntEnum<string name, string summary, list<EnumCase> cases, int width>
     : EnumInfo<name,

--- a/mlir/test/lib/Dialect/Test/TestOpsSyntax.td
+++ b/mlir/test/lib/Dialect/Test/TestOpsSyntax.td
@@ -432,6 +432,11 @@ def FormatOptionalDefaultAttrs : TEST_Op<"format_optional_default_attrs"> {
   let assemblyFormat = "($str^)? ($sym^)? ($e^)? attr-dict";
 }
 
+def FormatOptionalDefaultEnumAttrs : TEST_Op<"format_optional_default_enum_attr"> {
+  let arguments = (ins DefaultValuedEnumAttr<SomeI64Enum, I64Case5>:$e);
+  let assemblyFormat = "($e^)? attr-dict";
+}
+
 def FormatOptionalWithElse : TEST_Op<"format_optional_else"> {
   let arguments = (ins UnitAttr:$isFirstBranchPresent);
   let assemblyFormat = "(`then` $isFirstBranchPresent^):(`else`)? attr-dict";

--- a/mlir/test/mlir-tblgen/op-format.mlir
+++ b/mlir/test/mlir-tblgen/op-format.mlir
@@ -221,6 +221,13 @@ test.format_optional_default_attrs "foo" @foo case10
 // CHECK-NOT: case5
 test.format_optional_default_attrs "default" @default case5
 
+// CHECK: test.format_optional_default_enum_attr case10
+test.format_optional_default_enum_attr case10
+
+// CHECK: test.format_optional_default_enum_attr
+// CHECK-NOT: case5
+test.format_optional_default_enum_attr case5
+
 //===----------------------------------------------------------------------===//
 // Format optional operands and results
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Introduce DefaultValuedEnumAttr, which similarly to DefaultValuedAttr
decorates an enum attribute to have a default value from a specific enum
case when not present. The default is constructed as the fully-qualified
enum case symbol.

In comparison to DefaultValuedAttr, this allows using a TableGen EnumCase
variable instead of a raw string.