### PR TITLE
AMDGPU: cleanup promote-alloca-user-mult.ll test

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-user-mult.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-user-mult.ll
@@ -7,8 +7,7 @@
 
 %struct.barney = type { i8, double }
 
-; Function Attrs: nofree norecurse noreturn nounwind memory(readwrite, target_mem0: none, target_mem1: none)
-define amdgpu_kernel void @zot() local_unnamed_addr #0 {
+define amdgpu_kernel void @zot() {
 ; CHECK-LABEL: @zot(
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[TMP0:%.*]] = call noalias nonnull dereferenceable(64) ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
@@ -64,7 +63,4 @@ bb2:                                              ; preds = %bb2, %bb
   br label %bb2
 }
 
-declare ptr @hoge() local_unnamed_addr #1
-
-attributes #0 = { nofree norecurse noreturn nounwind memory(readwrite, target_mem0: none, target_mem1: none) "amdgpu-agpr-alloc"="0" "amdgpu-no-cluster-id-x" "amdgpu-no-cluster-id-y" "amdgpu-no-cluster-id-z" "amdgpu-no-completion-action" "amdgpu-no-default-queue" "amdgpu-no-dispatch-id" "amdgpu-no-dispatch-ptr" "amdgpu-no-flat-scratch-init" "amdgpu-no-heap-ptr" "amdgpu-no-hostcall-ptr" "amdgpu-no-implicitarg-ptr" "amdgpu-no-lds-kernel-id" "amdgpu-no-multigrid-sync-arg" "amdgpu-no-queue-ptr" "amdgpu-no-workgroup-id-x" "amdgpu-no-workgroup-id-y" "amdgpu-no-workgroup-id-z" "amdgpu-no-workitem-id-x" "amdgpu-no-workitem-id-y" "amdgpu-no-workitem-id-z" "uniform-work-group-size"="false" }
-attributes #1 = { "uniform-work-group-size"="false" }
+declare ptr @hoge()


### PR DESCRIPTION
Remove unnecessary attributes in test case as requested in post-merge feedback (#172771).