### PR TITLE
[compiler-rt] Add supported Arm arches for the baremetal profile lib

### DIFF
--- a/compiler-rt/cmake/Modules/AllSupportedArchDefs.cmake
+++ b/compiler-rt/cmake/Modules/AllSupportedArchDefs.cmake
@@ -17,6 +17,24 @@ set(WASM32 wasm32)
 set(WASM64 wasm64)
 set(VE ve)
 
+if (COMPILER_RT_PROFILE_BAREMETAL)
+  set(ARM64 aarch64 aarch64_be)
+  set(ARM32
+    arm
+    armhf
+    armv4t
+    armv5te
+    armv6m
+    armv7a
+    armv7m
+    armv7r
+    armebv7
+    armv8m.main
+    arm8.1m.main
+    armv8-r
+  )
+endif()
+
 if(APPLE)
   set(ARM64 arm64)
   set(ARM32 armv7 armv7s armv7k)

--- a/compiler-rt/cmake/Modules/AllSupportedArchDefs.cmake
+++ b/compiler-rt/cmake/Modules/AllSupportedArchDefs.cmake
@@ -30,7 +30,7 @@ if (COMPILER_RT_PROFILE_BAREMETAL)
     armv7r
     armebv7
     armv8m.main
-    arm8.1m.main
+    armv8.1m.main
     armv8-r
   )
 endif()

--- a/compiler-rt/cmake/Modules/AllSupportedArchDefs.cmake
+++ b/compiler-rt/cmake/Modules/AllSupportedArchDefs.cmake
@@ -18,20 +18,12 @@ set(WASM64 wasm64)
 set(VE ve)
 
 if (COMPILER_RT_PROFILE_BAREMETAL)
-  set(ARM64 aarch64 aarch64_be)
   set(ARM32
     arm
     armhf
     armv4t
     armv5te
     armv6m
-    armv7a
-    armv7m
-    armv7r
-    armebv7
-    armv8m.main
-    armv8.1m.main
-    armv8-r
   )
 endif()
 


### PR DESCRIPTION
Following https://github.com/llvm/llvm-project/pull/167998 add the list of supported baremetal Arm architectures to be able to build compiler_rt profile library for all variants in Arm Toolchain for Embedded, the list comes from architectures used in multilib configuration files in https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded/arm-multilib/json/variants