### PR TITLE
[libc++][ranges] Applied `[[nodiscard]]` to `empty_view`

### DIFF
--- a/libcxx/include/__ranges/empty_view.h
+++ b/libcxx/include/__ranges/empty_view.h
@@ -29,11 +29,11 @@ template <class _Tp>
   requires is_object_v<_Tp>
 class empty_view : public view_interface<empty_view<_Tp>> {
 public:
-  _LIBCPP_HIDE_FROM_ABI static constexpr _Tp* begin() noexcept { return nullptr; }
-  _LIBCPP_HIDE_FROM_ABI static constexpr _Tp* end() noexcept { return nullptr; }
-  _LIBCPP_HIDE_FROM_ABI static constexpr _Tp* data() noexcept { return nullptr; }
-  _LIBCPP_HIDE_FROM_ABI static constexpr size_t size() noexcept { return 0; }
-  _LIBCPP_HIDE_FROM_ABI static constexpr bool empty() noexcept { return true; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr _Tp* begin() noexcept { return nullptr; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr _Tp* end() noexcept { return nullptr; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr _Tp* data() noexcept { return nullptr; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr size_t size() noexcept { return 0; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static constexpr bool empty() noexcept { return true; }
 };
 
 template <class _Tp>

--- a/libcxx/test/libcxx/ranges/range.adaptors/range.empty/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/ranges/range.adaptors/range.empty/nodiscard.verify.cpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++20
+
+// Check that functions are marked [[nodiscard]]
+
+#include <ranges>
+
+void test() {
+  auto v = std::views::empty<int>;
+
+  // [range.empty.view]
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  v.begin();
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  v.end();
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  v.data();
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  v.size();
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  v.empty();
+}


### PR DESCRIPTION
`[[nodiscard]]` should be applied to functions where discarding the return value is most likely a correctness issue.

- https://libcxx.llvm.org/CodingGuidelines.html
- https://wg21.link/ranges
- https://wg21.link/range.empty

Towards #172124