### PR TITLE
[mlir] Emit an error when dense i1 array values are not `true` or `false`

### DIFF
--- a/mlir/lib/AsmParser/AttributeParser.cpp
+++ b/mlir/lib/AsmParser/AttributeParser.cpp
@@ -883,6 +883,8 @@ ParseResult DenseArrayElementParser::parseIntegerElement(Parser &p) {
                   !type.isUnsignedInteger());
     p.consumeToken();
   } else if (p.consumeIf(Token::integer)) {
+    if (type.isInteger(1))
+      return p.emitError("expected 'true' or 'false' values for i1 type");
     value = buildAttributeAPInt(type, isNegative, spelling);
     if (!value)
       return p.emitError("integer constant out of range");

--- a/mlir/test/IR/invalid-builtin-attributes.mlir
+++ b/mlir/test/IR/invalid-builtin-attributes.mlir
@@ -580,6 +580,16 @@ func.func @duplicate_dictionary_attr_key() {
 
 // -----
 
+// expected-error@below {{expected i1 type for 'true' or 'false' values}}
+#attr = array<i8: true>
+
+// -----
+
+// expected-error@below {{expected 'true' or 'false' values for i1 type}}
+#attr = array<i1: 0>
+
+// -----
+
 // expected-error@below {{expected '[' after 'distinct'}}
 #attr = distinct<
 


### PR DESCRIPTION
Fixes #173373.