### PR TITLE
[clang][bytecode] Add lifetime information for primitive array elements

### DIFF
--- a/clang/lib/AST/ByteCode/Descriptor.h
+++ b/clang/lib/AST/ByteCode/Descriptor.h
@@ -276,7 +276,6 @@ public:
   void dump(llvm::raw_ostream &OS) const;
   void dumpFull(unsigned Offset = 0, unsigned Indent = 0) const;
 };
-
 } // namespace interp
 } // namespace clang
 

--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -495,6 +495,59 @@ bool Pointer::isElementInitialized(unsigned Index) const {
   return isInitialized();
 }
 
+bool Pointer::isElementAlive(unsigned Index) const {
+  assert(getFieldDesc()->isPrimitiveArray());
+
+  InitMapPtr &IM = getInitMap();
+  if (!IM.hasInitMap())
+    return true;
+
+  if (IM.allInitialized())
+    return true;
+
+  return IM->isElementAlive(Index);
+}
+
+void Pointer::startLifetime() const {
+  if (!isBlockPointer())
+    return;
+  if (BS.Base < sizeof(InlineDescriptor))
+    return;
+
+  if (inArray()) {
+    const Descriptor *Desc = getFieldDesc();
+    InitMapPtr &IM = getInitMap();
+    if (!IM.hasInitMap())
+      IM.setInitMap(new InitMap(Desc->getNumElems(), IM.allInitialized()));
+
+    IM->startElementLifetime(getIndex());
+    assert(this->getLifetime() == Lifetime::Started);
+    return;
+  }
+
+  getInlineDesc()->LifeState = Lifetime::Started;
+}
+
+void Pointer::endLifetime() const {
+  if (!isBlockPointer())
+    return;
+  if (BS.Base < sizeof(InlineDescriptor))
+    return;
+
+  if (inArray()) {
+    const Descriptor *Desc = getFieldDesc();
+    InitMapPtr &IM = getInitMap();
+    if (!IM.hasInitMap())
+      IM.setInitMap(new InitMap(Desc->getNumElems(), IM.allInitialized()));
+
+    IM->endElementLifetime(getIndex());
+    assert(this->getLifetime() == Lifetime::Ended);
+    return;
+  }
+
+  getInlineDesc()->LifeState = Lifetime::Ended;
+}
+
 void Pointer::initialize() const {
   if (!isBlockPointer())
     return;
@@ -529,7 +582,6 @@ void Pointer::initializeElement(unsigned Index) const {
   assert(Index < getFieldDesc()->getNumElems());
 
   InitMapPtr &IM = getInitMap();
-
   if (IM.allInitialized())
     return;
 
@@ -565,6 +617,23 @@ bool Pointer::allElementsInitialized() const {
 
   InitMapPtr IM = getInitMap();
   return IM.allInitialized();
+}
+
+bool Pointer::allElementsAlive() const {
+  assert(getFieldDesc()->isPrimitiveArray());
+  assert(isArrayRoot());
+
+  if (isStatic() && BS.Base == 0)
+    return true;
+
+  if (isRoot() && BS.Base == sizeof(GlobalInlineDescriptor) &&
+      Offset == BS.Base) {
+    const auto &GD = block()->getBlockDesc<GlobalInlineDescriptor>();
+    return GD.InitState == GlobalInitState::Initialized;
+  }
+
+  InitMapPtr &IM = getInitMap();
+  return IM.allInitialized() || (IM.hasInitMap() && IM->allElementsAlive());
 }
 
 void Pointer::activate() const {

--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -15,6 +15,7 @@
 
 #include "Descriptor.h"
 #include "FunctionPointer.h"
+#include "InitMap.h"
 #include "InterpBlock.h"
 #include "clang/AST/ComparisonCategories.h"
 #include "clang/AST/Decl.h"
@@ -722,6 +723,9 @@ public:
   /// Like isInitialized(), but for primitive arrays.
   bool isElementInitialized(unsigned Index) const;
   bool allElementsInitialized() const;
+  bool allElementsAlive() const;
+  bool isElementAlive(unsigned Index) const;
+
   /// Activats a field.
   void activate() const;
   /// Deactivates an entire strurcutre.
@@ -732,24 +736,32 @@ public:
       return Lifetime::Started;
     if (BS.Base < sizeof(InlineDescriptor))
       return Lifetime::Started;
+
+    if (inArray() && !isArrayRoot()) {
+      InitMapPtr &IM = getInitMap();
+
+      if (!IM.hasInitMap()) {
+        if (IM.allInitialized())
+          return Lifetime::Started;
+        return getArray().getLifetime();
+      }
+
+      return IM->isElementAlive(getIndex()) ? Lifetime::Started
+                                            : Lifetime::Ended;
+    }
+
     return getInlineDesc()->LifeState;
   }
 
-  void endLifetime() const {
-    if (!isBlockPointer())
-      return;
-    if (BS.Base < sizeof(InlineDescriptor))
-      return;
-    getInlineDesc()->LifeState = Lifetime::Ended;
-  }
-
-  void startLifetime() const {
-    if (!isBlockPointer())
-      return;
-    if (BS.Base < sizeof(InlineDescriptor))
-      return;
-    getInlineDesc()->LifeState = Lifetime::Started;
-  }
+  /// Start the lifetime of this pointer. This works for pointer with an
+  /// InlineDescriptor as well as primitive array elements. Pointers are usually
+  /// alive by default, unless the underlying object has been allocated with
+  /// std::allocator. This function is used by std::construct_at.
+  void startLifetime() const;
+  /// Ends the lifetime of the pointer. This works for pointer with an
+  /// InlineDescriptor as well as primitive array elements. This function is
+  /// used by std::destroy_at.
+  void endLifetime() const;
 
   /// Strip base casts from this Pointer.
   /// The result is either a root pointer or something
@@ -802,7 +814,6 @@ private:
   friend class DeadBlock;
   friend class MemberPointer;
   friend class InterpState;
-  friend struct InitMap;
   friend class DynamicAllocator;
   friend class Program;
 
@@ -849,6 +860,8 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Pointer &P) {
   OS << ' ';
   if (const Descriptor *D = P.getFieldDesc())
     D->dump(OS);
+  if (P.isArrayElement())
+    OS << " index " << P.getIndex();
   return OS;
 }
 

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1852,11 +1852,9 @@ namespace WithinLifetime {
   } xstd; // both-error {{is not a constant expression}} \
           // both-note {{in call to}}
 
-  /// FIXME: We do not have per-element lifetime information for primitive arrays.
-  /// See https://github.com/llvm/llvm-project/issues/147528
   consteval bool test_dynamic(bool read_after_deallocate) {
     std::allocator<int> a;
-    int* p = a.allocate(1); // expected-note 2{{allocation performed here was not deallocated}}
+    int* p = a.allocate(1);
     // a.allocate starts the lifetime of an array,
     // the complete object of *p has started its lifetime
     if (__builtin_is_within_lifetime(p))
@@ -1869,12 +1867,12 @@ namespace WithinLifetime {
       return false;
     a.deallocate(p, 1);
     if (read_after_deallocate)
-      __builtin_is_within_lifetime(p); // ref-note {{read of heap allocated object that has been deleted}}
+      __builtin_is_within_lifetime(p); // both-note {{read of heap allocated object that has been deleted}}
     return true;
   }
-  static_assert(test_dynamic(false)); // expected-error {{not an integral constant expression}}
+  static_assert(test_dynamic(false));
   static_assert(test_dynamic(true)); // both-error {{not an integral constant expression}} \
-                                     // ref-note {{in call to}}
+                                     // both-note {{in call to}}
 }
 
 #ifdef __SIZEOF_INT128__

--- a/clang/test/AST/ByteCode/cxx23.cpp
+++ b/clang/test/AST/ByteCode/cxx23.cpp
@@ -12,6 +12,8 @@ inline constexpr void* operator new(__SIZE_TYPE__, void* p) noexcept { return p;
 namespace std {
 template<typename T, typename... Args>
 constexpr T* construct_at(T* p, Args&&... args) { return ::new((void*)p) T(static_cast<Args&&>(args)...); }
+template<typename T>
+constexpr void destroy_at(T *p) { p->~T(); } // #destroy
 }
 
 constexpr int f(int n) {  // all20-error {{constexpr function never produces a constant expression}}
@@ -528,6 +530,37 @@ namespace InactiveLocalsInConditionalOp {
   static_assert(test2(true));
 
 }
+
+namespace PrimitiveArrayLifetimes {
+  consteval int test1() {
+    int a[3];
+    assert_active(a[0]);
+    assert_active(a[1]);
+    assert_active(a[2]);
+    std::destroy_at(&a[0]);
+    assert_inactive(a[0]);
+
+    std::construct_at(&a[0]);
+    assert_active(a[0]);
+    return a[0];
+  }
+  static_assert(test1() == 0);
+
+  consteval int test2() {
+    int a[3] = {1,2,3};
+    assert_active(a[0]);
+    assert_active(a[1]);
+    assert_active(a[2]);
+    std::destroy_at(&a[0]);
+    assert_inactive(a[0]);
+
+    std::construct_at(&a[0]);
+    assert_active(a[0]);
+    return a[0];
+  }
+  static_assert(test2() == 0);
+}
+
 #endif
 
 namespace UnknownParams {

--- a/clang/test/AST/ByteCode/lifetimes26.cpp
+++ b/clang/test/AST/ByteCode/lifetimes26.cpp
@@ -1,8 +1,6 @@
 // RUN: %clang_cc1 -verify=expected,both -std=c++26 %s -fexperimental-new-constant-interpreter
 // RUN: %clang_cc1 -verify=ref,both      -std=c++26 %s
 
-// both-no-diagnostics
-
 namespace std {
   struct type_info;
   struct destroying_delete_t {
@@ -13,12 +11,26 @@ namespace std {
   } inline constexpr nothrow{};
   using size_t = decltype(sizeof(0));
   enum class align_val_t : size_t {};
+
+  using size_t = decltype(sizeof(0));
+  template<typename T> struct allocator {
+    constexpr T *allocate(size_t N) {
+      return (T*)__builtin_operator_new(sizeof(T) * N);
+    }
+    constexpr void deallocate(void *p) {
+      __builtin_operator_delete(p);
+    }
+  };
+  template<typename T, typename ...Args>
+  constexpr void construct_at(void *p, Args &&...args) {
+    new (p) T((Args&&)args...);
+  }
 };
 
 constexpr void *operator new(std::size_t, void *p) { return p; }
 namespace std {
   template<typename T> constexpr T *construct_at(T *p) { return new (p) T; }
-  template<typename T> constexpr void destroy_at(T *p) { p->~T(); }
+  template<typename T> constexpr void destroy_at(T *p) { p->~T(); } // #destroy
 }
 
 constexpr bool foo() {
@@ -49,18 +61,102 @@ static_assert((destroy_pointer(), true));
 
 
 namespace DestroyArrayElem {
-  /// This is proof that std::destroy_at'ing an array element
-  /// ends the lifetime of the entire array.
-  /// See https://github.com/llvm/llvm-project/issues/147528
-  /// Using destroy_at on array elements is currently a no-op due to this.
-  constexpr int test() {
+
+  constexpr int test1() {
     int a[4] = {};
+    std::destroy_at(&a); // both-error@#destroy {{object expression of non-scalar type 'int[4]' cannot be used in a pseudo-destructor expression}} \
+                         // both-note {{in instantiation of function template specialization 'std::destroy_at<int[4]>' requested here}} \
+                         // both-note {{subexpression not valid}}
+    return 0;
+  }
+  static_assert(test1() == 0); // both-error {{not an integral constant expression}} \
+                               // both-note {{in call to}}
 
-    std::destroy_at(&a[3]);
-    int r = a[1];
+  constexpr int test2() {
+
+    int a[4] = {};
+    std::destroy_at(&a[1]);
+    int r = a[1]; // both-note {{read of object outside its lifetime}}
+    std::construct_at(&a[1]);
+    return 0;
+  }
+  static_assert(test2() == 0); // both-error {{not an integral constant expression}} \
+                               // both-note {{in call to}}
+
+  constexpr int test3() {
+    int a[4]; /// Array with no init map.
     std::construct_at(&a[3]);
+    return a[3]; // both-note {{read of uninitialized object}}
+  }
+  static_assert(test3() == 0); // both-error {{not an integral constant expression}} \
+                               // both-note {{in call to}}
 
+  constexpr int test4(bool b) {
+    int a[4];
+    a[0] = 12;
+    std::construct_at(&a[3]);
+    return b ? a[0] : a[3]; // both-note {{read of uninitialized object}}
+  }
+  static_assert(test4(true) == 12);
+  static_assert(test4(false) == 0); // both-error {{not an integral constant expression}} \
+                                    // both-note {{in call to}}
+
+
+  constexpr int test5() {
+    int *a = std::allocator<int>{}.allocate(3);
+    a[0] = 1; // both-note {{assignment to object outside its lifetime}}
+    int b = a[1];
+    std::allocator<int>{}.deallocate(a);
+    return b;
+  }
+  static_assert(test5() == 1); // both-error {{not an integral constant expression}} \
+                               // both-note {{in call to}}
+
+  constexpr int test6() {
+    int *a = std::allocator<int>{}.allocate(3);
+    std::construct_at<int>(&a[0]);
+    a[0] = 1;
+    std::construct_at<int>(&a[1]);
+    a[1] = 2;
+    std::construct_at<int>(&a[2]);
+    a[2] = 3;
+
+    int b = a[1];
+    std::allocator<int>{}.deallocate(a);
+    return b;
+  }
+  static_assert(test6() == 2);
+
+  constexpr int test7() {
+    int *a = std::allocator<int>{}.allocate(3);
+    int *b = a + 3;
+    new (a + 0) int();
+    new (a + 1) int();
+    new (a + 2) int();
+
+    b = b - 1;
+    new (b) int(0);
+
+    bool r = a[0] == 0;
+
+    std::allocator<int>{}.deallocate(a);
     return r;
   }
-  static_assert(test() == 0);
+  static_assert(test7());
+
+  constexpr int test8() {
+    int *a = std::allocator<int>{}.allocate(3);
+    int *b = a + 3;
+    new (a + 0) int();
+    new (a + 1) int();
+    new (a + 2) int();
+
+    new (a) int();
+    std::destroy_at(b - 1);
+
+    bool r = *a == 0;
+    std::allocator<int>{}.deallocate(a);
+    return r;
+  }
+  static_assert(test8());
 }


### PR DESCRIPTION
Double the allocated size of the `InitMap` and use the second half for lifetime information.