### PR TITLE
[lldb][windows] add attach by name with --waitfor

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -250,7 +250,6 @@ Status ProcessWindows::DoAttachToProcessWithName(
             __FUNCTION__, process_name);
 
   lldb::pid_t pid = LLDB_INVALID_PROCESS_ID;
-
   while (pid == LLDB_INVALID_PROCESS_ID) {
     ProcessInstanceInfoList process_infos;
     uint32_t num_matches = Host::FindProcesses(match_info, process_infos);

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.h
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.h
@@ -49,6 +49,9 @@ public:
   Status DoAttachToProcessWithID(
       lldb::pid_t pid,
       const lldb_private::ProcessAttachInfo &attach_info) override;
+  Status
+  DoAttachToProcessWithName(const char *process_name,
+                            const ProcessAttachInfo &attach_info) override;
   Status DoResume(lldb::RunDirection direction) override;
   Status DoDestroy() override;
   Status DoHalt(bool &caused_stop) override;
@@ -100,6 +103,22 @@ public:
 
   void
   SetPseudoConsoleHandle(const std::shared_ptr<PseudoConsole> &pty) override;
+
+  /// Finds the pid matching the process_name.
+  ///
+  /// If there are multiple processes with the same name, this method will
+  /// return the first one.
+  ///
+  /// \param[in] process_name
+  ///     The name of the process to find.
+  ///
+  /// \param[out] error
+  ///     An error that indicates the success or failure of the search.
+  ///
+  /// \return
+  ///     Returns the pid of the process if a match was found. Returns \code
+  ///     LLDB_INVALID_PROCESS otherwise.
+  lldb::pid_t FindProcessByName(const char *process_name, Status &error);
 
 protected:
   ProcessWindows(lldb::TargetSP target_sp, lldb::ListenerSP listener_sp);

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.h
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.h
@@ -104,22 +104,6 @@ public:
   void
   SetPseudoConsoleHandle(const std::shared_ptr<PseudoConsole> &pty) override;
 
-  /// Finds the pid matching the process_name.
-  ///
-  /// If there are multiple processes with the same name, this method will
-  /// return the first one.
-  ///
-  /// \param[in] process_name
-  ///     The name of the process to find.
-  ///
-  /// \param[out] error
-  ///     An error that indicates the success or failure of the search.
-  ///
-  /// \return
-  ///     Returns the pid of the process if a match was found. Returns \code
-  ///     LLDB_INVALID_PROCESS otherwise.
-  lldb::pid_t FindProcessByName(const char *process_name, Status &error);
-
 protected:
   ProcessWindows(lldb::TargetSP target_sp, lldb::ListenerSP listener_sp);
 

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -59,7 +59,6 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         self.attach(program=program)
         self.continue_and_verify_pid()
 
-    @expectedFailureWindows
     def test_by_name_waitFor(self):
         """
         Tests waiting for, and attaching to a process by process name that


### PR DESCRIPTION
This patch adds the _attach by name --waitfor_ feature to lldb/lldb-dap on Windows.

`GDBRemoteProcess` takes advantage of the async thread to do this asynchronously, allowing cancelling the attach with `CTRL+C`. This patch adds an async thread to `ProcessWindows` to allow it to do the wait part asynchronously as well.

rdar://166879024