### PR TITLE
[Clang] Fix crash in EnumDecl::getValueRange with large __int128 constants

### DIFF
--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -5129,8 +5129,11 @@ void EnumDecl::getValueRange(llvm::APInt &Max, llvm::APInt &Min) const {
     unsigned NumBits = std::max(NumNegativeBits, NumPositiveBits + 1);
     Max = llvm::APInt(Bitwidth, 1) << (NumBits - 1);
     Min = -Max;
-  } else {
-    Max = llvm::APInt(Bitwidth, 1) << NumPositiveBits;
+ } else {
+    if (NumPositiveBits >= Bitwidth)
+      Max = llvm::APInt::getZero(Bitwidth);
+    else
+      Max = llvm::APInt(Bitwidth, 1) << NumPositiveBits;
     Min = llvm::APInt::getZero(Bitwidth);
   }
 }

--- a/clang/test/SemaCXX/pr173182.cpp
+++ b/clang/test/SemaCXX/pr173182.cpp
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -triple x86_64-unknown-linux-gnu %s
+
+enum E2 { // expected-warning {{enumeration values exceed range of largest integer}}
+  V2 = ((__int128)0x1000000000000000 << 64) + 1
+};
+
+__int128 get_val() {
+  return (enum E2)__int128(V2 >> 4);
+}


### PR DESCRIPTION
This PR fixes a crash (assertion failure) in `EnumDecl::getValueRange` when calculating the range of an enum that uses `__int128` types and covers the full 128-bit width.

**The Bug:**
When `NumPositiveBits` equals the integer width (e.g., 128 for `__int128`), the code previously attempted to calculate `Max = 1 << 128`. This triggered an assertion in `APInt::operator<<=` because the shift amount must be strictly less than the bit width.

**The Fix:**
Added a check to verify if `NumPositiveBits` is greater than or equal to `Bitwidth`. If so, `Max` is set to 0 (representing the wrapped value) to avoid the invalid shift operation.

**Tests:**
Added a regression test in `clang/test/SemaCXX/pr173182.cpp` which reproduces the crash using the code snippet from the issue.

Fixes #173182.