### PR TITLE
[InstCombine] Fold `(select C, (x bin_op a), x) bin_op b` into `x bin_op select C, (a bin_op b), b`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -863,6 +863,9 @@ Instruction *InstCombinerImpl::foldAddWithConstant(BinaryOperator &Add) {
   if (Instruction *NV = foldBinOpIntoSelectOrPhi(Add))
     return NV;
 
+  if (Instruction *FoldedLogic = foldBinOpSelectBinOp(Add))
+    return FoldedLogic;
+
   Value *X;
   Constant *Op00C;
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -4077,6 +4077,9 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
   if (Instruction *FoldedLogic = foldBinOpIntoSelectOrPhi(I))
     return FoldedLogic;
 
+  if (Instruction *FoldedLogic = foldBinOpSelectBinOp(I))
+    return FoldedLogic;
+
   if (Instruction *BitOp = matchBSwapOrBitReverse(I, /*MatchBSwaps*/ true,
                                                   /*MatchBitReversals*/ true))
     return BitOp;
@@ -5381,6 +5384,9 @@ Instruction *InstCombinerImpl::visitXor(BinaryOperator &I) {
   }
 
   if (Instruction *FoldedLogic = foldBinOpIntoSelectOrPhi(I))
+    return FoldedLogic;
+
+  if (Instruction *FoldedLogic = foldBinOpSelectBinOp(I))
     return FoldedLogic;
 
   // Y ^ (X | Y) --> X & ~Y

--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -667,6 +667,8 @@ public:
                                 bool FoldWithMultiUse = false,
                                 bool SimplifyBothArms = false);
 
+  Instruction *foldBinOpSelectBinOp(BinaryOperator &Op);
+
   /// This is a convenience wrapper function for the above two functions.
   Instruction *foldBinOpIntoSelectOrPhi(BinaryOperator &I);
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -317,6 +317,9 @@ Instruction *InstCombinerImpl::visitMul(BinaryOperator &I) {
   if (Instruction *FoldedMul = foldBinOpIntoSelectOrPhi(I))
     return FoldedMul;
 
+  if (Instruction *FoldedLogic = foldBinOpSelectBinOp(I))
+    return FoldedLogic;
+
   if (Value *FoldedMul = foldMulSelectToNegate(I, Builder))
     return replaceInstUsesWith(I, FoldedMul);
 

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1876,6 +1876,54 @@ static Value *simplifyInstructionWithPHI(Instruction &I, PHINode *PN,
   return nullptr;
 }
 
+// In some cases it is beneficial to fold a select into a binary operator.
+// For example:
+//   %1 = or %in, 4
+//   %2 = select %cond, %1, %in
+//   %3 = or %2, 1
+// =>
+//   %1 = select i1 %cond, 5, 1
+//   %2 = or %1, %in
+Instruction *InstCombinerImpl::foldBinOpSelectBinOp(BinaryOperator &Op) {
+  assert(Op.isAssociative() && "The operation must be associative!");
+
+  SelectInst *SI = dyn_cast<SelectInst>(Op.getOperand(0));
+  Value *PotentialConst = Op.getOperand(1);
+
+  Constant *Const;
+  if (!SI || !PotentialConst || !match(PotentialConst, m_ImmConstant(Const)) ||
+      !Op.hasOneUse() || !SI->hasOneUse())
+    return nullptr;
+
+  Value *TV = SI->getTrueValue();
+  Value *FV = SI->getFalseValue();
+  Value *Input, *NewTV, *NewFV;
+  Constant *Const2;
+
+  if (!TV || !FV)
+    return nullptr;
+
+  if (TV->hasOneUse() && match(TV, m_BinOp(Op.getOpcode(), m_Specific(FV),
+                                           m_ImmConstant(Const2)))) {
+    NewTV = ConstantFoldBinaryInstruction(Op.getOpcode(), Const, Const2);
+    NewFV = Const;
+    Input = FV;
+  } else if (FV->hasOneUse() &&
+             match(FV, m_BinOp(Op.getOpcode(), m_Specific(TV),
+                               m_ImmConstant(Const2)))) {
+    NewTV = Const;
+    NewFV = ConstantFoldBinaryInstruction(Op.getOpcode(), Const, Const2);
+    Input = TV;
+  } else
+    return nullptr;
+
+  if (!NewTV || !NewFV)
+    return nullptr;
+
+  Value *NewSI = Builder.CreateSelect(SI->getCondition(), NewTV, NewFV);
+  return BinaryOperator::Create(Op.getOpcode(), NewSI, Input);
+}
+
 Instruction *InstCombinerImpl::foldOpIntoPhi(Instruction &I, PHINode *PN,
                                              bool AllowMultipleUses) {
   unsigned NumPHIValues = PN->getNumIncomingValues();

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -650,9 +650,8 @@ define i8 @BinOpSelectBinOpMultiUseRegsWithSelect4(i8 %arg0, i8 %arg1, i1 %whatT
 define i8 @orSelectOrNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 1
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -680,9 +679,8 @@ define i8 @orSelectOrNoCommonBits2(i8 %arg0, i8 %arg1) {
 define i8 @orSelectOrReserved(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrReserved(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 2
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[ARG0]], i8 [[V1]]
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 13
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 13, i8 15
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -695,9 +693,8 @@ define i8 @orSelectOrReserved(i8 %arg0, i8 %arg1) {
 define i8 @orSelectOrSubset1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrSubset1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 2
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 13
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 15, i8 13
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -710,9 +707,8 @@ define i8 @orSelectOrSubset1(i8 %arg0, i8 %arg1) {
 define i8 @orSelectOrSubset2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrSubset2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 11
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 15, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -725,9 +721,8 @@ define i8 @orSelectOrSubset2(i8 %arg0, i8 %arg1) {
 define i8 @orSelectOrSomeCommon1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrSomeCommon1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 10
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 5
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 15, i8 5
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -740,9 +735,8 @@ define i8 @orSelectOrSomeCommon1(i8 %arg0, i8 %arg1) {
 define i8 @orSelectOrSomeCommon2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @orSelectOrSomeCommon2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 11
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 15, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -865,9 +859,8 @@ define i8 @andSelectandSame(i8 %arg0, i8 %arg1) {
 define i8 @xorSelectxorNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @xorSelectxorNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 4
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 1
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -895,9 +888,8 @@ define i8 @xorSelectxorNoCommonBits2(i8 %arg0, i8 %arg1) {
 define i8 @xorSelectxorSubset1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @xorSelectxorSubset1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 13
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 6, i8 13
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -910,9 +902,8 @@ define i8 @xorSelectxorSubset1(i8 %arg0, i8 %arg1) {
 define i8 @xorSelectxorSubset2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @xorSelectxorSubset2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 13
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 11
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 6, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -925,9 +916,8 @@ define i8 @xorSelectxorSubset2(i8 %arg0, i8 %arg1) {
 define i8 @xorSelectxorSomeCommon1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @xorSelectxorSomeCommon1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 5
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 14, i8 5
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -940,9 +930,8 @@ define i8 @xorSelectxorSomeCommon1(i8 %arg0, i8 %arg1) {
 define i8 @xorSelectxorSomeCommon2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @xorSelectxorSomeCommon2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 5
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 11
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 14, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -970,9 +959,8 @@ define i8 @xorSelectxorSame(i8 %arg0, i8 %arg1) {
 define i8 @addSelectaddNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 4
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 1
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1000,9 +988,8 @@ define i8 @addSelectaddNoCommonBits2(i8 %arg0, i8 %arg1) {
 define i8 @addSelectaddSubset1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddSubset1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 13
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 24, i8 13
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1015,9 +1002,8 @@ define i8 @addSelectaddSubset1(i8 %arg0, i8 %arg1) {
 define i8 @addSelectaddSubset2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddSubset2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 13
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 11
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 24, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1030,9 +1016,8 @@ define i8 @addSelectaddSubset2(i8 %arg0, i8 %arg1) {
 define i8 @addSelectaddSomeCommon1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddSomeCommon1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 5
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 16, i8 5
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1045,9 +1030,8 @@ define i8 @addSelectaddSomeCommon1(i8 %arg0, i8 %arg1) {
 define i8 @addSelectaddSomeCommon2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddSomeCommon2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 5
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 11
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 16, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1060,9 +1044,8 @@ define i8 @addSelectaddSomeCommon2(i8 %arg0, i8 %arg1) {
 define i8 @addSelectaddSame(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @addSelectaddSame(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 42
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 42
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 84, i8 42
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1121,9 +1104,8 @@ define i8 @subSelectsubNoCommonBitsConstOnLeft3(i8 %arg0, i8 %arg1) {
 define i8 @subSelectsubNoCommonBits1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubNoCommonBits1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -4
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -1
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 -5, i8 -1
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1151,9 +1133,8 @@ define i8 @subSelectsubNoCommonBits2(i8 %arg0, i8 %arg1) {
 define i8 @subSelectsubSubset1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubSubset1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -13
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 -24, i8 -13
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1166,9 +1147,8 @@ define i8 @subSelectsubSubset1(i8 %arg0, i8 %arg1) {
 define i8 @subSelectsubSubset2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubSubset2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -13
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -11
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 -24, i8 -11
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1181,9 +1161,8 @@ define i8 @subSelectsubSubset2(i8 %arg0, i8 %arg1) {
 define i8 @subSelectsubSomeCommon1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubSomeCommon1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -5
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 -16, i8 -5
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1196,9 +1175,8 @@ define i8 @subSelectsubSomeCommon1(i8 %arg0, i8 %arg1) {
 define i8 @subSelectsubSomeCommon2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubSomeCommon2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -5
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -11
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 -16, i8 -11
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1211,9 +1189,8 @@ define i8 @subSelectsubSomeCommon2(i8 %arg0, i8 %arg1) {
 define i8 @subSelectsubSame(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @subSelectsubSame(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -42
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -42
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 -84, i8 -42
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1257,9 +1234,8 @@ define i8 @mulSelectmulNoCommonBits2(i8 %arg0, i8 %arg1) {
 define i8 @mulSelectmulmulset1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulmulset1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 13
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 -113, i8 13
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1272,9 +1248,8 @@ define i8 @mulSelectmulmulset1(i8 %arg0, i8 %arg1) {
 define i8 @mulSelectmulmulset2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulmulset2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 13
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 11
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 -113, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1287,9 +1262,8 @@ define i8 @mulSelectmulmulset2(i8 %arg0, i8 %arg1) {
 define i8 @mulSelectmulSomeCommon1(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulSomeCommon1(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 11
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 5
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 55, i8 5
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1302,9 +1276,8 @@ define i8 @mulSelectmulSomeCommon1(i8 %arg0, i8 %arg1) {
 define i8 @mulSelectmulSomeCommon2(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulSomeCommon2(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 5
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 11
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 55, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1317,9 +1290,8 @@ define i8 @mulSelectmulSomeCommon2(i8 %arg0, i8 %arg1) {
 define i8 @mulSelectmulSame(i8 %arg0, i8 %arg1) {
 ; CHECK-LABEL: @mulSelectmulSame(
 ; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
-; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 42
-; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
-; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 42
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], i8 -28, i8 42
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[TMP1]], [[ARG0:%.*]]
 ; CHECK-NEXT:    ret i8 [[V3]]
 ;
   %v0 = icmp eq i8 %arg1, -1
@@ -1359,3 +1331,19 @@ define i8 @udivSelectudivSomeCommon1InfLoopRep(i8 %arg0, i8 %arg1, i1 %v0) {
   %v3 = udiv i8 %v2, 5
   ret i8 %v3
 }
+
+; vector tests
+define <4 x i8> @orSelectOrVectors(<4 x i8> %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrVectors(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[V0]], <4 x i8> <i8 5, i8 6, i8 27, i8 21>, <4 x i8> <i8 1, i8 4, i8 17, i8 5>
+; CHECK-NEXT:    [[V3:%.*]] = or <4 x i8> [[TMP1]], [[ARG0:%.*]]
+; CHECK-NEXT:    ret <4 x i8> [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or <4 x i8> %arg0,  <i8 4, i8 2, i8 11, i8 21>
+  %v2 = select i1 %v0, <4 x i8> %v1, <4 x i8> %arg0
+  %v3 = or <4 x i8> %v2, <i8 1, i8 4, i8 17, i8 5>
+  ret <4 x i8> %v3
+}
+

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -571,3 +571,791 @@ define i32 @OrSelectIcmpNonZero(i32 %a, i32 %b) {
   %or = or i32 %sel, %a
   ret i32 %or
 }
+
+define i8 @BinOpSelectBinOpMultiUseRegsWithSelect1(i8 %arg0, i8 %arg1, i1 %whatToReturn) {
+; CHECK-LABEL: @BinOpSelectBinOpMultiUseRegsWithSelect1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 1
+; CHECK-NEXT:    [[USE:%.*]] = add i8 [[V1]], 42
+; CHECK-NEXT:    [[RETVAL:%.*]] = select i1 [[WHATTORETURN:%.*]], i8 [[USE]], i8 [[V3]]
+; CHECK-NEXT:    ret i8 [[RETVAL]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 1, %v2
+  %use = add i8 %v1, 42
+  %retVal = select i1 %whatToReturn, i8 %use, i8 %v3
+  ret i8 %retVal
+}
+
+
+define i8 @BinOpSelectBinOpMultiUseRegsWithSelect2(i8 %arg0, i8 %arg1, i1 %whatToReturn) {
+; CHECK-LABEL: @BinOpSelectBinOpMultiUseRegsWithSelect2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 1
+; CHECK-NEXT:    [[USE:%.*]] = add i8 [[V2]], 42
+; CHECK-NEXT:    [[RETVAL:%.*]] = select i1 [[WHATTORETURN:%.*]], i8 [[USE]], i8 [[V3]]
+; CHECK-NEXT:    ret i8 [[RETVAL]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 1, %v2
+  %use = add i8 %v2, 42
+  %retVal = select i1 %whatToReturn, i8 %use, i8 %v3
+  ret i8 %retVal
+}
+
+define i8 @BinOpSelectBinOpMultiUseRegsWithSelect3(i8 %arg0, i8 %arg1, i1 %whatToReturn) {
+; CHECK-LABEL: @BinOpSelectBinOpMultiUseRegsWithSelect3(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 1
+; CHECK-NEXT:    [[RETVAL:%.*]] = select i1 [[WHATTORETURN:%.*]], i8 [[V1]], i8 [[V3]]
+; CHECK-NEXT:    ret i8 [[RETVAL]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 1, %v2
+  %retVal = select i1 %whatToReturn, i8 %v1, i8 %v3
+  ret i8 %retVal
+}
+
+define i8 @BinOpSelectBinOpMultiUseRegsWithSelect4(i8 %arg0, i8 %arg1, i1 %whatToReturn) {
+; CHECK-LABEL: @BinOpSelectBinOpMultiUseRegsWithSelect4(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[NOT_WHATTORETURN:%.*]] = xor i1 [[WHATTORETURN:%.*]], true
+; CHECK-NEXT:    [[V3:%.*]] = zext i1 [[NOT_WHATTORETURN]] to i8
+; CHECK-NEXT:    [[RETVAL:%.*]] = or i8 [[V2]], [[V3]]
+; CHECK-NEXT:    ret i8 [[RETVAL]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 1, %v2
+  %retVal = select i1 %whatToReturn, i8 %v2, i8 %v3
+  ret i8 %retVal
+}
+
+; or tests
+define i8 @orSelectOrNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 1
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @orSelectOrNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = zext i1 [[V0]] to i8
+; CHECK-NEXT:    [[V2:%.*]] = or i8 [[ARG0:%.*]], [[V1]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 4
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @orSelectOrReserved(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrReserved(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 2
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[ARG0]], i8 [[V1]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 13
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %arg0, i8 %v1
+  %v3 = or i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @orSelectOrSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrSubset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 2
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 13
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @orSelectOrSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrSubset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @orSelectOrSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 10
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @orSelectOrSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @orSelectOrSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrSame(
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 42
+; CHECK-NEXT:    ret i8 [[V1]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 42
+  ret i8 %v3
+}
+
+; and tests
+define i8 @andSelectandNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[ARG0:%.*]], 1
+; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i8 0, i8 [[TMP1]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @andSelectandNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3:%.*]] = and i8 [[V2:%.*]], 4
+; CHECK-NEXT:    [[V4:%.*]] = select i1 [[V0]], i8 0, i8 [[V3]]
+; CHECK-NEXT:    ret i8 [[V4]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @andSelectandSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandSubset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 9, i8 13
+; CHECK-NEXT:    [[V3:%.*]] = and i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @andSelectandSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandSubset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 9, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = and i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @andSelectandSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 1, i8 5
+; CHECK-NEXT:    [[V3:%.*]] = and i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @andSelectandSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V3_V:%.*]] = select i1 [[V0]], i8 1, i8 11
+; CHECK-NEXT:    [[V3:%.*]] = and i8 [[ARG0:%.*]], [[V3_V]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @andSelectandSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @andSelectandSame(
+; CHECK-NEXT:    [[V1:%.*]] = and i8 [[ARG0:%.*]], 42
+; CHECK-NEXT:    ret i8 [[V1]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = and i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = and i8 %v2, 42
+  ret i8 %v3
+}
+
+; xor tests
+define i8 @xorSelectxorNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 1
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @xorSelectxorNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = zext i1 [[V0]] to i8
+; CHECK-NEXT:    [[V2:%.*]] = xor i8 [[ARG0:%.*]], [[V1]]
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 4
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @xorSelectxorSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorSubset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 13
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @xorSelectxorSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorSubset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 13
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @xorSelectxorSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @xorSelectxorSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 5
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = xor i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @xorSelectxorSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @xorSelectxorSame(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = xor i8 [[ARG0:%.*]], 42
+; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i8 [[ARG0]], i8 [[V1]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = xor i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = xor i8 %v2, 42
+  ret i8 %v3
+}
+
+; add tests
+define i8 @addSelectaddNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 1
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @addSelectaddNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = zext i1 [[V0]] to i8
+; CHECK-NEXT:    [[V2:%.*]] = add i8 [[ARG0:%.*]], [[V1]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 4
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @addSelectaddSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddSubset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 13
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @addSelectaddSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddSubset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 13
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @addSelectaddSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @addSelectaddSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 5
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @addSelectaddSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @addSelectaddSame(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], 42
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], 42
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = add i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = add i8 %v2, 42
+  ret i8 %v3
+}
+
+; sub tests
+define i8 @subSelectsubNoCommonBitsConstOnLeft1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubNoCommonBitsConstOnLeft1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = sub i8 4, [[ARG0:%.*]]
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -1
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @subSelectsubNoCommonBitsConstOnLeft2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubNoCommonBitsConstOnLeft2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = sub i8 1, [[V2]]
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 1, %v2
+  ret i8 %v3
+}
+
+define i8 @subSelectsubNoCommonBitsConstOnLeft3(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubNoCommonBitsConstOnLeft3(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i8 4, [[TMP2:%.*]]
+; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i8 [[TMP1]], i8 [[TMP2]]
+; CHECK-NEXT:    [[V4:%.*]] = sub i8 1, [[V3]]
+; CHECK-NEXT:    ret i8 [[V4]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 4, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 1, %v2
+  ret i8 %v3
+}
+
+define i8 @subSelectsubNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -1
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @subSelectsubNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = sext i1 [[V0]] to i8
+; CHECK-NEXT:    [[V2:%.*]] = add i8 [[ARG0:%.*]], [[V1]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -4
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 1
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @subSelectsubSubset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubSubset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -13
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @subSelectsubSubset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubSubset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -13
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @subSelectsubSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @subSelectsubSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -5
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @subSelectsubSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @subSelectsubSame(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = add i8 [[ARG0:%.*]], -42
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = add i8 [[V2]], -42
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = sub i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = sub i8 %v2, 42
+  ret i8 %v3
+}
+
+; mul tests
+define i8 @mulSelectmulNoCommonBits1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulNoCommonBits1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = shl i8 [[ARG0:%.*]], 2
+; CHECK-NEXT:    [[V3:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V2:%.*]] = shl i8 [[V3]], 1
+; CHECK-NEXT:    ret i8 [[V2]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 2
+  ret i8 %v3
+}
+
+define i8 @mulSelectmulNoCommonBits2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulNoCommonBits2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG2:%.*]], 3
+; CHECK-NEXT:    [[ARG0:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG2]]
+; CHECK-NEXT:    [[V3:%.*]] = shl i8 [[ARG0]], 2
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 3
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 4
+  ret i8 %v3
+}
+
+define i8 @mulSelectmulmulset1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulmulset1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 13
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 13
+  ret i8 %v3
+}
+
+define i8 @mulSelectmulmulset2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulmulset2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 13
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 13
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @mulSelectmulSomeCommon1(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulSomeCommon1(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 11
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 11
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 5
+  ret i8 %v3
+}
+
+define i8 @mulSelectmulSomeCommon2(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulSomeCommon2(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 5
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 11
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 5
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 11
+  ret i8 %v3
+}
+
+define i8 @mulSelectmulSame(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @mulSelectmulSame(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = mul i8 [[ARG0:%.*]], 42
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = mul i8 [[V2]], 42
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = mul i8 %arg0, 42
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = mul i8 %v2, 42
+  ret i8 %v3
+}
+
+define i8 @orSelectOrUses(i8 %arg0, i8 %arg1) {
+; CHECK-LABEL: @orSelectOrUses(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[ARG1:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[ARG0:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 1
+; CHECK-NEXT:    [[RES:%.*]] = add i8 [[V1]], [[V3]]
+; CHECK-NEXT:    ret i8 [[RES]]
+;
+  %v0 = icmp eq i8 %arg1, -1
+  %v1 = or i8 %arg0, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = or i8 %v2, 1
+  %res = add i8 %v1, %v3
+  ret i8 %res
+}
+
+define i8 @udivSelectudivSomeCommon1InfLoopRep(i8 %arg0, i8 %arg1, i1 %v0) {
+; CHECK-LABEL: @udivSelectudivSomeCommon1InfLoopRep(
+; CHECK-NEXT:    [[V1:%.*]] = udiv i8 11, [[ARG0:%.*]]
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0:%.*]], i8 [[V1]], i8 [[ARG0]]
+; CHECK-NEXT:    [[V3:%.*]] = udiv i8 [[V2]], 5
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v01 = icmp sgt i8 %arg0, 0
+  %v1 = udiv i8 11, %arg0
+  %v2 = select i1 %v0, i8 %v1, i8 %arg0
+  %v3 = udiv i8 %v2, 5
+  ret i8 %v3
+}


### PR DESCRIPTION
Fixes #154246 .
Another approach than PR #172662 .

@nikic has mentioned in the comments that the approach I took in #172662 may be fragile. There may be cases where the folding may cause infinite loops (like we saw it with `div` and `rem` (for these ops I have fixed that PR too)).

This is another more stable approach. Although it comes with a bit more changes (I would rather say additions). I decided to add a new function for this optimization.

In my previous PR I was thinking about solving the issue in `SimplifyAssociativeOrCommutative`, but after some experimenting I came to the conclusion that it couldn't be done that elegantly as I have planed it.