### PR TITLE
[LLDB][NativePDB] NFC: Add language-agnostic interface to PdbAstBuilder

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
@@ -321,10 +321,7 @@ clang::DeclContext *PdbAstBuilder::GetOrCreateClangDeclContextForUid(PdbSymUid u
 }
 
 CompilerDeclContext PdbAstBuilder::GetOrCreateDeclContextForUid(PdbSymUid uid) {
-  clang::DeclContext *context = GetOrCreateClangDeclContextForUid(uid);
-  if (!context)
-    return {};
-  return ToCompilerDeclContext(*context);
+  return m_clang.CreateDeclContext(GetOrCreateClangDeclContextForUid(uid));
 }
 
 std::pair<clang::DeclContext *, std::string>
@@ -428,10 +425,7 @@ clang::DeclContext *PdbAstBuilder::GetParentClangDeclContext(PdbSymUid uid) {
 }
 
 CompilerDeclContext PdbAstBuilder::GetParentDeclContext(PdbSymUid uid) {
-  clang::DeclContext *context = GetParentClangDeclContext(uid);
-  if (!context)
-    return {};
-  return ToCompilerDeclContext(*context);
+  return m_clang.CreateDeclContext(GetParentClangDeclContext(uid));
 }
 
 bool PdbAstBuilder::CompleteType(CompilerType ct) {

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
@@ -430,8 +430,10 @@ CompilerDeclContext PdbAstBuilder::GetParentDeclContext(PdbSymUid uid) {
 }
 
 bool PdbAstBuilder::CompleteType(CompilerType ct) {
-  clang::QualType qt =
-      clang::QualType::getFromOpaquePtr(ct.GetOpaqueQualType());
+  if (GetClangASTImporter().CanImport(ct))
+    return GetClangASTImporter().CompleteType(ct);
+
+  clang::QualType qt = FromCompilerType(ct);
   if (qt.isNull())
     return false;
   clang::TagDecl *tag = qt->getAsTagDecl();
@@ -1465,6 +1467,10 @@ CompilerDecl PdbAstBuilder::ToCompilerDecl(clang::Decl &decl) {
 
 CompilerType PdbAstBuilder::ToCompilerType(clang::QualType qt) {
   return {m_clang.weak_from_this(), qt.getAsOpaquePtr()};
+}
+
+clang::QualType PdbAstBuilder::FromCompilerType(CompilerType ct) {
+  return ClangUtil::GetQualType(ct);
 }
 
 CompilerDeclContext

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
@@ -305,7 +305,8 @@ PdbAstBuilder::GetOrCreateDeclForUid(PdbSymUid uid) {
   return ToCompilerDecl(*result);
 }
 
-clang::DeclContext *PdbAstBuilder::GetOrCreateClangDeclContextForUid(PdbSymUid uid) {
+clang::DeclContext *
+PdbAstBuilder::GetOrCreateClangDeclContextForUid(PdbSymUid uid) {
   if (uid.kind() == PdbSymUidKind::CompilandSym) {
     if (uid.asCompilandSym().offset == 0)
       return FromCompilerDeclContext(GetTranslationUnitDecl());
@@ -1487,9 +1488,9 @@ void PdbAstBuilder::Dump(Stream &stream, llvm::StringRef filter,
 
 CompilerDeclContext
 PdbAstBuilder::FindNamespaceDecl(CompilerDeclContext parent_ctx,
-  llvm::StringRef name) {
-    clang::DeclContext *parent = FromCompilerDeclContext(parent_ctx);
-    NamespaceSet *set;
+                                 llvm::StringRef name) {
+  clang::DeclContext *parent = FromCompilerDeclContext(parent_ctx);
+  NamespaceSet *set;
 
   if (parent) {
     auto it = m_parent_to_namespaces.find(parent);

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
@@ -59,8 +59,10 @@ public:
 
   std::optional<lldb_private::CompilerDecl>
   GetOrCreateDeclForUid(PdbSymUid uid);
-  clang::DeclContext *GetOrCreateDeclContextForUid(PdbSymUid uid);
-  clang::DeclContext *GetParentDeclContext(PdbSymUid uid);
+  lldb_private::CompilerDeclContext GetOrCreateDeclContextForUid(PdbSymUid uid);
+  clang::DeclContext *GetOrCreateClangDeclContextForUid(PdbSymUid uid);
+  lldb_private::CompilerDeclContext GetParentDeclContext(PdbSymUid uid);
+  clang::DeclContext *GetParentClangDeclContext(PdbSymUid uid);
 
   clang::FunctionDecl *GetOrCreateFunctionDecl(PdbCompilandSymId func_id);
   clang::FunctionDecl *
@@ -70,13 +72,14 @@ public:
                                           PdbCompilandSymId var_id);
   clang::VarDecl *GetOrCreateVariableDecl(PdbGlobalSymId var_id);
   clang::TypedefNameDecl *GetOrCreateTypedefDecl(PdbGlobalSymId id);
-  void ParseDeclsForContext(clang::DeclContext &context);
+  void ParseDeclsForContext(lldb_private::CompilerDeclContext context);
 
   clang::QualType GetBasicType(lldb::BasicType type);
-  clang::QualType GetOrCreateType(PdbTypeSymId type);
+  clang::QualType GetOrCreateClangType(PdbTypeSymId type);
+  CompilerType GetOrCreateType(PdbTypeSymId type);
 
   bool CompleteTagDecl(clang::TagDecl &tag);
-  bool CompleteType(clang::QualType qt);
+  bool CompleteType(CompilerType ct);
 
   CompilerDecl ToCompilerDecl(clang::Decl &decl);
   CompilerType ToCompilerType(clang::QualType qt);
@@ -89,8 +92,9 @@ public:
 
   void Dump(Stream &stream, llvm::StringRef filter, bool show_color);
 
-  clang::NamespaceDecl *FindNamespaceDecl(const clang::DeclContext *parent,
-                                          llvm::StringRef name);
+  lldb_private::CompilerDeclContext
+  FindNamespaceDecl(lldb_private::CompilerDeclContext parent_ctx,
+                    llvm::StringRef name);
 
 private:
   clang::Decl *TryGetDecl(PdbSymUid uid) const;

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
@@ -84,6 +84,7 @@ public:
   CompilerDecl ToCompilerDecl(clang::Decl &decl);
   CompilerType ToCompilerType(clang::QualType qt);
   CompilerDeclContext ToCompilerDeclContext(clang::DeclContext &context);
+  clang::QualType FromCompilerType(CompilerType ct);
   clang::Decl *FromCompilerDecl(CompilerDecl decl);
   clang::DeclContext *FromCompilerDeclContext(CompilerDeclContext context);
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -2490,17 +2490,11 @@ SymbolFileNativePDB::GetDynamicArrayInfoForUID(
 
 bool SymbolFileNativePDB::CompleteType(CompilerType &compiler_type) {
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
-  auto clang_type_system = compiler_type.GetTypeSystem<TypeSystemClang>();
-  if (!clang_type_system)
+  auto ts = compiler_type.GetTypeSystem();
+  if (!ts || !ts->GetNativePDBParser())
     return false;
 
-  PdbAstBuilder *ast_builder =
-      static_cast<PdbAstBuilder *>(clang_type_system->GetNativePDBParser());
-  if (ast_builder &&
-      ast_builder->GetClangASTImporter().CanImport(compiler_type))
-    return ast_builder->GetClangASTImporter().CompleteType(compiler_type);
-
-  return ast_builder->CompleteType(compiler_type);
+  return ts->GetNativePDBParser()->CompleteType(compiler_type);
 }
 
 void SymbolFileNativePDB::GetTypes(lldb_private::SymbolContextScope *sc_scope,

--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
@@ -234,7 +234,7 @@ Error UdtRecordCompleter::visitKnownMember(CVMemberRecord &cvr,
     return Error::success();
 
   clang::QualType qt =
-      m_ast_builder.GetOrCreateType(PdbTypeSymId(nested.Type, false));
+      m_ast_builder.GetOrCreateClangType(PdbTypeSymId(nested.Type, false));
   if (qt.isNull())
     return Error::success();
   CompilerType ct = m_ast_builder.ToCompilerType(qt);
@@ -248,7 +248,7 @@ Error UdtRecordCompleter::visitKnownMember(CVMemberRecord &cvr,
     return Error::success();
 
   clang::DeclContext *decl_ctx =
-      m_ast_builder.GetOrCreateDeclContextForUid(m_id);
+      m_ast_builder.GetOrCreateClangDeclContextForUid(m_id);
   if (!decl_ctx)
     return Error::success();
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
@@ -276,7 +276,8 @@ Error UdtRecordCompleter::visitKnownMember(CVMemberRecord &cvr,
     }
   }
 
-  clang::QualType member_qt = m_ast_builder.GetOrCreateClangType(PdbTypeSymId(ti));
+  clang::QualType member_qt =
+      m_ast_builder.GetOrCreateClangType(PdbTypeSymId(ti));
   if (member_qt.isNull())
     return Error::success();
   TypeSystemClang::RequireCompleteType(m_ast_builder.ToCompilerType(member_qt));

--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
@@ -64,7 +64,7 @@ clang::QualType UdtRecordCompleter::AddBaseClassForTypeIndex(
     llvm::codeview::TypeIndex ti, llvm::codeview::MemberAccess access,
     std::optional<uint64_t> vtable_idx) {
   PdbTypeSymId type_id(ti);
-  clang::QualType qt = m_ast_builder.GetOrCreateType(type_id);
+  clang::QualType qt = m_ast_builder.GetOrCreateClangType(type_id);
 
   CVType udt_cvt = m_index.tpi().getType(ti);
 
@@ -85,7 +85,7 @@ void UdtRecordCompleter::AddMethod(llvm::StringRef name, TypeIndex type_idx,
                                    MemberAccess access, MethodOptions options,
                                    MemberAttributes attrs) {
   clang::QualType method_qt =
-      m_ast_builder.GetOrCreateType(PdbTypeSymId(type_idx));
+      m_ast_builder.GetOrCreateClangType(PdbTypeSymId(type_idx));
   if (method_qt.isNull())
     return;
   CompilerType method_ct = m_ast_builder.ToCompilerType(method_qt);
@@ -146,7 +146,7 @@ Error UdtRecordCompleter::visitKnownMember(CVMemberRecord &cvr,
 Error UdtRecordCompleter::visitKnownMember(
     CVMemberRecord &cvr, StaticDataMemberRecord &static_data_member) {
   clang::QualType member_type =
-      m_ast_builder.GetOrCreateType(PdbTypeSymId(static_data_member.Type));
+      m_ast_builder.GetOrCreateClangType(PdbTypeSymId(static_data_member.Type));
   if (member_type.isNull())
     return llvm::Error::success();
 
@@ -276,7 +276,7 @@ Error UdtRecordCompleter::visitKnownMember(CVMemberRecord &cvr,
     }
   }
 
-  clang::QualType member_qt = m_ast_builder.GetOrCreateType(PdbTypeSymId(ti));
+  clang::QualType member_qt = m_ast_builder.GetOrCreateClangType(PdbTypeSymId(ti));
   if (member_qt.isNull())
     return Error::success();
   TypeSystemClang::RequireCompleteType(m_ast_builder.ToCompilerType(member_qt));
@@ -425,7 +425,7 @@ UdtRecordCompleter::AddMember(TypeSystemClang &clang, Member *field,
 void UdtRecordCompleter::FinishRecord() {
   TypeSystemClang &clang = m_ast_builder.clang();
   clang::DeclContext *decl_ctx =
-      m_ast_builder.GetOrCreateDeclContextForUid(m_id);
+      m_ast_builder.GetOrCreateClangDeclContextForUid(m_id);
   m_record.ConstructRecord();
   // Maybe we should check the construsted record size with the size in pdb. If
   // they mismatch, it might be pdb has fields info missing.


### PR DESCRIPTION
This change implements part of https://discourse.llvm.org/t/rfc-lldb-make-pdbastbuilder-language-agnostic/89117, the goal of which is make `PdbAstBuilder` language-agnostic.

It adds several new interface methods to `PdbAstBuilder` which allow `SymbolFileNativePDB` to interact with it without using Clang-specific types. These new methods would make up much of the interface of a future abstract `PdbAstBuilder`. `SymbolFileNativePDB` is updated to use these.

The old Clang-specific methods were renamed if used by `UdtRecordCompleter` or internally, or removed where possible.