### PR TITLE
Revert "[VPlan] Use predicate from VPValue VPWidenSelectR::computeCost."

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -1964,8 +1964,9 @@ InstructionCost VPWidenSelectRecipe::computeCost(ElementCount VF,
   if (!ScalarCond)
     CondTy = VectorType::get(CondTy, VF);
 
-  llvm::CmpPredicate Pred;
-  match(getOperand(0), m_Cmp(Pred, m_VPValue(), m_VPValue()));
+  CmpInst::Predicate Pred = CmpInst::BAD_ICMP_PREDICATE;
+  if (auto *Cmp = dyn_cast<CmpInst>(SI->getCondition()))
+    Pred = Cmp->getPredicate();
   return Ctx.TTI.getCmpSelInstrCost(
       Instruction::Select, VectorTy, CondTy, Pred, Ctx.CostKind,
       {TTI::OK_AnyValue, TTI::OP_None}, {TTI::OK_AnyValue, TTI::OP_None}, SI);

--- a/llvm/test/Transforms/LoopVectorize/AArch64/select-costs.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/select-costs.ll
@@ -92,10 +92,10 @@ exit:
 
 define i32 @select_xor_cond(ptr %src, i1 %c.0) {
 ; CHECK: LV: Checking a loop in 'select_xor_cond'
-; CHECK: Cost of 1 for VF 2: WIDEN-SELECT ir<%sel> = select ir<%c>, ir<false>, ir<%c.0>
-; CHECK: Cost of 1 for VF 4: WIDEN-SELECT ir<%sel> = select ir<%c>, ir<false>, ir<%c.0>
-; CHECK: Cost of 1 for VF 8: WIDEN-SELECT ir<%sel> = select ir<%c>, ir<false>, ir<%c.0>
-; CHECK: Cost of 1 for VF 16: WIDEN-SELECT ir<%sel> = select ir<%c>, ir<false>, ir<%c.0>
+; CHECK: Cost of 6 for VF 2: WIDEN-SELECT ir<%sel> = select ir<%c>, ir<false>, ir<%c.0>
+; CHECK: Cost of 12 for VF 4: WIDEN-SELECT ir<%sel> = select ir<%c>, ir<false>, ir<%c.0>
+; CHECK: Cost of 24 for VF 8: WIDEN-SELECT ir<%sel> = select ir<%c>, ir<false>, ir<%c.0>
+; CHECK: Cost of 48 for VF 16: WIDEN-SELECT ir<%sel> = select ir<%c>, ir<false>, ir<%c.0>
 ; CHECK: LV: Selecting VF: 4.
 
 entry:


### PR DESCRIPTION
Reverts llvm/llvm-project#172915

Looks like this may be causing  https://lab.llvm.org/buildbot/#/builders/128/builds/9590 to fail