### PR TITLE
Fix incorrect array initialization with string literal in dependent settings (fixes #112189)

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -1023,6 +1023,10 @@ public:
     return skipRValueSubobjectAdjustments(CommaLHSs, Adjustments);
   }
 
+  /// If the expression is a (possibly parenthesized) string literal
+  /// then make a copy of it.
+  Expr *CloneIfIAmAStringLiteral(ASTContext &Ctx);
+
   /// Checks that the two Expr's will refer to the same value as a comparison
   /// operand.  The caller must ensure that the values referenced by the Expr's
   /// are not modified between E1 and E2 or the result my be invalid.

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -167,15 +167,14 @@ Expr *Expr::CloneIfIAmAStringLiteral(ASTContext &C) {
   else if (auto *GSE = dyn_cast<GenericSelectionExpr>(this)) {
     if (!GSE->isResultDependent()) {
       ArrayRef<Expr *> GSEAEs = GSE->getAssocExprs();
-      Expr **NewGSEAEs = new (C) Expr *[GSEAEs.size()];
-      std::copy(GSEAEs.begin(), GSEAEs.end(), NewGSEAEs);
+      SmallVector<Expr *> NewGSEAEs(GSEAEs);
       NewGSEAEs[GSE->getResultIndex()] =
           GSE->getResultExpr()->CloneIfIAmAStringLiteral(C);
 
       auto GSECreate = [&](auto *ExprOrTSI) -> Expr * {
         return GenericSelectionExpr::Create(
             C, GSE->getGenericLoc(), ExprOrTSI, GSE->getAssocTypeSourceInfos(),
-            ArrayRef<Expr *>(NewGSEAEs, GSEAEs.size()), GSE->getDefaultLoc(),
+            ArrayRef<Expr *>(NewGSEAEs), GSE->getDefaultLoc(),
             GSE->getRParenLoc(), GSE->containsUnexpandedParameterPack(),
             GSE->getResultIndex());
       };

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -4618,8 +4618,10 @@ bool TreeTransform<Derived>::TransformExprs(Expr *const *Inputs,
     }
 
     ExprResult Result =
-      IsCall ? getDerived().TransformInitializer(Inputs[I], /*DirectInit*/false)
-             : getDerived().TransformExpr(Inputs[I]);
+        IsCall
+            ? getDerived().TransformInitializer(Inputs[I], /*DirectInit*/ false)
+            : getDerived().TransformExpr(Inputs[I]->CloneIfIAmAStringLiteral(
+                  getSema().getASTContext()));
     if (Result.isInvalid())
       return true;
 

--- a/clang/test/SemaCXX/GH112189.cpp
+++ b/clang/test/SemaCXX/GH112189.cpp
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -verify %s
+// expected-no-diagnostics
+
+template<unsigned int SPACE>
+char foo_choose() {
+  char buffer[SPACE] {__builtin_choose_expr(6, "foo", "boo")};
+  return buffer[0];
+}
+
+int boro_choose()
+{
+  int r = foo_choose<10>();
+  r += foo_choose<100>();
+  return r + foo_choose<4>();
+}
+
+template<unsigned int SPACE>
+char foo_gen_ext() {
+  char buffer[SPACE] {__extension__ (_Generic(0, int: (__extension__ "foo" )))};
+  return buffer[0];
+}
+
+int boro_gen_ext()
+{
+  int r = foo_gen_ext<10>();
+  r += foo_gen_ext<100>();
+  return r + foo_gen_ext<4>();
+}
+
+template<unsigned int SPACE>
+char foo_paren_predef() {
+  char buffer[SPACE] {(((__FILE__)))};
+  return buffer[0];
+}
+
+int boro_paren_predef()
+{
+  int r = foo_paren_predef<200000>();
+  r += foo_paren_predef<300000>();
+  return r + foo_paren_predef<100000>();
+}


### PR DESCRIPTION
This is another attempt to fix https://github.com/llvm/llvm-project/issues/112189 (a rework of https://github.com/llvm/llvm-project/pull/156846).

We now clone (parenthesized) string literals only when doing `TreeTransform::TransformExprs` in a specific case.

All the non-dependent cases remain unaffected thus, and, perhaps, most of dependent too (except list initializers and, probably, some others, bot not many).