### PR TITLE
[lldb][NFC] Remove temp allocation SBCommandReturnObject::PutCString

### DIFF
--- a/lldb/source/API/SBCommandReturnObject.cpp
+++ b/lldb/source/API/SBCommandReturnObject.cpp
@@ -315,8 +315,8 @@ void SBCommandReturnObject::PutCString(const char *string, int len) {
   if (len == 0 || string == nullptr || *string == 0) {
     return;
   } else if (len > 0) {
-    std::string buffer(string, len);
-    ref().AppendMessage(buffer.c_str());
+    const llvm::StringRef buffer{string, static_cast<size_t>(len)};
+    ref().AppendMessage(buffer);
   } else
     ref().AppendMessage(string);
 }


### PR DESCRIPTION
Use llvm::StringRef instead of std::string to eliminate an unnecessary heap allocation when len > 0.

There should not be any functional difference.