### PR TITLE
[clang] Pass VFS to driver's `ExpansionContext`

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1273,8 +1273,7 @@ bool Driver::readConfigFile(StringRef FileName,
 
 bool Driver::loadConfigFiles() {
   llvm::cl::ExpansionContext ExpCtx(Saver.getAllocator(),
-                                    llvm::cl::tokenizeConfigFile);
-  ExpCtx.setVFS(&getVFS());
+                                    llvm::cl::tokenizeConfigFile, &getVFS());
 
   // Process options that change search path for config files.
   if (CLOptions) {


### PR DESCRIPTION
The `ExpansionContext` constructor calls `vfs::getRealFileSystem()` when not given VFS explicitly, leading to sandbox violations. This PR passes the VFS into the constructor instead of calling `setVFS()` later.