### PR TITLE
[AArch64] Add scal_to_vec patterns for lowering fp_to_int nodes

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -6699,10 +6699,18 @@ multiclass FPToIntegerSatPats<SDNode to_int_sat, SDNode to_int_sat_gi, string IN
             (!cast<Instruction>(INST # DSr) f32:$Rn)>;
   def : Pat<(f32 (bitconvert (i32 (to_int_sat f64:$Rn, i32)))),
             (!cast<Instruction>(INST # SDr) f64:$Rn)>;
+
+  def : Pat<(v1i64 (scalar_to_vector (i64 (to_int_sat f16:$Rn, i64)))),
+            (!cast<Instruction>(INST # DHr) f16:$Rn)>;
+  def : Pat<(v1i64 (scalar_to_vector (i64 (to_int_sat f32:$Rn, i64)))),
+            (!cast<Instruction>(INST # DSr) f32:$Rn)>;
   }
   def : Pat<(f32 (bitconvert (i32 (to_int_sat f32:$Rn, i32)))),
             (!cast<Instruction>(INST # v1i32) f32:$Rn)>;
   def : Pat<(f64 (bitconvert (i64 (to_int_sat f64:$Rn, i64)))),
+            (!cast<Instruction>(INST # v1i64) f64:$Rn)>;
+
+  def : Pat<(v1i64 (scalar_to_vector (i64 (to_int_sat f64:$Rn, i64)))),
             (!cast<Instruction>(INST # v1i64) f64:$Rn)>;
 
   let Predicates = [HasFullFP16] in {
@@ -6767,10 +6775,16 @@ multiclass FPToIntegerPats<SDNode to_int, SDNode to_int_sat, SDNode to_int_sat_g
             (!cast<Instruction>(INST # DSr) f32:$Rn)>;
   def : Pat<(f32 (bitconvert (i32 (to_int (round f64:$Rn))))),
             (!cast<Instruction>(INST # SDr) f64:$Rn)>;
+
+  def : Pat<(v1i64 (scalar_to_vector (i64 (to_int (round f32:$Rn))))),
+            (!cast<Instruction>(INST # DSr) f32:$Rn)>;
   }
   def : Pat<(f32 (bitconvert (i32 (to_int (round f32:$Rn))))),
             (!cast<Instruction>(INST # v1i32) f32:$Rn)>;
   def : Pat<(f64 (bitconvert (i64 (to_int (round f64:$Rn))))),
+            (!cast<Instruction>(INST # v1i64) f64:$Rn)>;
+
+  def : Pat<(v1i64 (scalar_to_vector (i64 (to_int (round f64:$Rn))))),
             (!cast<Instruction>(INST # v1i64) f64:$Rn)>;
 
   // These instructions saturate like fp_to_[su]int_sat.
@@ -6815,10 +6829,18 @@ multiclass FPToIntegerPats<SDNode to_int, SDNode to_int_sat, SDNode to_int_sat_g
             (!cast<Instruction>(INST # DSr) f32:$Rn)>;
   def : Pat<(f32 (bitconvert (i32 (to_int_sat (round f64:$Rn), i32)))),
             (!cast<Instruction>(INST # SDr) f64:$Rn)>;
+
+  def : Pat<(v1i64 (scalar_to_vector (i64 (to_int_sat (round f16:$Rn), i64)))),
+            (!cast<Instruction>(INST # DHr) f16:$Rn)>;
+  def : Pat<(v1i64 (scalar_to_vector (i64 (to_int_sat (round f32:$Rn), i64)))),
+            (!cast<Instruction>(INST # DSr) f32:$Rn)>;
   }
   def : Pat<(f32 (bitconvert (i32 (to_int_sat (round f32:$Rn), i32)))),
             (!cast<Instruction>(INST # v1i32) f32:$Rn)>;
   def : Pat<(f64 (bitconvert (i64 (to_int_sat (round f64:$Rn), i64)))),
+            (!cast<Instruction>(INST # v1i64) f64:$Rn)>;
+
+  def : Pat<(v1i64 (scalar_to_vector (i64 (to_int_sat (round f64:$Rn), i64)))),
             (!cast<Instruction>(INST # v1i64) f64:$Rn)>;
 }
 

--- a/llvm/test/CodeGen/AArch64/arm64-cvt-simd-fptoi.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-cvt-simd-fptoi.ll
@@ -962,7 +962,7 @@ define <1 x i64> @fcvtas_ds_round_vec_simd(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.round.f32(float %a)
   %i = fptosi float %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -978,7 +978,7 @@ define <1 x i64> @fcvtas_dd_round_vec_simd(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.round.f64(double %a)
   %i = fptosi double %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -995,7 +995,7 @@ define <1 x i64> @fcvtau_ds_round_vec_simd(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.round.f32(float %a)
   %i = fptoui float %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1011,7 +1011,7 @@ define <1 x i64> @fcvtau_dd_round_vec_simd(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.round.f64(double %a)
   %i = fptoui double %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1028,7 +1028,7 @@ define <1 x i64> @fcvtms_ds_round_vec_simd(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.floor.f32(float %a)
   %i = fptosi float %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1044,7 +1044,7 @@ define <1 x i64> @fcvtms_dd_round_vec_simd(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.floor.f64(double %a)
   %i = fptosi double %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1061,7 +1061,7 @@ define <1 x i64> @fcvtmu_ds_round_vec_simd(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.floor.f32(float %a)
   %i = fptoui float %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1077,7 +1077,7 @@ define <1 x i64> @fcvtmu_dd_round_vec_simd(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.floor.f64(double %a)
   %i = fptoui double %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1094,7 +1094,7 @@ define <1 x i64> @fcvtps_ds_round_vec_simd(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.ceil.f32(float %a)
   %i = fptosi float %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1110,7 +1110,7 @@ define <1 x i64> @fcvtps_dd_round_vec_simd(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.ceil.f64(double %a)
   %i = fptosi double %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1127,7 +1127,7 @@ define <1 x i64> @fcvtpu_ds_round_vec_simd(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.ceil.f32(float %a)
   %i = fptoui float %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1143,7 +1143,7 @@ define <1 x i64> @fcvtpu_dd_round_vec_simd(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.ceil.f64(double %a)
   %i = fptoui double %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1160,7 +1160,7 @@ define <1 x i64> @fcvtzs_ds_round_vec_simd(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.trunc.f32(float %a)
   %i = fptosi float %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1176,7 +1176,7 @@ define <1 x i64> @fcvtzs_dd_round_vec_simd(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.trunc.f64(double %a)
   %i = fptosi double %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1193,7 +1193,7 @@ define <1 x i64> @fcvtzu_ds_round_vec_simd(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.trunc.f32(float %a)
   %i = fptoui float %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1209,7 +1209,7 @@ define <1 x i64> @fcvtzu_dd_round_vec_simd(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.trunc.f64(double %a)
   %i = fptoui double %r to i64
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1421,7 +1421,7 @@ define <1 x i64> @fcvtzs_dh_sat_vec_simd(half %a) {
 ; CHECK-NEXT:    fcvtzs d0, h0
 ; CHECK-NEXT:    ret
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %a)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1437,7 +1437,7 @@ define <1 x i64> @fcvtzs_ds_sat_vec_simd(float %a) {
 ; CHECK-NEXT:    fcvtzs d0, s0
 ; CHECK-NEXT:    ret
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %a)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1452,7 +1452,7 @@ define <1 x i64> @fcvtzs_dd_sat_vec_simd(double %a) {
 ; CHECK-NEXT:    fcvtzs d0, d0
 ; CHECK-NEXT:    ret
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %a)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1468,7 +1468,7 @@ define <1 x i64> @fcvtzu_dh_sat_vec_simd(half %a) {
 ; CHECK-NEXT:    fcvtzu d0, h0
 ; CHECK-NEXT:    ret
   %i = call i64 @llvm.fptoui.sat.i64.f16(half %a)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1484,7 +1484,7 @@ define <1 x i64> @fcvtzu_ds_sat_vec_simd(float %a) {
 ; CHECK-NEXT:    fcvtzu d0, s0
 ; CHECK-NEXT:    ret
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %a)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -1499,7 +1499,7 @@ define <1 x i64> @fcvtzu_dd_sat_vec_simd(double %a) {
 ; CHECK-NEXT:    fcvtzu d0, d0
 ; CHECK-NEXT:    ret
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %a)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2324,7 +2324,7 @@ define <1 x i64> @fcvtas_dh_simd_vec(half %a) {
 ; CHECK-NEXT:    ret
   %r = call half @llvm.round.f16(half %a) nounwind readnone
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2341,7 +2341,7 @@ define <1 x i64> @fcvtas_ds_simd_vec(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.round.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2357,7 +2357,7 @@ define <1 x i64> @fcvtas_dd_simd_vec(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.round.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2374,7 +2374,7 @@ define <1 x i64> @fcvtau_ds_simd_vec(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.round.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2390,7 +2390,7 @@ define <1 x i64> @fcvtau_dd_simd_vec(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.round.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2407,7 +2407,7 @@ define <1 x i64> @fcvtau_dh_simd_vec(half %a) {
 ; CHECK-NEXT:    ret
   %r = call half @llvm.round.f16(half %a) nounwind readnone
   %i = call i64 @llvm.fptoui.sat.i64.f16(half %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2424,7 +2424,7 @@ define <1 x i64> @fcvtms_dh_simd_vec(half %a) {
 ; CHECK-NEXT:    ret
   %r = call half @llvm.floor.f16(half %a) nounwind readnone
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2441,7 +2441,7 @@ define <1 x i64> @fcvtms_ds_simd_vec(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.floor.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2457,7 +2457,7 @@ define <1 x i64> @fcvtms_dd_simd_vec(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.floor.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2474,7 +2474,7 @@ define <1 x i64> @fcvtmu_dh_simd_vec(half %a) {
 ; CHECK-NEXT:    ret
   %r = call half @llvm.floor.f16(half %a) nounwind readnone
   %i = call i64 @llvm.fptoui.sat.i64.f16(half %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2491,7 +2491,7 @@ define <1 x i64> @fcvtmu_ds_simd_vec(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.floor.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2507,7 +2507,7 @@ define <1 x i64> @fcvtmu_dd_simd_vec(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.floor.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2524,7 +2524,7 @@ define <1 x i64> @fcvtps_dh_simd_vec(half %a) {
 ; CHECK-NEXT:    ret
   %r = call half @llvm.ceil.f16(half %a) nounwind readnone
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2541,7 +2541,7 @@ define <1 x i64> @fcvtps_ds_simd_vec(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.ceil.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2557,7 +2557,7 @@ define <1 x i64> @fcvtps_dd_simd_vec(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.ceil.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2574,7 +2574,7 @@ define <1 x i64> @fcvtpu_dh_simd_vec(half %a) {
 ; CHECK-NEXT:    ret
   %r = call half @llvm.ceil.f16(half %a) nounwind readnone
   %i = call i64 @llvm.fptoui.sat.i64.f16(half %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2591,7 +2591,7 @@ define <1 x i64> @fcvtpu_ds_simd_vec(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.ceil.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2607,7 +2607,7 @@ define <1 x i64> @fcvtpu_dd_simd_vec(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.ceil.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2624,7 +2624,7 @@ define <1 x i64> @fcvtzs_dh_simd_vec(half %a) {
 ; CHECK-NEXT:    ret
   %r = call half @llvm.trunc.f16(half %a) nounwind readnone
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2641,7 +2641,7 @@ define <1 x i64> @fcvtzs_ds_simd_vec(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.trunc.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2657,7 +2657,7 @@ define <1 x i64> @fcvtzs_dd_simd_vec(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.trunc.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2674,7 +2674,7 @@ define <1 x i64> @fcvtzu_dh_simd_vec(half %a) {
 ; CHECK-NEXT:    ret
   %r = call half @llvm.trunc.f16(half %a) nounwind readnone
   %i = call i64 @llvm.fptoui.sat.i64.f16(half %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2691,7 +2691,7 @@ define <1 x i64> @fcvtzu_ds_simd_vec(float %a) {
 ; CHECK-NEXT:    ret
   %r = call float @llvm.trunc.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }
 
@@ -2707,6 +2707,6 @@ define <1 x i64> @fcvtzu_dd_simd_vec(double %a) {
 ; CHECK-NEXT:    ret
   %r = call double @llvm.trunc.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
-  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  %vec = insertelement <1 x i64> poison, i64 %i, i64 0
   ret <1 x i64> %vec
 }

--- a/llvm/test/CodeGen/AArch64/arm64-cvt-simd-fptoi.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-cvt-simd-fptoi.ll
@@ -812,7 +812,6 @@ define double @fcvtpu_dd_round_simd(double %a) {
   ret double %bc
 }
 
-
 define double @fcvtzs_ds_round_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtzs_ds_round_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
@@ -945,6 +944,274 @@ define double @fcvtzu_dd_round_simd(double %a) {
   ret double %bc
 }
 
+
+;
+; FPTOI rounding scalar_to_vector
+;
+
+define <1 x i64> @fcvtas_ds_round_vec_simd(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtas_ds_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtas x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtas_ds_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtas d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.round.f32(float %a)
+  %i = fptosi float %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtas_dd_round_vec_simd(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtas_dd_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtas d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtas_dd_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtas d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.round.f64(double %a)
+  %i = fptosi double %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtau_ds_round_vec_simd(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtau_ds_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtau x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtau_ds_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtau d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.round.f32(float %a)
+  %i = fptoui float %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtau_dd_round_vec_simd(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtau_dd_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtau d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtau_dd_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtau d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.round.f64(double %a)
+  %i = fptoui double %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtms_ds_round_vec_simd(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtms_ds_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtms x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtms_ds_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtms d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.floor.f32(float %a)
+  %i = fptosi float %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtms_dd_round_vec_simd(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtms_dd_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtms d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtms_dd_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtms d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.floor.f64(double %a)
+  %i = fptosi double %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtmu_ds_round_vec_simd(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtmu_ds_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtmu x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtmu_ds_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtmu d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.floor.f32(float %a)
+  %i = fptoui float %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtmu_dd_round_vec_simd(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtmu_dd_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtmu d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtmu_dd_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtmu d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.floor.f64(double %a)
+  %i = fptoui double %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtps_ds_round_vec_simd(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtps_ds_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtps x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtps_ds_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtps d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.ceil.f32(float %a)
+  %i = fptosi float %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtps_dd_round_vec_simd(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtps_dd_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtps d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtps_dd_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtps d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.ceil.f64(double %a)
+  %i = fptosi double %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtpu_ds_round_vec_simd(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtpu_ds_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtpu x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtpu_ds_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtpu d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.ceil.f32(float %a)
+  %i = fptoui float %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtpu_dd_round_vec_simd(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtpu_dd_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtpu d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtpu_dd_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtpu d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.ceil.f64(double %a)
+  %i = fptoui double %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzs_ds_round_vec_simd(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzs_ds_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzs x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzs_ds_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.trunc.f32(float %a)
+  %i = fptosi float %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzs_dd_round_vec_simd(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzs_dd_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzs d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzs_dd_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.trunc.f64(double %a)
+  %i = fptosi double %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzu_ds_round_vec_simd(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzu_ds_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzu x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzu_ds_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzu d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.trunc.f32(float %a)
+  %i = fptoui float %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzu_dd_round_vec_simd(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzu_dd_round_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzu d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzu_dd_round_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzu d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.trunc.f64(double %a)
+  %i = fptoui double %r to i64
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
 
 ;
 ; FPTOI saturating
@@ -1136,6 +1403,104 @@ define double @fcvtzu_dd_sat_simd(double %a) {
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %a)
   %bc = bitcast i64 %i to double
   ret double %bc
+}
+
+;
+; FPTOI saturating scalar_to_vector
+;
+
+define <1 x i64> @fcvtzs_dh_sat_vec_simd(half %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzs_dh_sat_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzs x8, h0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzs_dh_sat_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs d0, h0
+; CHECK-NEXT:    ret
+  %i = call i64 @llvm.fptosi.sat.i64.f16(half %a)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzs_ds_sat_vec_simd(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzs_ds_sat_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzs x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzs_ds_sat_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs d0, s0
+; CHECK-NEXT:    ret
+  %i = call i64 @llvm.fptosi.sat.i64.f32(float %a)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzs_dd_sat_vec_simd(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzs_dd_sat_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzs d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzs_dd_sat_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs d0, d0
+; CHECK-NEXT:    ret
+  %i = call i64 @llvm.fptosi.sat.i64.f64(double %a)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzu_dh_sat_vec_simd(half %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzu_dh_sat_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzu x8, h0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzu_dh_sat_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzu d0, h0
+; CHECK-NEXT:    ret
+  %i = call i64 @llvm.fptoui.sat.i64.f16(half %a)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzu_ds_sat_vec_simd(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzu_ds_sat_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzu x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzu_ds_sat_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzu d0, s0
+; CHECK-NEXT:    ret
+  %i = call i64 @llvm.fptoui.sat.i64.f32(float %a)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzu_dd_sat_vec_simd(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzu_dd_sat_vec_simd:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzu d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzu_dd_sat_vec_simd:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzu d0, d0
+; CHECK-NEXT:    ret
+  %i = call i64 @llvm.fptoui.sat.i64.f64(double %a)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
 }
 
 ;
@@ -1940,4 +2305,408 @@ define double @fcvtzu_dd_simd(double %a) {
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
   %bc = bitcast i64 %i to double
   ret double %bc
+}
+
+;
+; FPTOI saturating with rounding scalar_to_vector
+;
+
+define <1 x i64> @fcvtas_dh_simd_vec(half %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtas_dh_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtas x8, h0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtas_dh_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtas d0, h0
+; CHECK-NEXT:    ret
+  %r = call half @llvm.round.f16(half %a) nounwind readnone
+  %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtas_ds_simd_vec(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtas_ds_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtas x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtas_ds_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtas d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.round.f32(float %a)
+  %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtas_dd_simd_vec(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtas_dd_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtas d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtas_dd_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtas d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.round.f64(double %a)
+  %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtau_ds_simd_vec(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtau_ds_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtau x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtau_ds_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtau d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.round.f32(float %a)
+  %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtau_dd_simd_vec(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtau_dd_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtau d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtau_dd_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtau d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.round.f64(double %a)
+  %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtau_dh_simd_vec(half %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtau_dh_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtau x8, h0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtau_dh_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtau d0, h0
+; CHECK-NEXT:    ret
+  %r = call half @llvm.round.f16(half %a) nounwind readnone
+  %i = call i64 @llvm.fptoui.sat.i64.f16(half %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtms_dh_simd_vec(half %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtms_dh_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtms x8, h0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtms_dh_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtms d0, h0
+; CHECK-NEXT:    ret
+  %r = call half @llvm.floor.f16(half %a) nounwind readnone
+  %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtms_ds_simd_vec(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtms_ds_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtms x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtms_ds_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtms d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.floor.f32(float %a)
+  %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtms_dd_simd_vec(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtms_dd_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtms d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtms_dd_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtms d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.floor.f64(double %a)
+  %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtmu_dh_simd_vec(half %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtmu_dh_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtmu x8, h0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtmu_dh_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtmu d0, h0
+; CHECK-NEXT:    ret
+  %r = call half @llvm.floor.f16(half %a) nounwind readnone
+  %i = call i64 @llvm.fptoui.sat.i64.f16(half %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtmu_ds_simd_vec(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtmu_ds_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtmu x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtmu_ds_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtmu d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.floor.f32(float %a)
+  %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtmu_dd_simd_vec(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtmu_dd_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtmu d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtmu_dd_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtmu d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.floor.f64(double %a)
+  %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtps_dh_simd_vec(half %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtps_dh_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtps x8, h0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtps_dh_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtps d0, h0
+; CHECK-NEXT:    ret
+  %r = call half @llvm.ceil.f16(half %a) nounwind readnone
+  %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtps_ds_simd_vec(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtps_ds_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtps x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtps_ds_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtps d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.ceil.f32(float %a)
+  %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtps_dd_simd_vec(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtps_dd_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtps d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtps_dd_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtps d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.ceil.f64(double %a)
+  %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtpu_dh_simd_vec(half %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtpu_dh_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtpu x8, h0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtpu_dh_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtpu d0, h0
+; CHECK-NEXT:    ret
+  %r = call half @llvm.ceil.f16(half %a) nounwind readnone
+  %i = call i64 @llvm.fptoui.sat.i64.f16(half %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtpu_ds_simd_vec(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtpu_ds_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtpu x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtpu_ds_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtpu d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.ceil.f32(float %a)
+  %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtpu_dd_simd_vec(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtpu_dd_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtpu d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtpu_dd_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtpu d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.ceil.f64(double %a)
+  %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzs_dh_simd_vec(half %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzs_dh_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzs x8, h0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzs_dh_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs d0, h0
+; CHECK-NEXT:    ret
+  %r = call half @llvm.trunc.f16(half %a) nounwind readnone
+  %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzs_ds_simd_vec(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzs_ds_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzs x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzs_ds_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.trunc.f32(float %a)
+  %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzs_dd_simd_vec(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzs_dd_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzs d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzs_dd_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzs d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.trunc.f64(double %a)
+  %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzu_dh_simd_vec(half %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzu_dh_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzu x8, h0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzu_dh_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzu d0, h0
+; CHECK-NEXT:    ret
+  %r = call half @llvm.trunc.f16(half %a) nounwind readnone
+  %i = call i64 @llvm.fptoui.sat.i64.f16(half %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzu_ds_simd_vec(float %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzu_ds_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzu x8, s0
+; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzu_ds_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzu d0, s0
+; CHECK-NEXT:    ret
+  %r = call float @llvm.trunc.f32(float %a)
+  %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
+}
+
+define <1 x i64> @fcvtzu_dd_simd_vec(double %a) {
+; CHECK-NOFPRCVT-LABEL: fcvtzu_dd_simd_vec:
+; CHECK-NOFPRCVT:       // %bb.0:
+; CHECK-NOFPRCVT-NEXT:    fcvtzu d0, d0
+; CHECK-NOFPRCVT-NEXT:    ret
+;
+; CHECK-LABEL: fcvtzu_dd_simd_vec:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fcvtzu d0, d0
+; CHECK-NEXT:    ret
+  %r = call double @llvm.trunc.f64(double %a)
+  %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
+  %vec = insertelement <1 x i64> undef, i64 %i, i64 0
+  ret <1 x i64> %vec
 }


### PR DESCRIPTION
This patch adds patterns for lowering fp_to_int followed by scalar_to_vector node into SIMD FCVT instructions. This is done to prevent extra moves from being generated when GPR version would be used.