### PR TITLE
[mlir][Inliner] Fix crash when inlining callee without terminator

### DIFF
--- a/mlir/lib/Transforms/Utils/Inliner.cpp
+++ b/mlir/lib/Transforms/Utils/Inliner.cpp
@@ -682,7 +682,14 @@ Inliner::Impl::inlineCallsInSCC(InlinerInterfaceImpl &inlinerIface,
     useList.mergeUsesAfterInlining(it.targetNode, it.sourceNode);
 
     // then erase the call.
-    call.erase();
+    if (call.getOperation()->use_empty()) {
+      call.erase();
+    } else {
+      LDBG() << "CallOpInterface is still in use. call = " << call
+             << " returning failure";
+      call->emitError("not all uses of call were replaced");
+      return failure();
+    }
 
     // If we inlined in place, mark the node for deletion.
     if (inlineInPlace) {

--- a/mlir/test/Transforms/inlining-missing-terminator.mlir
+++ b/mlir/test/Transforms/inlining-missing-terminator.mlir
@@ -1,0 +1,14 @@
+// RUN: mlir-opt %s -inline -verify-diagnostics -split-input-file
+
+module {
+  llvm.func @gen_broadcast_scalar1d(%arg0: i32) -> i32 attributes {llvm.emit_c_interface} {
+    %0 = "test.broadcast_bounds_mismatch1"(%arg0) : (i32) -> i32
+    // Missing terminator here
+  }
+
+  llvm.func @_mlir_ciface_gen_broadcast_scalar1d(%arg0: i32) -> i32 attributes {llvm.emit_c_interface} {
+    // expected-error @+1 {{not all uses of call were replaced}}
+    %0 = llvm.call @gen_broadcast_scalar1d(%arg0) : (i32) -> i32
+    llvm.return %0 : i32
+  }
+}


### PR DESCRIPTION
Fixes #173561.

`call.erase()` would `segfault` previously if not all uses are replaced. 