### PR TITLE
[lldb-dap][test] Add Python 3.8 compatibility for test suite

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# FIXME: remove when LLDB_MINIMUM_PYTHON_VERSION > 3.8
+from __future__ import annotations
+
 import argparse
 import binascii
 import dataclasses
@@ -1707,8 +1710,12 @@ class DebugAdapterServer(DebugCommunication):
                 )
             )
 
+        # FIXME: use `str.removeprefix` when LLDB_MINIMUM_PYTHON_VERSION > 3.8
+        if out.startswith(expected_prefix):
+            out = out[len(expected_prefix) :]
+
         # If the listener expanded into multiple addresses, use the first.
-        connection = out.removeprefix(expected_prefix).rstrip("\r\n").split(",", 1)[0]
+        connection = out.rstrip("\r\n").split(",", 1)[0]
 
         return (process, connection)
 

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -1,3 +1,6 @@
+# FIXME: remove when LLDB_MINIMUM_PYTHON_VERSION > 3.8
+from __future__ import annotations
+
 import os
 import time
 from typing import Optional, Callable, Any, List, Union, Final


### PR DESCRIPTION
Python 3.8 does not support subscriptable built-in types (dict[int], list[str], etc.) without importing annotations from __future__. 
This change adds `annotations` imports and handles missing API functions.