### PR TITLE
[clang] Only propagate AtStartOfLine when expanding token stream and hit the end of TokenLexer

### DIFF
--- a/clang/lib/Lex/TokenLexer.cpp
+++ b/clang/lib/Lex/TokenLexer.cpp
@@ -632,7 +632,7 @@ bool TokenLexer::Lex(Token &Tok) {
     //
     // The 'extern' token should has 'StartOfLine' flag when current TokenLexer
     // exits and propagate line start/leading space info.
-    if (isLexingCXXModuleDirective()) {
+    if (!Macro && isLexingCXXModuleDirective()) {
       AtStartOfLine = true;
       setLexingCXXModuleDirective(false);
     }


### PR DESCRIPTION
This patch fix a bug introduced by https://github.com/llvm/llvm-project/pull/107168.

Consider the following code:
```c
#define str(s) # s 
#define xstr(s) str(s) 
#define INCFILE(n) vers ## n 

include xstr(INCFILE(2).h) 
```

The period has an unexpected `AtStartOfLine` flag when it's lexed from `TokenLexer`, after phase 4, we expected `include "vers2.h"`, but got `include "vers2 .h"`, an unexpected whitespace occurred before `.`.

We only need to propagate `AtStartOfLine` flag when current `TokenLexer` expanding an token stream.

No new test added because this issue was covered by `clang/test/Preprocessor/c99-6_10_3_4_p6.c`.