### PR TITLE
[lit] Drop shell feature from all upstream projects

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -126,8 +126,6 @@ config.recursiveExpansionLimit = 10
 
 # Setup test format.
 config.test_format = lit.formats.ShTest(execute_external)
-if execute_external:
-    config.available_features.add("shell")
 
 target_is_msvc = bool(re.match(r".*-windows-msvc$", config.target_triple))
 target_is_windows = bool(re.match(r".*-windows.*$", config.target_triple))

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -79,9 +79,6 @@ class LLVMConfig(object):
             if not self.use_lit_shell and lit_config.update_tests:
                 print("note: --update-tests is not supported when using external shell")
 
-        if not self.use_lit_shell:
-            features.add("shell")
-
         self.with_system_environment(
             [
                 "ASAN_SYMBOLIZER_PATH",


### PR DESCRIPTION
Now that no tests actually use the shell feature to conditionally run, drop the feature altogether to prevent backslide.