### PR TITLE
Revert "[llvm][clang] Enable IO sandbox for assert builds"

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -704,7 +704,7 @@ else()
   option(LLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
 endif()
 
-option(LLVM_ENABLE_IO_SANDBOX "Enable IO sandboxing in supported tools" ${LLVM_ENABLE_ASSERTIONS})
+option(LLVM_ENABLE_IO_SANDBOX "Enable IO sandboxing in supported tools" OFF)
 option(LLVM_ENABLE_EXPENSIVE_CHECKS "Enable expensive checks" OFF)
 
 set(LLVM_ABI_BREAKING_CHECKS "WITH_ASSERTS" CACHE STRING


### PR DESCRIPTION
Reverts llvm/llvm-project#171935.

The sandbox infrastructure was (incorrectly) only implemented for `clang -cc1` jobs created by the driver in llvm/llvm-project#165350. Direct `clang -cc1` invocations had the sandbox disabled. This reduced the coverage of our test suite and lead to sandbox violations for people using asserts-enabled Clang.

This PR temporarily disables the sandbox for asserts builds, so that we have time to investigate and fix sandbox violations for direct `clang -cc1` commands and re-enable for asserts builds at a later time.