### PR TITLE
[clang] Add FixItHint for designated init order

### DIFF
--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -3136,9 +3136,14 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
             SourceManager &SM = SemaRef.getSourceManager();
             const LangOptions &LangOpts = SemaRef.getLangOpts();
 
+            // if Record is derived, then the first n base-classes are
+            // initialized first, they cannot be initialized with designated
+            // init, so skip them
+            const auto IListInits =
+                IList->inits().drop_front(CxxRecord->getNumBases());
             // loop over each existing expression and apply replacement
             for (const auto &[OrigExpr, Repl] :
-                 llvm::zip(IList->inits(), ReorderedInitExprs)) {
+                 llvm::zip(IListInits, ReorderedInitExprs)) {
               CharSourceRange CharRange = CharSourceRange::getTokenRange(
                   Repl.InitExpr->getSourceRange());
               const auto InitText =

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -3094,59 +3094,60 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
         PrevField = *FI;
       }
 
-      const auto GenerateDesignatedInitReorderingFixit = [&]() -> FixItHint {
-        struct ReorderInfo {
-          int Pos{};
-          const Expr *InitExpr{};
-        };
+      const auto GenerateDesignatedInitReorderingFixit =
+          [&](SemaBase::SemaDiagnosticBuilder &Diags) {
+            struct ReorderInfo {
+              int Pos{};
+              const Expr *InitExpr{};
+            };
 
-        llvm::SmallDenseMap<IdentifierInfo *, int> MemberNameInx{};
-        llvm::SmallVector<ReorderInfo, 16> ReorderedInitExprs{};
+            llvm::SmallDenseMap<IdentifierInfo *, int> MemberNameInx{};
+            llvm::SmallVector<ReorderInfo, 16> ReorderedInitExprs{};
 
-        const auto *CxxRecord =
-            IList->getSemanticForm()->getType()->getAsCXXRecordDecl();
+            const auto *CxxRecord =
+                IList->getSemanticForm()->getType()->getAsCXXRecordDecl();
 
-        for (const auto &Field : CxxRecord->fields()) {
-          MemberNameInx[Field->getIdentifier()] = Field->getFieldIndex();
-        }
+            for (const auto &Field : CxxRecord->fields()) {
+              MemberNameInx[Field->getIdentifier()] = Field->getFieldIndex();
+            }
 
-        for (const auto *Init : IList->inits()) {
-          if (const auto *DI = dyn_cast_if_present<DesignatedInitExpr>(Init)) {
-            // We expect only one Designator
-            if (DI->size() != 1)
-              return {};
+            for (const auto *Init : IList->inits()) {
+              if (const auto *DI =
+                      dyn_cast_if_present<DesignatedInitExpr>(Init)) {
+                // We expect only one Designator
+                if (DI->size() != 1)
+                  return;
 
-            const auto *const FieldName = DI->getDesignator(0)->getFieldName();
-            // In case we have an unknown initializer in the source, not in the
-            // record
-            if (MemberNameInx.contains(FieldName))
-              ReorderedInitExprs.emplace_back(
-                  ReorderInfo{MemberNameInx.at(FieldName), Init});
-          }
-        }
+                const auto *const FieldName =
+                    DI->getDesignator(0)->getFieldName();
+                // In case we have an unknown initializer in the source, not in
+                // the record
+                if (MemberNameInx.contains(FieldName))
+                  ReorderedInitExprs.emplace_back(
+                      ReorderInfo{MemberNameInx.at(FieldName), Init});
+              }
+            }
 
-        llvm::sort(ReorderedInitExprs,
-                   [](const auto &A, const auto &B) { return A.Pos < B.Pos; });
+            llvm::sort(ReorderedInitExprs, [](const auto &A, const auto &B) {
+              return A.Pos < B.Pos;
+            });
 
-        // generate replacement
-        llvm::SmallString<128> FixedInitList{};
-        SourceManager &SM = SemaRef.getSourceManager();
-        const LangOptions &LangOpts = SemaRef.getLangOpts();
+            llvm::SmallString<128> FixedInitList{};
+            SourceManager &SM = SemaRef.getSourceManager();
+            const LangOptions &LangOpts = SemaRef.getLangOpts();
 
-        FixedInitList += "{";
-        for (const auto &Item : ReorderedInitExprs) {
-          CharSourceRange CharRange =
-              CharSourceRange::getTokenRange(Item.InitExpr->getSourceRange());
-          const auto InitText =
-              Lexer::getSourceText(CharRange, SM, LangOpts) + ", ";
-          FixedInitList += InitText.str();
-        }
-        FixedInitList.pop_back_n(2); // remove trailing comma
-        FixedInitList += "}";
+            // loop over each existing expression and apply replacement
+            for (const auto &[OrigExpr, Repl] :
+                 llvm::zip(IList->inits(), ReorderedInitExprs)) {
+              CharSourceRange CharRange = CharSourceRange::getTokenRange(
+                  Repl.InitExpr->getSourceRange());
+              const auto InitText =
+                  Lexer::getSourceText(CharRange, SM, LangOpts);
 
-        return FixItHint::CreateReplacement(IList->getSourceRange(),
-                                            FixedInitList);
-      };
+              Diags << FixItHint::CreateReplacement(OrigExpr->getSourceRange(),
+                                                    InitText.str());
+            }
+          };
 
       if (PrevField &&
           PrevField->getFieldIndex() > KnownField->getFieldIndex()) {
@@ -3157,10 +3158,10 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
         unsigned OldIndex = StructuredIndex - 1;
         if (StructuredList && OldIndex <= StructuredList->getNumInits()) {
           if (Expr *PrevInit = StructuredList->getInit(OldIndex)) {
-            auto ReorderFixit = GenerateDesignatedInitReorderingFixit();
-            SemaRef.Diag(PrevInit->getBeginLoc(),
-                         diag::note_previous_field_init)
-                << PrevField << PrevInit->getSourceRange() << ReorderFixit;
+            auto Diags = SemaRef.Diag(PrevInit->getBeginLoc(),
+                                      diag::note_previous_field_init)
+                         << PrevField << PrevInit->getSourceRange();
+            GenerateDesignatedInitReorderingFixit(Diags);
           }
         }
       }


### PR DESCRIPTION
Generates `FixItHint` for reordering incorrectly initialized designated initializers. 

[vid.webm](https://github.com/user-attachments/assets/079ae121-77a8-4ca7-9935-efc7f0a36d19)

From issue clangd/clangd#965 ([comment](https://github.com/clangd/clangd/issues/965#issuecomment-1001257300))
> What do you think about adding/improving fix actions for misordered initializers instead. Would it help much?

