### PR TITLE
[Github][CI] Trigger `code-lint` for clang-tidy documentations

### DIFF
--- a/.github/workflows/pr-code-lint.yml
+++ b/.github/workflows/pr-code-lint.yml
@@ -10,6 +10,7 @@ on:
       - 'users/**'
     paths:
       - 'clang-tools-extra/clang-tidy/**'
+      - 'clang-tools-extra/docs/clang-tidy/**'
       - '.github/workflows/pr-code-lint.yml'
 
 jobs:


### PR DESCRIPTION
Previously we added `doc8` to `code-lint` workflow. However, PRs contain only documentation changes won't trigger this workflow.

An example: https://github.com/llvm/llvm-project/pull/173699/checks didn't trigger `code-lint`.

This commit fixes the issue.