### PR TITLE
[IR2Vec] Introducing python bindings for IR2Vec

### DIFF
--- a/llvm/include/llvm/Analysis/IR2Vec.h
+++ b/llvm/include/llvm/Analysis/IR2Vec.h
@@ -615,8 +615,8 @@ class IR2VecVocabAnalysis : public AnalysisInfoMixin<IR2VecVocabAnalysis> {
   using VocabMap = std::map<std::string, ir2vec::Embedding>;
   std::optional<ir2vec::VocabStorage> Vocab;
 
-  Error readVocabulary(VocabMap &OpcVocab, VocabMap &TypeVocab,
-                       VocabMap &ArgVocab);
+  Error readVocabulary(StringRef EffectivePath, VocabMap &OpcVocab,
+                       VocabMap &TypeVocab, VocabMap &ArgVocab);
   void generateVocabStorage(VocabMap &OpcVocab, VocabMap &TypeVocab,
                             VocabMap &ArgVocab);
   void emitError(Error Err, LLVMContext &Ctx);

--- a/llvm/test/tools/llvm-ir2vec/python/init.py
+++ b/llvm/test/tools/llvm-ir2vec/python/init.py
@@ -1,0 +1,16 @@
+# RUN: env PYTHONPATH=%llvm_lib_dir %python %s %S/test.ll %ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json | FileCheck %s
+
+import sys
+import py_ir2vec
+
+ll_file = sys.argv[1]
+vocab_path = sys.argv[2]
+
+tool = py_ir2vec.initEmbedding(filename=ll_file, mode="sym", vocab_override=vocab_path)
+
+if tool is not None:
+    print("SUCCESS: Tool initialized")
+    print(f"Tool type: {type(tool).__name__}")
+
+# CHECK: SUCCESS: Tool initialized
+# CHECK: Tool type: IR2VecTool

--- a/llvm/test/tools/llvm-ir2vec/python/lit.local.cfg
+++ b/llvm/test/tools/llvm-ir2vec/python/lit.local.cfg
@@ -1,0 +1,11 @@
+import os
+import sys
+
+config.substitutions.append(('%python', sys.executable))
+config.substitutions.append(('%llvm_lib_dir', os.path.join(config.llvm_obj_root, 'lib')))
+
+# Add .py as a valid test suffix
+config.suffixes = ['.test', '.py']
+
+# Exclude test.ll from being treated as a test (it's input data)
+config.excludes = ['test.ll']

--- a/llvm/test/tools/llvm-ir2vec/python/test.ll
+++ b/llvm/test/tools/llvm-ir2vec/python/test.ll
@@ -1,0 +1,14 @@
+define dso_local noundef float @test(i32 noundef %a, float noundef %b) {
+entry:
+  %a.addr = alloca i32, align 4
+  %b.addr = alloca float, align 4
+  store i32 %a, ptr %a.addr, align 4
+  store float %b, ptr %b.addr, align 4
+  %0 = load i32, ptr %a.addr, align 4
+  %1 = load i32, ptr %a.addr, align 4
+  %mul = mul nsw i32 %0, %1
+  %conv = sitofp i32 %mul to float
+  %2 = load float, ptr %b.addr, align 4
+  %add = fadd float %conv, %2
+  ret float %add
+}

--- a/llvm/tools/llvm-ir2vec/CMakeLists.txt
+++ b/llvm/tools/llvm-ir2vec/CMakeLists.txt
@@ -32,3 +32,5 @@ add_llvm_tool(llvm-ir2vec
 
 target_include_directories(llvm-ir2vec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/utils)
 target_link_libraries(llvm-ir2vec PRIVATE emb_utils)
+
+add_subdirectory(bindings)

--- a/llvm/tools/llvm-ir2vec/bindings/CMakeLists.txt
+++ b/llvm/tools/llvm-ir2vec/bindings/CMakeLists.txt
@@ -1,0 +1,12 @@
+find_package(Python3 COMPONENTS Interpreter Development.Module)
+find_package(pybind11 CONFIG QUIET)
+
+if(Python3_FOUND AND pybind11_FOUND)
+  # Required for Python shared library
+  set_target_properties(ir2vec_utils PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  
+  pybind11_add_module(py_ir2vec MODULE ir2vec_bindings.cpp)
+  target_link_libraries(py_ir2vec PRIVATE ir2vec_utils)
+  
+  message(STATUS "Python bindings for llvm-ir2vec will be built")
+endif()

--- a/llvm/tools/llvm-ir2vec/bindings/ir2vec_bindings.cpp
+++ b/llvm/tools/llvm-ir2vec/bindings/ir2vec_bindings.cpp
@@ -1,0 +1,93 @@
+//===- ir2vec_bindings.cpp - Python Bindings for IR2Vec ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "utils.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/SourceMgr.h"
+
+#include <fstream>
+#include <memory>
+#include <string>
+
+namespace py = pybind11;
+using namespace llvm;
+using namespace llvm::ir2vec;
+
+namespace llvm {
+namespace ir2vec {
+void setIR2VecVocabPath(StringRef Path);
+StringRef getIR2VecVocabPath();
+} // namespace ir2vec
+} // namespace llvm
+
+namespace {
+
+bool fileNotValid(const std::string &Filename) {
+  std::ifstream F(Filename, std::ios_base::in | std::ios_base::binary);
+  return !F.good();
+}
+
+std::unique_ptr<Module> getLLVMIR(const std::string &Filename,
+                                  LLVMContext &Context) {
+  SMDiagnostic Err;
+  auto M = parseIRFile(Filename, Err, Context);
+  if (!M)
+    throw std::runtime_error("Failed to parse IR file.");
+  return M;
+}
+
+class PyIR2VecTool {
+private:
+  std::unique_ptr<LLVMContext> Ctx;
+  std::unique_ptr<Module> M;
+  std::unique_ptr<IR2VecTool> Tool;
+
+public:
+  PyIR2VecTool(std::string Filename, std::string Mode,
+               std::string VocabOverride) {
+    if (fileNotValid(Filename))
+      throw std::runtime_error("Invalid file path");
+
+    if (Mode != "sym" && Mode != "fa")
+      throw std::runtime_error("Invalid mode. Use 'sym' or 'fa'");
+
+    if (VocabOverride.empty())
+      throw std::runtime_error("Error - Empty Vocab Path not allowed");
+
+    setIR2VecVocabPath(VocabOverride);
+
+    Ctx = std::make_unique<LLVMContext>();
+    M = getLLVMIR(Filename, *Ctx);
+    Tool = std::make_unique<IR2VecTool>(*M);
+
+    bool Ok = Tool->initializeVocabulary();
+    if (!Ok)
+      throw std::runtime_error("Failed to initialize IR2Vec vocabulary");
+  }
+};
+
+} // namespace
+
+PYBIND11_MODULE(py_ir2vec, m) {
+  m.doc() = std::string("Python bindings for ") + ToolName;
+
+  py::class_<PyIR2VecTool>(m, "IR2VecTool")
+      .def(py::init<std::string, std::string, std::string>());
+
+  m.def(
+      "initEmbedding",
+      [](std::string filename, std::string mode, std::string vocab_override) {
+        return std::make_unique<PyIR2VecTool>(filename, mode, vocab_override);
+      },
+      py::arg("filename"), py::arg("mode") = "sym", py::arg("vocab_override"));
+}


### PR DESCRIPTION
# Introducing Python Bindings for llvm-ir2vec
- Addresses https://github.com/llvm/llvm-project/issues/141839
- (outdated description - will be updated soon)

## Summary

This patch refactors the llvm-ir2vec tool to support Python bindings. This done by the following changes

## Changes

### 1. Library Extraction (`lib/`)

- **Created `lib/EmbTool`**: Extracted embedding tool functionality from `llvm-ir2vec.cpp` into a separate library
  - `lib/emb-tool.cpp`: Core embedding generation logic
  - `lib/emb-tool.h`: Public interface for the embedding tool
  - `lib/CMakeLists.txt`: Library build configuration

### 2. Tool Refactoring

- **Simplified `llvm-ir2vec.cpp`**: Refactored to use the `EmbTool` library, removing code duplication
- Command-line tool now acts as a thin wrapper around the library functionality

### 3. Python Bindings (`bindings/`)

- **Added `bindings/ir2vec_bindings.cpp`**: pybind11-based Python bindings
  - Provides Pythonic interface for embedding generation
- **Added `bindings/CMakeLists.txt`**: Build configuration for Python module
  - Gracefully handles missing pybind11 dependency
  - Creates `py_ir2vec` Python module

### 4. Build System

- **Updated root `CMakeLists.txt`**: 
  - Builds library before tool and bindings
  - Links tool and bindings against `EmbTool` library
- All LLVM component dependencies properly propagated through the library

## Directory Structure
```
llvm-ir2vec/
├── lib/                      # Core library
│   ├── CMakeLists.txt
│   ├── emb-tool.cpp
│   └── emb-tool.h
├── bindings/                 # Python bindings
│   ├── CMakeLists.txt
│   └── ir2vec_bindings.cpp
├── CMakeLists.txt           # Root build config
└── llvm-ir2vec.cpp          # Command-line tool
```

## Benefits

1. **Code Reusability**: Core functionality now available as a library
2. **Python Integration**: Enables programmatic usage from Python scripts and notebooks
3. **Maintainability**: Single source of truth for embedding logic
4. **Backward Compatibility**: Existing command-line tool behavior unchanged
5. **Optional Dependencies**: Python bindings gracefully skipped if pybind11 unavailable


## Usage

```python
import py_ir2vec

tool = py_ir2vec.IR2VecTool("input.ll")
entities = tool.getEntityMappings()
triplets = tool.generateTriplets()
```

## Next Steps

- Python API method for embedding generation
- Extending an equivalent API structure to MIR2Vec
- Wheel file builds