### PR TITLE
[Flang][OpenMP] Fix crash on invalid atomic variable expressions

### DIFF
--- a/flang/lib/Semantics/check-omp-atomic.cpp
+++ b/flang/lib/Semantics/check-omp-atomic.cpp
@@ -587,8 +587,18 @@ void OmpStructureChecker::CheckAtomicVariable(
   }
 
   std::vector<SomeExpr> dsgs{GetAllDesignators(atom)};
-  assert(dsgs.size() == 1 && "Should have a single top-level designator");
+
+  // Procedure references are valid if they return a pointer to a scalar.
+  // Just return if we don't have exactly one designator - other checks will
+  // diagnose any actual errors.
+  if (dsgs.size() != 1) {
+    return;
+  }
+
   evaluate::SymbolVector syms{evaluate::GetSymbolVector(dsgs.front())};
+  if (syms.empty()) {
+    return;
+  }
 
   CheckAtomicType(syms.back(), source, atom.AsFortran(), checkTypeOnPointer);
 

--- a/flang/test/Semantics/OpenMP/atomic-invalid-variable.f90
+++ b/flang/test/Semantics/OpenMP/atomic-invalid-variable.f90
@@ -1,0 +1,32 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp
+! Test for issue #169484: Flang should not crash on invalid atomic variables
+! This test verifies that proper diagnostics are emitted for invalid atomic
+! constructs instead of crashing the compiler.
+
+subroutine test_atomic_invalid(a, b, i)
+  integer :: i, a, b
+  interface
+    function baz(i) result(res)
+      integer :: i, res
+    end function
+  end interface
+  
+  ! Valid atomic update - should work fine
+  !$omp atomic
+    b = b + a
+  
+  ! Invalid: z is undeclared, so z(1) is treated as a function reference
+  ! This should emit an error, not crash
+  !$omp atomic
+    !ERROR: Left-hand side of assignment is not definable
+    !ERROR: 'z(1_4)' is not a variable or pointer
+    z(1) = z(1) + 1
+  
+  ! Invalid: baz(i) is a function reference, not a variable
+  ! This should emit an error, not crash
+  !$omp atomic
+    !ERROR: Left-hand side of assignment is not definable
+    !ERROR: 'baz(i)' is not a variable or pointer
+    !ERROR: This is not a valid ATOMIC UPDATE operation
+    baz(i) = 1
+end subroutine


### PR DESCRIPTION
Fixes #169484

The compiler crashed with an assertion failure when processing OpenMP ATOMIC constructs containing invalid variable expressions like function references or undeclared variables.

## Root Cause: 
`CheckAtomicVariable()` assumed `GetAllDesignators()` always returns exactly one designator, but it returns an empty vector for function references.

## Fix: 
Replaced the assertion with proper validation that emits diagnostic errors instead of crashing.

## Testing: 
Added regression test [atomic-invalid-variable.f90]

<img width="733" height="303" alt="image" src="https://github.com/user-attachments/assets/1dead98a-4012-45a6-8233-2ac0b0678906" />
