### PR TITLE
[mlir][bytecode] fix on macos after #172901

### DIFF
--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -1350,8 +1350,9 @@ LogicalResult AttrTypeReader::initialize(
 }
 
 template <typename T>
-T AttrTypeReader::resolveEntry(SmallVectorImpl<Entry<T>> &entries, size_t index,
-                               StringRef entryType, uint64_t depth) {
+T AttrTypeReader::resolveEntry(SmallVectorImpl<Entry<T>> &entries,
+                               uint64_t index, StringRef entryType,
+                               uint64_t depth) {
   bool oldResolving = resolving;
   resolving = true;
   auto restoreResolving =


### PR DESCRIPTION
`uint64_t` != `size_t` on macos (use `uint64_t` to match other uses in this impl)