### PR TITLE
[clang-format] Avoid crashing on malformed template closers in mustBreak

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -793,6 +793,9 @@ clang-format
 - Rename ``(Binary|Decimal|Hex)MinDigits`` to ``...MinDigitsInsert`` and  add
   ``(Binary|Decimal|Hex)MaxDigitsSeparator`` suboptions to
   ``IntegerLiteralSeparator``.
+- Avoid crashing when formatting malformed template code that lacks a matching
+  template closer (e.g., broken ``enable_if`` declarations) by bailing out
+  instead of asserting. (#GH173382)
 
 libclang
 --------

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -675,7 +675,8 @@ bool ContinuationIndenter::mustBreak(const LineState &State) {
         return false;
       if (Tok->is(TT_TemplateCloser)) {
         Tok = Tok->MatchingParen;
-        assert(Tok);
+        if (!Tok)
+          return false; // Bail out on malformed template structure.
       }
       if (Tok->FirstAfterPPLine)
         return false;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -15421,6 +15421,22 @@ TEST_F(FormatTest, UnderstandContextOfRecordTypeKeywords) {
   verifyFormat("class A:");
 }
 
+TEST_F(FormatTest, DoesNotCrashOnMalformedEnableIf) {
+  const char *Code =
+      "template <typename T, typename TIString>\n"
+      "typename etl::enable_if<etl::is_integral<T>::value &&\n"
+      "                        !etl::is_same<T, bool>::value>::value,\n"
+      "  const TIString& > ::type\n"
+      "to_string(const T value, TIString& str,\n"
+      "          const etl::basic_format_spec<TIString>& format,\n"
+      "          const bool append = false) {\n"
+      "}\n";
+  // Ensure formatting malformed template syntax doesn't assert, regardless of
+  // whether clang-format considers the input complete.
+  EXPECT_NO_FATAL_FAILURE(format(Code, std::nullopt, SC_DoNotCheck));
+  EXPECT_NO_FATAL_FAILURE(format(messUp(Code), std::nullopt, SC_DoNotCheck));
+}
+
 TEST_F(FormatTest, DoNotInterfereWithErrorAndWarning) {
   verifyNoChange("#error Leave     all         white!!!!! space* alone!");
   verifyNoChange("#warning Leave     all         white!!!!! space* alone!");


### PR DESCRIPTION
If a template closer has no MatchingParen, return false instead of asserting so malformed enable_if declarations don’t force a break.

Fixes: https://github.com/llvm/llvm-project/issues/173382