### PR TITLE
[libclc] Fix LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR not overriding tool …

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -121,8 +121,9 @@ if( EXISTS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} )
   foreach( tool IN ITEMS clang llvm-as llvm-link opt )
     find_program( LLVM_CUSTOM_TOOL_${tool} ${tool}
       PATHS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )
-    set( ${tool}_exe ${LLVM_CUSTOM_TOOL_${tool}} )
-    set( ${tool}_target )
+    # Use CACHE FORCE to override the cache variables set by get_host_tool_path
+    set( ${tool}_exe ${LLVM_CUSTOM_TOOL_${tool}} CACHE STRING "" FORCE )
+    set( ${tool}_target "" CACHE STRING "" FORCE )
   endforeach()
 endif()
 


### PR DESCRIPTION
…paths

When `LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR` is set, the custom tool paths were not properly overriding the default tool paths set by `get_host_tool_path()`. This caused libclc to still depend on building in-tree tools even when custom tools were specified.

The issue was that `get_host_tool_path()` sets `${tool}_exe` and `${tool}_target` as `CACHE` variables with `FORCE`, but the custom tools block was using regular `set()` commands, which don't override cache variables.

Fix by using `CACHE STRING "" FORCE` when setting the custom tool paths, ensuring they properly override the cache variables set by `get_host_tool_path()`.

This allows users to specify external LLVM tools via `LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR` without triggering unnecessary builds of in-tree tools.