### PR TITLE
[MLIR][Python] Ensure `_Dialect` is imported for all dialects

### DIFF
--- a/mlir/python/mlir/dialects/amdgpu.py
+++ b/mlir/python/mlir/dialects/amdgpu.py
@@ -3,5 +3,6 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._amdgpu_ops_gen import *
+from ._amdgpu_ops_gen import _Dialect
 from ._amdgpu_enum_gen import *
 from .._mlir_libs._mlirDialectsAMDGPU import *

--- a/mlir/python/mlir/dialects/async_dialect/__init__.py
+++ b/mlir/python/mlir/dialects/async_dialect/__init__.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .._async_ops_gen import *
+from .._async_ops_gen import _Dialect

--- a/mlir/python/mlir/dialects/bufferization.py
+++ b/mlir/python/mlir/dialects/bufferization.py
@@ -3,4 +3,5 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._bufferization_ops_gen import *
+from ._bufferization_ops_gen import _Dialect
 from ._bufferization_enum_gen import *

--- a/mlir/python/mlir/dialects/cf.py
+++ b/mlir/python/mlir/dialects/cf.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._cf_ops_gen import *
+from ._cf_ops_gen import _Dialect

--- a/mlir/python/mlir/dialects/complex.py
+++ b/mlir/python/mlir/dialects/complex.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._complex_ops_gen import *
+from ._complex_ops_gen import _Dialect

--- a/mlir/python/mlir/dialects/emitc.py
+++ b/mlir/python/mlir/dialects/emitc.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._emitc_ops_gen import *
+from ._emitc_ops_gen import _Dialect

--- a/mlir/python/mlir/dialects/index.py
+++ b/mlir/python/mlir/dialects/index.py
@@ -3,4 +3,5 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._index_ops_gen import *
+from ._index_ops_gen import _Dialect
 from ._index_enum_gen import *

--- a/mlir/python/mlir/dialects/linalg/__init__.py
+++ b/mlir/python/mlir/dialects/linalg/__init__.py
@@ -9,6 +9,7 @@ from ..._mlir_libs._mlirDialectsLinalg import *
 # definitions following these steps:
 #   DSL -> YAML -> tblgen -> pytblgen -> build/.../_linalg_ops_gen.py.
 from .._linalg_ops_gen import *
+from .._linalg_ops_gen import _Dialect
 from .._linalg_enum_gen import *
 from .._linalg_enum_gen import _iteratortypeenum
 

--- a/mlir/python/mlir/dialects/llvm.py
+++ b/mlir/python/mlir/dialects/llvm.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._llvm_ops_gen import *
+from ._llvm_ops_gen import _Dialect
 from ._llvm_enum_gen import *
 from .._mlir_libs._mlirDialectsLLVM import *
 from ..ir import Value

--- a/mlir/python/mlir/dialects/math.py
+++ b/mlir/python/mlir/dialects/math.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._math_ops_gen import *
+from ._math_ops_gen import _Dialect

--- a/mlir/python/mlir/dialects/memref.py
+++ b/mlir/python/mlir/dialects/memref.py
@@ -6,6 +6,7 @@ from itertools import accumulate
 from typing import Optional
 
 from ._memref_ops_gen import *
+from ._memref_ops_gen import _Dialect
 from ._ods_common import _dispatch_mixed_values, MixedValues
 from .arith import ConstantOp, _is_integer_like_type
 from ..ir import Value, MemRefType, StridedLayoutAttr, ShapedType, Operation

--- a/mlir/python/mlir/dialects/nvgpu.py
+++ b/mlir/python/mlir/dialects/nvgpu.py
@@ -3,5 +3,6 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._nvgpu_ops_gen import *
+from ._nvgpu_ops_gen import _Dialect
 from ._nvgpu_enum_gen import *
 from .._mlir_libs._mlirDialectsNVGPU import *

--- a/mlir/python/mlir/dialects/nvvm.py
+++ b/mlir/python/mlir/dialects/nvvm.py
@@ -3,4 +3,5 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._nvvm_ops_gen import *
+from ._nvvm_ops_gen import _Dialect
 from ._nvvm_enum_gen import *

--- a/mlir/python/mlir/dialects/openacc.py
+++ b/mlir/python/mlir/dialects/openacc.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._acc_ops_gen import *
+from ._acc_ops_gen import _Dialect

--- a/mlir/python/mlir/dialects/openmp.py
+++ b/mlir/python/mlir/dialects/openmp.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._omp_ops_gen import *
+from ._omp_ops_gen import _Dialect

--- a/mlir/python/mlir/dialects/python_test.py
+++ b/mlir/python/mlir/dialects/python_test.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._python_test_ops_gen import *
+from ._python_test_ops_gen import _Dialect
 
 
 def register_python_test_dialect(registry):

--- a/mlir/python/mlir/dialects/rocdl.py
+++ b/mlir/python/mlir/dialects/rocdl.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._rocdl_ops_gen import *
+from ._rocdl_ops_gen import _Dialect

--- a/mlir/python/mlir/dialects/shape.py
+++ b/mlir/python/mlir/dialects/shape.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._shape_ops_gen import *
+from ._shape_ops_gen import _Dialect

--- a/mlir/python/mlir/dialects/shard.py
+++ b/mlir/python/mlir/dialects/shard.py
@@ -3,4 +3,5 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._shard_ops_gen import *
+from ._shard_ops_gen import _Dialect
 from ._shard_enum_gen import *

--- a/mlir/python/mlir/dialects/smt.py
+++ b/mlir/python/mlir/dialects/smt.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._smt_ops_gen import *
+from ._smt_ops_gen import _Dialect
 from ._smt_enum_gen import *
 
 from .._mlir_libs._mlirDialectsSMT import *

--- a/mlir/python/mlir/dialects/sparse_tensor.py
+++ b/mlir/python/mlir/dialects/sparse_tensor.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._sparse_tensor_ops_gen import *
+from ._sparse_tensor_ops_gen import _Dialect
 from ._sparse_tensor_enum_gen import *
 from .._mlir_libs._mlirDialectsSparseTensor import *
 from .._mlir_libs import _mlirSparseTensorPasses as _cextSparseTensorPasses

--- a/mlir/python/mlir/dialects/spirv.py
+++ b/mlir/python/mlir/dialects/spirv.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._spirv_ops_gen import *
+from ._spirv_ops_gen import _Dialect

--- a/mlir/python/mlir/dialects/tosa.py
+++ b/mlir/python/mlir/dialects/tosa.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._tosa_ops_gen import *
+from ._tosa_ops_gen import _Dialect

--- a/mlir/python/mlir/dialects/ub.py
+++ b/mlir/python/mlir/dialects/ub.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._ub_ops_gen import *
+from ._ub_ops_gen import _Dialect

--- a/mlir/python/mlir/dialects/vector.py
+++ b/mlir/python/mlir/dialects/vector.py
@@ -3,4 +3,5 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ._vector_ops_gen import *
+from ._vector_ops_gen import _Dialect
 from ._vector_enum_gen import *


### PR DESCRIPTION
`from ._xxx_ops_gen import _Dialect` appears in some dialect modules, like builtin, scf, irdl.. but not all of them. This PR ensures that for upstream dialects, `<dialect module>._Dialect` is availble, like `arith._Dialect`.

This PR is a prerequisite for the work I’m currently doing. Later on, I’d like to use these `_Dialect` objects via something like `conversion_target.add_legal_dialect(arith._Dialect)` (we could of course just use strings like `add_legal_dialect("arith")`, but compared to using a defined symbol, I think that’s more prone to typos).
