### PR TITLE
[lldb][NFC] Assert ASTNodeUPs and pass ASTNodes by reference in DIL

### DIFF
--- a/lldb/include/lldb/ValueObject/DILAST.h
+++ b/lldb/include/lldb/ValueObject/DILAST.h
@@ -83,8 +83,8 @@ public:
   ErrorNode() : ASTNode(0, NodeKind::eErrorNode) {}
   llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
 
-  static bool classof(const ASTNode *node) {
-    return node->GetKind() == NodeKind::eErrorNode;
+  static bool classof(const ASTNode &node) {
+    return node.GetKind() == NodeKind::eErrorNode;
   }
 };
 
@@ -97,8 +97,8 @@ public:
 
   std::string GetName() const { return m_name; }
 
-  static bool classof(const ASTNode *node) {
-    return node->GetKind() == NodeKind::eIdentifierNode;
+  static bool classof(const ASTNode &node) {
+    return node.GetKind() == NodeKind::eIdentifierNode;
   }
 
 private:
@@ -114,12 +114,12 @@ public:
 
   llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
 
-  ASTNode *GetBase() const { return m_base.get(); }
+  ASTNode &GetBase() const { return *m_base; }
   bool GetIsArrow() const { return m_is_arrow; }
   llvm::StringRef GetFieldName() const { return llvm::StringRef(m_field_name); }
 
-  static bool classof(const ASTNode *node) {
-    return node->GetKind() == NodeKind::eMemberOfNode;
+  static bool classof(const ASTNode &node) {
+    return node.GetKind() == NodeKind::eMemberOfNode;
   }
 
 private:
@@ -137,10 +137,10 @@ public:
   llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
 
   UnaryOpKind GetKind() const { return m_kind; }
-  ASTNode *GetOperand() const { return m_operand.get(); }
+  ASTNode &GetOperand() const { return *m_operand; }
 
-  static bool classof(const ASTNode *node) {
-    return node->GetKind() == NodeKind::eUnaryOpNode;
+  static bool classof(const ASTNode &node) {
+    return node.GetKind() == NodeKind::eUnaryOpNode;
   }
 
 private:
@@ -156,11 +156,11 @@ public:
 
   llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
 
-  ASTNode *GetBase() const { return m_base.get(); }
-  ASTNode *GetIndex() const { return m_index.get(); }
+  ASTNode &GetBase() const { return *m_base; }
+  ASTNode &GetIndex() const { return *m_index; }
 
-  static bool classof(const ASTNode *node) {
-    return node->GetKind() == NodeKind::eArraySubscriptNode;
+  static bool classof(const ASTNode &node) {
+    return node.GetKind() == NodeKind::eArraySubscriptNode;
   }
 
 private:
@@ -178,12 +178,12 @@ public:
 
   llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
 
-  ASTNode *GetBase() const { return m_base.get(); }
-  ASTNode *GetFirstIndex() const { return m_first_index.get(); }
-  ASTNode *GetLastIndex() const { return m_last_index.get(); }
+  ASTNode &GetBase() const { return *m_base; }
+  ASTNode &GetFirstIndex() const { return *m_first_index; }
+  ASTNode &GetLastIndex() const { return *m_last_index; }
 
-  static bool classof(const ASTNode *node) {
-    return node->GetKind() == NodeKind::eBitExtractionNode;
+  static bool classof(const ASTNode &node) {
+    return node.GetKind() == NodeKind::eBitExtractionNode;
   }
 
 private:
@@ -209,8 +209,8 @@ public:
   bool IsUnsigned() const { return m_is_unsigned; }
   IntegerTypeSuffix GetTypeSuffix() const { return m_type; }
 
-  static bool classof(const ASTNode *node) {
-    return node->GetKind() == NodeKind::eIntegerLiteralNode;
+  static bool classof(const ASTNode &node) {
+    return node.GetKind() == NodeKind::eIntegerLiteralNode;
   }
 
 private:
@@ -230,8 +230,8 @@ public:
 
   const llvm::APFloat &GetValue() const { return m_value; }
 
-  static bool classof(const ASTNode *node) {
-    return node->GetKind() == NodeKind::eFloatLiteralNode;
+  static bool classof(const ASTNode &node) {
+    return node.GetKind() == NodeKind::eFloatLiteralNode;
   }
 
 private:
@@ -247,8 +247,8 @@ public:
 
   bool GetValue() const & { return m_value; }
 
-  static bool classof(const ASTNode *node) {
-    return node->GetKind() == NodeKind::eBooleanLiteralNode;
+  static bool classof(const ASTNode &node) {
+    return node.GetKind() == NodeKind::eBooleanLiteralNode;
   }
 
 private:
@@ -265,11 +265,11 @@ public:
   llvm::Expected<lldb::ValueObjectSP> Accept(Visitor *v) const override;
 
   CompilerType GetType() const { return m_type; }
-  ASTNode *GetOperand() const { return m_operand.get(); }
+  ASTNode &GetOperand() const { return *m_operand; }
   CastKind GetCastKind() const { return m_cast_kind; }
 
-  static bool classof(const ASTNode *node) {
-    return node->GetKind() == NodeKind::eCastNode;
+  static bool classof(const ASTNode &node) {
+    return node.GetKind() == NodeKind::eCastNode;
   }
 
 private:
@@ -286,22 +286,22 @@ class Visitor {
 public:
   virtual ~Visitor() = default;
   virtual llvm::Expected<lldb::ValueObjectSP>
-  Visit(const IdentifierNode *node) = 0;
+  Visit(const IdentifierNode &node) = 0;
   virtual llvm::Expected<lldb::ValueObjectSP>
-  Visit(const MemberOfNode *node) = 0;
+  Visit(const MemberOfNode &node) = 0;
   virtual llvm::Expected<lldb::ValueObjectSP>
-  Visit(const UnaryOpNode *node) = 0;
+  Visit(const UnaryOpNode &node) = 0;
   virtual llvm::Expected<lldb::ValueObjectSP>
-  Visit(const ArraySubscriptNode *node) = 0;
+  Visit(const ArraySubscriptNode &node) = 0;
   virtual llvm::Expected<lldb::ValueObjectSP>
-  Visit(const BitFieldExtractionNode *node) = 0;
+  Visit(const BitFieldExtractionNode &node) = 0;
   virtual llvm::Expected<lldb::ValueObjectSP>
-  Visit(const IntegerLiteralNode *node) = 0;
+  Visit(const IntegerLiteralNode &node) = 0;
   virtual llvm::Expected<lldb::ValueObjectSP>
-  Visit(const FloatLiteralNode *node) = 0;
+  Visit(const FloatLiteralNode &node) = 0;
   virtual llvm::Expected<lldb::ValueObjectSP>
-  Visit(const BooleanLiteralNode *node) = 0;
-  virtual llvm::Expected<lldb::ValueObjectSP> Visit(const CastNode *node) = 0;
+  Visit(const BooleanLiteralNode &node) = 0;
+  virtual llvm::Expected<lldb::ValueObjectSP> Visit(const CastNode &node) = 0;
 };
 
 } // namespace lldb_private::dil

--- a/lldb/include/lldb/ValueObject/DILEval.h
+++ b/lldb/include/lldb/ValueObject/DILEval.h
@@ -45,29 +45,29 @@ public:
 
   /// Evaluate an ASTNode.
   /// \returns A non-null lldb::ValueObjectSP or an Error.
-  llvm::Expected<lldb::ValueObjectSP> Evaluate(const ASTNode *node);
+  llvm::Expected<lldb::ValueObjectSP> Evaluate(const ASTNode &node);
 
 private:
   /// Evaluate an ASTNode. If the result is a reference, it is also
   /// dereferenced using ValueObject::Dereference.
   /// \returns A non-null lldb::ValueObjectSP or an Error.
   llvm::Expected<lldb::ValueObjectSP>
-  EvaluateAndDereference(const ASTNode *node);
+  EvaluateAndDereference(const ASTNode &node);
   llvm::Expected<lldb::ValueObjectSP>
-  Visit(const IdentifierNode *node) override;
-  llvm::Expected<lldb::ValueObjectSP> Visit(const MemberOfNode *node) override;
-  llvm::Expected<lldb::ValueObjectSP> Visit(const UnaryOpNode *node) override;
+  Visit(const IdentifierNode &node) override;
+  llvm::Expected<lldb::ValueObjectSP> Visit(const MemberOfNode &node) override;
+  llvm::Expected<lldb::ValueObjectSP> Visit(const UnaryOpNode &node) override;
   llvm::Expected<lldb::ValueObjectSP>
-  Visit(const ArraySubscriptNode *node) override;
+  Visit(const ArraySubscriptNode &node) override;
   llvm::Expected<lldb::ValueObjectSP>
-  Visit(const BitFieldExtractionNode *node) override;
+  Visit(const BitFieldExtractionNode &node) override;
   llvm::Expected<lldb::ValueObjectSP>
-  Visit(const IntegerLiteralNode *node) override;
+  Visit(const IntegerLiteralNode &node) override;
   llvm::Expected<lldb::ValueObjectSP>
-  Visit(const FloatLiteralNode *node) override;
+  Visit(const FloatLiteralNode &node) override;
   llvm::Expected<lldb::ValueObjectSP>
-  Visit(const BooleanLiteralNode *node) override;
-  llvm::Expected<lldb::ValueObjectSP> Visit(const CastNode *node) override;
+  Visit(const BooleanLiteralNode &node) override;
+  llvm::Expected<lldb::ValueObjectSP> Visit(const CastNode &node) override;
 
   /// Perform usual unary conversions on a value. At the moment this
   /// includes array-to-pointer and integral promotion for eligible types.
@@ -76,7 +76,7 @@ private:
   llvm::Expected<CompilerType>
   PickIntegerType(lldb::TypeSystemSP type_system,
                   std::shared_ptr<ExecutionContextScope> ctx,
-                  const IntegerLiteralNode *literal);
+                  const IntegerLiteralNode &literal);
 
   // Used by the interpreter to create objects, perform casts, etc.
   lldb::TargetSP m_target;

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -569,7 +569,7 @@ ValueObjectSP StackFrame::DILGetValueForVariableExpressionPath(
                                use_dynamic, !no_synth_child, !no_fragile_ivar,
                                check_ptr_vs_member);
 
-  auto valobj_or_error = interpreter.Evaluate((*tree_or_error).get());
+  auto valobj_or_error = interpreter.Evaluate(**tree_or_error);
   if (!valobj_or_error) {
     error = Status::FromError(valobj_or_error.takeError());
     return ValueObjectConstResult::Create(nullptr, std::move(error));

--- a/lldb/source/ValueObject/DILAST.cpp
+++ b/lldb/source/ValueObject/DILAST.cpp
@@ -16,43 +16,43 @@ llvm::Expected<lldb::ValueObjectSP> ErrorNode::Accept(Visitor *v) const {
 }
 
 llvm::Expected<lldb::ValueObjectSP> IdentifierNode::Accept(Visitor *v) const {
-  return v->Visit(this);
+  return v->Visit(*this);
 }
 
 llvm::Expected<lldb::ValueObjectSP> MemberOfNode::Accept(Visitor *v) const {
-  return v->Visit(this);
+  return v->Visit(*this);
 }
 
 llvm::Expected<lldb::ValueObjectSP> UnaryOpNode::Accept(Visitor *v) const {
-  return v->Visit(this);
+  return v->Visit(*this);
 }
 
 llvm::Expected<lldb::ValueObjectSP>
 ArraySubscriptNode::Accept(Visitor *v) const {
-  return v->Visit(this);
+  return v->Visit(*this);
 }
 
 llvm::Expected<lldb::ValueObjectSP>
 BitFieldExtractionNode::Accept(Visitor *v) const {
-  return v->Visit(this);
+  return v->Visit(*this);
 }
 
 llvm::Expected<lldb::ValueObjectSP>
 IntegerLiteralNode::Accept(Visitor *v) const {
-  return v->Visit(this);
+  return v->Visit(*this);
 }
 
 llvm::Expected<lldb::ValueObjectSP> FloatLiteralNode::Accept(Visitor *v) const {
-  return v->Visit(this);
+  return v->Visit(*this);
 }
 
 llvm::Expected<lldb::ValueObjectSP>
 BooleanLiteralNode::Accept(Visitor *v) const {
-  return v->Visit(this);
+  return v->Visit(*this);
 }
 
 llvm::Expected<lldb::ValueObjectSP> CastNode::Accept(Visitor *v) const {
-  return v->Visit(this);
+  return v->Visit(*this);
 }
 
 } // namespace lldb_private::dil

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -239,20 +239,20 @@ Interpreter::Interpreter(lldb::TargetSP target, llvm::StringRef expr,
       m_fragile_ivar(fragile_ivar), m_check_ptr_vs_member(check_ptr_vs_member) {
 }
 
-llvm::Expected<lldb::ValueObjectSP> Interpreter::Evaluate(const ASTNode *node) {
+llvm::Expected<lldb::ValueObjectSP> Interpreter::Evaluate(const ASTNode &node) {
   // Evaluate an AST.
-  auto value_or_error = node->Accept(this);
+  auto value_or_error = node.Accept(this);
   // Convert SP with a nullptr to an error.
   if (value_or_error && !*value_or_error)
     return llvm::make_error<DILDiagnosticError>(m_expr, "invalid value object",
-                                                node->GetLocation());
+                                                node.GetLocation());
   // Return the computed value-or-error. The caller is responsible for
   // checking if an error occured during the evaluation.
   return value_or_error;
 }
 
 llvm::Expected<lldb::ValueObjectSP>
-Interpreter::EvaluateAndDereference(const ASTNode *node) {
+Interpreter::EvaluateAndDereference(const ASTNode &node) {
   auto valobj_or_err = Evaluate(node);
   if (!valobj_or_err)
     return valobj_or_err;
@@ -268,35 +268,35 @@ Interpreter::EvaluateAndDereference(const ASTNode *node) {
 }
 
 llvm::Expected<lldb::ValueObjectSP>
-Interpreter::Visit(const IdentifierNode *node) {
+Interpreter::Visit(const IdentifierNode &node) {
   lldb::DynamicValueType use_dynamic = m_use_dynamic;
 
   lldb::ValueObjectSP identifier =
-      LookupIdentifier(node->GetName(), m_exe_ctx_scope, use_dynamic);
+      LookupIdentifier(node.GetName(), m_exe_ctx_scope, use_dynamic);
 
   if (!identifier)
-    identifier = LookupGlobalIdentifier(node->GetName(), m_exe_ctx_scope,
+    identifier = LookupGlobalIdentifier(node.GetName(), m_exe_ctx_scope,
                                         m_target, use_dynamic);
   if (!identifier) {
     std::string errMsg =
-        llvm::formatv("use of undeclared identifier '{0}'", node->GetName());
+        llvm::formatv("use of undeclared identifier '{0}'", node.GetName());
     return llvm::make_error<DILDiagnosticError>(
-        m_expr, errMsg, node->GetLocation(), node->GetName().size());
+        m_expr, errMsg, node.GetLocation(), node.GetName().size());
   }
 
   return identifier;
 }
 
 llvm::Expected<lldb::ValueObjectSP>
-Interpreter::Visit(const UnaryOpNode *node) {
+Interpreter::Visit(const UnaryOpNode &node) {
   Status error;
-  auto op_or_err = Evaluate(node->GetOperand());
+  auto op_or_err = Evaluate(node.GetOperand());
   if (!op_or_err)
     return op_or_err;
 
   lldb::ValueObjectSP operand = *op_or_err;
 
-  switch (node->GetKind()) {
+  switch (node.GetKind()) {
   case UnaryOpKind::Deref: {
     lldb::ValueObjectSP dynamic_op = operand->GetDynamicValue(m_use_dynamic);
     if (dynamic_op)
@@ -311,7 +311,7 @@ Interpreter::Visit(const UnaryOpNode *node) {
     }
     if (error.Fail())
       return llvm::make_error<DILDiagnosticError>(m_expr, error.AsCString(),
-                                                  node->GetLocation());
+                                                  node.GetLocation());
 
     return child_sp;
   }
@@ -320,7 +320,7 @@ Interpreter::Visit(const UnaryOpNode *node) {
     lldb::ValueObjectSP value = operand->AddressOf(error);
     if (error.Fail())
       return llvm::make_error<DILDiagnosticError>(m_expr, error.AsCString(),
-                                                  node->GetLocation());
+                                                  node.GetLocation());
 
     return value;
   }
@@ -331,7 +331,7 @@ Interpreter::Visit(const UnaryOpNode *node) {
         return error.ToError();
     }
     llvm::Expected<lldb::ValueObjectSP> conv_op =
-        UnaryConversion(operand, node->GetOperand()->GetLocation());
+        UnaryConversion(operand, node.GetOperand().GetLocation());
     if (!conv_op)
       return conv_op;
     operand = *conv_op;
@@ -341,7 +341,7 @@ Interpreter::Visit(const UnaryOpNode *node) {
           llvm::formatv("invalid argument type '{0}' to unary expression",
                         operand_type.GetTypeName());
       return llvm::make_error<DILDiagnosticError>(m_expr, errMsg,
-                                                  node->GetLocation());
+                                                  node.GetLocation());
     }
     Scalar scalar;
     bool resolved = operand->ResolveValue(scalar);
@@ -361,7 +361,7 @@ Interpreter::Visit(const UnaryOpNode *node) {
         return error.ToError();
     }
     llvm::Expected<lldb::ValueObjectSP> conv_op =
-        UnaryConversion(operand, node->GetOperand()->GetLocation());
+        UnaryConversion(operand, node.GetOperand().GetLocation());
     if (!conv_op)
       return conv_op;
     operand = *conv_op;
@@ -373,25 +373,25 @@ Interpreter::Visit(const UnaryOpNode *node) {
           llvm::formatv("invalid argument type '{0}' to unary expression",
                         operand_type.GetTypeName());
       return llvm::make_error<DILDiagnosticError>(m_expr, errMsg,
-                                                  node->GetLocation());
+                                                  node.GetLocation());
     }
     return operand;
   }
   }
   return llvm::make_error<DILDiagnosticError>(m_expr, "invalid unary operation",
-                                              node->GetLocation());
+                                              node.GetLocation());
 }
 
 llvm::Expected<lldb::ValueObjectSP>
-Interpreter::Visit(const MemberOfNode *node) {
-  auto base_or_err = Evaluate(node->GetBase());
+Interpreter::Visit(const MemberOfNode &node) {
+  auto base_or_err = Evaluate(node.GetBase());
   if (!base_or_err)
     return base_or_err;
-  bool expr_is_ptr = node->GetIsArrow();
+  bool expr_is_ptr = node.GetIsArrow();
   lldb::ValueObjectSP base = *base_or_err;
 
   // Perform some basic type & correctness checking.
-  if (node->GetIsArrow()) {
+  if (node.GetIsArrow()) {
     if (!m_fragile_ivar) {
       // Make sure we aren't trying to deref an objective
       // C ivar if this is not allowed
@@ -418,14 +418,14 @@ Interpreter::Visit(const MemberOfNode *node) {
         std::string errMsg = llvm::formatv(
             "Failed to dereference synthetic value: {0}", deref_error);
         return llvm::make_error<DILDiagnosticError>(
-            m_expr, errMsg, node->GetLocation(), node->GetFieldName().size());
+            m_expr, errMsg, node.GetLocation(), node.GetFieldName().size());
       }
 
       // Some synthetic plug-ins fail to set the error in Dereference
       if (!base) {
         std::string errMsg = "Failed to dereference synthetic value";
         return llvm::make_error<DILDiagnosticError>(
-            m_expr, errMsg, node->GetLocation(), node->GetFieldName().size());
+            m_expr, errMsg, node.GetLocation(), node.GetFieldName().size());
       }
       expr_is_ptr = false;
     }
@@ -441,33 +441,33 @@ Interpreter::Visit(const MemberOfNode *node) {
                           "did you mean to use '->'?",
                           base->GetCompilerType().TypeDescription());
         return llvm::make_error<DILDiagnosticError>(
-            m_expr, errMsg, node->GetLocation(), node->GetFieldName().size());
+            m_expr, errMsg, node.GetLocation(), node.GetFieldName().size());
       } else {
         std::string errMsg =
             llvm::formatv("member reference type {0} is not a pointer; "
                           "did you mean to use '.'?",
                           base->GetCompilerType().TypeDescription());
         return llvm::make_error<DILDiagnosticError>(
-            m_expr, errMsg, node->GetLocation(), node->GetFieldName().size());
+            m_expr, errMsg, node.GetLocation(), node.GetFieldName().size());
       }
     }
   }
 
   lldb::ValueObjectSP field_obj =
-      base->GetChildMemberWithName(node->GetFieldName());
+      base->GetChildMemberWithName(node.GetFieldName());
   if (!field_obj) {
     if (m_use_synthetic) {
       field_obj = base->GetSyntheticValue();
       if (field_obj)
-        field_obj = field_obj->GetChildMemberWithName(node->GetFieldName());
+        field_obj = field_obj->GetChildMemberWithName(node.GetFieldName());
     }
 
     if (!m_use_synthetic || !field_obj) {
       std::string errMsg = llvm::formatv(
-          "\"{0}\" is not a member of \"({1}) {2}\"", node->GetFieldName(),
+          "\"{0}\" is not a member of \"({1}) {2}\"", node.GetFieldName(),
           base->GetTypeName().AsCString("<invalid type>"), base->GetName());
       return llvm::make_error<DILDiagnosticError>(
-          m_expr, errMsg, node->GetLocation(), node->GetFieldName().size());
+          m_expr, errMsg, node.GetLocation(), node.GetFieldName().size());
     }
   }
 
@@ -482,32 +482,32 @@ Interpreter::Visit(const MemberOfNode *node) {
   }
 
   CompilerType base_type = base->GetCompilerType();
-  if (node->GetIsArrow() && base->IsPointerType())
+  if (node.GetIsArrow() && base->IsPointerType())
     base_type = base_type.GetPointeeType();
   std::string errMsg = llvm::formatv(
-      "\"{0}\" is not a member of \"({1}) {2}\"", node->GetFieldName(),
+      "\"{0}\" is not a member of \"({1}) {2}\"", node.GetFieldName(),
       base->GetTypeName().AsCString("<invalid type>"), base->GetName());
   return llvm::make_error<DILDiagnosticError>(
-      m_expr, errMsg, node->GetLocation(), node->GetFieldName().size());
+      m_expr, errMsg, node.GetLocation(), node.GetFieldName().size());
 }
 
 llvm::Expected<lldb::ValueObjectSP>
-Interpreter::Visit(const ArraySubscriptNode *node) {
-  auto idx_or_err = EvaluateAndDereference(node->GetIndex());
+Interpreter::Visit(const ArraySubscriptNode &node) {
+  auto idx_or_err = EvaluateAndDereference(node.GetIndex());
   if (!idx_or_err)
     return idx_or_err;
   lldb::ValueObjectSP idx = *idx_or_err;
 
   if (!idx->GetCompilerType().IsIntegerOrUnscopedEnumerationType()) {
     return llvm::make_error<DILDiagnosticError>(
-        m_expr, "array subscript is not an integer", node->GetLocation());
+        m_expr, "array subscript is not an integer", node.GetLocation());
   }
 
   StreamString var_expr_path_strm;
   uint64_t child_idx = idx->GetValueAsUnsigned(0);
   lldb::ValueObjectSP child_valobj_sp;
 
-  auto base_or_err = Evaluate(node->GetBase());
+  auto base_or_err = Evaluate(node.GetBase());
   if (!base_or_err)
     return base_or_err;
   lldb::ValueObjectSP base = *base_or_err;
@@ -529,7 +529,7 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
           base->GetTypeName().AsCString("<invalid type>"),
           var_expr_path_strm.GetData());
       return llvm::make_error<DILDiagnosticError>(m_expr, std::move(err_msg),
-                                                  node->GetLocation());
+                                                  node.GetLocation());
     }
     if (is_objc_pointer) {
       lldb::ValueObjectSP synthetic = base->GetSyntheticValue();
@@ -539,7 +539,7 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
                           base->GetTypeName().AsCString("<invalid type>"),
                           var_expr_path_strm.GetData());
         return llvm::make_error<DILDiagnosticError>(m_expr, std::move(err_msg),
-                                                    node->GetLocation());
+                                                    node.GetLocation());
       }
       if (static_cast<uint32_t>(child_idx) >=
           synthetic->GetNumChildrenIgnoringErrors()) {
@@ -548,7 +548,7 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
             base->GetTypeName().AsCString("<invalid type>"),
             var_expr_path_strm.GetData());
         return llvm::make_error<DILDiagnosticError>(m_expr, std::move(err_msg),
-                                                    node->GetLocation());
+                                                    node.GetLocation());
       }
       child_valobj_sp = synthetic->GetChildAtIndex(child_idx);
       if (!child_valobj_sp) {
@@ -557,7 +557,7 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
             base->GetTypeName().AsCString("<invalid type>"),
             var_expr_path_strm.GetData());
         return llvm::make_error<DILDiagnosticError>(m_expr, std::move(err_msg),
-                                                    node->GetLocation());
+                                                    node.GetLocation());
       }
       if (m_use_dynamic != lldb::eNoDynamicValues) {
         if (auto dynamic_sp = child_valobj_sp->GetDynamicValue(m_use_dynamic))
@@ -576,7 +576,7 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
       if (base_type.IsPointerToVoid())
         err_msg = "subscript of pointer to incomplete type 'void'";
       return llvm::make_error<DILDiagnosticError>(m_expr, std::move(err_msg),
-                                                  node->GetLocation());
+                                                  node.GetLocation());
     }
   } else if (base_type.IsArrayType(nullptr, nullptr, &is_incomplete_array)) {
     child_valobj_sp = base->GetChildAtIndex(child_idx);
@@ -588,7 +588,7 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
           base->GetTypeName().AsCString("<invalid type>"),
           var_expr_path_strm.GetData());
       return llvm::make_error<DILDiagnosticError>(m_expr, std::move(err_msg),
-                                                  node->GetLocation());
+                                                  node.GetLocation());
     }
   } else if (base_type.IsScalarType()) {
     child_valobj_sp =
@@ -599,7 +599,7 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
           child_idx, base->GetTypeName().AsCString("<invalid type>"),
           var_expr_path_strm.GetData());
       return llvm::make_error<DILDiagnosticError>(m_expr, std::move(err_msg),
-                                                  node->GetLocation(), 1);
+                                                  node.GetLocation(), 1);
     }
   } else {
     lldb::ValueObjectSP synthetic = base->GetSyntheticValue();
@@ -608,7 +608,7 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
           llvm::formatv("\"{0}\" is not an array type",
                         base->GetTypeName().AsCString("<invalid type>"));
       return llvm::make_error<DILDiagnosticError>(m_expr, std::move(err_msg),
-                                                  node->GetLocation(), 1);
+                                                  node.GetLocation(), 1);
     }
     if (static_cast<uint32_t>(child_idx) >=
         synthetic->GetNumChildrenIgnoringErrors(child_idx + 1)) {
@@ -617,7 +617,7 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
           base->GetTypeName().AsCString("<invalid type>"),
           var_expr_path_strm.GetData());
       return llvm::make_error<DILDiagnosticError>(m_expr, std::move(err_msg),
-                                                  node->GetLocation(), 1);
+                                                  node.GetLocation(), 1);
     }
     child_valobj_sp = synthetic->GetChildAtIndex(child_idx);
     if (!child_valobj_sp) {
@@ -626,7 +626,7 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
           base->GetTypeName().AsCString("<invalid type>"),
           var_expr_path_strm.GetData());
       return llvm::make_error<DILDiagnosticError>(m_expr, std::move(err_msg),
-                                                  node->GetLocation(), 1);
+                                                  node.GetLocation(), 1);
     }
   }
 
@@ -643,17 +643,17 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
   if (!success)
     return llvm::make_error<DILDiagnosticError>(
         m_expr, "could not get the index as an integer",
-        node->GetIndex()->GetLocation());
+        node.GetIndex().GetLocation());
   return base->GetSyntheticArrayMember(signed_child_idx, true);
 }
 
 llvm::Expected<lldb::ValueObjectSP>
-Interpreter::Visit(const BitFieldExtractionNode *node) {
-  auto first_idx_or_err = EvaluateAndDereference(node->GetFirstIndex());
+Interpreter::Visit(const BitFieldExtractionNode &node) {
+  auto first_idx_or_err = EvaluateAndDereference(node.GetFirstIndex());
   if (!first_idx_or_err)
     return first_idx_or_err;
   lldb::ValueObjectSP first_idx = *first_idx_or_err;
-  auto last_idx_or_err = EvaluateAndDereference(node->GetLastIndex());
+  auto last_idx_or_err = EvaluateAndDereference(node.GetLastIndex());
   if (!last_idx_or_err)
     return last_idx_or_err;
   lldb::ValueObjectSP last_idx = *last_idx_or_err;
@@ -661,7 +661,7 @@ Interpreter::Visit(const BitFieldExtractionNode *node) {
   if (!first_idx->GetCompilerType().IsIntegerOrUnscopedEnumerationType() ||
       !last_idx->GetCompilerType().IsIntegerOrUnscopedEnumerationType()) {
     return llvm::make_error<DILDiagnosticError>(
-        m_expr, "bit index is not an integer", node->GetLocation());
+        m_expr, "bit index is not an integer", node.GetLocation());
   }
 
   bool success_first, success_last;
@@ -669,13 +669,13 @@ Interpreter::Visit(const BitFieldExtractionNode *node) {
   int64_t last_index = last_idx->GetValueAsSigned(0, &success_last);
   if (!success_first || !success_last)
     return llvm::make_error<DILDiagnosticError>(
-        m_expr, "could not get the index as an integer", node->GetLocation());
+        m_expr, "could not get the index as an integer", node.GetLocation());
 
   // if the format given is [high-low], swap range
   if (first_index > last_index)
     std::swap(first_index, last_index);
 
-  auto base_or_err = EvaluateAndDereference(node->GetBase());
+  auto base_or_err = EvaluateAndDereference(node.GetBase());
   if (!base_or_err)
     return base_or_err;
   lldb::ValueObjectSP base = *base_or_err;
@@ -687,7 +687,7 @@ Interpreter::Visit(const BitFieldExtractionNode *node) {
         last_index, base->GetTypeName().AsCString("<invalid type>"),
         base->GetName().AsCString());
     return llvm::make_error<DILDiagnosticError>(m_expr, message,
-                                                node->GetLocation());
+                                                node.GetLocation());
   }
   return child_valobj_sp;
 }
@@ -695,18 +695,18 @@ Interpreter::Visit(const BitFieldExtractionNode *node) {
 llvm::Expected<CompilerType>
 Interpreter::PickIntegerType(lldb::TypeSystemSP type_system,
                              std::shared_ptr<ExecutionContextScope> ctx,
-                             const IntegerLiteralNode *literal) {
+                             const IntegerLiteralNode &literal) {
   // Binary, Octal, Hexadecimal and literals with a U suffix are allowed to be
   // an unsigned integer.
-  bool unsigned_is_allowed = literal->IsUnsigned() || literal->GetRadix() != 10;
-  llvm::APInt apint = literal->GetValue();
+  bool unsigned_is_allowed = literal.IsUnsigned() || literal.GetRadix() != 10;
+  llvm::APInt apint = literal.GetValue();
 
   llvm::SmallVector<std::pair<lldb::BasicType, lldb::BasicType>, 3> candidates;
-  if (literal->GetTypeSuffix() <= IntegerTypeSuffix::None)
+  if (literal.GetTypeSuffix() <= IntegerTypeSuffix::None)
     candidates.emplace_back(lldb::eBasicTypeInt,
                             unsigned_is_allowed ? lldb::eBasicTypeUnsignedInt
                                                 : lldb::eBasicTypeInvalid);
-  if (literal->GetTypeSuffix() <= IntegerTypeSuffix::Long)
+  if (literal.GetTypeSuffix() <= IntegerTypeSuffix::Long)
     candidates.emplace_back(lldb::eBasicTypeLong,
                             unsigned_is_allowed ? lldb::eBasicTypeUnsignedLong
                                                 : lldb::eBasicTypeInvalid);
@@ -719,7 +719,7 @@ Interpreter::PickIntegerType(lldb::TypeSystemSP type_system,
     llvm::Expected<uint64_t> size = signed_type.GetBitSize(ctx.get());
     if (!size)
       return size.takeError();
-    if (!literal->IsUnsigned() && apint.isIntN(*size - 1))
+    if (!literal.IsUnsigned() && apint.isIntN(*size - 1))
       return signed_type;
     if (unsigned_ != lldb::eBasicTypeInvalid && apint.isIntN(*size))
       return type_system->GetBasicTypeFromAST(unsigned_);
@@ -728,11 +728,11 @@ Interpreter::PickIntegerType(lldb::TypeSystemSP type_system,
   return llvm::make_error<DILDiagnosticError>(
       m_expr,
       "integer literal is too large to be represented in any integer type",
-      literal->GetLocation());
+      literal.GetLocation());
 }
 
 llvm::Expected<lldb::ValueObjectSP>
-Interpreter::Visit(const IntegerLiteralNode *node) {
+Interpreter::Visit(const IntegerLiteralNode &node) {
   llvm::Expected<lldb::TypeSystemSP> type_system =
       GetTypeSystemFromCU(m_exe_ctx_scope);
   if (!type_system)
@@ -743,7 +743,7 @@ Interpreter::Visit(const IntegerLiteralNode *node) {
   if (!type)
     return type.takeError();
 
-  Scalar scalar = node->GetValue();
+  Scalar scalar = node.GetValue();
   // APInt from StringRef::getAsInteger comes with just enough bitwidth to
   // hold the value. This adjusts APInt bitwidth to match the compiler type.
   llvm::Expected<uint64_t> type_bitsize =
@@ -756,35 +756,35 @@ Interpreter::Visit(const IntegerLiteralNode *node) {
 }
 
 llvm::Expected<lldb::ValueObjectSP>
-Interpreter::Visit(const FloatLiteralNode *node) {
+Interpreter::Visit(const FloatLiteralNode &node) {
   llvm::Expected<lldb::TypeSystemSP> type_system =
       GetTypeSystemFromCU(m_exe_ctx_scope);
   if (!type_system)
     return type_system.takeError();
 
   bool isFloat =
-      &node->GetValue().getSemantics() == &llvm::APFloat::IEEEsingle();
+      &node.GetValue().getSemantics() == &llvm::APFloat::IEEEsingle();
   lldb::BasicType basic_type =
       isFloat ? lldb::eBasicTypeFloat : lldb::eBasicTypeDouble;
   CompilerType type = GetBasicType(*type_system, basic_type);
 
   if (!type)
     return llvm::make_error<DILDiagnosticError>(
-        m_expr, "unable to create a const literal", node->GetLocation());
+        m_expr, "unable to create a const literal", node.GetLocation());
 
-  Scalar scalar = node->GetValue();
+  Scalar scalar = node.GetValue();
   return ValueObject::CreateValueObjectFromScalar(m_target, scalar, type,
                                                   "result");
 }
 
 llvm::Expected<lldb::ValueObjectSP>
-Interpreter::Visit(const BooleanLiteralNode *node) {
-  bool value = node->GetValue();
+Interpreter::Visit(const BooleanLiteralNode &node) {
+  bool value = node.GetValue();
   return ValueObject::CreateValueObjectFromBool(m_target, value, "result");
 }
 
-llvm::Expected<lldb::ValueObjectSP> Interpreter::Visit(const CastNode *node) {
-  auto operand_or_err = Evaluate(node->GetOperand());
+llvm::Expected<lldb::ValueObjectSP> Interpreter::Visit(const CastNode &node) {
+  auto operand_or_err = Evaluate(node.GetOperand());
   if (!operand_or_err)
     return operand_or_err;
 
@@ -792,7 +792,7 @@ llvm::Expected<lldb::ValueObjectSP> Interpreter::Visit(const CastNode *node) {
   // Don't actually do the cast for now -- that code will be added later.
   // For now just return an error message.
   return llvm::make_error<DILDiagnosticError>(
-      m_expr, "Type casting is not supported here.", node->GetLocation());
+      m_expr, "Type casting is not supported here.", node.GetLocation());
 }
 
 } // namespace lldb_private::dil


### PR DESCRIPTION
1. Every `ASTNodeUP` is asserted before being used in creating another `ASTNodeUP`
2. Removed returning `nullptr` in `ParseIntegerLiteral` and `ParseFloatingPointLiteral` to avoid confusion
3. All `ASTNodes` are now passed by reference instead of pointer