### PR TITLE
[RuntimeLibcalls] Fix stack probes for aarch64 mingw

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -1999,9 +1999,6 @@ defvar SecurityCheckCookieIfWinMSVC =
     LibcallImpls<(add __security_check_cookie, __security_cookie),
                  isWindowsMSVCOrItaniumEnvironment>;
 
-defvar __chkstk_IfWinMSVC =
-    LibcallImpls<(add __chkstk), isWindowsMSVCEnvironment>;
-
 defvar LibmHasSinCosF32 = LibcallImpls<(add sincosf), hasSinCos>;
 defvar LibmHasSinCosF64 =  LibcallImpls<(add sincos), hasSinCos>;
 defvar LibmHasSinCosF80 = LibcallImpls<(add sincosl_f80), hasSinCos>;
@@ -2161,7 +2158,7 @@ def AArch64SystemLibrary : SystemRuntimeLibrary<
        DefaultLibmExp10,
        DefaultStackProtector,
        SecurityCheckCookieIfWinMSVC,
-       __chkstk_IfWinMSVC,
+       LibcallImpls<(add __chkstk), isOSWindows>,
        SMEABI_LibCalls_PreserveMost_From_X0,
        SMEABI_LibCalls_PreserveMost_From_X1,
        SMEABI_LibCalls_PreserveMost_From_X2)

--- a/llvm/test/CodeGen/AArch64/chkstk.ll
+++ b/llvm/test/CodeGen/AArch64/chkstk.ll
@@ -1,5 +1,7 @@
 ; RUN: llc -mtriple=aarch64-windows -verify-machineinstrs %s -o - \
 ; RUN:  | FileCheck -check-prefix CHECK-DEFAULT-CODE-MODEL %s
+; RUN: llc -mtriple=aarch64-w64-mingw32 -verify-machineinstrs %s -o - \
+; RUN:  | FileCheck -check-prefix CHECK-DEFAULT-CODE-MODEL %s
 ; RUN: llc < %s -mtriple=aarch64-windows -stop-after=prologepilog \
 ; RUN:  | FileCheck -check-prefix CHECK-REGSTATE %s
 


### PR DESCRIPTION
Before bb993a89a873ee832d063fb566c889ca3d0c2b72, the stack probes on aarch64 windows unconditionally called "__chkstk"; after this refactoring, it only got "__chkstk" for MSVC environments, and no stack probe at all for other environments.

Simplify RuntimeLibcalls.td to do the same for aarch64 as for arm, simply adding "__chkstk" for all Windows variants, and add a test to cover this case.