### PR TITLE
[mlir][Transforms][NFC] `remove-dead-values`: Split `OperationToCleanup`

### DIFF
--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -86,7 +86,12 @@ struct FunctionToCleanUp {
   BitVector nonLiveRets;
 };
 
-struct OperationToCleanup {
+struct ResultsToCleanup {
+  Operation *op;
+  BitVector nonLive;
+};
+
+struct OperandsToCleanup {
   Operation *op;
   BitVector nonLive;
   Operation *callee =
@@ -108,8 +113,8 @@ struct RDVFinalCleanupList {
   SmallVector<Operation *> operations;
   SmallVector<Value> values;
   SmallVector<FunctionToCleanUp> functions;
-  SmallVector<OperationToCleanup> operands;
-  SmallVector<OperationToCleanup> results;
+  SmallVector<OperandsToCleanup> operands;
+  SmallVector<ResultsToCleanup> results;
   SmallVector<BlockArgsToCleanup> blocks;
   SmallVector<SuccessorOperandsToCleanup> successorOperands;
 };
@@ -882,7 +887,7 @@ static void cleanUpDeadVals(RDVFinalCleanupList &list) {
 
   // 6. Operands
   LDBG() << "Cleaning up " << list.operands.size() << " operand lists";
-  for (OperationToCleanup &o : list.operands) {
+  for (OperandsToCleanup &o : list.operands) {
     // Handle call-specific cleanup only when we have a cached callee reference.
     // This avoids expensive symbol lookup and is defensive against future
     // changes.


### PR DESCRIPTION
The `callee` field does not make sense for op results. Split `OperationToCleanup` into `OperandsToCleanup` and `ResultsToCleanup`.

Depends on #173540.
