### PR TITLE
[lldb][AIX] Base files for ObjectContainerBigArchive

### DIFF
--- a/lldb/source/Plugins/ObjectContainer/Big-Archive/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectContainer/Big-Archive/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_lldb_library(lldbPluginObjectContainerBigArchive PLUGIN                     
+  ObjectContainerBigArchive.cpp                                                    
+                                                                                   
+  LINK_LIBS                                                                     
+    lldbCore                                                                    
+    lldbHost                                                                    
+    lldbSymbol                                                                  
+  LINK_COMPONENTS                                                               
+    Support                                                                     
+  )   

--- a/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.cpp
@@ -1,0 +1,69 @@
+//===-- ObjectContainerBigArchive.cpp -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ObjectContainerBigArchive.h"
+#include "lldb/Core/Module.h"
+#include "lldb/Core/ModuleSpec.h"
+#include "lldb/Core/PluginManager.h"
+#include "lldb/Utility/ArchSpec.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+LLDB_PLUGIN_DEFINE(ObjectContainerBigArchive)
+
+ObjectContainerBigArchive::Archive::Archive(const lldb_private::ArchSpec &arch,
+                                            const llvm::sys::TimePoint<> &time,
+                                            lldb::offset_t file_offset,
+                                            lldb::DataExtractorSP extractor_sp)
+    : m_arch(arch), m_modification_time(time), m_file_offset(file_offset),
+      m_objects(), m_extractor_sp(extractor_sp) {}
+
+ObjectContainerBigArchive::Archive::~Archive() = default;
+
+void ObjectContainerBigArchive::Initialize() {
+  PluginManager::RegisterPlugin(GetPluginNameStatic(),
+                                GetPluginDescriptionStatic(), CreateInstance,
+                                GetModuleSpecifications);
+}
+
+void ObjectContainerBigArchive::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
+
+ObjectContainer *ObjectContainerBigArchive::CreateInstance(
+    const lldb::ModuleSP &module_sp, DataBufferSP &data_sp,
+    lldb::offset_t data_offset, const FileSpec *file,
+    lldb::offset_t file_offset, lldb::offset_t length) {
+  return nullptr;
+}
+
+size_t ObjectContainerBigArchive::GetModuleSpecifications(
+    const lldb_private::FileSpec &file, lldb::DataBufferSP &data_sp,
+    lldb::offset_t data_offset, lldb::offset_t file_offset,
+    lldb::offset_t file_size, lldb_private::ModuleSpecList &specs) {
+  return 0;
+}
+
+ObjectContainerBigArchive::ObjectContainerBigArchive(
+    const lldb::ModuleSP &module_sp, DataBufferSP &data_sp,
+    lldb::offset_t data_offset, const lldb_private::FileSpec *file,
+    lldb::offset_t file_offset, lldb::offset_t size)
+    : ObjectContainer(module_sp, file, file_offset, size, data_sp, data_offset),
+      m_archive_sp() {}
+void ObjectContainerBigArchive::SetArchive(Archive::shared_ptr &archive_sp) {
+  m_archive_sp = archive_sp;
+}
+
+ObjectContainerBigArchive::~ObjectContainerBigArchive() = default;
+
+bool ObjectContainerBigArchive::ParseHeader() { return false; }
+
+ObjectFileSP ObjectContainerBigArchive::GetObjectFile(const FileSpec *file) {
+  return ObjectFileSP();
+}

--- a/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.cpp
@@ -56,6 +56,7 @@ ObjectContainerBigArchive::ObjectContainerBigArchive(
     lldb::offset_t file_offset, lldb::offset_t size)
     : ObjectContainer(module_sp, file, file_offset, size, data_sp, data_offset),
       m_archive_sp() {}
+
 void ObjectContainerBigArchive::SetArchive(Archive::shared_ptr &archive_sp) {
   m_archive_sp = archive_sp;
 }

--- a/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.h
+++ b/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.h
@@ -1,0 +1,138 @@
+//===-- ObjectContainerBigArchive.h -----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_OBJECTCONTAINER_BIG_ARCHIVE_OBJECTCONTAINERBIGARCHIVE_H
+#define LLDB_SOURCE_PLUGINS_OBJECTCONTAINER_BIG_ARCHIVE_OBJECTCONTAINERBIGARCHIVE_H
+
+#include "lldb/Symbol/ObjectContainer.h"
+#include "lldb/Utility/ArchSpec.h"
+#include "lldb/Utility/DataExtractor.h"
+#include "lldb/Utility/FileSpec.h"
+
+class ObjectContainerBigArchive : public lldb_private::ObjectContainer {
+public:
+  ObjectContainerBigArchive(const lldb::ModuleSP &module_sp,
+                            lldb::DataBufferSP &data_sp,
+                            lldb::offset_t data_offset,
+                            const lldb_private::FileSpec *file,
+                            lldb::offset_t offset, lldb::offset_t length);
+
+  ~ObjectContainerBigArchive() override;
+
+  // Static Functions
+  static void Initialize();
+
+  static void Terminate();
+
+  static llvm::StringRef GetPluginNameStatic() { return "big-archive"; }
+
+  static llvm::StringRef GetPluginDescriptionStatic() {
+    return "Big Archive object container reader.";
+  }
+
+  static lldb_private::ObjectContainer *
+  CreateInstance(const lldb::ModuleSP &module_sp, lldb::DataBufferSP &data_sp,
+                 lldb::offset_t data_offset, const lldb_private::FileSpec *file,
+                 lldb::offset_t offset, lldb::offset_t length);
+
+  static size_t GetModuleSpecifications(const lldb_private::FileSpec &file,
+                                        lldb::DataBufferSP &data_sp,
+                                        lldb::offset_t data_offset,
+                                        lldb::offset_t file_offset,
+                                        lldb::offset_t length,
+                                        lldb_private::ModuleSpecList &specs);
+
+  // Member Functions
+  bool ParseHeader() override;
+
+  size_t GetNumObjects() const override {
+    if (m_archive_sp)
+      return m_archive_sp->GetNumObjects();
+    return 0;
+  }
+
+  lldb::ObjectFileSP GetObjectFile(const lldb_private::FileSpec *file) override;
+
+  // PluginInterface protocol
+  llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
+
+protected:
+  struct Object {
+    Object();
+
+    void Clear();
+
+    lldb::offset_t Extract(const lldb_private::DataExtractor &data,
+                           lldb::offset_t offset);
+    /// Object name in the archive.
+    lldb_private::ConstString ar_name;
+
+    /// Object modification time in the archive.
+    uint32_t modification_time = 0;
+
+    /// Object user id in the archive.
+    uint16_t uid = 0;
+
+    /// Object group id in the archive.
+    uint16_t gid = 0;
+
+    /// Object octal file permissions in the archive.
+    uint16_t mode = 0;
+
+    /// Object size in bytes in the archive.
+    uint32_t size = 0;
+
+    /// File offset in bytes from the beginning of the file of the object data.
+    lldb::offset_t file_offset = 0;
+
+    /// Length of the object data.
+    lldb::offset_t file_size = 0;
+
+    void Dump(lldb_private::Stream *s) const;
+  };
+
+  class Archive {
+  public:
+    typedef std::shared_ptr<Archive> shared_ptr;
+    typedef std::multimap<lldb_private::FileSpec, shared_ptr> Map;
+
+    Archive(const lldb_private::ArchSpec &arch,
+            const llvm::sys::TimePoint<> &mod_time, lldb::offset_t file_offset,
+            lldb::DataExtractorSP extractor_sp);
+
+    ~Archive();
+
+    size_t GetNumObjects() const { return m_objects.size(); }
+
+    lldb::offset_t GetFileOffset() const { return m_file_offset; }
+
+    const lldb_private::ArchSpec &GetArchitecture() const { return m_arch; }
+
+    void SetArchitecture(const lldb_private::ArchSpec &arch) { m_arch = arch; }
+
+    lldb_private::DataExtractor &GetData() { return *m_extractor_sp.get(); }
+    lldb::DataExtractorSP &GetDataSP() { return m_extractor_sp; }
+
+  protected:
+    // Member Variables
+    lldb_private::ArchSpec m_arch;
+    llvm::sys::TimePoint<> m_modification_time;
+    lldb::offset_t m_file_offset;
+    std::vector<Object> m_objects;
+    ///< The data extractor for this object container
+    /// so we don't lose data if the .a files
+    /// gets modified
+    lldb::DataExtractorSP m_extractor_sp;
+  };
+
+  void SetArchive(Archive::shared_ptr &archive_sp);
+
+  Archive::shared_ptr m_archive_sp;
+};
+
+#endif // LLDB_SOURCE_PLUGINS_OBJECTCONTAINER_BIG_ARCHIVE_OBJECTCONTAINERBIGARCHIVE_H

--- a/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.h
+++ b/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.h
@@ -90,7 +90,7 @@ protected:
     /// File offset in bytes from the beginning of the file of the object data.
     lldb::offset_t file_offset = 0;
 
-    /// Length of the object data.
+    /// Length of the object data in bytes.
     lldb::offset_t file_size = 0;
 
     void Dump(lldb_private::Stream *s) const;

--- a/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.h
+++ b/lldb/source/Plugins/ObjectContainer/Big-Archive/ObjectContainerBigArchive.h
@@ -14,6 +14,10 @@
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/FileSpec.h"
 
+// This file represents an AIX Big Archive and combines several files into one.
+// It is the default library archive format for the AIX operating system.
+// Ref: https://www.ibm.com/docs/en/aix/7.3.0?topic=formats-ar-file-format-big
+
 class ObjectContainerBigArchive : public lldb_private::ObjectContainer {
 public:
   ObjectContainerBigArchive(const lldb::ModuleSP &module_sp,

--- a/lldb/source/Plugins/ObjectContainer/CMakeLists.txt
+++ b/lldb/source/Plugins/ObjectContainer/CMakeLists.txt
@@ -1,5 +1,6 @@
 set_property(DIRECTORY PROPERTY LLDB_PLUGIN_KIND ObjectContainer)
 
 add_subdirectory(BSD-Archive)
+add_subdirectory(Big-Archive) 
 add_subdirectory(Universal-Mach-O)
 add_subdirectory(Mach-O-Fileset)


### PR DESCRIPTION
This PR is in reference to porting LLDB on AIX. Ref discusssions: [llvm discourse](https://discourse.llvm.org/t/port-lldb-to-ibm-aix/80640) and https://github.com/llvm/llvm-project/issues/101657.
Complete changes together in this draft:
- https://github.com/llvm/llvm-project/pull/102601

**Description:**
Adding skeleton with base files for ObjectContainer archive for AIX.

Ref Doc: [AIX ar file format-big](https://www.ibm.com/docs/en/aix/7.3.0?topic=formats-ar-file-format-big)