### PR TITLE
[llvm-cov] Add show-function-summary option in coverage report

### DIFF
--- a/llvm/test/tools/llvm-cov/branch-templates.test
+++ b/llvm/test/tools/llvm-cov/branch-templates.test
@@ -1,6 +1,7 @@
 // RUN: llvm-profdata merge %S/Inputs/branch-templates.proftext -o %t.profdata
 // RUN: llvm-cov show --show-expansions --show-branches=count %S/Inputs/branch-templates.o32l -instr-profile %t.profdata -path-equivalence=/tmp,%S/Inputs | FileCheck %S/Inputs/branch-templates.cpp
 // RUN: llvm-cov report --show-branch-summary %S/Inputs/branch-templates.o32l -instr-profile %t.profdata -show-functions -path-equivalence=/tmp,%S/Inputs %S/Inputs/branch-templates.cpp | FileCheck %s -check-prefix=REPORT
+// RUN: llvm-cov report --show-branch-summary %S/Inputs/branch-templates.o32l -instr-profile %t.profdata -path-equivalence=/tmp,%S/Inputs | FileCheck %s -check-prefix=REPORTFILE
 // RUN: llvm-cov report --show-branch-summary --show-function-summary=false %S/Inputs/branch-templates.o32l -instr-profile %t.profdata -path-equivalence=/tmp,%S/Inputs | FileCheck %s -check-prefix=REPORT_NO_FUNCTION_SUMMARY
 
 // RUN: yaml2obj %S/Inputs/branch-templates-single.yaml -o %t.o

--- a/llvm/test/tools/llvm-cov/branch-templates.test
+++ b/llvm/test/tools/llvm-cov/branch-templates.test
@@ -1,7 +1,7 @@
 // RUN: llvm-profdata merge %S/Inputs/branch-templates.proftext -o %t.profdata
 // RUN: llvm-cov show --show-expansions --show-branches=count %S/Inputs/branch-templates.o32l -instr-profile %t.profdata -path-equivalence=/tmp,%S/Inputs | FileCheck %S/Inputs/branch-templates.cpp
 // RUN: llvm-cov report --show-branch-summary %S/Inputs/branch-templates.o32l -instr-profile %t.profdata -show-functions -path-equivalence=/tmp,%S/Inputs %S/Inputs/branch-templates.cpp | FileCheck %s -check-prefix=REPORT
-// RUN: llvm-cov report --show-branch-summary %S/Inputs/branch-templates.o32l -instr-profile %t.profdata -path-equivalence=/tmp,%S/Inputs | FileCheck %s -check-prefix=REPORTFILE
+// RUN: llvm-cov report --show-branch-summary --show-function-summary=false %S/Inputs/branch-templates.o32l -instr-profile %t.profdata -path-equivalence=/tmp,%S/Inputs | FileCheck %s -check-prefix=REPORT_NO_FUNCTION_SUMMARY
 
 // RUN: yaml2obj %S/Inputs/branch-templates-single.yaml -o %t.o
 // RUN: llvm-profdata merge %S/Inputs/branch-templates-single.proftext -o %t.profdata
@@ -29,3 +29,9 @@
 // REPORTFILE-NEXT: branch-templates.cpp          12                 3    75.00%           2                 0   100.00%          17                 4    76.47%           8                 4    50.00%
 // REPORTFILE-NEXT: ---
 // REPORTFILE-NEXT: TOTAL                         12                 3    75.00%           2                 0   100.00%          17                 4    76.47%           8                 4    50.00%
+
+// REPORT_NO_FUNCTION_SUMMARY:      Filename                 Regions    Missed Regions     Cover   Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
+// REPORT_NO_FUNCTION_SUMMARY-NEXT: ---
+// REPORT_NO_FUNCTION_SUMMARY-NEXT: branch-templates.cpp          12                 3    75.00%   17                 4    76.47%           8                 4    50.00%
+// REPORT_NO_FUNCTION_SUMMARY-NEXT: ---
+// REPORT_NO_FUNCTION_SUMMARY-NEXT: TOTAL                         12                 3    75.00%   17                 4    76.47%           8                 4    50.00%

--- a/llvm/tools/llvm-cov/CodeCoverage.cpp
+++ b/llvm/tools/llvm-cov/CodeCoverage.cpp
@@ -770,6 +770,10 @@ int CodeCoverageTool::run(Command Cmd, int argc, const char **argv) {
       cl::desc("Show region statistics in summary table"),
       cl::init(true));
 
+  cl::opt<bool> FunctionSummary(
+      "show-function-summary", cl::Optional,
+      cl::desc("Show function statistics in summary table"), cl::init(true));
+
   cl::opt<bool> BranchSummary(
       "show-branch-summary", cl::Optional,
       cl::desc("Show branch condition statistics in summary table"),
@@ -962,6 +966,7 @@ int CodeCoverageTool::run(Command Cmd, int argc, const char **argv) {
     ViewOpts.ShowMCDCSummary = MCDCSummary;
     ViewOpts.ShowBranchSummary = BranchSummary;
     ViewOpts.ShowRegionSummary = RegionSummary;
+    ViewOpts.ShowFunctionSummary = FunctionSummary;
     ViewOpts.ShowInstantiationSummary = InstantiationSummary;
     ViewOpts.ExportSummaryOnly = SummaryOnly;
     ViewOpts.NumThreads = NumThreads;

--- a/llvm/tools/llvm-cov/CoverageReport.cpp
+++ b/llvm/tools/llvm-cov/CoverageReport.cpp
@@ -251,18 +251,20 @@ void CoverageReport::render(const FileCoverageSummary &File,
       OS << column("-", FileReportColumns[3], Column::RightAlignment);
   }
 
-  OS << format("%*u", FileReportColumns[4],
-               (unsigned)File.FunctionCoverage.getNumFunctions());
-  OS << format("%*u", FileReportColumns[5],
-               (unsigned)(File.FunctionCoverage.getNumFunctions() -
-                          File.FunctionCoverage.getExecuted()));
-  if (File.FunctionCoverage.getNumFunctions())
-    Options.colored_ostream(OS, FuncCoverageColor)
-        << format("%*.2f", FileReportColumns[6] - 1,
-                  File.FunctionCoverage.getPercentCovered())
-        << '%';
-  else
-    OS << column("-", FileReportColumns[6], Column::RightAlignment);
+  if (Options.ShowFunctionSummary) {
+    OS << format("%*u", FileReportColumns[4],
+                 (unsigned)File.FunctionCoverage.getNumFunctions());
+    OS << format("%*u", FileReportColumns[5],
+                 (unsigned)(File.FunctionCoverage.getNumFunctions() -
+                            File.FunctionCoverage.getExecuted()));
+    if (File.FunctionCoverage.getNumFunctions())
+      Options.colored_ostream(OS, FuncCoverageColor)
+          << format("%*.2f", FileReportColumns[6] - 1,
+                    File.FunctionCoverage.getPercentCovered())
+          << '%';
+    else
+      OS << column("-", FileReportColumns[6], Column::RightAlignment);
+  }
 
   if (Options.ShowInstantiationSummary) {
     OS << format("%*u", FileReportColumns[7],
@@ -539,9 +541,11 @@ void CoverageReport::renderFileReports(
     OS << column("Regions", FileReportColumns[1], Column::RightAlignment)
        << column("Missed Regions", FileReportColumns[2], Column::RightAlignment)
        << column("Cover", FileReportColumns[3], Column::RightAlignment);
-  OS << column("Functions", FileReportColumns[4], Column::RightAlignment)
-     << column("Missed Functions", FileReportColumns[5], Column::RightAlignment)
-     << column("Executed", FileReportColumns[6], Column::RightAlignment);
+  if (Options.ShowFunctionSummary)
+    OS << column("Functions", FileReportColumns[4], Column::RightAlignment)
+       << column("Missed Functions", FileReportColumns[5],
+                 Column::RightAlignment)
+       << column("Executed", FileReportColumns[6], Column::RightAlignment);
   if (Options.ShowInstantiationSummary)
     OS << column("Instantiations", FileReportColumns[7], Column::RightAlignment)
        << column("Missed Insts.", FileReportColumns[8], Column::RightAlignment)

--- a/llvm/tools/llvm-cov/CoverageViewOptions.h
+++ b/llvm/tools/llvm-cov/CoverageViewOptions.h
@@ -40,6 +40,7 @@ struct CoverageViewOptions {
   bool ShowBranchSummary;
   bool ShowMCDCSummary;
   bool ShowRegionSummary;
+  bool ShowFunctionSummary;
   bool ShowInstantiationSummary;
   bool ShowDirectoryCoverage;
   bool ExportSummaryOnly;


### PR DESCRIPTION
Adds a command line argument to llvm-cov to optionally disable the function summary in the coverage report (but maintaining existing behavior by keeping it enabled by default).