### PR TITLE
[libc++][NFC] Replace tag dispatch with `if constexpr` in `<any>` and `<variant>`

### DIFF
--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -544,33 +544,25 @@ template <class _ValueType>
   return std::any_cast<_ValueType>(const_cast<any*>(__any));
 }
 
-template <class _RetType>
-inline _LIBCPP_HIDE_FROM_ABI _RetType __pointer_or_func_cast(void* __p, /*IsFunction*/ false_type) noexcept {
-  return static_cast<_RetType>(__p);
-}
-
-template <class _RetType>
-inline _LIBCPP_HIDE_FROM_ABI _RetType __pointer_or_func_cast(void*, /*IsFunction*/ true_type) noexcept {
-  return nullptr;
-}
-
 template <class _ValueType>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI add_pointer_t<_ValueType> any_cast(any* __any) _NOEXCEPT {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI add_pointer_t<_ValueType> any_cast([[maybe_unused]] any* __any) _NOEXCEPT {
   using __any_imp::_Action;
   static_assert(!is_void_v<_ValueType>, "_ValueType may not be void.");
   static_assert(!is_reference<_ValueType>::value, "_ValueType may not be a reference.");
-  typedef add_pointer_t<_ValueType> _ReturnType;
-  if (__any && __any->__h_) {
-    void* __p = __any->__call(
-        _Action::_Get,
-        nullptr,
+  if constexpr (!is_function_v<_ValueType>) {
+    using _ReturnType = add_pointer_t<_ValueType>;
+    if (__any && __any->__h_) {
+      void* __p = __any->__call(
+          _Action::_Get,
+          nullptr,
 #    if _LIBCPP_HAS_RTTI
-        &typeid(_ValueType),
+          &typeid(_ValueType),
 #    else
-        nullptr,
+          nullptr,
 #    endif
-        __any_imp::__get_fallback_typeid<_ValueType>());
-    return std::__pointer_or_func_cast<_ReturnType>(__p, is_function<_ValueType>{});
+          __any_imp::__get_fallback_typeid<_ValueType>());
+      return static_cast<_ReturnType>(__p);
+    }
   }
   return nullptr;
 }

--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -545,7 +545,7 @@ template <class _ValueType>
 }
 
 template <class _ValueType>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI add_pointer_t<_ValueType> any_cast([[maybe_unused]] any* __any) _NOEXCEPT {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI add_pointer_t<_ValueType> any_cast(any* __any) _NOEXCEPT {
   using __any_imp::_Action;
   static_assert(!is_void_v<_ValueType>, "_ValueType may not be void.");
   static_assert(!is_reference<_ValueType>::value, "_ValueType may not be a reference.");

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -917,12 +917,10 @@ protected:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __assign_alt(__alt<_Ip, _Tp>& __a, _Arg&& __arg) {
     if (this->index() == _Ip) {
       __a.__value = std::forward<_Arg>(__arg);
+    } else if constexpr (is_nothrow_constructible_v<_Tp, _Arg> || !is_nothrow_move_constructible_v<_Tp>) {
+      this->__emplace<_Ip>(std::forward<_Arg>(__arg));
     } else {
-      if constexpr (is_nothrow_constructible_v<_Tp, _Arg> || !is_nothrow_move_constructible_v<_Tp>) {
-        this->__emplace<_Ip>(std::forward<_Arg>(__arg));
-      } else {
-        this->__emplace<_Ip>(_Tp(std::forward<_Arg>(__arg)));
-      }
+      this->__emplace<_Ip>(_Tp(std::forward<_Arg>(__arg)));
     }
   }
 

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -918,17 +918,11 @@ protected:
     if (this->index() == _Ip) {
       __a.__value = std::forward<_Arg>(__arg);
     } else {
-      struct {
-        _LIBCPP_HIDDEN _LIBCPP_CONSTEXPR_SINCE_CXX20 void operator()(true_type) const {
-          __this->__emplace<_Ip>(std::forward<_Arg>(__arg));
-        }
-        _LIBCPP_HIDDEN _LIBCPP_CONSTEXPR_SINCE_CXX20 void operator()(false_type) const {
-          __this->__emplace<_Ip>(_Tp(std::forward<_Arg>(__arg)));
-        }
-        __assignment* __this;
-        _Arg&& __arg;
-      } __impl{this, std::forward<_Arg>(__arg)};
-      __impl(bool_constant < is_nothrow_constructible_v<_Tp, _Arg> || !is_nothrow_move_constructible_v < _Tp >> {});
+      if constexpr (is_nothrow_constructible_v<_Tp, _Arg> || !is_nothrow_move_constructible_v<_Tp>) {
+        this->__emplace<_Ip>(std::forward<_Arg>(__arg));
+      } else {
+        this->__emplace<_Ip>(_Tp(std::forward<_Arg>(__arg)));
+      }
     }
   }
 


### PR DESCRIPTION
Also simplify `any_cast<FunctionType>(ptr)` to directly return `nullptr`.