### PR TITLE
[bazel] Add potential bzlmod inclusion example

### DIFF
--- a/utils/bazel/MODULE.bazel
+++ b/utils/bazel/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "zlib-ng", version = "2.0.7", repo_name = "llvm_zlib")
 bazel_dep(name = "zstd", version = "1.5.7", repo_name = "llvm_zstd")
 
-llvm_repos_extension = use_extension(":extensions.bzl", "llvm_repos_extension")
+llvm_repos_extension = use_extension("@llvm-raw//utils/bazel:extensions.bzl", "llvm_repos_extension")
 use_repo(
     llvm_repos_extension,
     "gmp",
@@ -34,6 +34,5 @@ use_repo(
     "vulkan_sdk",
 )
 
-llvm_configure = use_repo_rule("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure")
-
-llvm_configure(name = "llvm-project")
+llvm = use_extension("@llvm-raw//utils/bazel:configure.bzl", "llvm")
+use_repo(llvm, "llvm-project")

--- a/utils/bazel/configure.bzl
+++ b/utils/bazel/configure.bzl
@@ -206,3 +206,37 @@ llvm_configure = repository_rule(
         "targets": attr.string_list(default = DEFAULT_TARGETS),
     },
 )
+
+def _llvm_impl(mctx):
+    targets = {t: True for t in DEFAULT_TARGETS}
+    for mod in mctx.modules:
+        if not mod.is_root:
+            continue
+        if mod.tags.configure:
+            targets = {}
+        for conf in mod.tags.configure:
+            for target in conf.targets:
+                targets[target] = True
+        break
+
+    llvm_configure(
+        name = "llvm-project",
+        targets = targets.keys(),
+    )
+
+    return mctx.extension_metadata(
+        reproducible = True,
+        root_module_direct_deps = "all",
+        root_module_direct_dev_deps = [],
+    )
+
+llvm = module_extension(
+    implementation = _llvm_impl,
+    tag_classes = {
+        "configure": tag_class(
+            attrs = {
+                "targets": attr.string_list(mandatory = True),
+            },
+        ),
+    },
+)

--- a/utils/bazel/examples/bzlmod/MODULE.bazel
+++ b/utils/bazel/examples/bzlmod/MODULE.bazel
@@ -1,0 +1,29 @@
+# Replace with the LLVM commit you want to use.
+LLVM_COMMIT = "2d1bc9f5a212dc4c8fa14a5741af2a7a5e60ff36"
+
+# The easiest way to calculate this for a new commit is to set it to empty and
+# then run a bazel build and it will report the digest necessary to cache the
+# archive and make the build reproducible.
+LLVM_INTEGRITY = "sha256-KST3jta9pEHT0igBUxNaUoJysbefc0yBJ22UEzWcINs="
+
+bazel_dep(name = "llvm-raw")
+archive_override(
+    module_name = "llvm-raw",
+    integrity = LLVM_INTEGRITY,
+    patch_cmds = [
+        "cat utils/bazel/MODULE.bazel | grep -v '\"llvm-raw\"' | sed 's|llvm-project-overlay|llvm-raw|g' > MODULE.bazel",
+    ],
+    strip_prefix = "llvm-project-" + LLVM_COMMIT,
+    urls = ["https://github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT)],
+)
+
+llvm = use_extension("@llvm-raw//utils/bazel:configure.bzl", "llvm")
+
+# Optionally configure LLVM targets here
+# llvm.configure(
+#     targets = [
+#         "X86",
+#         ...
+#     ],
+# )
+use_repo(llvm, "llvm-project")


### PR DESCRIPTION
Since the MODULE.bazel is not at the root of the repo, there is some
complexity on how to include this in your own bazel project using
bzlmod.

This example pulls the repo as llvm-raw, patches the MODULE.bazel
(notably putting it in the root of the repo), and then sets up the
llvm-project repository.

This isn't ideal and I'm not sure if we'd really want to use the
llvm-raw name in the BCR, but I wanted to put this up for discussion
