### PR TITLE
[LLVM][ADT] Make `scope-exit` CTAD-capable

### DIFF
--- a/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
+++ b/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
@@ -774,14 +774,13 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
   // This will be the address of the storage for paths, if we are using them,
   // or nullptr to signal we aren't.
   lldb::addr_t path_array_addr = 0x0;
-  std::optional<llvm::detail::scope_exit<std::function<void()>>>
-      path_array_cleanup;
+  std::optional<llvm::scope_exit<std::function<void()>>> path_array_cleanup;
 
   // This is the address to a buffer large enough to hold the largest path
   // conjoined with the library name we're passing in.  This is a convenience 
   // to avoid having to call malloc in the dlopen function.
   lldb::addr_t buffer_addr = 0x0;
-  std::optional<llvm::detail::scope_exit<std::function<void()>>> buffer_cleanup;
+  std::optional<llvm::scope_exit<std::function<void()>>> buffer_cleanup;
 
   // Set the values into our args and write them to the target:
   if (paths != nullptr) {

--- a/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
+++ b/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
@@ -231,7 +231,7 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
 
   /* Inject paths parameter into inferior */
   lldb::addr_t injected_paths{0x0};
-  std::optional<llvm::detail::scope_exit<std::function<void()>>> paths_cleanup;
+  std::optional<llvm::scope_exit<std::function<void()>>> paths_cleanup;
   if (paths) {
     llvm::SmallVector<llvm::UTF16, 261> search_paths;
 

--- a/llvm/include/llvm/ADT/ScopeExit.h
+++ b/llvm/include/llvm/ADT/ScopeExit.h
@@ -15,13 +15,9 @@
 #ifndef LLVM_ADT_SCOPEEXIT_H
 #define LLVM_ADT_SCOPEEXIT_H
 
-#include "llvm/Support/Compiler.h"
-
-#include <type_traits>
 #include <utility>
 
 namespace llvm {
-namespace detail {
 
 template <typename Callable> class scope_exit {
   Callable ExitFunction;
@@ -47,17 +43,15 @@ public:
   }
 };
 
-} // end namespace detail
+template <typename Callable> scope_exit(Callable) -> scope_exit<Callable>;
 
 // Keeps the callable object that is passed in, and execute it at the
 // destruction of the returned object (usually at the scope exit where the
 // returned object is kept).
 //
 // Interface is specified by p0052r2.
-template <typename Callable>
-[[nodiscard]] detail::scope_exit<std::decay_t<Callable>>
-make_scope_exit(Callable &&F) {
-  return detail::scope_exit<std::decay_t<Callable>>(std::forward<Callable>(F));
+template <typename Callable> [[nodiscard]] auto make_scope_exit(Callable &&F) {
+  return scope_exit(std::forward<Callable>(F));
 }
 
 } // end namespace llvm


### PR DESCRIPTION
This enables using it like

```cpp
llvm::scope_exit Cleanup([] { ... });
```
instead of
```cpp
auto Cleanup = llvm::make_scope_exit([] { ... });
```