### PR TITLE
[AMDGPU] expand-ir-insts: Remove LibcallLoweringModuleAnalysis usage

### DIFF
--- a/llvm/test/Transforms/ExpandIRInsts/AMDGPU/missing-analysis.ll
+++ b/llvm/test/Transforms/ExpandIRInsts/AMDGPU/missing-analysis.ll
@@ -1,6 +1,0 @@
-; RUN: not opt -mtriple=amdgcn -passes=expand-ir-insts -disable-output %s 2>&1 | FileCheck %s
-
-; CHECK: 'LibcallLoweringModuleAnalysis' analysis required
-define void @empty() {
-  ret void
-}


### PR DESCRIPTION
This is no longer necessary since the pass has stopped checking libcalls - which it did for the "frem" expansion - recently.