### PR TITLE
[ADT] Fix MSVC build after iterator C++20 fix

### DIFF
--- a/llvm/include/llvm/ADT/iterator.h
+++ b/llvm/include/llvm/ADT/iterator.h
@@ -85,7 +85,9 @@ public:
   using pointer = PointerT;
   using reference = ReferenceT;
 
-protected:
+  // Note: These were previously protected, but MSVC has trouble with SFINAE
+  // accessing protected members in derived class templates (specifically in
+  // iterator_adaptor_base::operator-). Making them public fixes the build.
   enum {
     IsRandomAccess = std::is_base_of<std::random_access_iterator_tag,
                                      IteratorCategoryT>::value,
@@ -93,6 +95,7 @@ protected:
                                       IteratorCategoryT>::value,
   };
 
+protected:
   /// A proxy object for computing a reference via indirecting a copy of an
   /// iterator. This is used in APIs which need to produce a reference via
   /// indirection but for which the iterator object might be a temporary. The


### PR DESCRIPTION
Fixes an MSCV build issue after the C++20 fix in https://github.com/llvm/llvm-project/pull/169772. See the [failure log](https://productionresultssa1.blob.core.windows.net/actions-results/604d315e-edbd-401f-9a85-9ec5fcbc4996/workflow-job-run-99b94847-47a4-5b95-9933-44db3e32a2a7/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-12-24T11%3A16%3A19Z&sig=3leOtxGMlJmAMzOCtakzD8%2FOQCXF2HfflooR%2Bm%2Bt7Ng%3D&ske=2025-12-24T21%3A53%3A06Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-12-24T09%3A53%3A06Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2025-12-24T11%3A06%3A14Z&sv=2025-11-05) in the IREE downstream project.

Making IsRandomAccess, IsBidirectional public ensures that they are always accessible, avoiding the access-related SFINAE ambiguity that causes different compilers to handle this differently.

The build is passing after this change: https://github.com/iree-org/iree/actions/runs/20485132054/job/58865989220?pr=22979
