### PR TITLE
[InstCombine] Fold redundant FP clamp selects; relax min-max-pattern bailout in visitFCmp

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8789,9 +8789,10 @@ Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {
     if (SelectInst *SI = dyn_cast<SelectInst>(I.user_back())) {
       Value *A, *B;
       SelectPatternResult SPR = matchSelectPattern(SI, A, B);
-      if (SPR.Flavor != SPF_UNKNOWN &&
-          !((SPR.Flavor == SPF_FMAXNUM || SPR.Flavor == SPF_FMINNUM) &&
-            isMinMaxCmpSelectEliminable(SPR.Flavor, A, B)))
+      bool IsRedundantMinMaxClamp =
+          (SPR.Flavor == SPF_FMAXNUM || SPR.Flavor == SPF_FMINNUM) &&
+          isMinMaxCmpSelectEliminable(SPR.Flavor, A, B);
+      if (SPR.Flavor != SPF_UNKNOWN && !IsRedundantMinMaxClamp)
         return nullptr;
     }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8700,10 +8700,11 @@ static bool isMinMaxCmpSelectEliminable(SelectPatternFlavor Flavor, Value *A,
   APSInt IntBoundary = (Flavor == SPF_FMAXNUM)
                            ? APSInt::getMinValue(BitWidth, IsUnsigned)
                            : APSInt::getMaxValue(BitWidth, IsUnsigned);
-  APSInt ToInt(BitWidth, IsUnsigned);
+  APSInt ConvertedInt(BitWidth, IsUnsigned);
   bool IsExact;
-  APF->convertToInteger(ToInt, APFloat::rmTowardZero, &IsExact);
-  return IsExact && ToInt == IntBoundary;
+  APFloat::opStatus Status =
+      APF->convertToInteger(ConvertedInt, APFloat::rmTowardZero, &IsExact);
+  return Status == APFloat::opOK && IsExact && ConvertedInt == IntBoundary;
 }
 
 Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8686,8 +8686,8 @@ static Instruction *foldFCmpWithFloorAndCeil(FCmpInst &I,
 /// representable by A.
 static bool isMinMaxCmpSelectEliminable(SelectPatternFlavor Flavor, Value *A,
                                         Value *B) {
-  ConstantFP *CFP;
-  if (!match(B, m_APFloat(CFP)))
+  const APFloat *APF;
+  if (!match(B, m_APFloat(APF)))
     return false;
 
   auto *I = dyn_cast<Instruction>(A);
@@ -8696,14 +8696,13 @@ static bool isMinMaxCmpSelectEliminable(SelectPatternFlavor Flavor, Value *A,
     return false;
 
   bool IsUnsigned = I->getOpcode() == Instruction::UIToFP;
-  unsigned BitWidth =
-      I->getOperand(0)->getType()->getScalarSizeInBits();
+  unsigned BitWidth = I->getOperand(0)->getType()->getScalarSizeInBits();
   APSInt IntBoundary = (Flavor == SPF_FMAXNUM)
                            ? APSInt::getMinValue(BitWidth, IsUnsigned)
                            : APSInt::getMaxValue(BitWidth, IsUnsigned);
   APSInt ToInt(BitWidth, IsUnsigned);
   bool IsExact;
-  CFP->getValueAPF().convertToInteger(ToInt, APFloat::rmTowardZero, &IsExact);
+  APF->convertToInteger(ToInt, APFloat::rmTowardZero, &IsExact);
   return IsExact && ToInt == IntBoundary;
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8686,14 +8686,8 @@ static Instruction *foldFCmpWithFloorAndCeil(FCmpInst &I,
 /// representable by A.
 static bool isMinMaxCmpSelectEliminable(SelectPatternFlavor Flavor, Value *A,
                                         Value *B) {
-  Constant *C = dyn_cast<Constant>(B);
-  if (isa<Constant>(A) || !C)
-    return false;
-
-  if (C->getType()->isVectorTy())
-    C = C->getSplatValue();
-  auto *CFP = dyn_cast_or_null<ConstantFP>(C);
-  if (!CFP)
+  ConstantFP *CFP;
+  if (!match(B, m_APFloat(CFP)))
     return false;
 
   auto *I = dyn_cast<Instruction>(A);

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8697,7 +8697,7 @@ static bool isMinMaxCmpSelectEliminable(SelectPatternFlavor Flavor, Value *A,
 
   bool IsUnsigned = I->getOpcode() == Instruction::UIToFP;
   unsigned BitWidth =
-      I->getOperand(0)->getType()->getScalarType()->getIntegerBitWidth();
+      I->getOperand(0)->getType()->getScalarSizeInBits();
   APSInt IntBoundary = (Flavor == SPF_FMAXNUM)
                            ? APSInt::getMinValue(BitWidth, IsUnsigned)
                            : APSInt::getMaxValue(BitWidth, IsUnsigned);

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -8704,13 +8704,13 @@ static bool isMinMaxCmpSelectEliminable(SelectPatternFlavor Flavor, Value *A,
   bool IsUnsigned = I->getOpcode() == Instruction::UIToFP;
   unsigned BitWidth =
       I->getOperand(0)->getType()->getScalarType()->getIntegerBitWidth();
-  APSInt MinOrMaxInt = (Flavor == SPF_FMAXNUM)
+  APSInt IntBoundary = (Flavor == SPF_FMAXNUM)
                            ? APSInt::getMinValue(BitWidth, IsUnsigned)
                            : APSInt::getMaxValue(BitWidth, IsUnsigned);
   APSInt ToInt(BitWidth, IsUnsigned);
   bool IsExact;
   CFP->getValueAPF().convertToInteger(ToInt, APFloat::rmTowardZero, &IsExact);
-  return IsExact && ToInt == MinOrMaxInt;
+  return IsExact && ToInt == IntBoundary;
 }
 
 Instruction *InstCombinerImpl::visitFCmpInst(FCmpInst &I) {

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -306,8 +306,8 @@ define float @test_select_nnan_nsz_fcmp_ult(float %x) {
 
 define float @test_select_fcmp_sitofp_max(i8 %x) {
 ; CHECK-LABEL: @test_select_fcmp_sitofp_max(
-; CHECK-NEXT:    [[TMP2:%.*]] = sitofp i8 [[TMP0:%.*]] to float
-; CHECK-NEXT:    ret float [[TMP2]]
+; CHECK-NEXT:    [[F:%.*]] = sitofp i8 [[X:%.*]] to float
+; CHECK-NEXT:    ret float [[F]]
 ;
   %f = sitofp i8 %x to float
   %cmp = fcmp ole float %f, -1.280000e+02
@@ -328,8 +328,8 @@ define <2 x float> @test_select_fcmp_sitofp_max_vec(<2 x i8> %x) {
 
 define float @test_select_fcmp_sitofp_min(i8 %x) {
 ; CHECK-LABEL: @test_select_fcmp_sitofp_min(
-; CHECK-NEXT:    [[TMP2:%.*]] = sitofp i8 [[TMP0:%.*]] to float
-; CHECK-NEXT:    ret float [[TMP2]]
+; CHECK-NEXT:    [[F:%.*]] = sitofp i8 [[X:%.*]] to float
+; CHECK-NEXT:    ret float [[F]]
 ;
   %f = sitofp i8 %x to float
   %cmp = fcmp oge float %f, 1.270000e+02
@@ -339,8 +339,8 @@ define float @test_select_fcmp_sitofp_min(i8 %x) {
 
 define float @test_select_fcmp_uitofp_min(i8 %x) {
 ; CHECK-LABEL: @test_select_fcmp_uitofp_min(
-; CHECK-NEXT:    [[TMP2:%.*]] = uitofp i8 [[TMP0:%.*]] to float
-; CHECK-NEXT:    ret float [[TMP2]]
+; CHECK-NEXT:    [[F:%.*]] = uitofp i8 [[X:%.*]] to float
+; CHECK-NEXT:    ret float [[F]]
 ;
   %f = uitofp i8 %x to float
   %cmp = fcmp oge float %f, 2.550000e+02

--- a/llvm/test/Transforms/InstCombine/fcmp-select.ll
+++ b/llvm/test/Transforms/InstCombine/fcmp-select.ll
@@ -303,3 +303,47 @@ define float @test_select_nnan_nsz_fcmp_ult(float %x) {
   %sel = select nnan nsz i1 %cmp, float %x, float -0.000000e+00
   ret float %sel
 }
+
+define float @test_select_fcmp_sitofp_max(i8 %x) {
+; CHECK-LABEL: @test_select_fcmp_sitofp_max(
+; CHECK-NEXT:    [[TMP2:%.*]] = sitofp i8 [[TMP0:%.*]] to float
+; CHECK-NEXT:    ret float [[TMP2]]
+;
+  %f = sitofp i8 %x to float
+  %cmp = fcmp ole float %f, -1.280000e+02
+  %sel = select i1 %cmp, float -1.280000e+02, float %f
+  ret float %sel
+}
+
+define <2 x float> @test_select_fcmp_sitofp_max_vec(<2 x i8> %x) {
+; CHECK-LABEL: @test_select_fcmp_sitofp_max_vec(
+; CHECK-NEXT:    [[F:%.*]] = sitofp <2 x i8> [[X:%.*]] to <2 x float>
+; CHECK-NEXT:    ret <2 x float> [[F]]
+;
+  %f = sitofp <2 x i8> %x to <2 x float>
+  %cmp = fcmp ole <2 x float> %f, splat (float -1.280000e+02)
+  %sel = select <2 x i1> %cmp, <2 x float> splat (float -1.280000e+02), <2 x float> %f
+  ret <2 x float> %sel
+}
+
+define float @test_select_fcmp_sitofp_min(i8 %x) {
+; CHECK-LABEL: @test_select_fcmp_sitofp_min(
+; CHECK-NEXT:    [[TMP2:%.*]] = sitofp i8 [[TMP0:%.*]] to float
+; CHECK-NEXT:    ret float [[TMP2]]
+;
+  %f = sitofp i8 %x to float
+  %cmp = fcmp oge float %f, 1.270000e+02
+  %sel = select i1 %cmp, float 1.270000e+02, float %f
+  ret float %sel
+}
+
+define float @test_select_fcmp_uitofp_min(i8 %x) {
+; CHECK-LABEL: @test_select_fcmp_uitofp_min(
+; CHECK-NEXT:    [[TMP2:%.*]] = uitofp i8 [[TMP0:%.*]] to float
+; CHECK-NEXT:    ret float [[TMP2]]
+;
+  %f = uitofp i8 %x to float
+  %cmp = fcmp oge float %f, 2.550000e+02
+  %sel = select i1 %cmp, float 2.550000e+02, float %f
+  ret float %sel
+}


### PR DESCRIPTION
visitFCmp() previously bailed out when a following select matched a clamp pattern. This blocks simplifications when the clamp is provably redundant.

This PR allows simplification for clamp selects of flavor SPF_FMAXNUM/ SPF_FMINNUM when one arm is a constant and the other is a sitofp/uitofp of an integer value, and the constant equals the exact min/max of that integer domain:
* SPF_FMAXNUM (pattern max(X,C)): redundant if C is the minimum integer mapped exactly to FP (e.g. X = sitofp i8, C = -128.0f).
* SPF_FMINNUM (pattern min(X,C)): redundant if C is the maximum integer mapped exactly to FP (e.g. X = uitofp i8, C = 255.0f).

This fixes a regression in #173454