### PR TITLE
[ORC] Initialize the native target in ReOptimize unit test.

### DIFF
--- a/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
@@ -34,6 +34,9 @@ public:
 
 protected:
   void SetUp() override {
+
+    OrcNativeTarget::initialize();
+
     auto JTMB = JITTargetMachineBuilder::detectHost();
     // Bail out if we can not detect the host.
     if (!JTMB) {


### PR DESCRIPTION
The ReOptimize unit test was accidentally depending on native target initialization in previous tests, causing it to be skipped if run on its own (using --gtest_filter).

Calling OrcNativeTarget::initialize() in the SetUp method of the test fixes this.