### PR TITLE
[clang] Add support for consteval null terminated strings

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -1746,15 +1746,22 @@ def subst_user_defined_msg : TextSubstitution<
   "%select{the message|the expression}0 in "
   "%select{a static assertion|this asm operand}0">;
 
-def err_user_defined_msg_invalid : Error<
-  "%sub{subst_user_defined_msg}0 must be a string literal or an "
-  "object with 'data()' and 'size()' member functions">;
+def err_user_defined_msg_invalid
+    : Error<"%sub{subst_user_defined_msg}0 must be a null terminated constant "
+            "string or an "
+            "object with 'data()' and 'size()' member functions">;
 def err_user_defined_msg_missing_member_function : Error<
   "the %select{message|string}0 object in "
   "%select{this static assertion|this asm operand}0 is missing %select{"
   "a 'size()' member function|"
   "a 'data()' member function|"
   "'data()' and 'size()' member functions}1">;
+def err_user_defined_msg_not_null_terminated_string
+    : Error<"%sub{subst_user_defined_msg}0 is not null terminated">;
+def ext_consteval_string_constants
+    : Extension<"consteval string constants are an extension">,
+      DefaultWarn,
+      InGroup<DiagGroup<"consteval-string-constants-extension">>;
 def err_user_defined_msg_invalid_mem_fn_ret_ty : Error<
   "%sub{subst_user_defined_msg}0 must have a '%select{size|data}1()' member "
   "function returning an object convertible to '%select{std::size_t|const char *}1'">;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -831,10 +831,11 @@ enum class CCEKind {
   ArrayBound,    ///< Array bound in array declarator or new-expression.
   ExplicitBool,  ///< Condition in an explicit(bool) specifier.
   Noexcept,      ///< Condition in a noexcept(bool) specifier.
-  StaticAssertMessageSize, ///< Call to size() in a static assert
-                           ///< message.
-  StaticAssertMessageData, ///< Call to data() in a static assert
-                           ///< message.
+  StaticAssertMessageSize,          ///< Call to size() in a static assert
+                                    ///< message.
+  StaticAssertMessageData,          ///< Call to data() in a static assert
+                                    ///< message.
+  StaticAssertNullTerminatedString, ///< tryEvaluateStrLen
 };
 
 /// Enums for the diagnostics of target, target_version and target_clones.

--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -294,13 +294,15 @@ bool Context::evaluateStrlen(State &Parent, const Expr *E, uint64_t &Result) {
     if (!FieldDesc->isPrimitiveArray())
       return false;
 
-    if (Ptr.isDummy() || Ptr.isUnknownSizeArray())
+    if (Ptr.isDummy() || Ptr.isUnknownSizeArray() || Ptr.isPastEnd())
       return false;
 
     unsigned N = Ptr.getNumElems();
     if (Ptr.elemSize() == 1) {
-      Result = strnlen(reinterpret_cast<const char *>(Ptr.getRawAddress()), N);
-      return Result != N;
+      unsigned Size = N - Ptr.getIndex();
+      Result =
+          strnlen(reinterpret_cast<const char *>(Ptr.getRawAddress()), Size);
+      return Result != Size;
     }
 
     PrimType ElemT = FieldDesc->getPrimType();

--- a/clang/test/SemaCXX/gnu-asm-constexpr.cpp
+++ b/clang/test/SemaCXX/gnu-asm-constexpr.cpp
@@ -77,7 +77,7 @@ struct string_view {
 
 
 void f() {
-    asm(("")); // expected-error {{the expression in this asm operand must be a string literal or an object with 'data()' and 'size()' member functions}}
+    asm(("")); // expected-error {{the expression in this asm operand must be a null terminated constant string or an object with 'data()' and 'size()' member functions}}
     asm((NotAString{})); // expected-error {{the string object in this asm operand is missing 'data()' and 'size()' member functions}}
     asm((MessageInvalidData{})); // expected-error {{the expression in this asm operand must have a 'data()' member function returning an object convertible to 'const char *'}} \
                                  // expected-error {{too few arguments to function call, expected 1, have 0}}
@@ -106,7 +106,7 @@ void test_dependent1(int i) {
 
 template void test_dependent1<int>(int);
 // expected-note@-1 {{in instantiation of function template specialization}}
-// expected-error@#err-int {{the expression in this asm operand must be a string literal or an object with 'data()' and 'size()' member functions}}
+// expected-error@#err-int {{the expression in this asm operand must be a null terminated constant string or an object with 'data()' and 'size()' member functions}}
 // expected-error@#err-int2 {{cannot initialize a value of type 'int' with an lvalue of type 'const char[3]'}}
 // expected-error@#err-int3 {{cannot initialize a value of type 'int' with an lvalue of type 'const char[2]'}}
 // expected-error@#err-int4 {{cannot initialize a value of type 'int' with an lvalue of type 'const char[7]'}}


### PR DESCRIPTION
Adds support for null terminated strings produced by constexpr evaluation. This makes it possible to perform analysis of format strings that previously were not possible, and is needed in the future to support __ptrauth qualifier options.