### PR TITLE
[dsymutil] Add new argument allow_invalid_macho

### DIFF
--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -883,7 +883,7 @@ bool DwarfLinkerForBinary::linkImpl(
       ObjectType == Linker::OutputFileType::Object)
     return MachOUtils::generateDsymCompanion(
         Options.VFS, Map, *Streamer->getAsmPrinter().OutStreamer, OutFile,
-        RelocationsToApply);
+        RelocationsToApply, Options.AllowInvalidMachO);
 
   Streamer->finish();
   return true;

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -883,7 +883,7 @@ bool DwarfLinkerForBinary::linkImpl(
       ObjectType == Linker::OutputFileType::Object)
     return MachOUtils::generateDsymCompanion(
         Options.VFS, Map, *Streamer->getAsmPrinter().OutStreamer, OutFile,
-        RelocationsToApply, Options.AllowSliceSectionHeaderOffsetOverflow);
+        RelocationsToApply, Options.AllowSectionHeaderOffsetOverflow);
 
   Streamer->finish();
   return true;

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -883,7 +883,7 @@ bool DwarfLinkerForBinary::linkImpl(
       ObjectType == Linker::OutputFileType::Object)
     return MachOUtils::generateDsymCompanion(
         Options.VFS, Map, *Streamer->getAsmPrinter().OutStreamer, OutFile,
-        RelocationsToApply, Options.AllowInvalidMachO);
+        RelocationsToApply, Options.AllowSliceSectionHeaderOffsetOverflow);
 
   Streamer->finish();
   return true;

--- a/llvm/tools/dsymutil/LinkUtils.h
+++ b/llvm/tools/dsymutil/LinkUtils.h
@@ -123,6 +123,10 @@ struct LinkOptions {
   bool IncludeSwiftModulesFromInterface = false;
   /// @}
 
+  /// Whether to allow generating Mach-O files that exceed certain format
+  /// limitations, such as sections with file offsets greater than 4GB.
+  bool AllowInvalidMachO = false;
+
   LinkOptions() = default;
 };
 

--- a/llvm/tools/dsymutil/LinkUtils.h
+++ b/llvm/tools/dsymutil/LinkUtils.h
@@ -123,9 +123,9 @@ struct LinkOptions {
   bool IncludeSwiftModulesFromInterface = false;
   /// @}
 
-  /// Whether to allow generating Mach-O files that exceed certain format
-  /// limitations, such as sections with file offsets greater than 4GB.
-  bool AllowInvalidMachO = false;
+  /// Whether to allow emitting Mach-O where, within a single slice, section
+  /// header offsets (section.offset, 32-bit) exceed 4GB (non-standard).
+  bool AllowSliceSectionHeaderOffsetOverflow = false;
 
   LinkOptions() = default;
 };

--- a/llvm/tools/dsymutil/LinkUtils.h
+++ b/llvm/tools/dsymutil/LinkUtils.h
@@ -125,7 +125,7 @@ struct LinkOptions {
 
   /// Whether to allow emitting Mach-O where, within a single slice, section
   /// header offsets (section.offset, 32-bit) exceed 4GB (non-standard).
-  bool AllowSliceSectionHeaderOffsetOverflow = false;
+  bool AllowSectionHeaderOffsetOverflow = false;
 
   LinkOptions() = default;
 };

--- a/llvm/tools/dsymutil/MachOUtils.cpp
+++ b/llvm/tools/dsymutil/MachOUtils.cpp
@@ -322,9 +322,10 @@ static void transferSegmentAndSections(
 }
 
 // Write the __DWARF segment load command to the output file.
-static bool createDwarfSegment(const MCAssembler& Asm,uint64_t VMAddr, uint64_t FileOffset,
-                               uint64_t FileSize, unsigned NumSections,
-                                MachObjectWriter &Writer) {
+static bool createDwarfSegment(const MCAssembler &Asm, uint64_t VMAddr,
+                               uint64_t FileOffset, uint64_t FileSize,
+                               unsigned NumSections, MachObjectWriter &Writer,
+                               bool AllowInvalidMachO) {
   Writer.writeSegmentLoadCommand("__DWARF", NumSections, VMAddr,
                                  alignTo(FileSize, 0x1000), FileOffset,
                                  FileSize, /* MaxProt */ 7,
@@ -340,7 +341,7 @@ static bool createDwarfSegment(const MCAssembler& Asm,uint64_t VMAddr, uint64_t 
       VMAddr = alignTo(VMAddr, Alignment);
       FileOffset = alignTo(FileOffset, Alignment);
     }
-    if (FileOffset > UINT32_MAX)
+    if (FileOffset > UINT32_MAX && !AllowInvalidMachO)
       return error("section " + Sec->getName() +
                    "'s file offset exceeds 4GB."
                    " Refusing to produce an invalid Mach-O file.");
@@ -374,7 +375,8 @@ bool generateDsymCompanion(
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS, const DebugMap &DM,
     MCStreamer &MS, raw_fd_ostream &OutFile,
     const std::vector<MachOUtils::DwarfRelocationApplicationInfo>
-        &RelocationsToApply) {
+        &RelocationsToApply,
+    bool AllowInvalidMachO) {
   auto &ObjectStreamer = static_cast<MCObjectStreamer &>(MS);
   MCAssembler &MCAsm = ObjectStreamer.getAssembler();
   auto &Writer = static_cast<MachObjectWriter &>(MCAsm.getWriter());
@@ -585,8 +587,9 @@ bool generateDsymCompanion(
   }
 
   // Write the load command for the __DWARF segment.
-  if (!createDwarfSegment(MCAsm, DwarfVMAddr, DwarfSegmentStart, DwarfSegmentSize,
-                          NumDwarfSections, Writer))
+  if (!createDwarfSegment(MCAsm, DwarfVMAddr, DwarfSegmentStart,
+                          DwarfSegmentSize, NumDwarfSections, Writer,
+                          AllowInvalidMachO))
     return false;
 
   assert(OutFile.tell() == LoadCommandSize + HeaderSize);

--- a/llvm/tools/dsymutil/MachOUtils.cpp
+++ b/llvm/tools/dsymutil/MachOUtils.cpp
@@ -325,7 +325,7 @@ static void transferSegmentAndSections(
 static bool createDwarfSegment(const MCAssembler &Asm, uint64_t VMAddr,
                                uint64_t FileOffset, uint64_t FileSize,
                                unsigned NumSections, MachObjectWriter &Writer,
-                               bool AllowSliceSectionHeaderOffsetOverflow) {
+                               bool AllowSectionHeaderOffsetOverflow) {
   Writer.writeSegmentLoadCommand("__DWARF", NumSections, VMAddr,
                                  alignTo(FileSize, 0x1000), FileOffset,
                                  FileSize, /* MaxProt */ 7,
@@ -348,7 +348,7 @@ static bool createDwarfSegment(const MCAssembler &Asm, uint64_t VMAddr,
     // such non-standard Mach-O, compatible readers can reconstruct the true
     // 64-bit offsets by walking sections in order and accumulating the sizes of
     // preceding sections.
-    if (FileOffset > UINT32_MAX && !AllowSliceSectionHeaderOffsetOverflow)
+    if (FileOffset > UINT32_MAX && !AllowSectionHeaderOffsetOverflow)
       return error("section " + Sec->getName() +
                    "'s file offset exceeds 4GB."
                    " Refusing to produce an invalid Mach-O file.");
@@ -383,7 +383,7 @@ bool generateDsymCompanion(
     MCStreamer &MS, raw_fd_ostream &OutFile,
     const std::vector<MachOUtils::DwarfRelocationApplicationInfo>
         &RelocationsToApply,
-    bool AllowSliceSectionHeaderOffsetOverflow) {
+    bool AllowSectionHeaderOffsetOverflow) {
   auto &ObjectStreamer = static_cast<MCObjectStreamer &>(MS);
   MCAssembler &MCAsm = ObjectStreamer.getAssembler();
   auto &Writer = static_cast<MachObjectWriter &>(MCAsm.getWriter());
@@ -596,7 +596,7 @@ bool generateDsymCompanion(
   // Write the load command for the __DWARF segment.
   if (!createDwarfSegment(MCAsm, DwarfVMAddr, DwarfSegmentStart,
                           DwarfSegmentSize, NumDwarfSections, Writer,
-                          AllowSliceSectionHeaderOffsetOverflow))
+                          AllowSectionHeaderOffsetOverflow))
     return false;
 
   assert(OutFile.tell() == LoadCommandSize + HeaderSize);

--- a/llvm/tools/dsymutil/MachOUtils.h
+++ b/llvm/tools/dsymutil/MachOUtils.h
@@ -60,7 +60,7 @@ bool generateDsymCompanion(
     MCStreamer &MS, raw_fd_ostream &OutFile,
     const std::vector<MachOUtils::DwarfRelocationApplicationInfo>
         &RelocationsToApply,
-    bool AllowSliceSectionHeaderOffsetOverflow);
+    bool AllowSectionHeaderOffsetOverflow);
 
 std::string getArchName(StringRef Arch);
 } // namespace MachOUtils

--- a/llvm/tools/dsymutil/MachOUtils.h
+++ b/llvm/tools/dsymutil/MachOUtils.h
@@ -59,7 +59,8 @@ bool generateDsymCompanion(
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS, const DebugMap &DM,
     MCStreamer &MS, raw_fd_ostream &OutFile,
     const std::vector<MachOUtils::DwarfRelocationApplicationInfo>
-        &RelocationsToApply);
+        &RelocationsToApply,
+    bool AllowInvalidMachO);
 
 std::string getArchName(StringRef Arch);
 } // namespace MachOUtils

--- a/llvm/tools/dsymutil/MachOUtils.h
+++ b/llvm/tools/dsymutil/MachOUtils.h
@@ -60,7 +60,7 @@ bool generateDsymCompanion(
     MCStreamer &MS, raw_fd_ostream &OutFile,
     const std::vector<MachOUtils::DwarfRelocationApplicationInfo>
         &RelocationsToApply,
-    bool AllowInvalidMachO);
+    bool AllowSliceSectionHeaderOffsetOverflow);
 
 std::string getArchName(StringRef Arch);
 } // namespace MachOUtils

--- a/llvm/tools/dsymutil/Options.td
+++ b/llvm/tools/dsymutil/Options.td
@@ -109,9 +109,10 @@ def update: F<"update">,
   HelpText<"Updates existing dSYM files to contain the latest accelerator tables and other DWARF optimizations.">,
   Group<grp_general>;
 
-def allow_invalid_macho: F<"allow-invalid-macho">,
-  HelpText<"Allow generating Mach-O files that exceed certain format limitations, such as sections with file offsets greater than 4GB."
-           "Use with caution, as such files may not be compatible with all tools.">,
+def allow_slice_section_header_offset_overflow : F<"allow-slice-section-header-offset-overflow">,
+  HelpText<"Allow emitting Mach-O where, within a single slice, section header offsets (section.offset, 32-bit) exceed the 4GB limit (non-standard). "
+           "This option overrides dsymutil's per-slice 4GB check when writing section headers. "
+           "Use with caution: some tools may not be able to read the output.">,
   Group<grp_general>;
 
 def: Flag<["-"], "u">,

--- a/llvm/tools/dsymutil/Options.td
+++ b/llvm/tools/dsymutil/Options.td
@@ -108,6 +108,12 @@ def fat64: F<"fat64">,
 def update: F<"update">,
   HelpText<"Updates existing dSYM files to contain the latest accelerator tables and other DWARF optimizations.">,
   Group<grp_general>;
+
+def allow_invalid_macho: F<"allow-invalid-macho">,
+  HelpText<"Allow generating Mach-O files that exceed certain format limitations, such as sections with file offsets greater than 4GB."
+           "Use with caution, as such files may not be compatible with all tools.">,
+  Group<grp_general>;
+
 def: Flag<["-"], "u">,
   Alias<update>,
   HelpText<"Alias for --update">,

--- a/llvm/tools/dsymutil/Options.td
+++ b/llvm/tools/dsymutil/Options.td
@@ -109,10 +109,10 @@ def update: F<"update">,
   HelpText<"Updates existing dSYM files to contain the latest accelerator tables and other DWARF optimizations.">,
   Group<grp_general>;
 
-def allow_slice_section_header_offset_overflow : F<"allow-slice-section-header-offset-overflow">,
-  HelpText<"Allow emitting Mach-O where, within a single slice, section header offsets (section.offset, 32-bit) exceed the 4GB limit (non-standard). "
-           "This option overrides dsymutil's per-slice 4GB check when writing section headers. "
-           "Use with caution: some tools may not be able to read the output.">,
+def allow_section_header_offset_overflow : F<"allow-section-header-offset-overflow">,
+  HelpText<"Allow emitting a section offset (32-bit) that, when applied, would exceed the Mach-O 4GB limit. "
+           "This leverages the fact that the offset can be computed as a 64-bit value if the sections are ordered (always the case for dsymutil). "
+           "Note that this generates an invalid Mach-O and requires explicit support by the tools that will need to consume it.">,
   Group<grp_general>;
 
 def: Flag<["-"], "u">,

--- a/llvm/tools/dsymutil/Options.td
+++ b/llvm/tools/dsymutil/Options.td
@@ -110,9 +110,9 @@ def update: F<"update">,
   Group<grp_general>;
 
 def allow_section_header_offset_overflow : F<"allow-section-header-offset-overflow">,
-  HelpText<"Allow emitting a section offset (32-bit) that, when applied, would exceed the Mach-O 4GB limit. "
-           "This leverages the fact that the offset can be computed as a 64-bit value if the sections are ordered (always the case for dsymutil). "
-           "Note that this generates an invalid Mach-O and requires explicit support by the tools that will need to consume it.">,
+  HelpText<"Allow emitting a 32-bit section offset that, when applied, may exceed the Mach-O 4 GB limit. "
+           "This leverages the fact that the offset can be computed as a 64-bit value when sections are ordered (which is always the case for dsymutil). "
+           "Note that this produces an invalid Mach-O and requires explicit support from the tools that consume it.">,
   Group<grp_general>;
 
 def: Flag<["-"], "u">,

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -315,7 +315,8 @@ static Expected<DsymutilOptions> getOptions(opt::InputArgList &Args) {
   Options.LinkOpts.Fat64 = Args.hasArg(OPT_fat64);
   Options.LinkOpts.KeepFunctionForStatic =
       Args.hasArg(OPT_keep_func_for_static);
-  Options.LinkOpts.AllowInvalidMachO = Args.hasArg(OPT_allow_invalid_macho);
+  Options.LinkOpts.AllowSliceSectionHeaderOffsetOverflow =
+      Args.hasArg(OPT_allow_slice_section_header_offset_overflow);
 
   if (opt::Arg *ReproducerPath = Args.getLastArg(OPT_use_reproducer)) {
     Options.ReproMode = ReproducerMode::Use;

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -315,6 +315,7 @@ static Expected<DsymutilOptions> getOptions(opt::InputArgList &Args) {
   Options.LinkOpts.Fat64 = Args.hasArg(OPT_fat64);
   Options.LinkOpts.KeepFunctionForStatic =
       Args.hasArg(OPT_keep_func_for_static);
+  Options.LinkOpts.AllowInvalidMachO = Args.hasArg(OPT_allow_invalid_macho);
 
   if (opt::Arg *ReproducerPath = Args.getLastArg(OPT_use_reproducer)) {
     Options.ReproMode = ReproducerMode::Use;

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -315,8 +315,8 @@ static Expected<DsymutilOptions> getOptions(opt::InputArgList &Args) {
   Options.LinkOpts.Fat64 = Args.hasArg(OPT_fat64);
   Options.LinkOpts.KeepFunctionForStatic =
       Args.hasArg(OPT_keep_func_for_static);
-  Options.LinkOpts.AllowSliceSectionHeaderOffsetOverflow =
-      Args.hasArg(OPT_allow_slice_section_header_offset_overflow);
+  Options.LinkOpts.AllowSectionHeaderOffsetOverflow =
+      Args.hasArg(OPT_allow_section_header_offset_overflow);
 
   if (opt::Arg *ReproducerPath = Args.getLastArg(OPT_use_reproducer)) {
     Options.ReproMode = ReproducerMode::Use;


### PR DESCRIPTION
Similar to the issue discussed in [#165940](https://github.com/llvm/llvm-project/pull/165940)￼ and in some apps I’ve seen at work, we’ve observed dSYM files being generated where a section’s offset exceeds 4GB.

This seems to happen because many DWARF sections produced for DWARF4 end up with an alignment of 0. Before [PR #168925](https://github.com/llvm/llvm-project/pull/168925)￼ (which added validation for sections with a zero alignment attribute), this could go unnoticed and result in an invalid MachO.

However, such a dSYM is effectively an invalid Mach-O file today. Unless/until Mach-O explicitly defines standards like:
["32-bit section offsets can exceed 4G but must be ordered for 64-bit offset reconstruction"](https://github.com/llvm/llvm-project/pull/165940#issuecomment-3483238444), I think the proper approach is to add a new argument to support this.