### PR TITLE
[BOLT] Add missing system-linux requirements to tests

### DIFF
--- a/bolt/test/AArch64/compact-code-model.s
+++ b/bolt/test/AArch64/compact-code-model.s
@@ -1,6 +1,8 @@
 ## Check that llvm-bolt successfully relaxes branches for compact (<128MB) code
 ## model.
 
+# REQUIRES: system-linux
+
 # RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
 # RUN: link_fdata %s %t.o %t.fdata
 # RUN: llvm-strip --strip-unneeded %t.o

--- a/bolt/test/dump-dot-func.test
+++ b/bolt/test/dump-dot-func.test
@@ -1,5 +1,7 @@
-# Test the --dump-dot-func option with multiple functions 
+# Test the --dump-dot-func option with multiple functions
 # (includes tests for both mangled/unmangled names)
+
+REQUIRES: system-linux
 
 RUN: %clangxx %p/Inputs/multi-func.cpp -o %t.exe -Wl,-q
 

--- a/bolt/test/dwarf5-missing-dwo.c
+++ b/bolt/test/dwarf5-missing-dwo.c
@@ -1,6 +1,8 @@
 // Check that llvm-bolt correctly reports a missing DWO file while updating
 // debug info.
 //
+// REQUIRES: system-linux
+//
 // RUN: %clang %cflags -g -dwarf5 -gsplit-dwarf=single -c %s -o %t.o
 // RUN: %clang %cflags %t.o -o %t.exe -Wl,-q
 // RUN: rm %t.o

--- a/bolt/test/dwo-name-retrieving.test
+++ b/bolt/test/dwo-name-retrieving.test
@@ -1,6 +1,8 @@
 ## Test DWO retrieval via relative path with a missing CompDir.
 ## Also, verify no crash for an absolute DWOName path.
 
+# REQUIRES: system-linux
+
 ## The case where DWOName is a relative path, and debug compilation directory does not exist.
 # RUN: rm -rf %t && mkdir -p %t && cd %t
 # RUN: %clang %cflags -g -gsplit-dwarf -fdebug-compilation-dir=/path/does/not/exist %p/Inputs/hello.c -o main.exe

--- a/bolt/test/indirect-goto-relocs.test
+++ b/bolt/test/indirect-goto-relocs.test
@@ -1,6 +1,8 @@
 // This test checks that BOLT creates entry points from sources
 // that use indirect goto.
 
+REQUIRES: system-linux
+
 RUN: %clang %cflags -pie %S/Inputs/indirect_goto.c -o %t.exe -Wl,-q
 RUN: llvm-bolt %t.exe -o %t.bolt --print-cfg | FileCheck --check-prefix=CHECK-PIE %s
 

--- a/bolt/test/lsda-section-name.cpp
+++ b/bolt/test/lsda-section-name.cpp
@@ -1,9 +1,11 @@
 // This test check that LSDA section named by .gcc_except_table.main is
 // disassembled by BOLT.
 
+// REQUIRES: system-linux
 // RUN: %clangxx %cxxflags -O3 -no-pie -c %s -o %t.o
 // RUN: %clangxx %cxxflags -O3 -no-pie -fuse-ld=lld %t.o -o %t
-// RUN: llvm-objcopy --rename-section .gcc_except_table=.gcc_except_table.main %t
+// RUN: llvm-objcopy --rename-section \
+// RUN: .gcc_except_table=.gcc_except_table.main %t
 // RUN: llvm-readelf -SW %t | FileCheck %s
 // RUN: llvm-bolt %t -o %t.bolt
 

--- a/bolt/test/timers.c
+++ b/bolt/test/timers.c
@@ -1,4 +1,7 @@
 // This test checks timers for metadata manager phases.
+
+// REQUIRES: system-linux
+
 // RUN: %clang %cflags %s -o %t.exe
 // RUN: link_fdata %s %t.exe %t.fdata
 // RUN: llvm-bolt %t.exe -o %t.null --data %t.fdata -w %t.yaml --time-rewrite \

--- a/bolt/test/yaml-profile-kind.c
+++ b/bolt/test/yaml-profile-kind.c
@@ -1,4 +1,7 @@
 /* This test checks the handling of YAML profile with different block orders.
+
+# REQUIRES: system-linux
+
 # RUN: %clang %cflags %s -o %t.exe
 # RUN: link_fdata %s %t.exe %t.fdata
 # RUN: llvm-bolt %t.exe -o %t.null -data %t.fdata -w %t.yaml


### PR DESCRIPTION
Several lit tests are failing on macOS, as they are linux-specific,
but not using the "REQUIRES: system-linux" setting.

This patch adds the missing requirements to tests failing on macOS.