### PR TITLE
[libclang/python]  Add release notes for `reparse` throwing

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -179,6 +179,8 @@ Clang Python Bindings Potentially Breaking Changes
 - Allow setting the path to the libclang library via environment variables: ``LIBCLANG_LIBRARY_PATH``
   to specifiy the path to the containing folder, or ``LIBCLANG_LIBRARY_FILE`` to specify the path to
   the library file
+- ``TranslationUnit.reparse`` will now throw an exception when an error occurs.
+  Previously, errors were silently ignored.
 
 What's New in Clang |release|?
 ==============================


### PR DESCRIPTION
``TranslationUnit.reparse`` will now throw an exception when an error occurs. Previously, errors were silently ignored.