### PR TITLE
[CodeGen][NPM] Do not implicitly flush pipeline when switching to CGSCC

### DIFF
--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -277,12 +277,17 @@ protected:
 
   void requireCGSCCOrder(PassManagerWrapper &PMW) const {
     assert(!AddInCGSCCOrder);
-    flushFPMsToMPM(PMW);
+    assert(PMW.FPM.isEmpty() && PMW.MFPM.isEmpty() &&
+           "Requiring CGSCC ordering requires flushing the current function "
+           "pipelines to the MPM.");
     AddInCGSCCOrder = true;
   }
+
   void stopAddingInCGSCCOrder(PassManagerWrapper &PMW) const {
     assert(AddInCGSCCOrder);
-    flushFPMsToMPM(PMW);
+    assert(PMW.FPM.isEmpty() && PMW.MFPM.isEmpty() &&
+           "Stopping CGSCC ordering requires flushing the current function "
+           "pipelines to the MPM.");
     AddInCGSCCOrder = false;
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -2206,6 +2206,7 @@ void AMDGPUCodeGenPassBuilder::addCodeGenPrepare(
   // many cases.
   flushFPMsToMPM(PMW);
   addModulePass(AMDGPULowerBufferFatPointersPass(TM), PMW);
+  flushFPMsToMPM(PMW);
   requireCGSCCOrder(PMW);
 
   addModulePass(AMDGPULowerIntrinsicsPass(TM), PMW);


### PR DESCRIPTION
Before this patch, switching to and from CGSCC ordering would implicitly flush the pipeline. #169867 tried to make breaking up the function pipeline more explicit, which this kind of defeats. Remove the implict flushing and add an assertion to ensure correct behavior is preserved.