### PR TITLE
[MC][WebAssembly] Add parameter to set table address type

### DIFF
--- a/lld/test/wasm/table-addrtype.s
+++ b/lld/test/wasm/table-addrtype.s
@@ -1,0 +1,41 @@
+# RUN: llvm-mc -filetype=obj -mattr=+reference-types -triple=wasm32-unknown-unknown %s -o %t.o
+# RUN: wasm-ld --no-entry -o %t.wasm %t.o
+# RUN: obj2yaml %t.wasm | FileCheck %s  -check-prefix=CHECK -dump-input=always
+
+# RUN: llvm-mc -filetype=obj -mattr=+reference-types -triple=wasm64-unknown-unknown %s -o %t.o
+# RUN: wasm-ld --no-entry -mwasm64 -o %t.wasm %t.o
+# RUN: obj2yaml %t.wasm | FileCheck %s  -check-prefix=CHECK -dump-input=always
+
+#      CHECK:  - Type:            TABLE
+# CHECK-NEXT:    Tables:
+# CHECK-NEXT:      - Index:           0
+# CHECK-NEXT:        ElemType:        EXTERNREF
+# CHECK-NEXT:        Limits:
+# CHECK-NEXT:          Minimum:         0x0
+	.tabletype table_i32, externref, i32
+table_i32:
+
+# CHECK-NEXT:      - Index:           1
+# CHECK-NEXT:        ElemType:        EXTERNREF
+# CHECK-NEXT:        Limits:
+# CHECK-NEXT:          Flags:         [ IS_64 ]
+# CHECK-NEXT:          Minimum:         0x0
+	.tabletype table_i64, externref, i64
+table_i64:
+
+	.globl	table_i32_get
+table_i32_get:
+    .functype table_i32_get (i32) -> (externref)
+    local.get 0
+    table.get table_i32
+    end_function
+
+	.globl	table_i64_get
+table_i64_get:
+    .functype table_i64_get (i64) -> (externref)
+    local.get 0
+    table.get table_i64
+    end_function
+
+    .export_name	table_i32_get, table_i32_get
+    .export_name	table_i64_get, table_i64_get

--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
@@ -958,7 +958,7 @@ public:
     }
 
     if (DirectiveID.getString() == ".tabletype") {
-      // .tabletype SYM, ELEMTYPE[, ADDR_TYPE[, MINSIZE[, MAXSIZE]]]
+      // .tabletype SYM, ELEMTYPE[, ADDR_TYPE][, MINSIZE[, MAXSIZE]]
       auto SymName = expectIdent();
       if (SymName.empty())
         return ParseStatus::Failure;
@@ -980,9 +980,15 @@ public:
         Limits.Flags |= wasm::WASM_LIMITS_FLAG_IS_64;
       }
 
+      // Address type is an optinal parameter with more optional parameters
+      // following.
       auto NextTok = Lexer.peekTok();
 
+      // Check if the next parameter is an address type by checking the token
+      // type.
       if (Lexer.is(AsmToken::Comma) && !NextTok.is(AsmToken::Integer)) {
+        // After confirming the next parameter is the address type,
+        // we can consume the tokens.
         auto AddrType = Lexer.Lex().getString();
         Parser.Lex();
 

--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
@@ -997,9 +997,10 @@ public:
         else if (AddrType == "i64")
           Limits.Flags |= wasm::WASM_LIMITS_FLAG_IS_64;
         else
-          return error(std::string(
-              "Expected address type or integer constant, instead got: ",
-              Lexer.getTok()));
+          return error(
+              std::string(
+                  "Expected address type or integer constant, instead got: "),
+              Lexer.getTok());
         ;
       }
 

--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.h
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmTypeCheck.h
@@ -79,7 +79,8 @@ class WebAssemblyAsmTypeCheck final {
                  const MCSymbolRefExpr *&SymRef);
   bool getGlobal(SMLoc ErrorLoc, const MCOperand &GlobalOp,
                  wasm::ValType &Type);
-  bool getTable(SMLoc ErrorLoc, const MCOperand &TableOp, wasm::ValType &Type);
+  bool getTable(SMLoc ErrorLoc, const MCOperand &TableOp, wasm::ValType &Type,
+                wasm::ValType &AddrType);
   bool getSignature(SMLoc ErrorLoc, const MCOperand &SigOp,
                     wasm::WasmSymbolType Type, const wasm::WasmSignature *&Sig);
   bool checkTryTable(SMLoc ErrorLoc, const MCInst &Inst);

--- a/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyTargetStreamer.cpp
+++ b/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyTargetStreamer.cpp
@@ -78,6 +78,10 @@ void WebAssemblyTargetAsmStreamer::emitTableType(const MCSymbolWasm *Sym) {
   const wasm::WasmTableType &Type = Sym->getTableType();
   OS << "\t.tabletype\t" << Sym->getName() << ", "
      << WebAssembly::typeToString(static_cast<wasm::ValType>(Type.ElemType));
+  if (Type.Limits.Flags & wasm::WASM_LIMITS_FLAG_IS_64)
+    OS << ", i64";
+  else
+    OS << ", i32";
   bool HasMaximum = Type.Limits.Flags & wasm::WASM_LIMITS_FLAG_HAS_MAX;
   if (Type.Limits.Minimum != 0 || HasMaximum) {
     OS << ", " << Type.Limits.Minimum;

--- a/llvm/test/CodeGen/WebAssembly/funcref-call.ll
+++ b/llvm/test/CodeGen/WebAssembly/funcref-call.ll
@@ -3,7 +3,7 @@
 
 %funcref = type ptr addrspace(20) ;; addrspace 20 is nonintegral
 
-; CHECK: .tabletype __funcref_call_table, funcref, 1
+; CHECK: .tabletype __funcref_call_table, funcref, i32, 1
 
 define void @call_funcref(%funcref %ref) {
 ; CHECK-LABEL: call_funcref:

--- a/llvm/test/CodeGen/WebAssembly/funcref-table_call.ll
+++ b/llvm/test/CodeGen/WebAssembly/funcref-table_call.ll
@@ -4,7 +4,7 @@
 
 @funcref_table = local_unnamed_addr addrspace(1) global [0 x %funcref] undef
 
-;  CHECK: .tabletype  __funcref_call_table, funcref, 1
+;  CHECK: .tabletype  __funcref_call_table, funcref, i32, 1
 
 declare %funcref @llvm.wasm.table.get.funcref(ptr addrspace(1), i32) nounwind
 

--- a/llvm/test/MC/WebAssembly/tabletype-invalid.s
+++ b/llvm/test/MC/WebAssembly/tabletype-invalid.s
@@ -18,7 +18,7 @@
 # CHECK: [[#@LINE+1]]:17: error: Unknown type in .tabletype directive: i42
 .tabletype sym, i42
 
-# CHECK: [[#@LINE+1]]:21: error: Expected integer constant, instead got:
+# CHECK: [[#@LINE+2]]:1: error: Expected address type or integer constant, instead got:
 .tabletype sym, i32,
 
 # CHECK: [[#@LINE+1]]:25: error: Expected integer constant, instead got:

--- a/llvm/test/MC/WebAssembly/type-checker-errors.s
+++ b/llvm/test/MC/WebAssembly/type-checker-errors.s
@@ -874,7 +874,6 @@ br_incorrect_func_signature:
 
 multiple_errors_in_function:
   .functype multiple_errors_in_function () -> ()
-# CHECK: :[[@LINE+2]]:3: error: type mismatch, expected [i32] but got []
 # CHECK: :[[@LINE+1]]:13: error: expected expression operand
   table.get 1
 


### PR DESCRIPTION
This adds an extra optional parameters to `.tabletype` to set the tables address type.

Unfortunately, to not break any existing code, I had to add an optional parameter that can be skipped in favor of subsequent optional parameters. This is a bit messed up, so I'm all ears for alternatives.

Fixes: https://github.com/llvm/llvm-project/issues/172907