### PR TITLE
[clang-tidy][NFC] Give structs, classes, and enums internal linkage where applicable

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidyOptions.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyOptions.cpp
@@ -67,6 +67,8 @@ template <> struct MappingTraits<ClangTidyOptions::StringPair> {
   }
 };
 
+namespace {
+
 struct NOptionMap {
   NOptionMap(IO &) {}
   NOptionMap(IO &, const ClangTidyOptions::OptionMap &OptionMap) {
@@ -83,6 +85,8 @@ struct NOptionMap {
   }
   std::vector<ClangTidyOptions::StringPair> Options;
 };
+
+} // namespace
 
 template <>
 void yamlize(IO &IO, ClangTidyOptions::OptionMap &Val, bool,
@@ -178,10 +182,14 @@ template <> struct MappingTraits<ClangTidyOptions::CustomCheckValue> {
   }
 };
 
+namespace {
+
 struct GlobListVariant {
   std::optional<std::string> AsString;
   std::optional<std::vector<std::string>> AsVector;
 };
+
+} // namespace
 
 template <>
 void yamlize(IO &IO, GlobListVariant &Val, bool, EmptyContext &Ctx) {

--- a/clang-tools-extra/clang-tidy/NoLintDirectiveHandler.cpp
+++ b/clang-tools-extra/clang-tidy/NoLintDirectiveHandler.cpp
@@ -35,8 +35,12 @@ namespace clang::tidy {
 // NoLintType
 //===----------------------------------------------------------------------===//
 
+namespace {
+
 // The type - one of NOLINT[NEXTLINE/BEGIN/END].
 enum class NoLintType { NoLint, NoLintNextLine, NoLintBegin, NoLintEnd };
+
+} // namespace
 
 // Convert a string like "NOLINTNEXTLINE" to its enum `Type::NoLintNextLine`.
 // Return `std::nullopt` if the string is unrecognized.

--- a/clang-tools-extra/clang-tidy/abseil/AbseilTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/AbseilTidyModule.cpp
@@ -32,6 +32,7 @@
 
 namespace clang::tidy {
 namespace abseil {
+namespace {
 
 class AbseilModule : public ClangTidyModule {
 public:
@@ -74,6 +75,8 @@ public:
         "abseil-upgrade-duration-conversions");
   }
 };
+
+} // namespace
 
 // Register the AbseilModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<AbseilModule> X("abseil-module",

--- a/clang-tools-extra/clang-tidy/altera/AlteraTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/altera/AlteraTidyModule.cpp
@@ -19,6 +19,7 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy {
 namespace altera {
+namespace {
 
 class AlteraModule : public ClangTidyModule {
 public:
@@ -35,6 +36,7 @@ public:
   }
 };
 
+} // namespace
 } // namespace altera
 
 // Register the AlteraTidyModule using this statically initialized variable.

--- a/clang-tools-extra/clang-tidy/android/AndroidTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/android/AndroidTidyModule.cpp
@@ -29,6 +29,7 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy {
 namespace android {
+namespace {
 
 /// This module is for Android specific checks.
 class AndroidModule : public ClangTidyModule {
@@ -58,6 +59,8 @@ public:
         "android-comparison-in-temp-failure-retry");
   }
 };
+
+} // namespace
 
 // Register the AndroidTidyModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<AndroidModule>

--- a/clang-tools-extra/clang-tidy/boost/BoostTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/boost/BoostTidyModule.cpp
@@ -15,6 +15,7 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy {
 namespace boost {
+namespace {
 
 class BoostModule : public ClangTidyModule {
 public:
@@ -23,6 +24,8 @@ public:
     CheckFactories.registerCheck<UseToStringCheck>("boost-use-to-string");
   }
 };
+
+} // namespace
 
 // Register the BoostModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<BoostModule> X("boost-module",

--- a/clang-tools-extra/clang-tidy/bugprone/BugproneTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/BugproneTidyModule.cpp
@@ -115,6 +115,7 @@
 
 namespace clang::tidy {
 namespace bugprone {
+namespace {
 
 class BugproneModule : public ClangTidyModule {
 public:
@@ -319,6 +320,7 @@ public:
   }
 };
 
+} // namespace
 } // namespace bugprone
 
 // Register the BugproneTidyModule using this statically initialized variable.

--- a/clang-tools-extra/clang-tidy/bugprone/EasilySwappableParametersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/EasilySwappableParametersCheck.cpp
@@ -106,6 +106,8 @@ static bool prefixSuffixCoverUnderThreshold(std::size_t Threshold,
 
 namespace model {
 
+namespace {
+
 /// The language features involved in allowing the mix between two parameters.
 enum class MixFlags : unsigned char {
   Invalid = 0, ///< Sentinel bit pattern. DO NOT USE!
@@ -129,6 +131,9 @@ enum class MixFlags : unsigned char {
 
   LLVM_MARK_AS_BITMASK_ENUM(/* LargestValue =*/ImplicitConversion)
 };
+
+} // namespace
+
 LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
 
 /// Returns whether the SearchedFlag is turned on in the Data.
@@ -178,6 +183,8 @@ static inline std::string formatMixFlags(MixFlags F) {
 }
 
 #endif // NDEBUG
+
+namespace {
 
 /// The results of the steps of an Implicit Conversion Sequence is saved in
 /// an instance of this record.
@@ -564,6 +571,8 @@ enum class ImplicitConversionModellingMode : unsigned char {
   /// standard conversion sequence.
   OneWaySingleStandardOnly
 };
+
+} // namespace
 
 static MixData
 isLRefEquallyBindingToType(const TheCheck &Check,
@@ -1594,6 +1603,8 @@ static bool lazyMapOfSetsIntersectionExists(const MapTy &Map, const ElemTy &E1,
   });
 }
 
+namespace {
+
 /// Implements the heuristic that marks two parameters related if there is
 /// a usage for both in the same strict expression subtree. A strict
 /// expression subtree is a tree which only includes Expr nodes, i.e. no
@@ -1754,6 +1765,8 @@ public:
            llvm::is_contained(ReturnedParams, Param2);
   }
 };
+
+} // namespace
 
 } // namespace relatedness_heuristic
 
@@ -1950,7 +1963,7 @@ static inline bool needsToPrintTypeInDiagnostic(const model::Mix &M) {
 /// Returns whether a particular Mix between the two parameters should have
 /// implicit conversions elaborated.
 static inline bool needsToElaborateImplicitConversion(const model::Mix &M) {
-  return hasFlag(M.flags(), model::MixFlags::ImplicitConversion);
+  return model::hasFlag(M.flags(), model::MixFlags::ImplicitConversion);
 }
 
 namespace {

--- a/clang-tools-extra/clang-tidy/bugprone/NotNullTerminatedResultCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NotNullTerminatedResultCheck.cpp
@@ -32,11 +32,11 @@ constexpr llvm::StringLiteral LengthExprName = "LengthExpr";
 constexpr llvm::StringLiteral WrongLengthExprName = "WrongLength";
 constexpr llvm::StringLiteral UnknownLengthName = "UnknownLength";
 
-enum class LengthHandleKind { Increase, Decrease };
-
 namespace {
-static Preprocessor *PP;
+enum class LengthHandleKind { Increase, Decrease };
 } // namespace
+
+static Preprocessor *PP;
 
 // Returns the expression of destination's capacity which is part of a
 // 'VariableArrayType', 'ConstantArrayTypeLoc' or an argument of a 'malloc()'

--- a/clang-tools-extra/clang-tidy/bugprone/StringIntegerAssignmentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/StringIntegerAssignmentCheck.cpp
@@ -40,6 +40,8 @@ void StringIntegerAssignmentCheck::registerMatchers(MatchFinder *Finder) {
       this);
 }
 
+namespace {
+
 class CharExpressionDetector {
 public:
   CharExpressionDetector(QualType CharType, const ASTContext &Ctx)
@@ -123,6 +125,8 @@ private:
   const QualType CharType;
   const ASTContext &Ctx;
 };
+
+} // namespace
 
 void StringIntegerAssignmentCheck::check(
     const MatchFinder::MatchResult &Result) {

--- a/clang-tools-extra/clang-tidy/bugprone/SuspiciousEnumUsageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SuspiciousEnumUsageCheck.cpp
@@ -30,6 +30,8 @@ static const char BitmaskVarErrorMessage[] =
 
 static const char BitmaskNoteMessage[] = "used here as a bitmask";
 
+namespace {
+
 /// Stores a min and a max value which describe an interval.
 struct ValueRange {
   llvm::APSInt MinVal;
@@ -46,6 +48,8 @@ struct ValueRange {
     MaxVal = MinMaxVal.second->getInitVal();
   }
 };
+
+} // namespace
 
 /// Return the number of EnumConstantDecls in an EnumDecl.
 static int enumLength(const EnumDecl *EnumDec) {

--- a/clang-tools-extra/clang-tidy/bugprone/UseAfterMoveCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UseAfterMoveCheck.cpp
@@ -397,11 +397,15 @@ void UseAfterMoveFinder::getReinits(
   }
 }
 
+namespace {
+
 enum MoveType {
   Forward = 0,      // std::forward
   Move = 1,         // std::move
   Invalidation = 2, // other
 };
+
+} // namespace
 
 static MoveType determineMoveType(const FunctionDecl *FuncDecl) {
   if (FuncDecl->isInStdNamespace()) {

--- a/clang-tools-extra/clang-tidy/cert/CERTTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/cert/CERTTidyModule.cpp
@@ -232,6 +232,7 @@ const llvm::StringRef CertErr33CCheckedFunctions = "^::aligned_alloc$;"
 
 namespace clang::tidy {
 namespace cert {
+namespace {
 
 class CERTModule : public ClangTidyModule {
 public:
@@ -360,6 +361,7 @@ public:
   }
 };
 
+} // namespace
 } // namespace cert
 
 // Register the MiscTidyModule using this statically initialized variable.

--- a/clang-tools-extra/clang-tidy/concurrency/ConcurrencyTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/concurrency/ConcurrencyTidyModule.cpp
@@ -14,6 +14,7 @@
 
 namespace clang::tidy {
 namespace concurrency {
+namespace {
 
 class ConcurrencyModule : public ClangTidyModule {
 public:
@@ -25,6 +26,7 @@ public:
   }
 };
 
+} // namespace
 } // namespace concurrency
 
 // Register the ConcurrencyTidyModule using this statically initialized

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/CppCoreGuidelinesTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/CppCoreGuidelinesTidyModule.cpp
@@ -54,6 +54,7 @@
 
 namespace clang::tidy {
 namespace cppcoreguidelines {
+namespace {
 
 /// A module containing checks of the C++ Core Guidelines
 class CppCoreGuidelinesModule : public ClangTidyModule {
@@ -153,6 +154,8 @@ public:
     return Options;
   }
 };
+
+} // namespace
 
 // Register the LLVMTidyModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<CppCoreGuidelinesModule>

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
@@ -95,10 +95,14 @@ static void updateAssignmentLevel(
   }
 }
 
+namespace {
+
 struct AssignmentPair {
   const FieldDecl *Field;
   const Expr *Init;
 };
+
+} // namespace
 
 static std::optional<AssignmentPair>
 isAssignmentToMemberOf(const CXXRecordDecl *Rec, const Stmt *S,

--- a/clang-tools-extra/clang-tidy/custom/CustomTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/custom/CustomTidyModule.cpp
@@ -11,15 +11,18 @@
 
 namespace clang::tidy {
 namespace custom {
+namespace {
 
 class CustomModule : public ClangTidyModule {
 public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {}
 };
 
+} // namespace
+
 // We need to register the checks more flexibly than builtin modules. The checks
 // will changed dynamically when switching to different source file.
-extern void registerCustomChecks(const ClangTidyOptions &Options,
+static void registerCustomChecks(const ClangTidyOptions &Options,
                                  ClangTidyCheckFactories &Factories) {
   static llvm::SmallSet<llvm::SmallString<32>, 8> CustomCheckNames{};
   if (!Options.CustomChecks.has_value() || Options.CustomChecks->empty())
@@ -38,11 +41,15 @@ extern void registerCustomChecks(const ClangTidyOptions &Options,
   }
 }
 
+namespace {
+
 struct CustomChecksRegisterInitializer {
   CustomChecksRegisterInitializer() noexcept {
     RegisterCustomChecks = &custom::registerCustomChecks;
   }
 };
+
+} // namespace
 
 static CustomChecksRegisterInitializer Init{};
 

--- a/clang-tools-extra/clang-tidy/custom/CustomTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/custom/CustomTidyModule.cpp
@@ -11,14 +11,6 @@
 
 namespace clang::tidy {
 namespace custom {
-namespace {
-
-class CustomModule : public ClangTidyModule {
-public:
-  void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {}
-};
-
-} // namespace
 
 // We need to register the checks more flexibly than builtin modules. The checks
 // will changed dynamically when switching to different source file.
@@ -47,6 +39,11 @@ struct CustomChecksRegisterInitializer {
   CustomChecksRegisterInitializer() noexcept {
     RegisterCustomChecks = &custom::registerCustomChecks;
   }
+};
+
+class CustomModule : public ClangTidyModule {
+public:
+  void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {}
 };
 
 } // namespace

--- a/clang-tools-extra/clang-tidy/darwin/DarwinTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/darwin/DarwinTidyModule.cpp
@@ -14,6 +14,7 @@
 
 namespace clang::tidy {
 namespace darwin {
+namespace {
 
 class DarwinModule : public ClangTidyModule {
 public:
@@ -24,6 +25,7 @@ public:
   }
 };
 
+} // namespace
 } // namespace darwin
 
 // Register the DarwinTidyModule using this statically initialized variable.

--- a/clang-tools-extra/clang-tidy/fuchsia/FuchsiaTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/fuchsia/FuchsiaTidyModule.cpp
@@ -23,6 +23,7 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy {
 namespace fuchsia {
+namespace {
 
 /// This module is for Fuchsia-specific checks.
 class FuchsiaModule : public ClangTidyModule {
@@ -48,6 +49,9 @@ public:
         "fuchsia-virtual-inheritance");
   }
 };
+
+} // namespace
+
 // Register the FuchsiaTidyModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<FuchsiaModule>
     X("fuchsia-module", "Adds Fuchsia platform checks.");

--- a/clang-tools-extra/clang-tidy/google/GoogleTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/google/GoogleTidyModule.cpp
@@ -34,6 +34,7 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy {
 namespace google {
+namespace {
 
 class GoogleModule : public ClangTidyModule {
 public:
@@ -94,6 +95,8 @@ public:
     return Options;
   }
 };
+
+} // namespace
 
 // Register the GoogleTidyModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<GoogleModule> X("google-module",

--- a/clang-tools-extra/clang-tidy/google/TodoCommentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/TodoCommentCheck.cpp
@@ -14,9 +14,11 @@
 namespace clang::tidy {
 
 namespace google::readability {
+namespace {
 
 enum class StyleKind { Parentheses, Hyphen };
 
+} // namespace
 } // namespace google::readability
 
 template <> struct OptionEnumMapping<google::readability::StyleKind> {

--- a/clang-tools-extra/clang-tidy/hicpp/HICPPTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/hicpp/HICPPTidyModule.cpp
@@ -43,6 +43,7 @@
 
 namespace clang::tidy {
 namespace hicpp {
+namespace {
 
 class HICPPModule : public ClangTidyModule {
 public:
@@ -110,6 +111,8 @@ public:
         "hicpp-vararg");
   }
 };
+
+} // namespace
 
 // Register the HICPPModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<HICPPModule>

--- a/clang-tools-extra/clang-tidy/linuxkernel/LinuxKernelTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/linuxkernel/LinuxKernelTidyModule.cpp
@@ -13,6 +13,7 @@
 
 namespace clang::tidy {
 namespace linuxkernel {
+namespace {
 
 /// This module is for checks specific to the Linux kernel.
 class LinuxKernelModule : public ClangTidyModule {
@@ -22,6 +23,9 @@ public:
         "linuxkernel-must-check-errs");
   }
 };
+
+} // namespace
+
 // Register the LinuxKernelTidyModule using this statically initialized
 // variable.
 static ClangTidyModuleRegistry::Add<LinuxKernelModule>

--- a/clang-tools-extra/clang-tidy/llvm/LLVMTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/LLVMTidyModule.cpp
@@ -23,6 +23,7 @@
 
 namespace clang::tidy {
 namespace llvm_check {
+namespace {
 
 class LLVMModule : public ClangTidyModule {
 public:
@@ -56,6 +57,8 @@ public:
     return Options;
   }
 };
+
+} // namespace
 
 // Register the LLVMTidyModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<LLVMModule> X("llvm-module",

--- a/clang-tools-extra/clang-tidy/llvmlibc/LLVMLibcTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/llvmlibc/LLVMLibcTidyModule.cpp
@@ -16,6 +16,7 @@
 
 namespace clang::tidy {
 namespace llvm_libc {
+namespace {
 
 class LLVMLibcModule : public ClangTidyModule {
 public:
@@ -30,6 +31,8 @@ public:
         "llvmlibc-restrict-system-libc-headers");
   }
 };
+
+} // namespace
 
 // Register the LLVMLibcTidyModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<LLVMLibcModule>

--- a/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
@@ -137,8 +137,12 @@ void ConstCorrectnessCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(FunctionScope, this);
 }
 
+namespace {
+
 /// Classify for a variable in what the Const-Check is interested.
 enum class VariableCategory { Value, Reference, Pointer };
+
+} // namespace
 
 void ConstCorrectnessCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *LocalScope = Result.Nodes.getNodeAs<Stmt>("scope");

--- a/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
@@ -38,6 +38,7 @@
 
 namespace clang::tidy {
 namespace misc {
+namespace {
 
 class MiscModule : public ClangTidyModule {
 public:
@@ -92,6 +93,7 @@ public:
   }
 };
 
+} // namespace
 } // namespace misc
 
 // Register the MiscTidyModule using this statically initialized variable.

--- a/clang-tools-extra/clang-tidy/modernize/LoopConvertCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/LoopConvertCheck.cpp
@@ -330,6 +330,8 @@ static StatementMatcher makePseudoArrayLoopMatcher() {
       .bind(LoopNamePseudoArray);
 }
 
+namespace {
+
 enum class IteratorCallKind {
   ICK_Member,
   ICK_ADL,
@@ -342,6 +344,8 @@ struct ContainerCall {
   bool IsArrow;
   IteratorCallKind CallKind;
 };
+
+} // namespace
 
 // Find the Expr likely initializing an iterator.
 //

--- a/clang-tools-extra/clang-tidy/modernize/ModernizeTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/ModernizeTidyModule.cpp
@@ -60,6 +60,7 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy {
 namespace modernize {
+namespace {
 
 class ModernizeModule : public ClangTidyModule {
 public:
@@ -139,6 +140,8 @@ public:
     CheckFactories.registerCheck<UseUsingCheck>("modernize-use-using");
   }
 };
+
+} // namespace
 
 // Register the ModernizeTidyModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<ModernizeModule> X("modernize-module",

--- a/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
@@ -21,12 +21,12 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy::modernize {
 
+namespace {
 struct EnableIfData {
   TemplateSpecializationTypeLoc Loc;
   TypeLoc Outer;
 };
 
-namespace {
 AST_MATCHER(FunctionDecl, hasOtherDeclarations) {
   auto It = Node.redecls_begin();
   auto EndIt = Node.redecls_end();

--- a/clang-tools-extra/clang-tidy/mpi/MPITidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/mpi/MPITidyModule.cpp
@@ -14,6 +14,7 @@
 
 namespace clang::tidy {
 namespace mpi {
+namespace {
 
 class MPIModule : public ClangTidyModule {
 public:
@@ -23,6 +24,7 @@ public:
   }
 };
 
+} // namespace
 } // namespace mpi
 
 // Register the MPITidyModule using this statically initialized variable.

--- a/clang-tools-extra/clang-tidy/objc/ObjCTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/objc/ObjCTidyModule.cpp
@@ -23,6 +23,7 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy {
 namespace objc {
+namespace {
 
 class ObjCModule : public ClangTidyModule {
 public:
@@ -44,6 +45,8 @@ public:
     CheckFactories.registerCheck<SuperSelfCheck>("objc-super-self");
   }
 };
+
+} // namespace
 
 // Register the ObjCTidyModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<ObjCModule>

--- a/clang-tools-extra/clang-tidy/openmp/OpenMPTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/openmp/OpenMPTidyModule.cpp
@@ -14,6 +14,7 @@
 
 namespace clang::tidy {
 namespace openmp {
+namespace {
 
 /// This module is for OpenMP-specific checks.
 class OpenMPModule : public ClangTidyModule {
@@ -25,6 +26,8 @@ public:
         "openmp-use-default-none");
   }
 };
+
+} // namespace
 
 // Register the OpenMPTidyModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<OpenMPModule>

--- a/clang-tools-extra/clang-tidy/performance/PerformanceTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/performance/PerformanceTidyModule.cpp
@@ -31,6 +31,7 @@
 
 namespace clang::tidy {
 namespace performance {
+namespace {
 
 class PerformanceModule : public ClangTidyModule {
 public:
@@ -72,6 +73,8 @@ public:
         "performance-unnecessary-value-param");
   }
 };
+
+} // namespace
 
 // Register the PerformanceModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<PerformanceModule>

--- a/clang-tools-extra/clang-tidy/plugin/ClangTidyPlugin.cpp
+++ b/clang-tools-extra/clang-tidy/plugin/ClangTidyPlugin.cpp
@@ -14,6 +14,7 @@
 #include "clang/Frontend/MultiplexConsumer.h"
 
 namespace clang::tidy {
+namespace {
 
 /// The core clang tidy plugin action. This just provides the AST consumer and
 /// command line flag parsing for using clang-tidy as a clang plugin.
@@ -74,6 +75,8 @@ public:
 private:
   std::unique_ptr<ClangTidyContext> Context;
 };
+
+} // namespace
 } // namespace clang::tidy
 
 // This anchor is used to force the linker to link in the generated object file

--- a/clang-tools-extra/clang-tidy/portability/AvoidPragmaOnceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/portability/AvoidPragmaOnceCheck.cpp
@@ -15,6 +15,8 @@
 
 namespace clang::tidy::portability {
 
+namespace {
+
 class PragmaOnceCallbacks : public PPCallbacks {
 public:
   PragmaOnceCallbacks(AvoidPragmaOnceCheck *Check, const SourceManager &SM)
@@ -37,6 +39,8 @@ private:
   AvoidPragmaOnceCheck *Check;
   const SourceManager &SM;
 };
+
+} // namespace
 
 void AvoidPragmaOnceCheck::registerPPCallbacks(const SourceManager &SM,
                                                Preprocessor *PP,

--- a/clang-tools-extra/clang-tidy/portability/PortabilityTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/portability/PortabilityTidyModule.cpp
@@ -17,6 +17,7 @@
 
 namespace clang::tidy {
 namespace portability {
+namespace {
 
 class PortabilityModule : public ClangTidyModule {
 public:
@@ -33,6 +34,8 @@ public:
         "portability-template-virtual-member-function");
   }
 };
+
+} // namespace
 
 // Register the PortabilityModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<PortabilityModule>

--- a/clang-tools-extra/clang-tidy/readability/ReadabilityTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ReadabilityTidyModule.cpp
@@ -68,6 +68,7 @@
 
 namespace clang::tidy {
 namespace readability {
+namespace {
 
 class ReadabilityModule : public ClangTidyModule {
 public:
@@ -186,6 +187,8 @@ public:
         "readability-use-std-min-max");
   }
 };
+
+} // namespace
 
 // Register the ReadabilityModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<ReadabilityModule>

--- a/clang-tools-extra/clang-tidy/zircon/ZirconTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/zircon/ZirconTidyModule.cpp
@@ -13,6 +13,7 @@
 
 namespace clang::tidy {
 namespace zircon {
+namespace {
 
 /// This module is for Zircon-specific checks.
 class ZirconModule : public ClangTidyModule {
@@ -22,6 +23,8 @@ public:
         "zircon-temporary-objects");
   }
 };
+
+} // namespace
 
 // Register the ZirconTidyModule using this statically initialized variable.
 static ClangTidyModuleRegistry::Add<ZirconModule>


### PR DESCRIPTION
Fixing the instances found by `misc-use-internal-linkage` in #172797.