### PR TITLE
Add missing include in ProgramStack.cpp

### DIFF
--- a/llvm/lib/Support/ProgramStack.cpp
+++ b/llvm/lib/Support/ProgramStack.cpp
@@ -20,6 +20,7 @@
 
 #ifndef LLVM_HAS_SPLIT_STACKS
 # include "llvm/Support/thread.h"
+#else
 # include <stdlib.h> // for malloc
 #endif
 

--- a/llvm/lib/Support/ProgramStack.cpp
+++ b/llvm/lib/Support/ProgramStack.cpp
@@ -20,6 +20,7 @@
 
 #ifndef LLVM_HAS_SPLIT_STACKS
 # include "llvm/Support/thread.h"
+# include <stdlib.h> // for malloc
 #endif
 
 using namespace llvm;


### PR DESCRIPTION
Darwin fails to build with `_LIBCPP_REMOVE_TRANSITIVE_INCLUDES=1`

```
[2025-12-19 12:30:48] /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/contrib/llvm-project/llvm/lib/Support/ProgramStack.cpp:114:17: error: use of undeclared identifier 'malloc'
[2025-12-19 12:30:48]   114 |   void *Stack = malloc(StackSize);
[2025-12-19 12:30:48]       |                 ^~~~~~
[2025-12-19 12:30:48] /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/contrib/llvm-project/llvm/lib/Support/ProgramStack.cpp:119:3: error: use of undeclared identifier 'free'
[2025-12-19 12:30:48]   119 |   free(Stack);
[2025-12-19 12:30:48]       |   ^~~~
[2025-12-19 12:30:48] 2 errors generated.
```