### PR TITLE
[clang-format] Align multi line expressions

### DIFF
--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -20855,6 +20855,22 @@ TEST_F(FormatTest, AlignWithLineBreaks) {
                Style);
   // clang-format on
 
+  Style = getLLVMStyle();
+  Style.AlignConsecutiveAssignments.Enabled = true;
+  verifyFormat("param->fault_depth = grid->jfault * grid->dz; //\n"
+               "grid->corner       = grid->jlid + 1;          //\n"
+               "param->peclet      = param->V                 //\n"
+               "                     * param->L * 1000.0      //\n"
+               "                     / param->kappa;          //",
+               Style);
+  Style.AlignOperands = FormatStyle::OAS_AlignAfterOperator;
+  verifyFormat("param->fault_depth = grid->jfault * grid->dz; //\n"
+               "grid->corner       = grid->jlid + 1;          //\n"
+               "param->peclet      = param->V                 //\n"
+               "                   * param->L * 1000.0        //\n"
+               "                   / param->kappa;            //",
+               Style);
+
   Style = getLLVMStyleWithColumns(70);
   Style.AlignConsecutiveDeclarations.Enabled = true;
   verifyFormat(


### PR DESCRIPTION
This patch updates the code in the `AlignTokens` function for finding regions to align.  Now it uses the same logic as the `AlignTokenSequence` function.  Previously it only recognized string literals split across multiple lines.

Fixes #171022.

The new way for finding where the expression ends identifies a ternary `?` or `:` operator at the start of the line as continuation of the preceding line.  The code around line 577 for figuring out whether there are multiple matches on the same line is updated so that it does not require the first token on a continued line not to match.

The sample in the bug report has `/**/`.  The added test has `//`.  This is because the mess up procedure in the test will remove the line break following `/**/`.

after, with `AlignConsecutiveAssignments` enabled

```C++
param->fault_depth = grid->jfault * grid->dz; //
grid->corner       = grid->jlid + 1;          //
param->peclet      = param->V                 //
                     * param->L * 1000.0      //
                     / param->kappa;          //
```

before

```C++
param->fault_depth = grid->jfault * grid->dz; //
grid->corner       = grid->jlid + 1;          //
param->peclet      = param->V                 //
                     * param->L * 1000.0      //
                / param->kappa;               //
```