### PR TITLE
[flang] Check for errors when analyzing array constructors

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2076,10 +2076,14 @@ MaybeExpr ArrayConstructorContext::ToExpr() {
 
 MaybeExpr ExpressionAnalyzer::Analyze(const parser::ArrayConstructor &array) {
   const parser::AcSpec &acSpec{array.v};
+  bool hadAnyFatalError{context_.AnyFatalError()};
   ArrayConstructorContext acContext{
       *this, AnalyzeTypeSpec(acSpec.type, GetFoldingContext())};
   for (const parser::AcValue &value : acSpec.values) {
     acContext.Add(value);
+  }
+  if (!hadAnyFatalError && context_.AnyFatalError()) {
+    return std::nullopt;
   }
   return acContext.ToExpr();
 }

--- a/flang/test/Semantics/bug127425.f90
+++ b/flang/test/Semantics/bug127425.f90
@@ -1,6 +1,8 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
 
 program main
+  implicit none
+  integer :: ja, jb, j3, j4, j5
   pointer (j1,ja)
   pointer (j2,jb)
   !ERROR: Values in array constructor must have the same declared type when no explicit type appears

--- a/flang/test/Semantics/bug127425.f90
+++ b/flang/test/Semantics/bug127425.f90
@@ -1,0 +1,8 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+
+program main
+  pointer (j1,ja)
+  pointer (j2,jb)
+  !ERROR: Values in array constructor must have the same declared type when no explicit type appears
+  if (any((/j1,j2,j3,j4,j5/)/=(/1,2,3,4,5/))) print *,'fail'
+end program main


### PR DESCRIPTION
Errors in array constructor values result in the array having
less elements than it should, which can cause other errors that
will confuse the user. Avoid this by not returning an expression
on errors.

Fixes #127425
