### PR TITLE
[RISCV] Support i32 SSHLAT for rv32ip.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -471,6 +471,10 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
     setOperationAction(ISD::SSUBSAT, MVT::i32, Legal);
     setOperationAction(ISD::SSHLSAT, MVT::i32, Legal);
     setOperationAction(ISD::USHLSAT, MVT::i32, Legal);
+  } else if (Subtarget.hasStdExtP() && !Subtarget.is64Bit()) {
+    // FIXME: Support i32 on RV64 by inserting into a v2i32 vector, doing
+    // pssha.w and extracting.
+    setOperationAction(ISD::SSHLSAT, MVT::i32, Legal);
   }
 
   static const unsigned FPLegalNodeTypes[] = {

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -469,10 +469,12 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
     setOperationAction(ISD::SADDSAT, MVT::i32, Legal);
     setOperationAction(ISD::USUBSAT, MVT::i32, Legal);
     setOperationAction(ISD::SSUBSAT, MVT::i32, Legal);
-    setOperationAction(ISD::SSHLSAT, MVT::i32, Legal);
     setOperationAction(ISD::USHLSAT, MVT::i32, Legal);
-  } else if (Subtarget.hasStdExtP() && !Subtarget.is64Bit()) {
-    // FIXME: Support i32 on RV64 by inserting into a v2i32 vector, doing
+  }
+
+  if ((Subtarget.hasStdExtP() || Subtarget.hasVendorXqcia()) &&
+      !Subtarget.is64Bit()) {
+    // FIXME: Support i32 on RV64+P by inserting into a v2i32 vector, doing
     // pssha.w and extracting.
     setOperationAction(ISD::SSHLSAT, MVT::i32, Legal);
   }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1585,6 +1585,8 @@ let Predicates = [HasStdExtP] in {
 } // Predicates = [HasStdExtP]
 
 let Predicates = [HasStdExtP, IsRV32] in {
+  def : PatGprGpr<sshlsat, SSHA>;
+
   // Load/Store patterns
   def : StPat<store, SW, GPR, v4i8>;
   def : StPat<store, SW, GPR, v2i16>;

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -150,16 +150,9 @@ define i64 @srxi_i64(i64 %x) {
 define i8 @shlsat_i8(i8 %a, i8 %b) {
 ; CHECK-LABEL: shlsat_i8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a2, a0, 24
-; CHECK-NEXT:    sll a0, a2, a1
-; CHECK-NEXT:    sra a1, a0, a1
-; CHECK-NEXT:    beq a2, a1, .LBB13_2
-; CHECK-NEXT:  # %bb.1:
-; CHECK-NEXT:    srai a2, a2, 31
-; CHECK-NEXT:    lui a0, 524288
-; CHECK-NEXT:    addi a0, a0, -1
-; CHECK-NEXT:    xor a0, a2, a0
-; CHECK-NEXT:  .LBB13_2:
+; CHECK-NEXT:    zext.b a1, a1
+; CHECK-NEXT:    slli a0, a0, 24
+; CHECK-NEXT:    ssha a0, a0, a1
 ; CHECK-NEXT:    srai a0, a0, 24
 ; CHECK-NEXT:    ret
  %sshlsat = tail call i8 @llvm.sshl.sat.i8(i8 %a,i8 %b)
@@ -169,16 +162,10 @@ define i8 @shlsat_i8(i8 %a, i8 %b) {
 define i16 @shlsat_i16(i16 %a, i16 %b) {
 ; CHECK-LABEL: shlsat_i16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a2, a0, 16
-; CHECK-NEXT:    sll a0, a2, a1
-; CHECK-NEXT:    sra a1, a0, a1
-; CHECK-NEXT:    beq a2, a1, .LBB14_2
-; CHECK-NEXT:  # %bb.1:
-; CHECK-NEXT:    srai a2, a2, 31
-; CHECK-NEXT:    lui a0, 524288
-; CHECK-NEXT:    addi a0, a0, -1
-; CHECK-NEXT:    xor a0, a2, a0
-; CHECK-NEXT:  .LBB14_2:
+; CHECK-NEXT:    slli a0, a0, 16
+; CHECK-NEXT:    slli a1, a1, 16
+; CHECK-NEXT:    srli a1, a1, 16
+; CHECK-NEXT:    ssha a0, a0, a1
 ; CHECK-NEXT:    srai a0, a0, 16
 ; CHECK-NEXT:    ret
  %sshlsat = tail call i16 @llvm.sshl.sat.i16(i16 %a,i16 %b)
@@ -188,16 +175,7 @@ define i16 @shlsat_i16(i16 %a, i16 %b) {
 define i32 @shlsat_i32(i32 %a, i32 %b) {
 ; CHECK-LABEL: shlsat_i32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    mv a2, a0
-; CHECK-NEXT:    sll a0, a0, a1
-; CHECK-NEXT:    sra a1, a0, a1
-; CHECK-NEXT:    beq a2, a1, .LBB15_2
-; CHECK-NEXT:  # %bb.1:
-; CHECK-NEXT:    srai a2, a2, 31
-; CHECK-NEXT:    lui a0, 524288
-; CHECK-NEXT:    addi a0, a0, -1
-; CHECK-NEXT:    xor a0, a2, a0
-; CHECK-NEXT:  .LBB15_2:
+; CHECK-NEXT:    ssha a0, a0, a1
 ; CHECK-NEXT:    ret
  %sshlsat = tail call i32 @llvm.sshl.sat.i32(i32 %a,i32 %b)
  ret i32 %sshlsat

--- a/llvm/test/CodeGen/RISCV/rv32p.ll
+++ b/llvm/test/CodeGen/RISCV/rv32p.ll
@@ -146,3 +146,59 @@ define i64 @srxi_i64(i64 %x) {
   %a = lshr i64 %x, 25
   ret i64 %a
 }
+
+define i8 @shlsat_i8(i8 %a, i8 %b) {
+; CHECK-LABEL: shlsat_i8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a2, a0, 24
+; CHECK-NEXT:    sll a0, a2, a1
+; CHECK-NEXT:    sra a1, a0, a1
+; CHECK-NEXT:    beq a2, a1, .LBB13_2
+; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    srai a2, a2, 31
+; CHECK-NEXT:    lui a0, 524288
+; CHECK-NEXT:    addi a0, a0, -1
+; CHECK-NEXT:    xor a0, a2, a0
+; CHECK-NEXT:  .LBB13_2:
+; CHECK-NEXT:    srai a0, a0, 24
+; CHECK-NEXT:    ret
+ %sshlsat = tail call i8 @llvm.sshl.sat.i8(i8 %a,i8 %b)
+ ret i8 %sshlsat
+}
+
+define i16 @shlsat_i16(i16 %a, i16 %b) {
+; CHECK-LABEL: shlsat_i16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a2, a0, 16
+; CHECK-NEXT:    sll a0, a2, a1
+; CHECK-NEXT:    sra a1, a0, a1
+; CHECK-NEXT:    beq a2, a1, .LBB14_2
+; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    srai a2, a2, 31
+; CHECK-NEXT:    lui a0, 524288
+; CHECK-NEXT:    addi a0, a0, -1
+; CHECK-NEXT:    xor a0, a2, a0
+; CHECK-NEXT:  .LBB14_2:
+; CHECK-NEXT:    srai a0, a0, 16
+; CHECK-NEXT:    ret
+ %sshlsat = tail call i16 @llvm.sshl.sat.i16(i16 %a,i16 %b)
+ ret i16 %sshlsat
+}
+
+define i32 @shlsat_i32(i32 %a, i32 %b) {
+; CHECK-LABEL: shlsat_i32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    mv a2, a0
+; CHECK-NEXT:    sll a0, a0, a1
+; CHECK-NEXT:    sra a1, a0, a1
+; CHECK-NEXT:    beq a2, a1, .LBB15_2
+; CHECK-NEXT:  # %bb.1:
+; CHECK-NEXT:    srai a2, a2, 31
+; CHECK-NEXT:    lui a0, 524288
+; CHECK-NEXT:    addi a0, a0, -1
+; CHECK-NEXT:    xor a0, a2, a0
+; CHECK-NEXT:  .LBB15_2:
+; CHECK-NEXT:    ret
+ %sshlsat = tail call i32 @llvm.sshl.sat.i32(i32 %a,i32 %b)
+ ret i32 %sshlsat
+}


### PR DESCRIPTION
The rv32ip ssha instruction treats the lower byte of rs2 as signed shift
amount. If the byte is positive, it is a saturating shift left. If the
byte is negative, it is an arithmetic shift right.

Because out of bounds shift amounts are poison in LLVM semantics, we
can assume the shift amount is a positive number and use ssha to
implement sshlsat.