### PR TITLE
[ThinLTO][COFF] Pass loop and slp vectorize options to LTO backend

### DIFF
--- a/lld/COFF/LTO.cpp
+++ b/lld/COFF/LTO.cpp
@@ -101,6 +101,10 @@ lto::Config BitcodeCompiler::createConfig() {
     checkError(c.addSaveTemps(std::string(ctx.config.outputFile) + ".",
                               /*UseInputModulePath*/ true,
                               ctx.config.saveTempsArgs));
+
+  c.PTO.LoopVectorization = c.OptLevel > 1;
+  c.PTO.SLPVectorization = c.OptLevel > 1;
+
   return c;
 }
 

--- a/lld/test/COFF/lto-slp-vectorize-pm.ll
+++ b/lld/test/COFF/lto-slp-vectorize-pm.ll
@@ -1,0 +1,48 @@
+; REQUIRES: x86
+; RUN: opt -module-summary %s -o %t.obj
+
+; Test SLP and Loop Vectorization are enabled by default at O2 and O3.
+; RUN: lld-link -opt:lldlto=0 -dll -noentry -opt:ltodebugpassmanager -lldsavetemps -out:%t1.dll %t.obj 2>&1 | FileCheck %s --check-prefix=CHECK-O0-SLP
+; RUN: llvm-dis %t.obj.4.opt.bc -o - | FileCheck %s --check-prefix=CHECK-O0-LPV
+
+; RUN: lld-link -opt:lldlto=1 -dll -noentry -opt:ltodebugpassmanager -lldsavetemps -out:%t2.dll %t.obj 2>&1 | FileCheck %s --check-prefix=CHECK-O1-SLP
+; RUN: llvm-dis %t.obj.4.opt.bc -o - | FileCheck %s --check-prefix=CHECK-O1-LPV
+
+; RUN: lld-link -opt:lldlto=2 -dll -noentry -opt:ltodebugpassmanager -lldsavetemps -out:%t3.dll %t.obj 2>&1 | FileCheck %s --check-prefix=CHECK-O2-SLP
+; RUN: llvm-dis %t.obj.4.opt.bc -o - | FileCheck %s --check-prefix=CHECK-O2-LPV
+
+; RUN: lld-link -opt:lldlto=3 -dll -noentry -opt:ltodebugpassmanager -lldsavetemps -out:%t4.dll %t.obj 2>&1 | FileCheck %s --check-prefix=CHECK-O3-SLP
+; RUN: llvm-dis %t.obj.4.opt.bc -o - | FileCheck %s --check-prefix=CHECK-O3-LPV
+
+; CHECK-O0-SLP-NOT: Running pass: SLPVectorizerPass
+; CHECK-O1-SLP-NOT: Running pass: SLPVectorizerPass
+; CHECK-O2-SLP: Running pass: SLPVectorizerPass
+; CHECK-O3-SLP: Running pass: SLPVectorizerPass
+; CHECK-O0-LPV-NOT: = !{!"llvm.loop.isvectorized", i32 1}
+; CHECK-O1-LPV-NOT: = !{!"llvm.loop.isvectorized", i32 1}
+; CHECK-O2-LPV: = !{!"llvm.loop.isvectorized", i32 1}
+; CHECK-O3-LPV: = !{!"llvm.loop.isvectorized", i32 1}
+
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-windows-msvc"
+
+define dllexport i32 @foo(ptr %a) {
+entry:
+  br label %for.body
+
+for.body:
+  %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.body ]
+  %red.05 = phi i32 [ 0, %entry ], [ %add, %for.body ]
+  %arrayidx = getelementptr inbounds i32, ptr %a, i64 %indvars.iv
+  %0 = load i32, ptr %arrayidx, align 4
+  %add = add nsw i32 %0, %red.05
+  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
+  %exitcond = icmp eq i64 %indvars.iv.next, 255
+  br i1 %exitcond, label %for.end, label %for.body, !llvm.loop !0
+
+for.end:
+  ret i32 %add
+}
+
+!0 = distinct !{!0, !1}
+!1 = !{!"llvm.loop.unroll.disable", i1 true}


### PR DESCRIPTION
Commit 21a4710c67 added this for ELF, this patch does the same for COFF. The differences in codegen were noticed whilst testing DTLTO for COFF.