### PR TITLE
[docs] Fix vendor group links in developer policy

### DIFF
--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -685,14 +685,13 @@ awareness of. For such changes, the following should be done:
   "vendors" github team to the review for their awareness. The purpose of these
   groups is to give vendors early notice that potentially disruptive changes
   are being considered but have not yet been accepted. Vendors can give early
-  testing feedback on the changes to alert us to unacceptable breakages. The
-  current list of vendor groups is:
+  testing feedback on the changes to alert us to unacceptable breakages. 
+  The current list of vendor groups includes Clang and libc++ vendors.
+  
+  These vendor groups are managed by the LLVM project administrators.
+  Interested vendors should contact the LLVM project to request access,
+  rather than joining directly via GitHub.
 
-  * `Clang vendors <https://github.com/orgs/llvm/teams/clang-vendors>`_
-  * `libc++ vendors <https://github.com/orgs/llvm/teams/libcxx-vendors>`_
-
-  People interested in joining the vendors group can do so by clicking the
-  "Join team" button on the linked github pages above.
 
 * When committing the change to the repository, add appropriate information
   about the potentially breaking changes to the ``Potentially Breaking Changes``


### PR DESCRIPTION
This fixes broken vendor group links in the DeveloperPolicy documentation.

The previous text suggested users could join vendor GitHub teams directly,
but those teams are private and not publicly joinable. This change removes
the broken links and updates the text to accurately describe the access
process.

Fixes #168647
