### PR TITLE
[lldb] Add Python 3.8 compatibility for lldbtest.py

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -27,6 +27,9 @@ OK
 $
 """
 
+# FIXME: remove when LLDB_MINIMUM_PYTHON_VERSION > 3.8
+from __future__ import annotations
+
 # System modules
 import abc
 from functools import wraps


### PR DESCRIPTION
follow up from 9892870687e0af00e798474aa5cecfd4647071e1 as we recently added type hints to this file