### PR TITLE
[InstCombine] Bail out on type mismatch in foldICmpBinOpWithConstantViaTruthTable

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -3093,7 +3093,7 @@ Instruction *InstCombinerImpl::foldICmpBinOpWithConstantViaTruthTable(
               m_Select(m_Value(A), m_Constant(C1), m_Constant(C2)))) ||
       !match(BO->getOperand(1),
              m_Select(m_Value(B), m_Constant(C3), m_Constant(C4))) ||
-      Cmp.getType() != A->getType())
+      Cmp.getType() != A->getType() || Cmp.getType() != B->getType())
     return nullptr;
 
   std::bitset<4> Table;

--- a/llvm/test/Transforms/InstCombine/icmp-binop.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-binop.ll
@@ -3,7 +3,6 @@
 
 declare void @use64(i64)
 declare void @llvm.assume(i1)
-
 define i1 @mul_unkV_oddC_eq(i32 %v) {
 ; CHECK-LABEL: @mul_unkV_oddC_eq(
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[V:%.*]], 0
@@ -485,5 +484,22 @@ define <2 x i1> @icmp_eq_or_of_selects_with_constant_vectorized_nonsplat(<2 x i1
   %s2 = select <2 x i1> %b, <2 x i64> <i64 256, i64 128>, <2 x i64> zeroinitializer
   %or = or <2 x i64> %s1, %s2
   %cmp = icmp eq <2 x i64> %or, <i64 65792, i64 65664>
+  ret <2 x i1> %cmp
+}
+
+define <2 x i1> @pr173177(<2 x i1> %a, i1 %b) {
+; CHECK-LABEL: @pr173177(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[S1:%.*]] = select <2 x i1> [[A:%.*]], <2 x i16> splat (i16 179), <2 x i16> splat (i16 1)
+; CHECK-NEXT:    [[S2:%.*]] = select i1 [[B:%.*]], <2 x i16> zeroinitializer, <2 x i16> splat (i16 255)
+; CHECK-NEXT:    [[AND:%.*]] = and <2 x i16> [[S1]], [[S2]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x i16> [[AND]], zeroinitializer
+; CHECK-NEXT:    ret <2 x i1> [[CMP]]
+;
+entry:
+  %s1 = select <2 x i1> %a, <2 x i16> splat (i16 179), <2 x i16> splat (i16 1)
+  %s2 = select i1 %b, <2 x i16> zeroinitializer, <2 x i16> splat (i16 255)
+  %and = and <2 x i16> %s1, %s2
+  %cmp = icmp eq <2 x i16> %and, zeroinitializer
   ret <2 x i1> %cmp
 }


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/173177
The previous implementation doesn't consider cases like `<2 x i1> icmp(binop(sel <2 x i1>, sel i1))`.