### PR TITLE
[offload] Change olLaunchKernel to accept argument arrays

### DIFF
--- a/offload/liboffload/API/Kernel.td
+++ b/offload/liboffload/API/Kernel.td
@@ -26,18 +26,31 @@ def olLaunchKernel : Function {
         "If a queue is not specified, kernel execution happens synchronously",
         "ArgumentsData may be set to NULL (to indicate no parameters)"
     ];
-    let params = [
-        Param<"ol_queue_handle_t", "Queue", "handle of the queue", PARAM_IN_OPTIONAL>,
-        Param<"ol_device_handle_t", "Device", "handle of the device to execute on", PARAM_IN>,
-        Param<"ol_symbol_handle_t", "Kernel", "handle of the kernel", PARAM_IN>,
-        Param<"const void*", "ArgumentsData", "pointer to the kernel argument struct", PARAM_IN_OPTIONAL>,
-        Param<"size_t", "ArgumentsSize", "size of the kernel argument struct", PARAM_IN>,
-        Param<"const ol_kernel_launch_size_args_t*", "LaunchSizeArgs", "pointer to the struct containing launch size parameters", PARAM_IN>,
+    let params =
+        [Param<"ol_queue_handle_t", "Queue", "handle of the queue",
+               PARAM_IN_OPTIONAL>,
+         Param<"ol_device_handle_t", "Device",
+               "handle of the device to execute on", PARAM_IN>,
+         Param<"ol_symbol_handle_t", "Kernel", "handle of the kernel",
+               PARAM_IN>,
+         Param<"const void**", "ArgumentsData",
+               "pointer to the kernel arguments array", PARAM_IN_OPTIONAL>,
+         Param<"const int64_t*", "ArgumentsSize",
+               "pointer to the kernel arguments sizes array",
+               PARAM_IN_OPTIONAL>,
+         Param<"uint32_t", "ArgumentsNum",
+               "Number of the elements in the arguments arrays", PARAM_IN>,
+         Param<"const ol_kernel_launch_size_args_t*", "LaunchSizeArgs",
+               "pointer to the struct containing launch size parameters",
+               PARAM_IN>,
     ];
-    let returns = [
-        Return<"OL_ERRC_INVALID_ARGUMENT", ["`ArgumentsSize > 0 && ArgumentsData == NULL`"]>,
-        Return<"OL_ERRC_INVALID_DEVICE", ["If Queue is non-null but does not belong to Device"]>,
-        Return<"OL_ERRC_SYMBOL_KIND", ["The provided symbol is not a kernel"]>,
+    let returns =
+        [Return<"OL_ERRC_INVALID_ARGUMENT",
+                ["`ArgumentsNum > 0 && (ArgumentsData == NULL || ArgumentsSize "
+                 "== NULL)`"]>,
+         Return<"OL_ERRC_INVALID_DEVICE",
+                ["If Queue is non-null but does not belong to Device"]>,
+         Return<"OL_ERRC_SYMBOL_KIND", ["The provided symbol is not a kernel"]>,
     ];
 }
 

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -581,8 +581,11 @@ KernelLaunchParamsTy GenericKernelTy::prepareArgs(
   }
 
   for (uint32_t I = KLEOffset; I < NumArgs; ++I) {
-    Args[I] =
-        (void *)((intptr_t)ArgPtrs[I - KLEOffset] + ArgOffsets[I - KLEOffset]);
+    if (ArgOffsets == nullptr)
+      Args[I] = ArgPtrs[I - KLEOffset];
+    else
+      Args[I] = (void *)((intptr_t)ArgPtrs[I - KLEOffset] +
+                         ArgOffsets[I - KLEOffset]);
     Ptrs[I] = &Args[I];
   }
   return KernelLaunchParamsTy{sizeof(void *) * NumArgs, &Args[0], &Ptrs[0]};

--- a/offload/plugins-nextgen/level_zero/src/L0Kernel.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Kernel.cpp
@@ -449,13 +449,14 @@ Error L0KernelTy::launchImpl(GenericDeviceTy &GenericDevice,
   for (int32_t I = 0; I < NumArgs; I++) {
     // Scope code to ease integration with downstream custom code.
     {
-      void *Arg = (static_cast<void **>(LaunchParams.Data))[I];
-      CALL_ZE_RET_ERROR(zeKernelSetArgumentValue, zeKernel, I, sizeof(Arg),
-                        Arg == nullptr ? nullptr : &Arg);
+      auto arg = KernelArgs.ArgPtrs[I];
+      CALL_ZE_RET_ERROR(zeKernelSetArgumentValue, zeKernel, I,
+                        KernelArgs.ArgSizes[I], arg);
+
       INFO(OMP_INFOTYPE_PLUGIN_KERNEL, DeviceId,
            "Kernel Pointer argument %" PRId32 " (value: " DPxMOD
            ") was set successfully for device %s.\n",
-           I, DPxPTR(Arg), IdStr);
+           I, DPxPTR(arg), IdStr);
     }
   }
 

--- a/offload/unittests/Conformance/include/mathtest/DeviceContext.hpp
+++ b/offload/unittests/Conformance/include/mathtest/DeviceContext.hpp
@@ -126,8 +126,9 @@ private:
                   llvm::StringRef KernelName) const noexcept;
 
   void launchKernelImpl(ol_symbol_handle_t KernelHandle, uint32_t NumGroups,
-                        uint32_t GroupSize, const void *KernelArgs,
-                        std::size_t KernelArgsSize) const noexcept;
+                        uint32_t GroupSize, const void **KernelArgs,
+                        const int64_t *KernelArgsSizes,
+                        std::size_t KernelArgsNum) const noexcept;
 
   std::size_t GlobalDeviceId;
   ol_device_handle_t DeviceHandle;

--- a/offload/unittests/Conformance/lib/DeviceContext.cpp
+++ b/offload/unittests/Conformance/lib/DeviceContext.cpp
@@ -286,9 +286,11 @@ DeviceContext::getKernelHandle(ol_program_handle_t ProgramHandle,
   return Handle;
 }
 
-void DeviceContext::launchKernelImpl(
-    ol_symbol_handle_t KernelHandle, uint32_t NumGroups, uint32_t GroupSize,
-    const void *KernelArgs, std::size_t KernelArgsSize) const noexcept {
+void DeviceContext::launchKernelImpl(ol_symbol_handle_t KernelHandle,
+                                     uint32_t NumGroups, uint32_t GroupSize,
+                                     const void **KernelArgs,
+                                     const int64_t *KernelArgsSizes,
+                                     std::size_t KernelArgsNum) const noexcept {
   ol_kernel_launch_size_args_t LaunchSizeArgs;
   LaunchSizeArgs.Dimensions = 1;
   LaunchSizeArgs.NumGroups = {NumGroups, 1, 1};
@@ -296,7 +298,7 @@ void DeviceContext::launchKernelImpl(
   LaunchSizeArgs.DynSharedMemory = 0;
 
   OL_CHECK(olLaunchKernel(nullptr, DeviceHandle, KernelHandle, KernelArgs,
-                          KernelArgsSize, &LaunchSizeArgs));
+                          KernelArgsSizes, KernelArgsNum, &LaunchSizeArgs));
 }
 
 [[nodiscard]] llvm::StringRef DeviceContext::getName() const noexcept {


### PR DESCRIPTION
olLaunchKernel previously accepted kernel arguments as a single contiguous buffer. While this was sufficient for CUDA and AMD plugins, Level Zero requires separate argument ptrs that cannot be derived from a flat buffer, without knowing the separate size of each argument.

This change updates the interface to accept an array of argument pointers and a corresponding array of argument sizes (void ** + int64_t *).


note: offload tests has to be updated to new api