### PR TITLE
[MCA] Fix -mcpu=help flag

### DIFF
--- a/llvm/test/tools/llvm-mca/mcpu-help.test
+++ b/llvm/test/tools/llvm-mca/mcpu-help.test
@@ -2,7 +2,7 @@
 
 # RUN: llvm-mca -mtriple=aarch64-unknown-linux-gnu -mcpu=help %t.no-input 2>&1 | FileCheck %s
 
-// Ensures -mcpu=help prints target info without erroring on missing input.
+// Ensures -mcpu=help still prints the CPU/features lists even when the input file after the flag is nonexistent.
 
 # CHECK: Available CPUs for this target:
 # CHECK: Available features for this target:

--- a/llvm/test/tools/llvm-mca/mcpu-help.test
+++ b/llvm/test/tools/llvm-mca/mcpu-help.test
@@ -1,0 +1,9 @@
+# REQUIRES: aarch64-registered-target
+
+# RUN: llvm-mca -mtriple=aarch64-unknown-linux-gnu -mcpu=help %t.no-input 2>&1 | FileCheck %s
+
+// Ensures -mcpu=help prints target info without erroring on missing input.
+
+# CHECK: Available CPUs for this target:
+# CHECK: Available features for this target:
+# CHECK-NOT: error:

--- a/llvm/test/tools/llvm-mca/mcpu-help.test
+++ b/llvm/test/tools/llvm-mca/mcpu-help.test
@@ -5,5 +5,7 @@
 // Ensures -mcpu=help still prints the CPU/features lists even when the input file after the flag is nonexistent.
 
 # CHECK: Available CPUs for this target:
+# CHECK: a64fx           - Select the a64fx processor.
+# CHECK: ampere1         - Select the ampere1 processor.
 # CHECK: Available features for this target:
 # CHECK-NOT: error:

--- a/llvm/tools/llvm-mca/llvm-mca.cpp
+++ b/llvm/tools/llvm-mca/llvm-mca.cpp
@@ -392,13 +392,6 @@ int main(int argc, char **argv) {
   if (!TheTarget)
     return 1;
 
-  ErrorOr<std::unique_ptr<MemoryBuffer>> BufferPtr =
-      MemoryBuffer::getFileOrSTDIN(InputFilename);
-  if (std::error_code EC = BufferPtr.getError()) {
-    WithColor::error() << InputFilename << ": " << EC.message() << '\n';
-    return 1;
-  }
-
   if (MCPU == "native")
     MCPU = std::string(llvm::sys::getHostCPUName());
 
@@ -418,8 +411,18 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  if (MCPU == "help")
+    return 0;
+
   if (!STI->isCPUStringValid(MCPU))
     return 1;
+
+  ErrorOr<std::unique_ptr<MemoryBuffer>> BufferPtr =
+      MemoryBuffer::getFileOrSTDIN(InputFilename);
+  if (std::error_code EC = BufferPtr.getError()) {
+    WithColor::error() << InputFilename << ": " << EC.message() << '\n';
+    return 1;
+  }
 
   if (!STI->getSchedModel().hasInstrSchedModel()) {
     WithColor::error()


### PR DESCRIPTION
Previously, using the `-mcpu=help` flag would require an empty stdin to be passed to print the CPU/Features
list.

- Moves the `MemoryBuffer::getFileOrSTDIN` call below an early return.
- Adds a test mcpu-help.test is included which tests the flag with a missing file. Previously, this would have resulted in an error with no outputted help list, but now provides the help list and ignores the missing file input.