### PR TITLE
[libc] add missing header to alloc-checker

### DIFF
--- a/libc/src/__support/alloc-checker.h
+++ b/libc/src/__support/alloc-checker.h
@@ -11,10 +11,11 @@
 
 #include "hdr/func/aligned_alloc.h"
 #include "hdr/func/malloc.h"
-#include "src/__support/CPP/new.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/os.h"
+
+#include <new>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/__support/alloc-checker.h
+++ b/libc/src/__support/alloc-checker.h
@@ -14,6 +14,7 @@
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/os.h"
+#include "src/__support/CPP/new.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/__support/alloc-checker.h
+++ b/libc/src/__support/alloc-checker.h
@@ -11,10 +11,10 @@
 
 #include "hdr/func/aligned_alloc.h"
 #include "hdr/func/malloc.h"
+#include "src/__support/CPP/new.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/os.h"
-#include "src/__support/CPP/new.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/__support/alloc-checker.h
+++ b/libc/src/__support/alloc-checker.h
@@ -11,6 +11,7 @@
 
 #include "hdr/func/aligned_alloc.h"
 #include "hdr/func/malloc.h"
+#include "src/__support/CPP/new.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/os.h"

--- a/libc/src/__support/alloc-checker.h
+++ b/libc/src/__support/alloc-checker.h
@@ -16,8 +16,6 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/os.h"
 
-#include <new>
-
 namespace LIBC_NAMESPACE_DECL {
 
 class AllocChecker {


### PR DESCRIPTION
Adding `#include "src/__support/CPP/new.h"` due to align_val_t usage within alloc-checker.h