### PR TITLE
[AArch64] emitAddress: Handle signed GOT.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
@@ -16,6 +16,7 @@
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/IR/Module.h"
 
 using namespace llvm;
 using namespace llvm::AArch64PAuth;
@@ -277,4 +278,14 @@ bool AArch64PointerAuth::runOnMachineFunction(MachineFunction &MF) {
   }
 
   return Modified;
+}
+
+bool llvm::AArch64PAuth::hasELFSignedGOT(const Module &M) {
+  if (M.getTargetTriple().isOSBinFormatELF()) {
+    const auto *Flag = mdconst::extract_or_null<ConstantInt>(
+        M.getModuleFlag("ptrauth-elf-got"));
+    return Flag && Flag->getZExtValue() == 1;
+  } else {
+    return false;
+  }
 }

--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.h
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.h
@@ -104,6 +104,9 @@ enum class AuthCheckMethod {
 /// Returns the number of bytes added by checkAuthenticatedRegister.
 unsigned getCheckerSizeInBytes(AuthCheckMethod Method);
 
+/// Returns whether the GOT entries of the module are signed.
+bool hasELFSignedGOT(const Module &M);
+
 } // end namespace AArch64PAuth
 } // end namespace llvm
 

--- a/llvm/test/CodeGen/AArch64/ptrauth-irelative.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-irelative.ll
@@ -1,6 +1,7 @@
 ; RUN: rm -rf %t
 ; RUN: split-file %s %t
-; RUN: llc -mtriple aarch64-linux-gnu -mattr=+pauth,+fpac -filetype=asm -o - %t/unsigned-got.ll | FileCheck %t/unsigned-got.ll
+; RUN: llc -mtriple aarch64-linux-gnu -mattr=+pauth -filetype=asm -o - %t/unsigned-got.ll | FileCheck %t/unsigned-got.ll
+; RUN: llc -mtriple aarch64-linux-gnu -mattr=+pauth -filetype=asm -o - %t/signed-got.ll | FileCheck --check-prefixes=CHECK,NOFPAC %t/signed-got.ll
 ; RUN: llc -mtriple aarch64-linux-gnu -mattr=+pauth,+fpac -filetype=asm -o - %t/signed-got.ll | FileCheck %t/signed-got.ll
 
 ;--- unsigned-got.ll
@@ -145,6 +146,12 @@ $comdat = comdat any
 ; CHECK-NEXT: add x16, x16, :got_auth_lo12:global
 ; CHECK-NEXT: ldr x0, [x16]
 ; CHECK-NEXT: autda x0, x16
+; NOFPAC-NEXT: mov x16, x0
+; NOFPAC-NEXT: xpacd x16
+; NOFPAC-NEXT: cmp x0, x16
+; NOFPAC-NEXT: b.eq .Lauth_success_0
+; NOFPAC-NEXT: brk #0xc472
+; NOFPAC-NEXT: .Lauth_success_0:
 ; CHECK-NEXT: mov x1, #4
 ; CHECK-NEXT: b __emupac_pacda
 ; CHECK-NEXT: .section .rodata
@@ -159,6 +166,12 @@ $comdat = comdat any
 ; CHECK-NEXT: add x16, x16, :got_auth_lo12:global
 ; CHECK-NEXT: ldr x0, [x16]
 ; CHECK-NEXT: autda x0, x16
+; NOFPAC-NEXT: mov x16, x0
+; NOFPAC-NEXT: xpacd x16
+; NOFPAC-NEXT: cmp x0, x16
+; NOFPAC-NEXT: b.eq .Lauth_success_1
+; NOFPAC-NEXT: brk #0xc472
+; NOFPAC-NEXT: .Lauth_success_1:
 ; CHECK-NEXT: add x0, x0, #8
 ; CHECK-NEXT: mov x1, #5
 ; CHECK-NEXT: b __emupac_pacda
@@ -174,6 +187,12 @@ $comdat = comdat any
 ; CHECK-NEXT: add x16, x16, :got_auth_lo12:global
 ; CHECK-NEXT: ldr x0, [x16]
 ; CHECK-NEXT: autda x0, x16
+; NOFPAC-NEXT: mov x16, x0
+; NOFPAC-NEXT: xpacd x16
+; NOFPAC-NEXT: cmp x0, x16
+; NOFPAC-NEXT: b.eq .Lauth_success_2
+; NOFPAC-NEXT: brk #0xc472
+; NOFPAC-NEXT: .Lauth_success_2:
 ; CHECK-NEXT: mov x16, #0
 ; CHECK-NEXT: movk x16, #256, lsl #16
 ; CHECK-NEXT: add x0, x0, x16

--- a/llvm/test/CodeGen/AArch64/ptrauth-irelative.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-irelative.ll
@@ -1,7 +1,7 @@
 ; RUN: rm -rf %t
 ; RUN: split-file %s %t
-; RUN: llc -mtriple aarch64-linux-gnu -mattr=+pauth -filetype=asm -o - %t/unsigned-got.ll | FileCheck %t/unsigned-got.ll
-; RUN: llc -mtriple aarch64-linux-gnu -mattr=+pauth -filetype=asm -o - %t/signed-got.ll | FileCheck %t/signed-got.ll
+; RUN: llc -mtriple aarch64-linux-gnu -mattr=+pauth,+fpac -filetype=asm -o - %t/unsigned-got.ll | FileCheck %t/unsigned-got.ll
+; RUN: llc -mtriple aarch64-linux-gnu -mattr=+pauth,+fpac -filetype=asm -o - %t/signed-got.ll | FileCheck %t/signed-got.ll
 
 ;--- unsigned-got.ll
 


### PR DESCRIPTION
This has no runtime impact on any real target at the moment because there is no target that supports both PAuth relocations and IFUNC, but even before it gets to runtime, this avoids link-time errors where a mix of non-signed GOT references and signed GOT references are used.

During the libc++ build, this could previously manifest as

error: both AUTH and non-AUTH GOT entries for '_ZTVNSt3__113basic_istreamIcNS_11char_traitsIcEEEE' requested, but only one type of GOT entry per symbol is supported