### PR TITLE
[libc++] Remove numpunct_byname::__init

### DIFF
--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -1477,9 +1477,6 @@ public:
 
 protected:
   ~numpunct_byname() override;
-
-private:
-  void __init(const char*);
 };
 
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
@@ -1494,9 +1491,6 @@ public:
 
 protected:
   ~numpunct_byname() override;
-
-private:
-  void __init(const char*);
 };
 #  endif // _LIBCPP_HAS_WIDE_CHARACTERS
 

--- a/libcxx/lib/abi/arm64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/arm64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1458,7 +1458,6 @@
 {'is_defined': True, 'name': '__ZNSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEC2EOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEaSEOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115future_categoryEv', 'type': 'FUNC'}
-{'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcEC1EPKcm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcEC2EPKcm', 'type': 'FUNC'}
@@ -1466,7 +1465,6 @@
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcED0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcED1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcED2Ev', 'type': 'FUNC'}
-{'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIwE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIwEC1EPKcm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIwEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIwEC2EPKcm', 'type': 'FUNC'}

--- a/libcxx/lib/abi/i686-linux-android21.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/i686-linux-android21.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1094,7 +1094,6 @@
 {'is_defined': True, 'name': '_ZNSt6__ndk115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEC2EOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEaSEOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115future_categoryEv', 'type': 'FUNC'}
-{'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcEC1EPKcj', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEj', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcEC2EPKcj', 'type': 'FUNC'}
@@ -1102,7 +1101,6 @@
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcED0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcED1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcED2Ev', 'type': 'FUNC'}
-{'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIwE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIwEC1EPKcj', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIwEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEj', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIwEC2EPKcj', 'type': 'FUNC'}

--- a/libcxx/lib/abi/powerpc-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/powerpc-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -453,7 +453,6 @@
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115__thread_structD1Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115__thread_structD2Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115future_categoryEv', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
-{'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcE6__initEPKc', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC1EPKcm', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC2EPKcm', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
@@ -461,7 +460,6 @@
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED0Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED1Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED2Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
-{'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwE6__initEPKc', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC1EPKcm', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC2EPKcm', 'storage_mapping_class': 'DS', 'type': 'FUNC'}

--- a/libcxx/lib/abi/powerpc64-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/powerpc64-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -453,7 +453,6 @@
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115__thread_structD1Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115__thread_structD2Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115future_categoryEv', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
-{'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcE6__initEPKc', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC1EPKcm', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC2EPKcm', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
@@ -461,7 +460,6 @@
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED0Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED1Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED2Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
-{'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwE6__initEPKc', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC1EPKcm', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC2EPKcm', 'storage_mapping_class': 'DS', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1456,7 +1456,6 @@
 {'is_defined': True, 'name': '__ZNSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEC2EOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEaSEOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115future_categoryEv', 'type': 'FUNC'}
-{'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcEC1EPKcm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcEC2EPKcm', 'type': 'FUNC'}
@@ -1464,7 +1463,6 @@
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcED0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcED1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIcED2Ev', 'type': 'FUNC'}
-{'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIwE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIwEC1EPKcm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIwEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__115numpunct_bynameIwEC2EPKcm', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-linux-android21.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-linux-android21.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1094,7 +1094,6 @@
 {'is_defined': True, 'name': '_ZNSt6__ndk115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEC2EOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEaSEOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115future_categoryEv', 'type': 'FUNC'}
-{'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcEC1EPKcm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcEC2EPKcm', 'type': 'FUNC'}
@@ -1102,7 +1101,6 @@
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcED0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcED1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIcED2Ev', 'type': 'FUNC'}
-{'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIwE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIwEC1EPKcm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIwEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk115numpunct_bynameIwEC2EPKcm', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-unknown-freebsd.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-unknown-freebsd.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1108,7 +1108,6 @@
 {'is_defined': True, 'name': '_ZNSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEC2EOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEaSEOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115future_categoryEv', 'type': 'FUNC'}
-{'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC1EPKcm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC2EPKcm', 'type': 'FUNC'}
@@ -1116,7 +1115,6 @@
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED2Ev', 'type': 'FUNC'}
-{'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC1EPKcm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC2EPKcm', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1106,7 +1106,6 @@
 {'is_defined': True, 'name': '_ZNSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEC2EOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEaSEOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115future_categoryEv', 'type': 'FUNC'}
-{'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC1EPKcm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC2EPKcm', 'type': 'FUNC'}
@@ -1114,7 +1113,6 @@
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED2Ev', 'type': 'FUNC'}
-{'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC1EPKcm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC2EPKcm', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.noexceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.noexceptions.nonew.abilist
@@ -1077,7 +1077,6 @@
 {'is_defined': True, 'name': '_ZNSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEC2EOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115basic_stringbufIcNS_11char_traitsIcEENS_9allocatorIcEEEaSEOS5_', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115future_categoryEv', 'type': 'FUNC'}
-{'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC1EPKcm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcEC2EPKcm', 'type': 'FUNC'}
@@ -1085,7 +1084,6 @@
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIcED2Ev', 'type': 'FUNC'}
-{'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwE6__initEPKc', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC1EPKcm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC1ERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEm', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__115numpunct_bynameIwEC2EPKcm', 'type': 'FUNC'}

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -3936,13 +3936,7 @@ wstring numpunct<wchar_t>::do_falsename() const { return L"false"; }
 
 // numpunct_byname<char>
 
-numpunct_byname<char>::numpunct_byname(const char* nm, size_t refs) : numpunct<char>(refs) { __init(nm); }
-
-numpunct_byname<char>::numpunct_byname(const string& nm, size_t refs) : numpunct<char>(refs) { __init(nm.c_str()); }
-
-numpunct_byname<char>::~numpunct_byname() {}
-
-void numpunct_byname<char>::__init(const char* nm) {
+numpunct_byname<char>::numpunct_byname(const char* nm, size_t refs) : numpunct<char>(refs) {
   typedef numpunct<char> base;
   if (strcmp(nm, "C") != 0) {
     __libcpp_unique_locale loc(nm);
@@ -3963,18 +3957,14 @@ void numpunct_byname<char>::__init(const char* nm) {
   }
 }
 
+numpunct_byname<char>::numpunct_byname(const string& nm, size_t refs) : numpunct_byname<char>(nm.c_str(), refs) {}
+
+numpunct_byname<char>::~numpunct_byname() {}
+
 // numpunct_byname<wchar_t>
 
 #if _LIBCPP_HAS_WIDE_CHARACTERS
-numpunct_byname<wchar_t>::numpunct_byname(const char* nm, size_t refs) : numpunct<wchar_t>(refs) { __init(nm); }
-
-numpunct_byname<wchar_t>::numpunct_byname(const string& nm, size_t refs) : numpunct<wchar_t>(refs) {
-  __init(nm.c_str());
-}
-
-numpunct_byname<wchar_t>::~numpunct_byname() {}
-
-void numpunct_byname<wchar_t>::__init(const char* nm) {
+numpunct_byname<wchar_t>::numpunct_byname(const char* nm, size_t refs) : numpunct<wchar_t>(refs) {
   if (strcmp(nm, "C") != 0) {
     __libcpp_unique_locale loc(nm);
     if (!loc)
@@ -3991,6 +3981,10 @@ void numpunct_byname<wchar_t>::__init(const char* nm) {
     // localization for truename and falsename is not available
   }
 }
+
+numpunct_byname<wchar_t>::numpunct_byname(const string& nm, size_t refs) : numpunct_byname<wchar_t>(nm.c_str(), refs) {}
+
+numpunct_byname<wchar_t>::~numpunct_byname() {}
 #endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 // num_get helpers


### PR DESCRIPTION
`numpunct_byname::__init` is only used inside the dylib, so we can remove it. To do that we can move the code into one of the constructors and delegate the other.
