### PR TITLE
[InstCombine] Prevent crash when folding struct-returning ops into vector selects

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1782,6 +1782,9 @@ static Value *foldOperationIntoSelectOperand(Instruction &I, SelectInst *SI,
 Instruction *InstCombinerImpl::FoldOpIntoSelect(Instruction &Op, SelectInst *SI,
                                                 bool FoldWithMultiUse,
                                                 bool SimplifyBothArms) {
+  if (SI->getCondition()->getType()->isVectorTy() &&
+      !Op.getType()->isVectorTy())
+    return nullptr;
   // Don't modify shared select instructions unless set FoldWithMultiUse
   if (!SI->hasOneUse() && !FoldWithMultiUse)
     return nullptr;


### PR DESCRIPTION
This patch adds a safety check to` FoldOpIntoSelect `to prevent an invalid transformation where an operation returning a struct type is folded into a vector select.

LLVM's SelectInst does not support selecting between two struct operands when the condition is a vector. This logic error is currently latent on main because no struct-returning intrinsics are marked as trivially vectorizable.

This was verified using the existing test `llvm/test/Transforms/InstCombine/select_frexp.ll`.

By temporarily marking llvm.frexp as vectorizable (as proposed in #112408), this existing test triggers an assertion failure in SelectInst::Create.

This patch ensures the test passes (by skipping the invalid fold) even when frexp vectorization is enabled.