### PR TITLE
[Clang] Serialize expansions of PackIndexingType

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -606,6 +606,7 @@ Bug Fixes to C++ Support
 - Fix a crash when extracting unavailable member type from alias in template deduction. (#GH165560)
 - Fix incorrect diagnostics for lambdas with init-captures inside braced initializers. (#GH163498)
 - Fixed an issue where templates prevented nested anonymous records from checking the deletion of special members. (#GH167217)
+- Fixed a serialization bug in PackIndexingType, where we failed to expand those packs from a PCH/module. (#GH172464)
 - Fixed spurious diagnoses of certain nested lambda expressions. (#GH149121) (#GH156579)
 - Fix the result of ``__is_pointer_interconvertible_base_of`` when arguments are qualified and passed via template parameters. (#GH135273)
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -606,7 +606,7 @@ Bug Fixes to C++ Support
 - Fix a crash when extracting unavailable member type from alias in template deduction. (#GH165560)
 - Fix incorrect diagnostics for lambdas with init-captures inside braced initializers. (#GH163498)
 - Fixed an issue where templates prevented nested anonymous records from checking the deletion of special members. (#GH167217)
-- Fixed a serialization bug in PackIndexingType, where we failed to expand those packs from a PCH/module. (#GH172464)
+- Fixed serialization of pack indexing types, where we failed to expand those packs from a PCH/module. (#GH172464)
 - Fixed spurious diagnoses of certain nested lambda expressions. (#GH149121) (#GH156579)
 - Fix the result of ``__is_pointer_interconvertible_base_of`` when arguments are qualified and passed via template parameters. (#GH135273)
 

--- a/clang/include/clang/AST/TypeProperties.td
+++ b/clang/include/clang/AST/TypeProperties.td
@@ -486,9 +486,12 @@ let Class = PackIndexingType in {
   def : Property<"isFullySubstituted", Bool> {
     let Read = [{ node->isFullySubstituted() }];
   }
+  def : Property<"expansions", Array<QualType>> {
+    let Read = [{ node->getExpansions() }];
+  }
 
   def : Creator<[{
-    return ctx.getPackIndexingType(pattern, indexExpression, isFullySubstituted);
+    return ctx.getPackIndexingType(pattern, indexExpression, isFullySubstituted, expansions);
   }]>;
 }
 

--- a/clang/test/PCH/pack-indexing-2.cpp
+++ b/clang/test/PCH/pack-indexing-2.cpp
@@ -1,0 +1,18 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -std=c++2c -x c++-header %t/GH172464.h -emit-pch -o %t/GH172464.pch
+// RUN: %clang_cc1 -std=c++2c -x c++ %t/GH172464.cpp -include-pch %t/GH172464.pch
+
+//--- GH172464.h
+template <class... Ts> struct _TypeInfo {
+	template <int id> using type = Ts...[id];
+};
+using TypeInfo = _TypeInfo<int>;
+
+TypeInfo::type<0> a;
+
+//--- GH172464.cpp
+int main() {
+  TypeInfo::type<0> a;
+}


### PR DESCRIPTION
We have already serialized isFullySubstituted, which hinges on the expansions; if they were lost, we would never expand them correctly from an imported AST.

Sadly this bug has been around a year, so there's a release note.

Fixes #172464