### PR TITLE
[NVPTX] fix illegal name for .extern .shared global variables

### DIFF
--- a/llvm/test/CodeGen/NVPTX/extern-shared-valid-name.ll
+++ b/llvm/test/CodeGen/NVPTX/extern-shared-valid-name.ll
@@ -1,0 +1,6 @@
+; RUN: llc -mtriple=nvptx64-nvidia-cuda %s -o - | FileCheck %s
+
+; Make sure the .extern .shared have the name legalization for nvptx applied
+
+; CHECK: .extern .shared .align 4 .b8 anon_$_715df5978ff3b97886f2449b20e80729_$_0[]
+@anon.715df5978ff3b97886f2449b20e80729.0 = external local_unnamed_addr addrspace(3) global [0 x i8], align 4


### PR DESCRIPTION
In ptx we can create a GV in AS(3) that will be compiled to a `.extern .shared` in ptx. Since the `.extern .shared` is not an "extern" in the traditional sense of the word it will not be linked based on name but rather refer to the shared memory allocated at kernel launch.

Since we don't care about the name it's tempting to make the GV unnamed.  Then the problem that the `nameUnamedGlobals` will use a name for the global that is invalid ptx occurs. For non-extern globals, this is later fixed by running the `NVPTXAssignValidGlobalNames` pass. However, It makes sure to not touch externs as changing the name of "traditional externs"  will cause linking issues down the road. 

This MR treats `.extern .shared` in the same manner as non-extern globals during `NVPTXAssignValidGlobalNames` to fix the invalid names given by `nameUnamedGlobals`.