### PR TITLE
[RISCV] vfadd.vf + splat (fneg)-> vfsub.vf

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -21027,10 +21027,10 @@ SDValue RISCVTargetLowering::PerformDAGCombine(SDNode *N,
     if (SDValue V = combineBinOpOfExtractToReduceTree(N, DAG, Subtarget))
       return V;
     SDValue N1 = N->getOperand(1);
-    if (!Subtarget.hasStdExtZfa() || N1.getOpcode() != ISD::SPLAT_VECTOR)
+    if (N1.getOpcode() != ISD::SPLAT_VECTOR)
       return SDValue();
     SDValue SplatN0 = N1->getOperand(0);
-    if (!SplatN0.hasOneUse() || SplatN0.getOpcode() != ISD::FNEG)
+    if (SplatN0.getOpcode() != ISD::FNEG || !SplatN0.hasOneUse())
       return SDValue();
     SDLoc DL(N);
     EVT VT = N->getValueType(0);

--- a/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
@@ -33,3 +33,14 @@ define <vscale x 8 x double> @vsplat_f64_neg1() {
 ; CHECK-NEXT:    ret
   ret <vscale x 8 x double> splat (double -1.0)
 }
+
+define <vscale x 8 x float> @vfsub_vf_nxv8f32(<vscale x 8 x float> %va) {
+; CHECK-LABEL: vfsub_vf_nxv8f32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fli.s fa5, 2.0
+; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
+; CHECK-NEXT:    vfsub.vf v8, v8, fa5
+; CHECK-NEXT:    ret
+  %vd = fadd <vscale x 8 x float> %va, splat (float -2.000000e+00)
+  ret <vscale x 8 x float> %vd
+}


### PR DESCRIPTION
We use fli+fneg to generate negative float.
Perhaps we could eliminate the fneg instruction.
Similarly, we may fold fma to vfnmacc.vf, vfnmsac.vf, vfnmsub.vf.