### PR TITLE
[clang-tidy] Give clear instruction when duplicates are detected in `check_alphabetical_order.py`

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/check_alphabetical_order.py
+++ b/clang-tools-extra/clang-tidy/tool/check_alphabetical_order.py
@@ -352,7 +352,8 @@ def _emit_duplicate_report(lines: Sequence[str], title: str) -> Optional[str]:
     if not (dups_detail := find_duplicate_entries(lines, title)):
         return None
     out: List[str] = []
-    out.append(f"Error: Duplicate entries in '{title}':\n")
+    out.append(f"Error: Duplicate entries in '{title}'.\n")
+    out.append("\nPlease merge these entries into a single bullet point.\n")
     for key, occs in dups_detail:
         out.append(f"\n-- Duplicate: {key}\n")
         for start_idx, block in occs:

--- a/clang-tools-extra/clang-tidy/tool/check_alphabetical_order_test.py
+++ b/clang-tools-extra/clang-tidy/tool/check_alphabetical_order_test.py
@@ -92,7 +92,9 @@ class TestAlphabeticalOrderCheck(unittest.TestCase):
 
         expected_report = textwrap.dedent(
             """\
-            Error: Duplicate entries in 'Changes in existing checks':
+            Error: Duplicate entries in 'Changes in existing checks'.
+
+            Please merge these entries into a single bullet point.
 
             -- Duplicate: - Improved :doc:`bugprone-easily-swappable-parameters
 
@@ -269,7 +271,9 @@ class TestAlphabeticalOrderCheck(unittest.TestCase):
             self.assertEqual(rc, 3)
             expected_report = textwrap.dedent(
                 """\
-                Error: Duplicate entries in 'Changes in existing checks':
+                Error: Duplicate entries in 'Changes in existing checks'.
+
+                Please merge these entries into a single bullet point.
 
                 -- Duplicate: - Improved :doc:`bugprone-easily-swappable-parameters
 


### PR DESCRIPTION
As of AI usage: Gemini 3 is used to generate the new instruction.

Related discussion: https://github.com/llvm/llvm-project/pull/173448#discussion_r2644988250