### PR TITLE
[ValueTracking] Support ptrtoaddr in inequality implication

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -9675,10 +9675,10 @@ isImpliedCondICmps(CmpPredicate LPred, const Value *L0, const Value *L1,
       match(L1, m_APInt(L1C)) && !L1C->isZero() &&
       match(L0, m_Sub(m_Value(A), m_Value(B))) &&
       ((A == R0 && B == R1) || (A == R1 && B == R0) ||
-       (match(A, m_PtrToInt(m_Specific(R0))) &&
-        match(B, m_PtrToInt(m_Specific(R1)))) ||
-       (match(A, m_PtrToInt(m_Specific(R1))) &&
-        match(B, m_PtrToInt(m_Specific(R0)))))) {
+       (match(A, m_PtrToIntOrAddr(m_Specific(R0))) &&
+        match(B, m_PtrToIntOrAddr(m_Specific(R1)))) ||
+       (match(A, m_PtrToIntOrAddr(m_Specific(R1))) &&
+        match(B, m_PtrToIntOrAddr(m_Specific(R0)))))) {
     return RPred.dropSameSign() == ICmpInst::ICMP_NE;
   }
 
@@ -10460,7 +10460,8 @@ addValueAffectedByCondition(Value *V,
 
     // Peek through unary operators to find the source of the condition.
     Value *Op;
-    if (match(I, m_CombineOr(m_PtrToInt(m_Value(Op)), m_Trunc(m_Value(Op))))) {
+    if (match(I, m_CombineOr(m_PtrToIntOrAddr(m_Value(Op)),
+                             m_Trunc(m_Value(Op))))) {
       if (isa<Instruction>(Op) || isa<Argument>(Op))
         InsertAffected(Op);
     }

--- a/llvm/test/Transforms/InstSimplify/ptrtoaddr.ll
+++ b/llvm/test/Transforms/InstSimplify/ptrtoaddr.ll
@@ -528,3 +528,60 @@ define i1 @non_zero_ptrtoint_smaller_addrsize(ptr addrspace(1) nonnull %p, i16 %
   %cmp = icmp ne i16 %or, 0
   ret i1 %cmp
 }
+
+define i1 @ptrtoaddr_diff_non_equal(ptr %p0, ptr %p1) {
+; CHECK-LABEL: define i1 @ptrtoaddr_diff_non_equal(
+; CHECK-SAME: ptr [[P0:%.*]], ptr [[P1:%.*]]) {
+; CHECK-NEXT:    [[I0:%.*]] = ptrtoaddr ptr [[P0]] to i64
+; CHECK-NEXT:    [[I1:%.*]] = ptrtoaddr ptr [[P1]] to i64
+; CHECK-NEXT:    [[DIFF:%.*]] = sub i64 [[I0]], [[I1]]
+; CHECK-NEXT:    [[COND:%.*]] = icmp eq i64 [[DIFF]], 12
+; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
+; CHECK-NEXT:    ret i1 false
+;
+  %i0 = ptrtoaddr ptr %p0 to i64
+  %i1 = ptrtoaddr ptr %p1 to i64
+  %diff = sub i64 %i0, %i1
+  %cond = icmp eq i64 %diff, 12
+  call void @llvm.assume(i1 %cond)
+  %cmp = icmp eq ptr %p0, %p1
+  ret i1 %cmp
+}
+
+define i1 @ptrtoaddr_diff_non_equal_addrsize(ptr addrspace(1) %p0, ptr addrspace(1) %p1) {
+; CHECK-LABEL: define i1 @ptrtoaddr_diff_non_equal_addrsize(
+; CHECK-SAME: ptr addrspace(1) [[P0:%.*]], ptr addrspace(1) [[P1:%.*]]) {
+; CHECK-NEXT:    [[I0:%.*]] = ptrtoaddr ptr addrspace(1) [[P0]] to i32
+; CHECK-NEXT:    [[I1:%.*]] = ptrtoaddr ptr addrspace(1) [[P1]] to i32
+; CHECK-NEXT:    [[DIFF:%.*]] = sub i32 [[I0]], [[I1]]
+; CHECK-NEXT:    [[COND:%.*]] = icmp eq i32 [[DIFF]], 12
+; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
+; CHECK-NEXT:    ret i1 false
+;
+  %i0 = ptrtoaddr ptr addrspace(1) %p0 to i32
+  %i1 = ptrtoaddr ptr addrspace(1) %p1 to i32
+  %diff = sub i32 %i0, %i1
+  %cond = icmp eq i32 %diff, 12
+  call void @llvm.assume(i1 %cond)
+  %cmp = icmp eq ptr addrspace(1) %p0, %p1
+  ret i1 %cmp
+}
+
+define i1 @ptrtoaddr_diff_non_equal_addrsize_commuted(ptr addrspace(1) %p0, ptr addrspace(1) %p1) {
+; CHECK-LABEL: define i1 @ptrtoaddr_diff_non_equal_addrsize_commuted(
+; CHECK-SAME: ptr addrspace(1) [[P0:%.*]], ptr addrspace(1) [[P1:%.*]]) {
+; CHECK-NEXT:    [[I0:%.*]] = ptrtoaddr ptr addrspace(1) [[P0]] to i32
+; CHECK-NEXT:    [[I1:%.*]] = ptrtoaddr ptr addrspace(1) [[P1]] to i32
+; CHECK-NEXT:    [[DIFF:%.*]] = sub i32 [[I0]], [[I1]]
+; CHECK-NEXT:    [[COND:%.*]] = icmp eq i32 [[DIFF]], 12
+; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
+; CHECK-NEXT:    ret i1 false
+;
+  %i0 = ptrtoaddr ptr addrspace(1) %p0 to i32
+  %i1 = ptrtoaddr ptr addrspace(1) %p1 to i32
+  %diff = sub i32 %i0, %i1
+  %cond = icmp eq i32 %diff, 12
+  call void @llvm.assume(i1 %cond)
+  %cmp = icmp eq ptr addrspace(1) %p1, %p0
+  ret i1 %cmp
+}


### PR DESCRIPTION
`ptrtoaddr(p1) - ptrtoaddr(p2) == non-zero` implies `p1 != p2`, same as for ptrtoint.