### PR TITLE
[clang] Use VFS in `-cc1gen-reproducer`

### DIFF
--- a/clang/tools/driver/cc1gen_reproducer_main.cpp
+++ b/clang/tools/driver/cc1gen_reproducer_main.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/IOSandbox.h"
 #include "llvm/Support/LLVMDriver.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -111,9 +112,10 @@ static std::string generateReproducerMetaInfo(const ClangInvocationInfo &Info) {
 
 /// Generates a reproducer for a set of arguments from a specific invocation.
 static std::optional<driver::Driver::CompilationDiagnosticReport>
-generateReproducerForInvocationArguments(ArrayRef<const char *> Argv,
-                                         const ClangInvocationInfo &Info,
-                                         const llvm::ToolContext &ToolContext) {
+generateReproducerForInvocationArguments(
+    ArrayRef<const char *> Argv, const ClangInvocationInfo &Info,
+    const llvm::ToolContext &ToolContext,
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS) {
   using namespace driver;
   auto TargetAndMode = ToolChain::getTargetAndModeFromProgramName(Argv[0]);
 
@@ -121,7 +123,6 @@ generateReproducerForInvocationArguments(ArrayRef<const char *> Argv,
 
   DiagnosticsEngine Diags(DiagnosticIDs::create(), DiagOpts,
                           new IgnoringDiagConsumer());
-  auto VFS = llvm::vfs::getRealFileSystem();
   ProcessWarningOptions(Diags, DiagOpts, *VFS, /*ReportDiags=*/false);
   Driver TheDriver(ToolContext.Path, llvm::sys::getDefaultTargetTriple(), Diags,
                    /*Title=*/"clang LLVM compiler", VFS);
@@ -167,10 +168,14 @@ int cc1gen_reproducer_main(ArrayRef<const char *> Argv, const char *Argv0,
     llvm::errs() << "error: missing invocation file\n";
     return 1;
   }
+  auto VFS = [] {
+    auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
+    return llvm::vfs::getRealFileSystem();
+  }();
   // Parse the invocation descriptor.
   StringRef Input = Argv[0];
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> Buffer =
-      llvm::MemoryBuffer::getFile(Input, /*IsText=*/true);
+      VFS->getBufferForFile(Input);
   if (!Buffer) {
     llvm::errs() << "error: failed to read " << Input << ": "
                  << Buffer.getError().message() << "\n";
@@ -190,7 +195,7 @@ int cc1gen_reproducer_main(ArrayRef<const char *> Argv, const char *Argv0,
   DriverArgs[0] = Path.c_str();
   std::optional<driver::Driver::CompilationDiagnosticReport> Report =
       generateReproducerForInvocationArguments(DriverArgs, InvocationInfo,
-                                               ToolContext);
+                                               ToolContext, VFS);
 
   // Emit the information about the reproduce files to stdout.
   int Result = 1;


### PR DESCRIPTION
This VFS bypasses the FS sandbox in `cc1gen_reproducer_main()` to get the initial VFS and then propagates it where necessary to prevent sandbox violations.