### PR TITLE
[compiler-rt] Remove REQUIRES: shell lines

### DIFF
--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -39,7 +39,7 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D LLVM_ENABLE_ASSERTIONS=ON \
       -D LLVM_BUILD_EXAMPLES=ON \
       -D COMPILER_RT_BUILD_LIBFUZZER=OFF \
-      -D LLVM_LIT_ARGS="-vv --xunit-xml-output ${BUILD_DIR}/test-results.xml --use-unique-output-file-name --timeout=60 --time-tests --succinct" \
+      -D LLVM_LIT_ARGS="-v --xunit-xml-output ${BUILD_DIR}/test-results.xml --use-unique-output-file-name --timeout=1200 --time-tests --succinct" \
       -D COMPILER_RT_BUILD_ORC=OFF \
       -D CMAKE_C_COMPILER_LAUNCHER=sccache \
       -D CMAKE_CXX_COMPILER_LAUNCHER=sccache \

--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -39,7 +39,7 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D LLVM_ENABLE_ASSERTIONS=ON \
       -D LLVM_BUILD_EXAMPLES=ON \
       -D COMPILER_RT_BUILD_LIBFUZZER=OFF \
-      -D LLVM_LIT_ARGS="-v --xunit-xml-output ${BUILD_DIR}/test-results.xml --use-unique-output-file-name --timeout=1200 --time-tests --succinct" \
+      -D LLVM_LIT_ARGS="-vv --xunit-xml-output ${BUILD_DIR}/test-results.xml --use-unique-output-file-name --timeout=60 --time-tests --succinct" \
       -D COMPILER_RT_BUILD_ORC=OFF \
       -D CMAKE_C_COMPILER_LAUNCHER=sccache \
       -D CMAKE_CXX_COMPILER_LAUNCHER=sccache \

--- a/compiler-rt/test/asan/TestCases/Linux/allocator_oom_test.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/allocator_oom_test.cpp
@@ -43,8 +43,8 @@
 // ASan shadow memory on s390 is too large for this test.
 // AArch64 bots fail on this test.
 // TODO(alekseys): Android lit do not run ulimit on device.
-// REQUIRES: shell, shadow-scale-3
-// UNSUPPORTED: android, target={{(s390|aarch64|powerpc64le).*}}
+// REQUIRES: shadow-scale-3
+// UNSUPPORTED: android, target={{(s390|aarch64|powerpc64le).*}}, system-windows
 
 #include <stdlib.h>
 #include <string.h>

--- a/compiler-rt/test/asan/TestCases/Linux/allocator_oom_test.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/allocator_oom_test.cpp
@@ -44,7 +44,7 @@
 // AArch64 bots fail on this test.
 // TODO(alekseys): Android lit do not run ulimit on device.
 // REQUIRES: shadow-scale-3
-// UNSUPPORTED: android, target={{(s390|aarch64|powerpc64le).*}}, system-windows
+// UNSUPPORTED: android, target={{(s390|aarch64|powerpc64le).*}}
 
 #include <stdlib.h>
 #include <string.h>

--- a/compiler-rt/test/asan/TestCases/Posix/deep_call_stack.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/deep_call_stack.cpp
@@ -1,6 +1,4 @@
 // Check that UAR mode can handle very deep recursion.
-// Requires ulimit
-// UNSUPPORTED: system-windows
 // TODO(boomanaiden154): This test currently fails with the internal
 // shell because python is not able to set RLIMIT_STACK. We should
 // reenable this when the behavior is fixed.

--- a/compiler-rt/test/asan/TestCases/Posix/deep_call_stack.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/deep_call_stack.cpp
@@ -1,5 +1,6 @@
 // Check that UAR mode can handle very deep recursion.
-// REQUIRES: shell
+// Requires ulimit
+// UNSUPPORTED: system-windows
 // TODO(boomanaiden154): This test currently fails with the internal
 // shell because python is not able to set RLIMIT_STACK. We should
 // reenable this when the behavior is fixed.

--- a/compiler-rt/test/asan/TestCases/log-path_test.cpp
+++ b/compiler-rt/test/asan/TestCases/log-path_test.cpp
@@ -32,7 +32,7 @@
 // RUN: not cat %t.log.*
 
 // FIXME: log_path is not supported on Windows yet.
-// XFAIL: target={{.*windows-msvc.*}}
+// UNSUPPORTED: system-windows
 
 #include <stdlib.h>
 #include <string.h>

--- a/compiler-rt/test/asan/TestCases/log-path_test.cpp
+++ b/compiler-rt/test/asan/TestCases/log-path_test.cpp
@@ -1,9 +1,6 @@
 // FIXME: https://code.google.com/p/address-sanitizer/issues/detail?id=316
 // UNSUPPORTED: ios, android
 //
-// The for loop in the backticks below requires bash.
-// REQUIRES: shell
-//
 // RUN: %clangxx_asan  %s -o %t
 
 // Regular run.

--- a/compiler-rt/test/asan/TestCases/scariness_score_test.cpp
+++ b/compiler-rt/test/asan/TestCases/scariness_score_test.cpp
@@ -75,8 +75,9 @@
 // REQUIRES: x86_64-target-arch
 // TODO(boomanaiden154): This test currently fails with the internal
 // shell because python is not able to set RLIMIT_STACK. We should
-// reenable this when the behavior is fixed.
-// UNSUPPORTED: system-darwin
+// reenable this when the behavior is fixed. Windows does not support
+// ulimit.
+// UNSUPPORTED: system-darwin, system-windows
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/compiler-rt/test/asan/TestCases/scariness_score_test.cpp
+++ b/compiler-rt/test/asan/TestCases/scariness_score_test.cpp
@@ -73,7 +73,6 @@
 // RUN: not %run %t 27 2>&1 | FileCheck %s --check-prefix=CHECK27
 // Parts of the test are too platform-specific:
 // REQUIRES: x86_64-target-arch
-// REQUIRES: shell
 // TODO(boomanaiden154): This test currently fails with the internal
 // shell because python is not able to set RLIMIT_STACK. We should
 // reenable this when the behavior is fixed.

--- a/compiler-rt/test/fuzzer/features_dir.test
+++ b/compiler-rt/test/fuzzer/features_dir.test
@@ -1,5 +1,5 @@
 # Tests -features_dir=F
-# REQUIRES: linux, shell
+# REQUIRES: linux
 RUN: %cpp_compiler %S/SimpleTest.cpp -o %t-SimpleTest
 RUN: rm -rf %t-C %t-F
 RUN: mkdir %t-C %t-F

--- a/compiler-rt/test/fuzzer/fork-sigusr.test
+++ b/compiler-rt/test/fuzzer/fork-sigusr.test
@@ -1,6 +1,5 @@
 # Check that libFuzzer honors SIGUSR1/SIGUSR2
 # Disabled on Windows which does not have SIGUSR1/SIGUSR2.
-REQUIRES: shell
 UNSUPPORTED: darwin, target={{.*windows.*}}, target=aarch64{{.*}}
 RUN: rm -rf %t
 RUN: mkdir -p %t

--- a/compiler-rt/test/fuzzer/merge-posix.test
+++ b/compiler-rt/test/fuzzer/merge-posix.test
@@ -1,4 +1,3 @@
-REQUIRES: shell
 XFAIL: ios
 RUN: %cpp_compiler %S/FullCoverageSetTest.cpp -o %t-FullCoverageSetTest
 

--- a/compiler-rt/test/fuzzer/merge-sigusr.test
+++ b/compiler-rt/test/fuzzer/merge-sigusr.test
@@ -1,7 +1,6 @@
 # Check that libFuzzer honors SIGUSR1/SIGUSR2
 # FIXME: Disabled on Windows for now because of reliance on posix only features
 # (eg: export, "&", pkill).
-REQUIRES: shell
 UNSUPPORTED: darwin, target={{.*windows.*}}
 RUN: rm -rf %t
 RUN: mkdir -p %t

--- a/compiler-rt/test/fuzzer/sigint.test
+++ b/compiler-rt/test/fuzzer/sigint.test
@@ -1,4 +1,4 @@
-REQUIRES: shell, msan
+REQUIRES: msan
 UNSUPPORTED: target=arm{{.*}}
 
 # Check that libFuzzer exits gracefully under SIGINT with MSan.

--- a/compiler-rt/test/fuzzer/sigusr.test
+++ b/compiler-rt/test/fuzzer/sigusr.test
@@ -1,6 +1,5 @@
 # FIXME: Disabled on Windows for now because of reliance on posix only features
 # (eg: export, "&", pkill).
-REQUIRES: shell
 UNSUPPORTED: darwin, target={{.*windows.*}}
 # Check that libFuzzer honors SIGUSR1/SIGUSR2
 RUN: rm -rf %t

--- a/compiler-rt/test/fuzzer/ulimit.test
+++ b/compiler-rt/test/fuzzer/ulimit.test
@@ -1,4 +1,5 @@
-REQUIRES: shell
+# Requires ulimit
+UNSUPPORTED: system-windows
 RUN: %cpp_compiler %S/SimpleTest.cpp -o %t-SimpleTest
 RUN: ulimit -s 1000
 RUN: not %run %t-SimpleTest

--- a/compiler-rt/test/hwasan/TestCases/print-memory-usage.c
+++ b/compiler-rt/test/hwasan/TestCases/print-memory-usage.c
@@ -1,5 +1,6 @@
 // Tests __hwasan_print_memory_usage.
-// REQUIRES: shell
+// Requires ulimit
+// UNSUPPORTED: system-windows
 // RUN: %clang_hwasan %s -o %t
 // RUN: ulimit -s 1000
 // RUN: %run %t 2>&1 | FileCheck %s

--- a/compiler-rt/test/memprof/TestCases/log_path_test.cpp
+++ b/compiler-rt/test/memprof/TestCases/log_path_test.cpp
@@ -1,6 +1,3 @@
-// The for loop in the backticks below requires bash.
-// REQUIRES: shell
-//
 // RUN: %clangxx_memprof  %s -o %t
 
 // stderr log_path

--- a/compiler-rt/test/msan/Linux/reexec_unlimited_stack.cpp
+++ b/compiler-rt/test/msan/Linux/reexec_unlimited_stack.cpp
@@ -1,6 +1,5 @@
 // MSAN re-execs on unlimited stacks. We use that to verify ReExec() uses the
 // right path.
-// REQUIRES: shell
 // RUN: %clangxx_msan -O0 %s -o %t && ulimit -s unlimited && %run %t | FileCheck %s
 
 #include <stdio.h>

--- a/compiler-rt/test/profile/instrprof-hostname.c
+++ b/compiler-rt/test/profile/instrprof-hostname.c
@@ -3,7 +3,8 @@
 // RUN: %run uname -n | tr -d '\n' > %t.n
 // RUN: llvm-profdata merge -o %t.profdata %{readfile:%t.n}.%t-%{readfile:%t.n}.profraw_%{readfile:%t.n}
 // RUN: %clang_profuse=%t.profdata -o - -S -emit-llvm %s | FileCheck %s
-// REQUIRES: shell
+// Requires uname
+// UNSUPPORTED: system-windows
 
 int main(int argc, const char *argv[]) {
   // CHECK: br i1 %{{.*}}, label %{{.*}}, label %{{.*}}, !prof ![[PD1:[0-9]+]]


### PR DESCRIPTION
The shell feature only implies that we are not running on Windows now that the internal shell is enabled by default everywhere. Remove where we can and rewrite to the more intentional UNSUPPORTED: system-windows when we still need to prevent tests from running on Windows.