### PR TITLE
[mlir][Presburger] make IntegerRelation::iterVarKind const

### DIFF
--- a/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
@@ -272,7 +272,7 @@ public:
   /// Return an interator over the variables of the specified kind
   /// starting at the relevant offset. The return type is auto in
   /// keeping with the convention for iterators.
-  auto iterVarKind(VarKind kind) {
+  auto iterVarKind(VarKind kind) const {
     return llvm::seq(getVarKindOffset(kind), getVarKindEnd(kind));
   }
 


### PR DESCRIPTION
`iterVarKind` is effectively const but not marked as such.