### PR TITLE
ValueTracking: Avoid calling computeKnownFPClass on matched constant

### DIFF
--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -19,6 +19,7 @@
 #include <optional>
 
 namespace llvm {
+class APFloat;
 
 struct KnownFPClass {
   /// Floating-point classes the value could be one of.
@@ -27,6 +28,9 @@ struct KnownFPClass {
   /// std::nullopt if the sign bit is unknown, true if the sign bit is
   /// definitely set or false if the sign bit is definitely unset.
   std::optional<bool> SignBit;
+
+  KnownFPClass() = default;
+  KnownFPClass(const APFloat &C);
 
   bool operator==(KnownFPClass Other) const {
     return KnownFPClasses == Other.KnownFPClasses && SignBit == Other.SignBit;

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -12,9 +12,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/KnownFPClass.h"
+#include "llvm/ADT/APFloat.h"
 #include "llvm/Support/ErrorHandling.h"
 
 using namespace llvm;
+
+KnownFPClass::KnownFPClass(const APFloat &C)
+    : KnownFPClasses(C.classify()), SignBit(C.isNegative()) {}
 
 /// Return true if it's possible to assume IEEE treatment of input denormals in
 /// \p F for \p Val.


### PR DESCRIPTION
The fmul case already tries to match a literal value, we don't
need to match it twice.