### PR TITLE
[SPIRV] Fix recently introduced test case that depends on assertions.

### DIFF
--- a/llvm/test/CodeGen/SPIRV/ga-inttoptr.ll
+++ b/llvm/test/CodeGen/SPIRV/ga-inttoptr.ll
@@ -1,3 +1,4 @@
+; REQUIRES: asserts
 ; RUN: not llc -O0 -mtriple=spirv64-unknown-unknown < %s 2>&1 | FileCheck %s
 ; CHECK: argument of incompatible type!
 


### PR DESCRIPTION
Added missing REQUIRES to ensure that the test case is properly executed.

The test case was introduced in this PR https://github.com/llvm/llvm-project/pull/172730