### PR TITLE
[runtimes] Rename the %{flags} Lit substitution to %{common_flags}

### DIFF
--- a/libcxx/test/benchmarks/spec.gen.py
+++ b/libcxx/test/benchmarks/spec.gen.py
@@ -11,7 +11,7 @@
 # RUN: mkdir -p %{temp}
 # RUN: echo "%{cxx}" > %{temp}/cxx.subs
 # RUN: echo "%{compile_flags}" > %{temp}/compile_flags.subs
-# RUN: echo "%{flags}" > %{temp}/flags.subs
+# RUN: echo "%{common_flags}" > %{temp}/common_flags.subs
 # RUN: echo "%{link_flags}" > %{temp}/link_flags.subs
 # RUN: echo "%{spec_dir}" > %{temp}/spec_dir.subs
 # RUN: %{python} %s %{temp}
@@ -24,7 +24,7 @@ import sys
 test_dir = pathlib.Path(sys.argv[1])
 cxx = (test_dir / 'cxx.subs').open().read().strip()
 compile_flags = (test_dir / 'compile_flags.subs').open().read().strip()
-flags = (test_dir / 'flags.subs').open().read().strip()
+common_flags = (test_dir / 'common_flags.subs').open().read().strip()
 link_flags = (test_dir / 'link_flags.subs').open().read().strip()
 spec_dir = pathlib.Path((test_dir / 'spec_dir.subs').open().read().strip())
 
@@ -46,7 +46,7 @@ default:
     copies               = 1
     threads              = 1
     CC                   = cc -O3 -std=c18 -Wno-implicit-function-declaration
-    CXX                  = {cxx} {compile_flags} {flags} {link_flags} -Wno-error
+    CXX                  = {cxx} {compile_flags} {common_flags} {link_flags} -Wno-error
     CC_VERSION_OPTION    = --version
     CXX_VERSION_OPTION   = --version
     EXTRA_PORTABILITY    = -DSPEC_NO_CXX17_SPECIAL_MATH_FUNCTIONS # because libc++ doesn't implement the special math functions yet

--- a/libcxx/test/configs/amdgpu-libc++-shared.cfg.in
+++ b/libcxx/test/configs/amdgpu-libc++-shared.cfg.in
@@ -1,6 +1,6 @@
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
   f'--target={config.target_triple} -Wno-multi-gpu -flto -mcpu=native'))
 config.substitutions.append(('%{compile_flags}',
     '-nogpulib -fno-builtin-printf -I %{include-dir} '

--- a/libcxx/test/configs/apple-libc++-shared.cfg.in
+++ b/libcxx/test/configs/apple-libc++-shared.cfg.in
@@ -28,7 +28,7 @@ ADDITIONAL_PARAMETERS = [
         """),
 ]
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else ''
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libcxx/test/configs/apple-libc++-system.cfg.in
+++ b/libcxx/test/configs/apple-libc++-system.cfg.in
@@ -9,7 +9,7 @@ import libcxx.test.params, libcxx.test.config, libcxx.test.dsl
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else ''
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libcxx/test/configs/armv7m-picolibc-libc++.cfg.in
+++ b/libcxx/test/configs/armv7m-picolibc-libc++.cfg.in
@@ -2,7 +2,7 @@ lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
 libc_linker_script = '@CMAKE_INSTALL_PREFIX@/lib/picolibcpp.ld'
 
-config.substitutions.append(('%{flags}', '--sysroot=@CMAKE_INSTALL_PREFIX@'))
+config.substitutions.append(('%{common_flags}', '--sysroot=@CMAKE_INSTALL_PREFIX@'))
 
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include-dir} -I %{target-include-dir} -I %{libcxx-dir}/test/support'

--- a/libcxx/test/configs/ibm-libc++-shared.cfg.in
+++ b/libcxx/test/configs/ibm-libc++-shared.cfg.in
@@ -10,7 +10,7 @@ if lit.util.isAIXTriple(config.target_triple):
   # way to retrieve the AIX version in the driver.
   config.target_triple = lit.util.addAIXVersion(config.target_triple)
 
-config.substitutions.append(('%{flags}', '-pthread'))
+config.substitutions.append(('%{common_flags}', '-pthread'))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -D__LIBC_NO_CPP_MATH_OVERLOADS__ -I %{include-dir} -I %{libcxx-dir}/test/support'
 ))

--- a/libcxx/test/configs/llvm-libc++-android.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-android.cfg.in
@@ -12,7 +12,7 @@ import libcxx.test.android
 import libcxx.test.config
 import libcxx.test.params
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '--sysroot @CMAKE_SYSROOT@' if '@CMAKE_SYSROOT@' else ''
 ))
 
@@ -27,8 +27,8 @@ if re.match(r'i686-linux-android(21|22|23)$', config.target_triple):
     compile_flags += ' -mstackrealign'
 config.substitutions.append(('%{compile_flags}', compile_flags))
 
-# The platform library is called "libc++.so" and the NDK library is called "libc++_shared.so". 
-# Use LD_LIBRARY_PATH to find the libcxx shared object because older Bionic dynamic loaders 
+# The platform library is called "libc++.so" and the NDK library is called "libc++_shared.so".
+# Use LD_LIBRARY_PATH to find the libcxx shared object because older Bionic dynamic loaders
 # don't support rpath lookup.
 config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib-dir} -l@LIBCXX_SHARED_OUTPUT_NAME@'

--- a/libcxx/test/configs/llvm-libc++-mingw.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-mingw.cfg.in
@@ -3,7 +3,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}', ''))
+config.substitutions.append(('%{common_flags}', ''))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{target-include-dir} -I %{include-dir} -I %{libcxx-dir}/test/support'
 ))

--- a/libcxx/test/configs/llvm-libc++-shared-clangcl.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-shared-clangcl.cfg.in
@@ -17,7 +17,7 @@ if '@CMAKE_BUILD_TYPE@'.upper() == 'DEBUG':
     fms_runtime_lib += '_dbg'
     cxx_lib += 'd'
 
-config.substitutions.append(('%{flags}', '--driver-mode=g++'))
+config.substitutions.append(('%{common_flags}', '--driver-mode=g++'))
 config.substitutions.append(('%{compile_flags}',
     '-fms-runtime-lib=' + fms_runtime_lib + ' -nostdinc++ -I %{target-include-dir} -I %{include-dir} -I %{libcxx-dir}/test/support -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_STDIO_ISO_WIDE_SPECIFIERS -DNOMINMAX' + dbg_include
 ))

--- a/libcxx/test/configs/llvm-libc++-shared-gcc.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-shared-gcc.cfg.in
@@ -4,7 +4,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}', '-pthread'))
+config.substitutions.append(('%{common_flags}', '-pthread'))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{target-include-dir} -I %{include-dir} -I %{libcxx-dir}/test/support'
 ))

--- a/libcxx/test/configs/llvm-libc++-shared-no-vcruntime-clangcl.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-shared-no-vcruntime-clangcl.cfg.in
@@ -18,7 +18,7 @@ if '@CMAKE_BUILD_TYPE@'.upper() == 'DEBUG':
     fms_runtime_lib += '_dbg'
     cxx_lib += 'd'
 
-config.substitutions.append(('%{flags}', '--driver-mode=g++'))
+config.substitutions.append(('%{common_flags}', '--driver-mode=g++'))
 config.substitutions.append(('%{compile_flags}',
     '-fms-runtime-lib=' + fms_runtime_lib + ' -nostdinc++ -I %{include-dir} -I %{target-include-dir} -I %{libcxx-dir}/test/support -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_STDIO_ISO_WIDE_SPECIFIERS -DNOMINMAX -D_HAS_EXCEPTIONS=0' + dbg_include
 ))

--- a/libcxx/test/configs/llvm-libc++-shared.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-shared.cfg.in
@@ -3,7 +3,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-pthread' + (' -isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else '')
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libcxx/test/configs/llvm-libc++-static-clangcl.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-static-clangcl.cfg.in
@@ -17,7 +17,7 @@ if '@CMAKE_BUILD_TYPE@'.upper() == 'DEBUG':
     fms_runtime_lib += '_dbg'
     cxx_lib += 'd'
 
-config.substitutions.append(('%{flags}', '--driver-mode=g++'))
+config.substitutions.append(('%{common_flags}', '--driver-mode=g++'))
 config.substitutions.append(('%{compile_flags}',
     '-fms-runtime-lib=' + fms_runtime_lib + ' -nostdinc++ -I %{target-include-dir} -I %{include-dir} -I %{libcxx-dir}/test/support -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_STDIO_ISO_WIDE_SPECIFIERS -DNOMINMAX' + dbg_include
 ))

--- a/libcxx/test/configs/llvm-libc++-static.cfg.in
+++ b/libcxx/test/configs/llvm-libc++-static.cfg.in
@@ -3,7 +3,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-pthread' + (' -isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else '')
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libcxx/test/configs/nvptx-libc++-shared.cfg.in
+++ b/libcxx/test/configs/nvptx-libc++-shared.cfg.in
@@ -1,6 +1,6 @@
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
   f'--target={config.target_triple} -Wno-multi-gpu -flto -march=native'))
 config.substitutions.append(('%{compile_flags}',
     '-nogpulib -fno-builtin-printf -I %{include-dir} '

--- a/libcxx/test/configs/stdlib-libstdc++.cfg.in
+++ b/libcxx/test/configs/stdlib-libstdc++.cfg.in
@@ -41,7 +41,7 @@ LIBSTDCXX_PARAMETERS = [
 ]
 
 # Configure the compiler and flags
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-pthread' + (' -isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else '')
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libcxx/test/configs/stdlib-native.cfg.in
+++ b/libcxx/test/configs/stdlib-native.cfg.in
@@ -6,7 +6,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-pthread' + (' -isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else '')
 ))
 config.substitutions.append(('%{compile_flags}', '-I %{libcxx-dir}/test/support'))

--- a/libcxx/test/extensions/libcxx/depr/depr.c.headers/include_as_c.sh.cpp
+++ b/libcxx/test/extensions/libcxx/depr/depr.c.headers/include_as_c.sh.cpp
@@ -18,7 +18,7 @@
 // NOTE: It's not common or recommended to have libc++ in the header search
 // path when compiling C files, but it does happen often enough.
 
-// RUN: %{cxx} -c -xc %s -fsyntax-only %{flags} %{compile_flags} -std=c99
+// RUN: %{cxx} -c -xc %s -fsyntax-only %{common_flags} %{compile_flags} -std=c99
 
 #include <__config>
 

--- a/libcxx/test/extensions/libcxx/odr_signature.assertion_semantics.sh.cpp
+++ b/libcxx/test/extensions/libcxx/odr_signature.assertion_semantics.sh.cpp
@@ -15,12 +15,12 @@
 // Test that we encode the assertion semantic in an ABI tag to avoid ODR violations when linking TUs that have different
 // values for it.
 
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DTU1  -U_LIBCPP_ASSERTION_SEMANTIC -D_LIBCPP_ASSERTION_SEMANTIC=_LIBCPP_ASSERTION_SEMANTIC_IGNORE        -o %t.tu1.o
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DTU2  -U_LIBCPP_ASSERTION_SEMANTIC -D_LIBCPP_ASSERTION_SEMANTIC=_LIBCPP_ASSERTION_SEMANTIC_OBSERVE       -o %t.tu2.o
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DTU3  -U_LIBCPP_ASSERTION_SEMANTIC -D_LIBCPP_ASSERTION_SEMANTIC=_LIBCPP_ASSERTION_SEMANTIC_QUICK_ENFORCE -o %t.tu3.o
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DTU4  -U_LIBCPP_ASSERTION_SEMANTIC -D_LIBCPP_ASSERTION_SEMANTIC=_LIBCPP_ASSERTION_SEMANTIC_ENFORCE       -o %t.tu4.o
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DMAIN                                                                                                    -o %t.main.o
-// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.tu3.o %t.tu4.o %t.main.o %{flags} %{link_flags} -o %t.exe
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DTU1  -U_LIBCPP_ASSERTION_SEMANTIC -D_LIBCPP_ASSERTION_SEMANTIC=_LIBCPP_ASSERTION_SEMANTIC_IGNORE        -o %t.tu1.o
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DTU2  -U_LIBCPP_ASSERTION_SEMANTIC -D_LIBCPP_ASSERTION_SEMANTIC=_LIBCPP_ASSERTION_SEMANTIC_OBSERVE       -o %t.tu2.o
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DTU3  -U_LIBCPP_ASSERTION_SEMANTIC -D_LIBCPP_ASSERTION_SEMANTIC=_LIBCPP_ASSERTION_SEMANTIC_QUICK_ENFORCE -o %t.tu3.o
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DTU4  -U_LIBCPP_ASSERTION_SEMANTIC -D_LIBCPP_ASSERTION_SEMANTIC=_LIBCPP_ASSERTION_SEMANTIC_ENFORCE       -o %t.tu4.o
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DMAIN                                                                                                    -o %t.main.o
+// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.tu3.o %t.tu4.o %t.main.o %{common_flags} %{link_flags} -o %t.exe
 // RUN: %{exec} %t.exe
 
 #include "test_macros.h"

--- a/libcxx/test/extensions/libcxx/odr_signature.exceptions.sh.cpp
+++ b/libcxx/test/extensions/libcxx/odr_signature.exceptions.sh.cpp
@@ -12,10 +12,10 @@
 // Test that we encode whether exceptions are supported in an ABI tag to avoid
 // ODR violations when linking TUs that have different values for it.
 
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DTU1  -fno-exceptions -o %t.tu1.o
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DTU2  -fexceptions    -o %t.tu2.o
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DMAIN                 -o %t.main.o
-// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.main.o %{flags} %{link_flags} -o %t.exe
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DTU1  -fno-exceptions -o %t.tu1.o
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DTU2  -fexceptions    -o %t.tu2.o
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DMAIN                 -o %t.main.o
+// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.main.o %{common_flags} %{link_flags} -o %t.exe
 // RUN: %{exec} %t.exe
 
 #include "test_macros.h"

--- a/libcxx/test/extensions/libcxx/odr_signature.hardening.sh.cpp
+++ b/libcxx/test/extensions/libcxx/odr_signature.hardening.sh.cpp
@@ -13,12 +13,12 @@
 // when linking TUs that have different values for it.
 
 // Note that GCC doesn't support `-Wno-macro-redefined`.
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DTU1  -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST      -o %t.tu1.o
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DTU2  -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE -o %t.tu2.o
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DTU3  -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG     -o %t.tu3.o
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DTU4  -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE      -o %t.tu4.o
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -DMAIN                                                                                    -o %t.main.o
-// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.tu3.o %t.tu4.o %t.main.o %{flags} %{link_flags} -o %t.exe
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DTU1  -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST      -o %t.tu1.o
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DTU2  -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE -o %t.tu2.o
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DTU3  -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG     -o %t.tu3.o
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DTU4  -U_LIBCPP_HARDENING_MODE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE      -o %t.tu4.o
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -DMAIN                                                                                    -o %t.main.o
+// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.tu3.o %t.tu4.o %t.main.o %{common_flags} %{link_flags} -o %t.exe
 // RUN: %{exec} %t.exe
 
 #include "test_macros.h"

--- a/libcxx/test/libcxx-03/language.support/support.rtti/type.info/type_info.comparison.merged.sh.cpp
+++ b/libcxx/test/libcxx-03/language.support/support.rtti/type.info/type_info.comparison.merged.sh.cpp
@@ -11,10 +11,10 @@
 // In MSVC mode, the two anonymous types have identical type index in both object files.
 // XFAIL: msvc
 
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.tu1.o -DTU1 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=1
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.tu2.o -DTU2 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=1
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.main.o -DMAIN -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=1
-// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.main.o %{flags} %{link_flags} -o %t.exe
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.tu1.o -DTU1 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=1
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.tu2.o -DTU2 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=1
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.main.o -DMAIN -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=1
+// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.main.o %{common_flags} %{link_flags} -o %t.exe
 // RUN: %{exec} %t.exe
 
 #include <cassert>

--- a/libcxx/test/libcxx-03/language.support/support.rtti/type.info/type_info.comparison.unmerged.sh.cpp
+++ b/libcxx/test/libcxx-03/language.support/support.rtti/type.info/type_info.comparison.unmerged.sh.cpp
@@ -8,10 +8,10 @@
 
 // UNSUPPORTED: no-rtti
 
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.tu1.o -DTU1 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.tu2.o -DTU2 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.main.o -DMAIN -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2
-// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.main.o %{flags} %{link_flags} -o %t.exe
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.tu1.o -DTU1 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.tu2.o -DTU2 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.main.o -DMAIN -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2
+// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.main.o %{common_flags} %{link_flags} -o %t.exe
 // RUN: %{exec} %t.exe
 
 #include <cassert>

--- a/libcxx/test/libcxx-03/libcpp_freestanding.sh.cpp
+++ b/libcxx/test/libcxx-03/libcpp_freestanding.sh.cpp
@@ -9,8 +9,8 @@
 // Test that _LIBCPP_FREESTANDING is not defined when -ffreestanding is not passed
 // to the compiler but defined when -ffreestanding is passed to the compiler.
 
-// RUN: %{cxx} %{flags} %{compile_flags} -fsyntax-only %s
-// RUN: %{cxx} %{flags} %{compile_flags} -fsyntax-only -ffreestanding -DFREESTANDING %s
+// RUN: %{cxx} %{common_flags} %{compile_flags} -fsyntax-only %s
+// RUN: %{cxx} %{common_flags} %{compile_flags} -fsyntax-only -ffreestanding -DFREESTANDING %s
 
 #include <__config>
 

--- a/libcxx/test/libcxx-03/module_std.gen.py
+++ b/libcxx/test/libcxx-03/module_std.gen.py
@@ -29,7 +29,7 @@ generator = module_test_generator(
     "%{clang-tidy}",
     "%{test-tools-dir}/clang_tidy_checks/libcxx-tidy.plugin",
     "%{cxx}",
-    "%{flags} %{compile_flags}",
+    "%{common_flags} %{compile_flags}",
     "std",
 )
 

--- a/libcxx/test/libcxx-03/module_std_compat.gen.py
+++ b/libcxx/test/libcxx-03/module_std_compat.gen.py
@@ -30,7 +30,7 @@ generator = module_test_generator(
     "%{clang-tidy}",
     "%{test-tools-dir}/clang_tidy_checks/libcxx-tidy.plugin",
     "%{cxx}",
-    "%{flags} %{compile_flags}",
+    "%{common_flags} %{compile_flags}",
     "std.compat",
 )
 

--- a/libcxx/test/libcxx-03/utilities/exception_guard.odr.sh.cpp
+++ b/libcxx/test/libcxx-03/utilities/exception_guard.odr.sh.cpp
@@ -12,9 +12,9 @@
 // Make sure that we don't get ODR violations with __exception_guard when
 // linking together TUs compiled with different values of -f[no-]exceptions.
 
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.except.o   -O1 -fexceptions
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.noexcept.o -O1 -fno-exceptions
-// RUN: %{cxx} %{flags} %{link_flags} -o %t.exe %t.except.o %t.noexcept.o
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.except.o   -O1 -fexceptions
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.noexcept.o -O1 -fno-exceptions
+// RUN: %{cxx} %{common_flags} %{link_flags} -o %t.exe %t.except.o %t.noexcept.o
 // RUN: %{run}
 
 #include <__cxx03/__utility/exception_guard.h>

--- a/libcxx/test/libcxx-03/vendor/apple/disable-availability.sh.cpp
+++ b/libcxx/test/libcxx-03/vendor/apple/disable-availability.sh.cpp
@@ -26,14 +26,14 @@
 // First, test the test. Make sure that we do (incorrectly) produce a weak definition when we
 // don't define _LIBCPP_DISABLE_AVAILABILITY. Otherwise, something may have changed in libc++
 // and this test might not work anymore.
-// RUN: %{cxx} %s %{flags} %{compile_flags} %{link_flags} -fvisibility=hidden -fvisibility-inlines-hidden -shared -o %t.1.dylib
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} %{link_flags} -fvisibility=hidden -fvisibility-inlines-hidden -shared -o %t.1.dylib
 // RUN: nm -m %t.1.dylib | c++filt | grep value > %t.1.symbols
 // RUN: grep weak %t.1.symbols
 
 // Now, make sure that 'weak' goes away when we define _LIBCPP_DISABLE_AVAILABILITY.
 // In fact, all references to the function might go away, so we just check that we don't emit
 // any weak reference.
-// RUN: %{cxx} %s %{flags} %{compile_flags} %{link_flags} -fvisibility=hidden -fvisibility-inlines-hidden -D_LIBCPP_DISABLE_AVAILABILITY -shared -o %t.2.dylib
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} %{link_flags} -fvisibility=hidden -fvisibility-inlines-hidden -D_LIBCPP_DISABLE_AVAILABILITY -shared -o %t.2.dylib
 // RUN: nm -m %t.2.dylib | c++filt | grep value > %t.2.symbols
 // RUN: not grep weak %t.2.symbols
 

--- a/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
+++ b/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
@@ -24,7 +24,7 @@
 // This test doesn't work as such on Windows.
 // UNSUPPORTED: windows
 
-// RUN: %{cxx} %{flags} %s -o %t.exe %{compile_flags} -g %{link_flags}
+// RUN: %{cxx} %{common_flags} %s -o %t.exe %{compile_flags} -g %{link_flags}
 // Ensure locale-independence for unicode tests.
 // RUN: env LANG=en_US.UTF-8 %{gdb} -nx -batch -iex "set autoload off" -ex "source %S/../../../utils/gdb/libcxx/printers.py" -ex "python register_libcxx_printer_loader()" -ex "source %S/gdb_pretty_printer_test.py" %t.exe
 

--- a/libcxx/test/libcxx/language.support/support.rtti/type.info/type_info.comparison.merged.sh.cpp
+++ b/libcxx/test/libcxx/language.support/support.rtti/type.info/type_info.comparison.merged.sh.cpp
@@ -11,10 +11,10 @@
 // In MSVC mode, the two anonymous types have identical type index in both object files.
 // XFAIL: msvc
 
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.tu1.o -DTU1 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=1
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.tu2.o -DTU2 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=1
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.main.o -DMAIN -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=1
-// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.main.o %{flags} %{link_flags} -o %t.exe
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.tu1.o -DTU1 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=1
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.tu2.o -DTU2 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=1
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.main.o -DMAIN -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=1
+// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.main.o %{common_flags} %{link_flags} -o %t.exe
 // RUN: %{exec} %t.exe
 
 #include <cassert>

--- a/libcxx/test/libcxx/language.support/support.rtti/type.info/type_info.comparison.unmerged.sh.cpp
+++ b/libcxx/test/libcxx/language.support/support.rtti/type.info/type_info.comparison.unmerged.sh.cpp
@@ -8,10 +8,10 @@
 
 // UNSUPPORTED: no-rtti
 
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.tu1.o -DTU1 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.tu2.o -DTU2 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.main.o -DMAIN -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2
-// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.main.o %{flags} %{link_flags} -o %t.exe
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.tu1.o -DTU1 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.tu2.o -DTU2 -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.main.o -DMAIN -D_LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION=2
+// RUN: %{cxx} %t.tu1.o %t.tu2.o %t.main.o %{common_flags} %{link_flags} -o %t.exe
 // RUN: %{exec} %t.exe
 
 #include <cassert>

--- a/libcxx/test/libcxx/libcpp_freestanding.sh.cpp
+++ b/libcxx/test/libcxx/libcpp_freestanding.sh.cpp
@@ -9,8 +9,8 @@
 // Test that _LIBCPP_FREESTANDING is not defined when -ffreestanding is not passed
 // to the compiler but defined when -ffreestanding is passed to the compiler.
 
-// RUN: %{cxx} %{flags} %{compile_flags} -fsyntax-only %s
-// RUN: %{cxx} %{flags} %{compile_flags} -fsyntax-only -ffreestanding -DFREESTANDING %s
+// RUN: %{cxx} %{common_flags} %{compile_flags} -fsyntax-only %s
+// RUN: %{cxx} %{common_flags} %{compile_flags} -fsyntax-only -ffreestanding -DFREESTANDING %s
 
 #include <__config>
 

--- a/libcxx/test/libcxx/module_std.gen.py
+++ b/libcxx/test/libcxx/module_std.gen.py
@@ -29,7 +29,7 @@ generator = module_test_generator(
     "%{clang-tidy}",
     "%{test-tools-dir}/clang_tidy_checks/libcxx-tidy.plugin",
     "%{cxx}",
-    "%{flags} %{compile_flags}",
+    "%{common_flags} %{compile_flags}",
     "std",
 )
 

--- a/libcxx/test/libcxx/module_std_compat.gen.py
+++ b/libcxx/test/libcxx/module_std_compat.gen.py
@@ -30,7 +30,7 @@ generator = module_test_generator(
     "%{clang-tidy}",
     "%{test-tools-dir}/clang_tidy_checks/libcxx-tidy.plugin",
     "%{cxx}",
-    "%{flags} %{compile_flags}",
+    "%{common_flags} %{compile_flags}",
     "std.compat",
 )
 

--- a/libcxx/test/libcxx/utilities/exception_guard.odr.sh.cpp
+++ b/libcxx/test/libcxx/utilities/exception_guard.odr.sh.cpp
@@ -12,9 +12,9 @@
 // Make sure that we don't get ODR violations with __exception_guard when
 // linking together TUs compiled with different values of -f[no-]exceptions.
 
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.except.o   -O1 -fexceptions
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.noexcept.o -O1 -fno-exceptions
-// RUN: %{cxx} %{flags} %{link_flags} -o %t.exe %t.except.o %t.noexcept.o
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.except.o   -O1 -fexceptions
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.noexcept.o -O1 -fno-exceptions
+// RUN: %{cxx} %{common_flags} %{link_flags} -o %t.exe %t.except.o %t.noexcept.o
 // RUN: %{run}
 
 #include <__utility/exception_guard.h>

--- a/libcxx/test/libcxx/vendor/apple/disable-availability.sh.cpp
+++ b/libcxx/test/libcxx/vendor/apple/disable-availability.sh.cpp
@@ -22,14 +22,14 @@
 // First, test the test. Make sure that we do (incorrectly) produce a weak definition when we
 // don't define _LIBCPP_DISABLE_AVAILABILITY. Otherwise, something may have changed in libc++
 // and this test might not work anymore.
-// RUN: %{cxx} %s %{flags} %{compile_flags} %{link_flags} -fvisibility=hidden -fvisibility-inlines-hidden -shared -o %t.1.dylib
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} %{link_flags} -fvisibility=hidden -fvisibility-inlines-hidden -shared -o %t.1.dylib
 // RUN: nm -m %t.1.dylib | c++filt | grep value > %t.1.symbols
 // RUN: grep weak %t.1.symbols
 
 // Now, make sure that 'weak' goes away when we define _LIBCPP_DISABLE_AVAILABILITY.
 // In fact, all references to the function might go away, so we just check that we don't emit
 // any weak reference.
-// RUN: %{cxx} %s %{flags} %{compile_flags} %{link_flags} -fvisibility=hidden -fvisibility-inlines-hidden -D_LIBCPP_DISABLE_AVAILABILITY -shared -o %t.2.dylib
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} %{link_flags} -fvisibility=hidden -fvisibility-inlines-hidden -D_LIBCPP_DISABLE_AVAILABILITY -shared -o %t.2.dylib
 // RUN: nm -m %t.2.dylib | c++filt | grep value > %t.2.symbols
 // RUN: not grep weak %t.2.symbols
 

--- a/libcxx/test/selftest/remote-substitutions.sh.cpp
+++ b/libcxx/test/selftest/remote-substitutions.sh.cpp
@@ -18,7 +18,7 @@
 // appear first in the command-line or not.
 
 // UNSUPPORTED: executor-has-no-bash
-// RUN: %{cxx} %s %{flags} %{compile_flags} %{link_flags} -o %t.exe
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} %{link_flags} -o %t.exe
 // RUN: %{exec} %t.exe 0
 // RUN: %{exec} bash -c '! %t.exe 1'
 

--- a/libcxx/test/selftest/sh.cpp/substitutions.sh.cpp
+++ b/libcxx/test/selftest/sh.cpp/substitutions.sh.cpp
@@ -8,12 +8,12 @@
 
 // Make sure we have access to the following substitutions at all times:
 // - %{cxx}
-// - %{flags}
+// - %{common_flags}
 // - %{compile_flags}
 // - %{link_flags}
 // - %{exec}
 
-// RUN: %{cxx} %s %{flags} %{compile_flags} %{link_flags} -o %t.exe
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} %{link_flags} -o %t.exe
 // RUN: %{exec} %t.exe
 
 #include <cassert>

--- a/libcxx/test/std/atomics/atomics.general/replace_failure_order_codegen.sh.cpp
+++ b/libcxx/test/std/atomics/atomics.general/replace_failure_order_codegen.sh.cpp
@@ -26,7 +26,7 @@
 // was not being replaced with memory_order_acquire in external
 // TSAN-instrumented tests.
 
-// RUN: %{cxx} -c %s %{flags} %{compile_flags} -O2 -stdlib=libc++ -S -emit-llvm -o %t.ll
+// RUN: %{cxx} -c %s %{common_flags} %{compile_flags} -O2 -stdlib=libc++ -S -emit-llvm -o %t.ll
 
 #include <atomic>
 

--- a/libcxx/test/std/namespace/addressable_functions.sh.cpp
+++ b/libcxx/test/std/namespace/addressable_functions.sh.cpp
@@ -12,9 +12,9 @@
 // in C++20, we test it in all standard modes because it's basic QOI to provide
 // a consistent behavior for that across standard modes.
 
-// RUN: %{cxx} %{flags} %{compile_flags} -c %s -o %t.tu1.o -DTU1
-// RUN: %{cxx} %{flags} %{compile_flags} -c %s -o %t.tu2.o -DTU2
-// RUN: %{cxx} %t.tu1.o %t.tu2.o %{flags} %{link_flags} -o %t.exe
+// RUN: %{cxx} %{common_flags} %{compile_flags} -c %s -o %t.tu1.o -DTU1
+// RUN: %{cxx} %{common_flags} %{compile_flags} -c %s -o %t.tu2.o -DTU2
+// RUN: %{cxx} %t.tu1.o %t.tu2.o %{common_flags} %{link_flags} -o %t.exe
 // RUN: %{exec} %t.exe
 
 // The functions checked below come from <iostream> & friends

--- a/libcxx/test/std/strings/basic.string/string.capacity/shrink_to_fit.explicit_instantiation.sh.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/shrink_to_fit.explicit_instantiation.sh.cpp
@@ -11,9 +11,9 @@
 // a regression test for the bug that was reported at https://stackoverflow.com/q/69520633/627587
 // and https://seedcentral.apple.com/sm/feedback_collector/radar/85053279.
 
-// RUN: %{cxx} %{flags} %{compile_flags} %s %{link_flags} -DTU1 -c -o %t.tu1.o
-// RUN: %{cxx} %{flags} %{compile_flags} %s %{link_flags} -DTU2 -c -o %t.tu2.o
-// RUN: %{cxx} %{flags} %t.tu1.o %t.tu2.o %{link_flags} -o %t.exe
+// RUN: %{cxx} %{common_flags} %{compile_flags} %s %{link_flags} -DTU1 -c -o %t.tu1.o
+// RUN: %{cxx} %{common_flags} %{compile_flags} %s %{link_flags} -DTU2 -c -o %t.tu2.o
+// RUN: %{cxx} %{common_flags} %t.tu1.o %t.tu2.o %{link_flags} -o %t.exe
 
 // UNSUPPORTED: no-localization
 

--- a/libcxx/test/std/utilities/format/format.arguments/format.arg.store/make_format_args.sh.cpp
+++ b/libcxx/test/std/utilities/format/format.arguments/format.arg.store/make_format_args.sh.cpp
@@ -10,8 +10,8 @@
 // UNSUPPORTED: no-wide-characters
 
 // Validate it works regardless of the signedness of `char`.
-// RUN: %{cxx} %{flags} %{compile_flags} -fsigned-char -fsyntax-only %s
-// RUN: %{cxx} %{flags} %{compile_flags} -funsigned-char -fsyntax-only %s
+// RUN: %{cxx} %{common_flags} %{compile_flags} -fsigned-char -fsyntax-only %s
+// RUN: %{cxx} %{common_flags} %{compile_flags} -funsigned-char -fsyntax-only %s
 
 // <format>
 

--- a/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/incomplete.sh.cpp
+++ b/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/incomplete.sh.cpp
@@ -15,9 +15,9 @@
 // the unique_ptr is created and destroyed, and a TU where the type is incomplete and
 // we check that a restricted set of operations can be performed on the unique_ptr.
 
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.tu1.o -DCOMPLETE
-// RUN: %{cxx} %s %{flags} %{compile_flags} -c -o %t.tu2.o -DINCOMPLETE
-// RUN: %{cxx} %t.tu1.o %t.tu2.o %{flags} %{link_flags} -o %t.exe
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.tu1.o -DCOMPLETE
+// RUN: %{cxx} %s %{common_flags} %{compile_flags} -c -o %t.tu2.o -DINCOMPLETE
+// RUN: %{cxx} %t.tu1.o %t.tu2.o %{common_flags} %{link_flags} -o %t.exe
 // RUN: %{exec} %t.exe
 
 #include <memory>

--- a/libcxx/utils/libcxx/test/config.py
+++ b/libcxx/utils/libcxx/test/config.py
@@ -51,7 +51,7 @@ def configure(parameters, features, config, lit_config):
             )
 
     # Print the basic substitutions
-    for sub in ("%{cxx}", "%{flags}", "%{compile_flags}", "%{link_flags}", "%{benchmark_flags}", "%{exec}"):
+    for sub in ("%{cxx}", "%{common_flags}", "%{compile_flags}", "%{link_flags}", "%{benchmark_flags}", "%{exec}"):
         note("Using {} substitution: '{}'".format(sub, _getSubstitution(sub, config)))
 
     # Print all available features

--- a/libcxx/utils/libcxx/test/dsl.py
+++ b/libcxx/utils/libcxx/test/dsl.py
@@ -447,7 +447,7 @@ class AddFeature(ConfigAction):
 
 class AddFlag(ConfigAction):
     """
-    This action adds the given flag to the %{flags} substitution.
+    This action adds the given flag to the %{common_flags} substitution.
 
     The flag can be a string or a callable, in which case it is called with the
     configuration to produce the actual flag (as a string).
@@ -460,7 +460,7 @@ class AddFlag(ConfigAction):
         flag = self._getFlag(config)
         _ensureFlagIsSupported(config, flag)
         config.substitutions = _appendToSubstitution(
-            config.substitutions, "%{flags}", flag
+            config.substitutions, "%{common_flags}", flag
         )
 
     def pretty(self, config, litParams):
@@ -468,7 +468,7 @@ class AddFlag(ConfigAction):
 
 class AddFlagIfSupported(ConfigAction):
     """
-    This action adds the given flag to the %{flags} substitution, only if
+    This action adds the given flag to the %{common_flags} substitution, only if
     the compiler supports the flag.
 
     The flag can be a string or a callable, in which case it is called with the
@@ -482,7 +482,7 @@ class AddFlagIfSupported(ConfigAction):
         flag = self._getFlag(config)
         if hasCompileFlag(config, flag):
             config.substitutions = _appendToSubstitution(
-                config.substitutions, "%{flags}", flag
+                config.substitutions, "%{common_flags}", flag
             )
 
     def pretty(self, config, litParams):

--- a/libcxxabi/test/configs/apple-libc++abi-shared.cfg.in
+++ b/libcxxabi/test/configs/apple-libc++abi-shared.cfg.in
@@ -25,7 +25,7 @@ ADDITIONAL_PARAMETERS = [
         """),
 ]
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else ''
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libcxxabi/test/configs/apple-libc++abi-system.cfg.in
+++ b/libcxxabi/test/configs/apple-libc++abi-system.cfg.in
@@ -9,7 +9,7 @@ import libcxx.test.params, libcxx.test.config, libcxx.test.dsl
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else ''
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libcxxabi/test/configs/armv7m-picolibc-libc++abi.cfg.in
+++ b/libcxxabi/test/configs/armv7m-picolibc-libc++abi.cfg.in
@@ -2,7 +2,7 @@ lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
 libc_linker_script = '@CMAKE_INSTALL_PREFIX@/lib/picolibcpp.ld'
 
-config.substitutions.append(('%{flags}', '--sysroot=@CMAKE_INSTALL_PREFIX@'))
+config.substitutions.append(('%{common_flags}', '--sysroot=@CMAKE_INSTALL_PREFIX@'))
 
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include} -I %{cxx-include} -I %{cxx-target-include} %{maybe-include-libunwind} -I %{libcxx}/test/support -I %{libcxx}/src -D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS'

--- a/libcxxabi/test/configs/ibm-libc++abi-shared.cfg.in
+++ b/libcxxabi/test/configs/ibm-libc++abi-shared.cfg.in
@@ -8,7 +8,7 @@ if lit.util.isAIXTriple(config.target_triple):
   # way to retrieve the AIX version in the driver.
   config.target_triple = lit.util.addAIXVersion(config.target_triple)
 
-config.substitutions.append(('%{flags}',''))
+config.substitutions.append(('%{common_flags}',''))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include} -I %{cxx-include} -I %{cxx-target-include} %{maybe-include-libunwind} ' +
     '-D__LIBC_NO_CPP_MATH_OVERLOADS__ ' +

--- a/libcxxabi/test/configs/llvm-libc++abi-android.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-android.cfg.in
@@ -12,16 +12,16 @@ import libcxx.test.android
 import libcxx.test.config
 import libcxx.test.params
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '--sysroot @CMAKE_SYSROOT@' if '@CMAKE_SYSROOT@' else ''
 ))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include} -I %{cxx-include} -I %{cxx-target-include} %{maybe-include-libunwind} -I %{libcxx}/test/support -I %{libcxx}/src -D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS'
 ))
 
-# The platform library is called "libc++.so" and the NDK library is called "libc++_shared.so". 
-# Use LD_LIBRARY_PATH to find the libcxx shared object because older Bionic dynamic loaders 
-# don't support rpath lookup. The Android libc++ shared library exports libc++abi, so we 
+# The platform library is called "libc++.so" and the NDK library is called "libc++_shared.so".
+# Use LD_LIBRARY_PATH to find the libcxx shared object because older Bionic dynamic loaders
+# don't support rpath lookup. The Android libc++ shared library exports libc++abi, so we
 # don't need to link with -lc++abi.
 config.substitutions.append(('%{link_flags}',
     '-nostdlib++ -L %{lib} -l@LIBCXX_SHARED_OUTPUT_NAME@'

--- a/libcxxabi/test/configs/llvm-libc++abi-merged.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-merged.cfg.in
@@ -2,7 +2,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else ''
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libcxxabi/test/configs/llvm-libc++abi-mingw.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-mingw.cfg.in
@@ -3,7 +3,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}', ''))
+config.substitutions.append(('%{common_flags}', ''))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include} -I %{cxx-include} -I %{cxx-target-include} %{maybe-include-libunwind} -I %{libcxx}/test/support -I %{libcxx}/src -D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS'
 ))

--- a/libcxxabi/test/configs/llvm-libc++abi-shared-clangcl.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-shared-clangcl.cfg.in
@@ -3,7 +3,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}', '--driver-mode=g++'))
+config.substitutions.append(('%{common_flags}', '--driver-mode=g++'))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include} -I %{cxx-include} -I %{cxx-target-include} %{maybe-include-libunwind} -I %{libcxx}/test/support -I %{libcxx}/src -D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_STDIO_ISO_WIDE_SPECIFIERS -DNOMINMAX'
 ))

--- a/libcxxabi/test/configs/llvm-libc++abi-shared.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-shared.cfg.in
@@ -3,7 +3,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else ''
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libcxxabi/test/configs/llvm-libc++abi-static-clangcl.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-static-clangcl.cfg.in
@@ -3,7 +3,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}', '--driver-mode=g++'))
+config.substitutions.append(('%{common_flags}', '--driver-mode=g++'))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include} -I %{cxx-include} -I %{cxx-target-include} %{maybe-include-libunwind} -I %{libcxx}/test/support  -I %{libcxx}/src -D_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_STDIO_ISO_WIDE_SPECIFIERS -DNOMINMAX'
 ))

--- a/libcxxabi/test/configs/llvm-libc++abi-static.cfg.in
+++ b/libcxxabi/test/configs/llvm-libc++abi-static.cfg.in
@@ -3,7 +3,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else ''
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libcxxabi/test/incomplete_type.sh.cpp
+++ b/libcxxabi/test/incomplete_type.sh.cpp
@@ -16,9 +16,9 @@
 // UNSUPPORTED: no-exceptions
 // UNSUPPORTED: no-rtti
 
-// RUN: %{cxx} %{flags} %{compile_flags} -Wno-unreachable-code -c %s -o %t.one.o
-// RUN: %{cxx} %{flags} %{compile_flags} -Wno-unreachable-code -c %s -o %t.two.o -DTU_ONE
-// RUN: %{cxx} %{flags} %t.one.o %t.two.o %{link_flags} -o %t.exe
+// RUN: %{cxx} %{common_flags} %{compile_flags} -Wno-unreachable-code -c %s -o %t.one.o
+// RUN: %{cxx} %{common_flags} %{compile_flags} -Wno-unreachable-code -c %s -o %t.two.o -DTU_ONE
+// RUN: %{cxx} %{common_flags} %t.one.o %t.two.o %{link_flags} -o %t.exe
 // RUN: %{exec} %t.exe
 
 #include <stdio.h>

--- a/libcxxabi/test/native/arm-linux-eabi/ttype-encoding-00.pass.sh.s
+++ b/libcxxabi/test/native/arm-linux-eabi/ttype-encoding-00.pass.sh.s
@@ -1,4 +1,4 @@
-@ RUN: %{cxx} %{flags} %{link_flags} %s -o %t.exe
+@ RUN: %{cxx} %{common_flags} %{link_flags} %s -o %t.exe
 @ RUN: %t.exe
 @ UNSUPPORTED: no-exceptions
 

--- a/libcxxabi/test/native/arm-linux-eabi/ttype-encoding-90.pass.sh.s
+++ b/libcxxabi/test/native/arm-linux-eabi/ttype-encoding-90.pass.sh.s
@@ -1,4 +1,4 @@
-@ RUN: %{cxx} %{flags} %{link_flags} %s -o %t.exe
+@ RUN: %{cxx} %{common_flags} %{link_flags} %s -o %t.exe
 @ RUN: %t.exe
 @ UNSUPPORTED: no-exceptions
 

--- a/libcxxabi/test/native/x86_64/lpstart-zero.pass.sh.s
+++ b/libcxxabi/test/native/x86_64/lpstart-zero.pass.sh.s
@@ -1,4 +1,4 @@
-# RUN: %{cxx} %{flags} %s %{link_flags} -no-pie -o %t.exe
+# RUN: %{cxx} %{common_flags} %s %{link_flags} -no-pie -o %t.exe
 # RUN: %{exec} %t.exe
 
 # REQUIRES: linux && target={{x86_64-.+}}

--- a/libcxxabi/test/vendor/ibm/aix_xlclang_nested_excp_32.pass.sh.s
+++ b/libcxxabi/test/vendor/ibm/aix_xlclang_nested_excp_32.pass.sh.s
@@ -12,7 +12,7 @@
 # REQUIRES: target=powerpc-ibm-aix{{.*}}
 # UNSUPPORTED: no-exceptions
 
-# RUN: %{cxx} %{flags} %s %{link_flags} \
+# RUN: %{cxx} %{common_flags} %s %{link_flags} \
 # RUN:   -o %t_32.exe
 # RUN: %{exec} %t_32.exe
 

--- a/libcxxabi/test/vendor/ibm/aix_xlclang_nested_excp_64.pass.sh.s
+++ b/libcxxabi/test/vendor/ibm/aix_xlclang_nested_excp_64.pass.sh.s
@@ -11,7 +11,7 @@
 # REQUIRES: target=powerpc64-ibm-aix{{.*}}
 # UNSUPPORTED: no-exceptions
 
-# RUN: %{cxx} %{flags} %s %{link_flags} \
+# RUN: %{cxx} %{common_flags} %s %{link_flags} \
 # RUN:   -o %t_64.exe
 # RUN: %{exec} %t_64.exe
 

--- a/libcxxabi/test/vendor/ibm/aix_xlclang_passing_excp_obj_32.pass.sh.S
+++ b/libcxxabi/test/vendor/ibm/aix_xlclang_passing_excp_obj_32.pass.sh.S
@@ -17,9 +17,9 @@
 # REQUIRES: target=powerpc-ibm-aix{{.*}}
 # UNSUPPORTED: no-exceptions
 
-// RUN: %{cxx} -c %s -o %t1_32.o -DT1_CPP_CODE %{flags} %{compile_flags}
-// RUN: %{cxx} -c %s -o %t2_32.o -DT2_CPP_CODE %{flags} %{compile_flags}
-// RUN: %{cxx} -o %t_32.exe %t1_32.o %t2_32.o %{flags} %{link_flags}
+// RUN: %{cxx} -c %s -o %t1_32.o -DT1_CPP_CODE %{common_flags} %{compile_flags}
+// RUN: %{cxx} -c %s -o %t2_32.o -DT2_CPP_CODE %{common_flags} %{compile_flags}
+// RUN: %{cxx} -o %t_32.exe %t1_32.o %t2_32.o %{common_flags} %{link_flags}
 // RUN: %{exec} %t_32.exe
 
 #if defined(T1_CPP_CODE)

--- a/libcxxabi/test/vendor/ibm/aix_xlclang_passing_excp_obj_64.pass.sh.S
+++ b/libcxxabi/test/vendor/ibm/aix_xlclang_passing_excp_obj_64.pass.sh.S
@@ -17,9 +17,9 @@
 # REQUIRES: target=powerpc64-ibm-aix{{.*}}
 # UNSUPPORTED: no-exceptions
 
-// RUN: %{cxx} -c %s -o %t1_64.o -DT1_CPP_CODE %{flags} %{compile_flags}
-// RUN: %{cxx} -c %s -o %t2_64.o -DT2_CPP_CODE %{flags} %{compile_flags}
-// RUN: %{cxx} -o %t_64.exe %t1_64.o %t2_64.o %{flags} %{link_flags}
+// RUN: %{cxx} -c %s -o %t1_64.o -DT1_CPP_CODE %{common_flags} %{compile_flags}
+// RUN: %{cxx} -c %s -o %t2_64.o -DT2_CPP_CODE %{common_flags} %{compile_flags}
+// RUN: %{cxx} -o %t_64.exe %t1_64.o %t2_64.o %{common_flags} %{link_flags}
 // RUN: %{exec} %t_64.exe
 
 #if defined(T1_CPP_CODE)

--- a/libunwind/test/aix_signal_unwind.pass.sh.S
+++ b/libunwind/test/aix_signal_unwind.pass.sh.S
@@ -13,14 +13,14 @@
 // REQUIRES: target={{.+}}-aix{{.*}}
 
 // Test when the function raising the signal does not save the link register
-// RUN: %{cxx} -x c++ %s -o %t.exe -DCXX_CODE %{flags} %{compile_flags}
+// RUN: %{cxx} -x c++ %s -o %t.exe -DCXX_CODE %{common_flags} %{compile_flags}
 // RUN: %{exec} %t.exe
 
 // Test when the function raising the signal does not store stack back chain.
-// RUN: %{cxx} -x c++ -c %s -o %t1.o -DCXX_CODE -DNOBACKCHAIN %{flags} \
+// RUN: %{cxx} -x c++ -c %s -o %t1.o -DCXX_CODE -DNOBACKCHAIN %{common_flags} \
 // RUN:   %{compile_flags}
-// RUN: %{cxx} -c %s -o %t2.o %{flags} %{compile_flags}
-// RUN: %{cxx} -o %t1.exe %t1.o %t2.o %{flags} %{link_flags}
+// RUN: %{cxx} -c %s -o %t2.o %{common_flags} %{compile_flags}
+// RUN: %{cxx} -o %t1.exe %t1.o %t2.o %{common_flags} %{link_flags}
 // RUN: %{exec} %t1.exe
 
 #ifdef CXX_CODE

--- a/libunwind/test/configs/apple-libunwind-system.cfg.in
+++ b/libunwind/test/configs/apple-libunwind-system.cfg.in
@@ -9,7 +9,7 @@ import libcxx.test.params, libcxx.test.config, libcxx.test.dsl
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-isysroot {}'.format('@CMAKE_OSX_SYSROOT@') if '@CMAKE_OSX_SYSROOT@' else ''
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libunwind/test/configs/armv7m-picolibc-libunwind.cfg.in
+++ b/libunwind/test/configs/armv7m-picolibc-libunwind.cfg.in
@@ -2,7 +2,7 @@ lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
 libc_linker_script = '@CMAKE_INSTALL_PREFIX@/lib/picolibcpp.ld'
 
-config.substitutions.append(('%{flags}', '--sysroot=@CMAKE_INSTALL_PREFIX@'))
+config.substitutions.append(('%{common_flags}', '--sysroot=@CMAKE_INSTALL_PREFIX@'))
 
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include}'

--- a/libunwind/test/configs/ibm-libunwind-shared.cfg.in
+++ b/libunwind/test/configs/ibm-libunwind-shared.cfg.in
@@ -9,7 +9,7 @@ if lit.util.isAIXTriple(config.target_triple):
   # way to retrieve the AIX version in the driver.
   config.target_triple = lit.util.addAIXVersion(config.target_triple)
 
-config.substitutions.append(('%{flags}', ''))
+config.substitutions.append(('%{common_flags}', ''))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include}'
 ))

--- a/libunwind/test/configs/llvm-libunwind-merged.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-merged.cfg.in
@@ -25,7 +25,7 @@ if '@CMAKE_DL_LIBS@':
 compile_flags.append('-funwind-tables')
 
 local_sysroot = '@CMAKE_OSX_SYSROOT@' or '@CMAKE_SYSROOT@'
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-isysroot {}'.format(local_sysroot) if local_sysroot else ''
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libunwind/test/configs/llvm-libunwind-shared-mingw.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-shared-mingw.cfg.in
@@ -3,7 +3,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}', ''))
+config.substitutions.append(('%{common_flags}', ''))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include} -funwind-tables'
 ))

--- a/libunwind/test/configs/llvm-libunwind-shared.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-shared.cfg.in
@@ -24,7 +24,7 @@ if '@CMAKE_DL_LIBS@':
 compile_flags.append('-funwind-tables')
 
 local_sysroot = '@CMAKE_OSX_SYSROOT@' or '@CMAKE_SYSROOT@'
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-isysroot {}'.format(local_sysroot) if local_sysroot else ''
 ))
 config.substitutions.append(('%{compile_flags}',

--- a/libunwind/test/configs/llvm-libunwind-static-mingw.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-static-mingw.cfg.in
@@ -3,7 +3,7 @@
 
 lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
 
-config.substitutions.append(('%{flags}', ''))
+config.substitutions.append(('%{common_flags}', ''))
 config.substitutions.append(('%{compile_flags}',
     '-nostdinc++ -I %{include} -funwind-tables'
 ))

--- a/libunwind/test/configs/llvm-libunwind-static.cfg.in
+++ b/libunwind/test/configs/llvm-libunwind-static.cfg.in
@@ -27,7 +27,7 @@ if '@CMAKE_DL_LIBS@':
 compile_flags.append('-funwind-tables')
 
 local_sysroot = '@CMAKE_OSX_SYSROOT@' or '@CMAKE_SYSROOT@'
-config.substitutions.append(('%{flags}',
+config.substitutions.append(('%{common_flags}',
     '-isysroot {}'.format(local_sysroot) if local_sysroot else ''
 ))
 config.substitutions.append(('%{compile_flags}',


### PR DESCRIPTION
These flags are common to compilation and linking, so %{common_flags} makes more sense.