### PR TITLE
[libc] Add stub pthread_attr_getschedparam / pthread_attr_setschedparam

### DIFF
--- a/libc/include/pthread.yaml
+++ b/libc/include/pthread.yaml
@@ -48,6 +48,13 @@ functions:
     arguments:
       - type: const pthread_attr_t *__restrict
       - type: size_t *__restrict
+  - name: pthread_attr_getschedparam
+    standards:
+      - POSIX
+    return_type: int
+    arguments:
+      - type: const pthread_attr_t *__restrict
+      - type: struct sched_param *__restrict
   - name: pthread_attr_getstack
     standards:
       - POSIX
@@ -83,6 +90,13 @@ functions:
     arguments:
       - type: pthread_attr_t *
       - type: size_t
+  - name: pthread_attr_setschedparam
+    standards:
+      - POSIX
+    return_type: int
+    arguments:
+      - type: pthread_attr_t *__restrict
+      - type: const struct sched_param *__restrict
   - name: pthread_attr_setstack
     standards:
       - POSIX

--- a/libc/src/pthread/CMakeLists.txt
+++ b/libc/src/pthread/CMakeLists.txt
@@ -61,6 +61,26 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  pthread_attr_getschedparam
+  SRCS
+    pthread_attr_getschedparam.cpp
+  HDRS
+    pthread_attr_getschedparam.h
+  DEPENDS
+    libc.include.pthread
+)
+
+add_entrypoint_object(
+  pthread_attr_setschedparam
+  SRCS
+    pthread_attr_setschedparam.cpp
+  HDRS
+    pthread_attr_setschedparam.h
+  DEPENDS
+    libc.include.pthread
+)
+
+add_entrypoint_object(
   pthread_attr_getstacksize
   SRCS
     pthread_attr_getstacksize.cpp

--- a/libc/src/pthread/pthread_attr_getschedparam.cpp
+++ b/libc/src/pthread/pthread_attr_getschedparam.cpp
@@ -1,0 +1,24 @@
+//===-- Implementation of the pthread_attr_getschedparam -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "pthread_attr_getschedparam.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+#include <pthread.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, pthread_attr_getschedparam,
+                   (const pthread_attr_t *attr,
+                    struct sched_param *schedparam)) {
+  return ENOTSUP;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/pthread/pthread_attr_getschedparam.h
+++ b/libc/src/pthread/pthread_attr_getschedparam.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for pthread_attr_getschedparam -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_GETSCHEDPARAM_H
+#define LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_GETSCHEDPARAM_H
+
+#include "src/__support/macros/config.h"
+#include <pthread.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+int pthread_attr_getschedparam(const pthread_attr_t *__restrict attr,
+                               struct sched_param *__restrict schedparam);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_GETSCHEDPARAM_H

--- a/libc/src/pthread/pthread_attr_setschedparam.cpp
+++ b/libc/src/pthread/pthread_attr_setschedparam.cpp
@@ -1,0 +1,24 @@
+//===-- Implementation of the pthread_attr_setschedparam -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "pthread_attr_setschedparam.h"
+
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+#include <pthread.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, pthread_attr_setschedparam,
+                   (pthread_attr_t * attr,
+                    const struct sched_param *schedparam)) {
+  return ENOTSUP;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/pthread/pthread_attr_setschedparam.h
+++ b/libc/src/pthread/pthread_attr_setschedparam.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for pthread_attr_setschedparam -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_SETSCHEDPARAM_H
+#define LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_SETSCHEDPARAM_H
+
+#include "src/__support/macros/config.h"
+#include <pthread.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+int pthread_attr_setschedparam(pthread_attr_t *__restrict attr,
+                               const struct sched_param *__restrict schedparam);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_PTHREAD_PTHREAD_ATTR_SETSCHEDPARAM_H


### PR DESCRIPTION
Add the boilerplate for declaring these POSIX functions and
providing implementations.  So far the only implementations are
just stubs that fail with ENOTSUP, and they are neither tested
nor included in any CMake entrypoints lists.  More work is still
required to add the actual fields to the pthread_attr_t and
implement the support in the Linux pthread_create et al, but that
is not done here.  It's not an especially large amount of work,
but more than just trivial.

The scaffolding here paves the way for that later work, but is
also immediately useful for filling out the subset of POSIX
pthread_attr_* functions that Fuchsia's libc already supports.
