### PR TITLE
Fix loop_annotation name in unit tests

### DIFF
--- a/mlir/test/Conversion/SCFToControlFlow/convert-to-cfg.mlir
+++ b/mlir/test/Conversion/SCFToControlFlow/convert-to-cfg.mlir
@@ -710,9 +710,9 @@ func.func @forall(%num_threads: index) {
 //      CHECK: ^[[bb3]](%{{.*}}: index):
 //      CHECK:   cf.cond_br %{{.*}}, ^[[bb4:.*]], ^[[bb5:.*]]
 //      CHECK: ^[[bb4]]:
-//      CHECK:   cf.br ^[[bb3]]({{.*}}) {llvm.loop_annotation = #[[FULL_UNROLL]]}
+//      CHECK:   cf.br ^[[bb3]]({{.*}}) {loop_annotation = #[[FULL_UNROLL]]}
 //      CHECK: ^[[bb5]]:
-//      CHECK:   cf.br ^[[bb1]]({{.*}}) {llvm.loop_annotation = #[[NO_UNROLL]]}
+//      CHECK:   cf.br ^[[bb1]]({{.*}}) {loop_annotation = #[[NO_UNROLL]]}
 //      CHECK: ^[[bb6]]:
 //      CHECK:   return
 #no_unroll = #llvm.loop_annotation<unroll = <disable = true>>
@@ -724,8 +724,8 @@ func.func @simple_std_for_loops_annotation(%arg0 : index, %arg1 : index, %arg2 :
     %c4 = arith.constant 4 : index
     scf.for %i1 = %c0 to %c4 step %c1 {
       %c1_0 = arith.constant 1 : index
-    } {llvm.loop_annotation = #full_unroll}
-  } {llvm.loop_annotation = #no_unroll}
+    } {loop_annotation = #full_unroll}
+  } {loop_annotation = #no_unroll}
   return
 }
 
@@ -735,7 +735,7 @@ func.func @simple_std_for_loops_annotation(%arg0 : index, %arg1 : index, %arg2 :
 // CHECK: #[[NO_UNROLL:.*]] = #llvm.loop_annotation<unroll = #[[LOOP_UNROLL_DISABLE]]>
 // CHECK: func @simple_while_loops_annotation
 //      CHECK: cf.br
-//      CHECK: cf.cond_br {{.*}} {llvm.loop_annotation = #[[NO_UNROLL]]}
+//      CHECK: cf.cond_br {{.*}} {loop_annotation = #[[NO_UNROLL]]}
 //      CHECK: return
 #no_unroll = #llvm.loop_annotation<unroll = <disable = true>>
 func.func @simple_while_loops_annotation(%arg0 : i1) {
@@ -743,7 +743,7 @@ func.func @simple_while_loops_annotation(%arg0 : i1) {
     scf.condition(%arg0)
   } do {
     scf.yield
-  } attributes {llvm.loop_annotation = #no_unroll}
+  } attributes {loop_annotation = #no_unroll}
   return
 }
 
@@ -754,7 +754,7 @@ func.func @simple_while_loops_annotation(%arg0 : i1) {
 // CHECK: func @do_while_loops_annotation
 // CHECK: cf.br
 // CHECK: cf.cond_br
-// CHECK: cf.br {{.*}} {llvm.loop_annotation = #[[NO_UNROLL]]}
+// CHECK: cf.br {{.*}} {loop_annotation = #[[NO_UNROLL]]}
 // CHECK: return
 #no_unroll = #llvm.loop_annotation<unroll = <disable = true>>
 func.func @do_while_loops_annotation() {
@@ -765,7 +765,7 @@ func.func @do_while_loops_annotation() {
   } do {
  ^bb0(%arg2: i32):    
     scf.yield %c0_i32: i32
-  } attributes {llvm.loop_annotation = #no_unroll}
+  } attributes {loop_annotation = #no_unroll}
   return
 }
 


### PR DESCRIPTION
The attribute name is `loop_annotation` instead of `llvm.loop_annotation`.