### PR TITLE
[llvm] Avoid resolving `.incbin` during symbol collection

### DIFF
--- a/clang/test/CodeGen/asm_incbin.c
+++ b/clang/test/CodeGen/asm_incbin.c
@@ -1,0 +1,8 @@
+// RUN: split-file %s %t
+//--- foo.h
+//--- tu.c
+asm(".incbin \"foo.h\"");
+// RUN: cd %t
+// RUN: %clang -c -emit-llvm %t/tu.c -o %t/tu.ll
+// RUN: llvm-dis %t/tu.ll -o - | FileCheck %s
+// CHECK: module asm ".incbin \22foo.h\22"

--- a/llvm/include/llvm/MC/MCParser/MCAsmParser.h
+++ b/llvm/include/llvm/MC/MCParser/MCAsmParser.h
@@ -150,7 +150,11 @@ protected: // Can only create subclasses.
   bool HadError = false;
 
   bool ShowParsedOperands = false;
-  bool ProcessIncbinFile = true;
+
+  /// Flag tracking whether we're only interested in symbols, which allows us to
+  /// avoid some work (e.g. resolving .incbin directives).
+  // TODO: Adopt this in more places.
+  bool SymbolScanningMode = false;
 
 public:
   MCAsmParser(const MCAsmParser &) = delete;
@@ -177,8 +181,7 @@ public:
   bool getShowParsedOperands() const { return ShowParsedOperands; }
   void setShowParsedOperands(bool Value) { ShowParsedOperands = Value; }
 
-  bool getProcessIncbinFile() const { return ProcessIncbinFile; }
-  void setProcessIncbinFile(bool Value) { ProcessIncbinFile = Value; }
+  void setSymbolScanningMode(bool Value) { SymbolScanningMode = Value; }
 
   /// Run the parser on the input source buffer.
   virtual bool Run(bool NoInitialTextSection, bool NoFinalize = false) = 0;

--- a/llvm/include/llvm/MC/MCParser/MCAsmParser.h
+++ b/llvm/include/llvm/MC/MCParser/MCAsmParser.h
@@ -150,6 +150,7 @@ protected: // Can only create subclasses.
   bool HadError = false;
 
   bool ShowParsedOperands = false;
+  bool ProcessIncbinFile = true;
 
 public:
   MCAsmParser(const MCAsmParser &) = delete;
@@ -175,6 +176,9 @@ public:
 
   bool getShowParsedOperands() const { return ShowParsedOperands; }
   void setShowParsedOperands(bool Value) { ShowParsedOperands = Value; }
+
+  bool getProcessIncbinFile() const { return ProcessIncbinFile; }
+  void setProcessIncbinFile(bool Value) { ProcessIncbinFile = Value; }
 
   /// Run the parser on the input source buffer.
   virtual bool Run(bool NoInitialTextSection, bool NoFinalize = false) = 0;

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -848,7 +848,8 @@ bool AsmParser::enterIncludeFile(const std::string &Filename) {
 /// returns true on failure.
 bool AsmParser::processIncbinFile(const std::string &Filename, int64_t Skip,
                                   const MCExpr *Count, SMLoc Loc) {
-  if (!getProcessIncbinFile())
+  // The .incbin file cannot introduce new symbols.
+  if (SymbolScanningMode)
     return false;
 
   std::string IncludedFile;

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -848,6 +848,9 @@ bool AsmParser::enterIncludeFile(const std::string &Filename) {
 /// returns true on failure.
 bool AsmParser::processIncbinFile(const std::string &Filename, int64_t Skip,
                                   const MCExpr *Count, SMLoc Loc) {
+  if (!getProcessIncbinFile())
+    return false;
+
   std::string IncludedFile;
   unsigned NewBuf =
       SrcMgr.AddIncludeFile(Filename, Lexer.getLoc(), IncludedFile);

--- a/llvm/lib/Object/ModuleSymbolTable.cpp
+++ b/llvm/lib/Object/ModuleSymbolTable.cpp
@@ -129,8 +129,7 @@ initializeRecordStreamer(const Module &M,
   // AsmPrinter::doInitialization()).
   Parser->setAssemblerDialect(InlineAsm::AD_ATT);
 
-  // The .incbin directive cannot introduce new symbols.
-  Parser->setProcessIncbinFile(false);
+  Parser->setSymbolScanningMode(true);
 
   Parser->setTargetParser(*TAP);
   if (Parser->Run(false))

--- a/llvm/lib/Object/ModuleSymbolTable.cpp
+++ b/llvm/lib/Object/ModuleSymbolTable.cpp
@@ -129,6 +129,9 @@ initializeRecordStreamer(const Module &M,
   // AsmPrinter::doInitialization()).
   Parser->setAssemblerDialect(InlineAsm::AD_ATT);
 
+  // The .incbin directive cannot introduce new symbols.
+  Parser->setProcessIncbinFile(false);
+
   Parser->setTargetParser(*TAP);
   if (Parser->Run(false))
     return;


### PR DESCRIPTION
With IO sandboxing enabled, Clang requires all FS accesses happen through the one "true" VFS instance. That instance is currently not being propagated into the assembly parser, and doing so would be super involved. This triggers sandbox violations whenever an `.incbin` directive is encountered, since the parser needs the VFS to open the file.

However, it seems that `asm()` directives are only parsed to get the symbols of an LLVM module, which cannot be affected by `.incbin` directives. This PR adds an option to the asm parser to avoid resolving `.incbin` directives when collecting module symbols, avoiding the sandbox violation.