### PR TITLE
[libc] Provide empty definitions for `teardown_main_tls` symbols

### DIFF
--- a/libc/src/stdlib/atexit.cpp
+++ b/libc/src/stdlib/atexit.cpp
@@ -16,7 +16,7 @@ namespace LIBC_NAMESPACE_DECL {
 
 constinit ExitCallbackList atexit_callbacks;
 Mutex handler_list_mtx(false, false, false, false);
-[[gnu::weak]] extern void teardown_main_tls();
+[[gnu::weak]] void teardown_main_tls() {}
 
 extern "C" {
 
@@ -27,8 +27,7 @@ int __cxa_atexit(AtExitCallback *callback, void *payload, void *) {
 void __cxa_finalize(void *dso) {
   if (!dso) {
     call_exit_callbacks(atexit_callbacks);
-    if (teardown_main_tls)
-      teardown_main_tls();
+    teardown_main_tls();
   }
 }
 

--- a/libc/src/stdlib/exit.cpp
+++ b/libc/src/stdlib/exit.cpp
@@ -20,15 +20,14 @@ extern "C" void __cxa_finalize(void *);
 //       as we have no way to ensure system libc will call the TLS destructors.
 //       We should run exit related tests in hermetic mode but this is currently
 //       blocked by https://github.com/llvm/llvm-project/issues/133925.
-extern "C" [[gnu::weak]] void __cxa_thread_finalize();
+extern "C" [[gnu::weak]] void __cxa_thread_finalize() {}
 
 // TODO: use recursive mutex to protect this routine.
 [[noreturn]] LLVM_LIBC_FUNCTION(void, exit, (int status)) {
 // FIXME: The NVPTX target does not support external weak symbols correctly
 //        despite being an ELF platform. Disable pending a future split.
 #if !defined(LIBC_TARGET_ARCH_IS_NVPTX)
-  if (__cxa_thread_finalize)
-    __cxa_thread_finalize();
+  __cxa_thread_finalize();
 #endif
   __cxa_finalize(nullptr);
   internal::exit(status);

--- a/libc/src/stdlib/exit.cpp
+++ b/libc/src/stdlib/exit.cpp
@@ -20,14 +20,15 @@ extern "C" void __cxa_finalize(void *);
 //       as we have no way to ensure system libc will call the TLS destructors.
 //       We should run exit related tests in hermetic mode but this is currently
 //       blocked by https://github.com/llvm/llvm-project/issues/133925.
-extern "C" [[gnu::weak]] void __cxa_thread_finalize() {}
+extern "C" [[gnu::weak]] void __cxa_thread_finalize();
 
 // TODO: use recursive mutex to protect this routine.
 [[noreturn]] LLVM_LIBC_FUNCTION(void, exit, (int status)) {
 // FIXME: The NVPTX target does not support external weak symbols correctly
 //        despite being an ELF platform. Disable pending a future split.
 #if !defined(LIBC_TARGET_ARCH_IS_NVPTX)
-  __cxa_thread_finalize();
+  if (__cxa_thread_finalize)
+    __cxa_thread_finalize();
 #endif
   __cxa_finalize(nullptr);
   internal::exit(status);

--- a/libc/src/stdlib/quick_exit.cpp
+++ b/libc/src/stdlib/quick_exit.cpp
@@ -16,12 +16,11 @@
 namespace LIBC_NAMESPACE_DECL {
 
 extern ExitCallbackList at_quick_exit_callbacks;
-[[gnu::weak]] extern void teardown_main_tls();
+[[gnu::weak]] void teardown_main_tls() {}
 
 [[noreturn]] LLVM_LIBC_FUNCTION(void, quick_exit, (int status)) {
   call_exit_callbacks(at_quick_exit_callbacks);
-  if (teardown_main_tls)
-    teardown_main_tls();
+  teardown_main_tls();
   internal::exit(status);
 }
 


### PR DESCRIPTION
This avoids the GOT slot being generated which is undesirable when using static linking. A better solution would be to reorganize the code to avoid the use of weak symbols altogether.

See #173409