### PR TITLE
[clang][ASTMatcher] Add forEachAdjacentSubstatements matcher

### DIFF
--- a/clang/docs/LibASTMatchersReference.html
+++ b/clang/docs/LibASTMatchersReference.html
@@ -8211,6 +8211,22 @@ with compoundStmt()
 </pre></td></tr>
 
 
+<tr><td>Matcher&lt;<a href="https://clang.llvm.org/doxygen/classclang_1_1CompoundStmt.html">CompoundStmt</a>&gt;</td><td class="name" onclick="toggle('forEachAdjacentSubstatements0')"><a name="forEachAdjacentSubstatements0Anchor">forEachAdjacentSubstatements</a></td><td>Matcher&lt;<a href="https://clang.llvm.org/doxygen/classclang_1_1Stmt.html">Stmt</a>&gt;, ..., Matcher&lt;<a href="https://clang.llvm.org/doxygen/classclang_1_1Stmt.html">Stmt</a>&gt;</td></tr>
+<tr><td colspan="4" class="doc" id="forEachAdjacentSubstatements0"><pre>Matches compound statements where all sets of adjacent substatements
+matching the provided sequence of matchers are found. Also matches
+StmtExprs that have CompoundStmt as children.
+
+Given
+  { {}; 1+2; {}; 3+4; }
+forEachAdjacentSubstatements(compoundStmt(), binaryOperator())
+  matches '{ {}; 1+2; {}; 3+4; }' twice
+with compoundStmt()
+  matching '{}' (first match) and '{}' (second match)
+with binaryOperator()
+  matching '1+2' (first match) and '3+4' (second match)
+</pre></td></tr>
+
+
 <tr><td>Matcher&lt;<a href="https://clang.llvm.org/doxygen/classclang_1_1CoroutineBodyStmt.html">CoroutineBodyStmt</a>&gt;</td><td class="name" onclick="toggle('hasBody5')"><a name="hasBody5Anchor">hasBody</a></td><td>Matcher&lt;<a href="https://clang.llvm.org/doxygen/classclang_1_1Stmt.html">Stmt</a>&gt; InnerMatcher</td></tr>
 <tr><td colspan="4" class="doc" id="hasBody5"><pre>Matches a 'for', 'while', 'while' statement or a function or coroutine
 definition that has a given body. Note that in case of functions or
@@ -9988,6 +10004,21 @@ hasAnySubstatement(compoundStmt())
   matches '{ {}; 1+2; }'
 with compoundStmt()
   matching '{}'
+</pre></td></tr>
+
+
+<tr><td>Matcher&lt;<a href="https://clang.llvm.org/doxygen/classclang_1_1StmtExpr.html">StmtExpr</a>&gt;</td><td class="name" onclick="toggle('forEachAdjacentSubstatements1')"><a name="forEachAdjacentSubstatements1Anchor">forEachAdjacentSubstatements</a></td><td>Matcher&lt;<a href="https://clang.llvm.org/doxygen/classclang_1_1Stmt.html">Stmt</a>&gt;, ..., Matcher&lt;<a href="https://clang.llvm.org/doxygen/classclang_1_1Stmt.html">Stmt</a>&gt;</td></tr>
+<tr><td colspan="4" class="doc" id="forEachAdjacentSubstatements1"><pre>Matches StmtExprs with compound statements containing all sets of
+adjacent substatements that match the provided sequence of matchers.
+
+Given
+  int x = ({ {}; 1+2; {}; 3+4; });
+forEachAdjacentSubstatements(compoundStmt(), binaryOperator())
+  matches '({ {}; 1+2; {}; 3+4; })' twice
+with compoundStmt()
+  matching '{}' (first match) and '{}' (second match)
+with binaryOperator()
+  matching '1+2' (first match) and '3+4' (second match)
 </pre></td></tr>
 
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -753,6 +753,7 @@ AST Matchers
 - Added ``hasExplicitParameters`` for ``LambdaExpr`` as an output attribute to
   AST JSON dumps.
 - Add ``arrayTypeLoc`` matcher for matching ``ArrayTypeLoc``.
+- Add ``forEachAdjacentSubstatements``.
 
 clang-format
 ------------

--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -5911,6 +5911,26 @@ AST_POLYMORPHIC_MATCHER_P(hasAnySubstatement,
                                           Builder) != CS->body_end();
 }
 
+
+/// Matches compound statements where one ore more sets of adjacent
+/// substatements matching the provided sequence of matchers. Also matches
+/// StmtExprs that have CompoundStmt as children.
+///
+/// Given
+/// \code
+///   { {}; 1+2; {}; 3+4; }
+/// \endcode
+/// forEachAdjacentSubstatements(compoundStmt(), binaryOperator())
+///   matches '{ {}; 1+2; {}; 3+4; }' twice
+/// with compoundStmt()
+///   matching '{}' (first match) and '{}' (second match)
+/// with binaryOperator()
+///   matching '1+2' (first match) and '3+4' (second match)
+extern const internal::VariadicFunction<
+    internal::ForEachAdjSubstatementsMatcherType, internal::Matcher<Stmt>,
+    internal::forEachAdjSubstatementsFunc>
+    forEachAdjacentSubstatements;
+
 /// Checks that a compound statement contains a specific number of
 /// child statements.
 ///

--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -5927,7 +5927,7 @@ AST_POLYMORPHIC_MATCHER_P(hasAnySubstatement,
 /// with binaryOperator()
 ///   matching '1+2' (first match) and '3+4' (second match)
 extern const internal::VariadicFunction<
-    internal::ForEachAdjSubstatementsMatcherType, internal::Matcher<Stmt>,
+    internal::ForEachAdjacentSubstatementsMatcherType, internal::Matcher<Stmt>,
     internal::forEachAdjSubstatementsFunc>
     forEachAdjacentSubstatements;
 

--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -5911,7 +5911,6 @@ AST_POLYMORPHIC_MATCHER_P(hasAnySubstatement,
                                           Builder) != CS->body_end();
 }
 
-
 /// Matches compound statements where one ore more sets of adjacent
 /// substatements matching the provided sequence of matchers. Also matches
 /// StmtExprs that have CompoundStmt as children.

--- a/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
@@ -2289,7 +2289,7 @@ HasOpNameMatcher hasAnyOperatorNameFunc(ArrayRef<const StringRef *> NameRefs);
 ///
 /// See \c forEachAdjacentSubstatements() in ASTMatchers.h for details.
 template <typename T, typename ArgT = std::vector<Matcher<Stmt>>>
-class ForEachAdjSubstatementsMatcher : public MatcherInterface<T> {
+class ForEachAdjacentSubstatementsMatcher : public MatcherInterface<T> {
   static_assert(std::is_same<T, CompoundStmt>::value ||
                     std::is_same<T, StmtExpr>::value,
                 "Matcher only supports `CompoundStmt` and `StmtExpr`");
@@ -2297,7 +2297,7 @@ class ForEachAdjSubstatementsMatcher : public MatcherInterface<T> {
                 "Matcher ArgT must be std::vector<Matcher<Stmt>>");
 
 public:
-  explicit ForEachAdjSubstatementsMatcher(std::vector<Matcher<Stmt>> Matchers)
+  explicit ForEachAdjacentSubstatementsMatcher(std::vector<Matcher<Stmt>> Matchers)
       : Matchers(std::move(Matchers)) {}
 
   bool matches(const T &Node, ASTMatchFinder *Finder,
@@ -2307,12 +2307,12 @@ private:
   std::vector<Matcher<Stmt>> Matchers;
 };
 
-using ForEachAdjSubstatementsMatcherType =
-    PolymorphicMatcher<ForEachAdjSubstatementsMatcher,
+using ForEachAdjacentSubstatementsMatcherType =
+    PolymorphicMatcher<ForEachAdjacentSubstatementsMatcher,
                        AST_POLYMORPHIC_SUPPORTED_TYPES(CompoundStmt, StmtExpr),
                        std::vector<Matcher<Stmt>>>;
 
-ForEachAdjSubstatementsMatcherType
+ForEachAdjacentSubstatementsMatcherType
 forEachAdjSubstatementsFunc(ArrayRef<const Matcher<Stmt> *> MatcherRefs);
 
 using HasOverloadOpNameMatcher =

--- a/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
@@ -413,8 +413,7 @@ public:
   template <typename T>
   DynTypedMatcher(const MatcherInterface<T> *Implementation)
       : SupportedKind(ASTNodeKind::getFromNodeKind<T>()),
-        RestrictKind(SupportedKind),
-        Implementation(Implementation) {}
+        RestrictKind(SupportedKind), Implementation(Implementation) {}
 
   /// Construct from a variadic function.
   enum VariadicOperator {
@@ -744,9 +743,10 @@ public:
                                       bool Directly) = 0;
 
   template <typename T>
-  bool matchesChildOf(const T &Node, const DynTypedMatcher &Matcher,
-                      BoundNodesTreeBuilder *Builder, BindKind Bind,
-                      llvm::function_ref<bool(BoundNodesTreeBuilder*)> MatchCallback) {
+  bool matchesChildOf(
+      const T &Node, const DynTypedMatcher &Matcher,
+      BoundNodesTreeBuilder *Builder, BindKind Bind,
+      llvm::function_ref<bool(BoundNodesTreeBuilder *)> MatchCallback) {
     static_assert(std::is_base_of<Decl, T>::value ||
                       std::is_base_of<Stmt, T>::value ||
                       std::is_base_of<NestedNameSpecifier, T>::value ||
@@ -763,12 +763,12 @@ public:
   bool matchesChildOf(const T &Node, const DynTypedMatcher &Matcher,
                       BoundNodesTreeBuilder *Builder, BindKind Bind) {
     static_assert(std::is_base_of<Decl, T>::value ||
-                  std::is_base_of<Stmt, T>::value ||
-                  std::is_base_of<NestedNameSpecifier, T>::value ||
-                  std::is_base_of<NestedNameSpecifierLoc, T>::value ||
-                  std::is_base_of<TypeLoc, T>::value ||
-                  std::is_base_of<QualType, T>::value ||
-                  std::is_base_of<Attr, T>::value,
+                      std::is_base_of<Stmt, T>::value ||
+                      std::is_base_of<NestedNameSpecifier, T>::value ||
+                      std::is_base_of<NestedNameSpecifierLoc, T>::value ||
+                      std::is_base_of<TypeLoc, T>::value ||
+                      std::is_base_of<QualType, T>::value ||
+                      std::is_base_of<Attr, T>::value,
                   "unsupported type for recursive matching");
     return matchesChildOf(DynTypedNode::create(Node), getASTContext(), Matcher,
                           Builder, Bind);
@@ -813,11 +813,10 @@ public:
   bool isTraversalIgnoringImplicitNodes() const;
 
 protected:
-  virtual bool matchesChildOf(const DynTypedNode &Node, ASTContext &Ctx,
-                              const DynTypedMatcher &Matcher,
-                              BoundNodesTreeBuilder *Builder,
-                              BindKind Bind,
-                              llvm::function_ref<bool(BoundNodesTreeBuilder *)> MatchCallback) = 0;
+  virtual bool matchesChildOf(
+      const DynTypedNode &Node, ASTContext &Ctx, const DynTypedMatcher &Matcher,
+      BoundNodesTreeBuilder *Builder, BindKind Bind,
+      llvm::function_ref<bool(BoundNodesTreeBuilder *)> MatchCallback) = 0;
 
   virtual bool matchesChildOf(const DynTypedNode &Node, ASTContext &Ctx,
                               const DynTypedMatcher &Matcher,
@@ -2321,7 +2320,8 @@ class ForEachAdjacentSubstatementsMatcher : public MatcherInterface<T> {
                 "Matcher ArgT must be std::vector<Matcher<Stmt>>");
 
 public:
-  explicit ForEachAdjacentSubstatementsMatcher(std::vector<Matcher<Stmt>> Matchers)
+  explicit ForEachAdjacentSubstatementsMatcher(
+      std::vector<Matcher<Stmt>> Matchers)
       : Matchers(std::move(Matchers)) {}
 
   bool matches(const T &Node, ASTMatchFinder *Finder,

--- a/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
@@ -411,9 +411,10 @@ class DynTypedMatcher {
 public:
   /// Takes ownership of the provided implementation pointer.
   template <typename T>
-  DynTypedMatcher(MatcherInterface<T> *Implementation)
+  DynTypedMatcher(const MatcherInterface<T> *Implementation)
       : SupportedKind(ASTNodeKind::getFromNodeKind<T>()),
-        RestrictKind(SupportedKind), Implementation(Implementation) {}
+        RestrictKind(SupportedKind),
+        Implementation(Implementation) {}
 
   /// Construct from a variadic function.
   enum VariadicOperator {
@@ -542,7 +543,7 @@ public:
 
 private:
   DynTypedMatcher(ASTNodeKind SupportedKind, ASTNodeKind RestrictKind,
-                  IntrusiveRefCntPtr<DynMatcherInterface> Implementation)
+                  IntrusiveRefCntPtr<const DynMatcherInterface> Implementation)
       : SupportedKind(SupportedKind), RestrictKind(RestrictKind),
         Implementation(std::move(Implementation)) {}
 
@@ -554,7 +555,7 @@ private:
   /// It allows to perform implicit and dynamic cast of matchers without
   /// needing to change \c Implementation.
   ASTNodeKind RestrictKind;
-  IntrusiveRefCntPtr<DynMatcherInterface> Implementation;
+  IntrusiveRefCntPtr<const DynMatcherInterface> Implementation;
 };
 
 /// Wrapper of a MatcherInterface<T> *that allows copying.
@@ -810,7 +811,7 @@ public:
   /// \param MatchCallback The callback that performs the actual matching
   /// \return true if the match succeeded, false otherwise
   virtual bool memoizedMatch(
-      const DynTypedMatcher::MatcherIDType &MatcherID,
+      const DynTypedMatcher &Matcher,
       const DynTypedNode &Node, BoundNodesTreeBuilder *Builder,
       llvm::function_ref<bool(BoundNodesTreeBuilder *)> MatchCallback) = 0;
 

--- a/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
@@ -722,16 +722,6 @@ public:
     AMM_ParentOnly
   };
 
-  /// Type of match operation for memoization purposes.
-  enum MatchType {
-    /// Matching ancestors.
-    MT_Ancestors,
-    /// Matching descendants.
-    MT_Descendants,
-    /// Matching children.
-    MT_Child
-  };
-
   virtual ~ASTMatchFinder() = default;
 
   /// Returns true if the given C++ class is directly or indirectly derived
@@ -812,17 +802,17 @@ public:
   /// It checks the memoization cache before executing the provided callback,
   /// and caches the result for future use.
   ///
+  /// The match type is assumed to be Child (matching children, not descendants).
+  ///
   /// \param MatcherID The unique identifier for this matcher operation
   /// \param Node The AST node to match against
   /// \param Builder The bound nodes builder (will be updated with cached result)
   /// \param MatchCallback The callback that performs the actual matching
-  /// \param Type The type of match (MT_Child, MT_Descendants, or MT_Ancestors)
   /// \return true if the match succeeded, false otherwise
   virtual bool memoizedMatch(
       const DynTypedMatcher::MatcherIDType &MatcherID,
       const DynTypedNode &Node, BoundNodesTreeBuilder *Builder,
-      llvm::function_ref<bool(BoundNodesTreeBuilder *)> MatchCallback,
-      MatchType Type) = 0;
+      llvm::function_ref<bool(BoundNodesTreeBuilder *)> MatchCallback) = 0;
 
 protected:
   virtual bool matchesChildOf(const DynTypedNode &Node, ASTContext &Ctx,

--- a/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
@@ -722,6 +722,16 @@ public:
     AMM_ParentOnly
   };
 
+  /// Type of match operation for memoization purposes.
+  enum MatchType {
+    /// Matching ancestors.
+    MT_Ancestors,
+    /// Matching descendants.
+    MT_Descendants,
+    /// Matching children.
+    MT_Child
+  };
+
   virtual ~ASTMatchFinder() = default;
 
   /// Returns true if the given C++ class is directly or indirectly derived
@@ -794,6 +804,25 @@ public:
   virtual bool IsMatchingInASTNodeNotAsIs() const = 0;
 
   bool isTraversalIgnoringImplicitNodes() const;
+
+  /// Memoized match execution for custom matchers.
+  ///
+  /// This method provides memoization support for custom matcher operations
+  /// that don't use the standard matchesChildOf/matchesDescendantOf methods.
+  /// It checks the memoization cache before executing the provided callback,
+  /// and caches the result for future use.
+  ///
+  /// \param MatcherID The unique identifier for this matcher operation
+  /// \param Node The AST node to match against
+  /// \param Builder The bound nodes builder (will be updated with cached result)
+  /// \param MatchCallback The callback that performs the actual matching
+  /// \param Type The type of match (MT_Child, MT_Descendants, or MT_Ancestors)
+  /// \return true if the match succeeded, false otherwise
+  virtual bool memoizedMatch(
+      const DynTypedMatcher::MatcherIDType &MatcherID,
+      const DynTypedNode &Node, BoundNodesTreeBuilder *Builder,
+      llvm::function_ref<bool(BoundNodesTreeBuilder *)> MatchCallback,
+      MatchType Type) = 0;
 
 protected:
   virtual bool matchesChildOf(const DynTypedNode &Node, ASTContext &Ctx,

--- a/clang/lib/ASTMatchers/ASTMatchFinder.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchFinder.cpp
@@ -595,9 +595,8 @@ public:
 
   // Matches children or descendants of 'Node' with a custom callback.
   bool memoizedMatchesRecursively(
-      const DynTypedNode &Node, ASTContext &Ctx,
-      const DynTypedMatcher &Matcher, BoundNodesTreeBuilder *Builder,
-      int MaxDepth, BindKind Bind,
+      const DynTypedNode &Node, ASTContext &Ctx, const DynTypedMatcher &Matcher,
+      BoundNodesTreeBuilder *Builder, int MaxDepth, BindKind Bind,
       llvm::function_ref<bool(BoundNodesTreeBuilder *)> MatchCallback) {
     // For AST-nodes that don't have an identity, we can't memoize.
     if (!Node.getMemoizationData() || !Builder->isComparable())
@@ -684,11 +683,11 @@ public:
   bool matchesChildOf(const DynTypedNode &Node, ASTContext &Ctx,
                       const DynTypedMatcher &Matcher,
                       BoundNodesTreeBuilder *Builder, BindKind Bind) override {
-    return matchesChildOf(Node, Ctx, Matcher, Builder, Bind,
-                         [this, &Node, &Matcher, Bind](
-                            BoundNodesTreeBuilder* Nodes) -> bool {
-                           return matchesRecursively(Node, Matcher, Nodes, 1, Bind);
-                         });
+    return matchesChildOf(
+        Node, Ctx, Matcher, Builder, Bind,
+        [this, &Node, &Matcher, Bind](BoundNodesTreeBuilder *Nodes) -> bool {
+          return matchesRecursively(Node, Matcher, Nodes, 1, Bind);
+        });
   }
   // Implements ASTMatchFinder::matchesDescendantOf.
   bool matchesDescendantOf(const DynTypedNode &Node, ASTContext &Ctx,
@@ -697,12 +696,11 @@ public:
                            BindKind Bind) override {
     if (ResultCache.size() > MaxMemoizationEntries)
       ResultCache.clear();
-    return memoizedMatchesRecursively(Node, Ctx, Matcher, Builder, INT_MAX,
-                                      Bind,
-                                      [this, &Node, &Matcher, Bind](
-                                          BoundNodesTreeBuilder* Nodes) -> bool {
-                                        return matchesRecursively(Node, Matcher, Nodes, INT_MAX, Bind);
-                                      });
+    return memoizedMatchesRecursively(
+        Node, Ctx, Matcher, Builder, INT_MAX, Bind,
+        [this, &Node, &Matcher, Bind](BoundNodesTreeBuilder *Nodes) -> bool {
+          return matchesRecursively(Node, Matcher, Nodes, INT_MAX, Bind);
+        });
   }
   // Implements ASTMatchFinder::matchesAncestorOf.
   bool matchesAncestorOf(const DynTypedNode &Node, ASTContext &Ctx,
@@ -717,7 +715,6 @@ public:
       return matchesParentOf(Node, Matcher, Builder);
     return matchesAnyAncestorOf(Node, Ctx, Matcher, Builder);
   }
-
 
   // Matches all registered matchers on the given node and calls the
   // result callback for every node that matches.

--- a/clang/lib/ASTMatchers/ASTMatchFinder.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchFinder.cpp
@@ -701,7 +701,7 @@ public:
   }
 
   // Implements ASTMatchFinder::memoizedMatch.
-  bool memoizedMatch(const DynTypedMatcher::MatcherIDType &MatcherID,
+  bool memoizedMatch(const DynTypedMatcher &Matcher,
                      const DynTypedNode &Node, BoundNodesTreeBuilder *Builder,
                      llvm::function_ref<bool(BoundNodesTreeBuilder *)>
                          MatchCallback) override {
@@ -714,7 +714,7 @@ public:
       return MatchCallback(Builder);
 
     MatchKey Key;
-    Key.MatcherID = MatcherID;
+    Key.MatcherID = Matcher.getID();
     Key.Node = Node;
     // Note that we key on the bindings *before* the match.
     Key.BoundNodes = *Builder;

--- a/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
@@ -485,13 +485,13 @@ static BoundNodesTreeBuilder extendBuilder(BoundNodesTreeBuilder &&Builder) {
   return Extended;
 }
 
-ForEachAdjSubstatementsMatcherType
+ForEachAdjacentSubstatementsMatcherType
 forEachAdjSubstatementsFunc(ArrayRef<const Matcher<Stmt> *> MatcherRefs) {
-  return ForEachAdjSubstatementsMatcherType(vectorFromMatcherRefs(MatcherRefs));
+  return ForEachAdjacentSubstatementsMatcherType(vectorFromMatcherRefs(MatcherRefs));
 }
 
 template <typename T, typename ArgT>
-bool ForEachAdjSubstatementsMatcher<T, ArgT>::matches(
+bool ForEachAdjacentSubstatementsMatcher<T, ArgT>::matches(
     const T &Node, ASTMatchFinder *Finder,
     BoundNodesTreeBuilder *Builder) const {
   const CompoundStmt *CS = CompoundStmtMatcher<T>::get(Node);
@@ -536,9 +536,9 @@ bool ForEachAdjSubstatementsMatcher<T, ArgT>::matches(
   return FoundAny;
 }
 
-template bool ForEachAdjSubstatementsMatcher<CompoundStmt>::matches(
+template bool ForEachAdjacentSubstatementsMatcher<CompoundStmt>::matches(
     const CompoundStmt &, ASTMatchFinder *, BoundNodesTreeBuilder *) const;
-template bool ForEachAdjSubstatementsMatcher<StmtExpr>::matches(
+template bool ForEachAdjacentSubstatementsMatcher<StmtExpr>::matches(
     const StmtExpr &, ASTMatchFinder *, BoundNodesTreeBuilder *) const;
 
 HasNameMatcher::HasNameMatcher(std::vector<std::string> N)
@@ -1121,7 +1121,7 @@ const internal::VariadicFunction<internal::Matcher<NamedDecl>, StringRef,
 const internal::VariadicFunction<internal::HasOpNameMatcher, StringRef,
                                  internal::hasAnyOperatorNameFunc>
     hasAnyOperatorName = {};
-const internal::VariadicFunction<internal::ForEachAdjSubstatementsMatcherType,
+const internal::VariadicFunction<internal::ForEachAdjacentSubstatementsMatcherType,
                                  internal::Matcher<Stmt>,
                                  internal::forEachAdjSubstatementsFunc>
     forEachAdjacentSubstatements = {};

--- a/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
@@ -501,16 +501,14 @@ bool ForEachAdjacentSubstatementsMatcher<T, ArgT>::matches(
   if (Matchers.empty())
     return false;
 
-  DynTypedNode DynNode = DynTypedNode::create(Node);
-
   // Create a DynTypedMatcher wrapper for this matcher instance to use for
   // memoization. The matcher sequence is implicitly part of the matcher
   // instance, so using 'this' pointer provides a unique identifier.
   DynTypedMatcher MatcherWrapper(this);
 
   // Use memoization to avoid re-running the same matcher on the same node.
-  return Finder->memoizedMatch(
-      MatcherWrapper, DynNode, Builder,
+  return Finder->memoizedMatch(static_cast<const Stmt&>(*CS),
+      MatcherWrapper, Builder,
       [this, CS, Finder](BoundNodesTreeBuilder *MemoBuilder) -> bool {
         // Search for all sequences of adjacent substatements that match the
         // matchers

--- a/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
@@ -551,8 +551,7 @@ bool ForEachAdjacentSubstatementsMatcher<T, ArgT>::matches(
         }
 
         return FoundAny;
-      },
-      ASTMatchFinder::MT_Child);
+      });
 }
 
 template bool ForEachAdjacentSubstatementsMatcher<CompoundStmt>::matches(

--- a/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
@@ -507,8 +507,8 @@ bool ForEachAdjacentSubstatementsMatcher<T, ArgT>::matches(
   DynTypedMatcher MatcherWrapper(this);
 
   // Use memoization to avoid re-running the same matcher on the same node.
-  return Finder->memoizedMatch(static_cast<const Stmt&>(*CS),
-      MatcherWrapper, Builder,
+  return Finder->matchesChildOf(static_cast<const Stmt&>(*CS),
+      MatcherWrapper, Builder, ASTMatchFinder::BK_All,
       [this, CS, Finder](BoundNodesTreeBuilder *MemoBuilder) -> bool {
         // Search for all sequences of adjacent substatements that match the
         // matchers

--- a/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchersInternal.cpp
@@ -487,7 +487,8 @@ static BoundNodesTreeBuilder extendBuilder(BoundNodesTreeBuilder &&Builder) {
 
 ForEachAdjacentSubstatementsMatcherType
 forEachAdjSubstatementsFunc(ArrayRef<const Matcher<Stmt> *> MatcherRefs) {
-  return ForEachAdjacentSubstatementsMatcherType(vectorFromMatcherRefs(MatcherRefs));
+  return ForEachAdjacentSubstatementsMatcherType(
+      vectorFromMatcherRefs(MatcherRefs));
 }
 
 template <typename T, typename ArgT>
@@ -507,8 +508,9 @@ bool ForEachAdjacentSubstatementsMatcher<T, ArgT>::matches(
   DynTypedMatcher MatcherWrapper(this);
 
   // Use memoization to avoid re-running the same matcher on the same node.
-  return Finder->matchesChildOf(static_cast<const Stmt&>(*CS),
-      MatcherWrapper, Builder, ASTMatchFinder::BK_All,
+  return Finder->matchesChildOf(
+      static_cast<const Stmt &>(*CS), MatcherWrapper, Builder,
+      ASTMatchFinder::BK_All,
       [this, CS, Finder](BoundNodesTreeBuilder *MemoBuilder) -> bool {
         // Search for all sequences of adjacent substatements that match the
         // matchers
@@ -527,9 +529,9 @@ bool ForEachAdjacentSubstatementsMatcher<T, ArgT>::matches(
           // Start with a fresh builder for this sequence
           BoundNodesTreeBuilder SequenceBuilder;
 
-          // Use enumerate to iterate over matchers and statements simultaneously
-          auto StmtRange =
-              llvm::make_range(StartIt, StartIt + Matchers.size());
+          // Use enumerate to iterate over matchers and statements
+          // simultaneously
+          auto StmtRange = llvm::make_range(StartIt, StartIt + Matchers.size());
           for (auto [Idx, Matcher, StmtPtr] :
                llvm::enumerate(Matchers, StmtRange)) {
             // Extend the builder before matching each statement
@@ -1134,9 +1136,9 @@ const internal::VariadicFunction<internal::Matcher<NamedDecl>, StringRef,
 const internal::VariadicFunction<internal::HasOpNameMatcher, StringRef,
                                  internal::hasAnyOperatorNameFunc>
     hasAnyOperatorName = {};
-const internal::VariadicFunction<internal::ForEachAdjacentSubstatementsMatcherType,
-                                 internal::Matcher<Stmt>,
-                                 internal::forEachAdjSubstatementsFunc>
+const internal::VariadicFunction<
+    internal::ForEachAdjacentSubstatementsMatcherType, internal::Matcher<Stmt>,
+    internal::forEachAdjSubstatementsFunc>
     forEachAdjacentSubstatements = {};
 const internal::VariadicFunction<internal::HasOverloadOpNameMatcher, StringRef,
                                  internal::hasAnyOverloadedOperatorNameFunc>

--- a/clang/lib/ASTMatchers/Dynamic/Registry.cpp
+++ b/clang/lib/ASTMatchers/Dynamic/Registry.cpp
@@ -289,6 +289,7 @@ RegistryMaps::RegistryMaps() {
   REGISTER_MATCHER(hasAnyPlacementArg);
   REGISTER_MATCHER(hasAnySelector);
   REGISTER_MATCHER(hasAnySubstatement);
+  REGISTER_MATCHER(forEachAdjacentSubstatements);
   REGISTER_MATCHER(hasAnyTemplateArgument);
   REGISTER_MATCHER(hasAnyTemplateArgumentLoc);
   REGISTER_MATCHER(hasAnyUsingShadowDecl);

--- a/clang/unittests/ASTMatchers/ASTMatchersTraversalTest.cpp
+++ b/clang/unittests/ASTMatchers/ASTMatchersTraversalTest.cpp
@@ -2410,13 +2410,13 @@ TEST(ForEachAdjSubstatements, MatchesMultipleAdjacentPairs) {
   // When multiple adjacent pairs exist, should match all of them
   EXPECT_TRUE(matchAndVerifyResultTrue(
       "void f() { {} 1+2; {} 3+4; }",
-      compoundStmt(forEachAdjacentSubstatements(
-          compoundStmt().bind("cs"), binaryOperator().bind("bo"))),
+      compoundStmt(forEachAdjacentSubstatements(compoundStmt().bind("cs"),
+                                                binaryOperator().bind("bo"))),
       std::make_unique<VerifyIdIsBoundTo<CompoundStmt>>("cs", 2)));
   EXPECT_TRUE(matchAndVerifyResultTrue(
       "void f() { {} 1+2; {} 3+4; }",
-      compoundStmt(forEachAdjacentSubstatements(
-          compoundStmt().bind("cs"), binaryOperator().bind("bo"))),
+      compoundStmt(forEachAdjacentSubstatements(compoundStmt().bind("cs"),
+                                                binaryOperator().bind("bo"))),
       std::make_unique<VerifyIdIsBoundTo<BinaryOperator>>("bo", 2)));
 }
 
@@ -2438,8 +2438,8 @@ TEST(ForEachAdjSubstatements, MatchesAllAdjacentPairs) {
   // When multiple adjacent pairs exist, should match all of them
   EXPECT_TRUE(matchAndVerifyResultTrue(
       "void f() { {} 1+2; int x; {} 3+4; }",
-      compoundStmt(forEachAdjacentSubstatements(
-          compoundStmt().bind("cs"), binaryOperator().bind("bo"))),
+      compoundStmt(forEachAdjacentSubstatements(compoundStmt().bind("cs"),
+                                                binaryOperator().bind("bo"))),
       std::make_unique<VerifyIdIsBoundTo<CompoundStmt>>("cs", 2)));
 }
 
@@ -2459,9 +2459,9 @@ TEST(ForEachAdjSubstatements, DoesNotMatchSingleStatement) {
 
 TEST(ForEachAdjSubstatements, MatchesDifferentStatementTypes) {
   // Test with different statement types
-  EXPECT_TRUE(
-      matches("void f() { for (;;); while (true); }",
-              compoundStmt(forEachAdjacentSubstatements(forStmt(), whileStmt()))));
+  EXPECT_TRUE(matches(
+      "void f() { for (;;); while (true); }",
+      compoundStmt(forEachAdjacentSubstatements(forStmt(), whileStmt()))));
 
   EXPECT_TRUE(matches(
       "void f() { int x; return; }",
@@ -2470,9 +2470,9 @@ TEST(ForEachAdjSubstatements, MatchesDifferentStatementTypes) {
 
 TEST(ForEachAdjSubstatements, WorksWithStmtExpr) {
   // Test that it works with StmtExpr (polymorphic support)
-  EXPECT_TRUE(matches(
-      "void f() { int x = ({ {} 1+2; }); }",
-      stmtExpr(forEachAdjacentSubstatements(compoundStmt(), binaryOperator()))));
+  EXPECT_TRUE(matches("void f() { int x = ({ {} 1+2; }); }",
+                      stmtExpr(forEachAdjacentSubstatements(
+                          compoundStmt(), binaryOperator()))));
 }
 
 TEST(ForEachAdjSubstatements, DoesNotMatchWrongOrder) {
@@ -2494,10 +2494,12 @@ TEST(ForEachAdjSubstatements, MatchesMultipleSequencesWithStatementsBetween) {
   constexpr llvm::StringRef Code =
       "void f() { {} 1+2; int x; {} 3+4; int y; {} 5+6; }";
   const auto Matcher = compoundStmt(forEachAdjacentSubstatements(
-          compoundStmt().bind("cs"), binaryOperator().bind("bo")));
-  EXPECT_TRUE(matchAndVerifyResultTrue(Code, Matcher,
+      compoundStmt().bind("cs"), binaryOperator().bind("bo")));
+  EXPECT_TRUE(matchAndVerifyResultTrue(
+      Code, Matcher,
       std::make_unique<VerifyIdIsBoundTo<CompoundStmt>>("cs", 3)));
-  EXPECT_TRUE(matchAndVerifyResultTrue(Code, Matcher,
+  EXPECT_TRUE(matchAndVerifyResultTrue(
+      Code, Matcher,
       std::make_unique<VerifyIdIsBoundTo<BinaryOperator>>("bo", 3)));
 }
 
@@ -2513,9 +2515,9 @@ TEST(ForEachAdjSubstatements, VariadicMatchesMultipleSequences) {
   // Test variadic version matches all sequences
   EXPECT_TRUE(matchAndVerifyResultTrue(
       "void f() { {} 1+2; 3+4; int x; {} 5+6; 7+8; }",
-      compoundStmt(forEachAdjacentSubstatements(
-          compoundStmt().bind("cs"), binaryOperator().bind("bo1"),
-          binaryOperator().bind("bo2"))),
+      compoundStmt(forEachAdjacentSubstatements(compoundStmt().bind("cs"),
+                                                binaryOperator().bind("bo1"),
+                                                binaryOperator().bind("bo2"))),
       std::make_unique<VerifyIdIsBoundTo<CompoundStmt>>("cs", 2)));
 }
 
@@ -2531,8 +2533,8 @@ TEST(ForEachAdjSubstatements, VariadicMatchesFiveAdjacentSubstatements) {
   // Test variadic version with 5 matchers
   EXPECT_TRUE(matches(
       "void f() { for (;;); while (true); if (true) {} return; 1+2; }",
-      compoundStmt(forEachAdjacentSubstatements(forStmt(), whileStmt(), ifStmt(),
-                                            returnStmt(), binaryOperator()))));
+      compoundStmt(forEachAdjacentSubstatements(
+          forStmt(), whileStmt(), ifStmt(), returnStmt(), binaryOperator()))));
 }
 
 TEST(ForEachAdjSubstatements, VariadicDoesNotMatchNonAdjacentSequence) {
@@ -2578,9 +2580,9 @@ TEST(ForEachAdjSubstatements, VariadicMatchesAllSequences) {
   // When multiple sequences exist, should match all of them
   EXPECT_TRUE(matchAndVerifyResultTrue(
       "void f() { {} 1+2; 3+4; int x; {} 5+6; 7+8; }",
-      compoundStmt(forEachAdjacentSubstatements(
-          compoundStmt().bind("cs"), binaryOperator().bind("bo1"),
-          binaryOperator().bind("bo2"))),
+      compoundStmt(forEachAdjacentSubstatements(compoundStmt().bind("cs"),
+                                                binaryOperator().bind("bo1"),
+                                                binaryOperator().bind("bo2"))),
       std::make_unique<VerifyIdIsBoundTo<CompoundStmt>>("cs", 2)));
 }
 
@@ -2637,19 +2639,19 @@ TEST(ForEachAdjSubstatements, MatchesOverlappingSequences) {
   // { {}; 1+2; {}; } has two sequences: {}->1+2 and 1+2->{}
   EXPECT_TRUE(matchAndVerifyResultTrue(
       "void f() { {} 1+2; {}; }",
-      compoundStmt(forEachAdjacentSubstatements(
-          compoundStmt().bind("cs"), binaryOperator().bind("bo"))),
+      compoundStmt(forEachAdjacentSubstatements(compoundStmt().bind("cs"),
+                                                binaryOperator().bind("bo"))),
       std::make_unique<VerifyIdIsBoundTo<CompoundStmt>>("cs", 1)));
   // The second sequence: binaryOperator followed by compoundStmt
   EXPECT_TRUE(matchAndVerifyResultTrue(
       "void f() { {} 1+2; {}; }",
-      compoundStmt(forEachAdjacentSubstatements(
-          binaryOperator().bind("bo"), compoundStmt().bind("cs"))),
+      compoundStmt(forEachAdjacentSubstatements(binaryOperator().bind("bo"),
+                                                compoundStmt().bind("cs"))),
       std::make_unique<VerifyIdIsBoundTo<BinaryOperator>>("bo", 1)));
   EXPECT_TRUE(matchAndVerifyResultTrue(
       "void f() { {} 1+2; {}; }",
-      compoundStmt(forEachAdjacentSubstatements(
-          binaryOperator().bind("bo"), compoundStmt().bind("cs"))),
+      compoundStmt(forEachAdjacentSubstatements(binaryOperator().bind("bo"),
+                                                compoundStmt().bind("cs"))),
       std::make_unique<VerifyIdIsBoundTo<CompoundStmt>>("cs", 1)));
 }
 


### PR DESCRIPTION
Implementation of this matcher was mostly generated by Cursor.
This matcher(like [hasAdjacentSubstatements](https://github.com/llvm/llvm-project/pull/169965)) needed for me at least to implement https://github.com/llvm/llvm-project/issues/133110 and https://github.com/llvm/llvm-project/issues/38471
Also maybe we will use it in https://github.com/llvm/llvm-project/pull/158462
