### PR TITLE
[mlir] Fix VectorType clone with shape of a different rank

### DIFF
--- a/mlir/lib/IR/BuiltinTypes.cpp
+++ b/mlir/lib/IR/BuiltinTypes.cpp
@@ -285,8 +285,10 @@ VectorType VectorType::scaleElementBitwidth(unsigned scale) {
 
 VectorType VectorType::cloneWith(std::optional<ArrayRef<int64_t>> shape,
                                  Type elementType) const {
-  return VectorType::get(shape.value_or(getShape()), elementType,
-                         getScalableDims());
+  ArrayRef<int64_t> shapeVal = shape.value_or(getShape());
+  SmallVector<bool> scalableDims(getScalableDims());
+  scalableDims.resize(shapeVal.size(), false);
+  return VectorType::get(shapeVal, elementType, scalableDims);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
If the new shape has a different number of dims, VectorType::verify() fail with error: 'number of dims must match'.