### PR TITLE
[libc++][NFC] Use lambdas when calling a segmented iterator algorithm

### DIFF
--- a/libcxx/include/__algorithm/copy.h
+++ b/libcxx/include/__algorithm/copy.h
@@ -69,25 +69,13 @@ struct __copy_impl {
         std::move(__first), std::move(__last), std::move(__result));
   }
 
-  template <class _InIter, class _OutIter>
-  struct _CopySegment {
-    using _Traits _LIBCPP_NODEBUG = __segmented_iterator_traits<_InIter>;
-
-    _OutIter& __result_;
-
-    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit _CopySegment(_OutIter& __result)
-        : __result_(__result) {}
-
-    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
-    operator()(typename _Traits::__local_iterator __lfirst, typename _Traits::__local_iterator __llast) {
-      __result_ = std::__copy(__lfirst, __llast, std::move(__result_)).second;
-    }
-  };
-
   template <class _InIter, class _OutIter, __enable_if_t<__is_segmented_iterator_v<_InIter>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
-    std::__for_each_segment(__first, __last, _CopySegment<_InIter, _OutIter>(__result));
+    using __local_iterator = typename __segmented_iterator_traits<_InIter>::__local_iterator;
+    std::__for_each_segment(__first, __last, [&__result](__local_iterator __lfirst, __local_iterator __llast) {
+      __result = std::__copy(std::move(__lfirst), std::move(__llast), std::move(__result)).second;
+    });
     return std::make_pair(__last, std::move(__result));
   }
 

--- a/libcxx/include/__algorithm/find.h
+++ b/libcxx/include/__algorithm/find.h
@@ -208,31 +208,22 @@ __find(__bit_iterator<_Cp, _IsConst> __first, __bit_iterator<_Cp, _IsConst> __la
 
 // segmented iterator implementation
 
-template <class>
-struct __find_segment;
-
 template <class _SegmentedIterator,
           class _Tp,
           class _Proj,
           __enable_if_t<__is_segmented_iterator_v<_SegmentedIterator>, int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _SegmentedIterator
 __find(_SegmentedIterator __first, _SegmentedIterator __last, const _Tp& __value, _Proj& __proj) {
-  return std::__find_segment_if(std::move(__first), std::move(__last), __find_segment<_Tp>(__value), __proj);
+  using __local_iterator = typename __segmented_iterator_traits<_SegmentedIterator>::__local_iterator;
+  return std::__find_segment_if(
+      std::move(__first),
+      std::move(__last),
+      [&__value](__local_iterator __lfirst, __local_iterator __llast, _Proj& __lproj) {
+        return std::__rewrap_iter(
+            __lfirst, std::__find(std::__unwrap_iter(__lfirst), std::__unwrap_iter(__llast), __value, __lproj));
+      },
+      __proj);
 }
-
-template <class _Tp>
-struct __find_segment {
-  const _Tp& __value_;
-
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR __find_segment(const _Tp& __value) : __value_(__value) {}
-
-  template <class _InputIterator, class _Proj>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _InputIterator
-  operator()(_InputIterator __first, _InputIterator __last, _Proj& __proj) const {
-    return std::__rewrap_iter(
-        __first, std::__find(std::__unwrap_iter(__first), std::__unwrap_iter(__last), __value_, __proj));
-  }
-};
 
 // public API
 template <class _InputIterator, class _Tp>

--- a/libcxx/include/__algorithm/move.h
+++ b/libcxx/include/__algorithm/move.h
@@ -50,25 +50,13 @@ struct __move_impl {
     return std::make_pair(std::move(__first), std::move(__result));
   }
 
-  template <class _InIter, class _OutIter>
-  struct _MoveSegment {
-    using _Traits _LIBCPP_NODEBUG = __segmented_iterator_traits<_InIter>;
-
-    _OutIter& __result_;
-
-    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 explicit _MoveSegment(_OutIter& __result)
-        : __result_(__result) {}
-
-    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
-    operator()(typename _Traits::__local_iterator __lfirst, typename _Traits::__local_iterator __llast) {
-      __result_ = std::__move<_AlgPolicy>(__lfirst, __llast, std::move(__result_)).second;
-    }
-  };
-
   template <class _InIter, class _OutIter, __enable_if_t<__is_segmented_iterator_v<_InIter>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
-    std::__for_each_segment(__first, __last, _MoveSegment<_InIter, _OutIter>(__result));
+    using __local_iterator = typename __segmented_iterator_traits<_InIter>::__local_iterator;
+    std::__for_each_segment(__first, __last, [&__result](__local_iterator __lfirst, __local_iterator __llast) {
+      __result = std::__move<_AlgPolicy>(__lfirst, __llast, std::move(__result)).second;
+    });
     return std::make_pair(__last, std::move(__result));
   }
 


### PR DESCRIPTION
Clang provides lambdas as an extension in C++03 now, so we can use them to simplify our code a bit.