### PR TITLE
[OFFLOAD] Make L0 provide more information about device to be consistent with other plugins

### DIFF
--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -275,6 +275,8 @@ public:
   const std::string_view getName() const { return DeviceName; }
   const char *getNameCStr() const { return DeviceName.c_str(); }
 
+  const char *getArchCStr() const;
+
   const std::string_view getZeId() const { return zeId; }
   const char *getZeIdCStr() const { return zeId.c_str(); }
 

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -547,6 +547,7 @@ Expected<InfoTreeNode> L0DeviceTy::obtainInfoImpl() {
   InfoTreeNode Info;
   Info.add("Device Number", getDeviceId());
   Info.add("Device Name", getNameCStr(), "", DeviceInfo::NAME);
+  Info.add("Product Name", getNameCStr(), "", DeviceInfo::PRODUCT_NAME);
   Info.add("Device Type", "GPU", "", DeviceInfo::TYPE);
   Info.add("Vendor", "Intel", "", DeviceInfo::VENDOR);
   Info.add("Vendor ID", getVendorId(), "", DeviceInfo::VENDOR_ID);
@@ -581,7 +582,8 @@ Expected<InfoTreeNode> L0DeviceTy::obtainInfoImpl() {
   MaxSize.add("y", getMaxGroupSizeY() * getMaxGroupCountY());
   MaxSize.add("z", getMaxGroupSizeZ() * getMaxGroupCountZ());
 
-  Info.add("Local memory size (bytes)", getMaxSharedLocalMemory());
+  Info.add("Local memory size (bytes)", getMaxSharedLocalMemory(), "",
+           DeviceInfo::WORK_GROUP_LOCAL_MEM_SIZE);
   Info.add("Global memory size (bytes)", getGlobalMemorySize(), "",
            DeviceInfo::GLOBAL_MEM_SIZE);
   Info.add("Cache size (bytes)", getCacheSize());

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -537,26 +537,26 @@ Error L0DeviceTy::initAsyncInfoImpl(AsyncInfoWrapperTy &AsyncInfoWrapper) {
   return Plugin::success();
 }
 
-const char *L0DeviceTy::getArchCStr() const{
-  switch(getDeviceArch()){
-    case DeviceArchTy::DeviceArch_Gen:
-      return "Intel GPU Xe";
-    case DeviceArchTy::DeviceArch_XeLPG:
-      return "Intel GPU Xe LPG";
-    case DeviceArchTy::DeviceArch_XeHPC:
-      return "Intel GPU Xe HPC";
-    case DeviceArchTy::DeviceArch_XeHPG:
-      return "Intel GPU Xe HPG";
-    case DeviceArchTy::DeviceArch_Xe2LP:
-      return "Intel GPU Xe2 LP";
-    case DeviceArchTy::DeviceArch_Xe2HP:
-      return "Intel GPU Xe HP";
-    case DeviceArchTy::DeviceArch_x86_64:
-      return "Intel X86 64";
-    default:
-      return "Intel GPU Unknown";
+const char *L0DeviceTy::getArchCStr() const {
+  switch (getDeviceArch()) {
+  case DeviceArchTy::DeviceArch_Gen:
+    return "Intel GPU Xe";
+  case DeviceArchTy::DeviceArch_XeLPG:
+    return "Intel GPU Xe LPG";
+  case DeviceArchTy::DeviceArch_XeHPC:
+    return "Intel GPU Xe HPC";
+  case DeviceArchTy::DeviceArch_XeHPG:
+    return "Intel GPU Xe HPG";
+  case DeviceArchTy::DeviceArch_Xe2LP:
+    return "Intel GPU Xe2 LP";
+  case DeviceArchTy::DeviceArch_Xe2HP:
+    return "Intel GPU Xe HP";
+  case DeviceArchTy::DeviceArch_x86_64:
+    return "Intel X86 64";
+  default:
+    return "Intel GPU Unknown";
   }
- }
+}
 
 static const char *DriverVersionToStrTable[] = {
     "1.0", "1.1", "1.2", "1.3",  "1.4",  "1.5", "1.6",

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -537,6 +537,27 @@ Error L0DeviceTy::initAsyncInfoImpl(AsyncInfoWrapperTy &AsyncInfoWrapper) {
   return Plugin::success();
 }
 
+const char *L0DeviceTy::getArchCStr() const{
+  switch(getDeviceArch()){
+    case DeviceArchTy::DeviceArch_Gen:
+      return "Intel GPU Xe";
+    case DeviceArchTy::DeviceArch_XeLPG:
+      return "Intel GPU Xe LPG";
+    case DeviceArchTy::DeviceArch_XeHPC:
+      return "Intel GPU Xe HPC";
+    case DeviceArchTy::DeviceArch_XeHPG:
+      return "Intel GPU Xe HPG";
+    case DeviceArchTy::DeviceArch_Xe2LP:
+      return "Intel GPU Xe2 LP";
+    case DeviceArchTy::DeviceArch_Xe2HP:
+      return "Intel GPU Xe HP";
+    case DeviceArchTy::DeviceArch_x86_64:
+      return "Intel X86 64";
+    default:
+      return "Intel GPU Unknown";
+  }
+ }
+
 static const char *DriverVersionToStrTable[] = {
     "1.0", "1.1", "1.2", "1.3",  "1.4",  "1.5", "1.6",
     "1.7", "1.8", "1.9", "1.10", "1.11", "1.12"};
@@ -547,7 +568,7 @@ Expected<InfoTreeNode> L0DeviceTy::obtainInfoImpl() {
   InfoTreeNode Info;
   Info.add("Device Number", getDeviceId());
   Info.add("Device Name", getNameCStr(), "", DeviceInfo::NAME);
-  Info.add("Product Name", getNameCStr(), "", DeviceInfo::PRODUCT_NAME);
+  Info.add("Product Name", getArchCStr(), "", DeviceInfo::PRODUCT_NAME);
   Info.add("Device Type", "GPU", "", DeviceInfo::TYPE);
   Info.add("Vendor", "Intel", "", DeviceInfo::VENDOR);
   Info.add("Vendor ID", getVendorId(), "", DeviceInfo::VENDOR_ID);


### PR DESCRIPTION
Update information about devices provided by level zero plugin in order to be more consistent with other plugins.