### PR TITLE
[MC][WebAssembly] add string support for import/export instructions

### DIFF
--- a/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
+++ b/llvm/lib/Target/WebAssembly/AsmParser/WebAssemblyAsmParser.cpp
@@ -415,6 +415,16 @@ public:
     return Name;
   }
 
+  StringRef expectIdentOrString() {
+    if (Lexer.isNot(AsmToken::Identifier) && Lexer.isNot(AsmToken::String)) {
+      error("Expected identifier or string, got: ", Lexer.getTok());
+      return StringRef();
+    }
+    auto Name = Lexer.getTok().getString();
+    Parser.Lex();
+    return Name;
+  }
+
   bool parseRegTypeList(SmallVectorImpl<wasm::ValType> &Types) {
     while (Lexer.is(AsmToken::Identifier)) {
       auto Type = WebAssembly::parseType(Lexer.getTok().getString());
@@ -1041,7 +1051,7 @@ public:
         return ParseStatus::Failure;
       if (expect(AsmToken::Comma, ","))
         return ParseStatus::Failure;
-      auto ExportName = expectIdent();
+      auto ExportName = expectIdentOrString();
       if (ExportName.empty())
         return ParseStatus::Failure;
       auto *WasmSym =
@@ -1057,7 +1067,7 @@ public:
         return ParseStatus::Failure;
       if (expect(AsmToken::Comma, ","))
         return ParseStatus::Failure;
-      auto ImportModule = expectIdent();
+      auto ImportModule = expectIdentOrString();
       if (ImportModule.empty())
         return ParseStatus::Failure;
       auto *WasmSym =
@@ -1073,7 +1083,7 @@ public:
         return ParseStatus::Failure;
       if (expect(AsmToken::Comma, ","))
         return ParseStatus::Failure;
-      auto ImportName = expectIdent();
+      auto ImportName = expectIdentOrString();
       if (ImportName.empty())
         return ParseStatus::Failure;
       auto *WasmSym =

--- a/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyTargetStreamer.cpp
+++ b/llvm/lib/Target/WebAssembly/MCTargetDesc/WebAssemblyTargetStreamer.cpp
@@ -96,20 +96,18 @@ void WebAssemblyTargetAsmStreamer::emitTagType(const MCSymbolWasm *Sym) {
 
 void WebAssemblyTargetAsmStreamer::emitImportModule(const MCSymbolWasm *Sym,
                                                     StringRef ImportModule) {
-  OS << "\t.import_module\t" << Sym->getName() << ", "
-                             << ImportModule << '\n';
+  OS << "\t.import_module\t" << Sym->getName() << ", \"" << ImportModule
+     << "\"\n";
 }
 
 void WebAssemblyTargetAsmStreamer::emitImportName(const MCSymbolWasm *Sym,
                                                   StringRef ImportName) {
-  OS << "\t.import_name\t" << Sym->getName() << ", "
-                           << ImportName << '\n';
+  OS << "\t.import_name\t" << Sym->getName() << ", \"" << ImportName << "\"\n";
 }
 
 void WebAssemblyTargetAsmStreamer::emitExportName(const MCSymbolWasm *Sym,
                                                   StringRef ExportName) {
-  OS << "\t.export_name\t" << Sym->getName() << ", "
-                           << ExportName << '\n';
+  OS << "\t.export_name\t" << Sym->getName() << ", \"" << ExportName << "\"\n";
 }
 
 void WebAssemblyTargetAsmStreamer::emitIndIdx(const MCExpr *Value) {

--- a/llvm/test/CodeGen/WebAssembly/export-name.ll
+++ b/llvm/test/CodeGen/WebAssembly/export-name.ll
@@ -12,5 +12,5 @@ declare void @test2() #1
 attributes #0 = { "wasm-export-name"="foo" }
 attributes #1 = { "wasm-export-name"="bar" }
 
-; CHECK: .export_name test, foo
-; CHECK: .export_name test2, bar
+; CHECK: .export_name test, "foo"
+; CHECK: .export_name test2, "bar"

--- a/llvm/test/CodeGen/WebAssembly/import-module.ll
+++ b/llvm/test/CodeGen/WebAssembly/import-module.ll
@@ -14,6 +14,6 @@ declare void @plain()
 attributes #0 = { "wasm-import-module"="bar" "wasm-import-name"="qux" }
 
 ; CHECK-NOT: .import_module plain
-;     CHECK: .import_module foo, bar
-;     CHECK: .import_name foo, qux
+;     CHECK: .import_module foo, "bar"
+;     CHECK: .import_name foo, "qux"
 ; CHECK-NOT: .import_module plain

--- a/llvm/test/CodeGen/WebAssembly/lower-em-ehsjlj-options.ll
+++ b/llvm/test/CodeGen/WebAssembly/lower-em-ehsjlj-options.ll
@@ -5,8 +5,8 @@
 target triple = "wasm32-unknown-unknown"
 
 ; EH: .functype  invoke_vi (i32, i32) -> ()
-; EH: .import_module  invoke_vi, env
-; EH: .import_name  invoke_vi, invoke_vi
+; EH: .import_module  invoke_vi, "env"
+; EH: .import_name  invoke_vi, "invoke_vi"
 ; EH-NOT: .functype  __invoke_void_i32
 ; EH-NOT: .import_module  __invoke_void_i32
 ; EH-NOT: .import_name  __invoke_void_i32

--- a/llvm/test/MC/WebAssembly/export-name-invalid.s
+++ b/llvm/test/MC/WebAssembly/export-name-invalid.s
@@ -6,7 +6,7 @@
 # CHECK: [[#@LINE+1]]:17: error: Expected ,, instead got:
 .export_name foo
 
-# CHECK: [[#@LINE+1]]:18: error: Expected identifier, got:
+# CHECK: [[#@LINE+1]]:18: error: Expected identifier or string, got:
 .export_name foo,
 
 # CHECK: [[#@LINE+1]]:22: error: Expected EOL, instead got: ,

--- a/llvm/test/MC/WebAssembly/export-name.s
+++ b/llvm/test/MC/WebAssembly/export-name.s
@@ -8,7 +8,7 @@ foo:
     .export_name foo, bar
     end_function
 
-# CHECK: .export_name foo, bar
+# CHECK: .export_name foo, "bar"
 
 # CHECK-OBJ:        - Type:            EXPORT
 # CHECK-OBJ-NEXT:     Exports:

--- a/llvm/test/MC/WebAssembly/import-module-invalid.s
+++ b/llvm/test/MC/WebAssembly/import-module-invalid.s
@@ -6,7 +6,7 @@
 # CHECK: [[#@LINE+1]]:19: error: Expected ,, instead got:
 .import_module foo
 
-# CHECK: [[#@LINE+1]]:20: error: Expected identifier, got:
+# CHECK: [[#@LINE+1]]:20: error: Expected identifier or string, got:
 .import_module foo,
 
 # CHECK: [[#@LINE+1]]:24: error: Expected EOL, instead got: ,

--- a/llvm/test/MC/WebAssembly/import-module.s
+++ b/llvm/test/MC/WebAssembly/import-module.s
@@ -13,8 +13,8 @@ test:
   .import_module  foo, bar
   .import_name  foo, qux
 
-# CHECK-ASM: .import_module  foo, bar
-# CHECK-ASM: .import_name  foo, qux
+# CHECK-ASM: .import_module  foo, "bar"
+# CHECK-ASM: .import_name  foo, "qux"
 
 # CHECK:        - Type:            IMPORT
 # CHECK-NEXT:     Imports:

--- a/llvm/test/MC/WebAssembly/import-name-invalid.s
+++ b/llvm/test/MC/WebAssembly/import-name-invalid.s
@@ -6,7 +6,7 @@
 # CHECK: [[#@LINE+1]]:17: error: Expected ,, instead got:
 .import_name foo
 
-# CHECK: [[#@LINE+1]]:18: error: Expected identifier, got:
+# CHECK: [[#@LINE+1]]:18: error: Expected identifier or string, got:
 .import_name foo,
 
 # CHECK: [[#@LINE+1]]:22: error: Expected EOL, instead got: ,


### PR DESCRIPTION
This change allows strings to be used as import modules, import names and export names alongside identifiers.

Fixes: https://github.com/llvm/llvm-project/issues/173479