### PR TITLE
[ORC] Fix ReOptimizeLayer buggy jit-dispatch signature in fa7f7a4cab4.

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
@@ -27,8 +27,9 @@ void ReOptimizeLayer::ReOptMaterializationUnitState::reoptimizeFailed() {
 }
 
 static void orc_rt_lite_reoptimize_helper(
-    shared::CWrapperFunctionBuffer (*JITDispatch)(
-        void *Ctx, void *Tag, const char *Data, size_t Size),
+    shared::CWrapperFunctionBuffer (*JITDispatch)(void *Ctx, void *Tag,
+                                                  const char *Data,
+                                                  size_t Size),
     void *JITDispatchCtx, void *Tag, uint64_t MUID, uint32_t CurVersion) {
   // Serialize the arguments into a WrapperFunctionBuffer and call dispatch.
   using SPSArgs = shared::SPSArgList<uint64_t, uint32_t>;

--- a/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
@@ -41,7 +41,7 @@ static void orc_rt_lite_reoptimize_helper(
     abort();
   }
   shared::WrapperFunctionBuffer Buf{
-      JITDispatch(JITDispatchCtx, Tag, ArgBytes.data(), ArgBytes.size() )};
+      JITDispatch(JITDispatchCtx, Tag, ArgBytes.data(), ArgBytes.size())};
 
   if (const char *ErrMsg = Buf.getOutOfBandError()) {
     errs() << "Reoptimization error: " << ErrMsg << "\naborting.\n";

--- a/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ReOptimizeLayer.cpp
@@ -28,7 +28,7 @@ void ReOptimizeLayer::ReOptMaterializationUnitState::reoptimizeFailed() {
 
 static void orc_rt_lite_reoptimize_helper(
     shared::CWrapperFunctionBuffer (*JITDispatch)(
-        void *Ctx, void *Tag, shared::CWrapperFunctionBuffer),
+        void *Ctx, void *Tag, const char *Data, size_t Size),
     void *JITDispatchCtx, void *Tag, uint64_t MUID, uint32_t CurVersion) {
   // Serialize the arguments into a WrapperFunctionBuffer and call dispatch.
   using SPSArgs = shared::SPSArgList<uint64_t, uint32_t>;
@@ -41,7 +41,7 @@ static void orc_rt_lite_reoptimize_helper(
     abort();
   }
   shared::WrapperFunctionBuffer Buf{
-      JITDispatch(JITDispatchCtx, Tag, ArgBytes.release())};
+      JITDispatch(JITDispatchCtx, Tag, ArgBytes.data(), ArgBytes.size() )};
 
   if (const char *ErrMsg = Buf.getOutOfBandError()) {
     errs() << "Reoptimization error: " << ErrMsg << "\naborting.\n";


### PR DESCRIPTION
fa7f7a4cab4 changed the jit-dispatch function signature used in the orc_rt_lite_reoptimize_helper function, but jit-dispatch still takes a raw data pointer and size argument.

Should fix the bug in https://lab.llvm.org/buildbot/#/builders/169/builds/18319 and similar builds.