### PR TITLE
[mlir] Enable perfect forwarding for `addWithLabel` and `insert` (NFC)

### DIFF
--- a/mlir/include/mlir/IR/PatternMatch.h
+++ b/mlir/include/mlir/IR/PatternMatch.h
@@ -872,7 +872,9 @@ public:
                                   ConstructorArgs &&...args) {
     // The following expands a call to emplace_back for each of the pattern
     // types 'Ts'.
-    (addImpl<Ts>(debugLabels, arg, args...), ...);
+    (addImpl<Ts>(debugLabels, std::forward<ConstructorArg>(arg),
+                 std::forward<ConstructorArgs>(args)...),
+     ...);
     return *this;
   }
 
@@ -938,7 +940,9 @@ public:
   RewritePatternSet &insert(ConstructorArg &&arg, ConstructorArgs &&...args) {
     // The following expands a call to emplace_back for each of the pattern
     // types 'Ts'.
-    (addImpl<Ts>(/*debugLabels=*/{}, arg, args...), ...);
+    (addImpl<Ts>(/*debugLabels=*/{}, std::forward<ConstructorArg>(arg),
+                 std::forward<ConstructorArgs>(args)...),
+     ...);
     return *this;
   }
 


### PR DESCRIPTION
This PR adds perfect forwarding support to `RewritePatternSet::addWithLabel` and `RewritePatternSet::insert`, preventing unnecessary copies when forwarding arguments, consistent with `RewritePatternSet::add`.