### PR TITLE
[clang] Fix IO sandbox violations in diagnostic filenames

### DIFF
--- a/clang/lib/Frontend/SARIFDiagnostic.cpp
+++ b/clang/lib/Frontend/SARIFDiagnostic.cpp
@@ -219,7 +219,7 @@ llvm::StringRef SARIFDiagnostic::emitFilename(StringRef Filename,
       // on that system, both aforementioned paths point to the same place.
 #ifdef _WIN32
       SmallString<256> TmpFilename = File->getName();
-      llvm::sys::fs::make_absolute(TmpFilename);
+      SM.getFileManager().makeAbsolutePath(TmpFilename);
       llvm::sys::path::native(TmpFilename);
       llvm::sys::path::remove_dots(TmpFilename, /* remove_dot_dot */ true);
       Filename = StringRef(TmpFilename.data(), TmpFilename.size());

--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -835,7 +835,7 @@ void TextDiagnostic::emitFilename(StringRef Filename, const SourceManager &SM) {
       // on that system, both aforementioned paths point to the same place.
 #ifdef _WIN32
       TmpFilename = File->getName();
-      llvm::sys::fs::make_absolute(TmpFilename);
+      SM.getFileManager().makeAbsolutePath(TmpFilename);
       llvm::sys::path::native(TmpFilename);
       llvm::sys::path::remove_dots(TmpFilename, /* remove_dot_dot */ true);
       Filename = StringRef(TmpFilename.data(), TmpFilename.size());


### PR DESCRIPTION
Update TextDiagnostic and SARIFDiagnostic emitFilename to use the FileManager's makeAbsolutePath instead of directly calling make_absolute. This fixes IO sandbox violation errors.