### PR TITLE
[HLSL] Add allresourcesbound option to DXC driver and set corresponding module flag

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -488,6 +488,9 @@ CODEGENOPT(StaticClosure, 1, 0, Benign)
 /// Assume that UAVs/SRVs may alias
 CODEGENOPT(ResMayAlias, 1, 0, Benign)
 
+/// Assume that not all resources are bound
+CODEGENOPT(AllResourcesBound, 1, 0, Benign)
+
 /// Controls how unwind v2 (epilog) information should be generated for x64
 /// Windows.
 ENUM_CODEGENOPT(WinX64EHUnwindV2, WinX64EHUnwindV2Mode,

--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -485,10 +485,10 @@ CODEGENOPT(ImportCallOptimization, 1, 0, Benign)
 /// (BlocksRuntime) on Windows.
 CODEGENOPT(StaticClosure, 1, 0, Benign)
 
-/// Assume that UAVs/SRVs may alias
+/// Assume that UAVs/SRVs may alias if enabled
 CODEGENOPT(ResMayAlias, 1, 0, Benign)
 
-/// Assume that not all resources are bound
+/// Assume that all resources are bound if enabled
 CODEGENOPT(AllResourcesBound, 1, 0, Benign)
 
 /// Controls how unwind v2 (epilog) information should be generated for x64

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9612,6 +9612,12 @@ class DXCJoinedOrSeparate<string name> : Option<["/", "-"], name,
   KIND_JOINED_OR_SEPARATE>, Group<dxc_Group>,
   Visibility<[DXCOption]>;
 
+def dxc_all_resources_bound : DXCFlag<"all-resources-bound">,
+  HelpText<"Enables agressive flattening">;
+def hlsl_all_resources_bound : Option<["-"], "hlsl-all-resources-bound", KIND_SEPARATE>,
+                      Group<dxc_Group>,
+                      Visibility<[ClangOption, CC1Option]>,
+  HelpText<"Enables agressive flattening">;
 def dxc_col_major : DXCFlag<"Zpc">, HelpText<"Pack matrices in column-major order">;
 def dxc_row_major : DXCFlag<"Zpr">, HelpText<"Pack matrices in row-major order">;
 def dxc_no_stdinc : DXCFlag<"hlsl-no-stdinc">,

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9614,10 +9614,11 @@ class DXCJoinedOrSeparate<string name> : Option<["/", "-"], name,
 
 def dxc_all_resources_bound : DXCFlag<"all-resources-bound">,
   HelpText<"Enables agressive flattening">;
-def hlsl_all_resources_bound : Option<["-"], "hlsl-all-resources-bound", KIND_SEPARATE>,
+def hlsl_all_resources_bound : Option<["/", "-"], "hlsl-all-resources-bound", KIND_FLAG>,
                       Group<dxc_Group>,
                       Visibility<[ClangOption, CC1Option]>,
-  HelpText<"Enables agressive flattening">;
+                      HelpText<"Enables agressive flattening">,
+                      MarshallingInfoFlag<CodeGenOpts<"AllResourcesBound">>;
 def dxc_col_major : DXCFlag<"Zpc">, HelpText<"Pack matrices in column-major order">;
 def dxc_row_major : DXCFlag<"Zpr">, HelpText<"Pack matrices in row-major order">;
 def dxc_no_stdinc : DXCFlag<"hlsl-no-stdinc">,

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -483,7 +483,9 @@ void CGHLSLRuntime::finishCodeGen() {
     addDxilValVersion(TargetOpts.DxilValidatorVersion, M);
   if (CodeGenOpts.ResMayAlias)
     M.setModuleFlag(llvm::Module::ModFlagBehavior::Error, "dx.resmayalias", 1);
-
+  if (CodeGenOpts.AllResourcesBound)
+    M.setModuleFlag(llvm::Module::ModFlagBehavior::Error,
+                    "dx.allresourcesbound", 1);
   // NativeHalfType corresponds to the -fnative-half-type clang option which is
   // aliased by clang-dxc's -enable-16bit-types option. This option is used to
   // set the UseNativeLowPrecision DXIL module flag in the DirectX backend

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3699,6 +3699,7 @@ static void RenderOpenCLOptions(const ArgList &Args, ArgStringList &CmdArgs,
 static void RenderHLSLOptions(const ArgList &Args, ArgStringList &CmdArgs,
                               types::ID InputType) {
   const unsigned ForwardedArguments[] = {
+      options::OPT_hlsl_all_resources_bound,
       options::OPT_dxil_validator_version,
       options::OPT_res_may_alias,
       options::OPT_D,

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -417,6 +417,12 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
     getDriver().Diag(diag::err_drv_dxc_invalid_matrix_layout);
 
   for (Arg *A : Args) {
+    if (A->getOption().getID() == options::OPT_dxc_all_resources_bound) {
+      DAL->AddFlagArg(nullptr,
+                      Opts.getOption(options::OPT_hlsl_all_resources_bound));
+      A->claim();
+      continue;
+    }
     if (A->getOption().getID() == options::OPT_dxil_validator_version) {
       StringRef ValVerStr = A->getValue();
       if (!isLegalValidatorVersion(ValVerStr, getDriver()))

--- a/clang/test/CodeGenHLSL/all-resources-bound.hlsl
+++ b/clang/test/CodeGenHLSL/all-resources-bound.hlsl
@@ -1,0 +1,7 @@
+// RUN: %clang_dxc -all-resources-bound -T lib_6_3 -HV 202x -Vd -Xclang -emit-llvm %s | FileCheck %s --check-prefix=FLAG
+// RUN: %clang_dxc -T lib_6_3 -HV 202x -Xclang -emit-llvm %s | FileCheck %s --check-prefix=NOFLAG
+
+// FLAG-DAG: ![[ARB:.*]] = !{i32 1, !"dx.allresourcesbound", i32 1}
+// FLAG-DAG: !llvm.module.flags = !{{{.*}}![[ARB]]{{.*}}}
+
+// NOFLAG-NOT: dx.allresourcesbound

--- a/clang/test/Options/all_resources_bound.hlsl
+++ b/clang/test/Options/all_resources_bound.hlsl
@@ -1,8 +1,8 @@
 // RUN: %clang_dxc -T lib_6_4 -all-resources-bound %s 2>&1 -### | FileCheck -check-prefix=ARB %s
 // RUN: %clang_dxc -T lib_6_4 %s 2>&1 -### | FileCheck -check-prefix=NO_ARB %s
 
-// ARB: "hlsl-all-resources-bound"
-// NO_ARB-NOT: "hlsl-all-resources-bound"
+// ARB: hlsl-all-resources-bound
+// NO_ARB-NOT: hlsl-all-resources-bound
 // assert expected CC1 option is present
 float4 main(float4 a : A) : SV_TARGET
 {

--- a/clang/test/Options/all_resources_bound.hlsl
+++ b/clang/test/Options/all_resources_bound.hlsl
@@ -1,8 +1,8 @@
 // RUN: %clang_dxc -T lib_6_4 -all-resources-bound %s 2>&1 -### | FileCheck -check-prefix=ARB %s
 // RUN: %clang_dxc -T lib_6_4 %s 2>&1 -### | FileCheck -check-prefix=NO_ARB %s
 
-// ARB: "-hlsl-all-resources-bound"
-// NO_ARB-NOT: "-hlsl-all-resources-bound"
+// ARB: "hlsl-all-resources-bound"
+// NO_ARB-NOT: "hlsl-all-resources-bound"
 // assert expected CC1 option is present
 float4 main(float4 a : A) : SV_TARGET
 {

--- a/clang/test/Options/all_resources_bound.hlsl
+++ b/clang/test/Options/all_resources_bound.hlsl
@@ -1,0 +1,10 @@
+// RUN: %clang_dxc -T lib_6_4 -all-resources-bound %s 2>&1 -### | FileCheck -check-prefix=ARB %s
+// RUN: %clang_dxc -T lib_6_4 %s 2>&1 -### | FileCheck -check-prefix=NO_ARB %s
+
+// ARB: "-hlsl-all-resources-bound"
+// NO_ARB-NOT: "-hlsl-all-resources-bound"
+// assert expected CC1 option is present
+float4 main(float4 a : A) : SV_TARGET
+{
+  return -a.yxxx;
+}

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -287,6 +287,13 @@ ModuleShaderFlags::gatherGlobalModuleFlags(const Module &M,
   if (CanSetResMayNotAlias && MMDI.ValidatorVersion < VersionTuple(1, 8))
     CSF.ResMayNotAlias = !DRM.uavs().empty();
 
+  // The command line option -all-resources-bound will set the
+  // dx.allresourcesbound module flag to 1
+  if (auto *AllResourcesBound = mdconst::extract_or_null<ConstantInt>(
+          M.getModuleFlag("dx.allresourcesbound")))
+    if (AllResourcesBound->getValue().getBoolValue())
+      CSF.AllResourcesBound = true;
+
   return CSF;
 }
 

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/all-resources-bound.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/all-resources-bound.ll
@@ -1,0 +1,25 @@
+; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
+
+; This test checks to ensure that setting the LLVM module flag
+; "dx.allresourcesbound" to 1 sets the corresponding DXIL shader flag 
+
+target triple = "dxil-pc-shadermodel6.8-library"
+
+; CHECK:      Combined Shader Flags for Module
+; CHECK-NEXT: Shader Flags Value: 0x00000100
+
+; CHECK: Note: shader requires additional functionality:
+; CHECK-NEXT: extra DXIL module flags:
+; CHECK-NEXT:       All resources bound for the duration of shader execution
+
+
+; CHECK: Function main : 0x00000100
+define float @main() #0 {  
+  ret float 0.0
+}
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 1, !"dx.allresourcesbound", i32 1}
+
+attributes #0 = { convergent norecurse nounwind "hlsl.export"}


### PR DESCRIPTION
This PR adds a new CC1 option and a new dxc driver option. The DXC option, when set, is translated into the new CC1 option.
The `all-resources-bound` dxc option will create a metadata module flag, and the print-dx-shader-flags pass will set the appropriate shader module flag from this metadata module flag.

Fixes https://github.com/llvm/llvm-project/issues/112264