### PR TITLE
[OCaml] Fix warnings in llvm_debuginfo

### DIFF
--- a/llvm/bindings/ocaml/debuginfo/debuginfo_ocaml.c
+++ b/llvm/bindings/ocaml/debuginfo/debuginfo_ocaml.c
@@ -15,6 +15,7 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
+#include <assert.h>
 #include <string.h>
 
 #include "caml/memory.h"
@@ -137,6 +138,8 @@ static LLVMDIFlags map_DIFlag(LLVMDIFlag_i DIF) {
   case i_DIFlagPtrToMemberRep:
     return LLVMDIFlagPtrToMemberRep;
   }
+  assert(0 && "Invalid LLVMDIFlag");
+  return 0;
 }
 
 /* unit -> int */
@@ -380,7 +383,6 @@ value llvm_dibuild_get_or_create_array(value Builder, value Data) {
 
 value llvm_dibuild_create_subroutine_type(value Builder, value File,
                                           value ParameterTypes, value Flags) {
-  mlsize_t Count = Wosize_val(ParameterTypes);
   LLVMMetadataRef *Temp = from_val_array(ParameterTypes);
   LLVMMetadataRef Metadata = LLVMDIBuilderCreateSubroutineType(
       DIBuilder_val(Builder), Metadata_val(File), Temp,


### PR DESCRIPTION
Fix an unused variable warning and a warning about missing return. As this is C code we don't have llvm_unreachable() here, so I went with an assert + dummy return.