### PR TITLE
[AArch64][SVE] Add MOVPRFX hints for unary undef pseudos.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -1187,6 +1187,9 @@ bool AArch64RegisterInfo::getRegAllocationHints(
         case AArch64::DestructiveBinaryImm:
           AddHintIfSuitable(R, Def.getOperand(2));
           break;
+        case AArch64::DestructiveUnaryPassthru:
+          AddHintIfSuitable(R, Def.getOperand(3));
+          break;
         }
       }
     }

--- a/llvm/lib/Target/AArch64/SVEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SVEInstrFormats.td
@@ -3165,7 +3165,7 @@ multiclass sve_fp_2op_p_zd<bits<7> opc, string asm,
   def : SVE_3_Op_Pat<packedvt1, int_op, packedvt1, vt2, packedvt3, !cast<Instruction>(NAME)>;
   def : SVE_1_Op_Passthru_Pat<vt1, ir_op, vt2, vt3, !cast<Instruction>(NAME)>;
 
-  def _UNDEF : PredOneOpPassthruPseudo<NAME, !cast<ZPRRegOp>(i_zprtype)>;
+  def _UNDEF : PredOneOpPassthruPseudo<NAME, !cast<ZPRRegOp>(i_zprtype), FalseLanesUndef>;
 
   defm : SVE_1_Op_PassthruUndef_Pat<vt1, ir_op, vt2, vt3, !cast<Instruction>(NAME # _UNDEF)>;
 }
@@ -3185,7 +3185,7 @@ multiclass sve_fp_2op_p_zdr<bits<7> opc, string asm,
   def : SVE_3_Op_Pat<packedvt1, int_op, packedvt1, vt2, vt3, !cast<Instruction>(NAME)>;
   def : SVE_1_Op_Passthru_Round_Pat<vt1, ir_op, vt2, vt3, !cast<Instruction>(NAME)>;
 
-  def _UNDEF : PredOneOpPassthruPseudo<NAME, !cast<ZPRRegOp>(i_zprtype)>;
+  def _UNDEF : PredOneOpPassthruPseudo<NAME, !cast<ZPRRegOp>(i_zprtype), FalseLanesUndef>;
 
   defm : SVE_1_Op_PassthruUndef_Round_Pat<vt1, ir_op, vt2, vt3, !cast<Instruction>(NAME # _UNDEF)>;
 }
@@ -3205,9 +3205,9 @@ multiclass sve_fp_2op_p_zd_HSD<bits<5> opc, string asm, SDPatternOperator op> {
   def : SVE_1_Op_Passthru_Pat<nxv2f32, op, nxv2i1, nxv2f32, !cast<Instruction>(NAME # _S)>;
   def : SVE_1_Op_Passthru_Pat<nxv2f64, op, nxv2i1, nxv2f64, !cast<Instruction>(NAME # _D)>;
 
-  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16>;
-  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32>;
-  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64>;
+  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16, FalseLanesUndef>;
+  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32, FalseLanesUndef>;
+  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64, FalseLanesUndef>;
 
   defm : SVE_1_Op_PassthruUndef_Pat<nxv8f16, op, nxv8i1, nxv8f16, !cast<Instruction>(NAME # _H_UNDEF)>;
   defm : SVE_1_Op_PassthruUndef_Pat<nxv4f16, op, nxv4i1, nxv4f16, !cast<Instruction>(NAME # _H_UNDEF)>;
@@ -4235,7 +4235,7 @@ multiclass sve2_int_un_pred_arit_s<bits<2> opc, string asm,
 
   def : SVE_3_Op_Pat<nxv4i32, op, nxv4i32, nxv4i1, nxv4i32, !cast<Instruction>(NAME # _S)>;
 
-  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32>;
+  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32, FalseLanesUndef>;
 
   defm : SVE_3_Op_Undef_Pat<nxv4i32, op, nxv4i32, nxv4i1,  nxv4i32, !cast<Pseudo>(NAME # _S_UNDEF)>;
 }
@@ -4255,10 +4255,10 @@ multiclass sve2_int_un_pred_arit<bits<2> opc, string asm, SDPatternOperator op> 
   def : SVE_3_Op_Pat<nxv4i32, op, nxv4i32, nxv4i1,  nxv4i32, !cast<Instruction>(NAME # _S)>;
   def : SVE_3_Op_Pat<nxv2i64, op, nxv2i64, nxv2i1,  nxv2i64, !cast<Instruction>(NAME # _D)>;
 
-  def _B_UNDEF : PredOneOpPassthruPseudo<NAME # _B, ZPR8>;
-  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16>;
-  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32>;
-  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64>;
+  def _B_UNDEF : PredOneOpPassthruPseudo<NAME # _B, ZPR8, FalseLanesUndef>;
+  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16, FalseLanesUndef>;
+  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32, FalseLanesUndef>;
+  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64, FalseLanesUndef>;
 
   defm : SVE_3_Op_Undef_Pat<nxv16i8, op, nxv16i8, nxv16i1, nxv16i8, !cast<Pseudo>(NAME # _B_UNDEF)>;
   defm : SVE_3_Op_Undef_Pat<nxv8i16, op, nxv8i16, nxv8i1,  nxv8i16, !cast<Pseudo>(NAME # _H_UNDEF)>;
@@ -4957,10 +4957,10 @@ multiclass sve_int_un_pred_arit<bits<3> opc, string asm,
   def : SVE_1_Op_Passthru_Pat<nxv4i32, op, nxv4i1,  nxv4i32, !cast<Instruction>(NAME # _S)>;
   def : SVE_1_Op_Passthru_Pat<nxv2i64, op, nxv2i1,  nxv2i64, !cast<Instruction>(NAME # _D)>;
 
-  def _B_UNDEF : PredOneOpPassthruPseudo<NAME # _B, ZPR8>;
-  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16>;
-  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32>;
-  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64>;
+  def _B_UNDEF : PredOneOpPassthruPseudo<NAME # _B, ZPR8, FalseLanesUndef>;
+  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16, FalseLanesUndef>;
+  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32, FalseLanesUndef>;
+  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64, FalseLanesUndef>;
 
   defm : SVE_1_Op_PassthruUndef_Pat<nxv16i8, op, nxv16i1, nxv16i8, !cast<Pseudo>(NAME # _B_UNDEF)>;
   defm : SVE_1_Op_PassthruUndef_Pat<nxv8i16, op, nxv8i1,  nxv8i16, !cast<Pseudo>(NAME # _H_UNDEF)>;
@@ -4993,9 +4993,9 @@ multiclass sve_int_un_pred_arit_h<bits<3> opc, string asm,
   def : SVE_InReg_Extend<nxv4i32, op, nxv4i1, nxv4i8, !cast<Instruction>(NAME # _S)>;
   def : SVE_InReg_Extend<nxv2i64, op, nxv2i1, nxv2i8, !cast<Instruction>(NAME # _D)>;
 
-  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16>;
-  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32>;
-  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64>;
+  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16, FalseLanesUndef>;
+  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32, FalseLanesUndef>;
+  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64, FalseLanesUndef>;
 
   defm : SVE_InReg_Extend_PassthruUndef<nxv8i16, op, nxv8i1, nxv8i8, !cast<Pseudo>(NAME # _H_UNDEF)>;
   defm : SVE_InReg_Extend_PassthruUndef<nxv4i32, op, nxv4i1, nxv4i8, !cast<Pseudo>(NAME # _S_UNDEF)>;
@@ -5022,8 +5022,8 @@ multiclass sve_int_un_pred_arit_w<bits<3> opc, string asm,
   def : SVE_InReg_Extend<nxv4i32, op, nxv4i1, nxv4i16, !cast<Instruction>(NAME # _S)>;
   def : SVE_InReg_Extend<nxv2i64, op, nxv2i1, nxv2i16, !cast<Instruction>(NAME # _D)>;
 
-  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32>;
-  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64>;
+  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32, FalseLanesUndef>;
+  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64, FalseLanesUndef>;
 
   defm : SVE_InReg_Extend_PassthruUndef<nxv4i32, op, nxv4i1, nxv4i16, !cast<Pseudo>(NAME # _S_UNDEF)>;
   defm : SVE_InReg_Extend_PassthruUndef<nxv2i64, op, nxv2i1, nxv2i16, !cast<Pseudo>(NAME # _D_UNDEF)>;
@@ -5044,7 +5044,7 @@ multiclass sve_int_un_pred_arit_d<bits<3> opc, string asm,
 
   def : SVE_InReg_Extend<nxv2i64, op, nxv2i1, nxv2i32, !cast<Instruction>(NAME # _D)>;
 
-  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64>;
+  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64, FalseLanesUndef>;
 
   defm : SVE_InReg_Extend_PassthruUndef<nxv2i64, op, nxv2i1, nxv2i32, !cast<Pseudo>(NAME # _D_UNDEF)>;
 }
@@ -5071,10 +5071,10 @@ multiclass sve_int_un_pred_arit_bitwise<bits<3> opc, string asm,
   def : SVE_1_Op_Passthru_Pat<nxv4i32, op, nxv4i1,  nxv4i32, !cast<Instruction>(NAME # _S)>;
   def : SVE_1_Op_Passthru_Pat<nxv2i64, op, nxv2i1,  nxv2i64, !cast<Instruction>(NAME # _D)>;
 
-  def _B_UNDEF : PredOneOpPassthruPseudo<NAME # _B, ZPR8>;
-  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16>;
-  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32>;
-  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64>;
+  def _B_UNDEF : PredOneOpPassthruPseudo<NAME # _B, ZPR8, FalseLanesUndef>;
+  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16, FalseLanesUndef>;
+  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32, FalseLanesUndef>;
+  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64, FalseLanesUndef>;
 
   defm : SVE_1_Op_PassthruUndef_Pat<nxv16i8, op, nxv16i1, nxv16i8, !cast<Pseudo>(NAME # _B_UNDEF)>;
   defm : SVE_1_Op_PassthruUndef_Pat<nxv8i16, op, nxv8i1,  nxv8i16, !cast<Pseudo>(NAME # _H_UNDEF)>;
@@ -5113,9 +5113,9 @@ multiclass sve_int_un_pred_arit_bitwise_fp<bits<3> opc, string asm,
   def : SVE_1_Op_Passthru_Pat<nxv4bf16, op, nxv4i1, nxv4bf16, !cast<Instruction>(NAME # _H)>;
   def : SVE_1_Op_Passthru_Pat<nxv2bf16, op, nxv2i1, nxv2bf16, !cast<Instruction>(NAME # _H)>;
 
-  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16>;
-  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32>;
-  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64>;
+  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16, FalseLanesUndef>;
+  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32, FalseLanesUndef>;
+  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64, FalseLanesUndef>;
 
   defm : SVE_1_Op_PassthruUndef_Pat<nxv8f16, op, nxv8i1, nxv8f16, !cast<Pseudo>(NAME # _H_UNDEF)>;
   defm : SVE_1_Op_PassthruUndef_Pat<nxv4f16, op, nxv4i1, nxv4f16, !cast<Pseudo>(NAME # _H_UNDEF)>;
@@ -5142,9 +5142,9 @@ multiclass sve_int_un_pred_arit_bitwise_fp_z<bits<3> opc, string asm, SDPatternO
 }
 
 multiclass sve_fp_un_pred_arit_hsd<SDPatternOperator op> {
-  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16>;
-  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32>;
-  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64>;
+  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16, FalseLanesUndef>;
+  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32, FalseLanesUndef>;
+  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64, FalseLanesUndef>;
 
   defm : SVE_1_Op_PassthruUndef_Pat<nxv8f16, op, nxv8i1, nxv8f16, !cast<Pseudo>(NAME # _H_UNDEF)>;
   defm : SVE_1_Op_PassthruUndef_Pat<nxv4f16, op, nxv4i1, nxv4f16, !cast<Pseudo>(NAME # _H_UNDEF)>;
@@ -5155,10 +5155,10 @@ multiclass sve_fp_un_pred_arit_hsd<SDPatternOperator op> {
 }
 
 multiclass sve_int_un_pred_arit_bhsd<SDPatternOperator op> {
-  def _B_UNDEF : PredOneOpPassthruPseudo<NAME # _B, ZPR8>;
-  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16>;
-  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32>;
-  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64>;
+  def _B_UNDEF : PredOneOpPassthruPseudo<NAME # _B, ZPR8, FalseLanesUndef>;
+  def _H_UNDEF : PredOneOpPassthruPseudo<NAME # _H, ZPR16, FalseLanesUndef>;
+  def _S_UNDEF : PredOneOpPassthruPseudo<NAME # _S, ZPR32, FalseLanesUndef>;
+  def _D_UNDEF : PredOneOpPassthruPseudo<NAME # _D, ZPR64, FalseLanesUndef>;
 
   defm : SVE_1_Op_PassthruUndef_Pat<nxv16i8, op, nxv16i1, nxv16i8, !cast<Pseudo>(NAME # _B_UNDEF)>;
   defm : SVE_1_Op_PassthruUndef_Pat<nxv8i16, op, nxv8i1,  nxv8i16, !cast<Pseudo>(NAME # _H_UNDEF)>;

--- a/llvm/test/CodeGen/AArch64/sched-movprfx.ll
+++ b/llvm/test/CodeGen/AArch64/sched-movprfx.ll
@@ -14,13 +14,14 @@ define <vscale x 2 x i64> @and_i64_zero(<vscale x 2 x i1> %pg, <vscale x 2 x i64
 ; CHECK-NEXT:    ptrue p1.d
 ; CHECK-NEXT:    movprfx z0, z2
 ; CHECK-NEXT:    abs z0.d, p1/m, z2.d
+; CHECK-NEXT:    sel z1.d, p0, z1.d, z2.d
 ; CHECK-NEXT:    add z0.d, z0.d, z1.d
 ; CHECK-NEXT:    ret
   %data0 = tail call <vscale x 2 x i64> @llvm.abs.nxv2i64(<vscale x 2 x i64> %c, i1 0)
   %data1 = call <vscale x 2 x i64> @llvm.masked.load.nxv2i64(ptr %base,
                                                             i32 1,
                                                             <vscale x 2 x i1> %pg,
-                                                            <vscale x 2 x i64> undef)
+                                                            <vscale x 2 x i64> %c)
   %out = add <vscale x 2 x i64> %data0, %data1
   ret <vscale x 2 x i64> %out
 }

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-int-arith.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-int-arith.ll
@@ -1385,10 +1385,10 @@ define void @abs_v128i16(ptr %a) vscale_range(2,0) #0 {
 ; CHECK-NEXT:    mov x11, #80 // =0x50
 ; CHECK-NEXT:    mov x12, #32 // =0x20
 ; CHECK-NEXT:    ld1h { z0.h }, p0/z, [x0, x8, lsl #1]
-; CHECK-NEXT:    ld1h { z1.h }, p0/z, [x0, x9, lsl #1]
-; CHECK-NEXT:    ld1h { z2.h }, p0/z, [x0, x10, lsl #1]
 ; CHECK-NEXT:    mov x13, #48 // =0x30
 ; CHECK-NEXT:    mov x14, #16 // =0x10
+; CHECK-NEXT:    ld1h { z1.h }, p0/z, [x0, x9, lsl #1]
+; CHECK-NEXT:    ld1h { z2.h }, p0/z, [x0, x10, lsl #1]
 ; CHECK-NEXT:    ld1h { z3.h }, p0/z, [x0, x11, lsl #1]
 ; CHECK-NEXT:    ld1h { z4.h }, p0/z, [x0, x12, lsl #1]
 ; CHECK-NEXT:    ld1h { z5.h }, p0/z, [x0, x13, lsl #1]
@@ -1398,19 +1398,17 @@ define void @abs_v128i16(ptr %a) vscale_range(2,0) #0 {
 ; CHECK-NEXT:    abs z2.h, p0/m, z2.h
 ; CHECK-NEXT:    abs z3.h, p0/m, z3.h
 ; CHECK-NEXT:    abs z4.h, p0/m, z4.h
+; CHECK-NEXT:    abs z5.h, p0/m, z5.h
+; CHECK-NEXT:    abs z6.h, p0/m, z6.h
 ; CHECK-NEXT:    st1h { z0.h }, p0, [x0, x8, lsl #1]
 ; CHECK-NEXT:    ld1h { z0.h }, p0/z, [x0]
 ; CHECK-NEXT:    st1h { z1.h }, p0, [x0, x9, lsl #1]
-; CHECK-NEXT:    movprfx z1, z5
-; CHECK-NEXT:    abs z1.h, p0/m, z5.h
 ; CHECK-NEXT:    st1h { z2.h }, p0, [x0, x10, lsl #1]
-; CHECK-NEXT:    movprfx z2, z6
-; CHECK-NEXT:    abs z2.h, p0/m, z6.h
 ; CHECK-NEXT:    abs z0.h, p0/m, z0.h
 ; CHECK-NEXT:    st1h { z3.h }, p0, [x0, x11, lsl #1]
 ; CHECK-NEXT:    st1h { z4.h }, p0, [x0, x12, lsl #1]
-; CHECK-NEXT:    st1h { z1.h }, p0, [x0, x13, lsl #1]
-; CHECK-NEXT:    st1h { z2.h }, p0, [x0, x14, lsl #1]
+; CHECK-NEXT:    st1h { z5.h }, p0, [x0, x13, lsl #1]
+; CHECK-NEXT:    st1h { z6.h }, p0, [x0, x14, lsl #1]
 ; CHECK-NEXT:    st1h { z0.h }, p0, [x0]
 ; CHECK-NEXT:    ret
   %op1 = load <128 x i16>, ptr %a

--- a/llvm/test/CodeGen/AArch64/sve-fixed-vector-llrint.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-vector-llrint.ll
@@ -599,19 +599,18 @@ define <8 x i64> @llrint_v8i64_v8f64(<8 x double> %x) nounwind {
 ; CHECK-NEXT:    splice z2.d, p0, z2.d, z3.d
 ; CHECK-NEXT:    ptrue p0.d, vl4
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-NEXT:    movprfx z1, z2
-; CHECK-NEXT:    frintx z1.d, p0/m, z2.d
-; CHECK-NEXT:    mov z4.d, z1.d[2]
+; CHECK-NEXT:    frintx z2.d, p0/m, z2.d
+; CHECK-NEXT:    mov z4.d, z2.d[2]
 ; CHECK-NEXT:    mov z5.d, z0.d[2]
-; CHECK-NEXT:    mov z2.d, z0.d[1]
-; CHECK-NEXT:    mov z3.d, z1.d[3]
+; CHECK-NEXT:    mov z1.d, z0.d[1]
+; CHECK-NEXT:    mov z3.d, z2.d[3]
 ; CHECK-NEXT:    mov z6.d, z0.d[3]
 ; CHECK-NEXT:    fcvtzs x8, d0
-; CHECK-NEXT:    mov z0.d, z1.d[1]
-; CHECK-NEXT:    fcvtzs x10, d1
+; CHECK-NEXT:    mov z0.d, z2.d[1]
+; CHECK-NEXT:    fcvtzs x10, d2
 ; CHECK-NEXT:    fcvtzs x11, d4
 ; CHECK-NEXT:    fcvtzs x12, d5
-; CHECK-NEXT:    fcvtzs x9, d2
+; CHECK-NEXT:    fcvtzs x9, d1
 ; CHECK-NEXT:    fcvtzs x13, d3
 ; CHECK-NEXT:    fcvtzs x14, d6
 ; CHECK-NEXT:    fcvtzs x15, d0
@@ -633,57 +632,55 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) nounwind {
 ; CHECK-LABEL: llrint_v16f64:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p1.d, vl2
-; CHECK-NEXT:    // kill: def $q6 killed $q6 def $z6
 ; CHECK-NEXT:    // kill: def $q4 killed $q4 def $z4
-; CHECK-NEXT:    // kill: def $q7 killed $q7 def $z7
-; CHECK-NEXT:    // kill: def $q5 killed $q5 def $z5
 ; CHECK-NEXT:    // kill: def $q2 killed $q2 def $z2
-; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-NEXT:    // kill: def $q5 killed $q5 def $z5
 ; CHECK-NEXT:    // kill: def $q3 killed $q3 def $z3
+; CHECK-NEXT:    // kill: def $q6 killed $q6 def $z6
+; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-NEXT:    // kill: def $q7 killed $q7 def $z7
 ; CHECK-NEXT:    // kill: def $q1 killed $q1 def $z1
 ; CHECK-NEXT:    ptrue p0.d, vl4
-; CHECK-NEXT:    splice z6.d, p1, z6.d, z7.d
 ; CHECK-NEXT:    splice z4.d, p1, z4.d, z5.d
 ; CHECK-NEXT:    splice z2.d, p1, z2.d, z3.d
+; CHECK-NEXT:    splice z6.d, p1, z6.d, z7.d
 ; CHECK-NEXT:    splice z0.d, p1, z0.d, z1.d
-; CHECK-NEXT:    movprfx z3, z6
-; CHECK-NEXT:    frintx z3.d, p0/m, z6.d
-; CHECK-NEXT:    movprfx z1, z4
-; CHECK-NEXT:    frintx z1.d, p0/m, z4.d
+; CHECK-NEXT:    frintx z4.d, p0/m, z4.d
 ; CHECK-NEXT:    frintx z2.d, p0/m, z2.d
+; CHECK-NEXT:    frintx z6.d, p0/m, z6.d
 ; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-NEXT:    mov z4.d, z3.d[2]
-; CHECK-NEXT:    mov z5.d, z1.d[2]
-; CHECK-NEXT:    mov z6.d, z2.d[3]
+; CHECK-NEXT:    mov z3.d, z4.d[2]
+; CHECK-NEXT:    mov z5.d, z2.d[3]
+; CHECK-NEXT:    mov z1.d, z6.d[2]
 ; CHECK-NEXT:    fcvtzs x11, d0
-; CHECK-NEXT:    fcvtzs x12, d1
+; CHECK-NEXT:    fcvtzs x12, d4
 ; CHECK-NEXT:    fcvtzs x13, d2
-; CHECK-NEXT:    fcvtzs x14, d3
-; CHECK-NEXT:    mov z7.d, z3.d[3]
-; CHECK-NEXT:    mov z16.d, z1.d[3]
-; CHECK-NEXT:    fcvtzs x9, d4
-; CHECK-NEXT:    fcvtzs x10, d5
-; CHECK-NEXT:    mov z4.d, z2.d[2]
+; CHECK-NEXT:    fcvtzs x14, d6
+; CHECK-NEXT:    mov z7.d, z6.d[3]
+; CHECK-NEXT:    mov z16.d, z0.d[3]
+; CHECK-NEXT:    fcvtzs x10, d3
+; CHECK-NEXT:    mov z3.d, z2.d[2]
+; CHECK-NEXT:    fcvtzs x8, d5
 ; CHECK-NEXT:    mov z5.d, z0.d[2]
-; CHECK-NEXT:    fcvtzs x8, d6
+; CHECK-NEXT:    fcvtzs x9, d1
+; CHECK-NEXT:    mov z1.d, z4.d[3]
 ; CHECK-NEXT:    mov z2.d, z2.d[1]
-; CHECK-NEXT:    mov z6.d, z0.d[3]
-; CHECK-NEXT:    mov z1.d, z1.d[1]
-; CHECK-NEXT:    mov z3.d, z3.d[1]
-; CHECK-NEXT:    fcvtzs x15, d4
-; CHECK-NEXT:    mov z4.d, z0.d[1]
+; CHECK-NEXT:    mov z17.d, z6.d[1]
+; CHECK-NEXT:    fcvtzs x17, d7
+; CHECK-NEXT:    fcvtzs x15, d3
+; CHECK-NEXT:    mov z3.d, z0.d[1]
 ; CHECK-NEXT:    fmov d0, x11
 ; CHECK-NEXT:    fcvtzs x16, d5
+; CHECK-NEXT:    mov z5.d, z4.d[1]
+; CHECK-NEXT:    fmov d4, x12
 ; CHECK-NEXT:    fcvtzs x11, d2
 ; CHECK-NEXT:    fmov d2, x13
-; CHECK-NEXT:    fcvtzs x17, d7
-; CHECK-NEXT:    fcvtzs x18, d16
-; CHECK-NEXT:    fcvtzs x0, d3
-; CHECK-NEXT:    fcvtzs x13, d4
-; CHECK-NEXT:    fmov d4, x12
-; CHECK-NEXT:    fcvtzs x12, d6
+; CHECK-NEXT:    fcvtzs x12, d16
+; CHECK-NEXT:    fcvtzs x13, d3
 ; CHECK-NEXT:    fmov d6, x14
-; CHECK-NEXT:    fcvtzs x14, d1
+; CHECK-NEXT:    fcvtzs x18, d1
+; CHECK-NEXT:    fcvtzs x14, d5
+; CHECK-NEXT:    fcvtzs x0, d17
 ; CHECK-NEXT:    fmov d3, x15
 ; CHECK-NEXT:    fmov d1, x16
 ; CHECK-NEXT:    fmov d5, x10
@@ -691,9 +688,9 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) nounwind {
 ; CHECK-NEXT:    mov v2.d[1], x11
 ; CHECK-NEXT:    mov v0.d[1], x13
 ; CHECK-NEXT:    mov v3.d[1], x8
-; CHECK-NEXT:    mov v6.d[1], x0
 ; CHECK-NEXT:    mov v4.d[1], x14
 ; CHECK-NEXT:    mov v1.d[1], x12
+; CHECK-NEXT:    mov v6.d[1], x0
 ; CHECK-NEXT:    mov v5.d[1], x18
 ; CHECK-NEXT:    mov v7.d[1], x17
 ; CHECK-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/sve-fixed-vector-lrint.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-vector-lrint.ll
@@ -635,54 +635,53 @@ define <16 x iXLen> @lrint_v16f32(<16 x float> %x) nounwind {
 ; CHECK-i32-NEXT:    splice z2.d, p0, z2.d, z3.d
 ; CHECK-i32-NEXT:    splice z0.d, p0, z0.d, z1.d
 ; CHECK-i32-NEXT:    ptrue p0.s, vl8
-; CHECK-i32-NEXT:    movprfx z1, z2
-; CHECK-i32-NEXT:    frintx z1.s, p0/m, z2.s
+; CHECK-i32-NEXT:    frintx z2.s, p0/m, z2.s
 ; CHECK-i32-NEXT:    frintx z0.s, p0/m, z0.s
-; CHECK-i32-NEXT:    mov z2.s, z1.s[5]
-; CHECK-i32-NEXT:    mov z3.s, z1.s[4]
+; CHECK-i32-NEXT:    mov z1.s, z2.s[5]
+; CHECK-i32-NEXT:    mov z3.s, z2.s[4]
 ; CHECK-i32-NEXT:    mov z5.s, z0.s[5]
 ; CHECK-i32-NEXT:    mov z7.s, z0.s[1]
 ; CHECK-i32-NEXT:    fcvtzs w11, s0
-; CHECK-i32-NEXT:    fcvtzs w13, s1
-; CHECK-i32-NEXT:    mov z4.s, z1.s[7]
-; CHECK-i32-NEXT:    mov z6.s, z1.s[6]
+; CHECK-i32-NEXT:    fcvtzs w13, s2
+; CHECK-i32-NEXT:    mov z4.s, z2.s[7]
+; CHECK-i32-NEXT:    mov z6.s, z2.s[6]
 ; CHECK-i32-NEXT:    mov z16.s, z0.s[7]
-; CHECK-i32-NEXT:    fcvtzs w8, s2
-; CHECK-i32-NEXT:    mov z2.s, z0.s[4]
+; CHECK-i32-NEXT:    fcvtzs w8, s1
+; CHECK-i32-NEXT:    mov z1.s, z0.s[4]
 ; CHECK-i32-NEXT:    fcvtzs w9, s3
-; CHECK-i32-NEXT:    mov z3.s, z1.s[1]
+; CHECK-i32-NEXT:    mov z3.s, z2.s[1]
 ; CHECK-i32-NEXT:    fcvtzs w10, s5
 ; CHECK-i32-NEXT:    fcvtzs w12, s7
 ; CHECK-i32-NEXT:    mov z5.s, z0.s[6]
-; CHECK-i32-NEXT:    mov z7.s, z1.s[2]
-; CHECK-i32-NEXT:    mov z17.s, z1.s[3]
-; CHECK-i32-NEXT:    fcvtzs w14, s2
-; CHECK-i32-NEXT:    mov z2.s, z0.s[2]
+; CHECK-i32-NEXT:    mov z7.s, z2.s[2]
+; CHECK-i32-NEXT:    mov z17.s, z2.s[3]
+; CHECK-i32-NEXT:    fcvtzs w14, s1
+; CHECK-i32-NEXT:    mov z1.s, z0.s[2]
 ; CHECK-i32-NEXT:    mov z18.s, z0.s[3]
 ; CHECK-i32-NEXT:    fcvtzs w15, s3
 ; CHECK-i32-NEXT:    fmov s0, w11
+; CHECK-i32-NEXT:    fmov s2, w13
 ; CHECK-i32-NEXT:    fmov s3, w9
 ; CHECK-i32-NEXT:    fcvtzs w16, s6
 ; CHECK-i32-NEXT:    fcvtzs w17, s5
+; CHECK-i32-NEXT:    fcvtzs w18, s1
 ; CHECK-i32-NEXT:    fcvtzs w11, s7
-; CHECK-i32-NEXT:    fcvtzs w18, s2
-; CHECK-i32-NEXT:    fmov s2, w13
 ; CHECK-i32-NEXT:    fcvtzs w9, s16
 ; CHECK-i32-NEXT:    fmov s1, w14
 ; CHECK-i32-NEXT:    mov v0.s[1], w12
-; CHECK-i32-NEXT:    mov v3.s[1], w8
-; CHECK-i32-NEXT:    fcvtzs w8, s4
 ; CHECK-i32-NEXT:    fcvtzs w12, s18
 ; CHECK-i32-NEXT:    mov v2.s[1], w15
+; CHECK-i32-NEXT:    mov v3.s[1], w8
+; CHECK-i32-NEXT:    fcvtzs w8, s4
 ; CHECK-i32-NEXT:    mov v1.s[1], w10
 ; CHECK-i32-NEXT:    fcvtzs w10, s17
 ; CHECK-i32-NEXT:    mov v0.s[2], w18
-; CHECK-i32-NEXT:    mov v3.s[2], w16
 ; CHECK-i32-NEXT:    mov v2.s[2], w11
+; CHECK-i32-NEXT:    mov v3.s[2], w16
 ; CHECK-i32-NEXT:    mov v1.s[2], w17
 ; CHECK-i32-NEXT:    mov v0.s[3], w12
-; CHECK-i32-NEXT:    mov v3.s[3], w8
 ; CHECK-i32-NEXT:    mov v2.s[3], w10
+; CHECK-i32-NEXT:    mov v3.s[3], w8
 ; CHECK-i32-NEXT:    mov v1.s[3], w9
 ; CHECK-i32-NEXT:    ret
 ;
@@ -750,8 +749,8 @@ define <32 x iXLen> @lrint_v32f32(<32 x float> %x) nounwind {
 ; CHECK-i32-NEXT:    // kill: def $q6 killed $q6 def $z6
 ; CHECK-i32-NEXT:    // kill: def $q7 killed $q7 def $z7
 ; CHECK-i32-NEXT:    // kill: def $q2 killed $q2 def $z2
-; CHECK-i32-NEXT:    // kill: def $q4 killed $q4 def $z4
 ; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 def $z3
+; CHECK-i32-NEXT:    // kill: def $q4 killed $q4 def $z4
 ; CHECK-i32-NEXT:    // kill: def $q5 killed $q5 def $z5
 ; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 def $z1
 ; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 def $z0
@@ -764,64 +763,62 @@ define <32 x iXLen> @lrint_v32f32(<32 x float> %x) nounwind {
 ; CHECK-i32-NEXT:    splice z0.d, p1, z0.d, z1.d
 ; CHECK-i32-NEXT:    stp x26, x25, [sp, #16] // 16-byte Folded Spill
 ; CHECK-i32-NEXT:    stp x20, x19, [sp, #64] // 16-byte Folded Spill
-; CHECK-i32-NEXT:    movprfx z3, z6
-; CHECK-i32-NEXT:    frintx z3.s, p0/m, z6.s
+; CHECK-i32-NEXT:    frintx z6.s, p0/m, z6.s
 ; CHECK-i32-NEXT:    frintx z2.s, p0/m, z2.s
-; CHECK-i32-NEXT:    movprfx z1, z4
-; CHECK-i32-NEXT:    frintx z1.s, p0/m, z4.s
+; CHECK-i32-NEXT:    frintx z4.s, p0/m, z4.s
 ; CHECK-i32-NEXT:    frintx z0.s, p0/m, z0.s
-; CHECK-i32-NEXT:    mov z4.s, z3.s[7]
-; CHECK-i32-NEXT:    mov z5.s, z3.s[6]
-; CHECK-i32-NEXT:    mov z6.s, z3.s[5]
-; CHECK-i32-NEXT:    mov z16.s, z1.s[7]
-; CHECK-i32-NEXT:    mov z7.s, z3.s[4]
-; CHECK-i32-NEXT:    mov z17.s, z1.s[6]
-; CHECK-i32-NEXT:    mov z18.s, z1.s[5]
-; CHECK-i32-NEXT:    mov z19.s, z1.s[4]
-; CHECK-i32-NEXT:    fcvtzs w7, s3
-; CHECK-i32-NEXT:    fcvtzs w8, s4
-; CHECK-i32-NEXT:    mov z4.s, z2.s[7]
-; CHECK-i32-NEXT:    fcvtzs w10, s5
-; CHECK-i32-NEXT:    mov z5.s, z2.s[6]
-; CHECK-i32-NEXT:    fcvtzs w13, s6
+; CHECK-i32-NEXT:    mov z1.s, z6.s[7]
+; CHECK-i32-NEXT:    mov z3.s, z6.s[6]
+; CHECK-i32-NEXT:    mov z5.s, z6.s[5]
+; CHECK-i32-NEXT:    mov z16.s, z4.s[7]
+; CHECK-i32-NEXT:    mov z7.s, z6.s[4]
+; CHECK-i32-NEXT:    mov z17.s, z4.s[6]
+; CHECK-i32-NEXT:    mov z18.s, z4.s[5]
+; CHECK-i32-NEXT:    mov z19.s, z4.s[4]
+; CHECK-i32-NEXT:    fcvtzs w7, s6
+; CHECK-i32-NEXT:    fcvtzs w8, s1
+; CHECK-i32-NEXT:    mov z1.s, z2.s[7]
+; CHECK-i32-NEXT:    fcvtzs w10, s3
+; CHECK-i32-NEXT:    mov z3.s, z2.s[6]
+; CHECK-i32-NEXT:    fcvtzs w13, s5
 ; CHECK-i32-NEXT:    fcvtzs w9, s16
-; CHECK-i32-NEXT:    mov z6.s, z2.s[4]
+; CHECK-i32-NEXT:    mov z5.s, z2.s[4]
 ; CHECK-i32-NEXT:    mov z16.s, z0.s[6]
 ; CHECK-i32-NEXT:    fcvtzs w14, s7
-; CHECK-i32-NEXT:    fcvtzs w11, s4
-; CHECK-i32-NEXT:    mov z4.s, z2.s[5]
+; CHECK-i32-NEXT:    fcvtzs w11, s1
+; CHECK-i32-NEXT:    mov z1.s, z2.s[5]
 ; CHECK-i32-NEXT:    mov z7.s, z0.s[7]
-; CHECK-i32-NEXT:    fcvtzs w16, s5
-; CHECK-i32-NEXT:    mov z5.s, z0.s[4]
+; CHECK-i32-NEXT:    fcvtzs w16, s3
+; CHECK-i32-NEXT:    mov z3.s, z0.s[4]
 ; CHECK-i32-NEXT:    fcvtzs w12, s17
 ; CHECK-i32-NEXT:    fcvtzs w15, s18
 ; CHECK-i32-NEXT:    fcvtzs w17, s19
 ; CHECK-i32-NEXT:    mov z17.s, z0.s[5]
-; CHECK-i32-NEXT:    fcvtzs w3, s4
-; CHECK-i32-NEXT:    mov z4.s, z3.s[1]
-; CHECK-i32-NEXT:    mov z18.s, z3.s[2]
-; CHECK-i32-NEXT:    fcvtzs w4, s6
+; CHECK-i32-NEXT:    fcvtzs w3, s1
+; CHECK-i32-NEXT:    mov z1.s, z6.s[1]
+; CHECK-i32-NEXT:    mov z18.s, z6.s[2]
+; CHECK-i32-NEXT:    fcvtzs w4, s5
 ; CHECK-i32-NEXT:    fcvtzs w0, s16
-; CHECK-i32-NEXT:    fcvtzs w6, s5
-; CHECK-i32-NEXT:    mov z16.s, z3.s[3]
-; CHECK-i32-NEXT:    mov z3.s, z0.s[1]
-; CHECK-i32-NEXT:    mov z5.s, z1.s[1]
+; CHECK-i32-NEXT:    fcvtzs w6, s3
+; CHECK-i32-NEXT:    mov z16.s, z6.s[3]
+; CHECK-i32-NEXT:    mov z5.s, z4.s[1]
 ; CHECK-i32-NEXT:    mov z6.s, z2.s[1]
-; CHECK-i32-NEXT:    fcvtzs w21, s1
+; CHECK-i32-NEXT:    fcvtzs w2, s1
+; CHECK-i32-NEXT:    mov z1.s, z0.s[1]
+; CHECK-i32-NEXT:    fcvtzs w21, s4
 ; CHECK-i32-NEXT:    fcvtzs w22, s0
 ; CHECK-i32-NEXT:    fcvtzs w23, s2
 ; CHECK-i32-NEXT:    fcvtzs w18, s7
-; CHECK-i32-NEXT:    fcvtzs w2, s4
-; CHECK-i32-NEXT:    mov z4.s, z1.s[2]
+; CHECK-i32-NEXT:    mov z3.s, z4.s[2]
 ; CHECK-i32-NEXT:    mov z7.s, z2.s[2]
 ; CHECK-i32-NEXT:    fcvtzs w5, s17
-; CHECK-i32-NEXT:    fcvtzs w24, s3
+; CHECK-i32-NEXT:    fcvtzs w24, s1
 ; CHECK-i32-NEXT:    fcvtzs w25, s5
 ; CHECK-i32-NEXT:    fcvtzs w26, s6
 ; CHECK-i32-NEXT:    fcvtzs w1, s18
 ; CHECK-i32-NEXT:    mov z18.s, z0.s[2]
-; CHECK-i32-NEXT:    mov z17.s, z1.s[3]
-; CHECK-i32-NEXT:    fcvtzs w19, s4
+; CHECK-i32-NEXT:    mov z17.s, z4.s[3]
+; CHECK-i32-NEXT:    fcvtzs w19, s3
 ; CHECK-i32-NEXT:    mov z19.s, z2.s[3]
 ; CHECK-i32-NEXT:    fcvtzs w20, s7
 ; CHECK-i32-NEXT:    mov z20.s, z0.s[3]
@@ -1133,19 +1130,18 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) nounwind {
 ; CHECK-i64-NEXT:    splice z2.d, p0, z2.d, z3.d
 ; CHECK-i64-NEXT:    ptrue p0.d, vl4
 ; CHECK-i64-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-i64-NEXT:    movprfx z1, z2
-; CHECK-i64-NEXT:    frintx z1.d, p0/m, z2.d
-; CHECK-i64-NEXT:    mov z4.d, z1.d[2]
+; CHECK-i64-NEXT:    frintx z2.d, p0/m, z2.d
+; CHECK-i64-NEXT:    mov z4.d, z2.d[2]
 ; CHECK-i64-NEXT:    mov z5.d, z0.d[2]
-; CHECK-i64-NEXT:    mov z2.d, z0.d[1]
-; CHECK-i64-NEXT:    mov z3.d, z1.d[3]
+; CHECK-i64-NEXT:    mov z1.d, z0.d[1]
+; CHECK-i64-NEXT:    mov z3.d, z2.d[3]
 ; CHECK-i64-NEXT:    mov z6.d, z0.d[3]
 ; CHECK-i64-NEXT:    fcvtzs x8, d0
-; CHECK-i64-NEXT:    mov z0.d, z1.d[1]
-; CHECK-i64-NEXT:    fcvtzs x10, d1
+; CHECK-i64-NEXT:    mov z0.d, z2.d[1]
+; CHECK-i64-NEXT:    fcvtzs x10, d2
 ; CHECK-i64-NEXT:    fcvtzs x11, d4
 ; CHECK-i64-NEXT:    fcvtzs x12, d5
-; CHECK-i64-NEXT:    fcvtzs x9, d2
+; CHECK-i64-NEXT:    fcvtzs x9, d1
 ; CHECK-i64-NEXT:    fcvtzs x13, d3
 ; CHECK-i64-NEXT:    fcvtzs x14, d6
 ; CHECK-i64-NEXT:    fcvtzs x15, d0
@@ -1235,57 +1231,55 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) nounwind {
 ; CHECK-i64-LABEL: lrint_v16f64:
 ; CHECK-i64:       // %bb.0:
 ; CHECK-i64-NEXT:    ptrue p1.d, vl2
-; CHECK-i64-NEXT:    // kill: def $q6 killed $q6 def $z6
 ; CHECK-i64-NEXT:    // kill: def $q4 killed $q4 def $z4
-; CHECK-i64-NEXT:    // kill: def $q7 killed $q7 def $z7
-; CHECK-i64-NEXT:    // kill: def $q5 killed $q5 def $z5
 ; CHECK-i64-NEXT:    // kill: def $q2 killed $q2 def $z2
-; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-i64-NEXT:    // kill: def $q5 killed $q5 def $z5
 ; CHECK-i64-NEXT:    // kill: def $q3 killed $q3 def $z3
+; CHECK-i64-NEXT:    // kill: def $q6 killed $q6 def $z6
+; CHECK-i64-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-i64-NEXT:    // kill: def $q7 killed $q7 def $z7
 ; CHECK-i64-NEXT:    // kill: def $q1 killed $q1 def $z1
 ; CHECK-i64-NEXT:    ptrue p0.d, vl4
-; CHECK-i64-NEXT:    splice z6.d, p1, z6.d, z7.d
 ; CHECK-i64-NEXT:    splice z4.d, p1, z4.d, z5.d
 ; CHECK-i64-NEXT:    splice z2.d, p1, z2.d, z3.d
+; CHECK-i64-NEXT:    splice z6.d, p1, z6.d, z7.d
 ; CHECK-i64-NEXT:    splice z0.d, p1, z0.d, z1.d
-; CHECK-i64-NEXT:    movprfx z3, z6
-; CHECK-i64-NEXT:    frintx z3.d, p0/m, z6.d
-; CHECK-i64-NEXT:    movprfx z1, z4
-; CHECK-i64-NEXT:    frintx z1.d, p0/m, z4.d
+; CHECK-i64-NEXT:    frintx z4.d, p0/m, z4.d
 ; CHECK-i64-NEXT:    frintx z2.d, p0/m, z2.d
+; CHECK-i64-NEXT:    frintx z6.d, p0/m, z6.d
 ; CHECK-i64-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-i64-NEXT:    mov z4.d, z3.d[2]
-; CHECK-i64-NEXT:    mov z5.d, z1.d[2]
-; CHECK-i64-NEXT:    mov z6.d, z2.d[3]
+; CHECK-i64-NEXT:    mov z3.d, z4.d[2]
+; CHECK-i64-NEXT:    mov z5.d, z2.d[3]
+; CHECK-i64-NEXT:    mov z1.d, z6.d[2]
 ; CHECK-i64-NEXT:    fcvtzs x11, d0
-; CHECK-i64-NEXT:    fcvtzs x12, d1
+; CHECK-i64-NEXT:    fcvtzs x12, d4
 ; CHECK-i64-NEXT:    fcvtzs x13, d2
-; CHECK-i64-NEXT:    fcvtzs x14, d3
-; CHECK-i64-NEXT:    mov z7.d, z3.d[3]
-; CHECK-i64-NEXT:    mov z16.d, z1.d[3]
-; CHECK-i64-NEXT:    fcvtzs x9, d4
-; CHECK-i64-NEXT:    fcvtzs x10, d5
-; CHECK-i64-NEXT:    mov z4.d, z2.d[2]
+; CHECK-i64-NEXT:    fcvtzs x14, d6
+; CHECK-i64-NEXT:    mov z7.d, z6.d[3]
+; CHECK-i64-NEXT:    mov z16.d, z0.d[3]
+; CHECK-i64-NEXT:    fcvtzs x10, d3
+; CHECK-i64-NEXT:    mov z3.d, z2.d[2]
+; CHECK-i64-NEXT:    fcvtzs x8, d5
 ; CHECK-i64-NEXT:    mov z5.d, z0.d[2]
-; CHECK-i64-NEXT:    fcvtzs x8, d6
+; CHECK-i64-NEXT:    fcvtzs x9, d1
+; CHECK-i64-NEXT:    mov z1.d, z4.d[3]
 ; CHECK-i64-NEXT:    mov z2.d, z2.d[1]
-; CHECK-i64-NEXT:    mov z6.d, z0.d[3]
-; CHECK-i64-NEXT:    mov z1.d, z1.d[1]
-; CHECK-i64-NEXT:    mov z3.d, z3.d[1]
-; CHECK-i64-NEXT:    fcvtzs x15, d4
-; CHECK-i64-NEXT:    mov z4.d, z0.d[1]
+; CHECK-i64-NEXT:    mov z17.d, z6.d[1]
+; CHECK-i64-NEXT:    fcvtzs x17, d7
+; CHECK-i64-NEXT:    fcvtzs x15, d3
+; CHECK-i64-NEXT:    mov z3.d, z0.d[1]
 ; CHECK-i64-NEXT:    fmov d0, x11
 ; CHECK-i64-NEXT:    fcvtzs x16, d5
+; CHECK-i64-NEXT:    mov z5.d, z4.d[1]
+; CHECK-i64-NEXT:    fmov d4, x12
 ; CHECK-i64-NEXT:    fcvtzs x11, d2
 ; CHECK-i64-NEXT:    fmov d2, x13
-; CHECK-i64-NEXT:    fcvtzs x17, d7
-; CHECK-i64-NEXT:    fcvtzs x18, d16
-; CHECK-i64-NEXT:    fcvtzs x0, d3
-; CHECK-i64-NEXT:    fcvtzs x13, d4
-; CHECK-i64-NEXT:    fmov d4, x12
-; CHECK-i64-NEXT:    fcvtzs x12, d6
+; CHECK-i64-NEXT:    fcvtzs x12, d16
+; CHECK-i64-NEXT:    fcvtzs x13, d3
 ; CHECK-i64-NEXT:    fmov d6, x14
-; CHECK-i64-NEXT:    fcvtzs x14, d1
+; CHECK-i64-NEXT:    fcvtzs x18, d1
+; CHECK-i64-NEXT:    fcvtzs x14, d5
+; CHECK-i64-NEXT:    fcvtzs x0, d17
 ; CHECK-i64-NEXT:    fmov d3, x15
 ; CHECK-i64-NEXT:    fmov d1, x16
 ; CHECK-i64-NEXT:    fmov d5, x10
@@ -1293,9 +1287,9 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) nounwind {
 ; CHECK-i64-NEXT:    mov v2.d[1], x11
 ; CHECK-i64-NEXT:    mov v0.d[1], x13
 ; CHECK-i64-NEXT:    mov v3.d[1], x8
-; CHECK-i64-NEXT:    mov v6.d[1], x0
 ; CHECK-i64-NEXT:    mov v4.d[1], x14
 ; CHECK-i64-NEXT:    mov v1.d[1], x12
+; CHECK-i64-NEXT:    mov v6.d[1], x0
 ; CHECK-i64-NEXT:    mov v5.d[1], x18
 ; CHECK-i64-NEXT:    mov v7.d[1], x17
 ; CHECK-i64-NEXT:    ret
@@ -1309,13 +1303,13 @@ define <32 x iXLen> @lrint_v32f64(<32 x double> %x) nounwind {
 ; CHECK-i32:       // %bb.0:
 ; CHECK-i32-NEXT:    ptrue p1.d, vl2
 ; CHECK-i32-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-i32-NEXT:    // kill: def $q2 killed $q2 def $z2
 ; CHECK-i32-NEXT:    // kill: def $q1 killed $q1 def $z1
 ; CHECK-i32-NEXT:    // kill: def $q3 killed $q3 def $z3
-; CHECK-i32-NEXT:    // kill: def $q2 killed $q2 def $z2
 ; CHECK-i32-NEXT:    // kill: def $q4 killed $q4 def $z4
-; CHECK-i32-NEXT:    // kill: def $q5 killed $q5 def $z5
 ; CHECK-i32-NEXT:    // kill: def $q7 killed $q7 def $z7
 ; CHECK-i32-NEXT:    // kill: def $q6 killed $q6 def $z6
+; CHECK-i32-NEXT:    // kill: def $q5 killed $q5 def $z5
 ; CHECK-i32-NEXT:    ptrue p0.d, vl4
 ; CHECK-i32-NEXT:    splice z0.d, p1, z0.d, z1.d
 ; CHECK-i32-NEXT:    splice z2.d, p1, z2.d, z3.d
@@ -1323,114 +1317,113 @@ define <32 x iXLen> @lrint_v32f64(<32 x double> %x) nounwind {
 ; CHECK-i32-NEXT:    ldp q1, q3, [sp]
 ; CHECK-i32-NEXT:    splice z6.d, p1, z6.d, z7.d
 ; CHECK-i32-NEXT:    frintx z0.d, p0/m, z0.d
-; CHECK-i32-NEXT:    splice z1.d, p1, z1.d, z3.d
 ; CHECK-i32-NEXT:    movprfx z18, z2
 ; CHECK-i32-NEXT:    frintx z18.d, p0/m, z2.d
+; CHECK-i32-NEXT:    splice z1.d, p1, z1.d, z3.d
 ; CHECK-i32-NEXT:    ldp q5, q3, [sp, #96]
+; CHECK-i32-NEXT:    frintx z4.d, p0/m, z4.d
 ; CHECK-i32-NEXT:    ldp q2, q7, [sp, #64]
-; CHECK-i32-NEXT:    splice z5.d, p1, z5.d, z3.d
-; CHECK-i32-NEXT:    movprfx z3, z4
-; CHECK-i32-NEXT:    frintx z3.d, p0/m, z4.d
-; CHECK-i32-NEXT:    mov z4.d, z0.d[1]
-; CHECK-i32-NEXT:    fcvtzs w8, d0
-; CHECK-i32-NEXT:    splice z2.d, p1, z2.d, z7.d
-; CHECK-i32-NEXT:    mov z19.d, z18.d[1]
-; CHECK-i32-NEXT:    ldp q7, q16, [sp, #32]
-; CHECK-i32-NEXT:    movprfx z17, z1
-; CHECK-i32-NEXT:    frintx z17.d, p0/m, z1.d
-; CHECK-i32-NEXT:    fcvtzs w10, d4
-; CHECK-i32-NEXT:    mov z1.d, z0.d[2]
-; CHECK-i32-NEXT:    fcvtzs w9, d18
-; CHECK-i32-NEXT:    mov z4.d, z0.d[3]
-; CHECK-i32-NEXT:    fcvtzs w11, d19
-; CHECK-i32-NEXT:    mov z20.d, z18.d[3]
-; CHECK-i32-NEXT:    fmov s0, w8
-; CHECK-i32-NEXT:    splice z7.d, p1, z7.d, z16.d
 ; CHECK-i32-NEXT:    movprfx z16, z6
 ; CHECK-i32-NEXT:    frintx z16.d, p0/m, z6.d
+; CHECK-i32-NEXT:    mov z19.d, z0.d[1]
+; CHECK-i32-NEXT:    fcvtzs w8, d0
+; CHECK-i32-NEXT:    splice z5.d, p1, z5.d, z3.d
+; CHECK-i32-NEXT:    splice z2.d, p1, z2.d, z7.d
+; CHECK-i32-NEXT:    ldp q3, q7, [sp, #32]
+; CHECK-i32-NEXT:    mov z20.d, z18.d[1]
+; CHECK-i32-NEXT:    fcvtzs w9, d18
+; CHECK-i32-NEXT:    movprfx z17, z1
+; CHECK-i32-NEXT:    frintx z17.d, p0/m, z1.d
+; CHECK-i32-NEXT:    mov z1.d, z0.d[2]
+; CHECK-i32-NEXT:    fcvtzs w10, d19
 ; CHECK-i32-NEXT:    mov z6.d, z18.d[2]
-; CHECK-i32-NEXT:    mov z18.d, z3.d[1]
-; CHECK-i32-NEXT:    fcvtzs w12, d3
+; CHECK-i32-NEXT:    splice z3.d, p1, z3.d, z7.d
+; CHECK-i32-NEXT:    mov z7.d, z0.d[3]
+; CHECK-i32-NEXT:    fmov s0, w8
+; CHECK-i32-NEXT:    fcvtzs w11, d20
+; CHECK-i32-NEXT:    mov z20.d, z18.d[3]
+; CHECK-i32-NEXT:    mov z18.d, z4.d[1]
+; CHECK-i32-NEXT:    fcvtzs w12, d4
+; CHECK-i32-NEXT:    mov z21.d, z4.d[2]
 ; CHECK-i32-NEXT:    fcvtzs w13, d1
 ; CHECK-i32-NEXT:    fmov s1, w9
+; CHECK-i32-NEXT:    mov v0.s[1], w10
 ; CHECK-i32-NEXT:    movprfx z19, z2
 ; CHECK-i32-NEXT:    frintx z19.d, p0/m, z2.d
-; CHECK-i32-NEXT:    mov v0.s[1], w10
-; CHECK-i32-NEXT:    mov z21.d, z3.d[2]
-; CHECK-i32-NEXT:    fcvtzs w8, d4
-; CHECK-i32-NEXT:    fcvtzs w14, d6
-; CHECK-i32-NEXT:    mov z6.d, z16.d[1]
 ; CHECK-i32-NEXT:    fcvtzs w15, d18
-; CHECK-i32-NEXT:    movprfx z18, z7
-; CHECK-i32-NEXT:    frintx z18.d, p0/m, z7.d
-; CHECK-i32-NEXT:    mov v1.s[1], w11
-; CHECK-i32-NEXT:    fmov s2, w12
-; CHECK-i32-NEXT:    mov z7.d, z17.d[1]
-; CHECK-i32-NEXT:    mov z4.d, z16.d[2]
+; CHECK-i32-NEXT:    movprfx z18, z3
+; CHECK-i32-NEXT:    frintx z18.d, p0/m, z3.d
+; CHECK-i32-NEXT:    mov z3.d, z4.d[3]
 ; CHECK-i32-NEXT:    fcvtzs w16, d16
-; CHECK-i32-NEXT:    mov v0.s[2], w13
-; CHECK-i32-NEXT:    fcvtzs w13, d17
-; CHECK-i32-NEXT:    fcvtzs w12, d6
-; CHECK-i32-NEXT:    mov z6.d, z19.d[1]
+; CHECK-i32-NEXT:    mov z4.d, z16.d[1]
+; CHECK-i32-NEXT:    fcvtzs w14, d6
+; CHECK-i32-NEXT:    mov v1.s[1], w11
 ; CHECK-i32-NEXT:    fcvtzs w11, d21
 ; CHECK-i32-NEXT:    movprfx z21, z5
 ; CHECK-i32-NEXT:    frintx z21.d, p0/m, z5.d
-; CHECK-i32-NEXT:    mov z3.d, z3.d[3]
-; CHECK-i32-NEXT:    mov v2.s[1], w15
-; CHECK-i32-NEXT:    mov z5.d, z18.d[1]
-; CHECK-i32-NEXT:    fcvtzs w15, d7
-; CHECK-i32-NEXT:    fcvtzs w0, d19
-; CHECK-i32-NEXT:    mov v1.s[2], w14
-; CHECK-i32-NEXT:    fcvtzs w14, d4
-; CHECK-i32-NEXT:    mov z7.d, z18.d[2]
-; CHECK-i32-NEXT:    fmov s4, w13
-; CHECK-i32-NEXT:    fcvtzs w13, d6
-; CHECK-i32-NEXT:    mov z6.d, z19.d[2]
+; CHECK-i32-NEXT:    fcvtzs w8, d7
+; CHECK-i32-NEXT:    fmov s2, w12
+; CHECK-i32-NEXT:    mov z7.d, z17.d[1]
+; CHECK-i32-NEXT:    mov z6.d, z16.d[2]
+; CHECK-i32-NEXT:    mov v0.s[2], w13
+; CHECK-i32-NEXT:    fcvtzs w12, d4
+; CHECK-i32-NEXT:    fcvtzs w13, d17
 ; CHECK-i32-NEXT:    fcvtzs w10, d3
 ; CHECK-i32-NEXT:    fmov s3, w16
+; CHECK-i32-NEXT:    mov v2.s[1], w15
+; CHECK-i32-NEXT:    mov z4.d, z18.d[1]
+; CHECK-i32-NEXT:    fcvtzs w15, d7
+; CHECK-i32-NEXT:    mov z5.d, z19.d[1]
 ; CHECK-i32-NEXT:    fcvtzs w17, d18
-; CHECK-i32-NEXT:    fcvtzs w18, d5
-; CHECK-i32-NEXT:    mov z5.d, z21.d[1]
+; CHECK-i32-NEXT:    fcvtzs w0, d19
+; CHECK-i32-NEXT:    mov z7.d, z21.d[1]
 ; CHECK-i32-NEXT:    fcvtzs w2, d21
-; CHECK-i32-NEXT:    fcvtzs w1, d7
-; CHECK-i32-NEXT:    mov z7.d, z21.d[2]
-; CHECK-i32-NEXT:    mov v4.s[1], w15
-; CHECK-i32-NEXT:    fcvtzs w15, d6
-; CHECK-i32-NEXT:    fmov s6, w0
-; CHECK-i32-NEXT:    mov v3.s[1], w12
 ; CHECK-i32-NEXT:    fcvtzs w9, d20
-; CHECK-i32-NEXT:    fcvtzs w12, d5
+; CHECK-i32-NEXT:    mov v1.s[2], w14
 ; CHECK-i32-NEXT:    mov z20.d, z17.d[2]
+; CHECK-i32-NEXT:    fcvtzs w14, d6
+; CHECK-i32-NEXT:    mov z6.d, z18.d[2]
+; CHECK-i32-NEXT:    fcvtzs w18, d4
+; CHECK-i32-NEXT:    fmov s4, w13
+; CHECK-i32-NEXT:    fcvtzs w13, d5
+; CHECK-i32-NEXT:    mov v3.s[1], w12
+; CHECK-i32-NEXT:    fcvtzs w12, d7
+; CHECK-i32-NEXT:    fcvtzs w16, d20
+; CHECK-i32-NEXT:    mov z20.d, z19.d[2]
+; CHECK-i32-NEXT:    mov z22.d, z21.d[2]
+; CHECK-i32-NEXT:    fcvtzs w1, d6
 ; CHECK-i32-NEXT:    fmov s5, w17
+; CHECK-i32-NEXT:    fmov s6, w0
+; CHECK-i32-NEXT:    fmov s7, w2
+; CHECK-i32-NEXT:    mov v4.s[1], w15
 ; CHECK-i32-NEXT:    mov z16.d, z16.d[3]
+; CHECK-i32-NEXT:    fcvtzs w15, d20
 ; CHECK-i32-NEXT:    mov z17.d, z17.d[3]
 ; CHECK-i32-NEXT:    mov z18.d, z18.d[3]
-; CHECK-i32-NEXT:    mov v6.s[1], w13
-; CHECK-i32-NEXT:    fcvtzs w13, d7
-; CHECK-i32-NEXT:    fmov s7, w2
-; CHECK-i32-NEXT:    fcvtzs w16, d20
 ; CHECK-i32-NEXT:    mov v5.s[1], w18
+; CHECK-i32-NEXT:    mov v6.s[1], w13
+; CHECK-i32-NEXT:    fcvtzs w13, d22
+; CHECK-i32-NEXT:    mov v7.s[1], w12
 ; CHECK-i32-NEXT:    mov z19.d, z19.d[3]
 ; CHECK-i32-NEXT:    mov z20.d, z21.d[3]
 ; CHECK-i32-NEXT:    mov v2.s[2], w11
 ; CHECK-i32-NEXT:    mov v3.s[2], w14
-; CHECK-i32-NEXT:    mov v7.s[1], w12
 ; CHECK-i32-NEXT:    fcvtzs w11, d16
+; CHECK-i32-NEXT:    mov v4.s[2], w16
 ; CHECK-i32-NEXT:    fcvtzs w12, d17
 ; CHECK-i32-NEXT:    fcvtzs w14, d18
+; CHECK-i32-NEXT:    mov v5.s[2], w1
 ; CHECK-i32-NEXT:    mov v6.s[2], w15
 ; CHECK-i32-NEXT:    fcvtzs w15, d19
-; CHECK-i32-NEXT:    mov v4.s[2], w16
-; CHECK-i32-NEXT:    mov v5.s[2], w1
+; CHECK-i32-NEXT:    mov v7.s[2], w13
+; CHECK-i32-NEXT:    fcvtzs w13, d20
 ; CHECK-i32-NEXT:    mov v0.s[3], w8
 ; CHECK-i32-NEXT:    mov v1.s[3], w9
 ; CHECK-i32-NEXT:    mov v2.s[3], w10
-; CHECK-i32-NEXT:    mov v7.s[2], w13
-; CHECK-i32-NEXT:    fcvtzs w13, d20
 ; CHECK-i32-NEXT:    mov v3.s[3], w11
-; CHECK-i32-NEXT:    mov v6.s[3], w15
 ; CHECK-i32-NEXT:    mov v4.s[3], w12
 ; CHECK-i32-NEXT:    mov v5.s[3], w14
+; CHECK-i32-NEXT:    mov v6.s[3], w15
 ; CHECK-i32-NEXT:    mov v7.s[3], w13
 ; CHECK-i32-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/AArch64/sve-llrint.ll
+++ b/llvm/test/CodeGen/AArch64/sve-llrint.ll
@@ -156,94 +156,93 @@ define <vscale x 16 x i64> @llrint_v16i64_v16f16(<vscale x 16 x half> %x) {
 ; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
 ; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x38, 0x1e, 0x22 // sp + 16 + 8 * VG
 ; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    uunpklo z2.s, z0.h
 ; CHECK-NEXT:    uunpkhi z3.s, z0.h
+; CHECK-NEXT:    uunpklo z2.s, z0.h
 ; CHECK-NEXT:    mov w8, #31743 // =0x7bff
 ; CHECK-NEXT:    uunpklo z7.s, z1.h
 ; CHECK-NEXT:    ptrue p0.d
 ; CHECK-NEXT:    mov z0.h, #-1025 // =0xfffffffffffffbff
 ; CHECK-NEXT:    uunpkhi z1.s, z1.h
 ; CHECK-NEXT:    mov z5.d, #0x8000000000000000
-; CHECK-NEXT:    mov z29.h, w8
 ; CHECK-NEXT:    mov z31.d, #0x8000000000000000
-; CHECK-NEXT:    uunpklo z4.d, z2.s
-; CHECK-NEXT:    uunpklo z24.d, z3.s
+; CHECK-NEXT:    mov z29.h, w8
 ; CHECK-NEXT:    uunpkhi z25.d, z3.s
+; CHECK-NEXT:    uunpklo z4.d, z2.s
 ; CHECK-NEXT:    uunpkhi z6.d, z2.s
+; CHECK-NEXT:    uunpklo z24.d, z3.s
 ; CHECK-NEXT:    uunpklo z26.d, z7.s
 ; CHECK-NEXT:    uunpkhi z7.d, z7.s
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
 ; CHECK-NEXT:    uunpklo z30.d, z1.s
+; CHECK-NEXT:    mov z2.d, #0x8000000000000000
 ; CHECK-NEXT:    mov z3.d, #0x8000000000000000
 ; CHECK-NEXT:    uunpkhi z1.d, z1.s
 ; CHECK-NEXT:    movprfx z27, z4
 ; CHECK-NEXT:    frintx z27.h, p0/m, z4.h
-; CHECK-NEXT:    frintx z24.h, p0/m, z24.h
-; CHECK-NEXT:    frintx z25.h, p0/m, z25.h
 ; CHECK-NEXT:    movprfx z28, z6
 ; CHECK-NEXT:    frintx z28.h, p0/m, z6.h
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
+; CHECK-NEXT:    frintx z25.h, p0/m, z25.h
+; CHECK-NEXT:    frintx z24.h, p0/m, z24.h
 ; CHECK-NEXT:    frintx z26.h, p0/m, z26.h
 ; CHECK-NEXT:    frintx z7.h, p0/m, z7.h
+; CHECK-NEXT:    mov z4.d, #0x8000000000000000
 ; CHECK-NEXT:    mov z6.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p1.h, p0/z, z27.h, z0.h
-; CHECK-NEXT:    fcmge p3.h, p0/z, z24.h, z0.h
+; CHECK-NEXT:    frintx z30.h, p0/m, z30.h
 ; CHECK-NEXT:    fcmge p4.h, p0/z, z25.h, z0.h
+; CHECK-NEXT:    fcmge p1.h, p0/z, z27.h, z0.h
 ; CHECK-NEXT:    fcmge p2.h, p0/z, z28.h, z0.h
+; CHECK-NEXT:    fcmge p3.h, p0/z, z24.h, z0.h
+; CHECK-NEXT:    fcvtzs z5.d, p4/m, z25.h
 ; CHECK-NEXT:    fcmge p5.h, p0/z, z26.h, z0.h
 ; CHECK-NEXT:    fcvtzs z2.d, p1/m, z27.h
-; CHECK-NEXT:    fcvtzs z4.d, p3/m, z24.h
-; CHECK-NEXT:    fcvtzs z5.d, p4/m, z25.h
-; CHECK-NEXT:    fcmgt p3.h, p0/z, z27.h, z29.h
 ; CHECK-NEXT:    fcvtzs z3.d, p2/m, z28.h
 ; CHECK-NEXT:    fcmge p4.h, p0/z, z7.h, z0.h
+; CHECK-NEXT:    fcvtzs z4.d, p3/m, z24.h
+; CHECK-NEXT:    fcmgt p3.h, p0/z, z27.h, z29.h
 ; CHECK-NEXT:    fcvtzs z6.d, p5/m, z26.h
 ; CHECK-NEXT:    fcmuo p1.h, p0/z, z27.h, z27.h
-; CHECK-NEXT:    movprfx z27, z30
-; CHECK-NEXT:    frintx z27.h, p0/m, z30.h
-; CHECK-NEXT:    movprfx z30, z1
-; CHECK-NEXT:    frintx z30.h, p0/m, z1.h
+; CHECK-NEXT:    mov z27.d, #0x8000000000000000
+; CHECK-NEXT:    fcvtzs z31.d, p4/m, z7.h
 ; CHECK-NEXT:    fcmgt p5.h, p0/z, z28.h, z29.h
 ; CHECK-NEXT:    fcmuo p2.h, p0/z, z28.h, z28.h
-; CHECK-NEXT:    mov z28.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z31.d, p4/m, z7.h
-; CHECK-NEXT:    fcmge p4.h, p0/z, z27.h, z0.h
+; CHECK-NEXT:    movprfx z28, z1
+; CHECK-NEXT:    frintx z28.h, p0/m, z1.h
+; CHECK-NEXT:    fcmge p4.h, p0/z, z30.h, z0.h
 ; CHECK-NEXT:    fcmgt p6.h, p0/z, z24.h, z29.h
 ; CHECK-NEXT:    fcmuo p7.h, p0/z, z24.h, z24.h
 ; CHECK-NEXT:    mov z24.d, #0x7fffffffffffffff
 ; CHECK-NEXT:    fcmgt p8.h, p0/z, z25.h, z29.h
-; CHECK-NEXT:    fcvtzs z28.d, p4/m, z27.h
+; CHECK-NEXT:    fcvtzs z27.d, p4/m, z30.h
 ; CHECK-NEXT:    fcmuo p10.h, p0/z, z25.h, z25.h
 ; CHECK-NEXT:    mov z25.d, #0x8000000000000000
 ; CHECK-NEXT:    sel z1.d, p5, z24.d, z3.d
-; CHECK-NEXT:    sel z3.d, p8, z24.d, z5.d
-; CHECK-NEXT:    fcmge p4.h, p0/z, z30.h, z0.h
+; CHECK-NEXT:    fcmge p4.h, p0/z, z28.h, z0.h
 ; CHECK-NEXT:    sel z0.d, p3, z24.d, z2.d
 ; CHECK-NEXT:    sel z2.d, p6, z24.d, z4.d
+; CHECK-NEXT:    sel z3.d, p8, z24.d, z5.d
 ; CHECK-NEXT:    mov z1.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    mov z3.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    ldr p10, [sp, #1, mul vl] // 2-byte Reload
 ; CHECK-NEXT:    fcmgt p9.h, p0/z, z26.h, z29.h
 ; CHECK-NEXT:    mov z2.d, p7/m, #0 // =0x0
 ; CHECK-NEXT:    ldr p7, [sp, #4, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcvtzs z25.d, p4/m, z30.h
+; CHECK-NEXT:    fcvtzs z25.d, p4/m, z28.h
+; CHECK-NEXT:    mov z3.d, p10/m, #0 // =0x0
+; CHECK-NEXT:    ldr p10, [sp, #1, mul vl] // 2-byte Reload
 ; CHECK-NEXT:    mov z0.d, p1/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p5.h, p0/z, z7.h, z29.h
-; CHECK-NEXT:    fcmgt p6.h, p0/z, z27.h, z29.h
+; CHECK-NEXT:    fcmgt p6.h, p0/z, z30.h, z29.h
 ; CHECK-NEXT:    sel z4.d, p9, z24.d, z6.d
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z30.h, z29.h
+; CHECK-NEXT:    fcmgt p4.h, p0/z, z28.h, z29.h
 ; CHECK-NEXT:    fcmuo p8.h, p0/z, z7.h, z7.h
 ; CHECK-NEXT:    sel z5.d, p5, z24.d, z31.d
 ; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    sel z6.d, p6, z24.d, z28.d
+; CHECK-NEXT:    fcmuo p9.h, p0/z, z30.h, z30.h
+; CHECK-NEXT:    sel z6.d, p6, z24.d, z27.d
 ; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p9.h, p0/z, z27.h, z27.h
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z26.h, z26.h
 ; CHECK-NEXT:    sel z7.d, p4, z24.d, z25.d
 ; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
+; CHECK-NEXT:    fcmuo p3.h, p0/z, z26.h, z26.h
 ; CHECK-NEXT:    mov z5.d, p8/m, #0 // =0x0
 ; CHECK-NEXT:    ldr p8, [sp, #3, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z30.h, z30.h
+; CHECK-NEXT:    fcmuo p0.h, p0/z, z28.h, z28.h
 ; CHECK-NEXT:    mov z6.d, p9/m, #0 // =0x0
 ; CHECK-NEXT:    ldr p9, [sp, #2, mul vl] // 2-byte Reload
 ; CHECK-NEXT:    mov z4.d, p3/m, #0 // =0x0
@@ -355,11 +354,12 @@ define <vscale x 32 x i64> @llrint_v32i64_v32f16(<vscale x 32 x half> %x) {
 ; CHECK-NEXT:    frintx z19.h, p0/m, z13.h
 ; CHECK-NEXT:    movprfx z13, z14
 ; CHECK-NEXT:    frintx z13.h, p0/m, z14.h
+; CHECK-NEXT:    frintx z20.h, p0/m, z20.h
 ; CHECK-NEXT:    frintx z16.h, p0/m, z16.h
 ; CHECK-NEXT:    mov z22.d, #0x8000000000000000
 ; CHECK-NEXT:    mov z23.d, #0x8000000000000000
-; CHECK-NEXT:    mov z14.d, #0x8000000000000000
 ; CHECK-NEXT:    frintx z15.h, p0/m, z15.h
+; CHECK-NEXT:    mov z14.d, #0x8000000000000000
 ; CHECK-NEXT:    fcmge p4.h, p0/z, z4.h, z28.h
 ; CHECK-NEXT:    fcmge p2.h, p0/z, z12.h, z28.h
 ; CHECK-NEXT:    fcmgt p9.h, p0/z, z12.h, z30.h
@@ -381,10 +381,8 @@ define <vscale x 32 x i64> @llrint_v32i64_v32f16(<vscale x 32 x half> %x) {
 ; CHECK-NEXT:    fcvtzs z12.d, p4/m, z11.h
 ; CHECK-NEXT:    fcmgt p4.h, p0/z, z11.h, z30.h
 ; CHECK-NEXT:    uunpkhi z11.d, z17.s
-; CHECK-NEXT:    movprfx z17, z20
-; CHECK-NEXT:    frintx z17.h, p0/m, z20.h
+; CHECK-NEXT:    mov z17.d, #0x8000000000000000
 ; CHECK-NEXT:    fcvtzs z25.d, p1/m, z6.h
-; CHECK-NEXT:    mov z20.d, #0x8000000000000000
 ; CHECK-NEXT:    fcvtzs z0.d, p5/m, z1.h
 ; CHECK-NEXT:    fcmge p6.h, p0/z, z10.h, z28.h
 ; CHECK-NEXT:    frintx z11.h, p0/m, z11.h
@@ -392,87 +390,87 @@ define <vscale x 32 x i64> @llrint_v32i64_v32f16(<vscale x 32 x half> %x) {
 ; CHECK-NEXT:    fcmge p1.h, p0/z, z13.h, z28.h
 ; CHECK-NEXT:    fcvtzs z18.d, p6/m, z10.h
 ; CHECK-NEXT:    fcmgt p11.h, p0/z, z10.h, z30.h
-; CHECK-NEXT:    fcmge p5.h, p0/z, z11.h, z28.h
 ; CHECK-NEXT:    fcvtzs z2.d, p3/m, z31.h
+; CHECK-NEXT:    fcmge p5.h, p0/z, z11.h, z28.h
 ; CHECK-NEXT:    fcvtzs z21.d, p1/m, z13.h
-; CHECK-NEXT:    fcmge p2.h, p0/z, z17.h, z28.h
+; CHECK-NEXT:    fcmge p2.h, p0/z, z20.h, z28.h
 ; CHECK-NEXT:    fcmge p3.h, p0/z, z16.h, z28.h
 ; CHECK-NEXT:    fcmuo p1.h, p0/z, z10.h, z10.h
 ; CHECK-NEXT:    sel z10.d, p4, z29.d, z12.d
 ; CHECK-NEXT:    sel z12.d, p11, z29.d, z18.d
 ; CHECK-NEXT:    fcvtzs z26.d, p5/m, z11.h
-; CHECK-NEXT:    fcvtzs z22.d, p2/m, z17.h
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z11.h, z30.h
+; CHECK-NEXT:    fcvtzs z22.d, p2/m, z20.h
 ; CHECK-NEXT:    fcvtzs z23.d, p3/m, z16.h
 ; CHECK-NEXT:    mov z10.d, p10/m, #0 // =0x0
 ; CHECK-NEXT:    mov z12.d, p1/m, #0 // =0x0
+; CHECK-NEXT:    fcmgt p4.h, p0/z, z11.h, z30.h
 ; CHECK-NEXT:    fcmge p6.h, p0/z, z19.h, z28.h
 ; CHECK-NEXT:    str z10, [x8, #7, mul vl]
 ; CHECK-NEXT:    fcmge p7.h, p0/z, z3.h, z28.h
 ; CHECK-NEXT:    str z12, [x8, #8, mul vl]
-; CHECK-NEXT:    mov z26.d, p4/m, z29.d
 ; CHECK-NEXT:    fcmge p2.h, p0/z, z15.h, z28.h
 ; CHECK-NEXT:    mov z28.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z14.d, p6/m, z19.h
+; CHECK-NEXT:    mov z26.d, p4/m, z29.d
 ; CHECK-NEXT:    fcmgt p5.h, p0/z, z16.h, z30.h
-; CHECK-NEXT:    fcmgt p3.h, p0/z, z17.h, z30.h
-; CHECK-NEXT:    fcvtzs z20.d, p7/m, z3.h
+; CHECK-NEXT:    fcvtzs z14.d, p6/m, z19.h
+; CHECK-NEXT:    fcvtzs z17.d, p7/m, z3.h
+; CHECK-NEXT:    fcmgt p3.h, p0/z, z20.h, z30.h
 ; CHECK-NEXT:    fcvtzs z28.d, p2/m, z15.h
 ; CHECK-NEXT:    fcmuo p1.h, p0/z, z11.h, z11.h
-; CHECK-NEXT:    fcmuo p2.h, p0/z, z16.h, z16.h
 ; CHECK-NEXT:    sel z11.d, p5, z29.d, z23.d
-; CHECK-NEXT:    sel z16.d, p3, z29.d, z22.d
+; CHECK-NEXT:    fcmuo p2.h, p0/z, z16.h, z16.h
 ; CHECK-NEXT:    fcmgt p4.h, p0/z, z19.h, z30.h
-; CHECK-NEXT:    fcmgt p3.h, p0/z, z15.h, z30.h
+; CHECK-NEXT:    sel z16.d, p3, z29.d, z22.d
 ; CHECK-NEXT:    mov z26.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    mov z11.d, p2/m, #0 // =0x0
+; CHECK-NEXT:    fcmgt p3.h, p0/z, z15.h, z30.h
 ; CHECK-NEXT:    fcmgt p1.h, p0/z, z13.h, z30.h
-; CHECK-NEXT:    fcmuo p6.h, p0/z, z17.h, z17.h
+; CHECK-NEXT:    mov z11.d, p2/m, #0 // =0x0
 ; CHECK-NEXT:    str z26, [x8, #15, mul vl]
 ; CHECK-NEXT:    sel z26.d, p4, z29.d, z14.d
+; CHECK-NEXT:    fcmuo p6.h, p0/z, z20.h, z20.h
+; CHECK-NEXT:    fcmgt p2.h, p0/z, z3.h, z30.h
 ; CHECK-NEXT:    str z11, [x8, #14, mul vl]
 ; CHECK-NEXT:    mov z28.d, p3/m, z29.d
-; CHECK-NEXT:    fcmgt p2.h, p0/z, z3.h, z30.h
 ; CHECK-NEXT:    fcmuo p4.h, p0/z, z13.h, z13.h
 ; CHECK-NEXT:    fcmuo p3.h, p0/z, z3.h, z3.h
 ; CHECK-NEXT:    sel z3.d, p1, z29.d, z21.d
 ; CHECK-NEXT:    mov z16.d, p6/m, #0 // =0x0
+; CHECK-NEXT:    sel z11.d, p2, z29.d, z17.d
 ; CHECK-NEXT:    fcmgt p12.h, p0/z, z27.h, z30.h
-; CHECK-NEXT:    sel z11.d, p2, z29.d, z20.d
-; CHECK-NEXT:    str z16, [x8, #13, mul vl]
 ; CHECK-NEXT:    mov z3.d, p4/m, #0 // =0x0
+; CHECK-NEXT:    str z16, [x8, #13, mul vl]
 ; CHECK-NEXT:    fcmuo p6.h, p0/z, z15.h, z15.h
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z4.h, z30.h
 ; CHECK-NEXT:    mov z11.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z9.d, p12/m, z29.d
+; CHECK-NEXT:    fcmgt p1.h, p0/z, z4.h, z30.h
 ; CHECK-NEXT:    str z3, [x8, #11, mul vl]
 ; CHECK-NEXT:    fcmuo p5.h, p0/z, z19.h, z19.h
-; CHECK-NEXT:    fcmgt p2.h, p0/z, z5.h, z30.h
+; CHECK-NEXT:    mov z9.d, p12/m, z29.d
 ; CHECK-NEXT:    str z11, [x8, #10, mul vl]
+; CHECK-NEXT:    fcmgt p2.h, p0/z, z5.h, z30.h
 ; CHECK-NEXT:    mov z28.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    sel z3.d, p1, z29.d, z7.d
 ; CHECK-NEXT:    fcmgt p4.h, p0/z, z6.h, z30.h
+; CHECK-NEXT:    sel z3.d, p1, z29.d, z7.d
+; CHECK-NEXT:    mov z26.d, p5/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p3.h, p0/z, z27.h, z27.h
 ; CHECK-NEXT:    str z28, [x8, #12, mul vl]
-; CHECK-NEXT:    mov z26.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    sel z7.d, p2, z29.d, z24.d
 ; CHECK-NEXT:    fcmgt p6.h, p0/z, z31.h, z30.h
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z1.h, z30.h
+; CHECK-NEXT:    sel z7.d, p2, z29.d, z24.d
 ; CHECK-NEXT:    str z26, [x8, #9, mul vl]
 ; CHECK-NEXT:    sel z24.d, p4, z29.d, z25.d
-; CHECK-NEXT:    mov z9.d, p3/m, #0 // =0x0
+; CHECK-NEXT:    fcmgt p1.h, p0/z, z1.h, z30.h
 ; CHECK-NEXT:    fcmuo p5.h, p0/z, z31.h, z31.h
-; CHECK-NEXT:    fcmuo p2.h, p0/z, z6.h, z6.h
+; CHECK-NEXT:    mov z9.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    mov z2.d, p6/m, z29.d
+; CHECK-NEXT:    fcmuo p2.h, p0/z, z6.h, z6.h
+; CHECK-NEXT:    fcmuo p3.h, p0/z, z5.h, z5.h
 ; CHECK-NEXT:    str z9, [x8, #5, mul vl]
 ; CHECK-NEXT:    mov z0.d, p1/m, z29.d
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z5.h, z5.h
-; CHECK-NEXT:    fcmuo p4.h, p0/z, z4.h, z4.h
 ; CHECK-NEXT:    mov z2.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    mov z24.d, p2/m, #0 // =0x0
+; CHECK-NEXT:    fcmuo p4.h, p0/z, z4.h, z4.h
 ; CHECK-NEXT:    fcmuo p0.h, p0/z, z1.h, z1.h
-; CHECK-NEXT:    mov z7.d, p3/m, #0 // =0x0
+; CHECK-NEXT:    mov z24.d, p2/m, #0 // =0x0
 ; CHECK-NEXT:    str z2, [x8, #6, mul vl]
+; CHECK-NEXT:    mov z7.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    mov z3.d, p4/m, #0 // =0x0
 ; CHECK-NEXT:    str z24, [x8, #3, mul vl]
 ; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
@@ -860,12 +858,11 @@ define <vscale x 32 x i64> @llrint_v32i64_v32f32(<vscale x 32 x float> %x) {
 ; CHECK-NEXT:    movprfx z17, z18
 ; CHECK-NEXT:    frintx z17.s, p0/m, z18.s
 ; CHECK-NEXT:    fcmge p6.s, p0/z, z30.s, z29.s
-; CHECK-NEXT:    movprfx z18, z19
-; CHECK-NEXT:    frintx z18.s, p0/m, z19.s
 ; CHECK-NEXT:    uunpkhi z7.d, z7.s
 ; CHECK-NEXT:    mov z31.s, w9
 ; CHECK-NEXT:    mov z2.d, #0x8000000000000000
 ; CHECK-NEXT:    mov z26.d, #0x8000000000000000
+; CHECK-NEXT:    frintx z19.s, p0/m, z19.s
 ; CHECK-NEXT:    uunpklo z6.d, z6.s
 ; CHECK-NEXT:    mov z28.d, #0x8000000000000000
 ; CHECK-NEXT:    fcvtzs z27.d, p3/m, z24.s
@@ -881,7 +878,7 @@ define <vscale x 32 x i64> @llrint_v32i64_v32f32(<vscale x 32 x float> %x) {
 ; CHECK-NEXT:    mov z8.d, #0x8000000000000000
 ; CHECK-NEXT:    frintx z6.s, p0/m, z6.s
 ; CHECK-NEXT:    mov z3.d, #0x7fffffffffffffff
-; CHECK-NEXT:    mov z19.d, #0x8000000000000000
+; CHECK-NEXT:    mov z18.d, #0x8000000000000000
 ; CHECK-NEXT:    fcmge p1.s, p0/z, z0.s, z29.s
 ; CHECK-NEXT:    fcmge p2.s, p0/z, z1.s, z29.s
 ; CHECK-NEXT:    fcmge p4.s, p0/z, z25.s, z29.s
@@ -901,94 +898,94 @@ define <vscale x 32 x i64> @llrint_v32i64_v32f32(<vscale x 32 x float> %x) {
 ; CHECK-NEXT:    fcvtzs z4.d, p3/m, z15.s
 ; CHECK-NEXT:    fcvtzs z16.d, p6/m, z13.s
 ; CHECK-NEXT:    fcmge p1.s, p0/z, z17.s, z29.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z18.s, z29.s
+; CHECK-NEXT:    fcmge p2.s, p0/z, z19.s, z29.s
 ; CHECK-NEXT:    fcmgt p12.s, p0/z, z30.s, z31.s
 ; CHECK-NEXT:    fcmgt p5.s, p0/z, z15.s, z31.s
-; CHECK-NEXT:    fcmge p3.s, p0/z, z20.s, z29.s
 ; CHECK-NEXT:    fcvtzs z21.d, p1/m, z17.s
-; CHECK-NEXT:    fcvtzs z23.d, p2/m, z18.s
-; CHECK-NEXT:    fcmgt p11.s, p0/z, z13.s, z31.s
+; CHECK-NEXT:    fcmge p3.s, p0/z, z20.s, z29.s
+; CHECK-NEXT:    fcvtzs z23.d, p2/m, z19.s
 ; CHECK-NEXT:    sel z7.d, p12, z3.d, z12.d
+; CHECK-NEXT:    fcmgt p11.s, p0/z, z13.s, z31.s
 ; CHECK-NEXT:    mov z4.d, p5/m, z3.d
 ; CHECK-NEXT:    fcmge p4.s, p0/z, z22.s, z29.s
 ; CHECK-NEXT:    fcvtzs z0.d, p3/m, z20.s
 ; CHECK-NEXT:    fcmge p6.s, p0/z, z5.s, z29.s
-; CHECK-NEXT:    sel z12.d, p11, z3.d, z16.d
 ; CHECK-NEXT:    fcmge p7.s, p0/z, z14.s, z29.s
-; CHECK-NEXT:    fcmuo p1.s, p0/z, z13.s, z13.s
+; CHECK-NEXT:    sel z12.d, p11, z3.d, z16.d
 ; CHECK-NEXT:    fcvtzs z8.d, p4/m, z22.s
+; CHECK-NEXT:    fcmuo p1.s, p0/z, z13.s, z13.s
 ; CHECK-NEXT:    fcmge p2.s, p0/z, z6.s, z29.s
 ; CHECK-NEXT:    mov z29.d, #0x8000000000000000
+; CHECK-NEXT:    fcvtzs z18.d, p7/m, z14.s
 ; CHECK-NEXT:    fcmuo p10.s, p0/z, z15.s, z15.s
 ; CHECK-NEXT:    mov z15.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z19.d, p7/m, z14.s
 ; CHECK-NEXT:    mov z12.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcvtzs z29.d, p2/m, z6.s
 ; CHECK-NEXT:    fcmgt p4.s, p0/z, z22.s, z31.s
+; CHECK-NEXT:    fcvtzs z29.d, p2/m, z6.s
+; CHECK-NEXT:    fcmgt p5.s, p0/z, z20.s, z31.s
+; CHECK-NEXT:    str z12, [x8, #8, mul vl]
 ; CHECK-NEXT:    fcvtzs z15.d, p6/m, z5.s
 ; CHECK-NEXT:    mov z4.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    str z12, [x8, #8, mul vl]
-; CHECK-NEXT:    fcmgt p5.s, p0/z, z20.s, z31.s
-; CHECK-NEXT:    fcmgt p3.s, p0/z, z18.s, z31.s
-; CHECK-NEXT:    str z4, [x8, #7, mul vl]
-; CHECK-NEXT:    fcmuo p1.s, p0/z, z22.s, z22.s
+; CHECK-NEXT:    fcmgt p3.s, p0/z, z19.s, z31.s
 ; CHECK-NEXT:    mov z8.d, p4/m, z3.d
-; CHECK-NEXT:    fcmuo p2.s, p0/z, z20.s, z20.s
+; CHECK-NEXT:    fcmuo p1.s, p0/z, z22.s, z22.s
+; CHECK-NEXT:    str z4, [x8, #7, mul vl]
 ; CHECK-NEXT:    mov z0.d, p5/m, z3.d
-; CHECK-NEXT:    fcmuo p6.s, p0/z, z18.s, z18.s
+; CHECK-NEXT:    fcmuo p2.s, p0/z, z20.s, z20.s
+; CHECK-NEXT:    fcmuo p6.s, p0/z, z19.s, z19.s
 ; CHECK-NEXT:    fcmgt p4.s, p0/z, z5.s, z31.s
 ; CHECK-NEXT:    mov z8.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    mov z0.d, p2/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p5.s, p0/z, z5.s, z5.s
 ; CHECK-NEXT:    sel z5.d, p3, z3.d, z23.d
-; CHECK-NEXT:    str z8, [x8, #15, mul vl]
+; CHECK-NEXT:    mov z0.d, p2/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p3.s, p0/z, z6.s, z31.s
-; CHECK-NEXT:    str z0, [x8, #14, mul vl]
+; CHECK-NEXT:    str z8, [x8, #15, mul vl]
 ; CHECK-NEXT:    fcmgt p1.s, p0/z, z17.s, z31.s
+; CHECK-NEXT:    str z0, [x8, #14, mul vl]
 ; CHECK-NEXT:    mov z5.d, p6/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p2.s, p0/z, z14.s, z31.s
-; CHECK-NEXT:    fcmuo p6.s, p0/z, z6.s, z6.s
-; CHECK-NEXT:    sel z6.d, p4, z3.d, z15.d
-; CHECK-NEXT:    str z5, [x8, #13, mul vl]
 ; CHECK-NEXT:    sel z0.d, p3, z3.d, z29.d
-; CHECK-NEXT:    fcmuo p4.s, p0/z, z17.s, z17.s
+; CHECK-NEXT:    fcmuo p6.s, p0/z, z6.s, z6.s
+; CHECK-NEXT:    str z5, [x8, #13, mul vl]
+; CHECK-NEXT:    sel z6.d, p4, z3.d, z15.d
 ; CHECK-NEXT:    sel z5.d, p1, z3.d, z21.d
-; CHECK-NEXT:    sel z29.d, p2, z3.d, z19.d
+; CHECK-NEXT:    fcmuo p4.s, p0/z, z17.s, z17.s
+; CHECK-NEXT:    sel z29.d, p2, z3.d, z18.d
 ; CHECK-NEXT:    mov z6.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    mov z0.d, p6/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p3.s, p0/z, z14.s, z14.s
-; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z6, [x8, #9, mul vl]
+; CHECK-NEXT:    mov z0.d, p6/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p1.s, p0/z, z1.s, z31.s
+; CHECK-NEXT:    str z6, [x8, #9, mul vl]
+; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
 ; CHECK-NEXT:    str z0, [x8, #12, mul vl]
-; CHECK-NEXT:    fcmgt p2.s, p0/z, z24.s, z31.s
 ; CHECK-NEXT:    mov z29.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    str z5, [x8, #11, mul vl]
-; CHECK-NEXT:    fcmgt p4.s, p0/z, z25.s, z31.s
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z30.s, z30.s
 ; CHECK-NEXT:    sel z5.d, p1, z3.d, z26.d
+; CHECK-NEXT:    fcmgt p2.s, p0/z, z24.s, z31.s
 ; CHECK-NEXT:    str z29, [x8, #10, mul vl]
-; CHECK-NEXT:    sel z26.d, p2, z3.d, z27.d
 ; CHECK-NEXT:    ldr z4, [sp] // 16-byte Folded Reload
 ; CHECK-NEXT:    str z11, [x8, #4, mul vl]
+; CHECK-NEXT:    fcmgt p4.s, p0/z, z25.s, z31.s
+; CHECK-NEXT:    fcmuo p3.s, p0/z, z30.s, z30.s
+; CHECK-NEXT:    sel z26.d, p2, z3.d, z27.d
 ; CHECK-NEXT:    fcmgt p6.s, p0/z, z9.s, z31.s
-; CHECK-NEXT:    sel z6.d, p4, z3.d, z28.d
-; CHECK-NEXT:    fcmuo p5.s, p0/z, z9.s, z9.s
-; CHECK-NEXT:    mov z7.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p1.s, p0/z, z4.s, z31.s
+; CHECK-NEXT:    fcmuo p5.s, p0/z, z9.s, z9.s
+; CHECK-NEXT:    sel z6.d, p4, z3.d, z28.d
+; CHECK-NEXT:    mov z7.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p2.s, p0/z, z25.s, z25.s
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z24.s, z24.s
 ; CHECK-NEXT:    sel z0.d, p6, z3.d, z10.d
-; CHECK-NEXT:    str z7, [x8, #5, mul vl]
+; CHECK-NEXT:    fcmuo p3.s, p0/z, z24.s, z24.s
 ; CHECK-NEXT:    fcmuo p4.s, p0/z, z1.s, z1.s
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z4.s, z4.s
 ; CHECK-NEXT:    sel z1.d, p1, z3.d, z2.d
+; CHECK-NEXT:    str z7, [x8, #5, mul vl]
+; CHECK-NEXT:    fcmuo p0.s, p0/z, z4.s, z4.s
 ; CHECK-NEXT:    mov z0.d, p5/m, #0 // =0x0
 ; CHECK-NEXT:    mov z6.d, p2/m, #0 // =0x0
 ; CHECK-NEXT:    mov z26.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
 ; CHECK-NEXT:    str z0, [x8, #6, mul vl]
+; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
 ; CHECK-NEXT:    str z6, [x8, #3, mul vl]
 ; CHECK-NEXT:    str z26, [x8, #2, mul vl]
 ; CHECK-NEXT:    str z5, [x8, #1, mul vl]
@@ -1299,8 +1296,7 @@ define <vscale x 32 x i64> @llrint_v32f64(<vscale x 32 x double> %x) {
 ; CHECK-NEXT:    str z10, [sp, #15, mul vl] // 16-byte Folded Spill
 ; CHECK-NEXT:    str z9, [sp, #16, mul vl] // 16-byte Folded Spill
 ; CHECK-NEXT:    str z8, [sp, #17, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0a, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x98, 0x01, 0x1e, 0x22 // sp + 16 + 152 * VG
+; CHECK-NEXT:    .cfi_escape 0x0f, 0x0a, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x90, 0x01, 0x1e, 0x22 // sp + 16 + 144 * VG
 ; CHECK-NEXT:    .cfi_offset w29, -16
 ; CHECK-NEXT:    .cfi_escape 0x10, 0x48, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x78, 0x1e, 0x22, 0x40, 0x1c // $d8 @ cfa - 8 * VG - 16
 ; CHECK-NEXT:    .cfi_escape 0x10, 0x49, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x70, 0x1e, 0x22, 0x40, 0x1c // $d9 @ cfa - 16 * VG - 16
@@ -1311,182 +1307,177 @@ define <vscale x 32 x i64> @llrint_v32f64(<vscale x 32 x double> %x) {
 ; CHECK-NEXT:    .cfi_escape 0x10, 0x4e, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x48, 0x1e, 0x22, 0x40, 0x1c // $d14 @ cfa - 56 * VG - 16
 ; CHECK-NEXT:    .cfi_escape 0x10, 0x4f, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x40, 0x1e, 0x22, 0x40, 0x1c // $d15 @ cfa - 64 * VG - 16
 ; CHECK-NEXT:    ldr z0, [x0]
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov x9, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z25.d, x9
 ; CHECK-NEXT:    ldr z7, [x0, #3, mul vl]
+; CHECK-NEXT:    ptrue p0.d
 ; CHECK-NEXT:    ldr z27, [x0, #4, mul vl]
 ; CHECK-NEXT:    ldr z4, [x0, #2, mul vl]
+; CHECK-NEXT:    mov x9, #-4332462841530417152 // =0xc3e0000000000000
+; CHECK-NEXT:    mov z25.d, x9
 ; CHECK-NEXT:    ldr z2, [x0, #1, mul vl]
-; CHECK-NEXT:    ldr z9, [x0, #15, mul vl]
-; CHECK-NEXT:    movprfx z5, z0
-; CHECK-NEXT:    frintx z5.d, p0/m, z0.d
-; CHECK-NEXT:    mov z0.d, #0x8000000000000000
-; CHECK-NEXT:    ldr z10, [x0, #14, mul vl]
+; CHECK-NEXT:    ldr z29, [x0, #6, mul vl]
+; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
 ; CHECK-NEXT:    frintx z7.d, p0/m, z7.d
+; CHECK-NEXT:    ldr z31, [x0, #7, mul vl]
 ; CHECK-NEXT:    movprfx z14, z27
 ; CHECK-NEXT:    frintx z14.d, p0/m, z27.d
-; CHECK-NEXT:    ldr z11, [x0, #13, mul vl]
 ; CHECK-NEXT:    frintx z4.d, p0/m, z4.d
-; CHECK-NEXT:    ldr z8, [x0, #12, mul vl]
 ; CHECK-NEXT:    ldr z27, [x0, #5, mul vl]
-; CHECK-NEXT:    ldr z18, [x0, #11, mul vl]
-; CHECK-NEXT:    ldr z13, [x0, #10, mul vl]
-; CHECK-NEXT:    ldr z29, [x0, #6, mul vl]
-; CHECK-NEXT:    fcmge p1.d, p0/z, z5.d, z25.d
+; CHECK-NEXT:    ldr z15, [x0, #8, mul vl]
 ; CHECK-NEXT:    mov x9, #4890909195324358655 // =0x43dfffffffffffff
-; CHECK-NEXT:    mov z24.d, #0x8000000000000000
-; CHECK-NEXT:    mov z30.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z28, z27
-; CHECK-NEXT:    frintx z28.d, p0/m, z27.d
-; CHECK-NEXT:    mov z1.d, x9
-; CHECK-NEXT:    fcmge p2.d, p0/z, z7.d, z25.d
-; CHECK-NEXT:    frintx z29.d, p0/m, z29.d
 ; CHECK-NEXT:    movprfx z3, z2
 ; CHECK-NEXT:    frintx z3.d, p0/m, z2.d
-; CHECK-NEXT:    fcmge p3.d, p0/z, z14.d, z25.d
-; CHECK-NEXT:    mov z6.d, #0x8000000000000000
-; CHECK-NEXT:    mov z12.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z0.d, p1/m, z5.d
-; CHECK-NEXT:    frintx z18.d, p0/m, z18.d
 ; CHECK-NEXT:    mov z2.d, #0x8000000000000000
+; CHECK-NEXT:    mov z24.d, #0x8000000000000000
+; CHECK-NEXT:    mov z30.d, #0x8000000000000000
+; CHECK-NEXT:    fcmge p1.d, p0/z, z0.d, z25.d
+; CHECK-NEXT:    movprfx z28, z27
+; CHECK-NEXT:    frintx z28.d, p0/m, z27.d
+; CHECK-NEXT:    frintx z29.d, p0/m, z29.d
+; CHECK-NEXT:    fcmge p2.d, p0/z, z7.d, z25.d
+; CHECK-NEXT:    mov z1.d, x9
+; CHECK-NEXT:    mov z6.d, #0x8000000000000000
+; CHECK-NEXT:    fcmge p3.d, p0/z, z14.d, z25.d
+; CHECK-NEXT:    ldr z11, [x0, #13, mul vl]
+; CHECK-NEXT:    ldr z18, [x0, #11, mul vl]
 ; CHECK-NEXT:    fcmge p5.d, p0/z, z4.d, z25.d
-; CHECK-NEXT:    mov z16.d, #0x8000000000000000
-; CHECK-NEXT:    mov z17.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z24.d, p2/m, z7.d
-; CHECK-NEXT:    frintx z10.d, p0/m, z10.d
-; CHECK-NEXT:    frintx z9.d, p0/m, z9.d
-; CHECK-NEXT:    fcvtzs z30.d, p3/m, z14.d
-; CHECK-NEXT:    frintx z13.d, p0/m, z13.d
-; CHECK-NEXT:    mov z21.d, #0x8000000000000000
-; CHECK-NEXT:    str z0, [sp] // 16-byte Folded Spill
-; CHECK-NEXT:    mov z22.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z0, z8
-; CHECK-NEXT:    frintx z0.d, p0/m, z8.d
-; CHECK-NEXT:    ldr z31, [x0, #7, mul vl]
-; CHECK-NEXT:    ldr z15, [x0, #8, mul vl]
 ; CHECK-NEXT:    ldr z19, [x0, #9, mul vl]
-; CHECK-NEXT:    fcmge p1.d, p0/z, z28.d, z25.d
-; CHECK-NEXT:    fcvtzs z6.d, p5/m, z4.d
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    fcmgt p10.d, p0/z, z14.d, z1.d
-; CHECK-NEXT:    mov z27.d, #0x7fffffffffffffff
-; CHECK-NEXT:    mov z23.d, #0x8000000000000000
 ; CHECK-NEXT:    movprfx z20, z31
 ; CHECK-NEXT:    frintx z20.d, p0/m, z31.d
 ; CHECK-NEXT:    frintx z15.d, p0/m, z15.d
+; CHECK-NEXT:    ldr z9, [x0, #15, mul vl]
+; CHECK-NEXT:    ldr z10, [x0, #14, mul vl]
+; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.d
+; CHECK-NEXT:    fcvtzs z24.d, p2/m, z7.d
+; CHECK-NEXT:    mov z12.d, #0x8000000000000000
+; CHECK-NEXT:    fcvtzs z30.d, p3/m, z14.d
 ; CHECK-NEXT:    mov z31.d, #0x8000000000000000
+; CHECK-NEXT:    frintx z18.d, p0/m, z18.d
+; CHECK-NEXT:    fcmge p1.d, p0/z, z28.d, z25.d
+; CHECK-NEXT:    mov z5.d, #0x8000000000000000
+; CHECK-NEXT:    ldr z8, [x0, #12, mul vl]
+; CHECK-NEXT:    fcmgt p10.d, p0/z, z14.d, z1.d
+; CHECK-NEXT:    ldr z13, [x0, #10, mul vl]
+; CHECK-NEXT:    fcvtzs z6.d, p5/m, z4.d
 ; CHECK-NEXT:    fcmge p2.d, p0/z, z29.d, z25.d
+; CHECK-NEXT:    mov z16.d, #0x8000000000000000
+; CHECK-NEXT:    mov z17.d, #0x8000000000000000
+; CHECK-NEXT:    frintx z10.d, p0/m, z10.d
+; CHECK-NEXT:    frintx z9.d, p0/m, z9.d
+; CHECK-NEXT:    mov z21.d, #0x8000000000000000
+; CHECK-NEXT:    fcvtzs z12.d, p1/m, z28.d
+; CHECK-NEXT:    frintx z13.d, p0/m, z13.d
+; CHECK-NEXT:    mov z22.d, #0x8000000000000000
+; CHECK-NEXT:    frintx z8.d, p0/m, z8.d
+; CHECK-NEXT:    mov z26.d, #0x8000000000000000
+; CHECK-NEXT:    mov z27.d, #0x7fffffffffffffff
+; CHECK-NEXT:    fcvtzs z31.d, p2/m, z29.d
+; CHECK-NEXT:    mov z23.d, #0x8000000000000000
 ; CHECK-NEXT:    fcmuo p8.d, p0/z, z14.d, z14.d
 ; CHECK-NEXT:    movprfx z14, z19
 ; CHECK-NEXT:    frintx z14.d, p0/m, z19.d
 ; CHECK-NEXT:    movprfx z19, z11
 ; CHECK-NEXT:    frintx z19.d, p0/m, z11.d
-; CHECK-NEXT:    fcmge p4.d, p0/z, z3.d, z25.d
-; CHECK-NEXT:    fcvtzs z12.d, p1/m, z28.d
 ; CHECK-NEXT:    mov z11.d, #0x8000000000000000
 ; CHECK-NEXT:    mov z30.d, p10/m, z27.d
-; CHECK-NEXT:    fcvtzs z31.d, p2/m, z29.d
+; CHECK-NEXT:    fcmge p4.d, p0/z, z3.d, z25.d
 ; CHECK-NEXT:    fcmge p5.d, p0/z, z20.d, z25.d
-; CHECK-NEXT:    fcmge p6.d, p0/z, z15.d, z25.d
-; CHECK-NEXT:    fcvtzs z2.d, p4/m, z3.d
 ; CHECK-NEXT:    mov z30.d, p8/m, #0 // =0x0
+; CHECK-NEXT:    fcmge p6.d, p0/z, z15.d, z25.d
+; CHECK-NEXT:    fcvtzs z5.d, p4/m, z3.d
 ; CHECK-NEXT:    fcmge p1.d, p0/z, z18.d, z25.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z19.d, z25.d
+; CHECK-NEXT:    str z30, [x8, #4, mul vl]
 ; CHECK-NEXT:    fcvtzs z16.d, p5/m, z20.d
+; CHECK-NEXT:    fcmge p2.d, p0/z, z19.d, z25.d
 ; CHECK-NEXT:    fcvtzs z17.d, p6/m, z15.d
-; CHECK-NEXT:    fcmgt p12.d, p0/z, z28.d, z1.d
-; CHECK-NEXT:    fcvtzs z21.d, p1/m, z18.d
-; CHECK-NEXT:    fcvtzs z22.d, p2/m, z19.d
 ; CHECK-NEXT:    fcmgt p5.d, p0/z, z20.d, z1.d
 ; CHECK-NEXT:    fcmge p3.d, p0/z, z10.d, z25.d
+; CHECK-NEXT:    fcvtzs z21.d, p1/m, z18.d
+; CHECK-NEXT:    fcvtzs z22.d, p2/m, z19.d
 ; CHECK-NEXT:    fcmgt p11.d, p0/z, z15.d, z1.d
-; CHECK-NEXT:    sel z8.d, p12, z27.d, z12.d
 ; CHECK-NEXT:    fcmge p4.d, p0/z, z9.d, z25.d
-; CHECK-NEXT:    sel z12.d, p5, z27.d, z16.d
 ; CHECK-NEXT:    fcmge p6.d, p0/z, z14.d, z25.d
 ; CHECK-NEXT:    fcvtzs z23.d, p3/m, z10.d
 ; CHECK-NEXT:    fcmge p7.d, p0/z, z13.d, z25.d
-; CHECK-NEXT:    fcvtzs z26.d, p4/m, z9.d
 ; CHECK-NEXT:    fcmuo p1.d, p0/z, z15.d, z15.d
-; CHECK-NEXT:    sel z15.d, p11, z27.d, z17.d
+; CHECK-NEXT:    sel z15.d, p5, z27.d, z16.d
+; CHECK-NEXT:    sel z16.d, p11, z27.d, z17.d
+; CHECK-NEXT:    fcvtzs z26.d, p4/m, z9.d
 ; CHECK-NEXT:    fcvtzs z11.d, p6/m, z14.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z0.d, z25.d
+; CHECK-NEXT:    fcmge p2.d, p0/z, z8.d, z25.d
 ; CHECK-NEXT:    mov z25.d, #0x8000000000000000
+; CHECK-NEXT:    mov z16.d, p1/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p4.d, p0/z, z9.d, z1.d
-; CHECK-NEXT:    mov z15.d, p1/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p5.d, p0/z, z10.d, z1.d
+; CHECK-NEXT:    str z16, [x8, #8, mul vl]
+; CHECK-NEXT:    fcvtzs z25.d, p2/m, z8.d
 ; CHECK-NEXT:    fcmgt p3.d, p0/z, z19.d, z1.d
-; CHECK-NEXT:    fcvtzs z25.d, p2/m, z0.d
-; CHECK-NEXT:    str z15, [x8, #8, mul vl]
-; CHECK-NEXT:    mov z26.d, p4/m, z27.d
 ; CHECK-NEXT:    fcmuo p9.d, p0/z, z20.d, z20.d
 ; CHECK-NEXT:    mov z20.d, #0x8000000000000000
+; CHECK-NEXT:    mov z26.d, p4/m, z27.d
 ; CHECK-NEXT:    fcmuo p1.d, p0/z, z9.d, z9.d
 ; CHECK-NEXT:    sel z9.d, p5, z27.d, z23.d
 ; CHECK-NEXT:    fcmuo p2.d, p0/z, z10.d, z10.d
 ; CHECK-NEXT:    sel z10.d, p3, z27.d, z22.d
-; CHECK-NEXT:    fcmuo p6.d, p0/z, z19.d, z19.d
 ; CHECK-NEXT:    fcvtzs z20.d, p7/m, z13.d
-; CHECK-NEXT:    mov z12.d, p9/m, #0 // =0x0
+; CHECK-NEXT:    mov z15.d, p9/m, #0 // =0x0
 ; CHECK-NEXT:    mov z26.d, p1/m, #0 // =0x0
 ; CHECK-NEXT:    mov z9.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    str z12, [x8, #7, mul vl]
-; CHECK-NEXT:    mov z10.d, p6/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p4.d, p0/z, z14.d, z1.d
+; CHECK-NEXT:    str z15, [x8, #7, mul vl]
+; CHECK-NEXT:    fcmgt p3.d, p0/z, z8.d, z1.d
 ; CHECK-NEXT:    str z26, [x8, #15, mul vl]
-; CHECK-NEXT:    fcmgt p3.d, p0/z, z0.d, z1.d
+; CHECK-NEXT:    fcmuo p6.d, p0/z, z19.d, z19.d
 ; CHECK-NEXT:    str z9, [x8, #14, mul vl]
 ; CHECK-NEXT:    fcmgt p1.d, p0/z, z18.d, z1.d
-; CHECK-NEXT:    str z10, [x8, #13, mul vl]
 ; CHECK-NEXT:    fcmgt p2.d, p0/z, z13.d, z1.d
-; CHECK-NEXT:    fcmuo p5.d, p0/z, z14.d, z14.d
-; CHECK-NEXT:    fcmuo p6.d, p0/z, z0.d, z0.d
-; CHECK-NEXT:    sel z0.d, p4, z27.d, z11.d
+; CHECK-NEXT:    sel z26.d, p4, z27.d, z11.d
 ; CHECK-NEXT:    mov z25.d, p3/m, z27.d
-; CHECK-NEXT:    sel z26.d, p1, z27.d, z21.d
-; CHECK-NEXT:    sel z9.d, p2, z27.d, z20.d
 ; CHECK-NEXT:    fcmuo p4.d, p0/z, z18.d, z18.d
-; CHECK-NEXT:    mov z0.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    mov z25.d, p6/m, #0 // =0x0
+; CHECK-NEXT:    mov z10.d, p6/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p3.d, p0/z, z13.d, z13.d
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z3.d, z1.d
-; CHECK-NEXT:    str z0, [x8, #9, mul vl]
-; CHECK-NEXT:    mov z26.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z25, [x8, #12, mul vl]
-; CHECK-NEXT:    fcmgt p2.d, p0/z, z4.d, z1.d
+; CHECK-NEXT:    sel z9.d, p2, z27.d, z20.d
+; CHECK-NEXT:    fcmgt p12.d, p0/z, z28.d, z1.d
+; CHECK-NEXT:    str z10, [x8, #13, mul vl]
+; CHECK-NEXT:    fcmuo p6.d, p0/z, z8.d, z8.d
+; CHECK-NEXT:    sel z8.d, p1, z27.d, z21.d
 ; CHECK-NEXT:    mov z9.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z7.d, z1.d
-; CHECK-NEXT:    str z26, [x8, #11, mul vl]
-; CHECK-NEXT:    mov z2.d, p1/m, z27.d
-; CHECK-NEXT:    fcmuo p3.d, p0/z, z28.d, z28.d
-; CHECK-NEXT:    fcmgt p6.d, p0/z, z29.d, z1.d
+; CHECK-NEXT:    fcmgt p1.d, p0/z, z3.d, z1.d
+; CHECK-NEXT:    fcmuo p5.d, p0/z, z14.d, z14.d
+; CHECK-NEXT:    mov z8.d, p4/m, #0 // =0x0
+; CHECK-NEXT:    mov z12.d, p12/m, z27.d
 ; CHECK-NEXT:    str z9, [x8, #10, mul vl]
+; CHECK-NEXT:    mov z25.d, p6/m, #0 // =0x0
+; CHECK-NEXT:    fcmgt p2.d, p0/z, z4.d, z1.d
+; CHECK-NEXT:    str z8, [x8, #11, mul vl]
+; CHECK-NEXT:    mov z5.d, p1/m, z27.d
+; CHECK-NEXT:    fcmgt p4.d, p0/z, z7.d, z1.d
+; CHECK-NEXT:    str z25, [x8, #12, mul vl]
+; CHECK-NEXT:    mov z26.d, p5/m, #0 // =0x0
+; CHECK-NEXT:    fcmuo p3.d, p0/z, z28.d, z28.d
 ; CHECK-NEXT:    mov z6.d, p2/m, z27.d
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z5.d, z1.d
-; CHECK-NEXT:    ldr z1, [sp] // 16-byte Folded Reload
-; CHECK-NEXT:    str z30, [x8, #4, mul vl]
+; CHECK-NEXT:    fcmgt p6.d, p0/z, z29.d, z1.d
+; CHECK-NEXT:    str z26, [x8, #9, mul vl]
+; CHECK-NEXT:    fcmgt p1.d, p0/z, z0.d, z1.d
+; CHECK-NEXT:    mov z24.d, p4/m, z27.d
+; CHECK-NEXT:    mov z12.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p5.d, p0/z, z29.d, z29.d
-; CHECK-NEXT:    sel z0.d, p4, z27.d, z24.d
-; CHECK-NEXT:    mov z8.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p2.d, p0/z, z7.d, z7.d
 ; CHECK-NEXT:    sel z25.d, p6, z27.d, z31.d
-; CHECK-NEXT:    mov z1.d, p1/m, z27.d
+; CHECK-NEXT:    str z12, [x8, #5, mul vl]
 ; CHECK-NEXT:    fcmuo p3.d, p0/z, z4.d, z4.d
-; CHECK-NEXT:    str z8, [x8, #5, mul vl]
 ; CHECK-NEXT:    fcmuo p4.d, p0/z, z3.d, z3.d
 ; CHECK-NEXT:    mov z25.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    mov z0.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z5.d, z5.d
+; CHECK-NEXT:    fcmuo p0.d, p0/z, z0.d, z0.d
+; CHECK-NEXT:    sel z0.d, p1, z27.d, z2.d
+; CHECK-NEXT:    mov z24.d, p2/m, #0 // =0x0
 ; CHECK-NEXT:    mov z6.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    str z25, [x8, #6, mul vl]
-; CHECK-NEXT:    mov z2.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z0, [x8, #3, mul vl]
-; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
+; CHECK-NEXT:    str z24, [x8, #3, mul vl]
+; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
 ; CHECK-NEXT:    str z6, [x8, #2, mul vl]
-; CHECK-NEXT:    str z2, [x8, #1, mul vl]
-; CHECK-NEXT:    str z1, [x8]
-; CHECK-NEXT:    addvl sp, sp, #1
+; CHECK-NEXT:    str z5, [x8, #1, mul vl]
+; CHECK-NEXT:    str z0, [x8]
 ; CHECK-NEXT:    ldr z23, [sp, #2, mul vl] // 16-byte Folded Reload
 ; CHECK-NEXT:    ldr z22, [sp, #3, mul vl] // 16-byte Folded Reload
 ; CHECK-NEXT:    ldr z21, [sp, #4, mul vl] // 16-byte Folded Reload

--- a/llvm/test/CodeGen/AArch64/sve-lrint.ll
+++ b/llvm/test/CodeGen/AArch64/sve-lrint.ll
@@ -157,94 +157,93 @@ define <vscale x 16 x iXLen> @lrint_v16f16(<vscale x 16 x half> %x) {
 ; CHECK-NEXT:    str p4, [sp, #7, mul vl] // 2-byte Spill
 ; CHECK-NEXT:    .cfi_escape 0x0f, 0x08, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x38, 0x1e, 0x22 // sp + 16 + 8 * VG
 ; CHECK-NEXT:    .cfi_offset w29, -16
-; CHECK-NEXT:    uunpklo z2.s, z0.h
 ; CHECK-NEXT:    uunpkhi z3.s, z0.h
+; CHECK-NEXT:    uunpklo z2.s, z0.h
 ; CHECK-NEXT:    mov w8, #31743 // =0x7bff
 ; CHECK-NEXT:    uunpklo z7.s, z1.h
 ; CHECK-NEXT:    ptrue p0.d
 ; CHECK-NEXT:    mov z0.h, #-1025 // =0xfffffffffffffbff
 ; CHECK-NEXT:    uunpkhi z1.s, z1.h
 ; CHECK-NEXT:    mov z5.d, #0x8000000000000000
-; CHECK-NEXT:    mov z29.h, w8
 ; CHECK-NEXT:    mov z31.d, #0x8000000000000000
-; CHECK-NEXT:    uunpklo z4.d, z2.s
-; CHECK-NEXT:    uunpklo z24.d, z3.s
+; CHECK-NEXT:    mov z29.h, w8
 ; CHECK-NEXT:    uunpkhi z25.d, z3.s
+; CHECK-NEXT:    uunpklo z4.d, z2.s
 ; CHECK-NEXT:    uunpkhi z6.d, z2.s
+; CHECK-NEXT:    uunpklo z24.d, z3.s
 ; CHECK-NEXT:    uunpklo z26.d, z7.s
 ; CHECK-NEXT:    uunpkhi z7.d, z7.s
-; CHECK-NEXT:    mov z2.d, #0x8000000000000000
 ; CHECK-NEXT:    uunpklo z30.d, z1.s
+; CHECK-NEXT:    mov z2.d, #0x8000000000000000
 ; CHECK-NEXT:    mov z3.d, #0x8000000000000000
 ; CHECK-NEXT:    uunpkhi z1.d, z1.s
 ; CHECK-NEXT:    movprfx z27, z4
 ; CHECK-NEXT:    frintx z27.h, p0/m, z4.h
-; CHECK-NEXT:    frintx z24.h, p0/m, z24.h
-; CHECK-NEXT:    frintx z25.h, p0/m, z25.h
 ; CHECK-NEXT:    movprfx z28, z6
 ; CHECK-NEXT:    frintx z28.h, p0/m, z6.h
-; CHECK-NEXT:    mov z4.d, #0x8000000000000000
+; CHECK-NEXT:    frintx z25.h, p0/m, z25.h
+; CHECK-NEXT:    frintx z24.h, p0/m, z24.h
 ; CHECK-NEXT:    frintx z26.h, p0/m, z26.h
 ; CHECK-NEXT:    frintx z7.h, p0/m, z7.h
+; CHECK-NEXT:    mov z4.d, #0x8000000000000000
 ; CHECK-NEXT:    mov z6.d, #0x8000000000000000
-; CHECK-NEXT:    fcmge p1.h, p0/z, z27.h, z0.h
-; CHECK-NEXT:    fcmge p3.h, p0/z, z24.h, z0.h
+; CHECK-NEXT:    frintx z30.h, p0/m, z30.h
 ; CHECK-NEXT:    fcmge p4.h, p0/z, z25.h, z0.h
+; CHECK-NEXT:    fcmge p1.h, p0/z, z27.h, z0.h
 ; CHECK-NEXT:    fcmge p2.h, p0/z, z28.h, z0.h
+; CHECK-NEXT:    fcmge p3.h, p0/z, z24.h, z0.h
+; CHECK-NEXT:    fcvtzs z5.d, p4/m, z25.h
 ; CHECK-NEXT:    fcmge p5.h, p0/z, z26.h, z0.h
 ; CHECK-NEXT:    fcvtzs z2.d, p1/m, z27.h
-; CHECK-NEXT:    fcvtzs z4.d, p3/m, z24.h
-; CHECK-NEXT:    fcvtzs z5.d, p4/m, z25.h
-; CHECK-NEXT:    fcmgt p3.h, p0/z, z27.h, z29.h
 ; CHECK-NEXT:    fcvtzs z3.d, p2/m, z28.h
 ; CHECK-NEXT:    fcmge p4.h, p0/z, z7.h, z0.h
+; CHECK-NEXT:    fcvtzs z4.d, p3/m, z24.h
+; CHECK-NEXT:    fcmgt p3.h, p0/z, z27.h, z29.h
 ; CHECK-NEXT:    fcvtzs z6.d, p5/m, z26.h
 ; CHECK-NEXT:    fcmuo p1.h, p0/z, z27.h, z27.h
-; CHECK-NEXT:    movprfx z27, z30
-; CHECK-NEXT:    frintx z27.h, p0/m, z30.h
-; CHECK-NEXT:    movprfx z30, z1
-; CHECK-NEXT:    frintx z30.h, p0/m, z1.h
+; CHECK-NEXT:    mov z27.d, #0x8000000000000000
+; CHECK-NEXT:    fcvtzs z31.d, p4/m, z7.h
 ; CHECK-NEXT:    fcmgt p5.h, p0/z, z28.h, z29.h
 ; CHECK-NEXT:    fcmuo p2.h, p0/z, z28.h, z28.h
-; CHECK-NEXT:    mov z28.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z31.d, p4/m, z7.h
-; CHECK-NEXT:    fcmge p4.h, p0/z, z27.h, z0.h
+; CHECK-NEXT:    movprfx z28, z1
+; CHECK-NEXT:    frintx z28.h, p0/m, z1.h
+; CHECK-NEXT:    fcmge p4.h, p0/z, z30.h, z0.h
 ; CHECK-NEXT:    fcmgt p6.h, p0/z, z24.h, z29.h
 ; CHECK-NEXT:    fcmuo p7.h, p0/z, z24.h, z24.h
 ; CHECK-NEXT:    mov z24.d, #0x7fffffffffffffff
 ; CHECK-NEXT:    fcmgt p8.h, p0/z, z25.h, z29.h
-; CHECK-NEXT:    fcvtzs z28.d, p4/m, z27.h
+; CHECK-NEXT:    fcvtzs z27.d, p4/m, z30.h
 ; CHECK-NEXT:    fcmuo p10.h, p0/z, z25.h, z25.h
 ; CHECK-NEXT:    mov z25.d, #0x8000000000000000
 ; CHECK-NEXT:    sel z1.d, p5, z24.d, z3.d
-; CHECK-NEXT:    sel z3.d, p8, z24.d, z5.d
-; CHECK-NEXT:    fcmge p4.h, p0/z, z30.h, z0.h
+; CHECK-NEXT:    fcmge p4.h, p0/z, z28.h, z0.h
 ; CHECK-NEXT:    sel z0.d, p3, z24.d, z2.d
 ; CHECK-NEXT:    sel z2.d, p6, z24.d, z4.d
+; CHECK-NEXT:    sel z3.d, p8, z24.d, z5.d
 ; CHECK-NEXT:    mov z1.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    mov z3.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    ldr p10, [sp, #1, mul vl] // 2-byte Reload
 ; CHECK-NEXT:    fcmgt p9.h, p0/z, z26.h, z29.h
 ; CHECK-NEXT:    mov z2.d, p7/m, #0 // =0x0
 ; CHECK-NEXT:    ldr p7, [sp, #4, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcvtzs z25.d, p4/m, z30.h
+; CHECK-NEXT:    fcvtzs z25.d, p4/m, z28.h
+; CHECK-NEXT:    mov z3.d, p10/m, #0 // =0x0
+; CHECK-NEXT:    ldr p10, [sp, #1, mul vl] // 2-byte Reload
 ; CHECK-NEXT:    mov z0.d, p1/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p5.h, p0/z, z7.h, z29.h
-; CHECK-NEXT:    fcmgt p6.h, p0/z, z27.h, z29.h
+; CHECK-NEXT:    fcmgt p6.h, p0/z, z30.h, z29.h
 ; CHECK-NEXT:    sel z4.d, p9, z24.d, z6.d
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z30.h, z29.h
+; CHECK-NEXT:    fcmgt p4.h, p0/z, z28.h, z29.h
 ; CHECK-NEXT:    fcmuo p8.h, p0/z, z7.h, z7.h
 ; CHECK-NEXT:    sel z5.d, p5, z24.d, z31.d
 ; CHECK-NEXT:    ldr p5, [sp, #6, mul vl] // 2-byte Reload
-; CHECK-NEXT:    sel z6.d, p6, z24.d, z28.d
+; CHECK-NEXT:    fcmuo p9.h, p0/z, z30.h, z30.h
+; CHECK-NEXT:    sel z6.d, p6, z24.d, z27.d
 ; CHECK-NEXT:    ldr p6, [sp, #5, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p9.h, p0/z, z27.h, z27.h
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z26.h, z26.h
 ; CHECK-NEXT:    sel z7.d, p4, z24.d, z25.d
 ; CHECK-NEXT:    ldr p4, [sp, #7, mul vl] // 2-byte Reload
+; CHECK-NEXT:    fcmuo p3.h, p0/z, z26.h, z26.h
 ; CHECK-NEXT:    mov z5.d, p8/m, #0 // =0x0
 ; CHECK-NEXT:    ldr p8, [sp, #3, mul vl] // 2-byte Reload
-; CHECK-NEXT:    fcmuo p0.h, p0/z, z30.h, z30.h
+; CHECK-NEXT:    fcmuo p0.h, p0/z, z28.h, z28.h
 ; CHECK-NEXT:    mov z6.d, p9/m, #0 // =0x0
 ; CHECK-NEXT:    ldr p9, [sp, #2, mul vl] // 2-byte Reload
 ; CHECK-NEXT:    mov z4.d, p3/m, #0 // =0x0
@@ -356,11 +355,12 @@ define <vscale x 32 x iXLen> @lrint_v32f16(<vscale x 32 x half> %x) {
 ; CHECK-NEXT:    frintx z19.h, p0/m, z13.h
 ; CHECK-NEXT:    movprfx z13, z14
 ; CHECK-NEXT:    frintx z13.h, p0/m, z14.h
+; CHECK-NEXT:    frintx z20.h, p0/m, z20.h
 ; CHECK-NEXT:    frintx z16.h, p0/m, z16.h
 ; CHECK-NEXT:    mov z22.d, #0x8000000000000000
 ; CHECK-NEXT:    mov z23.d, #0x8000000000000000
-; CHECK-NEXT:    mov z14.d, #0x8000000000000000
 ; CHECK-NEXT:    frintx z15.h, p0/m, z15.h
+; CHECK-NEXT:    mov z14.d, #0x8000000000000000
 ; CHECK-NEXT:    fcmge p4.h, p0/z, z4.h, z28.h
 ; CHECK-NEXT:    fcmge p2.h, p0/z, z12.h, z28.h
 ; CHECK-NEXT:    fcmgt p9.h, p0/z, z12.h, z30.h
@@ -382,10 +382,8 @@ define <vscale x 32 x iXLen> @lrint_v32f16(<vscale x 32 x half> %x) {
 ; CHECK-NEXT:    fcvtzs z12.d, p4/m, z11.h
 ; CHECK-NEXT:    fcmgt p4.h, p0/z, z11.h, z30.h
 ; CHECK-NEXT:    uunpkhi z11.d, z17.s
-; CHECK-NEXT:    movprfx z17, z20
-; CHECK-NEXT:    frintx z17.h, p0/m, z20.h
+; CHECK-NEXT:    mov z17.d, #0x8000000000000000
 ; CHECK-NEXT:    fcvtzs z25.d, p1/m, z6.h
-; CHECK-NEXT:    mov z20.d, #0x8000000000000000
 ; CHECK-NEXT:    fcvtzs z0.d, p5/m, z1.h
 ; CHECK-NEXT:    fcmge p6.h, p0/z, z10.h, z28.h
 ; CHECK-NEXT:    frintx z11.h, p0/m, z11.h
@@ -393,87 +391,87 @@ define <vscale x 32 x iXLen> @lrint_v32f16(<vscale x 32 x half> %x) {
 ; CHECK-NEXT:    fcmge p1.h, p0/z, z13.h, z28.h
 ; CHECK-NEXT:    fcvtzs z18.d, p6/m, z10.h
 ; CHECK-NEXT:    fcmgt p11.h, p0/z, z10.h, z30.h
-; CHECK-NEXT:    fcmge p5.h, p0/z, z11.h, z28.h
 ; CHECK-NEXT:    fcvtzs z2.d, p3/m, z31.h
+; CHECK-NEXT:    fcmge p5.h, p0/z, z11.h, z28.h
 ; CHECK-NEXT:    fcvtzs z21.d, p1/m, z13.h
-; CHECK-NEXT:    fcmge p2.h, p0/z, z17.h, z28.h
+; CHECK-NEXT:    fcmge p2.h, p0/z, z20.h, z28.h
 ; CHECK-NEXT:    fcmge p3.h, p0/z, z16.h, z28.h
 ; CHECK-NEXT:    fcmuo p1.h, p0/z, z10.h, z10.h
 ; CHECK-NEXT:    sel z10.d, p4, z29.d, z12.d
 ; CHECK-NEXT:    sel z12.d, p11, z29.d, z18.d
 ; CHECK-NEXT:    fcvtzs z26.d, p5/m, z11.h
-; CHECK-NEXT:    fcvtzs z22.d, p2/m, z17.h
-; CHECK-NEXT:    fcmgt p4.h, p0/z, z11.h, z30.h
+; CHECK-NEXT:    fcvtzs z22.d, p2/m, z20.h
 ; CHECK-NEXT:    fcvtzs z23.d, p3/m, z16.h
 ; CHECK-NEXT:    mov z10.d, p10/m, #0 // =0x0
 ; CHECK-NEXT:    mov z12.d, p1/m, #0 // =0x0
+; CHECK-NEXT:    fcmgt p4.h, p0/z, z11.h, z30.h
 ; CHECK-NEXT:    fcmge p6.h, p0/z, z19.h, z28.h
 ; CHECK-NEXT:    str z10, [x8, #7, mul vl]
 ; CHECK-NEXT:    fcmge p7.h, p0/z, z3.h, z28.h
 ; CHECK-NEXT:    str z12, [x8, #8, mul vl]
-; CHECK-NEXT:    mov z26.d, p4/m, z29.d
 ; CHECK-NEXT:    fcmge p2.h, p0/z, z15.h, z28.h
 ; CHECK-NEXT:    mov z28.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z14.d, p6/m, z19.h
+; CHECK-NEXT:    mov z26.d, p4/m, z29.d
 ; CHECK-NEXT:    fcmgt p5.h, p0/z, z16.h, z30.h
-; CHECK-NEXT:    fcmgt p3.h, p0/z, z17.h, z30.h
-; CHECK-NEXT:    fcvtzs z20.d, p7/m, z3.h
+; CHECK-NEXT:    fcvtzs z14.d, p6/m, z19.h
+; CHECK-NEXT:    fcvtzs z17.d, p7/m, z3.h
+; CHECK-NEXT:    fcmgt p3.h, p0/z, z20.h, z30.h
 ; CHECK-NEXT:    fcvtzs z28.d, p2/m, z15.h
 ; CHECK-NEXT:    fcmuo p1.h, p0/z, z11.h, z11.h
-; CHECK-NEXT:    fcmuo p2.h, p0/z, z16.h, z16.h
 ; CHECK-NEXT:    sel z11.d, p5, z29.d, z23.d
-; CHECK-NEXT:    sel z16.d, p3, z29.d, z22.d
+; CHECK-NEXT:    fcmuo p2.h, p0/z, z16.h, z16.h
 ; CHECK-NEXT:    fcmgt p4.h, p0/z, z19.h, z30.h
-; CHECK-NEXT:    fcmgt p3.h, p0/z, z15.h, z30.h
+; CHECK-NEXT:    sel z16.d, p3, z29.d, z22.d
 ; CHECK-NEXT:    mov z26.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    mov z11.d, p2/m, #0 // =0x0
+; CHECK-NEXT:    fcmgt p3.h, p0/z, z15.h, z30.h
 ; CHECK-NEXT:    fcmgt p1.h, p0/z, z13.h, z30.h
-; CHECK-NEXT:    fcmuo p6.h, p0/z, z17.h, z17.h
+; CHECK-NEXT:    mov z11.d, p2/m, #0 // =0x0
 ; CHECK-NEXT:    str z26, [x8, #15, mul vl]
 ; CHECK-NEXT:    sel z26.d, p4, z29.d, z14.d
+; CHECK-NEXT:    fcmuo p6.h, p0/z, z20.h, z20.h
+; CHECK-NEXT:    fcmgt p2.h, p0/z, z3.h, z30.h
 ; CHECK-NEXT:    str z11, [x8, #14, mul vl]
 ; CHECK-NEXT:    mov z28.d, p3/m, z29.d
-; CHECK-NEXT:    fcmgt p2.h, p0/z, z3.h, z30.h
 ; CHECK-NEXT:    fcmuo p4.h, p0/z, z13.h, z13.h
 ; CHECK-NEXT:    fcmuo p3.h, p0/z, z3.h, z3.h
 ; CHECK-NEXT:    sel z3.d, p1, z29.d, z21.d
 ; CHECK-NEXT:    mov z16.d, p6/m, #0 // =0x0
+; CHECK-NEXT:    sel z11.d, p2, z29.d, z17.d
 ; CHECK-NEXT:    fcmgt p12.h, p0/z, z27.h, z30.h
-; CHECK-NEXT:    sel z11.d, p2, z29.d, z20.d
-; CHECK-NEXT:    str z16, [x8, #13, mul vl]
 ; CHECK-NEXT:    mov z3.d, p4/m, #0 // =0x0
+; CHECK-NEXT:    str z16, [x8, #13, mul vl]
 ; CHECK-NEXT:    fcmuo p6.h, p0/z, z15.h, z15.h
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z4.h, z30.h
 ; CHECK-NEXT:    mov z11.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    mov z9.d, p12/m, z29.d
+; CHECK-NEXT:    fcmgt p1.h, p0/z, z4.h, z30.h
 ; CHECK-NEXT:    str z3, [x8, #11, mul vl]
 ; CHECK-NEXT:    fcmuo p5.h, p0/z, z19.h, z19.h
-; CHECK-NEXT:    fcmgt p2.h, p0/z, z5.h, z30.h
+; CHECK-NEXT:    mov z9.d, p12/m, z29.d
 ; CHECK-NEXT:    str z11, [x8, #10, mul vl]
+; CHECK-NEXT:    fcmgt p2.h, p0/z, z5.h, z30.h
 ; CHECK-NEXT:    mov z28.d, p6/m, #0 // =0x0
-; CHECK-NEXT:    sel z3.d, p1, z29.d, z7.d
 ; CHECK-NEXT:    fcmgt p4.h, p0/z, z6.h, z30.h
+; CHECK-NEXT:    sel z3.d, p1, z29.d, z7.d
+; CHECK-NEXT:    mov z26.d, p5/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p3.h, p0/z, z27.h, z27.h
 ; CHECK-NEXT:    str z28, [x8, #12, mul vl]
-; CHECK-NEXT:    mov z26.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    sel z7.d, p2, z29.d, z24.d
 ; CHECK-NEXT:    fcmgt p6.h, p0/z, z31.h, z30.h
-; CHECK-NEXT:    fcmgt p1.h, p0/z, z1.h, z30.h
+; CHECK-NEXT:    sel z7.d, p2, z29.d, z24.d
 ; CHECK-NEXT:    str z26, [x8, #9, mul vl]
 ; CHECK-NEXT:    sel z24.d, p4, z29.d, z25.d
-; CHECK-NEXT:    mov z9.d, p3/m, #0 // =0x0
+; CHECK-NEXT:    fcmgt p1.h, p0/z, z1.h, z30.h
 ; CHECK-NEXT:    fcmuo p5.h, p0/z, z31.h, z31.h
-; CHECK-NEXT:    fcmuo p2.h, p0/z, z6.h, z6.h
+; CHECK-NEXT:    mov z9.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    mov z2.d, p6/m, z29.d
+; CHECK-NEXT:    fcmuo p2.h, p0/z, z6.h, z6.h
+; CHECK-NEXT:    fcmuo p3.h, p0/z, z5.h, z5.h
 ; CHECK-NEXT:    str z9, [x8, #5, mul vl]
 ; CHECK-NEXT:    mov z0.d, p1/m, z29.d
-; CHECK-NEXT:    fcmuo p3.h, p0/z, z5.h, z5.h
-; CHECK-NEXT:    fcmuo p4.h, p0/z, z4.h, z4.h
 ; CHECK-NEXT:    mov z2.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    mov z24.d, p2/m, #0 // =0x0
+; CHECK-NEXT:    fcmuo p4.h, p0/z, z4.h, z4.h
 ; CHECK-NEXT:    fcmuo p0.h, p0/z, z1.h, z1.h
-; CHECK-NEXT:    mov z7.d, p3/m, #0 // =0x0
+; CHECK-NEXT:    mov z24.d, p2/m, #0 // =0x0
 ; CHECK-NEXT:    str z2, [x8, #6, mul vl]
+; CHECK-NEXT:    mov z7.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    mov z3.d, p4/m, #0 // =0x0
 ; CHECK-NEXT:    str z24, [x8, #3, mul vl]
 ; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
@@ -861,12 +859,11 @@ define <vscale x 32 x iXLen> @lrint_v32f32(<vscale x 32 x float> %x) {
 ; CHECK-NEXT:    movprfx z17, z18
 ; CHECK-NEXT:    frintx z17.s, p0/m, z18.s
 ; CHECK-NEXT:    fcmge p6.s, p0/z, z30.s, z29.s
-; CHECK-NEXT:    movprfx z18, z19
-; CHECK-NEXT:    frintx z18.s, p0/m, z19.s
 ; CHECK-NEXT:    uunpkhi z7.d, z7.s
 ; CHECK-NEXT:    mov z31.s, w9
 ; CHECK-NEXT:    mov z2.d, #0x8000000000000000
 ; CHECK-NEXT:    mov z26.d, #0x8000000000000000
+; CHECK-NEXT:    frintx z19.s, p0/m, z19.s
 ; CHECK-NEXT:    uunpklo z6.d, z6.s
 ; CHECK-NEXT:    mov z28.d, #0x8000000000000000
 ; CHECK-NEXT:    fcvtzs z27.d, p3/m, z24.s
@@ -882,7 +879,7 @@ define <vscale x 32 x iXLen> @lrint_v32f32(<vscale x 32 x float> %x) {
 ; CHECK-NEXT:    mov z8.d, #0x8000000000000000
 ; CHECK-NEXT:    frintx z6.s, p0/m, z6.s
 ; CHECK-NEXT:    mov z3.d, #0x7fffffffffffffff
-; CHECK-NEXT:    mov z19.d, #0x8000000000000000
+; CHECK-NEXT:    mov z18.d, #0x8000000000000000
 ; CHECK-NEXT:    fcmge p1.s, p0/z, z0.s, z29.s
 ; CHECK-NEXT:    fcmge p2.s, p0/z, z1.s, z29.s
 ; CHECK-NEXT:    fcmge p4.s, p0/z, z25.s, z29.s
@@ -902,94 +899,94 @@ define <vscale x 32 x iXLen> @lrint_v32f32(<vscale x 32 x float> %x) {
 ; CHECK-NEXT:    fcvtzs z4.d, p3/m, z15.s
 ; CHECK-NEXT:    fcvtzs z16.d, p6/m, z13.s
 ; CHECK-NEXT:    fcmge p1.s, p0/z, z17.s, z29.s
-; CHECK-NEXT:    fcmge p2.s, p0/z, z18.s, z29.s
+; CHECK-NEXT:    fcmge p2.s, p0/z, z19.s, z29.s
 ; CHECK-NEXT:    fcmgt p12.s, p0/z, z30.s, z31.s
 ; CHECK-NEXT:    fcmgt p5.s, p0/z, z15.s, z31.s
-; CHECK-NEXT:    fcmge p3.s, p0/z, z20.s, z29.s
 ; CHECK-NEXT:    fcvtzs z21.d, p1/m, z17.s
-; CHECK-NEXT:    fcvtzs z23.d, p2/m, z18.s
-; CHECK-NEXT:    fcmgt p11.s, p0/z, z13.s, z31.s
+; CHECK-NEXT:    fcmge p3.s, p0/z, z20.s, z29.s
+; CHECK-NEXT:    fcvtzs z23.d, p2/m, z19.s
 ; CHECK-NEXT:    sel z7.d, p12, z3.d, z12.d
+; CHECK-NEXT:    fcmgt p11.s, p0/z, z13.s, z31.s
 ; CHECK-NEXT:    mov z4.d, p5/m, z3.d
 ; CHECK-NEXT:    fcmge p4.s, p0/z, z22.s, z29.s
 ; CHECK-NEXT:    fcvtzs z0.d, p3/m, z20.s
 ; CHECK-NEXT:    fcmge p6.s, p0/z, z5.s, z29.s
-; CHECK-NEXT:    sel z12.d, p11, z3.d, z16.d
 ; CHECK-NEXT:    fcmge p7.s, p0/z, z14.s, z29.s
-; CHECK-NEXT:    fcmuo p1.s, p0/z, z13.s, z13.s
+; CHECK-NEXT:    sel z12.d, p11, z3.d, z16.d
 ; CHECK-NEXT:    fcvtzs z8.d, p4/m, z22.s
+; CHECK-NEXT:    fcmuo p1.s, p0/z, z13.s, z13.s
 ; CHECK-NEXT:    fcmge p2.s, p0/z, z6.s, z29.s
 ; CHECK-NEXT:    mov z29.d, #0x8000000000000000
+; CHECK-NEXT:    fcvtzs z18.d, p7/m, z14.s
 ; CHECK-NEXT:    fcmuo p10.s, p0/z, z15.s, z15.s
 ; CHECK-NEXT:    mov z15.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z19.d, p7/m, z14.s
 ; CHECK-NEXT:    mov z12.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    fcvtzs z29.d, p2/m, z6.s
 ; CHECK-NEXT:    fcmgt p4.s, p0/z, z22.s, z31.s
+; CHECK-NEXT:    fcvtzs z29.d, p2/m, z6.s
+; CHECK-NEXT:    fcmgt p5.s, p0/z, z20.s, z31.s
+; CHECK-NEXT:    str z12, [x8, #8, mul vl]
 ; CHECK-NEXT:    fcvtzs z15.d, p6/m, z5.s
 ; CHECK-NEXT:    mov z4.d, p10/m, #0 // =0x0
-; CHECK-NEXT:    str z12, [x8, #8, mul vl]
-; CHECK-NEXT:    fcmgt p5.s, p0/z, z20.s, z31.s
-; CHECK-NEXT:    fcmgt p3.s, p0/z, z18.s, z31.s
-; CHECK-NEXT:    str z4, [x8, #7, mul vl]
-; CHECK-NEXT:    fcmuo p1.s, p0/z, z22.s, z22.s
+; CHECK-NEXT:    fcmgt p3.s, p0/z, z19.s, z31.s
 ; CHECK-NEXT:    mov z8.d, p4/m, z3.d
-; CHECK-NEXT:    fcmuo p2.s, p0/z, z20.s, z20.s
+; CHECK-NEXT:    fcmuo p1.s, p0/z, z22.s, z22.s
+; CHECK-NEXT:    str z4, [x8, #7, mul vl]
 ; CHECK-NEXT:    mov z0.d, p5/m, z3.d
-; CHECK-NEXT:    fcmuo p6.s, p0/z, z18.s, z18.s
+; CHECK-NEXT:    fcmuo p2.s, p0/z, z20.s, z20.s
+; CHECK-NEXT:    fcmuo p6.s, p0/z, z19.s, z19.s
 ; CHECK-NEXT:    fcmgt p4.s, p0/z, z5.s, z31.s
 ; CHECK-NEXT:    mov z8.d, p1/m, #0 // =0x0
-; CHECK-NEXT:    mov z0.d, p2/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p5.s, p0/z, z5.s, z5.s
 ; CHECK-NEXT:    sel z5.d, p3, z3.d, z23.d
-; CHECK-NEXT:    str z8, [x8, #15, mul vl]
+; CHECK-NEXT:    mov z0.d, p2/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p3.s, p0/z, z6.s, z31.s
-; CHECK-NEXT:    str z0, [x8, #14, mul vl]
+; CHECK-NEXT:    str z8, [x8, #15, mul vl]
 ; CHECK-NEXT:    fcmgt p1.s, p0/z, z17.s, z31.s
+; CHECK-NEXT:    str z0, [x8, #14, mul vl]
 ; CHECK-NEXT:    mov z5.d, p6/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p2.s, p0/z, z14.s, z31.s
-; CHECK-NEXT:    fcmuo p6.s, p0/z, z6.s, z6.s
-; CHECK-NEXT:    sel z6.d, p4, z3.d, z15.d
-; CHECK-NEXT:    str z5, [x8, #13, mul vl]
 ; CHECK-NEXT:    sel z0.d, p3, z3.d, z29.d
-; CHECK-NEXT:    fcmuo p4.s, p0/z, z17.s, z17.s
+; CHECK-NEXT:    fcmuo p6.s, p0/z, z6.s, z6.s
+; CHECK-NEXT:    str z5, [x8, #13, mul vl]
+; CHECK-NEXT:    sel z6.d, p4, z3.d, z15.d
 ; CHECK-NEXT:    sel z5.d, p1, z3.d, z21.d
-; CHECK-NEXT:    sel z29.d, p2, z3.d, z19.d
+; CHECK-NEXT:    fcmuo p4.s, p0/z, z17.s, z17.s
+; CHECK-NEXT:    sel z29.d, p2, z3.d, z18.d
 ; CHECK-NEXT:    mov z6.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    mov z0.d, p6/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p3.s, p0/z, z14.s, z14.s
-; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z6, [x8, #9, mul vl]
+; CHECK-NEXT:    mov z0.d, p6/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p1.s, p0/z, z1.s, z31.s
+; CHECK-NEXT:    str z6, [x8, #9, mul vl]
+; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
 ; CHECK-NEXT:    str z0, [x8, #12, mul vl]
-; CHECK-NEXT:    fcmgt p2.s, p0/z, z24.s, z31.s
 ; CHECK-NEXT:    mov z29.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    str z5, [x8, #11, mul vl]
-; CHECK-NEXT:    fcmgt p4.s, p0/z, z25.s, z31.s
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z30.s, z30.s
 ; CHECK-NEXT:    sel z5.d, p1, z3.d, z26.d
+; CHECK-NEXT:    fcmgt p2.s, p0/z, z24.s, z31.s
 ; CHECK-NEXT:    str z29, [x8, #10, mul vl]
-; CHECK-NEXT:    sel z26.d, p2, z3.d, z27.d
 ; CHECK-NEXT:    ldr z4, [sp] // 16-byte Folded Reload
 ; CHECK-NEXT:    str z11, [x8, #4, mul vl]
+; CHECK-NEXT:    fcmgt p4.s, p0/z, z25.s, z31.s
+; CHECK-NEXT:    fcmuo p3.s, p0/z, z30.s, z30.s
+; CHECK-NEXT:    sel z26.d, p2, z3.d, z27.d
 ; CHECK-NEXT:    fcmgt p6.s, p0/z, z9.s, z31.s
-; CHECK-NEXT:    sel z6.d, p4, z3.d, z28.d
-; CHECK-NEXT:    fcmuo p5.s, p0/z, z9.s, z9.s
-; CHECK-NEXT:    mov z7.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p1.s, p0/z, z4.s, z31.s
+; CHECK-NEXT:    fcmuo p5.s, p0/z, z9.s, z9.s
+; CHECK-NEXT:    sel z6.d, p4, z3.d, z28.d
+; CHECK-NEXT:    mov z7.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p2.s, p0/z, z25.s, z25.s
-; CHECK-NEXT:    fcmuo p3.s, p0/z, z24.s, z24.s
 ; CHECK-NEXT:    sel z0.d, p6, z3.d, z10.d
-; CHECK-NEXT:    str z7, [x8, #5, mul vl]
+; CHECK-NEXT:    fcmuo p3.s, p0/z, z24.s, z24.s
 ; CHECK-NEXT:    fcmuo p4.s, p0/z, z1.s, z1.s
-; CHECK-NEXT:    fcmuo p0.s, p0/z, z4.s, z4.s
 ; CHECK-NEXT:    sel z1.d, p1, z3.d, z2.d
+; CHECK-NEXT:    str z7, [x8, #5, mul vl]
+; CHECK-NEXT:    fcmuo p0.s, p0/z, z4.s, z4.s
 ; CHECK-NEXT:    mov z0.d, p5/m, #0 // =0x0
 ; CHECK-NEXT:    mov z6.d, p2/m, #0 // =0x0
 ; CHECK-NEXT:    mov z26.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
 ; CHECK-NEXT:    str z0, [x8, #6, mul vl]
+; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
 ; CHECK-NEXT:    str z6, [x8, #3, mul vl]
 ; CHECK-NEXT:    str z26, [x8, #2, mul vl]
 ; CHECK-NEXT:    str z5, [x8, #1, mul vl]
@@ -1300,8 +1297,7 @@ define <vscale x 32 x iXLen> @lrint_v32f64(<vscale x 32 x double> %x) {
 ; CHECK-NEXT:    str z10, [sp, #15, mul vl] // 16-byte Folded Spill
 ; CHECK-NEXT:    str z9, [sp, #16, mul vl] // 16-byte Folded Spill
 ; CHECK-NEXT:    str z8, [sp, #17, mul vl] // 16-byte Folded Spill
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    .cfi_escape 0x0f, 0x0a, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x98, 0x01, 0x1e, 0x22 // sp + 16 + 152 * VG
+; CHECK-NEXT:    .cfi_escape 0x0f, 0x0a, 0x8f, 0x10, 0x92, 0x2e, 0x00, 0x11, 0x90, 0x01, 0x1e, 0x22 // sp + 16 + 144 * VG
 ; CHECK-NEXT:    .cfi_offset w29, -16
 ; CHECK-NEXT:    .cfi_escape 0x10, 0x48, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x78, 0x1e, 0x22, 0x40, 0x1c // $d8 @ cfa - 8 * VG - 16
 ; CHECK-NEXT:    .cfi_escape 0x10, 0x49, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x70, 0x1e, 0x22, 0x40, 0x1c // $d9 @ cfa - 16 * VG - 16
@@ -1312,182 +1308,177 @@ define <vscale x 32 x iXLen> @lrint_v32f64(<vscale x 32 x double> %x) {
 ; CHECK-NEXT:    .cfi_escape 0x10, 0x4e, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x48, 0x1e, 0x22, 0x40, 0x1c // $d14 @ cfa - 56 * VG - 16
 ; CHECK-NEXT:    .cfi_escape 0x10, 0x4f, 0x09, 0x92, 0x2e, 0x00, 0x11, 0x40, 0x1e, 0x22, 0x40, 0x1c // $d15 @ cfa - 64 * VG - 16
 ; CHECK-NEXT:    ldr z0, [x0]
-; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    mov x9, #-4332462841530417152 // =0xc3e0000000000000
-; CHECK-NEXT:    mov z25.d, x9
 ; CHECK-NEXT:    ldr z7, [x0, #3, mul vl]
+; CHECK-NEXT:    ptrue p0.d
 ; CHECK-NEXT:    ldr z27, [x0, #4, mul vl]
 ; CHECK-NEXT:    ldr z4, [x0, #2, mul vl]
+; CHECK-NEXT:    mov x9, #-4332462841530417152 // =0xc3e0000000000000
+; CHECK-NEXT:    mov z25.d, x9
 ; CHECK-NEXT:    ldr z2, [x0, #1, mul vl]
-; CHECK-NEXT:    ldr z9, [x0, #15, mul vl]
-; CHECK-NEXT:    movprfx z5, z0
-; CHECK-NEXT:    frintx z5.d, p0/m, z0.d
-; CHECK-NEXT:    mov z0.d, #0x8000000000000000
-; CHECK-NEXT:    ldr z10, [x0, #14, mul vl]
+; CHECK-NEXT:    ldr z29, [x0, #6, mul vl]
+; CHECK-NEXT:    frintx z0.d, p0/m, z0.d
 ; CHECK-NEXT:    frintx z7.d, p0/m, z7.d
+; CHECK-NEXT:    ldr z31, [x0, #7, mul vl]
 ; CHECK-NEXT:    movprfx z14, z27
 ; CHECK-NEXT:    frintx z14.d, p0/m, z27.d
-; CHECK-NEXT:    ldr z11, [x0, #13, mul vl]
 ; CHECK-NEXT:    frintx z4.d, p0/m, z4.d
-; CHECK-NEXT:    ldr z8, [x0, #12, mul vl]
 ; CHECK-NEXT:    ldr z27, [x0, #5, mul vl]
-; CHECK-NEXT:    ldr z18, [x0, #11, mul vl]
-; CHECK-NEXT:    ldr z13, [x0, #10, mul vl]
-; CHECK-NEXT:    ldr z29, [x0, #6, mul vl]
-; CHECK-NEXT:    fcmge p1.d, p0/z, z5.d, z25.d
+; CHECK-NEXT:    ldr z15, [x0, #8, mul vl]
 ; CHECK-NEXT:    mov x9, #4890909195324358655 // =0x43dfffffffffffff
-; CHECK-NEXT:    mov z24.d, #0x8000000000000000
-; CHECK-NEXT:    mov z30.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z28, z27
-; CHECK-NEXT:    frintx z28.d, p0/m, z27.d
-; CHECK-NEXT:    mov z1.d, x9
-; CHECK-NEXT:    fcmge p2.d, p0/z, z7.d, z25.d
-; CHECK-NEXT:    frintx z29.d, p0/m, z29.d
 ; CHECK-NEXT:    movprfx z3, z2
 ; CHECK-NEXT:    frintx z3.d, p0/m, z2.d
-; CHECK-NEXT:    fcmge p3.d, p0/z, z14.d, z25.d
-; CHECK-NEXT:    mov z6.d, #0x8000000000000000
-; CHECK-NEXT:    mov z12.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z0.d, p1/m, z5.d
-; CHECK-NEXT:    frintx z18.d, p0/m, z18.d
 ; CHECK-NEXT:    mov z2.d, #0x8000000000000000
+; CHECK-NEXT:    mov z24.d, #0x8000000000000000
+; CHECK-NEXT:    mov z30.d, #0x8000000000000000
+; CHECK-NEXT:    fcmge p1.d, p0/z, z0.d, z25.d
+; CHECK-NEXT:    movprfx z28, z27
+; CHECK-NEXT:    frintx z28.d, p0/m, z27.d
+; CHECK-NEXT:    frintx z29.d, p0/m, z29.d
+; CHECK-NEXT:    fcmge p2.d, p0/z, z7.d, z25.d
+; CHECK-NEXT:    mov z1.d, x9
+; CHECK-NEXT:    mov z6.d, #0x8000000000000000
+; CHECK-NEXT:    fcmge p3.d, p0/z, z14.d, z25.d
+; CHECK-NEXT:    ldr z11, [x0, #13, mul vl]
+; CHECK-NEXT:    ldr z18, [x0, #11, mul vl]
 ; CHECK-NEXT:    fcmge p5.d, p0/z, z4.d, z25.d
-; CHECK-NEXT:    mov z16.d, #0x8000000000000000
-; CHECK-NEXT:    mov z17.d, #0x8000000000000000
-; CHECK-NEXT:    fcvtzs z24.d, p2/m, z7.d
-; CHECK-NEXT:    frintx z10.d, p0/m, z10.d
-; CHECK-NEXT:    frintx z9.d, p0/m, z9.d
-; CHECK-NEXT:    fcvtzs z30.d, p3/m, z14.d
-; CHECK-NEXT:    frintx z13.d, p0/m, z13.d
-; CHECK-NEXT:    mov z21.d, #0x8000000000000000
-; CHECK-NEXT:    str z0, [sp] // 16-byte Folded Spill
-; CHECK-NEXT:    mov z22.d, #0x8000000000000000
-; CHECK-NEXT:    movprfx z0, z8
-; CHECK-NEXT:    frintx z0.d, p0/m, z8.d
-; CHECK-NEXT:    ldr z31, [x0, #7, mul vl]
-; CHECK-NEXT:    ldr z15, [x0, #8, mul vl]
 ; CHECK-NEXT:    ldr z19, [x0, #9, mul vl]
-; CHECK-NEXT:    fcmge p1.d, p0/z, z28.d, z25.d
-; CHECK-NEXT:    fcvtzs z6.d, p5/m, z4.d
-; CHECK-NEXT:    mov z26.d, #0x8000000000000000
-; CHECK-NEXT:    fcmgt p10.d, p0/z, z14.d, z1.d
-; CHECK-NEXT:    mov z27.d, #0x7fffffffffffffff
-; CHECK-NEXT:    mov z23.d, #0x8000000000000000
 ; CHECK-NEXT:    movprfx z20, z31
 ; CHECK-NEXT:    frintx z20.d, p0/m, z31.d
 ; CHECK-NEXT:    frintx z15.d, p0/m, z15.d
+; CHECK-NEXT:    ldr z9, [x0, #15, mul vl]
+; CHECK-NEXT:    ldr z10, [x0, #14, mul vl]
+; CHECK-NEXT:    fcvtzs z2.d, p1/m, z0.d
+; CHECK-NEXT:    fcvtzs z24.d, p2/m, z7.d
+; CHECK-NEXT:    mov z12.d, #0x8000000000000000
+; CHECK-NEXT:    fcvtzs z30.d, p3/m, z14.d
 ; CHECK-NEXT:    mov z31.d, #0x8000000000000000
+; CHECK-NEXT:    frintx z18.d, p0/m, z18.d
+; CHECK-NEXT:    fcmge p1.d, p0/z, z28.d, z25.d
+; CHECK-NEXT:    mov z5.d, #0x8000000000000000
+; CHECK-NEXT:    ldr z8, [x0, #12, mul vl]
+; CHECK-NEXT:    fcmgt p10.d, p0/z, z14.d, z1.d
+; CHECK-NEXT:    ldr z13, [x0, #10, mul vl]
+; CHECK-NEXT:    fcvtzs z6.d, p5/m, z4.d
 ; CHECK-NEXT:    fcmge p2.d, p0/z, z29.d, z25.d
+; CHECK-NEXT:    mov z16.d, #0x8000000000000000
+; CHECK-NEXT:    mov z17.d, #0x8000000000000000
+; CHECK-NEXT:    frintx z10.d, p0/m, z10.d
+; CHECK-NEXT:    frintx z9.d, p0/m, z9.d
+; CHECK-NEXT:    mov z21.d, #0x8000000000000000
+; CHECK-NEXT:    fcvtzs z12.d, p1/m, z28.d
+; CHECK-NEXT:    frintx z13.d, p0/m, z13.d
+; CHECK-NEXT:    mov z22.d, #0x8000000000000000
+; CHECK-NEXT:    frintx z8.d, p0/m, z8.d
+; CHECK-NEXT:    mov z26.d, #0x8000000000000000
+; CHECK-NEXT:    mov z27.d, #0x7fffffffffffffff
+; CHECK-NEXT:    fcvtzs z31.d, p2/m, z29.d
+; CHECK-NEXT:    mov z23.d, #0x8000000000000000
 ; CHECK-NEXT:    fcmuo p8.d, p0/z, z14.d, z14.d
 ; CHECK-NEXT:    movprfx z14, z19
 ; CHECK-NEXT:    frintx z14.d, p0/m, z19.d
 ; CHECK-NEXT:    movprfx z19, z11
 ; CHECK-NEXT:    frintx z19.d, p0/m, z11.d
-; CHECK-NEXT:    fcmge p4.d, p0/z, z3.d, z25.d
-; CHECK-NEXT:    fcvtzs z12.d, p1/m, z28.d
 ; CHECK-NEXT:    mov z11.d, #0x8000000000000000
 ; CHECK-NEXT:    mov z30.d, p10/m, z27.d
-; CHECK-NEXT:    fcvtzs z31.d, p2/m, z29.d
+; CHECK-NEXT:    fcmge p4.d, p0/z, z3.d, z25.d
 ; CHECK-NEXT:    fcmge p5.d, p0/z, z20.d, z25.d
-; CHECK-NEXT:    fcmge p6.d, p0/z, z15.d, z25.d
-; CHECK-NEXT:    fcvtzs z2.d, p4/m, z3.d
 ; CHECK-NEXT:    mov z30.d, p8/m, #0 // =0x0
+; CHECK-NEXT:    fcmge p6.d, p0/z, z15.d, z25.d
+; CHECK-NEXT:    fcvtzs z5.d, p4/m, z3.d
 ; CHECK-NEXT:    fcmge p1.d, p0/z, z18.d, z25.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z19.d, z25.d
+; CHECK-NEXT:    str z30, [x8, #4, mul vl]
 ; CHECK-NEXT:    fcvtzs z16.d, p5/m, z20.d
+; CHECK-NEXT:    fcmge p2.d, p0/z, z19.d, z25.d
 ; CHECK-NEXT:    fcvtzs z17.d, p6/m, z15.d
-; CHECK-NEXT:    fcmgt p12.d, p0/z, z28.d, z1.d
-; CHECK-NEXT:    fcvtzs z21.d, p1/m, z18.d
-; CHECK-NEXT:    fcvtzs z22.d, p2/m, z19.d
 ; CHECK-NEXT:    fcmgt p5.d, p0/z, z20.d, z1.d
 ; CHECK-NEXT:    fcmge p3.d, p0/z, z10.d, z25.d
+; CHECK-NEXT:    fcvtzs z21.d, p1/m, z18.d
+; CHECK-NEXT:    fcvtzs z22.d, p2/m, z19.d
 ; CHECK-NEXT:    fcmgt p11.d, p0/z, z15.d, z1.d
-; CHECK-NEXT:    sel z8.d, p12, z27.d, z12.d
 ; CHECK-NEXT:    fcmge p4.d, p0/z, z9.d, z25.d
-; CHECK-NEXT:    sel z12.d, p5, z27.d, z16.d
 ; CHECK-NEXT:    fcmge p6.d, p0/z, z14.d, z25.d
 ; CHECK-NEXT:    fcvtzs z23.d, p3/m, z10.d
 ; CHECK-NEXT:    fcmge p7.d, p0/z, z13.d, z25.d
-; CHECK-NEXT:    fcvtzs z26.d, p4/m, z9.d
 ; CHECK-NEXT:    fcmuo p1.d, p0/z, z15.d, z15.d
-; CHECK-NEXT:    sel z15.d, p11, z27.d, z17.d
+; CHECK-NEXT:    sel z15.d, p5, z27.d, z16.d
+; CHECK-NEXT:    sel z16.d, p11, z27.d, z17.d
+; CHECK-NEXT:    fcvtzs z26.d, p4/m, z9.d
 ; CHECK-NEXT:    fcvtzs z11.d, p6/m, z14.d
-; CHECK-NEXT:    fcmge p2.d, p0/z, z0.d, z25.d
+; CHECK-NEXT:    fcmge p2.d, p0/z, z8.d, z25.d
 ; CHECK-NEXT:    mov z25.d, #0x8000000000000000
+; CHECK-NEXT:    mov z16.d, p1/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p4.d, p0/z, z9.d, z1.d
-; CHECK-NEXT:    mov z15.d, p1/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p5.d, p0/z, z10.d, z1.d
+; CHECK-NEXT:    str z16, [x8, #8, mul vl]
+; CHECK-NEXT:    fcvtzs z25.d, p2/m, z8.d
 ; CHECK-NEXT:    fcmgt p3.d, p0/z, z19.d, z1.d
-; CHECK-NEXT:    fcvtzs z25.d, p2/m, z0.d
-; CHECK-NEXT:    str z15, [x8, #8, mul vl]
-; CHECK-NEXT:    mov z26.d, p4/m, z27.d
 ; CHECK-NEXT:    fcmuo p9.d, p0/z, z20.d, z20.d
 ; CHECK-NEXT:    mov z20.d, #0x8000000000000000
+; CHECK-NEXT:    mov z26.d, p4/m, z27.d
 ; CHECK-NEXT:    fcmuo p1.d, p0/z, z9.d, z9.d
 ; CHECK-NEXT:    sel z9.d, p5, z27.d, z23.d
 ; CHECK-NEXT:    fcmuo p2.d, p0/z, z10.d, z10.d
 ; CHECK-NEXT:    sel z10.d, p3, z27.d, z22.d
-; CHECK-NEXT:    fcmuo p6.d, p0/z, z19.d, z19.d
 ; CHECK-NEXT:    fcvtzs z20.d, p7/m, z13.d
-; CHECK-NEXT:    mov z12.d, p9/m, #0 // =0x0
+; CHECK-NEXT:    mov z15.d, p9/m, #0 // =0x0
 ; CHECK-NEXT:    mov z26.d, p1/m, #0 // =0x0
 ; CHECK-NEXT:    mov z9.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    str z12, [x8, #7, mul vl]
-; CHECK-NEXT:    mov z10.d, p6/m, #0 // =0x0
 ; CHECK-NEXT:    fcmgt p4.d, p0/z, z14.d, z1.d
+; CHECK-NEXT:    str z15, [x8, #7, mul vl]
+; CHECK-NEXT:    fcmgt p3.d, p0/z, z8.d, z1.d
 ; CHECK-NEXT:    str z26, [x8, #15, mul vl]
-; CHECK-NEXT:    fcmgt p3.d, p0/z, z0.d, z1.d
+; CHECK-NEXT:    fcmuo p6.d, p0/z, z19.d, z19.d
 ; CHECK-NEXT:    str z9, [x8, #14, mul vl]
 ; CHECK-NEXT:    fcmgt p1.d, p0/z, z18.d, z1.d
-; CHECK-NEXT:    str z10, [x8, #13, mul vl]
 ; CHECK-NEXT:    fcmgt p2.d, p0/z, z13.d, z1.d
-; CHECK-NEXT:    fcmuo p5.d, p0/z, z14.d, z14.d
-; CHECK-NEXT:    fcmuo p6.d, p0/z, z0.d, z0.d
-; CHECK-NEXT:    sel z0.d, p4, z27.d, z11.d
+; CHECK-NEXT:    sel z26.d, p4, z27.d, z11.d
 ; CHECK-NEXT:    mov z25.d, p3/m, z27.d
-; CHECK-NEXT:    sel z26.d, p1, z27.d, z21.d
-; CHECK-NEXT:    sel z9.d, p2, z27.d, z20.d
 ; CHECK-NEXT:    fcmuo p4.d, p0/z, z18.d, z18.d
-; CHECK-NEXT:    mov z0.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    mov z25.d, p6/m, #0 // =0x0
+; CHECK-NEXT:    mov z10.d, p6/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p3.d, p0/z, z13.d, z13.d
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z3.d, z1.d
-; CHECK-NEXT:    str z0, [x8, #9, mul vl]
-; CHECK-NEXT:    mov z26.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z25, [x8, #12, mul vl]
-; CHECK-NEXT:    fcmgt p2.d, p0/z, z4.d, z1.d
+; CHECK-NEXT:    sel z9.d, p2, z27.d, z20.d
+; CHECK-NEXT:    fcmgt p12.d, p0/z, z28.d, z1.d
+; CHECK-NEXT:    str z10, [x8, #13, mul vl]
+; CHECK-NEXT:    fcmuo p6.d, p0/z, z8.d, z8.d
+; CHECK-NEXT:    sel z8.d, p1, z27.d, z21.d
 ; CHECK-NEXT:    mov z9.d, p3/m, #0 // =0x0
-; CHECK-NEXT:    fcmgt p4.d, p0/z, z7.d, z1.d
-; CHECK-NEXT:    str z26, [x8, #11, mul vl]
-; CHECK-NEXT:    mov z2.d, p1/m, z27.d
-; CHECK-NEXT:    fcmuo p3.d, p0/z, z28.d, z28.d
-; CHECK-NEXT:    fcmgt p6.d, p0/z, z29.d, z1.d
+; CHECK-NEXT:    fcmgt p1.d, p0/z, z3.d, z1.d
+; CHECK-NEXT:    fcmuo p5.d, p0/z, z14.d, z14.d
+; CHECK-NEXT:    mov z8.d, p4/m, #0 // =0x0
+; CHECK-NEXT:    mov z12.d, p12/m, z27.d
 ; CHECK-NEXT:    str z9, [x8, #10, mul vl]
+; CHECK-NEXT:    mov z25.d, p6/m, #0 // =0x0
+; CHECK-NEXT:    fcmgt p2.d, p0/z, z4.d, z1.d
+; CHECK-NEXT:    str z8, [x8, #11, mul vl]
+; CHECK-NEXT:    mov z5.d, p1/m, z27.d
+; CHECK-NEXT:    fcmgt p4.d, p0/z, z7.d, z1.d
+; CHECK-NEXT:    str z25, [x8, #12, mul vl]
+; CHECK-NEXT:    mov z26.d, p5/m, #0 // =0x0
+; CHECK-NEXT:    fcmuo p3.d, p0/z, z28.d, z28.d
 ; CHECK-NEXT:    mov z6.d, p2/m, z27.d
-; CHECK-NEXT:    fcmgt p1.d, p0/z, z5.d, z1.d
-; CHECK-NEXT:    ldr z1, [sp] // 16-byte Folded Reload
-; CHECK-NEXT:    str z30, [x8, #4, mul vl]
+; CHECK-NEXT:    fcmgt p6.d, p0/z, z29.d, z1.d
+; CHECK-NEXT:    str z26, [x8, #9, mul vl]
+; CHECK-NEXT:    fcmgt p1.d, p0/z, z0.d, z1.d
+; CHECK-NEXT:    mov z24.d, p4/m, z27.d
+; CHECK-NEXT:    mov z12.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p5.d, p0/z, z29.d, z29.d
-; CHECK-NEXT:    sel z0.d, p4, z27.d, z24.d
-; CHECK-NEXT:    mov z8.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    fcmuo p2.d, p0/z, z7.d, z7.d
 ; CHECK-NEXT:    sel z25.d, p6, z27.d, z31.d
-; CHECK-NEXT:    mov z1.d, p1/m, z27.d
+; CHECK-NEXT:    str z12, [x8, #5, mul vl]
 ; CHECK-NEXT:    fcmuo p3.d, p0/z, z4.d, z4.d
-; CHECK-NEXT:    str z8, [x8, #5, mul vl]
 ; CHECK-NEXT:    fcmuo p4.d, p0/z, z3.d, z3.d
 ; CHECK-NEXT:    mov z25.d, p5/m, #0 // =0x0
-; CHECK-NEXT:    mov z0.d, p2/m, #0 // =0x0
-; CHECK-NEXT:    fcmuo p0.d, p0/z, z5.d, z5.d
+; CHECK-NEXT:    fcmuo p0.d, p0/z, z0.d, z0.d
+; CHECK-NEXT:    sel z0.d, p1, z27.d, z2.d
+; CHECK-NEXT:    mov z24.d, p2/m, #0 // =0x0
 ; CHECK-NEXT:    mov z6.d, p3/m, #0 // =0x0
 ; CHECK-NEXT:    str z25, [x8, #6, mul vl]
-; CHECK-NEXT:    mov z2.d, p4/m, #0 // =0x0
-; CHECK-NEXT:    str z0, [x8, #3, mul vl]
-; CHECK-NEXT:    mov z1.d, p0/m, #0 // =0x0
+; CHECK-NEXT:    mov z5.d, p4/m, #0 // =0x0
+; CHECK-NEXT:    str z24, [x8, #3, mul vl]
+; CHECK-NEXT:    mov z0.d, p0/m, #0 // =0x0
 ; CHECK-NEXT:    str z6, [x8, #2, mul vl]
-; CHECK-NEXT:    str z2, [x8, #1, mul vl]
-; CHECK-NEXT:    str z1, [x8]
-; CHECK-NEXT:    addvl sp, sp, #1
+; CHECK-NEXT:    str z5, [x8, #1, mul vl]
+; CHECK-NEXT:    str z0, [x8]
 ; CHECK-NEXT:    ldr z23, [sp, #2, mul vl] // 16-byte Folded Reload
 ; CHECK-NEXT:    ldr z22, [sp, #3, mul vl] // 16-byte Folded Reload
 ; CHECK-NEXT:    ldr z21, [sp, #4, mul vl] // 16-byte Folded Reload

--- a/llvm/test/CodeGen/AArch64/sve-streaming-mode-fixed-length-fp-extend-trunc.ll
+++ b/llvm/test/CodeGen/AArch64/sve-streaming-mode-fixed-length-fp-extend-trunc.ll
@@ -591,21 +591,18 @@ define void @fcvt_v16f16_v16f64(ptr %a, ptr %b) {
 ; CHECK-NEXT:    mov x8, #6 // =0x6
 ; CHECK-NEXT:    fcvt z1.d, p0/m, z1.h
 ; CHECK-NEXT:    ld1h { z5.d }, p0/z, [x0, x8, lsl #1]
-; CHECK-NEXT:    fcvt z2.d, p0/m, z2.h
 ; CHECK-NEXT:    mov x8, #2 // =0x2
-; CHECK-NEXT:    fcvt z3.d, p0/m, z3.h
+; CHECK-NEXT:    fcvt z2.d, p0/m, z2.h
 ; CHECK-NEXT:    ld1h { z7.d }, p0/z, [x0, x8, lsl #1]
+; CHECK-NEXT:    fcvt z3.d, p0/m, z3.h
+; CHECK-NEXT:    fcvt z6.d, p0/m, z6.h
 ; CHECK-NEXT:    fcvt z4.d, p0/m, z4.h
+; CHECK-NEXT:    fcvt z5.d, p0/m, z5.h
 ; CHECK-NEXT:    stp q0, q1, [x1, #96]
-; CHECK-NEXT:    movprfx z0, z5
-; CHECK-NEXT:    fcvt z0.d, p0/m, z5.h
-; CHECK-NEXT:    movprfx z1, z6
-; CHECK-NEXT:    fcvt z1.d, p0/m, z6.h
+; CHECK-NEXT:    fcvt z7.d, p0/m, z7.h
 ; CHECK-NEXT:    stp q2, q3, [x1, #64]
-; CHECK-NEXT:    movprfx z2, z7
-; CHECK-NEXT:    fcvt z2.d, p0/m, z7.h
-; CHECK-NEXT:    stp q4, q0, [x1, #32]
-; CHECK-NEXT:    stp q1, q2, [x1]
+; CHECK-NEXT:    stp q4, q5, [x1, #32]
+; CHECK-NEXT:    stp q6, q7, [x1]
 ; CHECK-NEXT:    ret
 ;
 ; NONEON-NOSVE-LABEL: fcvt_v16f16_v16f64:

--- a/llvm/test/CodeGen/AArch64/sve-streaming-mode-fixed-length-fp-to-int.ll
+++ b/llvm/test/CodeGen/AArch64/sve-streaming-mode-fixed-length-fp-to-int.ll
@@ -603,47 +603,45 @@ define void @fcvtzu_v16f16_v16i64(ptr %a, ptr %b) {
 ; CHECK-NEXT:    mov z2.h, z1.h[1]
 ; CHECK-NEXT:    mov z3.h, z0.h[3]
 ; CHECK-NEXT:    mov z4.h, z0.h[2]
-; CHECK-NEXT:    movprfx z5, z1
-; CHECK-NEXT:    ext z5.b, z5.b, z1.b, #8
 ; CHECK-NEXT:    movprfx z7, z1
 ; CHECK-NEXT:    fcvtzu z7.d, p0/m, z1.h
+; CHECK-NEXT:    movprfx z5, z1
+; CHECK-NEXT:    ext z5.b, z5.b, z1.b, #8
+; CHECK-NEXT:    movprfx z6, z0
+; CHECK-NEXT:    ext z6.b, z6.b, z0.b, #8
 ; CHECK-NEXT:    mov z16.h, z1.h[3]
 ; CHECK-NEXT:    mov z1.h, z1.h[2]
 ; CHECK-NEXT:    mov z17.h, z0.h[1]
-; CHECK-NEXT:    movprfx z6, z0
-; CHECK-NEXT:    ext z6.b, z6.b, z0.b, #8
 ; CHECK-NEXT:    fcvtzu z2.d, p0/m, z2.h
 ; CHECK-NEXT:    fcvtzu z3.d, p0/m, z3.h
 ; CHECK-NEXT:    fcvtzu z4.d, p0/m, z4.h
 ; CHECK-NEXT:    fcvtzu z0.d, p0/m, z0.h
-; CHECK-NEXT:    fcvtzu z16.d, p0/m, z16.h
 ; CHECK-NEXT:    mov z18.h, z5.h[3]
-; CHECK-NEXT:    fcvtzu z17.d, p0/m, z17.h
-; CHECK-NEXT:    fcvtzu z1.d, p0/m, z1.h
 ; CHECK-NEXT:    mov z19.h, z6.h[3]
 ; CHECK-NEXT:    mov z20.h, z6.h[2]
+; CHECK-NEXT:    fcvtzu z17.d, p0/m, z17.h
 ; CHECK-NEXT:    mov z21.h, z6.h[1]
+; CHECK-NEXT:    fcvtzu z16.d, p0/m, z16.h
+; CHECK-NEXT:    fcvtzu z1.d, p0/m, z1.h
 ; CHECK-NEXT:    fcvtzu z6.d, p0/m, z6.h
 ; CHECK-NEXT:    zip1 z2.d, z7.d, z2.d
 ; CHECK-NEXT:    mov z7.h, z5.h[2]
 ; CHECK-NEXT:    zip1 z3.d, z4.d, z3.d
 ; CHECK-NEXT:    mov z4.h, z5.h[1]
 ; CHECK-NEXT:    fcvtzu z19.d, p0/m, z19.h
-; CHECK-NEXT:    fcvtzu z5.d, p0/m, z5.h
 ; CHECK-NEXT:    fcvtzu z20.d, p0/m, z20.h
-; CHECK-NEXT:    zip1 z0.d, z0.d, z17.d
-; CHECK-NEXT:    movprfx z17, z21
-; CHECK-NEXT:    fcvtzu z17.d, p0/m, z21.h
-; CHECK-NEXT:    zip1 z1.d, z1.d, z16.d
-; CHECK-NEXT:    movprfx z16, z18
-; CHECK-NEXT:    fcvtzu z16.d, p0/m, z18.h
+; CHECK-NEXT:    fcvtzu z21.d, p0/m, z21.h
+; CHECK-NEXT:    fcvtzu z18.d, p0/m, z18.h
+; CHECK-NEXT:    fcvtzu z5.d, p0/m, z5.h
 ; CHECK-NEXT:    fcvtzu z7.d, p0/m, z7.h
+; CHECK-NEXT:    zip1 z0.d, z0.d, z17.d
+; CHECK-NEXT:    zip1 z1.d, z1.d, z16.d
 ; CHECK-NEXT:    fcvtzu z4.d, p0/m, z4.h
+; CHECK-NEXT:    stp q2, q1, [x1]
 ; CHECK-NEXT:    stp q0, q3, [x1, #64]
 ; CHECK-NEXT:    zip1 z0.d, z20.d, z19.d
-; CHECK-NEXT:    zip1 z3.d, z6.d, z17.d
-; CHECK-NEXT:    stp q2, q1, [x1]
-; CHECK-NEXT:    zip1 z1.d, z7.d, z16.d
+; CHECK-NEXT:    zip1 z3.d, z6.d, z21.d
+; CHECK-NEXT:    zip1 z1.d, z7.d, z18.d
 ; CHECK-NEXT:    zip1 z2.d, z5.d, z4.d
 ; CHECK-NEXT:    stp q3, q0, [x1, #96]
 ; CHECK-NEXT:    stp q2, q1, [x1, #32]
@@ -2306,47 +2304,45 @@ define void @fcvtzs_v16f16_v16i64(ptr %a, ptr %b) {
 ; CHECK-NEXT:    mov z2.h, z1.h[1]
 ; CHECK-NEXT:    mov z3.h, z0.h[3]
 ; CHECK-NEXT:    mov z4.h, z0.h[2]
-; CHECK-NEXT:    movprfx z5, z1
-; CHECK-NEXT:    ext z5.b, z5.b, z1.b, #8
 ; CHECK-NEXT:    movprfx z7, z1
 ; CHECK-NEXT:    fcvtzs z7.d, p0/m, z1.h
+; CHECK-NEXT:    movprfx z5, z1
+; CHECK-NEXT:    ext z5.b, z5.b, z1.b, #8
+; CHECK-NEXT:    movprfx z6, z0
+; CHECK-NEXT:    ext z6.b, z6.b, z0.b, #8
 ; CHECK-NEXT:    mov z16.h, z1.h[3]
 ; CHECK-NEXT:    mov z1.h, z1.h[2]
 ; CHECK-NEXT:    mov z17.h, z0.h[1]
-; CHECK-NEXT:    movprfx z6, z0
-; CHECK-NEXT:    ext z6.b, z6.b, z0.b, #8
 ; CHECK-NEXT:    fcvtzs z2.d, p0/m, z2.h
 ; CHECK-NEXT:    fcvtzs z3.d, p0/m, z3.h
 ; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.h
 ; CHECK-NEXT:    fcvtzs z0.d, p0/m, z0.h
-; CHECK-NEXT:    fcvtzs z16.d, p0/m, z16.h
 ; CHECK-NEXT:    mov z18.h, z5.h[3]
-; CHECK-NEXT:    fcvtzs z17.d, p0/m, z17.h
-; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.h
 ; CHECK-NEXT:    mov z19.h, z6.h[3]
 ; CHECK-NEXT:    mov z20.h, z6.h[2]
+; CHECK-NEXT:    fcvtzs z17.d, p0/m, z17.h
 ; CHECK-NEXT:    mov z21.h, z6.h[1]
+; CHECK-NEXT:    fcvtzs z16.d, p0/m, z16.h
+; CHECK-NEXT:    fcvtzs z1.d, p0/m, z1.h
 ; CHECK-NEXT:    fcvtzs z6.d, p0/m, z6.h
 ; CHECK-NEXT:    zip1 z2.d, z7.d, z2.d
 ; CHECK-NEXT:    mov z7.h, z5.h[2]
 ; CHECK-NEXT:    zip1 z3.d, z4.d, z3.d
 ; CHECK-NEXT:    mov z4.h, z5.h[1]
 ; CHECK-NEXT:    fcvtzs z19.d, p0/m, z19.h
-; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.h
 ; CHECK-NEXT:    fcvtzs z20.d, p0/m, z20.h
-; CHECK-NEXT:    zip1 z0.d, z0.d, z17.d
-; CHECK-NEXT:    movprfx z17, z21
-; CHECK-NEXT:    fcvtzs z17.d, p0/m, z21.h
-; CHECK-NEXT:    zip1 z1.d, z1.d, z16.d
-; CHECK-NEXT:    movprfx z16, z18
-; CHECK-NEXT:    fcvtzs z16.d, p0/m, z18.h
+; CHECK-NEXT:    fcvtzs z21.d, p0/m, z21.h
+; CHECK-NEXT:    fcvtzs z18.d, p0/m, z18.h
+; CHECK-NEXT:    fcvtzs z5.d, p0/m, z5.h
 ; CHECK-NEXT:    fcvtzs z7.d, p0/m, z7.h
+; CHECK-NEXT:    zip1 z0.d, z0.d, z17.d
+; CHECK-NEXT:    zip1 z1.d, z1.d, z16.d
 ; CHECK-NEXT:    fcvtzs z4.d, p0/m, z4.h
+; CHECK-NEXT:    stp q2, q1, [x1]
 ; CHECK-NEXT:    stp q0, q3, [x1, #64]
 ; CHECK-NEXT:    zip1 z0.d, z20.d, z19.d
-; CHECK-NEXT:    zip1 z3.d, z6.d, z17.d
-; CHECK-NEXT:    stp q2, q1, [x1]
-; CHECK-NEXT:    zip1 z1.d, z7.d, z16.d
+; CHECK-NEXT:    zip1 z3.d, z6.d, z21.d
+; CHECK-NEXT:    zip1 z1.d, z7.d, z18.d
 ; CHECK-NEXT:    zip1 z2.d, z5.d, z4.d
 ; CHECK-NEXT:    stp q3, q0, [x1, #96]
 ; CHECK-NEXT:    stp q2, q1, [x1, #32]

--- a/llvm/test/CodeGen/AArch64/sve-streaming-mode-fixed-length-int-to-fp.ll
+++ b/llvm/test/CodeGen/AArch64/sve-streaming-mode-fixed-length-int-to-fp.ll
@@ -551,41 +551,39 @@ define void @ucvtf_v16i16_v16f64(ptr %a, ptr %b) {
 ; CHECK-NEXT:    ptrue p0.d, vl2
 ; CHECK-NEXT:    movprfx z2, z0
 ; CHECK-NEXT:    ext z2.b, z2.b, z0.b, #8
-; CHECK-NEXT:    uunpklo z0.s, z0.h
 ; CHECK-NEXT:    uunpklo z3.s, z1.h
 ; CHECK-NEXT:    ext z1.b, z1.b, z1.b, #8
+; CHECK-NEXT:    uunpklo z0.s, z0.h
 ; CHECK-NEXT:    uunpklo z2.s, z2.h
-; CHECK-NEXT:    movprfx z4, z0
-; CHECK-NEXT:    ext z4.b, z4.b, z0.b, #8
 ; CHECK-NEXT:    uunpklo z1.s, z1.h
 ; CHECK-NEXT:    movprfx z5, z3
 ; CHECK-NEXT:    ext z5.b, z5.b, z3.b, #8
-; CHECK-NEXT:    uunpklo z0.d, z0.s
 ; CHECK-NEXT:    uunpklo z3.d, z3.s
-; CHECK-NEXT:    uunpklo z4.d, z4.s
-; CHECK-NEXT:    uunpklo z5.d, z5.s
+; CHECK-NEXT:    movprfx z4, z0
+; CHECK-NEXT:    ext z4.b, z4.b, z0.b, #8
+; CHECK-NEXT:    uunpklo z0.d, z0.s
 ; CHECK-NEXT:    movprfx z6, z2
 ; CHECK-NEXT:    ext z6.b, z6.b, z2.b, #8
 ; CHECK-NEXT:    movprfx z7, z1
 ; CHECK-NEXT:    ext z7.b, z7.b, z1.b, #8
+; CHECK-NEXT:    uunpklo z5.d, z5.s
+; CHECK-NEXT:    uunpklo z4.d, z4.s
 ; CHECK-NEXT:    uunpklo z2.d, z2.s
 ; CHECK-NEXT:    uunpklo z1.d, z1.s
 ; CHECK-NEXT:    ucvtf z0.d, p0/m, z0.d
 ; CHECK-NEXT:    ucvtf z3.d, p0/m, z3.d
 ; CHECK-NEXT:    uunpklo z6.d, z6.s
-; CHECK-NEXT:    ucvtf z4.d, p0/m, z4.d
 ; CHECK-NEXT:    uunpklo z7.d, z7.s
 ; CHECK-NEXT:    ucvtf z5.d, p0/m, z5.d
+; CHECK-NEXT:    ucvtf z4.d, p0/m, z4.d
 ; CHECK-NEXT:    ucvtf z2.d, p0/m, z2.d
 ; CHECK-NEXT:    ucvtf z1.d, p0/m, z1.d
+; CHECK-NEXT:    ucvtf z6.d, p0/m, z6.d
+; CHECK-NEXT:    ucvtf z7.d, p0/m, z7.d
 ; CHECK-NEXT:    stp q3, q5, [x1]
-; CHECK-NEXT:    movprfx z3, z7
-; CHECK-NEXT:    ucvtf z3.d, p0/m, z7.d
 ; CHECK-NEXT:    stp q0, q4, [x1, #64]
-; CHECK-NEXT:    movprfx z0, z6
-; CHECK-NEXT:    ucvtf z0.d, p0/m, z6.d
-; CHECK-NEXT:    stp q1, q3, [x1, #32]
-; CHECK-NEXT:    stp q2, q0, [x1, #96]
+; CHECK-NEXT:    stp q1, q7, [x1, #32]
+; CHECK-NEXT:    stp q2, q6, [x1, #96]
 ; CHECK-NEXT:    ret
 ;
 ; NONEON-NOSVE-LABEL: ucvtf_v16i16_v16f64:
@@ -1192,14 +1190,12 @@ define <8 x half> @ucvtf_v8i64_v8f16(ptr %a) {
 ; CHECK-NEXT:    splice z1.s, p0, z1.s, z0.s
 ; CHECK-NEXT:    splice z2.s, p0, z2.s, z3.s
 ; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    movprfx z0, z1
-; CHECK-NEXT:    fcvt z0.h, p0/m, z1.s
-; CHECK-NEXT:    movprfx z1, z2
-; CHECK-NEXT:    fcvt z1.h, p0/m, z2.s
+; CHECK-NEXT:    fcvt z1.h, p0/m, z1.s
+; CHECK-NEXT:    fcvt z2.h, p0/m, z2.s
 ; CHECK-NEXT:    ptrue p0.h, vl4
-; CHECK-NEXT:    uzp1 z2.h, z0.h, z0.h
-; CHECK-NEXT:    uzp1 z0.h, z1.h, z1.h
-; CHECK-NEXT:    splice z0.h, p0, z0.h, z2.h
+; CHECK-NEXT:    uzp1 z1.h, z1.h, z1.h
+; CHECK-NEXT:    uzp1 z0.h, z2.h, z2.h
+; CHECK-NEXT:    splice z0.h, p0, z0.h, z1.h
 ; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
 ; CHECK-NEXT:    ret
 ;
@@ -1952,41 +1948,39 @@ define void @scvtf_v16i16_v16f64(ptr %a, ptr %b) {
 ; CHECK-NEXT:    ptrue p0.d, vl2
 ; CHECK-NEXT:    movprfx z2, z0
 ; CHECK-NEXT:    ext z2.b, z2.b, z0.b, #8
-; CHECK-NEXT:    sunpklo z0.s, z0.h
 ; CHECK-NEXT:    sunpklo z3.s, z1.h
 ; CHECK-NEXT:    ext z1.b, z1.b, z1.b, #8
+; CHECK-NEXT:    sunpklo z0.s, z0.h
 ; CHECK-NEXT:    sunpklo z2.s, z2.h
-; CHECK-NEXT:    movprfx z4, z0
-; CHECK-NEXT:    ext z4.b, z4.b, z0.b, #8
 ; CHECK-NEXT:    sunpklo z1.s, z1.h
 ; CHECK-NEXT:    movprfx z5, z3
 ; CHECK-NEXT:    ext z5.b, z5.b, z3.b, #8
-; CHECK-NEXT:    sunpklo z0.d, z0.s
 ; CHECK-NEXT:    sunpklo z3.d, z3.s
-; CHECK-NEXT:    sunpklo z4.d, z4.s
-; CHECK-NEXT:    sunpklo z5.d, z5.s
+; CHECK-NEXT:    movprfx z4, z0
+; CHECK-NEXT:    ext z4.b, z4.b, z0.b, #8
+; CHECK-NEXT:    sunpklo z0.d, z0.s
 ; CHECK-NEXT:    movprfx z6, z2
 ; CHECK-NEXT:    ext z6.b, z6.b, z2.b, #8
 ; CHECK-NEXT:    movprfx z7, z1
 ; CHECK-NEXT:    ext z7.b, z7.b, z1.b, #8
+; CHECK-NEXT:    sunpklo z5.d, z5.s
+; CHECK-NEXT:    sunpklo z4.d, z4.s
 ; CHECK-NEXT:    sunpklo z2.d, z2.s
 ; CHECK-NEXT:    sunpklo z1.d, z1.s
 ; CHECK-NEXT:    scvtf z0.d, p0/m, z0.d
 ; CHECK-NEXT:    scvtf z3.d, p0/m, z3.d
 ; CHECK-NEXT:    sunpklo z6.d, z6.s
-; CHECK-NEXT:    scvtf z4.d, p0/m, z4.d
 ; CHECK-NEXT:    sunpklo z7.d, z7.s
 ; CHECK-NEXT:    scvtf z5.d, p0/m, z5.d
+; CHECK-NEXT:    scvtf z4.d, p0/m, z4.d
 ; CHECK-NEXT:    scvtf z2.d, p0/m, z2.d
 ; CHECK-NEXT:    scvtf z1.d, p0/m, z1.d
+; CHECK-NEXT:    scvtf z6.d, p0/m, z6.d
+; CHECK-NEXT:    scvtf z7.d, p0/m, z7.d
 ; CHECK-NEXT:    stp q3, q5, [x1]
-; CHECK-NEXT:    movprfx z3, z7
-; CHECK-NEXT:    scvtf z3.d, p0/m, z7.d
 ; CHECK-NEXT:    stp q0, q4, [x1, #64]
-; CHECK-NEXT:    movprfx z0, z6
-; CHECK-NEXT:    scvtf z0.d, p0/m, z6.d
-; CHECK-NEXT:    stp q1, q3, [x1, #32]
-; CHECK-NEXT:    stp q2, q0, [x1, #96]
+; CHECK-NEXT:    stp q1, q7, [x1, #32]
+; CHECK-NEXT:    stp q2, q6, [x1, #96]
 ; CHECK-NEXT:    ret
 ;
 ; NONEON-NOSVE-LABEL: scvtf_v16i16_v16f64:
@@ -2413,32 +2407,29 @@ define void @scvtf_v16i32_v16f64(ptr %a, ptr %b) {
 ; CHECK-NEXT:    movprfx z4, z1
 ; CHECK-NEXT:    ext z4.b, z4.b, z1.b, #8
 ; CHECK-NEXT:    sunpklo z0.d, z0.s
-; CHECK-NEXT:    sunpklo z1.d, z1.s
 ; CHECK-NEXT:    movprfx z6, z3
 ; CHECK-NEXT:    ext z6.b, z6.b, z3.b, #8
 ; CHECK-NEXT:    movprfx z7, z5
 ; CHECK-NEXT:    ext z7.b, z7.b, z5.b, #8
+; CHECK-NEXT:    sunpklo z1.d, z1.s
 ; CHECK-NEXT:    sunpklo z3.d, z3.s
 ; CHECK-NEXT:    sunpklo z5.d, z5.s
 ; CHECK-NEXT:    sunpklo z2.d, z2.s
 ; CHECK-NEXT:    sunpklo z4.d, z4.s
-; CHECK-NEXT:    scvtf z0.d, p0/m, z0.d
 ; CHECK-NEXT:    sunpklo z6.d, z6.s
 ; CHECK-NEXT:    sunpklo z7.d, z7.s
+; CHECK-NEXT:    scvtf z0.d, p0/m, z0.d
 ; CHECK-NEXT:    scvtf z1.d, p0/m, z1.d
 ; CHECK-NEXT:    scvtf z3.d, p0/m, z3.d
+; CHECK-NEXT:    scvtf z5.d, p0/m, z5.d
 ; CHECK-NEXT:    scvtf z2.d, p0/m, z2.d
 ; CHECK-NEXT:    scvtf z4.d, p0/m, z4.d
+; CHECK-NEXT:    scvtf z6.d, p0/m, z6.d
+; CHECK-NEXT:    scvtf z7.d, p0/m, z7.d
 ; CHECK-NEXT:    stp q1, q4, [x1, #64]
-; CHECK-NEXT:    movprfx z1, z5
-; CHECK-NEXT:    scvtf z1.d, p0/m, z5.d
+; CHECK-NEXT:    stp q5, q7, [x1]
+; CHECK-NEXT:    stp q3, q6, [x1, #32]
 ; CHECK-NEXT:    stp q0, q2, [x1, #96]
-; CHECK-NEXT:    movprfx z0, z6
-; CHECK-NEXT:    scvtf z0.d, p0/m, z6.d
-; CHECK-NEXT:    movprfx z2, z7
-; CHECK-NEXT:    scvtf z2.d, p0/m, z7.d
-; CHECK-NEXT:    stp q1, q2, [x1]
-; CHECK-NEXT:    stp q3, q0, [x1, #32]
 ; CHECK-NEXT:    ret
 ;
 ; NONEON-NOSVE-LABEL: scvtf_v16i32_v16f64:


### PR DESCRIPTION
Extend the hints added in #166926 to unary pseudos with undef inactive lanes.

If there's a reason I'm missing for not setting FalseLanesUndef on unary pseudos, please let me know and I'll attempt to do this a different way.