### PR TITLE
[MLIR] fix name of APFloat helper

### DIFF
--- a/mlir/lib/Conversion/ArithAndMathToAPFloat/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithAndMathToAPFloat/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_library(ArithAndMathToAPFloatUtils
+add_mlir_library(MLIRArithAndMathToAPFloatUtils
   Utils.cpp
   PARTIAL_SOURCES_INTENDED
 

--- a/mlir/lib/Conversion/ArithAndMathToAPFloat/CMakeLists.txt
+++ b/mlir/lib/Conversion/ArithAndMathToAPFloat/CMakeLists.txt
@@ -20,7 +20,7 @@ add_mlir_conversion_library(MLIRArithToAPFloat
   Core
 
   LINK_LIBS PUBLIC
-  ArithAndMathToAPFloatUtils
+  MLIRArithAndMathToAPFloatUtils
   MLIRArithDialect
   MLIRArithTransforms
   MLIRFuncDialect
@@ -43,7 +43,7 @@ add_mlir_conversion_library(MLIRMathToAPFloat
 
   LINK_LIBS PUBLIC
   MLIRTransformUtils
-  ArithAndMathToAPFloatUtils
+  MLIRArithAndMathToAPFloatUtils
   MLIRMathDialect
   MLIRFuncDialect
   MLIRFuncUtils


### PR DESCRIPTION
Some downstreams depend on our libraries having the uniform prefix.