### PR TITLE
MIPSr6: Set FSELECT Legal for f64

### DIFF
--- a/llvm/lib/Target/Mips/Disassembler/MipsDisassembler.cpp
+++ b/llvm/lib/Target/Mips/Disassembler/MipsDisassembler.cpp
@@ -1010,13 +1010,24 @@ static DecodeStatus DecodeFCCRegisterClass(MCInst &Inst, unsigned RegNo,
   return MCDisassembler::Success;
 }
 
-static DecodeStatus DecodeFGRCCRegisterClass(MCInst &Inst, unsigned RegNo,
-                                             uint64_t Address,
-                                             const MCDisassembler *Decoder) {
+static DecodeStatus DecodeFGR32CCRegisterClass(MCInst &Inst, unsigned RegNo,
+                                               uint64_t Address,
+                                               const MCDisassembler *Decoder) {
   if (RegNo > 31)
     return MCDisassembler::Fail;
 
-  MCRegister Reg = getReg(Decoder, Mips::FGRCCRegClassID, RegNo);
+  MCRegister Reg = getReg(Decoder, Mips::FGR32CCRegClassID, RegNo);
+  Inst.addOperand(MCOperand::createReg(Reg));
+  return MCDisassembler::Success;
+}
+
+static DecodeStatus DecodeFGR64CCRegisterClass(MCInst &Inst, unsigned RegNo,
+                                               uint64_t Address,
+                                               const MCDisassembler *Decoder) {
+  if (RegNo > 31)
+    return MCDisassembler::Fail;
+
+  MCRegister Reg = getReg(Decoder, Mips::FGR64CCRegClassID, RegNo);
   Inst.addOperand(MCOperand::createReg(Reg));
   return MCDisassembler::Success;
 }

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsBaseInfo.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsBaseInfo.h
@@ -153,6 +153,17 @@ inline static MCRegister getMSARegFromFReg(MCRegister Reg) {
   else
     return MCRegister();
 }
+
+inline static MCRegister getFloatRegFromFReg(MCRegister Reg) {
+  if (Reg >= Mips::F0 && Reg <= Mips::F31)
+    return Reg;
+  else if (Reg >= Mips::D0_64 && Reg <= Mips::D31_64)
+    return Reg - Mips::D0_64 + Mips::F0;
+  else if (Reg >= Mips::W0 && Reg <= Mips::W31)
+    return Reg - Mips::W0 + Mips::F0;
+  return Mips::NoRegister;
+}
+
 } // namespace llvm
 
 #endif

--- a/llvm/lib/Target/Mips/MicroMips32r6InstrInfo.td
+++ b/llvm/lib/Target/Mips/MicroMips32r6InstrInfo.td
@@ -943,72 +943,74 @@ class CVT_S_L_MMR6_DESC : CVT_MMR6_DESC_BASE<"cvt.s.l", FGR64Opnd, FGR32Opnd,
                                              II_CVT>, FGR_64;
 
 multiclass CMP_CC_MMR6<bits<6> format, string Typestr,
-                       RegisterOperand FGROpnd, InstrItinClass Itin> {
+                       RegisterOperand FGROpnd,
+                       RegisterOperand FGRCCOpnd,
+                       InstrItinClass Itin> {
   def CMP_AF_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
       !strconcat("cmp.af.", Typestr), format, FIELD_CMP_COND_AF>,
-      CMP_CONDN_DESC_BASE<"af", Typestr, FGROpnd, Itin>, HARDFLOAT,
+      CMP_CONDN_DESC_BASE<"af", Typestr, FGROpnd, FGRCCOpnd, Itin>, HARDFLOAT,
       ISA_MICROMIPS32R6;
   def CMP_UN_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
       !strconcat("cmp.un.", Typestr), format, FIELD_CMP_COND_UN>,
-      CMP_CONDN_DESC_BASE<"un", Typestr, FGROpnd, Itin, setuo>, HARDFLOAT,
+      CMP_CONDN_DESC_BASE<"un", Typestr, FGROpnd, FGRCCOpnd, Itin, setuo>, HARDFLOAT,
       ISA_MICROMIPS32R6;
   def CMP_EQ_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
       !strconcat("cmp.eq.", Typestr), format, FIELD_CMP_COND_EQ>,
-      CMP_CONDN_DESC_BASE<"eq", Typestr, FGROpnd, Itin, setoeq>, HARDFLOAT,
+      CMP_CONDN_DESC_BASE<"eq", Typestr, FGROpnd, FGRCCOpnd, Itin, setoeq>, HARDFLOAT,
       ISA_MICROMIPS32R6;
   def CMP_UEQ_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
       !strconcat("cmp.ueq.", Typestr), format, FIELD_CMP_COND_UEQ>,
-      CMP_CONDN_DESC_BASE<"ueq", Typestr, FGROpnd, Itin, setueq>, HARDFLOAT,
+      CMP_CONDN_DESC_BASE<"ueq", Typestr, FGROpnd, FGRCCOpnd, Itin, setueq>, HARDFLOAT,
       ISA_MICROMIPS32R6;
   def CMP_LT_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
       !strconcat("cmp.lt.", Typestr), format, FIELD_CMP_COND_LT>,
-      CMP_CONDN_DESC_BASE<"lt", Typestr, FGROpnd, Itin, setolt>, HARDFLOAT,
+      CMP_CONDN_DESC_BASE<"lt", Typestr, FGROpnd, FGRCCOpnd, Itin, setolt>, HARDFLOAT,
       ISA_MICROMIPS32R6;
   def CMP_ULT_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
       !strconcat("cmp.ult.", Typestr), format, FIELD_CMP_COND_ULT>,
-      CMP_CONDN_DESC_BASE<"ult", Typestr, FGROpnd, Itin, setult>, HARDFLOAT,
+      CMP_CONDN_DESC_BASE<"ult", Typestr, FGROpnd, FGRCCOpnd, Itin, setult>, HARDFLOAT,
       ISA_MICROMIPS32R6;
   def CMP_LE_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
       !strconcat("cmp.le.", Typestr), format, FIELD_CMP_COND_LE>,
-      CMP_CONDN_DESC_BASE<"le", Typestr, FGROpnd, Itin, setole>, HARDFLOAT,
+      CMP_CONDN_DESC_BASE<"le", Typestr, FGROpnd, FGRCCOpnd, Itin, setole>, HARDFLOAT,
       ISA_MICROMIPS32R6;
   def CMP_ULE_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
       !strconcat("cmp.ule.", Typestr), format, FIELD_CMP_COND_ULE>,
-      CMP_CONDN_DESC_BASE<"ule", Typestr, FGROpnd, Itin, setule>, HARDFLOAT,
+      CMP_CONDN_DESC_BASE<"ule", Typestr, FGROpnd, FGRCCOpnd, Itin, setule>, HARDFLOAT,
       ISA_MICROMIPS32R6;
 
   let mayRaiseFPException = 1 in {
     def CMP_SAF_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
         !strconcat("cmp.saf.", Typestr), format, FIELD_CMP_COND_SAF>,
-        CMP_CONDN_DESC_BASE<"saf", Typestr, FGROpnd, Itin>, HARDFLOAT,
+        CMP_CONDN_DESC_BASE<"saf", Typestr, FGROpnd, FGRCCOpnd, Itin>, HARDFLOAT,
         ISA_MICROMIPS32R6;
     def CMP_SUN_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
         !strconcat("cmp.sun.", Typestr), format, FIELD_CMP_COND_SUN>,
-        CMP_CONDN_DESC_BASE<"sun", Typestr, FGROpnd, Itin>, HARDFLOAT,
+        CMP_CONDN_DESC_BASE<"sun", Typestr, FGROpnd, FGRCCOpnd, Itin>, HARDFLOAT,
         ISA_MICROMIPS32R6;
     def CMP_SEQ_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
         !strconcat("cmp.seq.", Typestr), format, FIELD_CMP_COND_SEQ>,
-        CMP_CONDN_DESC_BASE<"seq", Typestr, FGROpnd, Itin>, HARDFLOAT,
+        CMP_CONDN_DESC_BASE<"seq", Typestr, FGROpnd, FGRCCOpnd, Itin>, HARDFLOAT,
         ISA_MICROMIPS32R6;
     def CMP_SUEQ_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
         !strconcat("cmp.sueq.", Typestr), format, FIELD_CMP_COND_SUEQ>,
-        CMP_CONDN_DESC_BASE<"sueq", Typestr, FGROpnd, Itin>, HARDFLOAT,
+        CMP_CONDN_DESC_BASE<"sueq", Typestr, FGROpnd, FGRCCOpnd, Itin>, HARDFLOAT,
         ISA_MICROMIPS32R6;
     def CMP_SLT_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
         !strconcat("cmp.slt.", Typestr), format, FIELD_CMP_COND_SLT>,
-        CMP_CONDN_DESC_BASE<"slt", Typestr, FGROpnd, Itin>, HARDFLOAT,
+        CMP_CONDN_DESC_BASE<"slt", Typestr, FGROpnd, FGRCCOpnd, Itin>, HARDFLOAT,
         ISA_MICROMIPS32R6;
     def CMP_SULT_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
         !strconcat("cmp.sult.", Typestr), format, FIELD_CMP_COND_SULT>,
-        CMP_CONDN_DESC_BASE<"sult", Typestr, FGROpnd, Itin>, HARDFLOAT,
+        CMP_CONDN_DESC_BASE<"sult", Typestr, FGROpnd, FGRCCOpnd, Itin>, HARDFLOAT,
         ISA_MICROMIPS32R6;
     def CMP_SLE_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
         !strconcat("cmp.sle.", Typestr), format, FIELD_CMP_COND_SLE>,
-        CMP_CONDN_DESC_BASE<"sle", Typestr, FGROpnd, Itin>, HARDFLOAT,
+        CMP_CONDN_DESC_BASE<"sle", Typestr, FGROpnd, FGRCCOpnd, Itin>, HARDFLOAT,
         ISA_MICROMIPS32R6;
     def CMP_SULE_#NAME : R6MMR6Rel, POOL32F_CMP_FM<
         !strconcat("cmp.sule.", Typestr), format, FIELD_CMP_COND_SULE>,
-        CMP_CONDN_DESC_BASE<"sule", Typestr, FGROpnd, Itin>, HARDFLOAT,
+        CMP_CONDN_DESC_BASE<"sule", Typestr, FGROpnd, FGRCCOpnd, Itin>, HARDFLOAT,
         ISA_MICROMIPS32R6;
   }
 }
@@ -1063,8 +1065,8 @@ class ROUND_W_S_MMR6_DESC : ABSS_FT_MMR6_DESC_BASE<"round.w.s", FGR32Opnd,
 class ROUND_W_D_MMR6_DESC : ABSS_FT_MMR6_DESC_BASE<"round.w.d", FGR64Opnd,
                                                    FGR64Opnd, II_ROUND>;
 
-class SEL_S_MMR6_DESC : COP1_SEL_DESC_BASE<"sel.s", FGR32Opnd, II_SEL_S>;
-class SEL_D_MMR6_DESC : COP1_SEL_D_DESC_BASE<"sel.d", FGR64Opnd, II_SEL_D>;
+class SEL_S_MMR6_DESC : COP1_SEL_DESC_BASE<"sel.s", FGR32Opnd, FGR32CCOpnd, II_SEL_S>;
+class SEL_D_MMR6_DESC : COP1_SEL_DESC_BASE<"sel.d", FGR64Opnd, FGR64CCOpnd, II_SEL_D>;
 
 class SELEQZ_S_MMR6_DESC : SELEQNEZ_DESC_BASE<"seleqz.s", FGR32Opnd,
                                               II_SELCCZ_S>;
@@ -1512,8 +1514,8 @@ let mayRaiseFPException = 1 in {
   }
 }
 
-defm S_MMR6 : CMP_CC_MMR6<0b000101, "s", FGR32Opnd, II_CMP_CC_S>;
-defm D_MMR6 : CMP_CC_MMR6<0b010101, "d", FGR64Opnd, II_CMP_CC_D>;
+defm S_MMR6 : CMP_CC_MMR6<0b000101, "s", FGR32Opnd, FGR32CCOpnd, II_CMP_CC_S>;
+defm D_MMR6 : CMP_CC_MMR6<0b010101, "d", FGR64Opnd, FGR64CCOpnd, II_CMP_CC_D>;
 let mayRaiseFPException = 1 in {
   def FLOOR_L_S_MMR6 : StdMMR6Rel, FLOOR_L_S_MMR6_ENC, FLOOR_L_S_MMR6_DESC,
                        ISA_MICROMIPS32R6;

--- a/llvm/lib/Target/Mips/Mips32r6InstrInfo.td
+++ b/llvm/lib/Target/Mips/Mips32r6InstrInfo.td
@@ -212,6 +212,7 @@ class SIGRIE_ENC : SIGRIE_FM;
 
 class CMP_CONDN_DESC_BASE<string CondStr, string Typestr,
                           RegisterOperand FGROpnd,
+                          RegisterOperand FGRCCOpnd,
                           InstrItinClass Itin,
                           SDPatternOperator Op = null_frag> {
   dag OutOperandList = (outs FGRCCOpnd:$fd);
@@ -223,88 +224,90 @@ class CMP_CONDN_DESC_BASE<string CondStr, string Typestr,
 }
 
 multiclass CMP_CC_M <FIELD_CMP_FORMAT Format, string Typestr,
-                     RegisterOperand FGROpnd, InstrItinClass Itin>{
+                     RegisterOperand FGROpnd,
+                     RegisterOperand FGRCCOpnd,
+                     InstrItinClass Itin>{
   let AdditionalPredicates = [NotInMicroMips] in {
     def CMP_F_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format, FIELD_CMP_COND_AF>,
-                      CMP_CONDN_DESC_BASE<"af", Typestr, FGROpnd, Itin>,
+                      CMP_CONDN_DESC_BASE<"af", Typestr, FGROpnd, FGRCCOpnd, Itin>,
                       MipsR6Arch<!strconcat("cmp.af.", Typestr)>,
                       ISA_MIPS32R6, HARDFLOAT;
     def CMP_UN_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format, FIELD_CMP_COND_UN>,
-                       CMP_CONDN_DESC_BASE<"un", Typestr, FGROpnd, Itin, setuo>,
+                       CMP_CONDN_DESC_BASE<"un", Typestr, FGROpnd, FGRCCOpnd, Itin, setuo>,
                        MipsR6Arch<!strconcat("cmp.un.", Typestr)>,
                        ISA_MIPS32R6, HARDFLOAT;
     def CMP_EQ_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format, FIELD_CMP_COND_EQ>,
-                       CMP_CONDN_DESC_BASE<"eq", Typestr, FGROpnd, Itin,
+                       CMP_CONDN_DESC_BASE<"eq", Typestr, FGROpnd, FGRCCOpnd, Itin,
                                            setoeq>,
                        MipsR6Arch<!strconcat("cmp.eq.", Typestr)>,
                        ISA_MIPS32R6, HARDFLOAT;
     def CMP_UEQ_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format,
                                                      FIELD_CMP_COND_UEQ>,
-                        CMP_CONDN_DESC_BASE<"ueq", Typestr, FGROpnd, Itin,
+                        CMP_CONDN_DESC_BASE<"ueq", Typestr, FGROpnd, FGRCCOpnd, Itin,
                                             setueq>,
                         MipsR6Arch<!strconcat("cmp.ueq.", Typestr)>,
                         ISA_MIPS32R6, HARDFLOAT;
     def CMP_LT_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format, FIELD_CMP_COND_LT>,
-                       CMP_CONDN_DESC_BASE<"lt", Typestr, FGROpnd, Itin,
+                       CMP_CONDN_DESC_BASE<"lt", Typestr, FGROpnd, FGRCCOpnd, Itin,
                                            setolt>,
                        MipsR6Arch<!strconcat("cmp.lt.", Typestr)>,
                        ISA_MIPS32R6, HARDFLOAT;
     def CMP_ULT_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format,
                                                      FIELD_CMP_COND_ULT>,
-                        CMP_CONDN_DESC_BASE<"ult", Typestr, FGROpnd, Itin,
+                        CMP_CONDN_DESC_BASE<"ult", Typestr, FGROpnd, FGRCCOpnd, Itin,
                                             setult>,
                         MipsR6Arch<!strconcat("cmp.ult.", Typestr)>,
                         ISA_MIPS32R6, HARDFLOAT;
     def CMP_LE_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format, FIELD_CMP_COND_LE>,
-                       CMP_CONDN_DESC_BASE<"le", Typestr, FGROpnd, Itin,
+                       CMP_CONDN_DESC_BASE<"le", Typestr, FGROpnd, FGRCCOpnd, Itin,
                                            setole>,
                        MipsR6Arch<!strconcat("cmp.le.", Typestr)>,
                        ISA_MIPS32R6, HARDFLOAT;
     def CMP_ULE_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format,
                                                      FIELD_CMP_COND_ULE>,
-                        CMP_CONDN_DESC_BASE<"ule", Typestr, FGROpnd, Itin,
+                        CMP_CONDN_DESC_BASE<"ule", Typestr, FGROpnd, FGRCCOpnd, Itin,
                                             setule>,
                         MipsR6Arch<!strconcat("cmp.ule.", Typestr)>,
                         ISA_MIPS32R6, HARDFLOAT;
     let mayRaiseFPException = 1 in { 
       def CMP_SAF_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format,
                                                        FIELD_CMP_COND_SAF>,
-                          CMP_CONDN_DESC_BASE<"saf", Typestr, FGROpnd, Itin>,
+                          CMP_CONDN_DESC_BASE<"saf", Typestr, FGROpnd, FGRCCOpnd, Itin>,
                           MipsR6Arch<!strconcat("cmp.saf.", Typestr)>,
                           ISA_MIPS32R6, HARDFLOAT;
       def CMP_SUN_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format,
                                                        FIELD_CMP_COND_SUN>,
-                          CMP_CONDN_DESC_BASE<"sun", Typestr, FGROpnd, Itin>,
+                          CMP_CONDN_DESC_BASE<"sun", Typestr, FGROpnd, FGRCCOpnd, Itin>,
                           MipsR6Arch<!strconcat("cmp.sun.", Typestr)>,
                           ISA_MIPS32R6, HARDFLOAT;
       def CMP_SEQ_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format,
                                                        FIELD_CMP_COND_SEQ>,
-                          CMP_CONDN_DESC_BASE<"seq", Typestr, FGROpnd, Itin>,
+                          CMP_CONDN_DESC_BASE<"seq", Typestr, FGROpnd, FGRCCOpnd, Itin>,
                           MipsR6Arch<!strconcat("cmp.seq.", Typestr)>,
                           ISA_MIPS32R6, HARDFLOAT;
       def CMP_SUEQ_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format,
                                                         FIELD_CMP_COND_SUEQ>,
-                           CMP_CONDN_DESC_BASE<"sueq", Typestr, FGROpnd, Itin>,
+                           CMP_CONDN_DESC_BASE<"sueq", Typestr, FGROpnd, FGRCCOpnd, Itin>,
                            MipsR6Arch<!strconcat("cmp.sueq.", Typestr)>,
                            ISA_MIPS32R6, HARDFLOAT;
       def CMP_SLT_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format,
                                                        FIELD_CMP_COND_SLT>,
-                          CMP_CONDN_DESC_BASE<"slt", Typestr, FGROpnd, Itin>,
+                          CMP_CONDN_DESC_BASE<"slt", Typestr, FGROpnd, FGRCCOpnd, Itin>,
                           MipsR6Arch<!strconcat("cmp.slt.", Typestr)>,
                           ISA_MIPS32R6, HARDFLOAT;
       def CMP_SULT_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format,
                                                         FIELD_CMP_COND_SULT>,
-                           CMP_CONDN_DESC_BASE<"sult", Typestr, FGROpnd, Itin>,
+                           CMP_CONDN_DESC_BASE<"sult", Typestr, FGROpnd, FGRCCOpnd, Itin>,
                            MipsR6Arch<!strconcat("cmp.sult.", Typestr)>,
                            ISA_MIPS32R6, HARDFLOAT;
       def CMP_SLE_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format,
                                                        FIELD_CMP_COND_SLE>,
-                          CMP_CONDN_DESC_BASE<"sle", Typestr, FGROpnd, Itin>,
+                          CMP_CONDN_DESC_BASE<"sle", Typestr, FGROpnd, FGRCCOpnd, Itin>,
                           MipsR6Arch<!strconcat("cmp.sle.", Typestr)>,
                           ISA_MIPS32R6, HARDFLOAT;
       def CMP_SULE_#NAME : R6MMR6Rel, COP1_CMP_CONDN_FM<Format,
                                                         FIELD_CMP_COND_SULE>,
-                           CMP_CONDN_DESC_BASE<"sule", Typestr, FGROpnd, Itin>,
+                           CMP_CONDN_DESC_BASE<"sule", Typestr, FGROpnd, FGRCCOpnd, Itin>,
                            MipsR6Arch<!strconcat("cmp.sule.", Typestr)>,
                            ISA_MIPS32R6, HARDFLOAT;
     }
@@ -611,7 +614,9 @@ class MUHU_DESC   : MUL_R6_DESC_BASE<"muhu", GPR32Opnd, II_MUHU, mulhu>;
 class MUL_R6_DESC : MUL_R6_DESC_BASE<"mul", GPR32Opnd, II_MUL, mul>;
 class MULU_DESC   : MUL_R6_DESC_BASE<"mulu", GPR32Opnd, II_MULU>;
 
-class COP1_SEL_DESC_BASE<string instr_asm, RegisterOperand FGROpnd,
+class COP1_SEL_DESC_BASE<string instr_asm,
+                         RegisterOperand FGROpnd,
+                         RegisterOperand FGRCCOpnd,
                          InstrItinClass itin> {
   dag OutOperandList = (outs FGROpnd:$fd);
   dag InOperandList = (ins FGRCCOpnd:$fd_in, FGROpnd:$fs, FGROpnd:$ft);
@@ -623,21 +628,9 @@ class COP1_SEL_DESC_BASE<string instr_asm, RegisterOperand FGROpnd,
   InstrItinClass Itinerary = itin;
 }
 
-class COP1_SEL_D_DESC_BASE<string instr_asm, RegisterOperand FGROpnd,
-                           InstrItinClass itin> {
-  dag OutOperandList = (outs FGROpnd:$fd);
-  dag InOperandList = (ins FGROpnd:$fd_in, FGROpnd:$fs, FGROpnd:$ft);
-  string AsmString = !strconcat(instr_asm, "\t$fd, $fs, $ft");
-  list<dag> Pattern = [(set FGROpnd:$fd, (MipsFSelect FGROpnd:$fd_in,
-                                                      FGROpnd:$ft,
-                                                      FGROpnd:$fs))];
-  string Constraints = "$fd_in = $fd";
-  InstrItinClass Itinerary = itin;
-}
-
-class SEL_D_DESC : COP1_SEL_D_DESC_BASE<"sel.d", FGR64Opnd, II_SEL_D>,
+class SEL_D_DESC : COP1_SEL_DESC_BASE<"sel.d", FGR64Opnd, FGR64CCOpnd, II_SEL_D>,
                    MipsR6Arch<"sel.d">;
-class SEL_S_DESC : COP1_SEL_DESC_BASE<"sel.s", FGR32Opnd, II_SEL_S>,
+class SEL_S_DESC : COP1_SEL_DESC_BASE<"sel.s", FGR32Opnd, FGR32CCOpnd, II_SEL_S>,
                    MipsR6Arch<"sel.s">;
 
 class SELEQNE_Z_DESC_BASE<string instr_asm, RegisterOperand GPROpnd>
@@ -921,8 +914,8 @@ let AdditionalPredicates = [NotInMicroMips] in {
 }
 def CLO_R6 : R6MMR6Rel, CLO_R6_ENC, CLO_R6_DESC, ISA_MIPS32R6;
 def CLZ_R6 : R6MMR6Rel, CLZ_R6_ENC, CLZ_R6_DESC, ISA_MIPS32R6;
-defm S : CMP_CC_M<FIELD_CMP_FORMAT_S, "s", FGR32Opnd, II_CMP_CC_S>;
-defm D : CMP_CC_M<FIELD_CMP_FORMAT_D, "d", FGR64Opnd, II_CMP_CC_D>;
+defm S : CMP_CC_M<FIELD_CMP_FORMAT_S, "s", FGR32Opnd, FGR32CCOpnd, II_CMP_CC_S>;
+defm D : CMP_CC_M<FIELD_CMP_FORMAT_D, "d", FGR64Opnd, FGR64CCOpnd, II_CMP_CC_D>;
 let AdditionalPredicates = [NotInMicroMips] in {
   def DIV : R6MMR6Rel, DIV_ENC, DIV_DESC, ISA_MIPS32R6;
   def DIVU : R6MMR6Rel, DIVU_ENC, DIVU_DESC, ISA_MIPS32R6;

--- a/llvm/lib/Target/Mips/MipsMTInstrInfo.td
+++ b/llvm/lib/Target/Mips/MipsMTInstrInfo.td
@@ -140,7 +140,7 @@ def MFTC1 : MipsAsmPseudoInst<(outs GPR32Opnd:$rt), (ins FGR32Opnd:$ft),
 def MFTHC1 : MipsAsmPseudoInst<(outs GPR32Opnd:$rt), (ins FGR32Opnd:$ft),
                                "mfthc1 $rt, $ft">, ASE_MT;
 
-def CFTC1 : MipsAsmPseudoInst<(outs GPR32Opnd:$rt), (ins FGRCCOpnd:$ft),
+def CFTC1 : MipsAsmPseudoInst<(outs GPR32Opnd:$rt), (ins FGR32CCOpnd:$ft),
                               "cftc1 $rt, $ft">, ASE_MT;
 
 
@@ -169,7 +169,7 @@ def MTTC1 : MipsAsmPseudoInst<(outs FGR32Opnd:$ft), (ins GPR32Opnd:$rt),
 def MTTHC1 : MipsAsmPseudoInst<(outs FGR32Opnd:$ft), (ins GPR32Opnd:$rt),
                                "mtthc1 $rt, $ft">, ASE_MT;
 
-def CTTC1 : MipsAsmPseudoInst<(outs FGRCCOpnd:$ft), (ins GPR32Opnd:$rt),
+def CTTC1 : MipsAsmPseudoInst<(outs FGR32CCOpnd:$ft), (ins GPR32Opnd:$rt),
                               "cttc1 $rt, $ft">, ASE_MT;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/Mips/MipsRegisterInfo.td
+++ b/llvm/lib/Target/Mips/MipsRegisterInfo.td
@@ -429,7 +429,8 @@ def FCC : RegisterClass<"Mips", [i32], 32, (sequence "FCC%u", 0, 7)>,
 
 // MIPS32r6/MIPS64r6 store FPU condition codes in normal FGR registers.
 // This class allows us to represent this in codegen patterns.
-def FGRCC : RegisterClass<"Mips", [i32], 32, (sequence "F%u", 0, 31)>;
+def FGR32CC : RegisterClass<"Mips", [i32], 32, (sequence "F%u", 0, 31)>;
+def FGR64CC : RegisterClass<"Mips", [i32, f32, f64], 64, (sequence "D%u_64", 0, 31)>;
 
 def MSA128F16 : RegisterClass<"Mips", [f16], 128, (sequence "W%u", 0, 31)>;
 
@@ -701,7 +702,13 @@ def StrictlyFGR32Opnd : RegisterOperand<FGR32> {
   let ParserMatchClass = StrictlyFGR32AsmOperand;
 }
 
-def FGRCCOpnd : RegisterOperand<FGRCC> {
+def FGR64CCOpnd : RegisterOperand<FGR64CC> {
+  // The assembler doesn't use register classes so we can re-use
+  // FGR64AsmOperand.
+  let ParserMatchClass = FGR64AsmOperand;
+}
+
+def FGR32CCOpnd : RegisterOperand<FGR32CC> {
   // The assembler doesn't use register classes so we can re-use
   // FGR32AsmOperand.
   let ParserMatchClass = FGR32AsmOperand;

--- a/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
@@ -307,7 +307,7 @@ MipsSETargetLowering::MipsSETargetLowering(const MipsTargetMachine &TM,
 
     assert(Subtarget.isFP64bit() && "FR=1 is required for MIPS32r6");
     setOperationAction(ISD::SETCC, MVT::f64, Legal);
-    setOperationAction(ISD::SELECT, MVT::f64, Custom);
+    setOperationAction(ISD::SELECT, MVT::f64, Legal);
     setOperationAction(ISD::SELECT_CC, MVT::f64, Expand);
 
     setOperationAction(ISD::BRCOND, MVT::Other, Legal);

--- a/llvm/lib/Target/Mips/MipsSEInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsSEInstrInfo.cpp
@@ -246,7 +246,7 @@ void MipsSEInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
         return;
     }
   } else if (Opc == 0 && Mips::FGR32RegClass.contains(DestReg) &&
-      Mips::FGR64RegClass.contains(SrcReg) && I != MBB.begin()) {
+             Mips::FGR64RegClass.contains(SrcReg) && I != MBB.begin()) {
     // Who produces SrcReg? If SrcReg is produced by CMP_*, then it's OK.
     // Who uses DestReg? If DestReg is only used by SEL_*, then it's OK.
     if (isWritedByFCMP(I, SrcReg) || isOnlyReadsBySEL(I, DestReg)) {

--- a/llvm/test/CodeGen/Mips/analyzebranch.ll
+++ b/llvm/test/CodeGen/Mips/analyzebranch.ll
@@ -127,12 +127,12 @@ define double @foo(double %a, double %b) nounwind readnone {
 ;
 ; MIPS64R6-LABEL: foo:
 ; MIPS64R6:       # %bb.0: # %entry
+; MIPS64R6-NEXT:    mov.d $f0, $f12
 ; MIPS64R6-NEXT:    dmtc1 $zero, $f1
 ; MIPS64R6-NEXT:    cmp.lt.d $f1, $f1, $f12
 ; MIPS64R6-NEXT:    mfc1 $1, $f1
 ; MIPS64R6-NEXT:    andi $1, $1, 1
-; MIPS64R6-NEXT:    bnez $1, .LBB0_2
-; MIPS64R6-NEXT:    mov.d	$f0, $f12
+; MIPS64R6-NEXT:    bnezc $1, .LBB0_2
 ; MIPS64R6-NEXT:  # %bb.1: # %if.else
 ; MIPS64R6-NEXT:    dmtc1 $zero, $f0
 ; MIPS64R6-NEXT:    cmp.ule.d $f1, $f13, $f0

--- a/llvm/test/CodeGen/Mips/fpbr.ll
+++ b/llvm/test/CodeGen/Mips/fpbr.ll
@@ -117,7 +117,7 @@ entry:
 ; GPR:           mfc1     $[[GPRCC:[0-9]+]], $[[FGRCC:f[0-9]+]]
 ; FIXME: We ought to be able to transform not+bnez -> beqz
 ; GPR:           not      $[[GPRCC]], $[[GPRCC]]
-; 32-GPR:        bnez     $[[GPRCC]], $BB3_2
+; 32-GPR:        bnezc    $[[GPRCC]], $BB3_2
 ; 64-GPR:        bnezc    $[[GPRCC]], .LBB3_2
 
   %cmp = fcmp oeq double %f2, %f3
@@ -148,7 +148,7 @@ entry:
 ; 64-GPR:        cmp.ule.d $[[FGRCC:f[0-9]+]], $f13, $f12
 ; GPR:           mfc1     $[[GPRCC:[0-9]+]], $[[FGRCC:f[0-9]+]]
 ; GPR-NOT:       not      $[[GPRCC]], $[[GPRCC]]
-; 32-GPR:        bnez     $[[GPRCC]], $BB4_2
+; 32-GPR:        bnezc    $[[GPRCC]], $BB4_2
 ; 64-GPR:        bnezc    $[[GPRCC]], .LBB4_2
 
   %cmp = fcmp olt double %f2, %f3
@@ -179,7 +179,7 @@ entry:
 ; 64-GPR:        cmp.ult.d $[[FGRCC:f[0-9]+]], $f13, $f12
 ; GPR:           mfc1     $[[GPRCC:[0-9]+]], $[[FGRCC:f[0-9]+]]
 ; GPR-NOT:       not      $[[GPRCC]], $[[GPRCC]]
-; 32-GPR:        beqz     $[[GPRCC]], $BB5_2
+; 32-GPR:        beqzc    $[[GPRCC]], $BB5_2
 ; 64-GPR:        beqzc    $[[GPRCC]], .LBB5_2
 
   %cmp = fcmp ugt double %f2, %f3

--- a/llvm/test/CodeGen/Mips/llvm-ir/select-dbl.ll
+++ b/llvm/test/CodeGen/Mips/llvm-ir/select-dbl.ll
@@ -68,8 +68,8 @@ define double @tst_select_i1_double(i1 signext %s, double %x, double %y) {
 ; 32R6:       # %bb.0: # %entry
 ; 32R6-NEXT:    mtc1 $7, $f1
 ; 32R6-NEXT:    mthc1 $6, $f1
-; 32R6-NEXT:    mtc1 $4, $f0
 ; 32R6-NEXT:    ldc1 $f2, 16($sp)
+; 32R6-NEXT:    mtc1 $4, $f0
 ; 32R6-NEXT:    jr $ra
 ; 32R6-NEXT:    sel.d $f0, $f2, $f1
 ;
@@ -110,8 +110,8 @@ define double @tst_select_i1_double(i1 signext %s, double %x, double %y) {
 ; MM32R6:       # %bb.0: # %entry
 ; MM32R6-NEXT:    mtc1 $7, $f1
 ; MM32R6-NEXT:    mthc1 $6, $f1
-; MM32R6-NEXT:    mtc1 $4, $f0
 ; MM32R6-NEXT:    ldc1 $f2, 16($sp)
+; MM32R6-NEXT:    mtc1 $4, $f0
 ; MM32R6-NEXT:    sel.d $f0, $f2, $f1
 ; MM32R6-NEXT:    jrc $ra
 entry:
@@ -229,8 +229,6 @@ define double @tst_select_fcmp_olt_double(double %x, double %y) {
 ; 32R6-LABEL: tst_select_fcmp_olt_double:
 ; 32R6:       # %bb.0: # %entry
 ; 32R6-NEXT:    cmp.lt.d $f0, $f12, $f14
-; 32R6-NEXT:    mfc1 $1, $f0
-; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
 ; 32R6-NEXT:    sel.d $f0, $f14, $f12
 ;
@@ -256,8 +254,6 @@ define double @tst_select_fcmp_olt_double(double %x, double %y) {
 ; 64R6-LABEL: tst_select_fcmp_olt_double:
 ; 64R6:       # %bb.0: # %entry
 ; 64R6-NEXT:    cmp.lt.d $f0, $f12, $f13
-; 64R6-NEXT:    mfc1 $1, $f0
-; 64R6-NEXT:    mtc1 $1, $f0
 ; 64R6-NEXT:    jr $ra
 ; 64R6-NEXT:    sel.d $f0, $f13, $f12
 ;
@@ -271,8 +267,6 @@ define double @tst_select_fcmp_olt_double(double %x, double %y) {
 ; MM32R6-LABEL: tst_select_fcmp_olt_double:
 ; MM32R6:       # %bb.0: # %entry
 ; MM32R6-NEXT:    cmp.lt.d $f0, $f12, $f14
-; MM32R6-NEXT:    mfc1 $1, $f0
-; MM32R6-NEXT:    mtc1 $1, $f0
 ; MM32R6-NEXT:    sel.d $f0, $f14, $f12
 ; MM32R6-NEXT:    jrc $ra
 entry:
@@ -311,8 +305,6 @@ define double @tst_select_fcmp_ole_double(double %x, double %y) {
 ; 32R6-LABEL: tst_select_fcmp_ole_double:
 ; 32R6:       # %bb.0: # %entry
 ; 32R6-NEXT:    cmp.le.d $f0, $f12, $f14
-; 32R6-NEXT:    mfc1 $1, $f0
-; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
 ; 32R6-NEXT:    sel.d $f0, $f14, $f12
 ;
@@ -338,8 +330,6 @@ define double @tst_select_fcmp_ole_double(double %x, double %y) {
 ; 64R6-LABEL: tst_select_fcmp_ole_double:
 ; 64R6:       # %bb.0: # %entry
 ; 64R6-NEXT:    cmp.le.d $f0, $f12, $f13
-; 64R6-NEXT:    mfc1 $1, $f0
-; 64R6-NEXT:    mtc1 $1, $f0
 ; 64R6-NEXT:    jr $ra
 ; 64R6-NEXT:    sel.d $f0, $f13, $f12
 ;
@@ -353,8 +343,6 @@ define double @tst_select_fcmp_ole_double(double %x, double %y) {
 ; MM32R6-LABEL: tst_select_fcmp_ole_double:
 ; MM32R6:       # %bb.0: # %entry
 ; MM32R6-NEXT:    cmp.le.d $f0, $f12, $f14
-; MM32R6-NEXT:    mfc1 $1, $f0
-; MM32R6-NEXT:    mtc1 $1, $f0
 ; MM32R6-NEXT:    sel.d $f0, $f14, $f12
 ; MM32R6-NEXT:    jrc $ra
 entry:
@@ -393,8 +381,6 @@ define double @tst_select_fcmp_ogt_double(double %x, double %y) {
 ; 32R6-LABEL: tst_select_fcmp_ogt_double:
 ; 32R6:       # %bb.0: # %entry
 ; 32R6-NEXT:    cmp.lt.d $f0, $f14, $f12
-; 32R6-NEXT:    mfc1 $1, $f0
-; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
 ; 32R6-NEXT:    sel.d $f0, $f14, $f12
 ;
@@ -420,8 +406,6 @@ define double @tst_select_fcmp_ogt_double(double %x, double %y) {
 ; 64R6-LABEL: tst_select_fcmp_ogt_double:
 ; 64R6:       # %bb.0: # %entry
 ; 64R6-NEXT:    cmp.lt.d $f0, $f13, $f12
-; 64R6-NEXT:    mfc1 $1, $f0
-; 64R6-NEXT:    mtc1 $1, $f0
 ; 64R6-NEXT:    jr $ra
 ; 64R6-NEXT:    sel.d $f0, $f13, $f12
 ;
@@ -435,8 +419,6 @@ define double @tst_select_fcmp_ogt_double(double %x, double %y) {
 ; MM32R6-LABEL: tst_select_fcmp_ogt_double:
 ; MM32R6:       # %bb.0: # %entry
 ; MM32R6-NEXT:    cmp.lt.d $f0, $f14, $f12
-; MM32R6-NEXT:    mfc1 $1, $f0
-; MM32R6-NEXT:    mtc1 $1, $f0
 ; MM32R6-NEXT:    sel.d $f0, $f14, $f12
 ; MM32R6-NEXT:    jrc $ra
 entry:
@@ -475,8 +457,6 @@ define double @tst_select_fcmp_oge_double(double %x, double %y) {
 ; 32R6-LABEL: tst_select_fcmp_oge_double:
 ; 32R6:       # %bb.0: # %entry
 ; 32R6-NEXT:    cmp.le.d $f0, $f14, $f12
-; 32R6-NEXT:    mfc1 $1, $f0
-; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
 ; 32R6-NEXT:    sel.d $f0, $f14, $f12
 ;
@@ -502,8 +482,6 @@ define double @tst_select_fcmp_oge_double(double %x, double %y) {
 ; 64R6-LABEL: tst_select_fcmp_oge_double:
 ; 64R6:       # %bb.0: # %entry
 ; 64R6-NEXT:    cmp.le.d $f0, $f13, $f12
-; 64R6-NEXT:    mfc1 $1, $f0
-; 64R6-NEXT:    mtc1 $1, $f0
 ; 64R6-NEXT:    jr $ra
 ; 64R6-NEXT:    sel.d $f0, $f13, $f12
 ;
@@ -517,8 +495,6 @@ define double @tst_select_fcmp_oge_double(double %x, double %y) {
 ; MM32R6-LABEL: tst_select_fcmp_oge_double:
 ; MM32R6:       # %bb.0: # %entry
 ; MM32R6-NEXT:    cmp.le.d $f0, $f14, $f12
-; MM32R6-NEXT:    mfc1 $1, $f0
-; MM32R6-NEXT:    mtc1 $1, $f0
 ; MM32R6-NEXT:    sel.d $f0, $f14, $f12
 ; MM32R6-NEXT:    jrc $ra
 entry:
@@ -557,8 +533,6 @@ define double @tst_select_fcmp_oeq_double(double %x, double %y) {
 ; 32R6-LABEL: tst_select_fcmp_oeq_double:
 ; 32R6:       # %bb.0: # %entry
 ; 32R6-NEXT:    cmp.eq.d $f0, $f12, $f14
-; 32R6-NEXT:    mfc1 $1, $f0
-; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
 ; 32R6-NEXT:    sel.d $f0, $f14, $f12
 ;
@@ -584,8 +558,6 @@ define double @tst_select_fcmp_oeq_double(double %x, double %y) {
 ; 64R6-LABEL: tst_select_fcmp_oeq_double:
 ; 64R6:       # %bb.0: # %entry
 ; 64R6-NEXT:    cmp.eq.d $f0, $f12, $f13
-; 64R6-NEXT:    mfc1 $1, $f0
-; 64R6-NEXT:    mtc1 $1, $f0
 ; 64R6-NEXT:    jr $ra
 ; 64R6-NEXT:    sel.d $f0, $f13, $f12
 ;
@@ -599,8 +571,6 @@ define double @tst_select_fcmp_oeq_double(double %x, double %y) {
 ; MM32R6-LABEL: tst_select_fcmp_oeq_double:
 ; MM32R6:       # %bb.0: # %entry
 ; MM32R6-NEXT:    cmp.eq.d $f0, $f12, $f14
-; MM32R6-NEXT:    mfc1 $1, $f0
-; MM32R6-NEXT:    mtc1 $1, $f0
 ; MM32R6-NEXT:    sel.d $f0, $f14, $f12
 ; MM32R6-NEXT:    jrc $ra
 entry:
@@ -639,11 +609,8 @@ define double @tst_select_fcmp_one_double(double %x, double %y) {
 ; 32R6-LABEL: tst_select_fcmp_one_double:
 ; 32R6:       # %bb.0: # %entry
 ; 32R6-NEXT:    cmp.ueq.d $f0, $f12, $f14
-; 32R6-NEXT:    mfc1 $1, $f0
-; 32R6-NEXT:    xori $1, $1, 1
-; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
-; 32R6-NEXT:    sel.d $f0, $f14, $f12
+; 32R6-NEXT:    sel.d $f0, $f12, $f14
 ;
 ; M3-LABEL: tst_select_fcmp_one_double:
 ; M3:       # %bb.0: # %entry
@@ -667,11 +634,8 @@ define double @tst_select_fcmp_one_double(double %x, double %y) {
 ; 64R6-LABEL: tst_select_fcmp_one_double:
 ; 64R6:       # %bb.0: # %entry
 ; 64R6-NEXT:    cmp.ueq.d $f0, $f12, $f13
-; 64R6-NEXT:    mfc1 $1, $f0
-; 64R6-NEXT:    xori $1, $1, 1
-; 64R6-NEXT:    mtc1 $1, $f0
 ; 64R6-NEXT:    jr $ra
-; 64R6-NEXT:    sel.d $f0, $f13, $f12
+; 64R6-NEXT:    sel.d $f0, $f12, $f13
 ;
 ; MM32R3-LABEL: tst_select_fcmp_one_double:
 ; MM32R3:       # %bb.0: # %entry
@@ -683,10 +647,7 @@ define double @tst_select_fcmp_one_double(double %x, double %y) {
 ; MM32R6-LABEL: tst_select_fcmp_one_double:
 ; MM32R6:       # %bb.0: # %entry
 ; MM32R6-NEXT:    cmp.ueq.d $f0, $f12, $f14
-; MM32R6-NEXT:    mfc1 $1, $f0
-; MM32R6-NEXT:    xori $1, $1, 1
-; MM32R6-NEXT:    mtc1 $1, $f0
-; MM32R6-NEXT:    sel.d $f0, $f14, $f12
+; MM32R6-NEXT:    sel.d $f0, $f12, $f14
 ; MM32R6-NEXT:    jrc $ra
 entry:
   %s = fcmp one double %x, %y

--- a/llvm/test/CodeGen/Mips/longbranch/branch-limits-fp-micromipsr6.mir
+++ b/llvm/test/CodeGen/Mips/longbranch/branch-limits-fp-micromipsr6.mir
@@ -71,7 +71,7 @@ body:             |
   ; MM-LABEL: name: a
   ; MM: bb.0.entry:
   ; MM:   successors: %bb.2(0x50000000), %bb.1(0x30000000)
-  ; MM:   $f0 = CMP_EQ_D_MMR6 killed $d12_64, killed $d14_64
+  ; MM:   $d0_64 = CMP_EQ_D_MMR6 killed $d12_64, killed $d14_64
   ; MM:   BC1EQZC_MMR6 $d0_64, %bb.2, implicit-def $at
   ; MM: bb.1.entry:
   ; MM:   successors: %bb.3(0x80000000)
@@ -86,7 +86,7 @@ body:             |
   ; PIC-LABEL: name: a
   ; PIC: bb.0.entry:
   ; PIC:   successors: %bb.3(0x50000000), %bb.1(0x30000000)
-  ; PIC:   $f0 = CMP_EQ_D_MMR6 killed $d12_64, killed $d14_64
+  ; PIC:   $d0_64 = CMP_EQ_D_MMR6 killed $d12_64, killed $d14_64
   ; PIC:   BC1EQZC_MMR6 $d0_64, %bb.3, implicit-def $at
   ; PIC: bb.1.entry:
   ; PIC:   successors: %bb.2(0x80000000)
@@ -112,7 +112,7 @@ body:             |
     successors: %bb.1(0x50000000), %bb.2(0x30000000)
     liveins: $d12_64, $d14_64
 
-    $f0 = CMP_EQ_D_MMR6 killed $d12_64, killed $d14_64
+    $d0_64 = CMP_EQ_D_MMR6 killed $d12_64, killed $d14_64
     BC1NEZC_MMR6 killed $d0_64, %bb.2, implicit-def $at
 
   bb.1.if.then:
@@ -163,7 +163,7 @@ body:             |
   ; MM-LABEL: name: b
   ; MM: bb.0.entry:
   ; MM:   successors: %bb.2(0x30000000), %bb.1(0x50000000)
-  ; MM:   $f0 = CMP_UEQ_D_MMR6 killed $d12_64, killed $d14_64
+  ; MM:   $d0_64 = CMP_UEQ_D_MMR6 killed $d12_64, killed $d14_64
   ; MM:   BC1NEZC_MMR6 $d0_64, %bb.2, implicit-def $at
   ; MM: bb.1.entry:
   ; MM:   successors: %bb.3(0x80000000)
@@ -178,7 +178,7 @@ body:             |
   ; PIC-LABEL: name: b
   ; PIC: bb.0.entry:
   ; PIC:   successors: %bb.3(0x30000000), %bb.1(0x50000000)
-  ; PIC:   $f0 = CMP_UEQ_D_MMR6 killed $d12_64, killed $d14_64
+  ; PIC:   $d0_64 = CMP_UEQ_D_MMR6 killed $d12_64, killed $d14_64
   ; PIC:   BC1NEZC_MMR6 $d0_64, %bb.3, implicit-def $at
   ; PIC: bb.1.entry:
   ; PIC:   successors: %bb.2(0x80000000)
@@ -204,7 +204,7 @@ body:             |
     successors: %bb.1(0x30000000), %bb.2(0x50000000)
     liveins: $d12_64, $d14_64
 
-    $f0 = CMP_UEQ_D_MMR6 killed $d12_64, killed $d14_64
+    $d0_64 = CMP_UEQ_D_MMR6 killed $d12_64, killed $d14_64
     BC1EQZC_MMR6 killed $d0_64, %bb.2, implicit-def $at
 
   bb.1.if.then:

--- a/llvm/test/CodeGen/Mips/longbranch/branch-limits-fp-mipsr6.mir
+++ b/llvm/test/CodeGen/Mips/longbranch/branch-limits-fp-mipsr6.mir
@@ -72,7 +72,7 @@ body:             |
   ; R6-LABEL: name: a
   ; R6: bb.0.entry:
   ; R6:   successors: %bb.2(0x50000000), %bb.1(0x30000000)
-  ; R6:   $f0 = CMP_EQ_D killed $d12_64, killed $d14_64
+  ; R6:   $d0_64 = CMP_EQ_D killed $d12_64, killed $d14_64
   ; R6:   BC1NEZ $d0_64, %bb.2 {
   ; R6:     $zero = SLL $zero, 0
   ; R6:   }
@@ -91,7 +91,7 @@ body:             |
   ; PIC-LABEL: name: a
   ; PIC: bb.0.entry:
   ; PIC:   successors: %bb.3(0x50000000), %bb.1(0x30000000)
-  ; PIC:   $f0 = CMP_EQ_D killed $d12_64, killed $d14_64
+  ; PIC:   $d0_64 = CMP_EQ_D killed $d12_64, killed $d14_64
   ; PIC:   BC1NEZ $d0_64, %bb.3 {
   ; PIC:     $zero = SLL $zero, 0
   ; PIC:   }
@@ -121,7 +121,7 @@ body:             |
     successors: %bb.1(0x50000000), %bb.2(0x30000000)
     liveins: $d12_64, $d14_64
 
-    $f0 = CMP_EQ_D killed $d12_64, killed $d14_64
+    $d0_64 = CMP_EQ_D killed $d12_64, killed $d14_64
     BC1EQZ killed $d0_64, %bb.2, implicit-def $at
 
   bb.1.if.then:
@@ -172,7 +172,7 @@ body:             |
   ; R6-LABEL: name: b
   ; R6: bb.0.entry:
   ; R6:   successors: %bb.2(0x50000000), %bb.1(0x30000000)
-  ; R6:   $f0 = CMP_EQ_D killed $d12_64, killed $d14_64
+  ; R6:   $d0_64 = CMP_EQ_D killed $d12_64, killed $d14_64
   ; R6:   BC1EQZ $d0_64, %bb.2 {
   ; R6:     $zero = SLL $zero, 0
   ; R6:   }
@@ -191,7 +191,7 @@ body:             |
   ; PIC-LABEL: name: b
   ; PIC: bb.0.entry:
   ; PIC:   successors: %bb.3(0x50000000), %bb.1(0x30000000)
-  ; PIC:   $f0 = CMP_EQ_D killed $d12_64, killed $d14_64
+  ; PIC:   $d0_64 = CMP_EQ_D killed $d12_64, killed $d14_64
   ; PIC:   BC1EQZ $d0_64, %bb.3 {
   ; PIC:     $zero = SLL $zero, 0
   ; PIC:   }
@@ -221,7 +221,7 @@ body:             |
     successors: %bb.1(0x50000000), %bb.2(0x30000000)
     liveins: $d12_64, $d14_64
 
-    $f0 = CMP_EQ_D killed $d12_64, killed $d14_64
+    $d0_64 = CMP_EQ_D killed $d12_64, killed $d14_64
     BC1NEZ killed $d0_64, %bb.2, implicit-def $at
 
   bb.1.if.then:

--- a/llvm/test/CodeGen/Mips/micromips-mtc-mfc.ll
+++ b/llvm/test/CodeGen/Mips/micromips-mtc-mfc.ll
@@ -27,7 +27,7 @@ define double @foo(double %a, double %b) {
 ; MM6-NEXT:    mtc1 $zero, $f1 # encoding: [0x54,0x01,0x28,0x3b]
 ; MM6-NEXT:    mthc1 $zero, $f1 # encoding: [0x54,0x01,0x38,0x3b]
 ; MM6-NEXT:    cmp.ule.d $f1, $f12, $f1 # encoding: [0x54,0x2c,0x09,0xd5]
-; MM6-NEXT:    mfc1 $2, $f1 # encoding: [0x54,0x41,0x20,0x3b]
+; MM6-NEXT:    mfc1 $2, $f1 # encoding: [0x44,0x02,0x08,0x00]
 ; MM6-NEXT:    andi16 $2, $2, 1 # encoding: [0x2d,0x21]
 ; MM6-NEXT:    jrc $ra # encoding: [0x45,0xbf]
 entry:
@@ -56,8 +56,6 @@ define double @bar(double %x, double %y) {
 ; MM6-LABEL: bar:
 ; MM6:       # %bb.0: # %entry
 ; MM6-NEXT:    cmp.lt.d $f0, $f12, $f14 # encoding: [0x55,0xcc,0x01,0x15]
-; MM6-NEXT:    mfc1 $1, $f0 # encoding: [0x54,0x20,0x20,0x3b]
-; MM6-NEXT:    mtc1 $1, $f0 # encoding: [0x54,0x20,0x28,0x3b]
 ; MM6-NEXT:    sel.d $f0, $f14, $f12 # encoding: [0x55,0x8e,0x02,0xb8]
 ; MM6-NEXT:    jrc $ra # encoding: [0x45,0xbf]
 entry:

--- a/llvm/test/CodeGen/Mips/select.ll
+++ b/llvm/test/CodeGen/Mips/select.ll
@@ -248,8 +248,8 @@ define double @i32_icmp_ne_f64_val(i32 signext %s, double %f0, double %f1) nounw
 ; 32R6-NEXT:    mthc1 $7, $f1
 ; 32R6-NEXT:    sltu $1, $zero, $4
 ; 32R6-NEXT:    negu $1, $1
-; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    ldc1 $f2, 16($sp)
+; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
 ; 32R6-NEXT:    sel.d $f0, $f2, $f1
 ;
@@ -458,8 +458,6 @@ define double @f32_fcmp_ogt_f64_val(double %f0, double %f1, float %f2, float %f3
 ; 32R6-NEXT:    lwc1 $f0, 16($sp)
 ; 32R6-NEXT:    lwc1 $f1, 20($sp)
 ; 32R6-NEXT:    cmp.lt.s $f0, $f1, $f0
-; 32R6-NEXT:    mfc1 $1, $f0
-; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
 ; 32R6-NEXT:    sel.d $f0, $f14, $f12
 ;
@@ -480,8 +478,6 @@ define double @f32_fcmp_ogt_f64_val(double %f0, double %f1, float %f2, float %f3
 ; 64R6-LABEL: f32_fcmp_ogt_f64_val:
 ; 64R6:       # %bb.0: # %entry
 ; 64R6-NEXT:    cmp.lt.s $f0, $f15, $f14
-; 64R6-NEXT:    mfc1 $1, $f0
-; 64R6-NEXT:    mtc1 $1, $f0
 ; 64R6-NEXT:    jr $ra
 ; 64R6-NEXT:    sel.d $f0, $f13, $f12
 entry:
@@ -514,8 +510,6 @@ define double @f64_fcmp_oeq_f64_val(double %f0, double %f1, double %f2, double %
 ; 32R6-NEXT:    ldc1 $f0, 24($sp)
 ; 32R6-NEXT:    ldc1 $f1, 16($sp)
 ; 32R6-NEXT:    cmp.eq.d $f0, $f1, $f0
-; 32R6-NEXT:    mfc1 $1, $f0
-; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
 ; 32R6-NEXT:    sel.d $f0, $f14, $f12
 ;
@@ -536,8 +530,6 @@ define double @f64_fcmp_oeq_f64_val(double %f0, double %f1, double %f2, double %
 ; 64R6-LABEL: f64_fcmp_oeq_f64_val:
 ; 64R6:       # %bb.0: # %entry
 ; 64R6-NEXT:    cmp.eq.d $f0, $f14, $f15
-; 64R6-NEXT:    mfc1 $1, $f0
-; 64R6-NEXT:    mtc1 $1, $f0
 ; 64R6-NEXT:    jr $ra
 ; 64R6-NEXT:    sel.d $f0, $f13, $f12
 entry:
@@ -570,8 +562,6 @@ define double @f64_fcmp_olt_f64_val(double %f0, double %f1, double %f2, double %
 ; 32R6-NEXT:    ldc1 $f0, 24($sp)
 ; 32R6-NEXT:    ldc1 $f1, 16($sp)
 ; 32R6-NEXT:    cmp.lt.d $f0, $f1, $f0
-; 32R6-NEXT:    mfc1 $1, $f0
-; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
 ; 32R6-NEXT:    sel.d $f0, $f14, $f12
 ;
@@ -592,8 +582,6 @@ define double @f64_fcmp_olt_f64_val(double %f0, double %f1, double %f2, double %
 ; 64R6-LABEL: f64_fcmp_olt_f64_val:
 ; 64R6:       # %bb.0: # %entry
 ; 64R6-NEXT:    cmp.lt.d $f0, $f14, $f15
-; 64R6-NEXT:    mfc1 $1, $f0
-; 64R6-NEXT:    mtc1 $1, $f0
 ; 64R6-NEXT:    jr $ra
 ; 64R6-NEXT:    sel.d $f0, $f13, $f12
 entry:
@@ -626,8 +614,6 @@ define double @f64_fcmp_ogt_f64_val(double %f0, double %f1, double %f2, double %
 ; 32R6-NEXT:    ldc1 $f0, 16($sp)
 ; 32R6-NEXT:    ldc1 $f1, 24($sp)
 ; 32R6-NEXT:    cmp.lt.d $f0, $f1, $f0
-; 32R6-NEXT:    mfc1 $1, $f0
-; 32R6-NEXT:    mtc1 $1, $f0
 ; 32R6-NEXT:    jr $ra
 ; 32R6-NEXT:    sel.d $f0, $f14, $f12
 ;
@@ -648,8 +634,6 @@ define double @f64_fcmp_ogt_f64_val(double %f0, double %f1, double %f2, double %
 ; 64R6-LABEL: f64_fcmp_ogt_f64_val:
 ; 64R6:       # %bb.0: # %entry
 ; 64R6-NEXT:    cmp.lt.d $f0, $f15, $f14
-; 64R6-NEXT:    mfc1 $1, $f0
-; 64R6-NEXT:    mtc1 $1, $f0
 ; 64R6-NEXT:    jr $ra
 ; 64R6-NEXT:    sel.d $f0, $f13, $f12
 entry:


### PR DESCRIPTION
FIX: #172459
Since SETCC returns i1 in IR level, and SEL_D needs f64, currently, we expand FSELECT to:
   MTC1_D64
   SEL
which may generate needless mfc1 and mtc1.

In this patch, we add FGR64CC Register type, and support F32 to F64 in MipsSEInstrInfo::copyPhysReg.