### PR TITLE
[MLIR][Bufferization]: Handle invalid memref element types

### DIFF
--- a/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
@@ -961,6 +961,14 @@ FailureOr<BufferLikeType> bufferization::detail::defaultGetBufferType(
   assert(llvm::isa<TensorType>(value.getType()) && "expected tensor type");
   auto tensorType = cast<TensorType>(value.getType());
 
+  auto elementType = tensorType.getElementType();
+
+  if (!BaseMemRefType::isValidElementType(elementType))
+    return getOwnerOfValue(value)->emitError()
+           << "cannot bufferize value of type " << tensorType
+           << ": element type " << elementType
+           << " is not a valid memref element type";
+
   // No further analysis is possible for a block argument.
   if (llvm::isa<BlockArgument>(value)) {
     return cast<BufferLikeType>(

--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-module-bufferize-invalid.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-module-bufferize-invalid.mlir
@@ -134,3 +134,12 @@ func.func @func_multiple_yields(%t: tensor<5xf32>) -> tensor<5xf32> {
 ^bb1(%arg1 : tensor<5xf32>):
   func.return %arg1 : tensor<5xf32>
 }
+
+// -----
+
+func.func @non_memref_elem_type() -> tensor<1x!quant.uniform<i8:f32, 1.0>> {
+  // expected-error @below{{cannot bufferize value of type 'tensor<1x!quant.uniform<i8:f32, 1.000000e+00>>': element type '!quant.uniform<i8:f32, 1.000000e+00>' is not a valid memref element type}}
+  // expected-error @below{{failed to bufferize op}}
+  %t = tensor.empty() : tensor<1x!quant.uniform<i8:f32, 1.0>>
+  return %t : tensor<1x!quant.uniform<i8:f32, 1.0>>
+}


### PR DESCRIPTION
Fixes #128329, Fixes #128330, Fixes #173565, Fixes #114730

There is an assertion failure in `-one-shot-bufferize` when tensors that have an element type that can't be a memref element type are encountered. https://github.com/llvm/llvm-project/blob/f8d3f47e1fd09392aa30df83849b25acd8c59a25/mlir/include/mlir/IR/BuiltinTypes.h#L440

We can't emit a to_tensor for ops that do implement `BufferizableOpInterface`, and i don't think quantizing is the right move either, so erroring seemed like the best fit.

After some trial and error, `defaultGetBufferType` seems like the most functional and least invasive place to put this check.