### PR TITLE
[mlir] Fix assertion crash (#159673)

### DIFF
--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -132,8 +132,6 @@ SymbolTable::SymbolTable(Operation *symbolTableOp)
 
     auto inserted = symbolTable.insert({name, &op});
     (void)inserted;
-    assert(inserted.second &&
-           "expected region to contain uniquely named symbol operations");
   }
 }
 


### PR DESCRIPTION
MLIR crashes with assertion 'inserted.second && "expected region to contain uniquely named symbol operations"' failed when constructing a symbol table from another symbol table that has duplicate symbols.

The API allowed a SymbolTable instance to be in this state in the first place, I think copying it should be allowed in that state as well. Simply removing the assert allows construction of the instance, and allows a subsequent run of the verifier to report the actual error.