### PR TITLE
[clangd] Fix crash on hover over 64bit enums with MSB set

### DIFF
--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -455,7 +455,7 @@ std::optional<std::string> printExprValue(const Expr *E,
 
   // Show enums symbolically, not numerically like APValue::printPretty().
   if (T->isEnumeralType() && Constant.Val.isInt() &&
-      Constant.Val.getInt().getSignificantBits() <= 64) {
+      Constant.Val.getInt().isRepresentableByInt64()) {
     // Compare to int64_t to avoid bit-width match requirements.
     int64_t Val = Constant.Val.getInt().getExtValue();
     for (const EnumConstantDecl *ECD : T->castAsEnumDecl()->enumerators())
@@ -466,7 +466,7 @@ std::optional<std::string> printExprValue(const Expr *E,
   }
   // Show hex value of integers if they're at least 10 (or negative!)
   if (T->isIntegralOrEnumerationType() && Constant.Val.isInt() &&
-      Constant.Val.getInt().getSignificantBits() <= 64 &&
+      Constant.Val.getInt().isRepresentableByInt64() &&
       Constant.Val.getInt().uge(10))
     return llvm::formatv("{0} ({1})", Constant.Val.getAsString(Ctx, T),
                          printHex(Constant.Val.getInt()))

--- a/clang-tools-extra/clangd/Hover.cpp
+++ b/clang-tools-extra/clangd/Hover.cpp
@@ -57,6 +57,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/ScopedPrinter.h"
 #include "llvm/Support/raw_ostream.h"
@@ -454,15 +455,24 @@ std::optional<std::string> printExprValue(const Expr *E,
     return std::nullopt;
 
   // Show enums symbolically, not numerically like APValue::printPretty().
-  if (T->isEnumeralType() && Constant.Val.isInt() &&
-      Constant.Val.getInt().isRepresentableByInt64()) {
-    // Compare to int64_t to avoid bit-width match requirements.
-    int64_t Val = Constant.Val.getInt().getExtValue();
-    for (const EnumConstantDecl *ECD : T->castAsEnumDecl()->enumerators())
-      if (ECD->getInitVal() == Val)
-        return llvm::formatv("{0} ({1})", ECD->getNameAsString(),
-                             printHex(Constant.Val.getInt()))
-            .str();
+  if (T->isEnumeralType() && Constant.Val.isInt()) {
+    const llvm::APSInt &Val = Constant.Val.getInt();
+    if (Val.isRepresentableByInt64()) {
+      // Compare to int64_t to avoid bit-width match requirements.
+      int64_t Val = Constant.Val.getInt().getExtValue();
+      for (const EnumConstantDecl *ECD : T->castAsEnumDecl()->enumerators())
+        if (ECD->getInitVal() == Val)
+          return llvm::formatv("{0} ({1})", ECD->getNameAsString(),
+                               printHex(Constant.Val.getInt()))
+              .str();
+    } else if (const auto UVal = Constant.Val.getInt().tryZExtValue()) {
+      for (const EnumConstantDecl *ECD : T->castAsEnumDecl()->enumerators())
+        if (ECD->getInitVal().getZExtValue() == *UVal)
+          return llvm::formatv("{0} ({1})", ECD->getNameAsString(),
+                               printHex(Constant.Val.getInt()))
+              .str();
+    } else
+      llvm_unreachable("Unhandled branch in enum symbolic representation");
   }
   // Show hex value of integers if they're at least 10 (or negative!)
   if (T->isIntegralOrEnumerationType() && Constant.Val.isInt() &&

--- a/clang-tools-extra/clangd/unittests/HoverTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HoverTests.cpp
@@ -5192,10 +5192,10 @@ TEST(Hover, FunctionParameters) {
 TEST(Hover, GH2381) {
   Annotations Code(R"cpp(
   struct Foo {
-    enum Bar {
-      A = -42UL,
-      B = ~0UL,
-      C = 0xFFFFFFFFFFFFFFFFUL,
+    enum Bar : unsigned long long int {
+      A = -42ULL,
+      B = ~0ULL,
+      C = 0xFFFFFFFFFFFFFFFFULL,
     };
   };
   constexpr auto va$a^ = Foo::A;
@@ -5204,48 +5204,54 @@ TEST(Hover, GH2381) {
   )cpp");
 
   TestTU TU = TestTU::withCode(Code.code());
-  auto AST = TU.build();
 
-  {
-    auto H = getHover(AST, Code.point("a"), format::getLLVMStyle(), nullptr);
+  for (const auto *Triplet :
+       {"--target=x86_64-pc-windows-msvc", "--target=x86_64-pc-linux-gnu"}) {
+    SCOPED_TRACE(Triplet);
+    TU.ExtraArgs.push_back(Triplet);
+    auto AST = TU.build();
 
-    ASSERT_TRUE(H);
-    EXPECT_EQ(H->Name, "va");
-    EXPECT_EQ(H->Kind, index::SymbolKind::Variable);
-    EXPECT_EQ(H->NamespaceScope, "");
-    EXPECT_EQ(H->LocalScope, "");
-    EXPECT_EQ(H->Type, "const Foo::Bar");
-    EXPECT_EQ(H->Definition, "constexpr auto va = Foo::A");
-    // FIXME: Should be "A (FFFFFFFFFFFFFFD6)
-    EXPECT_EQ(H->Value, "18446744073709551574");
-  }
+    {
+      auto H = getHover(AST, Code.point("a"), format::getLLVMStyle(), nullptr);
 
-  {
-    auto H = getHover(AST, Code.point("b"), format::getLLVMStyle(), nullptr);
+      ASSERT_TRUE(H);
+      EXPECT_EQ(H->Name, "va");
+      EXPECT_EQ(H->Kind, index::SymbolKind::Variable);
+      EXPECT_EQ(H->NamespaceScope, "");
+      EXPECT_EQ(H->LocalScope, "");
+      EXPECT_EQ(H->Type, "const Foo::Bar");
+      EXPECT_EQ(H->Definition, "constexpr auto va = Foo::A");
+      // FIXME: Should be "A (FFFFFFFFFFFFFFD6)
+      EXPECT_EQ(H->Value, "18446744073709551574");
+    }
 
-    ASSERT_TRUE(H);
-    EXPECT_EQ(H->Name, "vb");
-    EXPECT_EQ(H->Kind, index::SymbolKind::Variable);
-    EXPECT_EQ(H->NamespaceScope, "");
-    EXPECT_EQ(H->LocalScope, "");
-    EXPECT_EQ(H->Type, "const Foo::Bar");
-    EXPECT_EQ(H->Definition, "constexpr auto vb = Foo::B");
-    // FIXME: Should be "B (0xFFFFFFFFFFFFFFFF)");
-    EXPECT_EQ(H->Value, "18446744073709551615");
-  }
+    {
+      auto H = getHover(AST, Code.point("b"), format::getLLVMStyle(), nullptr);
 
-  {
-    auto H = getHover(AST, Code.point("c"), format::getLLVMStyle(), nullptr);
+      ASSERT_TRUE(H);
+      EXPECT_EQ(H->Name, "vb");
+      EXPECT_EQ(H->Kind, index::SymbolKind::Variable);
+      EXPECT_EQ(H->NamespaceScope, "");
+      EXPECT_EQ(H->LocalScope, "");
+      EXPECT_EQ(H->Type, "const Foo::Bar");
+      EXPECT_EQ(H->Definition, "constexpr auto vb = Foo::B");
+      // FIXME: Should be "B (0xFFFFFFFFFFFFFFFF)");
+      EXPECT_EQ(H->Value, "18446744073709551615");
+    }
 
-    ASSERT_TRUE(H);
-    EXPECT_EQ(H->Name, "vc");
-    EXPECT_EQ(H->Kind, index::SymbolKind::Variable);
-    EXPECT_EQ(H->NamespaceScope, "");
-    EXPECT_EQ(H->LocalScope, "");
-    EXPECT_EQ(H->Type, "const Foo::Bar");
-    EXPECT_EQ(H->Definition, "constexpr auto vc = Foo::C");
-    // FIXME: Should be "C (0xFFFFFFFFFFFFFFFF)");
-    EXPECT_EQ(H->Value, "18446744073709551615");
+    {
+      auto H = getHover(AST, Code.point("c"), format::getLLVMStyle(), nullptr);
+
+      ASSERT_TRUE(H);
+      EXPECT_EQ(H->Name, "vc");
+      EXPECT_EQ(H->Kind, index::SymbolKind::Variable);
+      EXPECT_EQ(H->NamespaceScope, "");
+      EXPECT_EQ(H->LocalScope, "");
+      EXPECT_EQ(H->Type, "const Foo::Bar");
+      EXPECT_EQ(H->Definition, "constexpr auto vc = Foo::C");
+      // FIXME: Should be "C (0xFFFFFFFFFFFFFFFF)");
+      EXPECT_EQ(H->Value, "18446744073709551615");
+    }
   }
 }
 } // namespace

--- a/clang-tools-extra/clangd/unittests/HoverTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HoverTests.cpp
@@ -5189,6 +5189,65 @@ TEST(Hover, FunctionParameters) {
   }
 }
 
+TEST(Hover, GH2381) {
+  Annotations Code(R"cpp(
+  struct Foo {
+    enum Bar {
+      A = -42UL,
+      B = ~0UL,
+      C = 0xFFFFFFFFFFFFFFFFUL,
+    };
+  };
+  constexpr auto va$a^ = Foo::A;
+  constexpr auto vb$b^ = Foo::B;
+  constexpr auto vc$c^ = Foo::C;
+  )cpp");
+
+  TestTU TU = TestTU::withCode(Code.code());
+  auto AST = TU.build();
+
+  {
+    auto H = getHover(AST, Code.point("a"), format::getLLVMStyle(), nullptr);
+
+    ASSERT_TRUE(H);
+    EXPECT_EQ(H->Name, "va");
+    EXPECT_EQ(H->Kind, index::SymbolKind::Variable);
+    EXPECT_EQ(H->NamespaceScope, "");
+    EXPECT_EQ(H->LocalScope, "");
+    EXPECT_EQ(H->Type, "const Foo::Bar");
+    EXPECT_EQ(H->Definition, "constexpr auto va = Foo::A");
+    // FIXME: Should be "A (FFFFFFFFFFFFFFD6)
+    EXPECT_EQ(H->Value, "18446744073709551574");
+  }
+
+  {
+    auto H = getHover(AST, Code.point("b"), format::getLLVMStyle(), nullptr);
+
+    ASSERT_TRUE(H);
+    EXPECT_EQ(H->Name, "vb");
+    EXPECT_EQ(H->Kind, index::SymbolKind::Variable);
+    EXPECT_EQ(H->NamespaceScope, "");
+    EXPECT_EQ(H->LocalScope, "");
+    EXPECT_EQ(H->Type, "const Foo::Bar");
+    EXPECT_EQ(H->Definition, "constexpr auto vb = Foo::B");
+    // FIXME: Should be "B (0xFFFFFFFFFFFFFFFF)");
+    EXPECT_EQ(H->Value, "18446744073709551615");
+  }
+
+  {
+    auto H = getHover(AST, Code.point("c"), format::getLLVMStyle(), nullptr);
+
+    ASSERT_TRUE(H);
+    EXPECT_EQ(H->Name, "vc");
+    EXPECT_EQ(H->Kind, index::SymbolKind::Variable);
+    EXPECT_EQ(H->NamespaceScope, "");
+    EXPECT_EQ(H->LocalScope, "");
+    EXPECT_EQ(H->Type, "const Foo::Bar");
+    EXPECT_EQ(H->Definition, "constexpr auto vc = Foo::C");
+    // FIXME: Should be "C (0xFFFFFFFFFFFFFFFF)");
+    EXPECT_EQ(H->Value, "18446744073709551615");
+  }
+}
 } // namespace
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/unittests/HoverTests.cpp
+++ b/clang-tools-extra/clangd/unittests/HoverTests.cpp
@@ -5195,12 +5195,10 @@ TEST(Hover, GH2381) {
     enum Bar : unsigned long long int {
       A = -42ULL,
       B = ~0ULL,
-      C = 0xFFFFFFFFFFFFFFFFULL,
     };
   };
   constexpr auto va$a^ = Foo::A;
   constexpr auto vb$b^ = Foo::B;
-  constexpr auto vc$c^ = Foo::C;
   )cpp");
 
   TestTU TU = TestTU::withCode(Code.code());
@@ -5221,8 +5219,7 @@ TEST(Hover, GH2381) {
       EXPECT_EQ(H->LocalScope, "");
       EXPECT_EQ(H->Type, "const Foo::Bar");
       EXPECT_EQ(H->Definition, "constexpr auto va = Foo::A");
-      // FIXME: Should be "A (FFFFFFFFFFFFFFD6)
-      EXPECT_EQ(H->Value, "18446744073709551574");
+      EXPECT_EQ(H->Value, "A (0xffffffffffffffd6)");
     }
 
     {
@@ -5235,22 +5232,7 @@ TEST(Hover, GH2381) {
       EXPECT_EQ(H->LocalScope, "");
       EXPECT_EQ(H->Type, "const Foo::Bar");
       EXPECT_EQ(H->Definition, "constexpr auto vb = Foo::B");
-      // FIXME: Should be "B (0xFFFFFFFFFFFFFFFF)");
-      EXPECT_EQ(H->Value, "18446744073709551615");
-    }
-
-    {
-      auto H = getHover(AST, Code.point("c"), format::getLLVMStyle(), nullptr);
-
-      ASSERT_TRUE(H);
-      EXPECT_EQ(H->Name, "vc");
-      EXPECT_EQ(H->Kind, index::SymbolKind::Variable);
-      EXPECT_EQ(H->NamespaceScope, "");
-      EXPECT_EQ(H->LocalScope, "");
-      EXPECT_EQ(H->Type, "const Foo::Bar");
-      EXPECT_EQ(H->Definition, "constexpr auto vc = Foo::C");
-      // FIXME: Should be "C (0xFFFFFFFFFFFFFFFF)");
-      EXPECT_EQ(H->Value, "18446744073709551615");
+      EXPECT_EQ(H->Value, "B (0xffffffffffffffff)");
     }
   }
 }


### PR DESCRIPTION
Fix clangd crash when hovering over 64bit values with MSB set. 

Fixes clangd/clangd#2381