### PR TITLE
[mlir][vector] Skip vector mask elimination for funcs without body

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/VectorMaskElimination.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorMaskElimination.cpp
@@ -99,6 +99,10 @@ void eliminateVectorMasks(IRRewriter &rewriter, FunctionOpInterface function,
   if (!vscaleRange)
     return;
 
+  // Early exit for functions without a body.
+  if (function.isExternal())
+    return;
+
   OpBuilder::InsertionGuard g(rewriter);
 
   // Build worklist so we can safely insert new ops in

--- a/mlir/test/Dialect/Vector/eliminate-masks.mlir
+++ b/mlir/test/Dialect/Vector/eliminate-masks.mlir
@@ -45,6 +45,12 @@ func.func @eliminate_redundant_masks_through_insert_and_extracts(%tensor: tensor
 
 // -----
 
+// Test to ensure that functions without a body are skipped.
+// CHECK-LABEL: func.func private @negative_no_func_body()
+func.func private @negative_no_func_body()
+
+// -----
+
 // CHECK-LABEL: @negative_extract_slice_size_shrink
 // CHECK-NOT: vector.constant_mask
 // CHECK: %[[MASK:.*]] = vector.create_mask


### PR DESCRIPTION
Avoids a crash in test-eliminate-vector-masks pass by bailing out when the target function has no body.

Fixes https://github.com/llvm/llvm-project/issues/132160.

