### PR TITLE
[flang] Remove REQUIRES: shell lines form tests

### DIFF
--- a/flang/test/Driver/pass-plugin-not-found.f90
+++ b/flang/test/Driver/pass-plugin-not-found.f90
@@ -1,6 +1,6 @@
 ! Check the correct error diagnostic is reported when a pass plugin shared object isn't found
 
-! REQUIRES: plugins, shell
+! REQUIRES: plugins
 
 ! RUN: not %flang -fpass-plugin=X.Y %s 2>&1 | FileCheck %s --check-prefix=ERROR
 ! RUN: not %flang_fc1 -emit-llvm -o /dev/null -fpass-plugin=X.Y %s 2>&1 | FileCheck %s --check-prefix=ERROR

--- a/flang/test/Driver/pass-plugin.f90
+++ b/flang/test/Driver/pass-plugin.f90
@@ -2,7 +2,7 @@
 
 ! UNSUPPORTED: system-windows
 
-! REQUIRES: plugins, shell, examples
+! REQUIRES: plugins, examples
 
 ! RUN: %flang -S %s %loadbye -Xflang -fdebug-pass-manager -o /dev/null \
 ! RUN: 2>&1 | FileCheck %s

--- a/flang/test/Driver/plugin-invalid-name.f90
+++ b/flang/test/Driver/plugin-invalid-name.f90
@@ -1,6 +1,6 @@
 ! Check the correct error diagnostic is reported when a plugin name isn't found
 
-! REQUIRES: plugins, shell
+! REQUIRES: plugins
 
 ! RUN: not %flang_fc1 -plugin -wrong-name %s 2>&1 | FileCheck %s --check-prefix=ERROR
 

--- a/flang/test/Examples/feature-list-class.f90
+++ b/flang/test/Examples/feature-list-class.f90
@@ -1,5 +1,5 @@
 ! UNSUPPORTED: system-windows
-! REQUIRES: plugins, shell, examples
+! REQUIRES: plugins, examples
 
 ! RUN: %flang_fc1 -load %llvmshlibdir/flangFeatureList%pluginext \
 ! RUN:            -plugin feature-list %s 2>&1 | FileCheck %s

--- a/flang/test/Examples/feature-list-functions.f90
+++ b/flang/test/Examples/feature-list-functions.f90
@@ -1,5 +1,5 @@
 ! UNSUPPORTED: system-windows
-! REQUIRES: plugins, shell, examples
+! REQUIRES: plugins, examples
 
 ! RUN: %flang_fc1 -load %llvmshlibdir/flangFeatureList%pluginext \
 ! RUN:            -plugin feature-list %s 2>&1 | FileCheck %s

--- a/flang/test/Examples/omp-atomic.f90
+++ b/flang/test/Examples/omp-atomic.f90
@@ -1,4 +1,4 @@
-! REQUIRES: plugins, examples, shell
+! REQUIRES: plugins, examples
 
 ! RUN: %flang_fc1 -load %llvmshlibdir/flangOmpReport%pluginext -plugin flang-omp-report -fopenmp %s -o - | FileCheck %s
 

--- a/flang/test/Examples/omp-declarative-directive.f90
+++ b/flang/test/Examples/omp-declarative-directive.f90
@@ -1,4 +1,4 @@
-! REQUIRES: plugins, examples, shell
+! REQUIRES: plugins, examples
 
 ! RUN: %flang_fc1 -load %llvmshlibdir/flangOmpReport%pluginext -plugin flang-omp-report -fopenmp %s -o - | FileCheck %s
 

--- a/flang/test/Examples/omp-device-constructs.f90
+++ b/flang/test/Examples/omp-device-constructs.f90
@@ -1,4 +1,4 @@
-! REQUIRES: plugins, examples, shell
+! REQUIRES: plugins, examples
 
 !RUN: %flang_fc1 -load %llvmshlibdir/flangOmpReport%pluginext -plugin flang-omp-report -fopenmp %s -o - | FileCheck %s
 

--- a/flang/test/Examples/omp-in-reduction-clause.f90
+++ b/flang/test/Examples/omp-in-reduction-clause.f90
@@ -1,4 +1,4 @@
-! REQUIRES: plugins, examples, shell
+! REQUIRES: plugins, examples
 
 ! RUN: %flang_fc1 -load %llvmshlibdir/flangOmpReport%pluginext -plugin flang-omp-report -fopenmp -fopenmp-version=50 %s -o - | FileCheck %s
 

--- a/flang/test/Examples/omp-nowait.f90
+++ b/flang/test/Examples/omp-nowait.f90
@@ -1,4 +1,4 @@
-! REQUIRES: plugins, examples, shell
+! REQUIRES: plugins, examples
 
 ! RUN: %flang_fc1 -load %llvmshlibdir/flangOmpReport%pluginext -plugin flang-omp-report -fopenmp %s -o - | FileCheck %s
 

--- a/flang/test/Examples/omp-order-clause.f90
+++ b/flang/test/Examples/omp-order-clause.f90
@@ -1,4 +1,4 @@
-! REQUIRES: plugins, examples, shell
+! REQUIRES: plugins, examples
 
 ! RUN: %flang_fc1 -load %llvmshlibdir/flangOmpReport%pluginext -plugin flang-omp-report -fopenmp -fopenmp-version=50 %s -o - | FileCheck %s
 

--- a/flang/test/Examples/omp-sections.f90
+++ b/flang/test/Examples/omp-sections.f90
@@ -1,4 +1,4 @@
-! REQUIRES: plugins, examples, shell
+! REQUIRES: plugins, examples
 
 ! RUN: %flang_fc1 -load %llvmshlibdir/flangOmpReport%pluginext -plugin flang-omp-report -fopenmp %s -o - | FileCheck %s
 

--- a/flang/test/Examples/print-fns-calls.f90
+++ b/flang/test/Examples/print-fns-calls.f90
@@ -1,7 +1,7 @@
 ! Check the Flang Print Function Names example plugin doesn't count/print function/subroutine calls (should only count definitions)
 ! This requires that the examples are built (LLVM_BUILD_EXAMPLES=ON) to access flangPrintFunctionNames.so
 
-! REQUIRES: plugins, examples, shell
+! REQUIRES: plugins, examples
 
 ! RUN: %flang_fc1 -load %llvmshlibdir/flangPrintFunctionNames%pluginext -plugin print-fns %s 2>&1 | FileCheck %s
 

--- a/flang/test/Examples/print-fns-definitions.f90
+++ b/flang/test/Examples/print-fns-definitions.f90
@@ -2,7 +2,7 @@
 ! This includes internal and external Function/Subroutines, but not Statement Functions
 ! This requires that the examples are built (LLVM_BUILD_EXAMPLES=ON) to access flangPrintFunctionNames.so
 
-! REQUIRES: plugins, examples, shell
+! REQUIRES: plugins, examples
 
 ! RUN: %flang_fc1 -load %llvmshlibdir/flangPrintFunctionNames%pluginext -plugin print-fns %s 2>&1 | FileCheck %s
 

--- a/flang/test/Examples/print-fns-interfaces.f90
+++ b/flang/test/Examples/print-fns-interfaces.f90
@@ -2,7 +2,7 @@
 ! (It should only count definitions, which will appear elsewhere for interfaced functions/subroutines)
 ! This requires that the examples are built (LLVM_BUILD_EXAMPLES=ON) to access flangPrintFunctionNames.so
 
-! REQUIRES: plugins, examples, shell
+! REQUIRES: plugins, examples
 
 ! RUN: %flang_fc1 -load %llvmshlibdir/flangPrintFunctionNames%pluginext -plugin print-fns %s 2>&1 | FileCheck %s
 


### PR DESCRIPTION
The shell feature only implies that we are not running on Windows now that the internal shell feature is available everywhere. Replace it with UNSUPPORTED: system-windows on non-portable tests so we can eventually get rid of the feature.