### PR TITLE
[llvm][lli] fix lli crash when run variable arguments function as a interpret

### DIFF
--- a/llvm/lib/ExecutionEngine/Interpreter/Execution.cpp
+++ b/llvm/lib/ExecutionEngine/Interpreter/Execution.cpp
@@ -1082,7 +1082,7 @@ void Interpreter::visitVAStartInst(VAStartInst &I) {
   GenericValue ArgIndex;
   ArgIndex.UIntPairVal.first = ECStack.size() - 1;
   ArgIndex.UIntPairVal.second = 0;
-  SetValue(&I, ArgIndex, SF);
+  SetValue(I.getArgList(), ArgIndex, SF);
 }
 
 void Interpreter::visitVAEndInst(VAEndInst &I) {
@@ -1729,7 +1729,8 @@ void Interpreter::visitVAArgInst(VAArgInst &I) {
 
   // Get the incoming valist parameter.  LLI treats the valist as a
   // (ec-stack-depth var-arg-index) pair.
-  GenericValue VAList = getOperandValue(I.getOperand(0), SF);
+  Value *V = I.getOperand(0);
+  GenericValue VAList = getOperandValue(V, SF);
   GenericValue Dest;
   GenericValue Src = ECStack[VAList.UIntPairVal.first]
                       .VarArgs[VAList.UIntPairVal.second];
@@ -1749,8 +1750,9 @@ void Interpreter::visitVAArgInst(VAArgInst &I) {
   // Set the Value of this Instruction.
   SetValue(&I, Dest, SF);
 
-  // Move the pointer to the next vararg.
+  // Move the pointer to the next vararg and set new value back.
   ++VAList.UIntPairVal.second;
+  SetValue(V, VAList, SF);
 }
 
 void Interpreter::visitExtractElementInst(ExtractElementInst &I) {

--- a/llvm/test/ExecutionEngine/Interpreter/test-interp-variable-arguments.ll
+++ b/llvm/test/ExecutionEngine/Interpreter/test-interp-variable-arguments.ll
@@ -1,0 +1,24 @@
+; RUN: %lli -jit-kind=mcjit -force-interpreter=true %s | FileCheck %s
+; CHECK: result is 6
+
+
+@.str = private constant [14 x i8] c"result is %d\0A\00", align 1
+
+declare i32 @printf(ptr, ...)
+
+define i32 @sum(i32 %0, ...)  {
+  %2 = alloca ptr, align 8
+  call void @llvm.va_start.p0(ptr nonnull %2)
+  %3 = va_arg ptr %2, i32
+  %4 = add nsw i32 %3, %0
+  %5 = va_arg ptr %2, i32
+  %6 = add nsw i32 %4, %5
+  call void @llvm.va_end.p0(ptr nonnull %2)
+  ret i32 %6
+}
+
+define i32 @main() {
+  %1 = tail call i32 (i32, ...) @sum(i32 noundef 1, i32 noundef 2, i32 noundef 3)
+  %2 = tail call i32 (ptr, ...) @printf(ptr @.str, i32 noundef %1)
+  ret i32 0
+}


### PR DESCRIPTION
Run `lli` comand with the flag `-force-interpreter=true` to execute LLVM bitcode, if `lli` run `variable arguments` function in the bitcode, it will crash.
Fix #173718