### PR TITLE
[clang-tidy] Skip ObjC fast-enum loop vars in init-variables

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/InitVariablesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/InitVariablesCheck.cpp
@@ -21,6 +21,7 @@ namespace clang::tidy::cppcoreguidelines {
 
 namespace {
 AST_MATCHER(VarDecl, isLocalVarDecl) { return Node.isLocalVarDecl(); }
+AST_MATCHER(VarDecl, isObjCForDecl) { return Node.isObjCForDecl(); }
 } // namespace
 
 InitVariablesCheck::InitVariablesCheck(StringRef Name,
@@ -41,7 +42,7 @@ void InitVariablesCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       varDecl(unless(hasInitializer(anything())), unless(isInstantiated()),
               isLocalVarDecl(), unless(isStaticLocal()), isDefinition(),
-              unless(hasParent(cxxCatchStmt())),
+              unless(isObjCForDecl()), unless(hasParent(cxxCatchStmt())),
               optionally(hasParent(declStmt(hasParent(
                   cxxForRangeStmt(hasLoopVariable(varDecl().bind(BadDecl))))))),
               unless(equalsBoundNode(BadDecl)))

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -463,6 +463,10 @@ Changes in existing checks
   <clang-tidy/checks/cppcoreguidelines/init-variables>` check by fixing the
   insertion location for function pointers with multiple parameters.
 
+- Improved :doc:`cppcoreguidelines-init-variables
+  <clang-tidy/checks/cppcoreguidelines/init-variables>` check to avoid false
+  positives on Objective-C fast enumeration loop variables.
+
 - Improved :doc:`cppcoreguidelines-macro-usage
   <clang-tidy/checks/cppcoreguidelines/macro-usage>` check by excluding macro
   bodies that starts with ``__attribute__((..))`` keyword.

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/init-variables-objc.m
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/init-variables-objc.m
@@ -1,0 +1,21 @@
+// RUN: %check_clang_tidy %s cppcoreguidelines-init-variables %t -- -- -fobjc-arc
+
+@interface NSObject
+@end
+
+@interface NSNumber : NSObject
+@end
+
+@protocol NSFastEnumeration
+@end
+
+@interface NSArray<ObjectType> : NSObject <NSFastEnumeration>
+@end
+
+void testFastEnumeration(NSArray<NSNumber *> *array) {
+  for (NSNumber *n in array) {
+  }
+}
+
+// Regression test for https://github.com/llvm/llvm-project/issues/173435.
+// CHECK-MESSAGES-NOT: warning: variable 'n' is not initialized


### PR DESCRIPTION
Avoid cppcoreguidelines-init-variables warnings on Objective-C fast enumeration loop variables by excluding ObjC for-in declarations. Add a regression test covering the GitHub report.

Fixes: https://github.com/llvm/llvm-project/issues/173435