### PR TITLE
[clang-tools-extra] Remove use of REQUIRES: shell

### DIFF
--- a/clang-tools-extra/clangd/test/system-include-extractor.test
+++ b/clang-tools-extra/clangd/test/system-include-extractor.test
@@ -1,5 +1,8 @@
 # RUN: rm -rf %t.dir && mkdir -p %t.dir
 
+# The mock driver below is a shell script:
+# UNSUPPORTED: system-windows
+
 # Create a bin directory to store the mock-driver and add it to the path
 # RUN: mkdir -p %t.dir/bin
 # RUN: %python -c "print(__import__('os').environ['PATH'])" | tr -d '\n' > %t.path

--- a/clang-tools-extra/clangd/test/system-include-extractor.test
+++ b/clang-tools-extra/clangd/test/system-include-extractor.test
@@ -1,8 +1,5 @@
 # RUN: rm -rf %t.dir && mkdir -p %t.dir
 
-# The mock driver below is a shell script:
-# REQUIRES: shell
-
 # Create a bin directory to store the mock-driver and add it to the path
 # RUN: mkdir -p %t.dir/bin
 # RUN: %python -c "print(__import__('os').environ['PATH'])" | tr -d '\n' > %t.path

--- a/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check-not-enable.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check-not-enable.cpp
@@ -1,7 +1,6 @@
 // RUN: sed -e "s:INPUT_DIR:%S/Inputs/custom-query-check:g" -e "s:OUT_DIR:%t:g" -e "s:MAIN_FILE:%s:g" %S/Inputs/custom-query-check/vfsoverlay.yaml > %t.yaml
 // RUN: clang-tidy --allow-no-checks %t/main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK
 // RUN: clang-tidy --allow-no-checks %t/main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml --list-checks | FileCheck %s --check-prefix=LIST-CHECK
-// REQUIRES: shell
 
 
 long V;

--- a/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check-not-enable.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check-not-enable.cpp
@@ -1,3 +1,5 @@
+// sed command does not work as-is on Windows.
+// UNSUPPORTED: system-windows
 // RUN: sed -e "s:INPUT_DIR:%S/Inputs/custom-query-check:g" -e "s:OUT_DIR:%t:g" -e "s:MAIN_FILE:%s:g" %S/Inputs/custom-query-check/vfsoverlay.yaml > %t.yaml
 // RUN: clang-tidy --allow-no-checks %t/main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml | FileCheck %s --check-prefix=CHECK
 // RUN: clang-tidy --allow-no-checks %t/main.cpp -checks='-*,custom-*' -vfsoverlay %t.yaml --list-checks | FileCheck %s --check-prefix=LIST-CHECK

--- a/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: shell
 // REQUIRES: custom-check
 
 // RUN: sed -e "s:INPUT_DIR:%S/Inputs/custom-query-check:g" -e "s:OUT_DIR:%t:g" -e "s:MAIN_FILE:%s:g" %S/Inputs/custom-query-check/vfsoverlay.yaml > %t.yaml

--- a/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/custom-query-check.cpp
@@ -1,3 +1,5 @@
+// sed command does not work as-is on Windows.
+// UNSUPPORTED: system-windows
 // REQUIRES: custom-check
 
 // RUN: sed -e "s:INPUT_DIR:%S/Inputs/custom-query-check:g" -e "s:OUT_DIR:%t:g" -e "s:MAIN_FILE:%s:g" %S/Inputs/custom-query-check/vfsoverlay.yaml > %t.yaml

--- a/clang-tools-extra/test/clang-tidy/infrastructure/hide-progress-flag-scripts.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/hide-progress-flag-scripts.cpp
@@ -11,7 +11,6 @@
 // CHECK-RUN-QUIET-NOT: [1/1]
 // CHECK-RUN-QUIET: 42 is a magic number;
 
-// REQUIRES: shell
 // RUN: sed 's/42/99/' %s > %t-diff.cpp
 
 // RUN: not diff -U0 %s %t-diff.cpp | %clang_tidy_diff -checks=-*,readability-magic-numbers -quiet -hide-progress -- -std=c++11 2>&1 | FileCheck %s --check-prefix=CHECK-DIFF-QUIET


### PR DESCRIPTION
REQUIRES: shell does not have the intended effect now that the internal shell is enabled by default and only prevents tests from running on Windows. This patch removes the directive for portable tests and switches it to a UNSUPPORTED: system-windows tag for non-portable tests to make the intention more clear.