### PR TITLE
[mlir][scf] Fix `FoldTensorCastOfOutputIntoForallOp` for multi-result scf.forall

### DIFF
--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -2021,11 +2021,11 @@ struct FoldTensorCastOfOutputIntoForallOp
     // After `mergeBlocks` happened, the destinations in the terminator were
     // mapped to the tensor.cast old-typed results of the output bbArgs. The
     // destination have to be updated to point to the output bbArgs directly.
-    auto newOutputIterArgs = newForallOp.getRegionIterArgs();
+    ArrayRef<BlockArgument> newIterArgs = newForallOp.getRegionIterArgs();
     for (auto [yieldOp, iterArgsIndex] : yieldOpToIterArgsIndex) {
       auto parallelCombiningOp = cast<ParallelCombiningOpInterface>(yieldOp);
       parallelCombiningOp.getUpdatedDestinations().assign(
-          newOutputIterArgs[iterArgsIndex]);
+          newIterArgs[iterArgsIndex]);
     }
 
     // Cast results back to the original types.

--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -1990,8 +1990,13 @@ struct FoldTensorCastOfOutputIntoForallOp
     for (auto [index, iterArg] :
          llvm::enumerate(forallOp.getRegionIterArgs())) {
       for (Operation *user : iterArg.getUsers()) {
-        if (isa<ParallelCombiningOpInterface>(user))
-          yieldOpToIterArgsIndex[user] = index;
+        if (isa<ParallelCombiningOpInterface>(user)) {
+          auto [it, inserted] = yieldOpToIterArgsIndex.try_emplace(user, index);
+          if (!inserted) {
+            return rewriter.notifyMatchFailure(
+                forallOp, "expected exactly one iter arg per yielding op");
+          }
+        }
       }
     }
 


### PR DESCRIPTION
This PR fixes a bug in `FoldTensorCastOfOutputIntoForallOp` where incorrect folding occurs when `scf.forall` has multiple results and `parallel_insert_slice` operations yield results in a non-ascending order. The fix introduces a `yieldOpToIterArgsIndex` mapping to correctly associate yield operations with their corresponding output iterator arguments. Fixes #172981.