### PR TITLE
[LoopInterchange] Move `enable-loopinterchange` option to opt driver

### DIFF
--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -206,10 +206,6 @@ static cl::opt<bool> ExtraVectorizerPasses(
 static cl::opt<bool> RunNewGVN("enable-newgvn", cl::init(false), cl::Hidden,
                                cl::desc("Run the NewGVN pass"));
 
-static cl::opt<bool>
-    EnableLoopInterchange("enable-loopinterchange", cl::init(false), cl::Hidden,
-                          cl::desc("Enable the LoopInterchange Pass"));
-
 static cl::opt<bool> EnableUnrollAndJam("enable-unroll-and-jam",
                                         cl::init(false), cl::Hidden,
                                         cl::desc("Enable Unroll And Jam Pass"));
@@ -324,7 +320,7 @@ PipelineTuningOptions::PipelineTuningOptions() {
   LoopVectorization = true;
   SLPVectorization = false;
   LoopUnrolling = true;
-  LoopInterchange = EnableLoopInterchange;
+  LoopInterchange = false;
   LoopFusion = false;
   ForgetAllSCEVInLoopUnroll = ForgetSCEVInLoopUnroll;
   LicmMssaOptCap = SetLicmMssaOptCap;

--- a/llvm/tools/opt/NewPMDriver.cpp
+++ b/llvm/tools/opt/NewPMDriver.cpp
@@ -238,6 +238,10 @@ static cl::opt<bool> DisableLoopUnrolling(
     "disable-loop-unrolling",
     cl::desc("Disable loop unrolling in all relevant passes"), cl::init(false));
 
+static cl::opt<bool>
+    EnableLoopInterchange("enable-loopinterchange", cl::init(false), cl::Hidden,
+                          cl::desc("Enable the LoopInterchange Pass"));
+
 template <typename PassManagerT>
 bool tryParsePipelineText(PassBuilder &PB,
                           const cl::opt<std::string> &PipelineOpt) {
@@ -459,6 +463,7 @@ bool llvm::runPassPipeline(
   PTO.LoopUnrolling = !DisableLoopUnrolling;
   PTO.UnifiedLTO = UnifiedLTO;
   PTO.LoopFusion = EnableLoopFusion;
+  PTO.LoopInterchange = EnableLoopInterchange;
   PassBuilder PB(TM, PTO, P, &PIC);
   registerEPCallbacks(PB);
 


### PR DESCRIPTION
When using the clang (or flang) driver, there are two options to control loop-interchange: `-f[no]-loop-interchange` and `-mllvm -enable-loopinterchange`. The latter is used in the constructor of `PipelineTuningOptions`, but it's always overwritten later depending on the former option (the default value is used if `-f[no]-loop-interchange` is not specified). That is, although the driver accepts `-mllvm -enable-loopinterchange`, it has no effect. As this behavior is confusing, `-enable-loopinterchange` should only be exposed via the opt driver.