### PR TITLE
MIPSr6: Set SETCC CondCode not supported by hardware to Expand

### DIFF
--- a/llvm/lib/Target/Mips/MicroMips32r6InstrInfo.td
+++ b/llvm/lib/Target/Mips/MicroMips32r6InstrInfo.td
@@ -1776,8 +1776,8 @@ def : MipsPat<(select i32:$cond, immz, i32:$f),
 defm : SelectInt_Pats<i32, OR_MM, XORI_MMR6, SLTi_MM, SLTiu_MM, SELEQZ_MMR6,
                       SELNEZ_MMR6, immZExt16, i32>, ISA_MICROMIPS32R6;
 
-defm S_MMR6 : Cmp_Pats<f32, NOR_MMR6, ZERO>, ISA_MICROMIPS32R6;
-defm D_MMR6 : Cmp_Pats<f64, NOR_MMR6, ZERO>, ISA_MICROMIPS32R6;
+defm S_MMR6 : Cmp_Pats<f32>, ISA_MICROMIPS32R6;
+defm D_MMR6 : Cmp_Pats<f64>, ISA_MICROMIPS32R6;
 
 def : MipsPat<(f32 fpimm0), (MTC1_MMR6 ZERO)>, ISA_MICROMIPS32R6;
 def : MipsPat<(f32 fpimm0neg), (FNEG_S_MMR6(MTC1_MMR6 ZERO))>,

--- a/llvm/lib/Target/Mips/Mips32r6InstrInfo.td
+++ b/llvm/lib/Target/Mips/Mips32r6InstrInfo.td
@@ -1047,13 +1047,7 @@ def : MipsInstAlias<"lapc $rd, $imm",
 //===----------------------------------------------------------------------===//
 
 // comparisons supported via another comparison
-multiclass Cmp_Pats<ValueType VT, Instruction NOROp, Register ZEROReg> {
-def : MipsPat<(setone VT:$lhs, VT:$rhs),
-      (NOROp (!cast<Instruction>("CMP_UEQ_"#NAME) VT:$lhs, VT:$rhs), ZEROReg)>;
-def : MipsPat<(seto VT:$lhs, VT:$rhs),
-      (NOROp (!cast<Instruction>("CMP_UN_"#NAME) VT:$lhs, VT:$rhs), ZEROReg)>;
-def : MipsPat<(setune VT:$lhs, VT:$rhs),
-      (NOROp (!cast<Instruction>("CMP_EQ_"#NAME) VT:$lhs, VT:$rhs), ZEROReg)>;
+multiclass Cmp_Pats<ValueType VT> {
 def : MipsPat<(seteq VT:$lhs, VT:$rhs),
       (!cast<Instruction>("CMP_EQ_"#NAME) VT:$lhs, VT:$rhs)>;
 def : MipsPat<(setgt VT:$lhs, VT:$rhs),
@@ -1064,13 +1058,11 @@ def : MipsPat<(setlt VT:$lhs, VT:$rhs),
       (!cast<Instruction>("CMP_LT_"#NAME) VT:$lhs, VT:$rhs)>;
 def : MipsPat<(setle VT:$lhs, VT:$rhs),
       (!cast<Instruction>("CMP_LE_"#NAME) VT:$lhs, VT:$rhs)>;
-def : MipsPat<(setne VT:$lhs, VT:$rhs),
-      (NOROp (!cast<Instruction>("CMP_EQ_"#NAME) VT:$lhs, VT:$rhs), ZEROReg)>;
 }
 
 let AdditionalPredicates = [NotInMicroMips] in {
-  defm S : Cmp_Pats<f32, NOR, ZERO>, ISA_MIPS32R6;
-  defm D : Cmp_Pats<f64, NOR, ZERO>, ISA_MIPS32R6;
+  defm S : Cmp_Pats<f32>, ISA_MIPS32R6;
+  defm D : Cmp_Pats<f64>, ISA_MIPS32R6;
 }
 
 // i32 selects

--- a/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
@@ -317,11 +317,19 @@ MipsSETargetLowering::MipsSETargetLowering(const MipsTargetMachine &TM,
     setCondCodeAction(ISD::SETOGT, MVT::f32, Expand);
     setCondCodeAction(ISD::SETUGE, MVT::f32, Expand);
     setCondCodeAction(ISD::SETUGT, MVT::f32, Expand);
+    setCondCodeAction(ISD::SETONE, MVT::f32, Expand);
+    setCondCodeAction(ISD::SETO, MVT::f32, Expand);
+    setCondCodeAction(ISD::SETUNE, MVT::f32, Expand);
+    setCondCodeAction(ISD::SETNE, MVT::f32, Expand);
 
     setCondCodeAction(ISD::SETOGE, MVT::f64, Expand);
     setCondCodeAction(ISD::SETOGT, MVT::f64, Expand);
     setCondCodeAction(ISD::SETUGE, MVT::f64, Expand);
     setCondCodeAction(ISD::SETUGT, MVT::f64, Expand);
+    setCondCodeAction(ISD::SETONE, MVT::f64, Expand);
+    setCondCodeAction(ISD::SETO, MVT::f64, Expand);
+    setCondCodeAction(ISD::SETUNE, MVT::f64, Expand);
+    setCondCodeAction(ISD::SETNE, MVT::f64, Expand);
   }
 
   if (Subtarget.hasMips64r6()) {

--- a/llvm/test/CodeGen/Mips/fcmp.ll
+++ b/llvm/test/CodeGen/Mips/fcmp.ll
@@ -227,7 +227,7 @@ define i32 @one_f32(float %a, float %b) nounwind {
 
 ; MM32R6-DAG:    cmp.ueq.s $[[T0:f[0-9]+]], $f12, $f14
 ; MMR6-DAG:      mfc1 $[[T1:[0-9]+]], $[[T0]]
-; MMR6-DAG:      not $[[T2:[0-9]+]], $[[T1]]
+; MMR6-DAG:      not16 $[[T2:[0-9]+]], $[[T1]]
 ; MMR6-DAG:      andi16 $2, $[[T2]], 1
 
   %1 = fcmp one float %a, %b
@@ -263,7 +263,7 @@ define i32 @ord_f32(float %a, float %b) nounwind {
 
 ; MM32R6-DAG:    cmp.un.s $[[T0:f[0-9]+]], $f12, $f14
 ; MMR6-DAG:      mfc1 $[[T1:[0-9]+]], $[[T0]]
-; MMR6-DAG:      not $[[T2:[0-9]+]], $[[T1]]
+; MMR6-DAG:      not16 $[[T2:[0-9]+]], $[[T1]]
 ; MMR6-DAG:      andi16 $2, $[[T2]], 1
 
   %1 = fcmp ord float %a, %b
@@ -464,7 +464,7 @@ define i32 @une_f32(float %a, float %b) nounwind {
 
 ; MM32R6-DAG:    cmp.eq.s $[[T0:f[0-9]+]], $f12, $f14
 ; MMR6-DAG:      mfc1 $[[T1:[0-9]+]], $[[T0]]
-; MMR6-DAG:      not $[[T2:[0-9]+]], $[[T1]]
+; MMR6-DAG:      not16 $[[T2:[0-9]+]], $[[T1]]
 ; MMR6-DAG:      andi16 $2, $[[T2]], 1
 
   %1 = fcmp une float %a, %b
@@ -732,7 +732,7 @@ define i32 @one_f64(double %a, double %b) nounwind {
 
 ; MM32R6-DAG:    cmp.ueq.d $[[T0:f[0-9]+]], $f12, $f14
 ; MMR6-DAG:      mfc1 $[[T1:[0-9]+]], $[[T0]]
-; MMR6-DAG:      not $[[T2:[0-9]+]], $[[T1]]
+; MMR6-DAG:      not16 $[[T2:[0-9]+]], $[[T1]]
 ; MMR6-DAG:      andi16 $2, $[[T2]], 1
 
   %1 = fcmp one double %a, %b
@@ -768,7 +768,7 @@ define i32 @ord_f64(double %a, double %b) nounwind {
 
 ; MM32R6-DAG:    cmp.un.d $[[T0:f[0-9]+]], $f12, $f14
 ; MMR6-DAG:      mfc1 $[[T1:[0-9]+]], $[[T0]]
-; MMR6-DAG:      not $[[T2:[0-9]+]], $[[T1]]
+; MMR6-DAG:      not16 $[[T2:[0-9]+]], $[[T1]]
 ; MMR6-DAG:      andi16 $2, $[[T2]], 1
 
   %1 = fcmp ord double %a, %b
@@ -969,7 +969,7 @@ define i32 @une_f64(double %a, double %b) nounwind {
 
 ; MM32R6-DAG:    cmp.eq.d $[[T0:f[0-9]+]], $f12, $f14
 ; MMR6-DAG:      mfc1 $[[T1:[0-9]+]], $[[T0]]
-; MMR6-DAG:      not $[[T2:[0-9]+]], $[[T1]]
+; MMR6-DAG:      not16 $[[T2:[0-9]+]], $[[T1]]
 ; MMR6-DAG:      andi16 $2, $[[T2]], 1
 
   %1 = fcmp une double %a, %b

--- a/llvm/test/CodeGen/Mips/llvm-ir/select-dbl.ll
+++ b/llvm/test/CodeGen/Mips/llvm-ir/select-dbl.ll
@@ -640,7 +640,7 @@ define double @tst_select_fcmp_one_double(double %x, double %y) {
 ; 32R6:       # %bb.0: # %entry
 ; 32R6-NEXT:    cmp.ueq.d $f0, $f12, $f14
 ; 32R6-NEXT:    mfc1 $1, $f0
-; 32R6-NEXT:    not $1, $1
+; 32R6-NEXT:    xori $1, $1, 1
 ; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
 ; 32R6-NEXT:    sel.d $f0, $f14, $f12
@@ -668,7 +668,7 @@ define double @tst_select_fcmp_one_double(double %x, double %y) {
 ; 64R6:       # %bb.0: # %entry
 ; 64R6-NEXT:    cmp.ueq.d $f0, $f12, $f13
 ; 64R6-NEXT:    mfc1 $1, $f0
-; 64R6-NEXT:    not $1, $1
+; 64R6-NEXT:    xori $1, $1, 1
 ; 64R6-NEXT:    mtc1 $1, $f0
 ; 64R6-NEXT:    jr $ra
 ; 64R6-NEXT:    sel.d $f0, $f13, $f12
@@ -684,7 +684,7 @@ define double @tst_select_fcmp_one_double(double %x, double %y) {
 ; MM32R6:       # %bb.0: # %entry
 ; MM32R6-NEXT:    cmp.ueq.d $f0, $f12, $f14
 ; MM32R6-NEXT:    mfc1 $1, $f0
-; MM32R6-NEXT:    not $1, $1
+; MM32R6-NEXT:    xori $1, $1, 1
 ; MM32R6-NEXT:    mtc1 $1, $f0
 ; MM32R6-NEXT:    sel.d $f0, $f14, $f12
 ; MM32R6-NEXT:    jrc $ra

--- a/llvm/test/CodeGen/Mips/llvm-ir/select-flt.ll
+++ b/llvm/test/CodeGen/Mips/llvm-ir/select-flt.ll
@@ -595,11 +595,8 @@ define float @tst_select_fcmp_one_float(float %x, float %y) {
 ; 32R6-LABEL: tst_select_fcmp_one_float:
 ; 32R6:       # %bb.0: # %entry
 ; 32R6-NEXT:    cmp.ueq.s $f0, $f12, $f14
-; 32R6-NEXT:    mfc1 $1, $f0
-; 32R6-NEXT:    not $1, $1
-; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
-; 32R6-NEXT:    sel.s $f0, $f14, $f12
+; 32R6-NEXT:    sel.s $f0, $f12, $f14
 ;
 ; M3-LABEL: tst_select_fcmp_one_float:
 ; M3:       # %bb.0: # %entry
@@ -623,11 +620,8 @@ define float @tst_select_fcmp_one_float(float %x, float %y) {
 ; 64R6-LABEL: tst_select_fcmp_one_float:
 ; 64R6:       # %bb.0: # %entry
 ; 64R6-NEXT:    cmp.ueq.s $f0, $f12, $f13
-; 64R6-NEXT:    mfc1 $1, $f0
-; 64R6-NEXT:    not $1, $1
-; 64R6-NEXT:    mtc1 $1, $f0
 ; 64R6-NEXT:    jr $ra
-; 64R6-NEXT:    sel.s $f0, $f13, $f12
+; 64R6-NEXT:    sel.s $f0, $f12, $f13
 ;
 ; MM32R3-LABEL: tst_select_fcmp_one_float:
 ; MM32R3:       # %bb.0: # %entry
@@ -639,10 +633,7 @@ define float @tst_select_fcmp_one_float(float %x, float %y) {
 ; MM32R6-LABEL: tst_select_fcmp_one_float:
 ; MM32R6:       # %bb.0: # %entry
 ; MM32R6-NEXT:    cmp.ueq.s $f0, $f12, $f14
-; MM32R6-NEXT:    mfc1 $1, $f0
-; MM32R6-NEXT:    not $1, $1
-; MM32R6-NEXT:    mtc1 $1, $f0
-; MM32R6-NEXT:    sel.s $f0, $f14, $f12
+; MM32R6-NEXT:    sel.s $f0, $f12, $f14
 ; MM32R6-NEXT:    jrc $ra
 entry:
   %s = fcmp one float %x, %y


### PR DESCRIPTION
With the current custom match rules, we may generate code like
```
  cmp.ueq.s $f0, $f12, $f14
  mfc1 $1, $f0
  not $1, $1
  mtc1 $1, $f0
  sel.s $f0, $f14, $f12
  jrc $ra
```
With Expand, we can get:
```
  cmp.ueq.s $f0, $f12, $f14
  sel.s $f0, $f12, $f14
  jrc $ra
```