### PR TITLE
[AArch64] Fix wrong AArch64Subtarget construction.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -749,10 +749,9 @@ void AArch64AsmPrinter::emitHwasanMemaccessSymbols(Module &M) {
 
   const Triple &TT = TM.getTargetTriple();
   assert(TT.isOSBinFormatELF());
-  std::unique_ptr<MCSubtargetInfo> STI(
-      TM.getTarget().createMCSubtargetInfo(TT, "", ""));
-  assert(STI && "Unable to create subtarget info");
-  this->STI = static_cast<const AArch64Subtarget *>(&*STI);
+  AArch64Subtarget STI(TT, TM.getTargetCPU(), TM.getTargetCPU(),
+                       TM.getTargetFeatureString(), TM, true);
+  this->STI = &STI;
 
   MCSymbol *HwasanTagMismatchV1Sym =
       OutContext.getOrCreateSymbol("__hwasan_tag_mismatch");
@@ -2493,10 +2492,9 @@ const MCExpr *AArch64AsmPrinter::emitPAuthRelocationAsIRelative(
   if (KeyID != AArch64PACKey::DA)
     return nullptr;
 
-  std::unique_ptr<MCSubtargetInfo> STI(
-      TM.getTarget().createMCSubtargetInfo(TT, "", ""));
-  assert(STI && "Unable to create subtarget info");
-  this->STI = static_cast<const AArch64Subtarget *>(&*STI);
+  AArch64Subtarget STI(TT, TM.getTargetCPU(), TM.getTargetCPU(),
+                       TM.getTargetFeatureString(), TM, true);
+  this->STI = &STI;
 
   MCSymbol *Place = OutStreamer->getContext().createTempSymbol();
   OutStreamer->emitLabel(Place);
@@ -2520,9 +2518,9 @@ const MCExpr *AArch64AsmPrinter::emitPAuthRelocationAsIRelative(
                                      .addReg(AArch64::X0)
                                      .addExpr(Target)
                                      .addImm(0),
-                                 *STI);
+                                 STI);
   } else {
-    emitAddress(AArch64::X0, Target, AArch64::X16, IsDSOLocal, *STI);
+    emitAddress(AArch64::X0, Target, AArch64::X16, IsDSOLocal, STI);
   }
   if (HasAddressDiversity) {
     auto *PlacePlusDisc = MCBinaryExpr::createAdd(
@@ -2530,7 +2528,7 @@ const MCExpr *AArch64AsmPrinter::emitPAuthRelocationAsIRelative(
         MCConstantExpr::create(Disc, OutStreamer->getContext()),
         OutStreamer->getContext());
     emitAddress(AArch64::X1, PlacePlusDisc, AArch64::X16, /*IsDSOLocal=*/true,
-                *STI);
+                STI);
   } else {
     if (!isUInt<16>(Disc)) {
       OutContext.reportError(SMLoc(), "AArch64 PAC Discriminator '" +
@@ -2559,13 +2557,13 @@ const MCExpr *AArch64AsmPrinter::emitPAuthRelocationAsIRelative(
   const MCSymbolRefExpr *EmuPACRef =
       MCSymbolRefExpr::create(EmuPAC, OutStreamer->getContext());
   OutStreamer->emitInstruction(MCInstBuilder(AArch64::B).addExpr(EmuPACRef),
-                               *STI);
+                               STI);
 
   // We need a RET despite the above tail call because the deactivation symbol
   // may replace the tail call with a NOP.
   if (DSExpr)
     OutStreamer->emitInstruction(
-        MCInstBuilder(AArch64::RET).addReg(AArch64::LR), *STI);
+        MCInstBuilder(AArch64::RET).addReg(AArch64::LR), STI);
   OutStreamer->popSection();
 
   return MCSymbolRefExpr::create(IRelativeSym, AArch64::S_FUNCINIT,


### PR DESCRIPTION
The AArch64Subtarget construction was wrong for two reasons: firstly, createMCSubtargetInfo() does not create an AArch64Subtarget object, and secondly, the target CPU and features were left blank. This has been benign so far since no methods were called that depended on this, but it is undefined for the first reason, and creating the subtarget info in a state that the user did not request for the second reason. This commit fixes both issues.