### PR TITLE
[SDAG] SetCC: remove spurious extensions

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -14316,6 +14316,34 @@ SDValue DAGCombiner::visitSETCC(SDNode *N) {
       }
     }
   }
+
+  // (setcc (zext a), (zext b), setu??) -> (setcc a, b, setu??)
+  // (setcc (sext a), (sext b), sets??) -> (setcc a, b, sets??)
+  if ((ISD::isUnsignedIntSetCC(Cond) && N0.getOpcode() == ISD::ZERO_EXTEND &&
+       N1.getOpcode() == ISD::ZERO_EXTEND) ||
+      (ISD::isSignedIntSetCC(Cond) && N0.getOpcode() == ISD::SIGN_EXTEND &&
+       N1.getOpcode() == ISD::SIGN_EXTEND)) {
+    SDValue LHS = N0.getOperand(0), RHS = N1.getOperand(0);
+    EVT SmallVT =
+        LHS.getScalarValueSizeInBits() > RHS.getScalarValueSizeInBits()
+            ? LHS.getValueType()
+            : RHS.getValueType();
+    if (!LegalOperations ||
+        (SmallVT.isSimple() &&
+         TLI.isCondCodeLegal(Cond, SmallVT.getSimpleVT()))) {
+      LHS = DAG.getExtOrTrunc(ISD::isSignedIntSetCC(Cond), LHS, SDLoc(LHS),
+                              SmallVT);
+      RHS = DAG.getExtOrTrunc(ISD::isSignedIntSetCC(Cond), RHS, SDLoc(RHS),
+                              SmallVT);
+      SDValue NewSetCC =
+          DAG.getSetCC(DL, getSetCCResultType(SmallVT), LHS, RHS, Cond);
+      // Promote to a legal type for setcc, then adjust back to VT (if before
+      // LegalOperations)
+      return DAG.getZExtOrTrunc(
+          TLI.promoteTargetBoolean(DAG, NewSetCC, N0.getValueType()), DL, VT);
+    }
+  }
+
   return SDValue();
 }
 

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -14328,9 +14328,8 @@ SDValue DAGCombiner::visitSETCC(SDNode *N) {
         LHS.getScalarValueSizeInBits() > RHS.getScalarValueSizeInBits()
             ? LHS.getValueType()
             : RHS.getValueType();
-    if (!LegalOperations ||
-        (SmallVT.isSimple() &&
-         TLI.isCondCodeLegal(Cond, SmallVT.getSimpleVT()))) {
+    if (SmallVT.isSimple() &&
+        TLI.isCondCodeLegal(Cond, SmallVT.getSimpleVT())) {
       LHS = DAG.getExtOrTrunc(ISD::isSignedIntSetCC(Cond), LHS, SDLoc(LHS),
                               SmallVT);
       RHS = DAG.getExtOrTrunc(ISD::isSignedIntSetCC(Cond), RHS, SDLoc(RHS),

--- a/llvm/test/CodeGen/AArch64/arm64-vcmp.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-vcmp.ll
@@ -240,25 +240,7 @@ define <16 x i1> @abdu_cmp(<16 x i8> %a, <16 x i8> %b, <16 x i8> %g) {
 ; CHECK-LABEL: abdu_cmp:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    uabd.16b v0, v0, v1
-; CHECK-NEXT:    ushll.8h v1, v2, #0
-; CHECK-NEXT:    ushll2.8h v2, v2, #0
-; CHECK-NEXT:    ushll2.8h v3, v0, #0
-; CHECK-NEXT:    ushll.8h v0, v0, #0
-; CHECK-NEXT:    ushll.4s v4, v1, #0
-; CHECK-NEXT:    ushll2.4s v1, v1, #0
-; CHECK-NEXT:    ushll.4s v5, v2, #0
-; CHECK-NEXT:    ushll2.4s v2, v2, #0
-; CHECK-NEXT:    ushll2.4s v6, v3, #0
-; CHECK-NEXT:    ushll.4s v7, v0, #0
-; CHECK-NEXT:    ushll2.4s v0, v0, #0
-; CHECK-NEXT:    ushll.4s v3, v3, #0
-; CHECK-NEXT:    cmhi.4s v2, v2, v6
-; CHECK-NEXT:    cmhi.4s v0, v1, v0
-; CHECK-NEXT:    cmhi.4s v1, v4, v7
-; CHECK-NEXT:    cmhi.4s v3, v5, v3
-; CHECK-NEXT:    uzp1.8h v0, v1, v0
-; CHECK-NEXT:    uzp1.8h v2, v3, v2
-; CHECK-NEXT:    uzp1.16b v0, v0, v2
+; CHECK-NEXT:    cmhi.16b v0, v2, v0
 ; CHECK-NEXT:    ret
   %za = zext <16 x i8> %a to <16 x i32>
   %zb = zext <16 x i8> %b to <16 x i32>
@@ -273,25 +255,7 @@ define <16 x i1> @abdu_cmp(<16 x i8> %a, <16 x i8> %b, <16 x i8> %g) {
 define <16 x i1> @sext_cmp(<16 x i8> %a, <16 x i8> %b) {
 ; CHECK-LABEL: sext_cmp:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    sshll.8h v2, v0, #0
-; CHECK-NEXT:    sshll2.8h v0, v0, #0
-; CHECK-NEXT:    sshll2.8h v3, v1, #0
-; CHECK-NEXT:    sshll.8h v1, v1, #0
-; CHECK-NEXT:    sshll.4s v4, v2, #0
-; CHECK-NEXT:    sshll2.4s v2, v2, #0
-; CHECK-NEXT:    sshll.4s v5, v0, #0
-; CHECK-NEXT:    sshll2.4s v0, v0, #0
-; CHECK-NEXT:    sshll2.4s v6, v3, #0
-; CHECK-NEXT:    sshll.4s v7, v1, #0
-; CHECK-NEXT:    sshll2.4s v1, v1, #0
-; CHECK-NEXT:    sshll.4s v3, v3, #0
-; CHECK-NEXT:    cmgt.4s v0, v6, v0
-; CHECK-NEXT:    cmgt.4s v3, v3, v5
-; CHECK-NEXT:    cmgt.4s v1, v1, v2
-; CHECK-NEXT:    cmgt.4s v2, v7, v4
-; CHECK-NEXT:    uzp1.8h v0, v3, v0
-; CHECK-NEXT:    uzp1.8h v1, v2, v1
-; CHECK-NEXT:    uzp1.16b v0, v1, v0
+; CHECK-NEXT:    cmgt.16b v0, v1, v0
 ; CHECK-NEXT:    ret
   %za = sext <16 x i8> %a to <16 x i32>
   %zb = sext <16 x i8> %b to <16 x i32>


### PR DESCRIPTION
https://godbolt.org/z/T89oa3nWb <- this is what happens when DAGCombiner/TLI produces `zext` going into `setcc`. In general case, these `zext` end up producing many instructions.

regarding transformation of (setslt (zext) (zext)) -> (setult ...) that could be done as a separate pattern/patch