### PR TITLE
[lldb] Change bitfield range character from '-' to ':' in DIL

### DIFF
--- a/lldb/docs/dil-expr-lang.ebnf
+++ b/lldb/docs/dil-expr-lang.ebnf
@@ -15,7 +15,7 @@ unary_operator = "*" | "&" | "+" | "-";
 
 postfix_expression = primary_expression
                    | postfix_expression "[" expression "]"
-                   | postfix_expression "[" expression "-" expression "]"
+                   | postfix_expression "[" expression ":" expression "]"
                    | postfix_expression "." id_expression
                    | postfix_expression "->" id_expression ;
 

--- a/lldb/include/lldb/ValueObject/DILLexer.h
+++ b/lldb/include/lldb/ValueObject/DILLexer.h
@@ -26,6 +26,7 @@ public:
   enum Kind {
     amp,
     arrow,
+    colon,
     coloncolon,
     eof,
     float_constant,

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -595,7 +595,7 @@ Interpreter::Visit(const ArraySubscriptNode &node) {
         base->GetSyntheticBitFieldChild(child_idx, child_idx, true);
     if (!child_valobj_sp) {
       std::string err_msg = llvm::formatv(
-          "bitfield range {0}-{1} is not valid for \"({2}) {3}\"", child_idx,
+          "bitfield range {0}:{1} is not valid for \"({2}) {3}\"", child_idx,
           child_idx, base->GetTypeName().AsCString("<invalid type>"),
           var_expr_path_strm.GetData());
       return llvm::make_error<DILDiagnosticError>(m_expr, std::move(err_msg),
@@ -683,7 +683,7 @@ Interpreter::Visit(const BitFieldExtractionNode &node) {
       base->GetSyntheticBitFieldChild(first_index, last_index, true);
   if (!child_valobj_sp) {
     std::string message = llvm::formatv(
-        "bitfield range {0}-{1} is not valid for \"({2}) {3}\"", first_index,
+        "bitfield range {0}:{1} is not valid for \"({2}) {3}\"", first_index,
         last_index, base->GetTypeName().AsCString("<invalid type>"),
         base->GetName().AsCString());
     return llvm::make_error<DILDiagnosticError>(m_expr, message,

--- a/lldb/source/ValueObject/DILLexer.cpp
+++ b/lldb/source/ValueObject/DILLexer.cpp
@@ -24,6 +24,8 @@ llvm::StringRef Token::GetTokenName(Kind kind) {
     return "amp";
   case Kind::arrow:
     return "arrow";
+  case Kind::colon:
+    return "colon";
   case Kind::coloncolon:
     return "coloncolon";
   case Kind::eof:
@@ -150,10 +152,10 @@ llvm::Expected<Token> DILLexer::Lex(llvm::StringRef expr,
   }
 
   constexpr std::pair<Token::Kind, const char *> operators[] = {
-      {Token::amp, "&"},      {Token::arrow, "->"},   {Token::coloncolon, "::"},
-      {Token::l_paren, "("},  {Token::l_square, "["}, {Token::minus, "-"},
-      {Token::period, "."},   {Token::plus, "+"},     {Token::r_paren, ")"},
-      {Token::r_square, "]"}, {Token::star, "*"},
+      {Token::amp, "&"},     {Token::arrow, "->"},   {Token::coloncolon, "::"},
+      {Token::colon, ":"},   {Token::l_paren, "("},  {Token::l_square, "["},
+      {Token::minus, "-"},   {Token::period, "."},   {Token::plus, "+"},
+      {Token::r_paren, ")"}, {Token::r_square, "]"}, {Token::star, "*"},
   };
   for (auto [kind, str] : operators) {
     if (remainder.consume_front(str))

--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -180,7 +180,7 @@ ASTNodeUP DILParser::ParseUnaryExpression() {
 //  postfix_expression:
 //    primary_expression
 //    postfix_expression "[" expression "]"
-//    postfix_expression "[" expression "-" expression "]"
+//    postfix_expression "[" expression ":" expression "]"
 //    postfix_expression "." id_expression
 //    postfix_expression "->" id_expression
 //
@@ -195,7 +195,7 @@ ASTNodeUP DILParser::ParsePostfixExpression() {
       m_dil_lexer.Advance();
       ASTNodeUP index = ParseExpression();
       assert(index && "ASTNodeUP must not contain a nullptr");
-      if (CurToken().GetKind() == Token::minus) {
+      if (CurToken().GetKind() == Token::colon) {
         m_dil_lexer.Advance();
         ASTNodeUP last_index = ParseExpression();
         assert(last_index && "ASTNodeUP must not contain a nullptr");

--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -201,6 +201,10 @@ ASTNodeUP DILParser::ParsePostfixExpression() {
         assert(last_index && "ASTNodeUP must not contain a nullptr");
         lhs = std::make_unique<BitFieldExtractionNode>(
             loc, std::move(lhs), std::move(index), std::move(last_index));
+      } else if (CurToken().GetKind() == Token::minus) {
+        BailOut("use of '-' for bitfield range is deprecated; use ':' instead",
+                CurToken().GetLocation(), CurToken().GetSpelling().length());
+        return std::make_unique<ErrorNode>();
       } else {
         lhs = std::make_unique<ArraySubscriptNode>(loc, std::move(lhs),
                                                    std::move(index));

--- a/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
@@ -70,7 +70,7 @@ class TestFrameVarDILArraySubscript(TestBase):
         self.expect(
             "frame var 'idx_1_ref[0]'",
             error=True,
-            substrs=["bitfield range 0-0 is not valid"],
+            substrs=["bitfield range 0:0 is not valid"],
         )
 
         # Base should be a "pointer to T" and index should be of an integral type.

--- a/lldb/test/API/commands/frame/var-dil/basics/BitFieldExtraction/TestFrameVarDILBitFieldExtraction.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/BitFieldExtraction/TestFrameVarDILBitFieldExtraction.py
@@ -20,46 +20,46 @@ class TestFrameVarDILBitFieldExtraction(TestBase):
         self.runCmd("settings set target.experimental.use-DIL true")
 
         # Test ranges and type
-        self.expect_var_path("value[0-1]", value="3", type="int:2")
-        self.expect_var_path("value[4-7]", value="7", type="int:4")
-        self.expect_var_path("value[7-0]", value="115", type="int:8")
+        self.expect_var_path("value[0:1]", value="3", type="int:2")
+        self.expect_var_path("value[4:7]", value="7", type="int:4")
+        self.expect_var_path("value[7:0]", value="115", type="int:8")
 
         # Test reference and dereferenced pointer
-        self.expect_var_path("value_ref[0-1]", value="3", type="int:2")
-        self.expect_var_path("(*value_ptr)[0-1]", value="3", type="int:2")
+        self.expect_var_path("value_ref[0:1]", value="3", type="int:2")
+        self.expect_var_path("(*value_ptr)[0:1]", value="3", type="int:2")
 
         # Test ranges as variable, reference, enum
-        self.expect_var_path("value[idx_0-idx_1]", value="3", type="int:2")
-        self.expect_var_path("value[0-idx_1_ref]", value="3", type="int:2")
-        self.expect_var_path("value[idx_1_ref-0]", value="3", type="int:2")
-        self.expect_var_path("value[0-enum_one]", value="3", type="int:2")
-        self.expect_var_path("value[enum_one-0]", value="3", type="int:2")
+        self.expect_var_path("value[idx_0:idx_1]", value="3", type="int:2")
+        self.expect_var_path("value[0:idx_1_ref]", value="3", type="int:2")
+        self.expect_var_path("value[idx_1_ref:0]", value="3", type="int:2")
+        self.expect_var_path("value[0:enum_one]", value="3", type="int:2")
+        self.expect_var_path("value[enum_one:0]", value="3", type="int:2")
 
         # Test array and pointer
         self.expect(
-            "frame var 'int_arr[0-2]'",
+            "frame var 'int_arr[0:2]'",
             error=True,
-            substrs=["bitfield range 0-2 is not valid"],
+            substrs=["bitfield range 0:2 is not valid"],
         )
         self.expect(
-            "frame var 'value_ptr[0-1]'",
+            "frame var 'value_ptr[0:1]'",
             error=True,
-            substrs=["bitfield range 0-1 is not valid"],
+            substrs=["bitfield range 0:1 is not valid"],
         )
 
         # Test invalid input
         self.expect(
-            "frame var 'value[1-]'",
+            "frame var 'value[1:]'",
             error=True,
             substrs=["Unexpected token: <']' (r_square)>"],
         )
         self.expect(
-            "frame var 'value[1-2.0]'",
+            "frame var 'value[1:2.0]'",
             error=True,
             substrs=["bit index is not an integer"],
         )
         self.expect(
-            "frame var 'value[2.0-1]'",
+            "frame var 'value[2.0:1]'",
             error=True,
             substrs=["bit index is not an integer"],
         )

--- a/lldb/test/API/commands/frame/var-dil/basics/BitFieldExtraction/TestFrameVarDILBitFieldExtraction.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/BitFieldExtraction/TestFrameVarDILBitFieldExtraction.py
@@ -63,3 +63,8 @@ class TestFrameVarDILBitFieldExtraction(TestBase):
             error=True,
             substrs=["bit index is not an integer"],
         )
+        self.expect(
+            "frame var 'value[0-2]'",
+            error=True,
+            substrs=["use of '-' for bitfield range is deprecated; use ':' instead"],
+        )


### PR DESCRIPTION
Change the bitfield extraction range character from '-' to a more common ':'.