### PR TITLE
Fix insert DBG_VALUE after terminator Failure for Hexagon

### DIFF
--- a/llvm/test/CodeGen/Hexagon/livedebugvalues-bundle-terminator.mir
+++ b/llvm/test/CodeGen/Hexagon/livedebugvalues-bundle-terminator.mir
@@ -1,0 +1,38 @@
+# RUN: llc -march=hexagon -run-pass=livedebugvalues -verify-machineinstrs %s -o - | FileCheck %s
+# CHECK: BUNDLE
+--- |
+
+  define void @foo() !dbg !5 {
+    ret void
+  }
+
+  !llvm.dbg.cu = !{!0}
+  !llvm.module.flags = !{!3, !4}
+  !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
+  !1 = !DIFile(filename: "t.c", directory: "/")
+  !3 = !{i32 2, !"Debug Info Version", i32 3}
+  !4 = !{i32 1, !"PIC Level", i32 2}
+  !5 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !6, isDefinition: true, unit: !0)
+  !6 = !DISubroutineType(types: !7)
+  !7 = !{null}
+  !8 = !DILocalVariable(name: "x", scope: !5, file: !1, line: 1, type: !9)
+  !9 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+  !10 = !DILocation(line: 1, column: 1, scope: !5)
+
+...
+---
+name:            foo
+tracksRegLiveness: true
+stack:
+  - { id: 0, type: spill-slot, size: 4, alignment: 4 }
+body:             |
+  bb.0:
+    liveins: $r29, $r31
+    
+    DBG_VALUE $r29, $noreg, !8, !DIExpression(), debug-location !10
+    
+    BUNDLE implicit-def $pc, implicit killed $r29, implicit $r31, debug-location !10 :: (store (s32) into %stack.0) {
+      S2_storeri_io %stack.0, 0, killed $r29 :: (store (s32) into %stack.0)
+      PS_jmpret $r31, implicit-def $pc
+    }
+...


### PR DESCRIPTION
This patch fixes an assertion failure on VLIW targets like Hexagon,
where a packet can contain both a terminator and a spill/copy. The
existing code did not look inside bundles, hence, it could leave a
transfer anchored on a terminator. When LiveDebugValues later
attempted to insert a DBG_VALUE after that packet, it hit:

  Assertion `!TR.TransferInst->isTerminator() && "Cannot insert
DBG_VALUE after terminator"' failed

The change switches to instr_iterator and walks each packet with
getBundleStart/getBundleEnd. Packets containing a terminator are skipped
for insertion; non‑terminator ops in other packets are still processed
normally. This avoids illegal insertion points while keeping spill/copy
tracking intact.