### PR TITLE
[mlir][arith] Fix SelectOp unsafe int range inference with uninitialized range case

### DIFF
--- a/mlir/lib/Dialect/Arith/IR/InferIntRangeInterfaceImpls.cpp
+++ b/mlir/lib/Dialect/Arith/IR/InferIntRangeInterfaceImpls.cpp
@@ -329,7 +329,11 @@ void arith::SelectOp::inferResultRangesFromOptional(
       setResultRange(getResult(), trueCase);
     return;
   }
-  setResultRange(getResult(), IntegerValueRange::join(trueCase, falseCase));
+
+  if (trueCase.isUninitialized() || falseCase.isUninitialized())
+    setResultRange(getResult(), IntegerValueRange{});
+  else
+    setResultRange(getResult(), IntegerValueRange::join(trueCase, falseCase));
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/Arith/IR/InferIntRangeInterfaceImpls.cpp
+++ b/mlir/lib/Dialect/Arith/IR/InferIntRangeInterfaceImpls.cpp
@@ -331,7 +331,7 @@ void arith::SelectOp::inferResultRangesFromOptional(
   }
 
   // When one of the ranges is uninitialized, set the whole range to max
-  // otherwise the result will ignore the uninitialized range
+  // otherwise the result will ignore the uninitialized range.
   if (trueCase.isUninitialized() || falseCase.isUninitialized())
     setResultRange(getResult(), IntegerValueRange::getMaxRange(getResult()));
   else

--- a/mlir/lib/Dialect/Arith/IR/InferIntRangeInterfaceImpls.cpp
+++ b/mlir/lib/Dialect/Arith/IR/InferIntRangeInterfaceImpls.cpp
@@ -330,8 +330,10 @@ void arith::SelectOp::inferResultRangesFromOptional(
     return;
   }
 
+  // When one of the ranges is uninitialized, set the whole range to max
+  // otherwise the result will ignore the uninitialized range
   if (trueCase.isUninitialized() || falseCase.isUninitialized())
-    setResultRange(getResult(), IntegerValueRange{});
+    setResultRange(getResult(), IntegerValueRange::getMaxRange(getResult()));
   else
     setResultRange(getResult(), IntegerValueRange::join(trueCase, falseCase));
 }

--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -4544,6 +4544,8 @@ static void nvvmInferResultRanges(Operation *op, Value result,
   if (auto rangeAttr = op->getAttrOfType<LLVM::ConstantRangeAttr>("range")) {
     setResultRanges(result, {rangeAttr.getLower(), rangeAttr.getUpper(),
                              rangeAttr.getLower(), rangeAttr.getUpper()});
+  } else {
+    setResultRanges(result, IntegerValueRange::getMaxRange(result).getValue());
   }
 }
 

--- a/mlir/test/Dialect/Arith/int-range-interface.mlir
+++ b/mlir/test/Dialect/Arith/int-range-interface.mlir
@@ -663,6 +663,24 @@ func.func @select_union(%arg0 : index, %arg1 : i1) -> i1 {
     func.return %5 : i1
 }
 
+// CHECK-LABEL: func @select_undefined_union
+// CHECK-COUNT-2: arith.select
+// CHECK: %[[ret:.*]] = arith.cmpi eq
+// CHECK: return %[[ret]]
+
+func.func @select_undefined_union(%arg0: i1) -> i1 {
+  %c32 = arith.constant 32 : index
+  %c64 = arith.constant 64 : index
+  %0 = test.without_bounds : index
+  %1 = arith.select %arg0, %0, %c64 : index
+  %2 = arith.cmpi eq, %1, %c64 : index
+  %3 = test.without_bounds : index
+  %4 = arith.select %2, %c32, %3 : index
+  %5 = arith.cmpi eq, %4, %c32 : index
+
+  return %5 : i1
+}
+
 // CHECK-LABEL: func @if_union
 // CHECK: %[[true:.*]] = arith.constant true
 // CHECK: return %[[true]]

--- a/mlir/test/Dialect/LLVMIR/nvvm-test-range.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm-test-range.mlir
@@ -4,6 +4,8 @@ gpu.module @module{
         %tidx = nvvm.read.ptx.sreg.tid.x range <i32, 0, 32> : i32
         %tidy = nvvm.read.ptx.sreg.tid.y range <i32, 0, 128> : i32
         %tidz = nvvm.read.ptx.sreg.tid.z range <i32, 0, 4> : i32
+        %cidx = nvvm.read.ptx.sreg.cluster.ctaid.x : i32 // unspecified range
+        %cond = ub.poison : i1
         %c64 = arith.constant 64 : i32
         
         %1 = arith.cmpi sgt, %tidx, %c64 : i32
@@ -18,6 +20,9 @@ gpu.module @module{
         scf.if %3 {
             gpu.printf "threadidz"
         }
+        %4 = arith.select %cond, %cidx, %c64 : i32
+        gpu.printf "ctaidx", %4 : i32
+
         gpu.return
     }
 }
@@ -33,3 +38,4 @@ gpu.module @module{
 // CHECK: gpu.printf "threadidy"
 // CHECK: scf.if %[[false]] {
 // CHECK: gpu.printf "threadidz"
+// CHECK: arith.select

--- a/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
+++ b/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
@@ -869,7 +869,7 @@ void TestWithBoundsOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
 
 void TestWithoutBoundsOp::inferResultRangesFromOptional(
     ArrayRef<IntegerValueRange> argRanges, SetIntLatticeFn setResultRanges) {
-  // mimic ops with uninitialized range
+  // Mimic ops with uninitialized range.
   setResultRanges(getResult(), IntegerValueRange{});
 }
 

--- a/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
+++ b/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
@@ -864,6 +864,16 @@ void TestWithBoundsOp::inferResultRanges(ArrayRef<ConstantIntRanges> argRanges,
 }
 
 //===----------------------------------------------------------------------===//
+// TestWithoutBoundsOp
+//===----------------------------------------------------------------------===//
+
+void TestWithoutBoundsOp::inferResultRangesFromOptional(
+    ArrayRef<IntegerValueRange> argRanges, SetIntLatticeFn setResultRanges) {
+  // mimic ops with uninitialized range
+  setResultRanges(getResult(), IntegerValueRange{});
+}
+
+//===----------------------------------------------------------------------===//
 // TestWithBoundsRegionOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3182,6 +3182,23 @@ def TestWithBoundsOp : TEST_Op<"with_bounds",
   let assemblyFormat = "attr-dict `:` type($fakeVal)";
 }
 
+def TestWithoutBoundsOp : TEST_Op<"without_bounds",
+                         [DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRangesFromOptional"]>,
+                         NoMemoryEffect]> {
+  let description = [{
+    Creates a value with uninitialized range for integer range analysis tests.
+
+    Example:
+
+    ```mlir
+    %0 = test.without_bounds : index
+    ```
+  }];
+  let results = (outs InferIntRangeType:$result);
+
+  let assemblyFormat = "attr-dict `:` type($result)";
+}
+
 def TestWithBoundsRegionOp : TEST_Op<"with_bounds_region",
                           [DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRanges"]>,
                            SingleBlock, NoTerminator]> {

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3184,7 +3184,7 @@ def TestWithBoundsOp : TEST_Op<"with_bounds",
 
 def TestWithoutBoundsOp : TEST_Op<"without_bounds",
                          [DeclareOpInterfaceMethods<InferIntRangeInterface, ["inferResultRangesFromOptional"]>,
-                         NoMemoryEffect]> {
+                          NoMemoryEffect]> {
   let description = [{
     Creates a value with uninitialized range for integer range analysis tests.
 


### PR DESCRIPTION
This PR fixes a bug in `arith::SelectOp::inferResultRangesFromOptional` where uninitialized SelectOp branch int ranges were incorrectly joined with initialized int ranges during dataflow analysis, leading to incorrect folding in `-int-range-optimizations`. 

**The Issue:**
When a `arith.select` branch has an uninitialized range (e.g., from an op like `nvvm.read.ptx.sreg.cluster.ctaid.x`, `scf.switch`, `llvm.call`, ... that lacks range inference), the analysis computed `IntegerValueRange::join(Uninitialized, Constant) = Constant`. This caused the `arith.select` to be replaced with the constant, ignoring the dynamic branch.

**Example:**
```mlir
// The bug before fix: -int-range-optimizations replaces %1 with %c32
// led to incorrect results and unsafe behaviours
%0 = nvvm.read.ptx.sreg.cluster.ctaid.x : i32 // Uninitialized int range
%c32 = arith.constant 32 : i32
%1 = arith.select %cond, %0, %c32 : i32
```

**The Fix:**
Explicitly ensure `inferResultRangesFromOptional` all select cases have initialized ranges before combining them. If any case is uninitialized, the result is now treated as max range. Also added default max range for `nvvmInferResultRanges` and `test.without_bounds` op to simulate and test uninitialized ranges.
