### PR TITLE
[MLIR] quick fix errors introduced in #173228

### DIFF
--- a/mlir/lib/CAPI/Dialect/Complex.cpp
+++ b/mlir/lib/CAPI/Dialect/Complex.cpp
@@ -10,12 +10,15 @@
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"
 #include "mlir/CAPI/Registration.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
+
+using namespace mlir;
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Complex, complex,
                                       mlir::complex::ComplexDialect)
 
 bool mlirAttributeIsAComplex(MlirAttribute attr) {
-  return isa<ComplexAttr>(unwrap(attr));
+  return isa<complex::NumberAttr>(unwrap(attr));
 }
 
 MlirAttribute mlirComplexAttrDoubleGet(MlirContext ctx, MlirType type,
@@ -31,11 +34,11 @@ MlirAttribute mlirComplexAttrDoubleGetChecked(MlirLocation loc, MlirType type,
 }
 
 double mlirComplexAttrGetRealDouble(MlirAttribute attr) {
-  return cast<complex::NumberAttr>(unwrap(attr)).getRealAsDouble();
+  return cast<complex::NumberAttr>(unwrap(attr)).getReal().convertToDouble();
 }
 
 double mlirComplexAttrGetImagDouble(MlirAttribute attr) {
-  return cast<complex::NumberAttr>(unwrap(attr)).getImagAsDouble();
+  return cast<complex::NumberAttr>(unwrap(attr)).getImag().convertToDouble();
 }
 
 MlirTypeID mlirComplexAttrGetTypeID(void) {


### PR DESCRIPTION
My bad, I thought that the build was being run for PRs, everything succeeded and didn't test out on local.

Now main branch is throwing these errors on CI:

```
[490/2482] Building CXX object tools/mlir/lib/CAPI/Dialect/CMakeFiles/obj.MLIRCAPIComplex.dir/Complex.cpp.o
FAILED: tools/mlir/lib/CAPI/Dialect/CMakeFiles/obj.MLIRCAPIComplex.dir/Complex.cpp.o 
/usr/local/bin/c++ -DGTEST_HAS_RTTI=0 -DMLIR_CAPI_BUILDING_LIBRARY=1 -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GLIBCXX_USE_CXX11_ABI=1 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/tcwg-buildbot/worker/clang-aarch64-sve2-vla/stage1/tools/mlir/lib/CAPI/Dialect -I/home/tcwg-buildbot/worker/clang-aarch64-sve2-vla/llvm/mlir/lib/CAPI/Dialect -I/home/tcwg-buildbot/worker/clang-aarch64-sve2-vla/stage1/tools/mlir/include -I/home/tcwg-buildbot/worker/clang-aarch64-sve2-vla/llvm/mlir/include -I/home/tcwg-buildbot/worker/clang-aarch64-sve2-vla/stage1/include -I/home/tcwg-buildbot/worker/clang-aarch64-sve2-vla/llvm/llvm/include -mcpu=neoverse-v2 -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wno-pass-failed -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -Wundef -Werror=mismatched-tags -O3 -DNDEBUG -std=c++17 -fvisibility=hidden  -fno-exceptions -funwind-tables -fno-rtti -UNDEBUG -MD -MT tools/mlir/lib/CAPI/Dialect/CMakeFiles/obj.MLIRCAPIComplex.dir/Complex.cpp.o -MF tools/mlir/lib/CAPI/Dialect/CMakeFiles/obj.MLIRCAPIComplex.dir/Complex.cpp.o.d -o tools/mlir/lib/CAPI/Dialect/CMakeFiles/obj.MLIRCAPIComplex.dir/Complex.cpp.o -c /home/tcwg-buildbot/worker/clang-aarch64-sve2-vla/llvm/mlir/lib/CAPI/Dialect/Complex.cpp
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:15:45: error: no member named 'complex' in namespace 'mlir'
   15 |                                       mlir::complex::ComplexDialect)
      |                                       ~~~~~~^
../llvm/mlir/include/mlir/CAPI/Registration.h:39:30: note: expanded from macro 'MLIR_DEFINE_CAPI_DIALECT_REGISTRATION'
   39 |     unwrap(registry)->insert<ClassName>();                                     \
      |                              ^~~~~~~~~
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:15:45: error: no member named 'complex' in namespace 'mlir'
   15 |                                       mlir::complex::ComplexDialect)
      |                                       ~~~~~~^
../llvm/mlir/include/mlir/CAPI/Registration.h:42:51: note: expanded from macro 'MLIR_DEFINE_CAPI_DIALECT_REGISTRATION'
   42 |     return wrap(unwrap(context)->getOrLoadDialect<ClassName>());               \
      |                                                   ^~~~~~~~~
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:15:45: error: no member named 'complex' in namespace 'mlir'
   15 |                                       mlir::complex::ComplexDialect)
      |                                       ~~~~~~^
../llvm/mlir/include/mlir/CAPI/Registration.h:45:17: note: expanded from macro 'MLIR_DEFINE_CAPI_DIALECT_REGISTRATION'
   45 |     return wrap(ClassName::getDialectNamespace());                             \
      |                 ^~~~~~~~~
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:18:14: error: use of undeclared identifier 'ComplexAttr'
   18 |   return isa<ComplexAttr>(unwrap(attr));
      |              ^~~~~~~~~~~
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:24:7: error: use of undeclared identifier 'complex'
   24 |       complex::NumberAttr::get(cast<ComplexType>(unwrap(type)), real, imag));
      |       ^
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:24:37: error: unknown type name 'ComplexType'; did you mean 'mlir::ComplexType'?
   24 |       complex::NumberAttr::get(cast<ComplexType>(unwrap(type)), real, imag));
      |                                     ^~~~~~~~~~~
      |                                     mlir::ComplexType
tools/mlir/include/mlir/IR/BuiltinTypes.h.inc:733:7: note: 'mlir::ComplexType' declared here
  733 | class ComplexType : public ::mlir::Type::TypeBase<ComplexType, ::mlir::Type, detail::ComplexTypeStorage> {
      |       ^
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:24:32: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
   24 |       complex::NumberAttr::get(cast<ComplexType>(unwrap(type)), real, imag));
      |                                ^
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:29:15: error: use of undeclared identifier 'complex'
   29 |   return wrap(complex::NumberAttr::getChecked(
      |               ^
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:30:25: error: unknown type name 'ComplexType'; did you mean 'mlir::ComplexType'?
   30 |       unwrap(loc), cast<ComplexType>(unwrap(type)), real, imag));
      |                         ^~~~~~~~~~~
      |                         mlir::ComplexType
tools/mlir/include/mlir/IR/BuiltinTypes.h.inc:733:7: note: 'mlir::ComplexType' declared here
  733 | class ComplexType : public ::mlir::Type::TypeBase<ComplexType, ::mlir::Type, detail::ComplexTypeStorage> {
      |       ^
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:30:20: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
   30 |       unwrap(loc), cast<ComplexType>(unwrap(type)), real, imag));
      |                    ^
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:34:15: error: use of undeclared identifier 'complex'
   34 |   return cast<complex::NumberAttr>(unwrap(attr)).getRealAsDouble();
      |               ^
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:38:15: error: use of undeclared identifier 'complex'
   38 |   return cast<complex::NumberAttr>(unwrap(attr)).getImagAsDouble();
      |               ^
../llvm/mlir/lib/CAPI/Dialect/Complex.cpp:42:15: error: use of undeclared identifier 'complex'
   42 |   return wrap(complex::NumberAttr::getTypeID());
      |               ^
```

This PR fixes these errors.
Tested on local that `MLIRCAPIComplex` target (the one erroring) now compiles correctly on local.