### PR TITLE
[libclc] Compile clc_convert_float2int.cl and clc_convert_int2float.cl separately

### DIFF
--- a/libclc/clc/lib/generic/SOURCES
+++ b/libclc/clc/lib/generic/SOURCES
@@ -20,6 +20,8 @@ common/clc_sign.cl
 common/clc_smoothstep.cl
 common/clc_step.cl
 conversion/clc_convert_float2float.cl
+conversion/clc_convert_float2int.cl
+conversion/clc_convert_int2float.cl
 conversion/clc_convert_integer.cl
 geometric/clc_cross.cl
 geometric/clc_distance.cl

--- a/libclc/clc/lib/generic/conversion/clc_convert_integer.cl
+++ b/libclc/clc/lib/generic/conversion/clc_convert_integer.cl
@@ -59,6 +59,3 @@
 #undef __CLC_U_GENTYPE_SRC
 #undef __CLC_FUNCTION
 #undef __CLC_FUNCTION_SAT
-
-#include <clc_convert_float2int.cl>
-#include <clc_convert_int2float.cl>


### PR DESCRIPTION
776f5933c9d4 merged into clc_convert_integer.cl to avoid many regressions, e.g. in function _Z17convert_float_rtnc:
  in block %1 / %1:
    >   ret float %2
    <   %.inv.i.i = fcmp ole float %2, -1.280000e+02
    <   %3 = select i1 %.inv.i.i, float -1.280000e+02, float %2
    <   %4 = fptosi float %3 to i8
    <   %.not.i = icmp eq i8 %0, 127
    <   %5 = icmp sge i8 %0, %4
    <   %.not2.i = select i1 %.not.i, i1 true, i1 %5
    <   %6 = bitcast float %2 to i32
    <   %7 = sub nsw i32 -2147483648, %6
    <   %8 = icmp slt i8 %0, 0
    <   %9 = select i1 %8, i32 %7, i32 %6
    <   %10 = icmp sgt i32 %9, -2139095041
    <   %11 = select i1 %10, i32 -1, i32 1
    <   %12 = add nsw i32 %11, %9
    <   %13 = sub i32 -2147483648, %12
    <   %14 = icmp slt i32 %12, 0
    <   %15 = icmp ne i32 %12, 0
    <   %16 = or i1 %10, %15
    <   %17 = select i1 %16, i32 %12, i32 -2147483648
    <   %18 = select i1 %14, i32 %13, i32 %17
    <   %19 = icmp eq i32 %6, -8388608
    <   %20 = bitcast i32 %18 to float
    <   %21 = select i1 %19, float 0xFFF0000000000000, float %20
    <   %22 = select i1 %.not2.i, float %2, float %21
    <   ret float %22
This regression is fixed by 993054d96fdf.