### PR TITLE
[LLVM][NFC] Remove unused YAML strong typedefs

### DIFF
--- a/llvm/lib/ObjectYAML/ELFYAML.cpp
+++ b/llvm/lib/ObjectYAML/ELFYAML.cpp
@@ -2055,12 +2055,6 @@ void MappingTraits<ELFYAML::CallGraphEntryWeight>::mapping(
   IO.mapRequired("Weight", E.Weight);
 }
 
-LLVM_YAML_STRONG_TYPEDEF(uint8_t, MIPS_AFL_REG)
-LLVM_YAML_STRONG_TYPEDEF(uint8_t, MIPS_ABI_FP)
-LLVM_YAML_STRONG_TYPEDEF(uint32_t, MIPS_AFL_EXT)
-LLVM_YAML_STRONG_TYPEDEF(uint32_t, MIPS_AFL_ASE)
-LLVM_YAML_STRONG_TYPEDEF(uint32_t, MIPS_AFL_FLAGS1)
-
 } // end namespace yaml
 
 } // end namespace llvm


### PR DESCRIPTION
These were found while testing an [upcoming clang-tidy change](https://github.com/llvm/llvm-project/pull/172797). They were originally added in 04d9e65, and I'm not sure what purpose they serve. (I'm also not sure who to add as reviewers)