### PR TITLE
[BOLT] Add Dockerfile for testing

### DIFF
--- a/bolt/utils/docker-tests/Dockerfile
+++ b/bolt/utils/docker-tests/Dockerfile
@@ -1,0 +1,49 @@
+FROM docker.io/library/ubuntu:24.04 AS builder
+
+# Install perf as it is missing from 24.04 packages:
+# https://bugs.launchpad.net/ubuntu/+source/linux-hwe-6.14/+bug/2117147
+
+ARG PERF_VER=6.17
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+    ca-certificates wget xz-utils \
+    libtraceevent-dev libtracefs-dev \
+    build-essential flex bison \
+    libelf-dev libdw-dev zlib1g-dev liblzma-dev libcap-dev libnuma-dev \
+    python3 python3-dev python3-setuptools \
+    pkg-config; \
+  rm -rf /var/lib/apt/lists/*; \
+  wget -O /tmp/perf.tar.xz "https://mirrors.edge.kernel.org/pub/linux/kernel/tools/perf/v${PERF_VER}.0/perf-${PERF_VER}.0.tar.xz"; \
+  mkdir -p /src && tar -C /src -xf /tmp/perf.tar.xz; \
+  cd "/src/perf-${PERF_VER}.0"; \
+  make -C tools/perf -j"$(nproc)"; \
+  install -m 0755 tools/perf/perf /usr/local/bin/perf; \
+  /usr/local/bin/perf --version >&2
+
+# Install tools for BOLT compilation.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates git \
+      build-essential cmake ninja-build python3 zstd ccache \
+      python3-psutil && \
+    rm -rf /var/lib/apt/lists
+
+WORKDIR /home/bolt
+
+# Get sources, compile BOLT, and run test suites.
+RUN git clone --depth 1 https://github.com/llvm/llvm-project
+RUN git clone --depth 1 https://github.com/rafaelauler/bolt-tests
+
+RUN mkdir build && \
+    cd build && \
+    cmake -G Ninja ../llvm-project/llvm \
+      -DLLVM_ENABLE_PROJECTS="bolt;clang;lld" \
+      -DLLVM_TARGETS_TO_BUILD="AArch64;X86" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DLLVM_CCACHE_BUILD=ON \
+      -DLLVM_ENABLE_ASSERTIONS=ON \
+      -DLLVM_EXTERNAL_PROJECTS="bolttests" \
+      -DLLVM_EXTERNAL_BOLTTESTS_SOURCE_DIR=../bolt-tests
+
+RUN cd build && ninja check-bolt
+RUN cd build && ninja check-large-bolt

--- a/bolt/utils/docker-tests/Dockerfile
+++ b/bolt/utils/docker-tests/Dockerfile
@@ -1,20 +1,30 @@
 FROM docker.io/library/ubuntu:24.04 AS builder
 
-# Install perf as it is missing from 24.04 packages:
+# Perf package dropped for a range of Ubuntu releases, so we build it manually.
+# See Ubuntu bug tracker:
 # https://bugs.launchpad.net/ubuntu/+source/linux-hwe-6.14/+bug/2117147
 
+# Download perf version 6.17 to guarantee it has all code we need to cover
+# AArch64 SPE and BRBE support. Can drop once perf is available in Ubuntu again
+# and sufficiently recent.
 ARG PERF_VER=6.17
+ARG PERF_SHA256="ee55669e1a580015925cf586d148f65aa4390213ba5d8377260a13878bc54c5c"
+
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends ca-certificates wget; \
+  wget -O /tmp/perf.tar.xz "https://mirrors.edge.kernel.org/pub/linux/kernel/tools/perf/v${PERF_VER}.0/perf-${PERF_VER}.0.tar.xz"; \
+  echo "${PERF_SHA256} /tmp/perf.tar.xz" | sha256sum -c -;
+
+# Compile perf.
 RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
-    ca-certificates wget xz-utils \
-    libtraceevent-dev libtracefs-dev \
+    xz-utils libtraceevent-dev libtracefs-dev \
     build-essential flex bison \
     libelf-dev libdw-dev zlib1g-dev liblzma-dev libcap-dev libnuma-dev \
     python3 python3-dev python3-setuptools \
     pkg-config; \
-  rm -rf /var/lib/apt/lists/*; \
-  wget -O /tmp/perf.tar.xz "https://mirrors.edge.kernel.org/pub/linux/kernel/tools/perf/v${PERF_VER}.0/perf-${PERF_VER}.0.tar.xz"; \
   mkdir -p /src && tar -C /src -xf /tmp/perf.tar.xz; \
   cd "/src/perf-${PERF_VER}.0"; \
   make -C tools/perf -j"$(nproc)"; \
@@ -23,7 +33,7 @@ RUN set -eux; \
 
 # Install tools for BOLT compilation.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates git \
+    apt-get install -y --no-install-recommends git \
       build-essential cmake ninja-build python3 zstd ccache \
       python3-psutil && \
     rm -rf /var/lib/apt/lists


### PR DESCRIPTION
Add utils/docker-tests/Dockerfile to facilitate in-tre and out-of-tree testing.

Builds perf from source to work around an Ubuntu 24.04 issue.

To reproduce a specific issue adjust the Dockerfile like:
```
RUN git clone https://github.com/llvm/llvm-project
RUN cd llvm-project && git checkout <SHA>
```