### PR TITLE
[FindGRPC.cmake] Make sure that `PACKAGE_VERSION` is not overwritten when doing `find_package(gRPC)`

### DIFF
--- a/cmake/Modules/FindGRPC.cmake
+++ b/cmake/Modules/FindGRPC.cmake
@@ -16,7 +16,11 @@ find_package(Threads REQUIRED)
 set(protobuf_MODULE_COMPATIBLE TRUE)
 find_package(Protobuf CONFIG HINTS ${GRPC_INSTALL_PATH})
 message(STATUS "Using protobuf ${Protobuf_VERSION}")
+# There's a `c-ares` library whose CMake file sets the `PACKAGE_VERSION` variable.
+# Preserve the original `PACKAGE_VERSION` value and restore it.
+set(PACKAGE_VERSION_PREV "${PACKAGE_VERSION}")
 find_package(gRPC CONFIG HINTS ${GRPC_INSTALL_PATH})
+set(PACKAGE_VERSION "${PACKAGE_VERSION_PREV}")
 message(STATUS "Using gRPC ${gRPC_VERSION}")
 
 if (Protobuf_FOUND AND gRPC_FOUND)


### PR DESCRIPTION
`PACKAGE_VERSION` is important since it sets the `LLVM_VERSION_STRING` string.