### PR TITLE
[llvm][utils] Make git-llvm-push not convert remote URLs

### DIFF
--- a/llvm/utils/git-llvm-push
+++ b/llvm/utils/git-llvm-push
@@ -375,9 +375,10 @@ class LLVMPRAutomator:
 
         git_env = self._get_git_env()
 
-        upstream_url = self._get_url_for_remote(self.config.upstream_remote)
         refspec = f"refs/heads/{self.config.base_branch}:refs/remotes/{self.config.upstream_remote}/{self.config.base_branch}"
-        self.runner.run_command(["git", "fetch", upstream_url, refspec], env=git_env)
+        self.runner.run_command(
+            ["git", "fetch", self.config.upstream_remote, refspec], env=git_env
+        )
 
         try:
             self.runner.run_command(["git", "rebase", target], env=git_env)
@@ -408,23 +409,6 @@ class LLVMPRAutomator:
                     ["git", "rebase", "--abort"], check=False, env=git_env
                 )
             raise LlvmPrError("rebase operation failed.") from e
-
-    def _get_url_for_remote(self, remote_name: str) -> str:
-        """Gets the URL for a remote."""
-        remote_url_result = self.runner.run_command(
-            ["git", "remote", "get-url", remote_name],
-            capture_output=True,
-            text=True,
-            read_only=True,
-        )
-        remote_url = remote_url_result.stdout.strip()
-        if remote_url.startswith("git@github.com:"):
-            return remote_url
-        if remote_url.startswith("https://github.com/"):
-            return remote_url
-        raise LlvmPrError(
-            f"Unsupported remote URL format for {remote_name}: {remote_url}"
-        )
 
     def _get_commit_stack(self) -> List[str]:
         target = f"{self.config.upstream_remote}/{self.config.base_branch}"
@@ -479,12 +463,10 @@ class LLVMPRAutomator:
 
         git_env = self._get_git_env()
 
-        remote_url = self._get_url_for_remote(self.remote)
-
         push_command = [
             "git",
             "push",
-            remote_url,
+            self.remote,
             f"{commit_hash}:refs/heads/{branch_name}",
         ]
         self.runner.run_command(push_command, env=git_env)

--- a/llvm/utils/git-llvm-push
+++ b/llvm/utils/git-llvm-push
@@ -375,11 +375,9 @@ class LLVMPRAutomator:
 
         git_env = self._get_git_env()
 
-        https_upstream_url = self._get_https_url_for_remote(self.config.upstream_remote)
+        upstream_url = self._get_url_for_remote(self.config.upstream_remote)
         refspec = f"refs/heads/{self.config.base_branch}:refs/remotes/{self.config.upstream_remote}/{self.config.base_branch}"
-        self.runner.run_command(
-            ["git", "fetch", https_upstream_url, refspec], env=git_env
-        )
+        self.runner.run_command(["git", "fetch", upstream_url, refspec], env=git_env)
 
         try:
             self.runner.run_command(["git", "rebase", target], env=git_env)
@@ -411,8 +409,8 @@ class LLVMPRAutomator:
                 )
             raise LlvmPrError("rebase operation failed.") from e
 
-    def _get_https_url_for_remote(self, remote_name: str) -> str:
-        """Gets the URL for a remote and converts it to HTTPS if necessary."""
+    def _get_url_for_remote(self, remote_name: str) -> str:
+        """Gets the URL for a remote."""
         remote_url_result = self.runner.run_command(
             ["git", "remote", "get-url", remote_name],
             capture_output=True,
@@ -421,7 +419,7 @@ class LLVMPRAutomator:
         )
         remote_url = remote_url_result.stdout.strip()
         if remote_url.startswith("git@github.com:"):
-            return remote_url.replace("git@github.com:", "https://github.com/")
+            return remote_url
         if remote_url.startswith("https://github.com/"):
             return remote_url
         raise LlvmPrError(
@@ -481,12 +479,12 @@ class LLVMPRAutomator:
 
         git_env = self._get_git_env()
 
-        https_remote_url = self._get_https_url_for_remote(self.remote)
+        remote_url = self._get_url_for_remote(self.remote)
 
         push_command = [
             "git",
             "push",
-            https_remote_url,
+            remote_url,
             f"{commit_hash}:refs/heads/{branch_name}",
         ]
         self.runner.run_command(push_command, env=git_env)


### PR DESCRIPTION
Previously git-llvm-push would convert all remote URLs to HTTPS, including SSH remotes for reasons not motivated in the original PR. This would cause issues in some setups where the HTTPs remote would be read-only. This patch makes it so that git-llvm-push does not convert SSH remotes to HTTPS remotes, preserving what the user originally intended.

Fixes #172828.