### PR TITLE
[AArch64][NFC] Fix label checks on ZCM tests

### DIFF
--- a/llvm/test/CodeGen/AArch64/arm64-zero-cycle-regmove-fpr.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-zero-cycle-regmove-fpr.ll
@@ -1,12 +1,13 @@
-; RUN: llc < %s -mtriple=arm64-linux-gnu | FileCheck %s -check-prefixes=NOZCM-FPR128-CPU --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=generic | FileCheck %s -check-prefixes=NOZCM-FPR128-CPU --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 | FileCheck %s -check-prefixes=ZCM-FPR128-CPU --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 -mattr=-zcm-fpr128 | FileCheck %s -check-prefixes=NOZCM-FPR128-ATTR --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mattr=+zcm-fpr128 | FileCheck %s -check-prefixes=ZCM-FPR128-ATTR --match-full-lines
+; RUN: llc < %s -mtriple=arm64-linux-gnu | FileCheck %s -check-prefixes=ALL,NOZCM-FPR128-CPU --match-full-lines
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=generic | FileCheck %s -check-prefixes=ALL,NOZCM-FPR128-CPU --match-full-lines
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 | FileCheck %s -check-prefixes=ALL,ZCM-FPR128-CPU --match-full-lines
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 -mattr=-zcm-fpr128 | FileCheck %s -check-prefixes=ALL,NOZCM-FPR128-ATTR --match-full-lines
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mattr=+zcm-fpr128 | FileCheck %s -check-prefixes=ALL,ZCM-FPR128-ATTR --match-full-lines
 
 define void @zero_cycle_regmove_FPR64(double %a, double %b, double %c, double %d) {
 entry:
-; CHECK-LABEL: t:
+; ALL-LABEL: {{_?zero_cycle_regmove_FPR64}}:{{ *}}{{(;|//)}}{{ *}}@zero_cycle_regmove_FPR64
+
 ; NOZCM-FPR128-CPU: fmov d0, d2
 ; NOZCM-FPR128-CPU: fmov d1, d3
 ; NOZCM-FPR128-CPU: fmov [[REG2:d[0-9]+]], d3
@@ -47,7 +48,8 @@ declare float @foo_double(double, double)
 
 define void @zero_cycle_regmove_FPR32(float %a, float %b, float %c, float %d) {
 entry:
-; CHECK-LABEL: t:
+; ALL-LABEL: {{_?zero_cycle_regmove_FPR32}}:{{ *}}{{(;|//)}}{{ *}}@zero_cycle_regmove_FPR32
+
 ; NOZCM-FPR128-CPU: fmov s0, s2
 ; NOZCM-FPR128-CPU: fmov s1, s3
 ; NOZCM-FPR128-CPU: fmov [[REG2:s[0-9]+]], s3
@@ -88,7 +90,8 @@ declare float @foo_float(float, float)
 
 define void @zero_cycle_regmove_FPR16(half %a, half %b, half %c, half %d) {
 entry:
-; CHECK-LABEL: t:
+; ALL-LABEL: {{_?zero_cycle_regmove_FPR16}}:{{ *}}{{(;|//)}}{{ *}}@zero_cycle_regmove_FPR16
+
 ; NOZCM-FPR128-CPU: fmov s0, s2
 ; NOZCM-FPR128-CPU: fmov s1, s3
 ; NOZCM-FPR128-CPU: fmov [[REG2:s[0-9]+]], s3

--- a/llvm/test/CodeGen/AArch64/arm64-zero-cycle-regmove-fpr.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-zero-cycle-regmove-fpr.ll
@@ -1,12 +1,12 @@
-; RUN: llc < %s -mtriple=arm64-linux-gnu | FileCheck %s -check-prefixes=ALL,NOZCM-FPR128-CPU --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=generic | FileCheck %s -check-prefixes=ALL,NOZCM-FPR128-CPU --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 | FileCheck %s -check-prefixes=ALL,ZCM-FPR128-CPU --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 -mattr=-zcm-fpr128 | FileCheck %s -check-prefixes=ALL,NOZCM-FPR128-ATTR --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mattr=+zcm-fpr128 | FileCheck %s -check-prefixes=ALL,ZCM-FPR128-ATTR --match-full-lines
+; RUN: llc < %s -mtriple=arm64-linux-gnu | FileCheck %s -check-prefixes=CHECK,NOZCM-FPR128-CPU --match-full-lines
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=generic | FileCheck %s -check-prefixes=CHECK,NOZCM-FPR128-CPU --match-full-lines
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 | FileCheck %s -check-prefixes=CHECK,ZCM-FPR128-CPU --match-full-lines
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 -mattr=-zcm-fpr128 | FileCheck %s -check-prefixes=CHECK,NOZCM-FPR128-ATTR --match-full-lines
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mattr=+zcm-fpr128 | FileCheck %s -check-prefixes=CHECK,ZCM-FPR128-ATTR --match-full-lines
 
 define void @zero_cycle_regmove_FPR64(double %a, double %b, double %c, double %d) {
 entry:
-; ALL-LABEL: {{_?zero_cycle_regmove_FPR64}}:{{ *}}{{(;|//)}}{{ *}}@zero_cycle_regmove_FPR64
+; CHECK-LABEL: {{_?zero_cycle_regmove_FPR64}}:{{ *}}{{(;|//)}}{{ *}}@zero_cycle_regmove_FPR64
 
 ; NOZCM-FPR128-CPU: fmov d0, d2
 ; NOZCM-FPR128-CPU: fmov d1, d3
@@ -48,7 +48,7 @@ declare float @foo_double(double, double)
 
 define void @zero_cycle_regmove_FPR32(float %a, float %b, float %c, float %d) {
 entry:
-; ALL-LABEL: {{_?zero_cycle_regmove_FPR32}}:{{ *}}{{(;|//)}}{{ *}}@zero_cycle_regmove_FPR32
+; CHECK-LABEL: {{_?zero_cycle_regmove_FPR32}}:{{ *}}{{(;|//)}}{{ *}}@zero_cycle_regmove_FPR32
 
 ; NOZCM-FPR128-CPU: fmov s0, s2
 ; NOZCM-FPR128-CPU: fmov s1, s3
@@ -90,7 +90,7 @@ declare float @foo_float(float, float)
 
 define void @zero_cycle_regmove_FPR16(half %a, half %b, half %c, half %d) {
 entry:
-; ALL-LABEL: {{_?zero_cycle_regmove_FPR16}}:{{ *}}{{(;|//)}}{{ *}}@zero_cycle_regmove_FPR16
+; CHECK-LABEL: {{_?zero_cycle_regmove_FPR16}}:{{ *}}{{(;|//)}}{{ *}}@zero_cycle_regmove_FPR16
 
 ; NOZCM-FPR128-CPU: fmov s0, s2
 ; NOZCM-FPR128-CPU: fmov s1, s3

--- a/llvm/test/CodeGen/AArch64/arm64-zero-cycle-regmove-gpr.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-zero-cycle-regmove-gpr.ll
@@ -1,12 +1,13 @@
-; RUN: llc < %s -mtriple=arm64-linux-gnu | FileCheck %s -check-prefixes=NOTCPU-LINUX --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=generic | FileCheck %s -check-prefixes=NOTCPU-APPLE --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 | FileCheck %s -check-prefixes=CPU --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 -mattr=-zcm-gpr64 | FileCheck %s -check-prefixes=NOTATTR --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mattr=+zcm-gpr64 | FileCheck %s -check-prefixes=ATTR --match-full-lines
+; RUN: llc < %s -mtriple=arm64-linux-gnu | FileCheck %s -check-prefixes=ALL,NOTCPU-LINUX 
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=generic | FileCheck %s -check-prefixes=ALL,NOTCPU-APPLE 
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 | FileCheck %s -check-prefixes=ALL,CPU 
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 -mattr=-zcm-gpr64 | FileCheck %s -check-prefixes=ALL,NOTATTR 
+; RUN: llc < %s -mtriple=arm64-apple-macosx -mattr=+zcm-gpr64 | FileCheck %s -check-prefixes=ALL,ATTR 
 
 define void @zero_cycle_regmove_GPR32(i32 %a, i32 %b, i32 %c, i32 %d) {
 entry:
-; CHECK-LABEL: t:
+; ALL-LABEL: {{_?zero_cycle_regmove_GPR32}}:{{ *}}{{(;|//)}}{{ *}}@zero_cycle_regmove_GPR32
+
 ; NOTCPU-LINUX: mov w0, w2
 ; NOTCPU-LINUX: mov w1, w3
 ; NOTCPU-LINUX: mov [[REG2:w[0-9]+]], w3


### PR DESCRIPTION
Previous checks were dead code. Now we share single `ALL-LABEL` checks by all run lines. Note: the regex is currently needed for `--match-full-lines` which is needed by itself because the previous versions of these tests suffered from false positives due to partial matching: https://github.com/llvm/llvm-project/pull/143680.