### PR TITLE
[CI] Fix printing of test report in summary view

### DIFF
--- a/.ci/generate_test_report_github.py
+++ b/.ci/generate_test_report_github.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    report = generate_test_report_lib.generate_report_from_files(
+    report, explained = generate_test_report_lib.generate_report_from_files(
         generate_test_report_lib.compute_platform_title(),
         args.return_code,
         args.build_test_logs,


### PR DESCRIPTION
ffe973a3e76eab1f19cfd58418891ffa24f6ad46 changed some of the internal APIs to return a tuple instead of just the report. This callsite was never updated which resulted in the tuple being printed to the summary view when we only wanted the report.