### PR TITLE
[flang] No ENTRY in interfaces

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -4871,7 +4871,13 @@ bool SubprogramVisitor::Pre(const parser::FunctionStmt &) {
   }
   return BeginAttrs();
 }
-bool SubprogramVisitor::Pre(const parser::EntryStmt &) { return BeginAttrs(); }
+bool SubprogramVisitor::Pre(const parser::EntryStmt &stmt) {
+  if (inInterfaceBlock()) {
+    Say(std::get<parser::Name>(stmt.t).source,
+        "An ENTRY statement may not appear in an interface body"_err_en_US);
+  }
+  return BeginAttrs();
+}
 
 void SubprogramVisitor::Post(const parser::FunctionStmt &stmt) {
   const auto &name{std::get<parser::Name>(stmt.t)};

--- a/flang/test/Semantics/entry01.f90
+++ b/flang/test/Semantics/entry01.f90
@@ -7,6 +7,10 @@ module m1
   interface
     module subroutine separate
     end subroutine
+    subroutine hasentry
+      !ERROR: An ENTRY statement may not appear in an interface body
+      entry ent
+    end subroutine
   end interface
  contains
   subroutine modproc


### PR DESCRIPTION
The ISO Fortran standard syntactically allows an ENTRY statement in an interface body, but doesn't define what it would mean, and no other compiler accepts it.

Fixes https://github.com/llvm/llvm-project/issues/173523.