### PR TITLE
[Clang] Remove remaining REQUIRES: shell statements

### DIFF
--- a/clang/test/Analysis/z3-crosscheck-max-attempts.cpp
+++ b/clang/test/Analysis/z3-crosscheck-max-attempts.cpp
@@ -27,7 +27,7 @@
 // RUN: env Z3_SOLVER_RESULTS="UNDEF,UNDEF,SAT"   %{mocked_clang} %{attempts}=3 -verify=accepted
 
 
-// REQUIRES: z3, z3-mock, asserts, shell, system-linux
+// REQUIRES: z3, z3-mock, asserts, system-linux
 
 // refuted-no-diagnostics
 

--- a/clang/test/Analysis/z3/D83660.c
+++ b/clang/test/Analysis/z3/D83660.c
@@ -3,7 +3,7 @@
 // RUN: %clang_analyze_cc1 -analyzer-constraints=z3 \
 // RUN:   -analyzer-checker=core %s -verify
 //
-// REQUIRES: z3, z3-mock, asserts, shell, system-linux
+// REQUIRES: z3, z3-mock, asserts, system-linux
 //
 // Works only with the z3 constraint manager.
 // expected-no-diagnostics

--- a/clang/test/Modules/crash-vfs-relative-incdir.m
+++ b/clang/test/Modules/crash-vfs-relative-incdir.m
@@ -1,4 +1,4 @@
-// REQUIRES: crash-recovery, shell, system-darwin
+// REQUIRES: crash-recovery, system-darwin
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t/m

--- a/clang/test/Modules/crash-vfs-run-reproducer.m
+++ b/clang/test/Modules/crash-vfs-run-reproducer.m
@@ -1,4 +1,4 @@
-// REQUIRES: crash-recovery, shell, system-darwin
+// REQUIRES: crash-recovery, system-darwin
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t/i %t/m %t


### PR DESCRIPTION
Now that the internal shell is enabled everywhere by default, the shell feature makes little sense and essentially only implies windows is unsupported. These tests all already require specific POSIX systems, so the feature is no-op. Remove them to eventually remove the shell feature from lit.