### PR TITLE
workflows/release-sources: Disable building sub-project tarballs by default

### DIFF
--- a/.github/workflows/release-sources.yml
+++ b/.github/workflows/release-sources.yml
@@ -24,6 +24,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/release-sources.yml'
+      - 'llvm/utils/release/export.sh'
     types:
       - opened
       - synchronize

--- a/llvm/utils/release/export.sh
+++ b/llvm/utils/release/export.sh
@@ -17,6 +17,7 @@ projects="llvm bolt clang cmake compiler-rt libcxx libcxxabi libclc clang-tools-
 
 release=""
 rc=""
+subprojects=""
 yyyymmdd=$(date +'%Y%m%d')
 snapshot=""
 template='${PROJECT}-${RELEASE}${RC}.src.tar.xz'
@@ -37,13 +38,14 @@ Flags:
   -rc       | --rc <num>                           The release candidate number
   -final    | --final                              When provided, this option will disable the rc flag
   -git-ref  | --git-ref <git-ref>                  (optional) Use <git-ref> to determine the release and don't export the test-suite files
+  -sub-projects | --sub-projects                   Generate tarballs fore each sub-project (off by default).
   -template | --template <template>                (optional) Possible placeholders: \$PROJECT \$YYYYMMDD \$GIT_REF \$RELEASE \$RC.
                                                    Defaults to '${template}'.
 
 The following list shows the filenames (with <placeholders>) for the artifacts
 that are being generated (given that you don't touch --template).
 
-$(echo "$projects "| sed 's/\([a-z-]\+\) /  * \1-<RELEASE><RC>.src.tar.xz \n/g')
+$(test -n "$subprojects" && echo "$projects "| sed 's/\([a-z-]\+\) /  * \1-<RELEASE><RC>.src.tar.xz \n/g')
 
 Additional files being generated:
 
@@ -128,12 +130,14 @@ export_sources() {
             -cJf test-suite-$release$rc.src.tar.xz test-suite-$release$rc.src
     fi
 
-    for proj in $projects; do
-        echo "Creating tarball for $proj ..."
-        pushd $llvm_src_dir/$proj
-        git archive --prefix=$proj-$release$rc.src/ $tree_id . | xz -T0 >$target_dir/$(template_file $proj)
-        popd
-    done
+    if [ -n "$subprojects" ]; then
+        for proj in $projects; do
+            echo "Creating tarball for $proj ..."
+            pushd $llvm_src_dir/$proj
+            git archive --prefix=$proj-$release$rc.src/ $tree_id . | xz -T0 >$target_dir/$(template_file $proj)
+            popd
+        done
+    fi
 }
 
 while [ $# -gt 0 ]; do
@@ -149,6 +153,9 @@ while [ $# -gt 0 ]; do
         -final | --final )
             rc="final"
             ;;
+	-sub-projects | --sub-projects )
+	    subprojects=1
+	    ;;
         -git-ref | --git-ref )
             shift
             snapshot="$1"

--- a/llvm/utils/release/export.sh
+++ b/llvm/utils/release/export.sh
@@ -38,7 +38,7 @@ Flags:
   -rc       | --rc <num>                           The release candidate number
   -final    | --final                              When provided, this option will disable the rc flag
   -git-ref  | --git-ref <git-ref>                  (optional) Use <git-ref> to determine the release and don't export the test-suite files
-  -sub-projects | --sub-projects                   Generate tarballs fore each sub-project (off by default).
+  -sub-projects | --sub-projects                   Generate tarballs for each sub-project (off by default).
   -template | --template <template>                (optional) Possible placeholders: \$PROJECT \$YYYYMMDD \$GIT_REF \$RELEASE \$RC.
                                                    Defaults to '${template}'.
 

--- a/llvm/utils/release/export.sh
+++ b/llvm/utils/release/export.sh
@@ -31,6 +31,7 @@ Usage: $(basename $0) [-release|--release <major>.<minor>.<patch>]
                       [-final|--final]
                       [-git-ref|--git-ref <git-ref>]
                       [-template|--template <template>]
+                      [-sub-projects|--sub-projects]
 
 Flags:
 
@@ -153,9 +154,9 @@ while [ $# -gt 0 ]; do
         -final | --final )
             rc="final"
             ;;
-	-sub-projects | --sub-projects )
-	    subprojects=1
-	    ;;
+        -sub-projects | --sub-projects )
+            subprojects=1
+            ;;
         -git-ref | --git-ref )
             shift
             snapshot="$1"


### PR DESCRIPTION
Sub-project tarbball creation has been disabled in the export.sh script by default.  It can be enabled by passing the --sub-project option. This will not be used for official releases, but the option will allow users to generate the sub-project tarballs themseleves if they want to.

https://discourse.llvm.org/t/rfc-do-something-with-the-subproject-tarballs-in-the-release-page/75024/