### PR TITLE
[clang][test][darwin] disable lld-repro for macOS

### DIFF
--- a/clang/test/Driver/lld-repro.c
+++ b/clang/test/Driver/lld-repro.c
@@ -1,5 +1,5 @@
 // REQUIRES: lld
-// UNSUPPORTED: target={{.*-(ps4|ps5)}}, target={{.*}}-zos{{.*}}
+// UNSUPPORTED: target={{.*-(ps4|ps5)}}, target={{.*}}-zos{{.*}}, target={{.*}}-macosx{{.*}}, target={{.*}}-darwin{{.*}}
 
 // RUN: echo "-nostartfiles -nostdlib -fuse-ld=lld -gen-reproducer=error -fcrash-diagnostics-dir=%t" \
 // RUN:   | sed -e 's/\\/\\\\/g' > %t.rsp


### PR DESCRIPTION
lld doesn't support macOS, disable its driver test on macOS.