### PR TITLE
[lld] Adjust compressed-debug-level test for s390x with DFLTCC

### DIFF
--- a/lld/test/ELF/compressed-debug-level.test
+++ b/lld/test/ELF/compressed-debug-level.test
@@ -18,7 +18,7 @@
 # RUN: llvm-readelf --sections %t.6 | FileCheck -check-prefixes=HEADER,LEVEL6 %s
 
 # HEADER: [Nr] Name        Type     Address  Off    Size
-# LEVEL1: [ 1] .debug_info PROGBITS 00000000 000094 0000{{1[def]|21}}
+# LEVEL1: [ 1] .debug_info PROGBITS 00000000 000094 0000{{1[cdef]|21}}
 # LEVEL6: [ 1] .debug_info PROGBITS 00000000 000094 00001{{[abc]}}
 
 ## A little arbitrary debug section which has a different size after


### PR DESCRIPTION
After enabling DFLTCC in zlib-ng for s390x this test starts failing, because slightly better compression is produced at level 1. Add 1c as a permissible output.