### PR TITLE
[libc++] Revert undesired `[[nodiscard]]` added to conversion functions

### DIFF
--- a/libcxx/docs/CodingGuidelines.rst
+++ b/libcxx/docs/CodingGuidelines.rst
@@ -165,6 +165,8 @@ have a recommended practice where to put them, so libc++ applies it whenever it 
   This protects programmers from assuming too much about how the internals of a function work, making code more robust
   in the presence of future optimizations.
 
+``[[nodiscard]]`` should not be applied to conversion functions because Clang already diagnoses unused cast results.
+
 Applications of ``[[nodiscard]]`` are code like any other code, so we aim to test them on public interfaces. This can be
 done with a ``.verify.cpp`` test. Many examples are available. Just look for tests with the suffix
 ``.nodiscard.verify.cpp``.

--- a/libcxx/include/__ios/fpos.h
+++ b/libcxx/include/__ios/fpos.h
@@ -28,7 +28,7 @@ private:
 public:
   _LIBCPP_HIDE_FROM_ABI fpos(streamoff __off = streamoff()) : __st_(), __off_(__off) {}
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI operator streamoff() const { return __off_; }
+  _LIBCPP_HIDE_FROM_ABI operator streamoff() const { return __off_; }
 
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _StateT state() const { return __st_; }
   _LIBCPP_HIDE_FROM_ABI void state(_StateT __st) { __st_ = __st; }

--- a/libcxx/include/ios
+++ b/libcxx/include/ios
@@ -575,9 +575,9 @@ public:
 #    ifdef _LIBCPP_CXX03_LANG
   // Preserve the ability to compare with literal 0,
   // and implicitly convert to bool, but not implicitly convert to int.
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI operator void*() const { return fail() ? nullptr : (void*)this; }
+  _LIBCPP_HIDE_FROM_ABI operator void*() const { return fail() ? nullptr : (void*)this; }
 #    else
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI explicit operator bool() const { return !fail(); }
+  _LIBCPP_HIDE_FROM_ABI explicit operator bool() const { return !fail(); }
 #    endif
 
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool operator!() const { return fail(); }

--- a/libcxx/test/libcxx/input.output/iostreams.base/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/input.output/iostreams.base/nodiscard.verify.cpp
@@ -46,11 +46,6 @@ void test() {
   {
     std::ios& ref = stream;
 
-#if TEST_STD_VER >= 11
-    ref.operator bool(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-#else
-    ref.operator void*(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
-#endif
     !ref;             // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
     ref.rdstate();    // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
     ref.good();       // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
@@ -70,8 +65,6 @@ void test() {
   {
     std::fpos<std::mbstate_t> pos;
 
-    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-    pos.operator std::streamoff();
     pos.state(); // expected-warning {{ignoring return value of function declared with 'nodiscard' attribute}}
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     pos + std::streamoff(0);


### PR DESCRIPTION
Because
- no one should use them in explicit function call forms, and
- value-discarding casts to non-`void` are already diagnosed by Clang.

Also add explanation for this to `CodingGuidelines.rst`.