### PR TITLE
[Sema][WebAssembly] use `getLangASFromTargetAS` for wasm tables (NFC)

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -8189,8 +8189,8 @@ NamedDecl *Sema::ActOnVariableDeclarator(
   if (const auto *ATy = dyn_cast<ArrayType>(NewVD->getType())) {
     if (ATy && ATy->getElementType().isWebAssemblyReferenceType() &&
         !NewVD->hasLocalStorage()) {
-      QualType Type = Context.getAddrSpaceQualType(
-          NewVD->getType(), Context.getLangASForBuiltinAddressSpace(1));
+      QualType Type = Context.getAddrSpaceQualType(NewVD->getType(),
+                                                   getLangASFromTargetAS(1));
       NewVD->setType(Type);
     }
   }


### PR DESCRIPTION
Replace `Context.getLangASForBuiltinAddressSpace(1)` with `getLangASFromTargetAS(1)` in `SemaDecl.cpp` to determine the language address space for WebAssembly tables.

`getLangASForBuiltinAddressSpace` is meant to map from the numeric values used in Builtins<Target>.def to language address spaces in the case where different language modes have similar address spaces (usually all mapping to the same backend i.e. LLVM aspace). For example for the AMDGPU target the numeric value 0 in BuiltinsAMDGPU.def is mapped to LangAS::Default for CUDA/HIP and LangAS::opencl_generic for OpenCL.

This usage in SemaDecl.cpp is not this case.
The webassembly target does not override `getOpenCLBuiltinAddressSpace` or `getCUDABuiltinAddressSpace`, so we end up calling `getLangASFromTargetAS` indirectly before this patch anyway.