### PR TITLE
[libc++][ranges] Applied `[[nodiscard]]` to `drop_view`

### DIFF
--- a/libcxx/include/__ranges/drop_view.h
+++ b/libcxx/include/__ranges/drop_view.h
@@ -80,14 +80,14 @@ public:
     _LIBCPP_ASSERT_UNCATEGORIZED(__count_ >= 0, "count must be greater than or equal to zero.");
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin()
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto begin()
     requires(!(__simple_view<_View> && random_access_range<const _View> && sized_range<const _View>))
   {
     if constexpr (random_access_range<_View> && sized_range<_View>) {
@@ -104,20 +104,20 @@ public:
     return __tmp;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
     requires random_access_range<const _View> && sized_range<const _View>
   {
     const auto __dist = std::min(ranges::distance(__base_), __count_);
     return ranges::begin(__base_) + __dist;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end()
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto end()
     requires(!__simple_view<_View>)
   {
     return ranges::end(__base_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
     requires range<const _View>
   {
     return ranges::end(__base_);
@@ -129,13 +129,13 @@ public:
     return __s < __c ? 0 : __s - __c;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size()
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto size()
     requires sized_range<_View>
   {
     return __size(*this);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
     requires sized_range<const _View>
   {
     return __size(*this);

--- a/libcxx/test/libcxx/ranges/range.adaptors/range.drop/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/ranges/range.adaptors/range.drop/nodiscard.verify.cpp
@@ -1,0 +1,144 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++20
+
+// Check that functions are marked [[nodiscard]]
+
+#include <ranges>
+#include <span>
+#include <vector>
+#include <utility>
+
+#include "test_macros.h"
+#include "test_iterators.h"
+
+void test() {
+  // [range.drop.view]
+
+  {
+    std::vector<int> range;
+
+    auto v = std::views::drop(range, 0);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    v.base();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::move(v).base();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    v.begin();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::as_const(v).begin();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    v.end();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::as_const(v).end();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    v.size();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::as_const(v).size();
+  }
+
+  // [range.drop.overview]
+
+  { // The `empty_view` case.
+    auto emptyView = std::views::empty<int>;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::drop(emptyView, 0);
+  }
+
+  { // The `span | basic_string_view | iota_view | subrange (StoreSize == false)` case.
+    int arr[]{94, 82, 49};
+    auto subrange = std::ranges::subrange(arr, arr + 3);
+    LIBCPP_STATIC_ASSERT(!decltype(subrange)::_StoreSize);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::drop(subrange, 3);
+  }
+
+  { // The the `subrange (StoreSize == true)` case.
+    struct SizedViewWithUnsizedSentinel : std::ranges::view_base {
+      using iterator = random_access_iterator<int*>;
+      using sentinel = sentinel_wrapper<random_access_iterator<int*>>;
+
+      int* begin_ = nullptr;
+      int* end_   = nullptr;
+      constexpr SizedViewWithUnsizedSentinel(int* begin, int* end) : begin_(begin), end_(end) {}
+
+      constexpr auto begin() const { return iterator(begin_); }
+      constexpr auto end() const { return sentinel(iterator(end_)); }
+      constexpr std::size_t size() const { return end_ - begin_; }
+    };
+    static_assert(std::ranges::random_access_range<SizedViewWithUnsizedSentinel>);
+    static_assert(std::ranges::sized_range<SizedViewWithUnsizedSentinel>);
+    static_assert(
+        !std::sized_sentinel_for<SizedViewWithUnsizedSentinel::sentinel, SizedViewWithUnsizedSentinel::iterator>);
+    static_assert(std::ranges::view<SizedViewWithUnsizedSentinel>);
+
+    int arr[]{94, 82, 49};
+
+    using View = SizedViewWithUnsizedSentinel;
+    View view{arr, arr + 3};
+
+    using Subrange = std::ranges::subrange<View::iterator, View::sentinel, std::ranges::subrange_kind::sized>;
+    auto subrange  = Subrange(view.begin(), view.end(), std::ranges::distance(view.begin(), view.end()));
+    LIBCPP_STATIC_ASSERT(decltype(subrange)::_StoreSize);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::drop(subrange, 3);
+  }
+
+#if TEST_STD_VER >= 23
+  { // The `repeat_view` "_RawRange models sized_range" case.
+    auto repeatView = std::ranges::repeat_view<int, int>(1, 8);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::drop(repeatView, 3);
+  }
+
+  { // The `repeat_view` "otherwise" case.
+    auto repeatView = std::ranges::repeat_view<int>(1);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::drop(repeatView, 3);
+  }
+#endif
+
+  { // The "otherwise" case.
+    struct SizedView : std::ranges::view_base {
+      int* begin_ = nullptr;
+      int* end_   = nullptr;
+      constexpr SizedView(int* begin, int* end) : begin_(begin), end_(end) {}
+
+      constexpr auto begin() const { return forward_iterator<int*>(begin_); }
+      constexpr auto end() const { return sized_sentinel<forward_iterator<int*>>(forward_iterator<int*>(end_)); }
+    };
+    static_assert(std::ranges::forward_range<SizedView>);
+    static_assert(std::ranges::sized_range<SizedView>);
+    static_assert(std::ranges::view<SizedView>);
+
+    int arr[]{94, 82, 49};
+
+    SizedView view{arr, arr + 3};
+    auto subrange = std::ranges::subrange(view.begin(), view.end());
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::drop(subrange, 3);
+  }
+
+  {
+    struct X {};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::drop(X{});
+  }
+}


### PR DESCRIPTION
`[[nodiscard]]` should be applied to functions where discarding the return value is most likely a correctness issue.

- https://libcxx.llvm.org/CodingGuidelines.html
- https://wg21.link/range.drop

Towards #172124