### PR TITLE
[clang] Define __PTRAUTH_INTRINSICS__ for arm64e-apple-* targets

### DIFF
--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -1786,8 +1786,10 @@ void clang::targets::getAppleMachOAArch64Defines(MacroBuilder &Builder,
   Builder.defineMacro("__arm64", "1");
   Builder.defineMacro("__arm64__", "1");
 
-  if (Triple.isArm64e())
+  if (Triple.isArm64e()) {
     Builder.defineMacro("__arm64e__", "1");
+    Builder.defineMacro("__PTRAUTH_INTRINSICS__", "1");
+  }
 }
 
 void AppleMachOAArch64TargetInfo::getOSDefines(const LangOptions &Opts,

--- a/clang/test/Preprocessor/arm64e.c
+++ b/clang/test/Preprocessor/arm64e.c
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -E -dM -ffreestanding -triple=arm64e-apple-ios < /dev/null | FileCheck %s
 
 // CHECK: #define __ARM64_ARCH_8__ 1
+// CHECK: #define __PTRAUTH_INTRINSICS__ 1
 // CHECK: #define __arm64__ 1
 // CHECK: #define __arm64e__ 1


### PR DESCRIPTION
The macro is set by Xcode clang for the arm64e-apple-* targets, and ifdefed in the macOS and iPhoneOS SDKs.