### PR TITLE
Revert "[AA] Improve precision for monotonic atomic load/store operations"

### DIFF
--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -433,7 +433,7 @@ ModRefInfo AAResults::getModRefInfo(const LoadInst *L,
                                     const MemoryLocation &Loc,
                                     AAQueryInfo &AAQI) {
   // Be conservative in the face of atomic.
-  if (isStrongerThanMonotonic(L->getOrdering()))
+  if (isStrongerThan(L->getOrdering(), AtomicOrdering::Unordered))
     return ModRefInfo::ModRef;
 
   // If the load address doesn't alias the given address, it doesn't read
@@ -443,13 +443,6 @@ ModRefInfo AAResults::getModRefInfo(const LoadInst *L,
     if (AR == AliasResult::NoAlias)
       return ModRefInfo::NoModRef;
   }
-
-  assert(!isStrongerThanMonotonic(L->getOrdering()) &&
-         "Stronger atomic orderings should have been handled above!");
-
-  if (isStrongerThanUnordered(L->getOrdering()))
-    return ModRefInfo::ModRef;
-
   // Otherwise, a load just reads.
   return ModRefInfo::Ref;
 }
@@ -458,7 +451,7 @@ ModRefInfo AAResults::getModRefInfo(const StoreInst *S,
                                     const MemoryLocation &Loc,
                                     AAQueryInfo &AAQI) {
   // Be conservative in the face of atomic.
-  if (isStrongerThanMonotonic(S->getOrdering()))
+  if (isStrongerThan(S->getOrdering(), AtomicOrdering::Unordered))
     return ModRefInfo::ModRef;
 
   if (Loc.Ptr) {
@@ -476,13 +469,7 @@ ModRefInfo AAResults::getModRefInfo(const StoreInst *S,
       return ModRefInfo::NoModRef;
   }
 
-  assert(!isStrongerThanMonotonic(S->getOrdering()) &&
-         "Stronger atomic orderings should have been handled above!");
-
-  if (isStrongerThanUnordered(S->getOrdering()))
-    return ModRefInfo::ModRef;
-
-  // A store just writes.
+  // Otherwise, a store just writes.
   return ModRefInfo::Mod;
 }
 

--- a/llvm/test/Transforms/DeadStoreElimination/atomic-todo.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/atomic-todo.ll
@@ -1,0 +1,23 @@
+; XFAIL: *
+; RUN: opt -passes=dse -S < %s | FileCheck %s
+
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
+target triple = "x86_64-apple-macosx10.7.0"
+
+; Basic correctness tests for atomic stores.
+; Note that it turns out essentially every transformation DSE does is legal on
+; atomic ops, just some transformations are not allowed across release-acquire pairs.
+
+@x = common global i32 0, align 4
+@y = common global i32 0, align 4
+
+; DSE across monotonic load (allowed as long as the eliminated store isUnordered)
+define i32 @test9() {
+; CHECK-LABEL: test9
+; CHECK-NOT: store i32 0
+; CHECK: store i32 1
+  store i32 0, ptr @x
+  %x = load atomic i32, ptr @y monotonic, align 4
+  store i32 1, ptr @x
+  ret i32 %x
+}


### PR DESCRIPTION
Reverts llvm/llvm-project#158169

The improved AA precision for atomic store operations causes the DSE pass to optimize out the object variables.