### PR TITLE
[clang-doc] Fix nullptr dereference in JSONGenerator::insertComment

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -98,11 +98,12 @@ static void insertComment(Object &Description, json::Value &Comment,
   // The comment has a Children array for the actual text, with meta attributes
   // alongside it in the Object.
   if (auto *Obj = Comment.getAsObject()) {
-    if (auto *Children = Obj->getArray("Children"); Children->empty())
+    if (auto *Children = Obj->getArray("Children");
+        Children && Children->empty())
       return;
   }
   // The comment is just an array of text comments.
-  else if (auto *Array = Comment.getAsArray(); Array->empty()) {
+  else if (auto *Array = Comment.getAsArray(); Array && Array->empty()) {
     return;
   }
 


### PR DESCRIPTION
The `if` statements in `insertComment` didn't check whether or not the comment JSON object was a nullptr before dereferencing it. This crash only happened when running clang-doc on larger codebases, like `clang`.