### PR TITLE
InjectTLIMappings: remove incompatible attributes from vector declarations.

### DIFF
--- a/llvm/test/Transforms/Util/add-TLI-mappings.ll
+++ b/llvm/test/Transforms/Util/add-TLI-mappings.ll
@@ -42,7 +42,7 @@
 ; LIBMVEC-X86-SAME: [2 x ptr] [
 ; LIBMVEC-X86-SAME:   ptr @_ZGVbN2v_sin,
 ; LIBMVEC-X86-SAME:   ptr @_ZGVdN4v_sin
-; SLEEFGNUABI-SAME: [16 x ptr] [
+; SLEEFGNUABI-SAME: [18 x ptr] [
 ; SLEEFGNUABI-SAME:   ptr @_ZGVnN2vl8_modf,
 ; SLEEFGNUABI-SAME:   ptr @_ZGVsNxvl8_modf,
 ; SLEEFGNUABI-SAME:   ptr @_ZGVnN4vl4_modff,
@@ -58,8 +58,10 @@
 ; SLEEFGNUABI-SAME:   ptr @_ZGVnN4vl4l4_sincospif,
 ; SLEEFGNUABI-SAME:   ptr @_ZGVsNxvl4l4_sincospif,
 ; SLEEFGNUABI_SAME;   ptr @_ZGVnN4v_log10f,
-; SLEEFGNUABI-SAME:   ptr @_ZGVsMxv_log10f
-; ARMPL-SAME:       [16 x ptr] [
+; SLEEFGNUABI-SAME:   ptr @_ZGVsMxv_log10f,
+; SLEEFGNUABI-SAME:   ptr @_ZGVnN2vv_ldexp,
+; SLEEFGNUABI-SAME:   ptr @_ZGVsMxvv_ldexp
+; ARMPL-SAME:       [18 x ptr] [
 ; ARMPL-SAME:         ptr @armpl_vmodfq_f64,
 ; ARMPL-SAME:         ptr @armpl_svmodf_f64_x,
 ; ARMPL-SAME:         ptr @armpl_vmodfq_f32,
@@ -75,7 +77,9 @@
 ; ARMPL-SAME:         ptr @armpl_vsincospiq_f32,
 ; ARMPL-SAME:         ptr @armpl_svsincospi_f32_x,
 ; ARMPL-SAME:         ptr @armpl_vlog10q_f32,
-; ARMPL-SAME:         ptr @armpl_svlog10_f32_x
+; ARMPL-SAME:         ptr @armpl_svlog10_f32_x,
+; ARMPL-SAME:         ptr @armpl_vldexpq_f64,
+; ARMPL-SAME:         ptr @armpl_svldexp_f64_x
 ; COMMON-SAME:      ], section "llvm.metadata"
 
 define double @modf_f64(double %in, ptr %iptr) {
@@ -181,6 +185,16 @@ define float @call_llvm.log10.f32(float %in) {
 
 declare float @llvm.log10.f32(float) #0
 
+define double @ldexp_f64_signext(double %x, i32 signext %exp) {
+; COMMON-LABEL: @ldexp_f64_signext(
+; SLEEFGNUABI:  call double @ldexp(double %{{.*}}, i32 signext %{{.*}}) #[[LDEXP:[0-9]+]]
+; ARMPL:        call double @ldexp(double %{{.*}}, i32 signext %{{.*}}) #[[LDEXP:[0-9]+]]
+  %call = tail call double @ldexp(double %x, i32 signext %exp)
+  ret double %call
+}
+
+declare double @ldexp(double, i32 signext) #0
+
 ; SVML: declare <2 x double> @__svml_sin2(<2 x double>)
 ; SVML: declare <4 x double> @__svml_sin4(<4 x double>)
 ; SVML: declare <8 x double> @__svml_sin8(<8 x double>)
@@ -233,6 +247,7 @@ declare float @llvm.log10.f32(float) #0
 
 ; SLEEFGNUABI_RISCV: declare <vscale x 2 x double> @Sleef_sindx_u10rvvm2(<vscale x 2 x double>)
 ; SLEEFGNUABI_RISCV: declare <vscale x 4 x float> @Sleef_log10fx_u10rvvm2(<vscale x 4 x float>)
+; SLEEFGNUABI_RISCV: declare <vscale x 2 x double> @Sleef_ldexpdx_rvvm2(<vscale x 2 x double>, <vscale x 2 x i32>)
 
 ; ARMPL: declare aarch64_vector_pcs <2 x double> @armpl_vmodfq_f64(<2 x double>, ptr)
 ; ARMPL: declare <vscale x 2 x double> @armpl_svmodf_f64_x(<vscale x 2 x double>, ptr, <vscale x 2 x i1>)


### PR DESCRIPTION
Some attributes (e.g., the signext attribute) are not supported on vector types; adding them would cause the verifier pass to fail.