### PR TITLE
[clang-tidy][NFC][Docs] Fix typo in bugprone-macro-parentheses

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/macro-parentheses.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/macro-parentheses.rst
@@ -19,5 +19,5 @@ with parentheses. This ensures that the argument value is calculated
 properly.
 
 This check corresponds to the CERT C Coding Standard rule
-`PRE20-C. Macro replacement lists should be parenthesized.
+`PRE02-C. Macro replacement lists should be parenthesized.
 <https://wiki.sei.cmu.edu/confluence/display/c/PRE02-C.+Macro+replacement+lists+should+be+parenthesized>`_


### PR DESCRIPTION
Link title for `CERT C Coding Standard rule PRE20-C` should be `PRE02-C` to match target.