### PR TITLE
[AMDGPU] Add TDM Descriptor Optimization Pass

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.h
@@ -59,6 +59,7 @@ FunctionPass *createAMDGPUCodeGenPreparePass();
 FunctionPass *createAMDGPULateCodeGenPrepareLegacyPass();
 FunctionPass *createAMDGPUReserveWWMRegsPass();
 FunctionPass *createAMDGPURewriteOutArgumentsPass();
+FunctionPass *createAMDGPUTDMOptimizationPass();
 ModulePass *
 createAMDGPULowerModuleLDSLegacyPass(const AMDGPUTargetMachine *TM = nullptr);
 ModulePass *createAMDGPULowerBufferFatPointersPass();
@@ -169,6 +170,8 @@ extern char &AMDGPUPrepareAGPRAllocLegacyID;
 
 void initializeAMDGPUReserveWWMRegsLegacyPass(PassRegistry &);
 extern char &AMDGPUReserveWWMRegsLegacyID;
+
+void initializeAMDGPUTDMOptimizationPass(PassRegistry &);
 
 void initializeAMDGPURewriteOutArgumentsPass(PassRegistry &);
 extern char &AMDGPURewriteOutArgumentsID;

--- a/llvm/lib/Target/AMDGPU/AMDGPUTDMOptimization.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTDMOptimization.cpp
@@ -1,0 +1,566 @@
+//===-- AMDGPUTDMOptimization.cpp - TDM Descriptor Optimization ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass optimizes Tensor Data Movement (TDM) descriptor creation patterns.
+// It identifies insertelement chains that create descriptors and transforms
+// them to use alloca+field updates, which SROA later optimizes to
+// INSERT_SUBREG.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AMDGPU.h"
+#include "AMDGPUSubtarget.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Type.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "amdgpu-tdm-optimization"
+
+static cl::opt<unsigned>
+    TDMOptBenefitThreshold("amdgpu-tdm-opt-threshold", cl::Hidden, cl::init(10),
+                           cl::desc("Minimum optimization benefit threshold "
+                                    "for TDM descriptor optimization"));
+
+namespace llvm {
+void initializeAMDGPUTDMOptimizationPass(PassRegistry &);
+}
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Pattern Detection Data Structures
+//===----------------------------------------------------------------------===//
+
+/// Represents a single descriptor creation pattern
+struct DescriptorPattern {
+  Type *DescType;   ///< <4 x i32> or <8 x i32>
+  Value *BaseValue; ///< Base template (constant or computed)
+  SmallVector<InsertElementInst *, 8>
+      Chain; ///< Chain of insertelement instructions
+  SmallVector<unsigned, 8> VariableFields; ///< Fields that change
+  SmallVector<unsigned, 8> ConstantFields; ///< Fields that stay constant
+  BasicBlock *Location;                    ///< Where the pattern is located
+  Loop *ContainingLoop; ///< Loop containing this pattern (if any)
+
+  /// Calculate field reuse ratio (constant fields / total fields)
+  float getFieldReuseRatio() const {
+    unsigned totalFields = cast<FixedVectorType>(DescType)->getNumElements();
+    return (float)ConstantFields.size() / totalFields;
+  }
+
+  /// Check if this pattern is worth optimizing
+  /// Note: This is a preliminary check. The final decision also considers
+  /// whether multiple patterns can be chained together (see groupSimilarPatterns).
+  bool isWorthOptimizing() const {
+    // Optimize if significant field reuse potential
+    if (getFieldReuseRatio() >= 0.5f)
+      return true;
+
+    // Optimize address descriptors (common case)
+    if (isAddressDescriptor() && ConstantFields.size() >= 1)
+      return true;
+
+    return false;
+  }
+
+  /// Check if this is an address descriptor (<4 x i32>)
+  bool isAddressDescriptor() const {
+    auto *VecTy = cast<FixedVectorType>(DescType);
+    return VecTy->getNumElements() == 4 &&
+           VecTy->getElementType()->isIntegerTy(32);
+  }
+
+  /// Check if this is a tensor descriptor (<8 x i32>)
+  bool isTensorDescriptor() const {
+    auto *VecTy = cast<FixedVectorType>(DescType);
+    return VecTy->getNumElements() == 8 &&
+           VecTy->getElementType()->isIntegerTy(32);
+  }
+};
+
+/// Groups similar descriptor patterns for optimization
+struct DescriptorGroup {
+  SmallVector<DescriptorPattern, 4> Patterns;
+  Type *SharedType;
+  Value *SharedBase; ///< Common base value (if any)
+  SmallVector<unsigned, 8> SharedConstantFields;
+
+  /// Calculate total optimization benefit
+  unsigned getOptimizationBenefit() const {
+    unsigned benefit = 0;
+    for (const auto &pattern : Patterns) {
+      // Base benefit from field reuse
+      benefit += pattern.ConstantFields.size() * 2;
+
+      // Extra benefit for loop patterns
+      if (pattern.ContainingLoop)
+        benefit *= 5;
+    }
+    return benefit;
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// AMDGPUTDMOptimization Pass
+//===----------------------------------------------------------------------===//
+
+class AMDGPUTDMOptimization : public FunctionPass {
+private:
+  LoopInfo *LI = nullptr;
+
+  /// Detected patterns in the function
+  SmallVector<DescriptorPattern, 16> DetectedPatterns;
+
+  /// Groups of optimizable patterns
+  SmallVector<DescriptorGroup, 8> OptimizationGroups;
+
+public:
+  static char ID;
+
+  AMDGPUTDMOptimization() : FunctionPass(ID) {
+    initializeAMDGPUTDMOptimizationPass(*PassRegistry::getPassRegistry());
+  }
+
+  bool runOnFunction(Function &F) override;
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+private:
+  /// Main optimization phases
+  bool detectDescriptorPatterns(Function &F);
+  void groupSimilarPatterns();
+  bool transformPatterns(Function &F);
+
+  /// Pattern detection helpers
+  bool isDescriptorType(Type *Ty) const;
+  DescriptorPattern analyzeInsertChain(InsertElementInst *FinalInsert);
+  Value *extractBaseValue(const DescriptorPattern &Pattern);
+
+  /// Transformation helpers
+  bool transformDescriptorGroup(DescriptorGroup &Group, Function &F);
+  Value *createSharedStorage(DescriptorGroup &Group, IRBuilder<> &Builder);
+  void transformSinglePattern(DescriptorPattern &Pattern, Value *SharedStorage,
+                              IRBuilder<> &Builder);
+
+  /// Utility functions
+  Loop *getContainingLoop(BasicBlock *BB);
+  bool arePatternsSimilar(const DescriptorPattern &A,
+                          const DescriptorPattern &B);
+};
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+bool AMDGPUTDMOptimization::runOnFunction(Function &F) {
+  LI = &getAnalysis<LoopInfoWrapperPass>().getLoopInfo();
+
+  LLVM_DEBUG(dbgs() << "Running TDM optimization on function: " << F.getName()
+                    << "\n");
+
+  // Phase 1: Detect descriptor patterns
+  if (!detectDescriptorPatterns(F)) {
+    LLVM_DEBUG(dbgs() << "No descriptor patterns found\n");
+    return false;
+  }
+
+  LLVM_DEBUG(dbgs() << "Found " << DetectedPatterns.size()
+                    << " descriptor patterns\n");
+
+  // Phase 2: Group similar patterns for optimization
+  groupSimilarPatterns();
+
+  LLVM_DEBUG(dbgs() << "Created " << OptimizationGroups.size()
+                    << " optimization groups\n");
+
+  // Phase 3: Transform patterns
+  bool Changed = transformPatterns(F);
+
+  // Cleanup for next function
+  DetectedPatterns.clear();
+  OptimizationGroups.clear();
+
+  return Changed;
+}
+
+void AMDGPUTDMOptimization::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<LoopInfoWrapperPass>();
+  AU.setPreservesCFG();
+}
+
+//===----------------------------------------------------------------------===//
+// Pattern Detection
+//===----------------------------------------------------------------------===//
+
+bool AMDGPUTDMOptimization::detectDescriptorPatterns(Function &F) {
+  bool FoundPatterns = false;
+
+  // Scan function for insertelement instructions that create descriptors
+  for (auto &BB : F) {
+    for (auto &I : BB) {
+      auto *IE = dyn_cast<InsertElementInst>(&I);
+      if (!IE || !isDescriptorType(IE->getType()))
+        continue;
+
+      // Check if this is the final insert in a descriptor creation chain
+      // Only optimize chains that end at call instructions (descriptor consumers)
+      if (!IE->hasOneUse())
+        continue;
+
+      User *SingleUser = *IE->user_begin();
+      // Skip if user is another insertelement (chain continues)
+      // Skip if user is NOT a call instruction (e.g., shufflevector is intermediate)
+      if (isa<InsertElementInst>(SingleUser) || !isa<CallInst>(SingleUser))
+        continue;
+
+      // Analyze the complete chain
+      DescriptorPattern Pattern = analyzeInsertChain(IE);
+      if (Pattern.Chain.empty())
+        continue;
+
+      // Check if worth optimizing
+      if (!Pattern.isWorthOptimizing()) {
+        LLVM_DEBUG(
+            dbgs() << "Pattern not worth optimizing: field reuse ratio = "
+                   << Pattern.getFieldReuseRatio() << "\n");
+        continue;
+      }
+
+      LLVM_DEBUG(
+          dbgs() << "Found optimizable pattern: "
+                 << (Pattern.isAddressDescriptor() ? "Address" : "Tensor")
+                 << " descriptor with " << Pattern.ConstantFields.size()
+                 << " constant fields\n");
+
+      DetectedPatterns.push_back(std::move(Pattern));
+      FoundPatterns = true;
+    }
+  }
+
+  return FoundPatterns;
+}
+
+bool AMDGPUTDMOptimization::isDescriptorType(Type *Ty) const {
+  auto *VecTy = dyn_cast<FixedVectorType>(Ty);
+  if (!VecTy || !VecTy->getElementType()->isIntegerTy(32))
+    return false;
+
+  unsigned NumElements = VecTy->getNumElements();
+  return NumElements == 4 || NumElements == 8; // Address or tensor descriptors
+}
+
+DescriptorPattern
+AMDGPUTDMOptimization::analyzeInsertChain(InsertElementInst *FinalInsert) {
+  DescriptorPattern Pattern;
+  Pattern.DescType = FinalInsert->getType();
+  Pattern.Location = FinalInsert->getParent();
+  Pattern.ContainingLoop = getContainingLoop(Pattern.Location);
+
+  // Trace back the insertelement chain
+  SmallVector<InsertElementInst *, 8> Chain;
+  Value *CurrentVal = FinalInsert;
+
+  while (auto *IE = dyn_cast<InsertElementInst>(CurrentVal)) {
+    Chain.push_back(IE);
+    CurrentVal = IE->getOperand(0); // Vector being inserted into
+  }
+
+  // Reverse to get forward order
+  std::reverse(Chain.begin(), Chain.end());
+  Pattern.Chain = Chain;
+
+  // Extract base value (the initial vector)
+  Pattern.BaseValue = extractBaseValue(Pattern);
+
+  // Analyze which fields are constant vs variable
+  unsigned NumElements =
+      cast<FixedVectorType>(Pattern.DescType)->getNumElements();
+  SmallBitVector FieldSet(NumElements, false);
+
+  for (auto *IE : Chain) {
+    if (auto *CI = dyn_cast<ConstantInt>(IE->getOperand(2))) {
+      unsigned Idx = CI->getZExtValue();
+      if (Idx < NumElements) {
+        FieldSet.set(Idx);
+        Pattern.VariableFields.push_back(Idx);
+      }
+    }
+  }
+
+  // Fields not in chain are constant
+  for (unsigned i = 0; i < NumElements; ++i) {
+    if (!FieldSet[i])
+      Pattern.ConstantFields.push_back(i);
+  }
+
+  return Pattern;
+}
+
+Value *
+AMDGPUTDMOptimization::extractBaseValue(const DescriptorPattern &Pattern) {
+  if (Pattern.Chain.empty())
+    return nullptr;
+
+  // Get the vector being inserted into by the first insert
+  Value *Base = Pattern.Chain[0]->getOperand(0);
+
+  // If base is a constant vector or another recognizable pattern, return it
+  if (isa<Constant>(Base))
+    return Base;
+
+  // For shufflevector results, we might want to trace further back
+  if (auto *SV = dyn_cast<ShuffleVectorInst>(Base))
+    return SV; // Keep shufflevector as base for now
+
+  return Base;
+}
+
+Loop *AMDGPUTDMOptimization::getContainingLoop(BasicBlock *BB) {
+  return LI ? LI->getLoopFor(BB) : nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// Pattern Grouping
+//===----------------------------------------------------------------------===//
+
+void AMDGPUTDMOptimization::groupSimilarPatterns() {
+  // Simple grouping strategy: group by type and base similarity
+  for (auto &Pattern : DetectedPatterns) {
+    bool Added = false;
+
+    // Try to add to existing group
+    for (auto &Group : OptimizationGroups) {
+      if (Group.SharedType == Pattern.DescType &&
+          arePatternsSimilar(Group.Patterns[0], Pattern)) {
+        Group.Patterns.push_back(Pattern);
+        Added = true;
+        break;
+      }
+    }
+
+    // Create new group if needed
+    if (!Added) {
+      DescriptorGroup NewGroup;
+      NewGroup.SharedType = Pattern.DescType;
+      NewGroup.SharedBase = Pattern.BaseValue;
+      NewGroup.Patterns.push_back(Pattern);
+      OptimizationGroups.push_back(std::move(NewGroup));
+    }
+  }
+
+  // Remove groups that don't meet optimization criteria
+  OptimizationGroups.erase(
+      std::remove_if(OptimizationGroups.begin(), OptimizationGroups.end(),
+                     [](const DescriptorGroup &Group) {
+                       // Skip groups that don't meet benefit threshold
+                       if (Group.getOptimizationBenefit() < TDMOptBenefitThreshold)
+                         return true;
+
+                       // CRITICAL: Skip groups where the base is a non-constant SSA value.
+                       // Non-constant bases (like shufflevector results) are already
+                       // available as SSA values that all descriptors can share directly.
+                       // Chaining would only create unnecessary data dependencies between
+                       // descriptors without saving any instructions.
+                       //
+                       // We ONLY benefit from chaining when the base is a constant that
+                       // needs to be materialized repeatedly (REG_SEQUENCE from constants).
+                       if (Group.SharedBase && !isa<Constant>(Group.SharedBase)) {
+                         LLVM_DEBUG(dbgs() << "Skipping group with non-constant SSA base - "
+                                           << "no materialization savings\n");
+                         return true;
+                       }
+
+                       // Skip groups with only ONE pattern in a loop.
+                       // The optimization creates alloca + store/load which SROA
+                       // converts to a phi node. For a single pattern, this is
+                       // counterproductive - it creates loop-carried dependencies
+                       // for constant fields that should stay in SGPRs.
+                       // We only benefit when there are MULTIPLE patterns to chain.
+                       if (Group.Patterns.size() == 1 &&
+                           Group.Patterns[0].ContainingLoop) {
+                         LLVM_DEBUG(dbgs() << "Skipping single pattern in loop - "
+                                           << "no chaining benefit\n");
+                         return true;
+                       }
+
+                       return false;
+                     }),
+      OptimizationGroups.end());
+}
+
+bool AMDGPUTDMOptimization::arePatternsSimilar(const DescriptorPattern &A,
+                                               const DescriptorPattern &B) {
+  // Patterns are similar if they have same type and similar field usage
+  if (A.DescType != B.DescType)
+    return false;
+
+  // Check if constant fields overlap significantly
+  SmallBitVector AConstants(
+      cast<FixedVectorType>(A.DescType)->getNumElements());
+  SmallBitVector BConstants(
+      cast<FixedVectorType>(B.DescType)->getNumElements());
+
+  for (unsigned Field : A.ConstantFields)
+    AConstants.set(Field);
+  for (unsigned Field : B.ConstantFields)
+    BConstants.set(Field);
+
+  // Count overlapping constant fields
+  auto Intersection = AConstants & BConstants;
+  unsigned OverlapCount = Intersection.count();
+  unsigned TotalConstants = std::max(AConstants.count(), BConstants.count());
+
+  return TotalConstants > 0 && (float)OverlapCount / TotalConstants >= 0.5f;
+}
+
+//===----------------------------------------------------------------------===//
+// Pattern Transformation
+//===----------------------------------------------------------------------===//
+
+bool AMDGPUTDMOptimization::transformPatterns(Function &F) {
+  bool Changed = false;
+
+  for (auto &Group : OptimizationGroups) {
+    LLVM_DEBUG(dbgs() << "Transforming group with " << Group.Patterns.size()
+                      << " patterns, benefit = "
+                      << Group.getOptimizationBenefit() << "\n");
+
+    if (transformDescriptorGroup(Group, F))
+      Changed = true;
+  }
+
+  return Changed;
+}
+
+bool AMDGPUTDMOptimization::transformDescriptorGroup(DescriptorGroup &Group,
+                                                     Function &F) {
+  if (Group.Patterns.empty())
+    return false;
+
+  // Find the best location to place shared storage
+  BasicBlock *StorageLocation = Group.Patterns[0].Location;
+
+  // If patterns are in a loop, try to hoist storage outside loop
+  if (auto *Loop = Group.Patterns[0].ContainingLoop) {
+    if (auto *Preheader = Loop->getLoopPreheader()) {
+      StorageLocation = Preheader;
+      LLVM_DEBUG(dbgs() << "Hoisting storage outside loop\n");
+    }
+  }
+
+  // Create shared storage at the beginning of the storage block
+  IRBuilder<> Builder(&StorageLocation->front());
+  Value *SharedStorage = createSharedStorage(Group, Builder);
+
+  if (!SharedStorage)
+    return false;
+
+  // If base is non-constant (e.g., shufflevector result), store it just before
+  // the first pattern's chain. This ensures the base value is defined before
+  // we try to store it.
+  if (Group.SharedBase && !isa<Constant>(Group.SharedBase)) {
+    // Insert the store just before the first insertelement in the first pattern
+    IRBuilder<> BaseBuilder(Group.Patterns[0].Chain.front());
+    BaseBuilder.CreateStore(Group.SharedBase, SharedStorage);
+    LLVM_DEBUG(dbgs() << "Stored non-constant base before first pattern\n");
+  }
+
+  // Transform each pattern in the group
+  for (auto &Pattern : Group.Patterns) {
+    IRBuilder<> PatternBuilder(Pattern.Chain.back());
+    transformSinglePattern(Pattern, SharedStorage, PatternBuilder);
+  }
+
+  return true;
+}
+
+Value *AMDGPUTDMOptimization::createSharedStorage(DescriptorGroup &Group,
+                                                  IRBuilder<> &Builder) {
+  // Create alloca in address space 5 (AMDGPU private memory)
+  auto *StorageType = Group.SharedType;
+  auto *Storage = Builder.CreateAlloca(
+      StorageType, /*AddrSpace=*/5, /*ArraySize=*/nullptr, "tdm_desc_storage");
+
+  // Initialize with base template if available
+  if (Group.SharedBase) {
+    auto *BaseConstant = dyn_cast<Constant>(Group.SharedBase);
+    if (BaseConstant) {
+      Builder.CreateStore(BaseConstant, Storage);
+      LLVM_DEBUG(dbgs() << "Initialized storage with constant base\n");
+    }
+  }
+
+  return Storage;
+}
+
+void AMDGPUTDMOptimization::transformSinglePattern(DescriptorPattern &Pattern,
+                                                   Value *SharedStorage,
+                                                   IRBuilder<> &Builder) {
+  // Create field pointers for variable fields
+  SmallVector<Value *, 8> FieldPointers;
+  for (unsigned FieldIdx : Pattern.VariableFields) {
+    Value *FieldPtr =
+        Builder.CreateGEP(Pattern.DescType, SharedStorage,
+                          {Builder.getInt32(0), Builder.getInt32(FieldIdx)},
+                          "tdm_field_" + Twine(FieldIdx) + "_ptr");
+    FieldPointers.push_back(FieldPtr);
+  }
+
+  // Update variable fields with values from the original chain
+  for (unsigned i = 0;
+       i < Pattern.VariableFields.size() && i < Pattern.Chain.size(); ++i) {
+    auto *InsertInst = Pattern.Chain[i];
+    Value *NewValue = InsertInst->getOperand(1); // Value being inserted
+    Builder.CreateStore(NewValue, FieldPointers[i]);
+  }
+
+  // Replace final result with load from shared storage
+  Value *OptimizedDescriptor =
+      Builder.CreateLoad(Pattern.DescType, SharedStorage, "tdm_optimized_desc");
+
+  // Replace all uses of the final insert with the load
+  Pattern.Chain.back()->replaceAllUsesWith(OptimizedDescriptor);
+
+  // Clean up the now-dead insertelement chain in reverse order
+  // (each instruction uses the previous one, so delete from end to start)
+  for (auto It = Pattern.Chain.rbegin(); It != Pattern.Chain.rend(); ++It) {
+    InsertElementInst *IE = *It;
+    if (IE->use_empty()) {
+      IE->eraseFromParent();
+    }
+  }
+
+  LLVM_DEBUG(dbgs() << "Transformed pattern with "
+                    << Pattern.VariableFields.size() << " variable fields\n");
+}
+
+} // end anonymous namespace
+
+char AMDGPUTDMOptimization::ID = 0;
+
+INITIALIZE_PASS_BEGIN(AMDGPUTDMOptimization, DEBUG_TYPE,
+                      "AMDGPU TDM Descriptor Optimization", false, false)
+INITIALIZE_PASS_DEPENDENCY(LoopInfoWrapperPass)
+INITIALIZE_PASS_END(AMDGPUTDMOptimization, DEBUG_TYPE,
+                    "AMDGPU TDM Descriptor Optimization", false, false)
+
+namespace llvm {
+FunctionPass *createAMDGPUTDMOptimizationPass() {
+  return new AMDGPUTDMOptimization();
+}
+} // namespace llvm

--- a/llvm/lib/Target/AMDGPU/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/CMakeLists.txt
@@ -117,6 +117,7 @@ add_llvm_target(AMDGPUCodeGen
   AMDGPUTargetMachine.cpp
   AMDGPUTargetObjectFile.cpp
   AMDGPUTargetTransformInfo.cpp
+  AMDGPUTDMOptimization.cpp
   AMDGPUWaitSGPRHazards.cpp
   AMDGPUUnifyDivergentExitNodes.cpp
   R600MachineCFGStructurizer.cpp

--- a/llvm/test/CodeGen/AMDGPU/tdm-optimization.ll
+++ b/llvm/test/CodeGen/AMDGPU/tdm-optimization.ll
@@ -1,0 +1,378 @@
+; NOTE: Test cases for TDM descriptor optimization pass.
+;
+; The pass should ONLY optimize when:
+;   1. Base is a CONSTANT that needs repeated materialization
+;   2. Multiple patterns exist to chain together (single pattern in loop is skipped)
+;
+; The pass should SKIP when:
+;   1. Base is a non-constant SSA value (already shared, no materialization savings)
+;   2. Single pattern inside a loop (creates counterproductive phi nodes)
+;
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -passes=amdgpu-tdm-optimization -S < %s | FileCheck %s
+
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7"
+target triple = "amdgcn-amd-amdhsa"
+
+declare void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32>, <8 x i32>, i32 immarg)
+declare void @llvm.amdgcn.s.barrier()
+declare i32 @llvm.amdgcn.workitem.id.x()
+
+;===----------------------------------------------------------------------===;
+; CASE 1: Constant Base + Multiple Patterns → SHOULD OPTIMIZE
+;         Tests both address descriptors (4xi32) and tensor descriptors (8xi32)
+;===----------------------------------------------------------------------===;
+
+; Address descriptors with constant base - SHOULD OPTIMIZE
+; CHECK-LABEL: @opt_addr_constant_base_multi
+; CHECK: %tdm_desc_storage = alloca <4 x i32>
+; CHECK: store <4 x i32> <i32 1,
+define amdgpu_kernel void @opt_addr_constant_base_multi(i32 %val1, i32 %val2, i32 %val3, i32 %val4) {
+entry:
+  ; Two address descriptors from constant base
+  %addr1.0 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %val1, i64 1
+  %addr1.1 = insertelement <4 x i32> %addr1.0, i32 %val2, i64 2
+  %addr1   = insertelement <4 x i32> %addr1.1, i32 0, i64 3
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %addr1, <8 x i32> zeroinitializer, i32 0)
+
+  %addr2.0 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %val3, i64 1
+  %addr2.1 = insertelement <4 x i32> %addr2.0, i32 %val4, i64 2
+  %addr2   = insertelement <4 x i32> %addr2.1, i32 0, i64 3
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %addr2, <8 x i32> zeroinitializer, i32 0)
+  ret void
+}
+
+; Tensor descriptors with constant base - SHOULD OPTIMIZE
+; CHECK-LABEL: @opt_tensor_constant_base_multi
+; CHECK: %tdm_desc_storage = alloca <8 x i32>
+; CHECK: store <8 x i32> <i32 122683392,
+define amdgpu_kernel void @opt_tensor_constant_base_multi(i32 %val1, i32 %val2, i32 %val3, i32 %val4) {
+entry:
+  ; Two tensor descriptors from constant base
+  %tensor1.0 = insertelement <8 x i32> <i32 122683392, i32 poison, i32 poison, i32 8388608, i32 16, i32 128, i32 0, i32 0>, i32 %val1, i64 1
+  %tensor1   = insertelement <8 x i32> %tensor1.0, i32 %val2, i64 2
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> zeroinitializer, <8 x i32> %tensor1, i32 0)
+
+  %tensor2.0 = insertelement <8 x i32> <i32 122683392, i32 poison, i32 poison, i32 8388608, i32 16, i32 128, i32 0, i32 0>, i32 %val3, i64 1
+  %tensor2   = insertelement <8 x i32> %tensor2.0, i32 %val4, i64 2
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> zeroinitializer, <8 x i32> %tensor2, i32 0)
+  ret void
+}
+
+;===----------------------------------------------------------------------===;
+; CASE 2: SSA Base + Multiple Patterns → SHOULD SKIP
+;         Tests both address descriptors (4xi32) and tensor descriptors (8xi32)
+;===----------------------------------------------------------------------===;
+
+; Address descriptors with SSA base (insertelement result) - SHOULD SKIP
+; CHECK-LABEL: @skip_addr_ssa_base_multi
+; CHECK-NOT: alloca <4 x i32>
+; CHECK: insertelement <4 x i32> %addr_base
+; CHECK: insertelement <4 x i32> %addr_base
+define amdgpu_kernel void @skip_addr_ssa_base_multi(i32 %flag, i32 %val1, i32 %val2, i32 %val3) {
+entry:
+  ; Create SSA base via insertelement (not a constant)
+  %addr_base = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %flag, i64 0
+
+  ; Two address descriptors from SSA base - should NOT optimize
+  %addr1 = insertelement <4 x i32> %addr_base, i32 %val1, i64 1
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %addr1, <8 x i32> zeroinitializer, i32 0)
+
+  %addr2 = insertelement <4 x i32> %addr_base, i32 %val2, i64 1
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %addr2, <8 x i32> zeroinitializer, i32 0)
+  ret void
+}
+
+; Tensor descriptors with SSA base (shufflevector result) - SHOULD SKIP
+; CHECK-LABEL: @skip_tensor_ssa_base_multi
+; CHECK-NOT: alloca <8 x i32>
+; CHECK: shufflevector
+; CHECK: insertelement <8 x i32> %tensor_base
+; CHECK: insertelement <8 x i32> %tensor_base
+define amdgpu_kernel void @skip_tensor_ssa_base_multi(i32 %n, i32 %val1, i32 %val2) {
+entry:
+  ; Create SSA base via shufflevector (not a constant)
+  %base_dim0 = shl i32 %n, 16
+  %tensor_base.0 = insertelement <8 x i32> <i32 122683392, i32 poison, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>, i32 %base_dim0, i64 1
+  %tensor_base = shufflevector <8 x i32> %tensor_base.0, <8 x i32> <i32 poison, i32 poison, i32 poison, i32 8388608, i32 16, i32 128, i32 0, i32 0>, <8 x i32> <i32 0, i32 1, i32 poison, i32 11, i32 12, i32 13, i32 14, i32 15>
+
+  ; Two tensor descriptors from SSA base - should NOT optimize
+  %tensor1 = insertelement <8 x i32> %tensor_base, i32 %val1, i64 2
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> zeroinitializer, <8 x i32> %tensor1, i32 0)
+
+  %tensor2 = insertelement <8 x i32> %tensor_base, i32 %val2, i64 2
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> zeroinitializer, <8 x i32> %tensor2, i32 0)
+  ret void
+}
+
+;===----------------------------------------------------------------------===;
+; CASE 3: Loop + Constant Base + Single Pattern → SHOULD SKIP
+;         Single pattern in loop creates counterproductive phi nodes
+;===----------------------------------------------------------------------===;
+
+; Single address descriptor in loop - SHOULD SKIP
+; CHECK-LABEL: @skip_addr_loop_single
+; CHECK-NOT: alloca
+; CHECK: insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>
+define amdgpu_kernel void @skip_addr_loop_single(i32 %n, i32 %lds_base) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
+
+  ; Compute loop-varying offset
+  %k_offset = mul i32 %i, 128
+  %lds_offset = add i32 %lds_base, %k_offset
+
+  ; Single address descriptor from constant base - all fields loop-dependent
+  %addr.0 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %lds_offset, i64 1
+  %addr.1 = insertelement <4 x i32> %addr.0, i32 %k_offset, i64 2
+  %addr   = insertelement <4 x i32> %addr.1, i32 0, i64 3
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %addr, <8 x i32> zeroinitializer, i32 0)
+  call void @llvm.amdgcn.s.barrier()
+
+  %i.next = add i32 %i, 1
+  %cond = icmp slt i32 %i.next, %n
+  br i1 %cond, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+; Single tensor descriptor in loop - SHOULD SKIP
+; CHECK-LABEL: @skip_tensor_loop_single
+; CHECK-NOT: alloca
+; CHECK: insertelement <8 x i32> <i32 122683392
+define amdgpu_kernel void @skip_tensor_loop_single(i32 %n, i32 %base_dim) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
+
+  ; Compute loop-varying dimensions
+  %k_offset = mul i32 %i, 128
+  %k_remaining = sub i32 %n, %k_offset
+  %dim1 = shl i32 %k_remaining, 16
+  %dim1_or = or i32 %dim1, %base_dim
+
+  ; Single tensor descriptor from constant base - all fields loop-dependent
+  %tensor.0 = insertelement <8 x i32> <i32 122683392, i32 poison, i32 poison, i32 8388608, i32 16, i32 128, i32 0, i32 0>, i32 %dim1_or, i64 1
+  %tensor   = insertelement <8 x i32> %tensor.0, i32 %k_remaining, i64 2
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> zeroinitializer, <8 x i32> %tensor, i32 0)
+  call void @llvm.amdgcn.s.barrier()
+
+  %i.next = add i32 %i, 1
+  %cond = icmp slt i32 %i.next, %n
+  br i1 %cond, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+;===----------------------------------------------------------------------===;
+; CASE 4: Loop + Constant Base + Multiple Patterns → SHOULD OPTIMIZE
+;         Multiple patterns in loop benefit from chaining
+;===----------------------------------------------------------------------===;
+
+; Multiple address descriptors in loop with constant base - SHOULD OPTIMIZE
+; CHECK-LABEL: @opt_addr_loop_multi
+; CHECK: %tdm_desc_storage = alloca <4 x i32>
+; CHECK: store <4 x i32> <i32 1,
+define amdgpu_kernel void @opt_addr_loop_multi(i32 %n, i32 %lds_base) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
+
+  ; Compute loop-varying offsets
+  %k_offset = mul i32 %i, 128
+  %lds_offset1 = add i32 %lds_base, %k_offset
+  %lds_offset2 = add i32 %lds_offset1, 8192
+
+  ; Two address descriptors from constant base
+  %addr1.0 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %lds_offset1, i64 1
+  %addr1.1 = insertelement <4 x i32> %addr1.0, i32 %k_offset, i64 2
+  %addr1   = insertelement <4 x i32> %addr1.1, i32 0, i64 3
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %addr1, <8 x i32> zeroinitializer, i32 0)
+
+  %addr2.0 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %lds_offset2, i64 1
+  %addr2.1 = insertelement <4 x i32> %addr2.0, i32 %k_offset, i64 2
+  %addr2   = insertelement <4 x i32> %addr2.1, i32 0, i64 3
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %addr2, <8 x i32> zeroinitializer, i32 0)
+  call void @llvm.amdgcn.s.barrier()
+
+  %i.next = add i32 %i, 1
+  %cond = icmp slt i32 %i.next, %n
+  br i1 %cond, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+; Multiple tensor descriptors in loop with constant base - SHOULD OPTIMIZE
+; CHECK-LABEL: @opt_tensor_loop_multi
+; CHECK: %tdm_desc_storage = alloca <8 x i32>
+; CHECK: store <8 x i32> <i32 122683392,
+define amdgpu_kernel void @opt_tensor_loop_multi(i32 %n, i32 %base_dim) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i32 [ 0, %entry ], [ %i.next, %loop ]
+
+  ; Compute loop-varying dimensions
+  %k_offset = mul i32 %i, 128
+  %k_remaining1 = sub i32 %n, %k_offset
+  %k_remaining2 = sub i32 %k_remaining1, 64
+  %dim1 = shl i32 %k_remaining1, 16
+  %dim1_or = or i32 %dim1, %base_dim
+  %dim2 = shl i32 %k_remaining2, 16
+  %dim2_or = or i32 %dim2, %base_dim
+
+  ; Two tensor descriptors from constant base
+  %tensor1.0 = insertelement <8 x i32> <i32 122683392, i32 poison, i32 poison, i32 8388608, i32 16, i32 128, i32 0, i32 0>, i32 %dim1_or, i64 1
+  %tensor1   = insertelement <8 x i32> %tensor1.0, i32 %k_remaining1, i64 2
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> zeroinitializer, <8 x i32> %tensor1, i32 0)
+
+  %tensor2.0 = insertelement <8 x i32> <i32 122683392, i32 poison, i32 poison, i32 8388608, i32 16, i32 128, i32 0, i32 0>, i32 %dim2_or, i64 1
+  %tensor2   = insertelement <8 x i32> %tensor2.0, i32 %k_remaining2, i64 2
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> zeroinitializer, <8 x i32> %tensor2, i32 0)
+  call void @llvm.amdgcn.s.barrier()
+
+  %i.next = add i32 %i, 1
+  %cond = icmp slt i32 %i.next, %n
+  br i1 %cond, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+;===----------------------------------------------------------------------===;
+; Negative Tests: Patterns that should NOT be optimized
+;===----------------------------------------------------------------------===;
+
+; All fields variable, no constants - low benefit, should not optimize
+; CHECK-LABEL: @test_no_opt_low_reuse(
+; CHECK-NOT: alloca
+; CHECK: insertelement <4 x i32> <i32 poison
+define amdgpu_kernel void @test_no_opt_low_reuse(i32 %val1, i32 %val2, i32 %val3, i32 %val4) {
+entry:
+  %insert1 = insertelement <4 x i32> <i32 poison, i32 poison, i32 poison, i32 poison>, i32 %val1, i64 0
+  %insert2 = insertelement <4 x i32> %insert1, i32 %val2, i64 1
+  %insert3 = insertelement <4 x i32> %insert2, i32 %val3, i64 2
+  %insert4 = insertelement <4 x i32> %insert3, i32 %val4, i64 3
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %insert4, <8 x i32> zeroinitializer, i32 0)
+  ret void
+}
+
+;===----------------------------------------------------------------------===;
+; Threshold Testing: Verify different benefit scores work with threshold
+;===----------------------------------------------------------------------===;
+
+; Test: Low benefit (should not optimize with high threshold=50)
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -passes=amdgpu-tdm-optimization -amdgpu-tdm-opt-threshold=50 -S < %s | FileCheck %s --check-prefix=THRESHOLD50
+; THRESHOLD50-LABEL: @test_threshold_high_blocks_opt(
+; THRESHOLD50-NOT: alloca
+; THRESHOLD50: insertelement
+define amdgpu_kernel void @test_threshold_high_blocks_opt(i32 %val1, i32 %val2) {
+entry:
+  ; Two patterns with 3 constant fields each = benefit 12, below threshold=50
+  %desc1 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %val1, i64 1
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %desc1, <8 x i32> zeroinitializer, i32 0)
+
+  %desc2 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %val2, i64 1
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %desc2, <8 x i32> zeroinitializer, i32 0)
+  ret void
+}
+
+; Test: Same pattern should optimize with lower threshold=2
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -passes=amdgpu-tdm-optimization -amdgpu-tdm-opt-threshold=2 -S < %s | FileCheck %s --check-prefix=THRESHOLD2
+; THRESHOLD2-LABEL: @test_threshold_low_allows_opt(
+; THRESHOLD2: alloca <4 x i32>
+; THRESHOLD2: store <4 x i32> <i32 1,
+define amdgpu_kernel void @test_threshold_low_allows_opt(i32 %val1, i32 %val2) {
+entry:
+  ; Two patterns - benefit 12, above threshold=2
+  %desc1 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %val1, i64 1
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %desc1, <8 x i32> zeroinitializer, i32 0)
+
+  %desc2 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %val2, i64 1
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %desc2, <8 x i32> zeroinitializer, i32 0)
+  ret void
+}
+
+; Test: Loop with MULTIPLE patterns gets loop multiplier benefit
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -passes=amdgpu-tdm-optimization -amdgpu-tdm-opt-threshold=20 -S < %s | FileCheck %s --check-prefix=THRESHOLD-LOOP
+; THRESHOLD-LOOP-LABEL: @test_threshold_loop_multiplier(
+; THRESHOLD-LOOP: alloca <4 x i32>
+define amdgpu_kernel void @test_threshold_loop_multiplier(ptr %data, i32 %count) {
+entry:
+  br label %loop
+
+loop:
+  %i = phi i32 [ 0, %entry ], [ %next, %loop ]
+  %ptr = getelementptr i32, ptr %data, i32 %i
+  %val = load i32, ptr %ptr
+
+  ; Two patterns in loop: benefit = 2 * 3 * 2 * 5 = 60 (above threshold=20)
+  %desc1 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %val, i64 1
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %desc1, <8 x i32> zeroinitializer, i32 0)
+
+  %val2 = add i32 %val, 100
+  %desc2 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %val2, i64 1
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %desc2, <8 x i32> zeroinitializer, i32 0)
+
+  %next = add i32 %i, 1
+  %cond = icmp ult i32 %next, %count
+  br i1 %cond, label %loop, label %exit
+
+exit:
+  ret void
+}
+
+;===----------------------------------------------------------------------===;
+; Cleanup Tests: Verify that insertelement chains are removed after transformation
+;===----------------------------------------------------------------------===;
+
+; Verify cleanup of address descriptor chains
+; CHECK-LABEL: @test_cleanup_address_descriptor(
+; CHECK: %tdm_desc_storage = alloca <4 x i32>
+; CHECK: store <4 x i32> <i32 1,
+; CHECK-NOT: insertelement <4 x i32> <i32 1, i32 poison
+define amdgpu_kernel void @test_cleanup_address_descriptor(i32 %val1, i32 %val2, i32 %val3, i32 %val4) {
+entry:
+  ; First pattern - chain should be removed
+  %insert1 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %val1, i64 1
+  %insert2 = insertelement <4 x i32> %insert1, i32 %val2, i64 2
+  %insert3 = insertelement <4 x i32> %insert2, i32 %val3, i64 3
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %insert3, <8 x i32> zeroinitializer, i32 0)
+
+  ; Second pattern - also removed
+  %insert4 = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %val4, i64 1
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %insert4, <8 x i32> zeroinitializer, i32 0)
+  ret void
+}
+
+; Verify cleanup with multiple patterns sharing storage
+; CHECK-LABEL: @test_cleanup_multiple_patterns(
+; CHECK: %tdm_desc_storage = alloca <4 x i32>
+; CHECK-NOT: alloca <4 x i32>
+; CHECK: load <4 x i32>, ptr addrspace(5) %tdm_desc_storage
+; CHECK: call void @llvm.amdgcn.tensor.load.to.lds.d2
+; CHECK: load <4 x i32>, ptr addrspace(5) %tdm_desc_storage
+; CHECK: call void @llvm.amdgcn.tensor.load.to.lds.d2
+define amdgpu_kernel void @test_cleanup_multiple_patterns(i32 %a1, i32 %a2, i32 %b1, i32 %b2) {
+entry:
+  ; First pattern
+  %insert1a = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %a1, i64 1
+  %insert2a = insertelement <4 x i32> %insert1a, i32 %a2, i64 2
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %insert2a, <8 x i32> zeroinitializer, i32 0)
+
+  ; Second pattern (shares base template with first)
+  %insert1b = insertelement <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>, i32 %b1, i64 1
+  %insert2b = insertelement <4 x i32> %insert1b, i32 %b2, i64 2
+  call void @llvm.amdgcn.tensor.load.to.lds.d2(<4 x i32> %insert2b, <8 x i32> zeroinitializer, i32 0)
+  ret void
+}


### PR DESCRIPTION
AMDGPU code generation frequently creates tensor and address descriptors using sequences of `insertelement` instructions. When these patterns have significant field reuse or cross-iteration dependencies, the current approach generates inefficient `REG_SEQUENCE` operations in MIR, instead of `INSERT_SUBREG` chains, leading to suboptimal register allocation.

This PR introduces the `AMDGPUTDMOptimization` pass that:

  1. Pattern Detection: Identifies descriptor creation chains with reusable constant fields
  2. Grouping: Groups similar patterns to maximize optimization opportunities
  3. Transformation: Converts `insertelement` chains to `alloca` + field updates in address space 5
  4. Integration: Works with SROA to generate `INSERT_SUBREG` operations for optimal register allocation