### PR TITLE
[lldb-dap] Do not show warnings on Completions request.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
+++ b/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
@@ -244,6 +244,10 @@ class TestDAP_completions(lldbdap_testcase.DAPTestCaseBase):
         self.assertTrue(res["success"])
 
         self.continue_to_next_stop()
+
+        # Stopped at breakpoint 1
+        # 'var' variable is in scope, completions should not show any warning.
+        self.dap_server.get_completions("var ")
         self.continue_to_next_stop()
 
         # We are stopped inside `main`. Variables `var1` and `var2` are in scope.
@@ -267,4 +271,11 @@ class TestDAP_completions(lldbdap_testcase.DAPTestCaseBase):
                 variable_var1_completion,
                 variable_var2_completion,
             ],
+        )
+
+        self.continue_to_exit()
+        console_str = self.get_console()
+        # we check in console to avoid waiting for output event.
+        self.assertNotIn(
+            "Expression 'var' is both an LLDB command and variable", console_str
         )

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -637,7 +637,7 @@ ReplMode DAP::DetectReplMode(lldb::SBFrame &frame, std::string &expression,
                       "a variable. To evaluate the expression as an LLDB "
                       "command, use '{}' as a prefix.\n",
                       first, configuration.commandEscapePrefix);
-    this->SendOutput(OutputType::Console, warning_msg);
+    SendOutput(OutputType::Console, warning_msg);
   }
 
   // Variables take preference to commands in auto, since commands can always

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -270,7 +270,7 @@ struct DAP final : public DAPTransport::MessageHandler {
   ///     either an expression or a statement, depending on the rest of
   ///     the expression.
   /// \return the expression mode
-  ReplMode DetectReplMode(lldb::SBFrame frame, std::string &expression,
+  ReplMode DetectReplMode(lldb::SBFrame &frame, std::string &expression,
                           bool partial_expression);
 
   /// Create a `protocol::Source` object as described in the debug adapter


### PR DESCRIPTION
Why typing a command that happens to start with a variable, there are warnings complaining about the ambiguous expression. 