### PR TITLE
[HLSL] Improve `packoffset` error message

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13333,7 +13333,10 @@ def warn_hlsl_packoffset_mix : Warning<"cannot mix packoffset elements with nonp
     InGroup<HLSLMixPackOffset>;
 def err_hlsl_packoffset_overlap : Error<"packoffset overlap between %0, %1">;
 def err_hlsl_packoffset_cross_reg_boundary : Error<"packoffset cannot cross register boundary">;
-def err_hlsl_packoffset_alignment_mismatch : Error<"packoffset at 'y' not match alignment %0 required by %1">;
+def err_hlsl_invalid_register_or_packoffset
+    : Error<"register or packoffset bind is not valid">;
+def err_hlsl_packoffset_alignment_mismatch
+    : Error<"packoffset at 'y' does not match alignment %0 required by %1">;
 def err_hlsl_pointers_unsupported : Error<
   "%select{pointers|references}0 are unsupported in HLSL">;
 def err_hlsl_missing_resource_class : Error<"HLSL resource needs to have [[hlsl::resource_class()]] attribute">;

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -1943,8 +1943,8 @@ void SemaHLSL::handlePackOffsetAttr(Decl *D, const ParsedAttr &AL) {
   // Check Component is valid for T.
   if (Component) {
     unsigned Size = getASTContext().getTypeSize(T);
-    if (IsAggregateTy || Size > 128) {
-      Diag(AL.getLoc(), diag::err_hlsl_packoffset_cross_reg_boundary);
+    if (IsAggregateTy) {
+      Diag(AL.getLoc(), diag::err_hlsl_invalid_register_or_packoffset);
       return;
     } else {
       // Make sure Component + sizeof(T) <= 4.

--- a/clang/test/SemaHLSL/packoffset-invalid.hlsl
+++ b/clang/test/SemaHLSL/packoffset-invalid.hlsl
@@ -48,14 +48,14 @@ struct ST {
 
 cbuffer Aggregate
 {
-    // expected-error@+1{{packoffset cannot cross register boundary}}
+    // expected-error@+1{{register or packoffset bind is not valid}}
     ST A1 : packoffset(c0.y);
-    // expected-error@+1{{packoffset cannot cross register boundary}}
+    // expected-error@+1{{register or packoffset bind is not valid}}
     float A2[2] : packoffset(c1.w);
 }
 
 cbuffer Double {
-    // expected-error@+1{{packoffset at 'y' not match alignment 64 required by 'double'}}
+    // expected-error@+1{{packoffset at 'y' does not match alignment 64 required by 'double'}}
     double d : packoffset(c.y);
     // expected-error@+1{{packoffset cannot cross register boundary}}
 	double2 d2 : packoffset(c.z);


### PR DESCRIPTION
Aggregate types cannot have a component specified on a `packoffset` annotation (i.e. `packoffset(c1.y)`). If the component is preset and it is not 'x', the reported error is `register or packoffset bind is not valid`.

For non-aggregate types with a component that does not fit the constant buffer row size of 128 bits minus the component offset, the error message is `packoffset cannot cross register boundary`.

Also fixes grammar in a related error message.

Fixes #128109