### PR TITLE
[DebugInfo] Suppress template parameter information in the skeleton CU.

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -1420,7 +1420,8 @@ bool DwarfUnit::applySubprogramDefinitionAttributes(const DISubprogram *SP,
   }
 
   // Add function template parameters.
-  addTemplateParams(SPDie, SP->getTemplateParams());
+  if (!Minimal)
+    addTemplateParams(SPDie, SP->getTemplateParams());
 
   // Add the linkage name if we have one and it isn't in the Decl.
   StringRef LinkageName = SP->getLinkageName();

--- a/llvm/test/DebugInfo/X86/fission-template.ll
+++ b/llvm/test/DebugInfo/X86/fission-template.ll
@@ -20,9 +20,7 @@
 ; CHECK:          DW_TAG_subprogram
 ; CHECK-NEXT:     DW_AT_linkage_name	("_Z2f2IiEvv")
 ; CHECK-NEXT:     DW_AT_name	("f2<int>")
-; CHECK:          DW_TAG_template_type_parameter
-; CHECK-NEXT:       DW_AT_type	(0x{{.*}} "int")
-; CHECK-NEXT:       DW_AT_name	("T")
+; CHECK-NOT:      DW_TAG_template_type_parameter
 ; CHECK:      .debug_info.dwo contents:
 ; CHECK:        DW_TAG_compile_unit
 ; CHECK:          DW_TAG_subprogram


### PR DESCRIPTION
Suppress template parameter information to optimize gmlt-like inline scope information in the skeleton CU.

Such information may not need to be copied to the skeleton CU?

A project within ByteDance enabled flags such as `-fsplit-dwarf-inlining` and `-O3`, resulting in a **5%** reduction in overall size, with the debug_info section reduced by over **30%**:
<img width="3448" height="1634" alt="image" src="https://github.com/user-attachments/assets/5b5041e7-e106-4711-a56d-a41e9c5b6b74" />
