### PR TITLE
[Github][CI] Add note about AI tools in good-first-issue text

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -28,7 +28,7 @@ This issue may be a good introductory issue for people new to working on LLVM. I
 
 1. Check that no other contributor is working on this issue. If someone is assigned to the issue or claimed to be working on it, ping the person. After one week without a response, the assignee may be changed.
 1. Leave a comment indicating that you are working on the issue, or just create a [pull request](https://github.com/llvm/llvm-project/pulls) after following the steps below. [Mention](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this issue in the description of the pull request.
-1. Fix the issue locally.
+1. Fix the issue locally. Note that using AI tools to fix is forbidden by [LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html#ai-generated-contributions).
 1. [Run the test suite](https://llvm.org/docs/TestingGuide.html#unit-and-regression-tests) locally. Remember that the subdirectories under `test/` create fine-grained testing targets, so you can e.g. use `make check-clang-ast` to only run Clang's AST tests.
 1. Create a Git commit.
 1. Run [`git clang-format HEAD~1`](https://clang.llvm.org/docs/ClangFormat.html#git-integration) to format your changes.

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -28,7 +28,7 @@ This issue may be a good introductory issue for people new to working on LLVM. I
 
 1. Check that no other contributor is working on this issue. If someone is assigned to the issue or claimed to be working on it, ping the person. After one week without a response, the assignee may be changed.
 1. Leave a comment indicating that you are working on the issue, or just create a [pull request](https://github.com/llvm/llvm-project/pulls) after following the steps below. [Mention](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this issue in the description of the pull request.
-1. Fix the issue locally. Note that using AI tools to fix is forbidden by [LLVM Developer Policy](https://llvm.org/docs/DeveloperPolicy.html#ai-generated-contributions).
+1. Fix the issue locally. Be aware that [LLVM's AI policy](https://llvm.org/docs/AIToolPolicy.html#details) forbids the use of AI tools to fix good first issues since it squanders a learning opportunity. Using LLMs to search and learn is permitted, since the goal is learning.
 1. [Run the test suite](https://llvm.org/docs/TestingGuide.html#unit-and-regression-tests) locally. Remember that the subdirectories under `test/` create fine-grained testing targets, so you can e.g. use `make check-clang-ast` to only run Clang's AST tests.
 1. Create a Git commit.
 1. Run [`git clang-format HEAD~1`](https://clang.llvm.org/docs/ClangFormat.html#git-integration) to format your changes.


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/172515, we have a new paragraph in LLVM policy about AI:
> The one exception we reserve is for GitHub issues labelled with the “good first issue” label. These issues are selected by LLVM contributors to help newcomers get familiar with the code base. Thus, it makes no sense to fix them using AI tools. Using AI tools to fix issues labelled as “good first issues” is forbidden.

We should add disclosure about it in the introduction note for developers to see clearly.