### PR TITLE
[lldb][RISCV] update RISCV target features in expressions

### DIFF
--- a/lldb/include/lldb/Utility/ArchSpec.h
+++ b/lldb/include/lldb/Utility/ArchSpec.h
@@ -14,6 +14,7 @@
 #include "lldb/lldb-forward.h"
 #include "lldb/lldb-private-enumerations.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/TargetParser/SubtargetFeature.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cstddef>
 #include <cstdint>
@@ -542,6 +543,14 @@ public:
 
   void SetFlags(const std::string &elf_abi);
 
+  const llvm::SubtargetFeatures &GetSubtargetFeatures() const {
+    return m_subtarget_features;
+  }
+
+  void SetSubtargetFeatures(llvm::SubtargetFeatures &&subtarget_features) {
+    m_subtarget_features = std::move(subtarget_features);
+  }
+
 protected:
   void UpdateCore();
 
@@ -552,6 +561,8 @@ protected:
   // Additional arch flags which we cannot get from triple and core For MIPS
   // these are application specific extensions like micromips, mips16 etc.
   uint32_t m_flags = 0;
+
+  llvm::SubtargetFeatures m_subtarget_features;
 
   // Called when m_def or m_entry are changed.  Fills in all remaining members
   // with default values.

--- a/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
+++ b/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
@@ -1590,23 +1590,28 @@ DisassemblerLLVMC::DisassemblerLLVMC(const ArchSpec &arch,
   }
 
   if (triple.isRISCV() && !cpu_or_features_overriden) {
-    uint32_t arch_flags = arch.GetFlags();
-    if (arch_flags & ArchSpec::eRISCV_rvc)
-      features_str += "+c,";
-    if (arch_flags & ArchSpec::eRISCV_rve)
-      features_str += "+e,";
-    if ((arch_flags & ArchSpec::eRISCV_float_abi_single) ==
-        ArchSpec::eRISCV_float_abi_single)
-      features_str += "+f,";
-    if ((arch_flags & ArchSpec::eRISCV_float_abi_double) ==
-        ArchSpec::eRISCV_float_abi_double)
-      features_str += "+f,+d,";
-    if ((arch_flags & ArchSpec::eRISCV_float_abi_quad) ==
-        ArchSpec::eRISCV_float_abi_quad)
-      features_str += "+f,+d,+q,";
-    // FIXME: how do we detect features such as `+a`, `+m`?
-    // Turn them on by default now, since everyone seems to use them
-    features_str += "+a,+m,";
+    auto subtarget_features = arch.GetSubtargetFeatures().getString();
+    if (!subtarget_features.empty()) {
+      features_str += subtarget_features;
+    } else {
+      uint32_t arch_flags = arch.GetFlags();
+      if (arch_flags & ArchSpec::eRISCV_rvc)
+        features_str += "+c,";
+      if (arch_flags & ArchSpec::eRISCV_rve)
+        features_str += "+e,";
+      if ((arch_flags & ArchSpec::eRISCV_float_abi_single) ==
+          ArchSpec::eRISCV_float_abi_single)
+        features_str += "+f,";
+      if ((arch_flags & ArchSpec::eRISCV_float_abi_double) ==
+          ArchSpec::eRISCV_float_abi_double)
+        features_str += "+f,+d,";
+      if ((arch_flags & ArchSpec::eRISCV_float_abi_quad) ==
+          ArchSpec::eRISCV_float_abi_quad)
+        features_str += "+f,+d,+q,";
+      // FIXME: how do we detect features such as `+a`, `+m`?
+      // Turn them on by default now, since everyone seems to use them
+      features_str += "+a,+m,";
+    }
   }
 
   // We use m_disasm_up.get() to tell whether we are valid or not, so if this

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -499,6 +499,12 @@ static void SetupTargetOpts(CompilerInstance &compiler,
     compiler.getTargetOpts().FeaturesAsWritten.push_back("+sse2");
   }
 
+  if (target_machine == llvm::Triple::riscv32 ||
+      target_machine == llvm::Triple::riscv64) {
+    llvm::copy(target_arch.GetSubtargetFeatures().getFeatures(),
+               std::back_inserter(compiler.getTargetOpts().FeaturesAsWritten));
+  }
+
   // Set the target CPU to generate code for. This will be empty for any CPU
   // that doesn't really need to make a special
   // CPU string.

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -275,6 +275,10 @@ private:
                                  uint64_t length,
                                  lldb_private::ArchSpec &arch_spec);
 
+  static void ParseRISCVAttributes(lldb_private::DataExtractor &data,
+                                   uint64_t length,
+                                   lldb_private::ArchSpec &arch_spec);
+
   /// Parses the elf section headers and returns the uuid, debug link name,
   /// crc, archspec.
   static size_t GetSectionHeaderInfo(SectionHeaderColl &section_headers,

--- a/lldb/test/API/riscv/disassembler/Makefile
+++ b/lldb/test/API/riscv/disassembler/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/riscv/disassembler/TestDisassembler.py
+++ b/lldb/test/API/riscv/disassembler/TestDisassembler.py
@@ -1,0 +1,71 @@
+"""
+Tests that LLDB can correctly set up a disassembler using extensions from the .riscv.attributes section.
+"""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestDisassembler(TestBase):
+    expected_zbb_instrs = ["andn", "orn", "xnor", "rol", "ror", "ret"]
+
+    def _get_llvm_tool(self, tool):
+        clang = self.getCompiler()
+        bindir = os.path.dirname(clang)
+        candidate = os.path.join(bindir, tool)
+        if os.path.exists(candidate):
+            return candidate
+        return lldbutil.which(tool)
+
+    def _strip_riscv_attributes(self):
+        """
+        Strips the .riscv.attributes section.
+        """
+        exe = self.getBuildArtifact("a.out")
+        stripped = self.getBuildArtifact("stripped.out")
+
+        objcopy_path = self._get_llvm_tool("llvm-objcopy")
+        self.assertTrue(objcopy_path, "llvm-objcopy not found")
+
+        out = subprocess.run(
+            [objcopy_path, "--remove-section=.riscv.attributes", exe, stripped],
+            check=True,
+        )
+
+        return os.path.basename(stripped)
+
+    @skipIf(archs=no_match("^riscv.*"))
+    def test_without_riscv_attributes(self):
+        """
+        Tests disassembly of a riscv binary without the .riscv.attributes.
+        Without the .riscv.attributes section lldb won't set up a disassembler to
+        handle the bitmanip extension, so it is not expected to see zbb instructions
+        in the output.
+        """
+        self.build(dictionary={"CFLAGS_EXTRAS": "-march=rv64gc_zbb"})
+        stripped_exe = self._strip_riscv_attributes()
+
+        lldbutil.run_to_name_breakpoint(self, "main", exe_name=stripped_exe)
+
+        self.expect("disassemble --name do_zbb_stuff")
+        output = self.res.GetOutput()
+
+        for instr in self.expected_zbb_instrs:
+            self.assertFalse(instr in output, "Zbb instructions should not be disassembled")
+
+    @skipIf(archs=no_match("^riscv.*"))
+    def test_with_riscv_attributes(self):
+        """
+        Tests disassembly of a riscv binary with the .riscv.attributes.
+        """
+        self.build(dictionary={"CFLAGS_EXTRAS": "-march=rv64gc_zbb"})
+
+        lldbutil.run_to_name_breakpoint(self, "main")
+
+        self.expect("disassemble --name do_zbb_stuff")
+        output = self.res.GetOutput()
+
+        for instr in self.expected_zbb_instrs:
+            self.assertTrue(instr in output, "Invalid disassembler output")

--- a/lldb/test/API/riscv/disassembler/main.cpp
+++ b/lldb/test/API/riscv/disassembler/main.cpp
@@ -1,0 +1,12 @@
+void do_zbb_stuff() {
+  asm volatile("andn a2, a0, a1\n"
+               "orn a2, a0, a1\n"
+               "xnor a2, a0, a1\n"
+               "rol a2, a0, a1\n"
+               "ror a2, a0, a1\n");
+}
+
+int main() {
+  do_zbb_stuff();
+  return 0;
+}


### PR DESCRIPTION
This patch updates CompilerInstance initialization to use SubtargetFeatures from ArchSpec.