### PR TITLE
[mlir][dataflow] Fix DataFlowFramework crash by add isBlockEnd logic in the ProgramPoint::print

### DIFF
--- a/mlir/lib/Analysis/DataFlowFramework.cpp
+++ b/mlir/lib/Analysis/DataFlowFramework.cpp
@@ -70,7 +70,9 @@ void ProgramPoint::print(raw_ostream &os) const {
   if (!isBlockEnd()) {
     os << "<before operation>:"
        << OpWithFlags(getNextOp(), OpPrintingFlags().skipRegions());
+    return;
   }
+  os << "<beginning of empty block>";
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Analysis/DataFlowFramework.cpp
+++ b/mlir/lib/Analysis/DataFlowFramework.cpp
@@ -67,8 +67,10 @@ void ProgramPoint::print(raw_ostream &os) const {
        << OpWithFlags(getPrevOp(), OpPrintingFlags().skipRegions());
     return;
   }
-  os << "<before operation>:"
-     << OpWithFlags(getNextOp(), OpPrintingFlags().skipRegions());
+  if (!isBlockEnd()) {
+    os << "<before operation>:"
+       << OpWithFlags(getNextOp(), OpPrintingFlags().skipRegions());
+  }
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Running -test-dead-code-analysis -debug on the following IR will trigger a data-flow analysis framework assert, you can see https://github.com/llvm/llvm-project/blob/2d6b1b174194198498eb10ae811632b3dd945ecf/mlir/include/mlir/Analysis/DataFlowFramework.h#L110 Fix DataFlowFramework crash by add isBlockEnd logic in the ProgramPoint::print.
```
func.func @trs(%idx1: index, %idx2: index, %s: f32) {
  scf.parallel (%i) = (%idx1) to (%idx2) step (%idx2) {
    %r = memref.alloca() : memref<10xf32>
    scf.forall (%e2) in (%idx2) {
      %a = memref.load %r[%idx2] : memref<10xf32>
    }
  }
  return
}
```