### PR TITLE
[clang-tidy] Remove `allow-long-titles` option in doc8 config

### DIFF
--- a/clang-tools-extra/clang-tidy/doc8.ini
+++ b/clang-tools-extra/clang-tidy/doc8.ini
@@ -1,3 +1,3 @@
 [doc8]
-
-ignore-path=clang-tools-extra/docs/clang-tidy/Integrations.rst,clang-tools-extra/docs/clang-tidy/checks/abseil/unchecked-statusor-access.rst
+ignore-path = clang-tools-extra/docs/clang-tidy/Integrations.rst,
+    clang-tools-extra/docs/clang-tidy/checks/abseil/unchecked-statusor-access.rst

--- a/clang-tools-extra/clang-tidy/doc8.ini
+++ b/clang-tools-extra/clang-tidy/doc8.ini
@@ -1,4 +1,3 @@
 [doc8]
 
-allow-long-titles = true
-ignore-path=clang-tools-extra/docs/clang-tidy/Integrations.rst
+ignore-path=clang-tools-extra/docs/clang-tidy/Integrations.rst,clang-tools-extra/docs/clang-tidy/checks/abseil/unchecked-statusor-access.rst

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/use-internal-linkage.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/use-internal-linkage.rst
@@ -17,7 +17,7 @@ Example:
   int v1; // can be marked as static
 
   void fn1() {} // can be marked as static
-  
+
   struct S1 {}; // can be moved into anonymous namespace
 
   namespace {


### PR DESCRIPTION
There is a bug in `doc8` where `allow-long-titles` option incorrectly skipping non-title lines. So we have to disable it before they solve the problem and make a new release.