### PR TITLE
[clang][modules] print mtime of input files when recorded in "module-file-info"

### DIFF
--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -254,7 +254,7 @@ public:
   /// \returns true to continue receiving the next input file, false to stop.
   virtual bool visitInputFileAsRequested(StringRef FilenameAsRequested,
                                          StringRef Filename, bool isSystem,
-                                         bool isOverridden,
+                                         bool isOverridden, time_t StoredTime,
                                          bool isExplicitModule) {
     return true;
   }

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -111,7 +111,7 @@ public:
   /// considered stable.
   bool visitInputFileAsRequested(StringRef FilenameAsRequested,
                                  StringRef Filename, bool isSystem,
-                                 bool isOverridden,
+                                 bool isOverridden, time_t StoredTime,
                                  bool isExplicitModule) override {
     if (StableDirs.empty())
       return false;

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -798,7 +798,7 @@ namespace {
     /// \returns true to continue receiving the next input file, false to stop.
     bool visitInputFileAsRequested(StringRef FilenameAsRequested,
                                    StringRef Filename, bool isSystem,
-                                   bool isOverridden,
+                                   bool isOverridden, time_t StoredTime,
                                    bool isExplicitModule) override {
 
       Out.indent(2) << "Input file: " << FilenameAsRequested;
@@ -822,6 +822,9 @@ namespace {
       }
 
       Out << "\n";
+
+      if (StoredTime > 0)
+        Out.indent(4) << "MTime: " << llvm::itostr(StoredTime) << "\n";
 
       return true;
     }

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5996,8 +5996,7 @@ bool ASTReader::readASTFileControlBlock(
           }
           shouldContinue = Listener.visitInputFileAsRequested(
               *FilenameAsRequestedBuf, Filename, isSystemFile, Overridden,
-              StoredTime,
-              /*IsExplicitModule=*/false);
+              StoredTime, /*IsExplicitModule=*/false);
           break;
         }
         if (!shouldContinue)

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5980,6 +5980,7 @@ bool ASTReader::readASTFileControlBlock(
         case INPUT_FILE_HASH:
           break;
         case INPUT_FILE:
+          time_t StoredTime = static_cast<time_t>(Record[2]);
           bool Overridden = static_cast<bool>(Record[3]);
           auto [UnresolvedFilenameAsRequested, UnresolvedFilename] =
               getUnresolvedInputFilenames(Record, Blob);
@@ -5995,6 +5996,7 @@ bool ASTReader::readASTFileControlBlock(
           }
           shouldContinue = Listener.visitInputFileAsRequested(
               *FilenameAsRequestedBuf, Filename, isSystemFile, Overridden,
+              StoredTime,
               /*IsExplicitModule=*/false);
           break;
         }

--- a/clang/test/Modules/module-file-info-mtime.m
+++ b/clang/test/Modules/module-file-info-mtime.m
@@ -1,0 +1,24 @@
+// Hardcode the mtime for a input file & check that is emitted in pcm during a implicit module invocation.
+
+// RUN: rm -fr %t
+// RUN: split-file %s %t
+// RUN: touch -m -a -t 202508011501 %t/BuildDir/A/A.h
+// RUN: %clang_cc1 -fmodules -fmodules-cache-path=%t/cache -fdisable-module-hash -fimplicit-module-maps %t/client.m -fsyntax-only -I%t/BuildDir
+// RUN: %clang_cc1 -module-file-info %t/cache/A.pcm | FileCheck %s
+
+// CHECK: Module name: A
+// CHECK: Module map file: {{.*}}module.modulemap
+// CHECK: Input file: {{.*}}A.h
+// CHECK-NEXT: MTime: 1754085660
+
+
+//--- BuildDir/A/module.modulemap
+module A [system] {
+  umbrella "."
+}
+
+//--- BuildDir/A/A.h
+typedef int local_t;
+
+//--- client.m
+#import <A/A.h>

--- a/clang/test/Modules/module-file-info-mtime.m
+++ b/clang/test/Modules/module-file-info-mtime.m
@@ -1,15 +1,14 @@
-// Hardcode the mtime for a input file & check that is emitted in pcm during a implicit module invocation.
+// Check that mtime from a input file of a pcm is emitted, when it was built from an implicit module invocation.
 
 // RUN: rm -fr %t
 // RUN: split-file %s %t
-// RUN: touch -m -a -t 202508011501 %t/BuildDir/A/A.h
 // RUN: %clang_cc1 -fmodules -fmodules-cache-path=%t/cache -fdisable-module-hash -fimplicit-module-maps %t/client.m -fsyntax-only -I%t/BuildDir
 // RUN: %clang_cc1 -module-file-info %t/cache/A.pcm | FileCheck %s
 
 // CHECK: Module name: A
 // CHECK: Module map file: {{.*}}module.modulemap
 // CHECK: Input file: {{.*}}A.h
-// CHECK-NEXT: MTime: 1754085660
+// CHECK-NEXT: MTime: {{[0-9]+}} 
 
 
 //--- BuildDir/A/module.modulemap

--- a/clang/test/Modules/module_file_info.m
+++ b/clang/test/Modules/module_file_info.m
@@ -48,15 +48,15 @@
 // MACROS-NEXT: -DBLARG
 // MACROS-NEXT: -DWIBBLE=WOBBLE
 // CHECK: Input file: {{.*}}module.modulemap
-// CHECK-NEXT: Input file: {{.*}}module.private.modulemap
-// CHECK-NEXT: Input file: {{.*}}DependsOnModule.h
-// CHECK-NEXT: Input file: {{.*}}module.modulemap
-// CHECK-NEXT: Input file: {{.*}}other.h
-// CHECK-NEXT: Input file: {{.*}}not_cxx.h
-// CHECK-NEXT: Input file: {{.*}}not_coroutines.h
-// CHECK-NEXT: Input file: {{.*}}SubFramework.h
-// CHECK-NEXT: Input file: {{.*}}Other.h
-// CHECK-NEXT: Input file: {{.*}}DependsOnModulePrivate.h
+// CHECK: Input file: {{.*}}module.private.modulemap
+// CHECK: Input file: {{.*}}DependsOnModule.h
+// CHECK: Input file: {{.*}}module.modulemap
+// CHECK: Input file: {{.*}}other.h
+// CHECK: Input file: {{.*}}not_cxx.h
+// CHECK: Input file: {{.*}}not_coroutines.h
+// CHECK: Input file: {{.*}}SubFramework.h
+// CHECK: Input file: {{.*}}Other.h
+// CHECK: Input file: {{.*}}DependsOnModulePrivate.h
 
 // CHECK: Diagnostic options:
 // CHECK:   IgnoreWarnings: Yes


### PR DESCRIPTION
When debugging issues related to invalidation for implicit module compilations, it can be helpful to consult the PCM to see what the saved mtime was.