### PR TITLE
[TwoAddressInstruction] Track MadeChange when eliminating REG_SEQUENCE

### DIFF
--- a/llvm/lib/CodeGen/TwoAddressInstructionPass.cpp
+++ b/llvm/lib/CodeGen/TwoAddressInstructionPass.cpp
@@ -1865,8 +1865,10 @@ bool TwoAddressInstructionImpl::run() {
 
       // Expand REG_SEQUENCE instructions. This will position mi at the first
       // expanded instruction.
-      if (mi->isRegSequence())
+      if (mi->isRegSequence()) {
         eliminateRegSequence(mi);
+        MadeChange = true;
+      }
 
       DistanceMap.insert(std::make_pair(&*mi, ++Dist));
 


### PR DESCRIPTION
When `eliminateRegSequence()` is called, the pass modifies the `MachineFunction` but `MadeChange` was not being set to true. 
This causes the pass to incorrectly return `PreservedAnalyses::all()` even though changes were made.