### PR TITLE
[X86] Add instcombine tests showing potential to fold shifted blendv masks into regular cmp+select sequences

### DIFF
--- a/llvm/test/Transforms/InstCombine/X86/blend_x86.ll
+++ b/llvm/test/Transforms/InstCombine/X86/blend_x86.ll
@@ -309,6 +309,54 @@ define <4 x float> @sel_v16i8_bitcast_shuffle_bitcast_cmp(<8 x float> %a, <8 x f
   ret <4 x float> %res
 }
 
+define <16 x i8> @shl_pblendvb_v16i8(<16 x i8> %a0, <16 x i8> %a1, <16 x i8> %a2) {
+; CHECK-LABEL: @shl_pblendvb_v16i8(
+; CHECK-NEXT:    [[S:%.*]] = shl <16 x i8> [[A2:%.*]], splat (i8 1)
+; CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i8> @llvm.x86.sse41.pblendvb(<16 x i8> [[A0:%.*]], <16 x i8> [[A1:%.*]], <16 x i8> [[S]])
+; CHECK-NEXT:    ret <16 x i8> [[TMP1]]
+;
+  %s = shl <16 x i8> %a2, splat (i8 1)
+  %r = tail call <16 x i8> @llvm.x86.sse41.pblendvb(<16 x i8> %a0, <16 x i8> %a1, <16 x i8> %s)
+  ret <16 x i8> %r
+}
+
+define <32 x i8> @shl_pblendvb_v32i8(<32 x i8> %a0, <32 x i8> %a1, <32 x i8> %a2) {
+; CHECK-LABEL: @shl_pblendvb_v32i8(
+; CHECK-NEXT:    [[S:%.*]] = shl nuw <32 x i8> splat (i8 1), [[A2:%.*]]
+; CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.x86.avx2.pblendvb(<32 x i8> [[A0:%.*]], <32 x i8> [[A1:%.*]], <32 x i8> [[S]])
+; CHECK-NEXT:    ret <32 x i8> [[TMP2]]
+;
+  %s = shl <32 x i8> splat (i8 1), %a2
+  %r = tail call <32 x i8> @llvm.x86.avx2.pblendvb(<32 x i8> %a0, <32 x i8> %a1, <32 x i8> %s)
+  ret <32 x i8> %r
+}
+
+define <4 x float> @shl_blendvps_v4f32(<4 x float> %a0, <4 x float> %a1, <4 x i32> %a2) {
+; CHECK-LABEL: @shl_blendvps_v4f32(
+; CHECK-NEXT:    [[S:%.*]] = shl <4 x i32> [[A2:%.*]], splat (i32 31)
+; CHECK-NEXT:    [[B:%.*]] = bitcast <4 x i32> [[S]] to <4 x float>
+; CHECK-NEXT:    [[TMP1:%.*]] = call <4 x float> @llvm.x86.sse41.blendvps(<4 x float> [[A0:%.*]], <4 x float> [[A1:%.*]], <4 x float> [[B]])
+; CHECK-NEXT:    ret <4 x float> [[TMP1]]
+;
+  %s = shl <4 x i32> %a2, splat (i32 31)
+  %b = bitcast <4 x i32> %s to <4 x float>
+  %r = call <4 x float> @llvm.x86.sse41.blendvps(<4 x float> %a0, <4 x float> %a1, <4 x float> %b)
+  ret <4 x float> %r
+}
+
+define <4 x double> @shl_blendvpd_v4f64(<4 x double> %a0, <4 x double> %a1, <4 x i64> %a2) {
+; CHECK-LABEL: @shl_blendvpd_v4f64(
+; CHECK-NEXT:    [[S:%.*]] = shl nuw <4 x i64> splat (i64 1), [[A2:%.*]]
+; CHECK-NEXT:    [[B:%.*]] = bitcast <4 x i64> [[S]] to <4 x double>
+; CHECK-NEXT:    [[TMP2:%.*]] = call <4 x double> @llvm.x86.avx.blendv.pd.256(<4 x double> [[A0:%.*]], <4 x double> [[A1:%.*]], <4 x double> [[B]])
+; CHECK-NEXT:    ret <4 x double> [[TMP2]]
+;
+  %s = shl <4 x i64> splat (i64 1), %a2
+  %b = bitcast <4 x i64> %s to <4 x double>
+  %r = call <4 x double> @llvm.x86.avx.blendv.pd.256(<4 x double> %a0, <4 x double> %a1, <4 x double> %b)
+  ret <4 x double> %r
+}
+
 declare <16 x i8> @llvm.x86.sse41.pblendvb(<16 x i8>, <16 x i8>, <16 x i8>)
 declare <4 x float> @llvm.x86.sse41.blendvps(<4 x float>, <4 x float>, <4 x float>)
 declare <2 x double> @llvm.x86.sse41.blendvpd(<2 x double>, <2 x double>, <2 x double>)


### PR DESCRIPTION
When converting blendv intrinsics to generic selects, we currently just handle direct sext(vXi1) masks but other arithmetic can be converted with a suitable comparison - with shift lefts being the more useful.