### PR TITLE
[NFC][LLVM][AArch64] Simplify `checkPartialMappingIdx`

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64GenRegisterBankInfo.def
+++ b/llvm/lib/Target/AArch64/AArch64GenRegisterBankInfo.def
@@ -155,12 +155,7 @@ bool AArch64GenRegisterBankInfo::checkPartialMappingIdx(
     return false;
 
   PartialMappingIdx Previous = Order.front();
-  bool First = true;
-  for (const auto &Current : Order) {
-    if (First) {
-      First = false;
-      continue;
-    }
+  for (const auto &Current : Order.drop_front()) {
     if (Previous + 1 != Current)
       return false;
     Previous = Current;


### PR DESCRIPTION
Remove `First` check by skipping iterating over first element.