### PR TITLE
[ValueTracking] Support ptrtoaddr in computeKnownBits()

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -1462,6 +1462,7 @@ static void computeKnownBitsFromOperator(const Operator *I,
   case Instruction::UIToFP:
     break; // Can't work with floating point.
   case Instruction::PtrToInt:
+  case Instruction::PtrToAddr:
   case Instruction::IntToPtr:
     // Fall through and handle them the same as zext/trunc.
     [[fallthrough]];

--- a/llvm/test/Analysis/ScalarEvolution/ptrtoaddr-i32-index-width.ll
+++ b/llvm/test/Analysis/ScalarEvolution/ptrtoaddr-i32-index-width.ll
@@ -46,7 +46,7 @@ define void @ptrtoaddr_of_nullptr(ptr %out0) {
 ; CHECK-LABEL: 'ptrtoaddr_of_nullptr'
 ; CHECK-NEXT:  Classifying expressions for: @ptrtoaddr_of_nullptr
 ; CHECK-NEXT:    %p0 = ptrtoaddr ptr null to i32
-; CHECK-NEXT:    --> %p0 U: full-set S: full-set
+; CHECK-NEXT:    --> %p0 U: [0,1) S: [0,1)
 ; CHECK-NEXT:  Determining loop execution counts for: @ptrtoaddr_of_nullptr
 ;
   %p0 = ptrtoaddr ptr null to i32

--- a/llvm/test/Analysis/ScalarEvolution/ptrtoaddr.ll
+++ b/llvm/test/Analysis/ScalarEvolution/ptrtoaddr.ll
@@ -46,7 +46,7 @@ define void @ptrtoaddr_of_nullptr(ptr %out0) {
 ; CHECK-LABEL: 'ptrtoaddr_of_nullptr'
 ; CHECK-NEXT:  Classifying expressions for: @ptrtoaddr_of_nullptr
 ; CHECK-NEXT:    %p0 = ptrtoaddr ptr null to i64
-; CHECK-NEXT:    --> %p0 U: full-set S: full-set
+; CHECK-NEXT:    --> %p0 U: [0,1) S: [0,1)
 ; CHECK-NEXT:  Determining loop execution counts for: @ptrtoaddr_of_nullptr
 ;
   %p0 = ptrtoaddr ptr null to i64

--- a/llvm/test/Transforms/InstCombine/ptrtoaddr.ll
+++ b/llvm/test/Transforms/InstCombine/ptrtoaddr.ll
@@ -309,3 +309,53 @@ define i32 @ptrtoaddr_of_gep_of_null_addrsize(i32 %offset) {
   %addr = ptrtoaddr ptr addrspace(1) %gep to i32
   ret i32 %addr
 }
+
+define i1 @ptrtoaddr_knownbits(ptr align 4 %p) {
+; CHECK-LABEL: define i1 @ptrtoaddr_knownbits(
+; CHECK-SAME: ptr align 4 [[P:%.*]]) {
+; CHECK-NEXT:    ret i1 true
+;
+  %p.addr = ptrtoaddr ptr %p to i64
+  %and = and i64 %p.addr, 3
+  %cmp = icmp eq i64 %and, 0
+  ret i1 %cmp
+}
+
+define i1 @ptrtoaddr_knownbits_mask_too_large(ptr align 4 %p) {
+; CHECK-LABEL: define i1 @ptrtoaddr_knownbits_mask_too_large(
+; CHECK-SAME: ptr align 4 [[P:%.*]]) {
+; CHECK-NEXT:    [[P_ADDR:%.*]] = ptrtoaddr ptr [[P]] to i64
+; CHECK-NEXT:    [[AND:%.*]] = and i64 [[P_ADDR]], 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[AND]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %p.addr = ptrtoaddr ptr %p to i64
+  %and = and i64 %p.addr, 7
+  %cmp = icmp eq i64 %and, 0
+  ret i1 %cmp
+}
+
+define i1 @ptrtoaddr_knownbits_addrsize(ptr addrspace(1) align 4 %p) {
+; CHECK-LABEL: define i1 @ptrtoaddr_knownbits_addrsize(
+; CHECK-SAME: ptr addrspace(1) align 4 [[P:%.*]]) {
+; CHECK-NEXT:    ret i1 true
+;
+  %p.addr = ptrtoaddr ptr addrspace(1) %p to i32
+  %and = and i32 %p.addr, 3
+  %cmp = icmp eq i32 %and, 0
+  ret i1 %cmp
+}
+
+define i1 @ptrtoaddr_knownbits_addrsize_mask_too_large(ptr addrspace(1) align 4 %p) {
+; CHECK-LABEL: define i1 @ptrtoaddr_knownbits_addrsize_mask_too_large(
+; CHECK-SAME: ptr addrspace(1) align 4 [[P:%.*]]) {
+; CHECK-NEXT:    [[P_ADDR:%.*]] = ptrtoaddr ptr addrspace(1) [[P]] to i32
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[P_ADDR]], 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[AND]], 0
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %p.addr = ptrtoaddr ptr addrspace(1) %p to i32
+  %and = and i32 %p.addr, 7
+  %cmp = icmp eq i32 %and, 0
+  ret i1 %cmp
+}


### PR DESCRIPTION
ptrtoaddr can be handled the same as ptrtoint here. The pointer known bits cover the full pointer width, and ptrtoaddr either passes those through directly or truncates to the address size.