### PR TITLE
[lldb/cmake] create staging directory for headers

### DIFF
--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -303,6 +303,11 @@ list(REMOVE_ITEM root_public_headers ${root_private_headers})
 # Skip the initial copy of lldb-defines.h. The fixed version is generated at build time.
 list(REMOVE_ITEM root_public_headers ${LLDB_SOURCE_DIR}/include/lldb/lldb-defines.h)
 
+add_custom_command(
+  OUTPUT ${lldb_header_staging_dir}
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${lldb_header_staging_dir}
+  COMMENT "LLDB headers: create staging directory for LLDB headers")
+
 find_program(unifdef_EXECUTABLE unifdef)
 
 add_custom_target(liblldb-header-staging)
@@ -333,7 +338,7 @@ foreach(header
   add_dependencies(liblldb-stage-header-${basename} lldb-sbapi-dwarf-enums)
   add_dependencies(liblldb-header-staging liblldb-stage-header-${basename})
   add_custom_command(
-    DEPENDS ${header} OUTPUT ${staged_header}
+    DEPENDS ${header} ${lldb_header_staging_dir} OUTPUT ${staged_header}
     COMMAND ${copy_command}
     COMMENT "LLDB headers: stage LLDB headers in include directory")
 


### PR DESCRIPTION
copy_command can either become `cmake -E copy`, which handles target directory creation automatically, or `unifdef >` which fails without explicitly created directory and consequently so does version-header-fix.py later on.