### PR TITLE
[mlir][tensor] Add ValueBoundsOpInterface for ExpandShapeOp and CollapseShapeOp

### DIFF
--- a/mlir/lib/Dialect/Tensor/IR/ValueBoundsOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/ValueBoundsOpInterfaceImpl.cpp
@@ -40,7 +40,7 @@ struct CollapseShapeOpInterface
     assert(value == collapseOp.getResult() && "invalid value");
 
     // Multiply the expressions for the dimensions in the reassociation group.
-    const ReassociationIndices reassocIndices =
+    const ReassociationIndices &reassocIndices =
         collapseOp.getReassociationIndices()[dim];
     AffineExpr productExpr =
         cstr.getExpr(collapseOp.getSrc(), reassocIndices[0]);


### PR DESCRIPTION
Mirroring https://github.com/llvm/llvm-project/pull/164438 and https://github.com/llvm/llvm-project/pull/164955