### PR TITLE
[libc++][ranges] Applied `[[nodiscard]]` to `take_view`

### DIFF
--- a/libcxx/include/__ranges/take_view.h
+++ b/libcxx/include/__ranges/take_view.h
@@ -75,15 +75,15 @@ public:
     _LIBCPP_ASSERT_UNCATEGORIZED(__count >= 0, "count has to be greater than or equal to zero");
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _View base() const&
     requires copy_constructible<_View>
   {
     return __base_;
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _View base() && { return std::move(__base_); }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin()
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto begin()
     requires(!__simple_view<_View>)
   {
     if constexpr (sized_range<_View>) {
@@ -99,7 +99,7 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto begin() const
     requires range<const _View>
   {
     if constexpr (sized_range<const _View>) {
@@ -115,7 +115,7 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end()
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto end()
     requires(!__simple_view<_View>)
   {
     if constexpr (sized_range<_View>) {
@@ -129,7 +129,7 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto end() const
     requires range<const _View>
   {
     if constexpr (sized_range<const _View>) {
@@ -143,14 +143,14 @@ public:
     }
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size()
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto size()
     requires sized_range<_View>
   {
     auto __n = ranges::size(__base_);
     return ranges::min(__n, static_cast<decltype(__n)>(__count_));
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto size() const
     requires sized_range<const _View>
   {
     auto __n = ranges::size(__base_);
@@ -178,7 +178,7 @@ public:
     requires _Const && convertible_to<sentinel_t<_View>, sentinel_t<_Base>>
       : __end_(std::move(__s.__end_)) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr sentinel_t<_Base> base() const { return __end_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr sentinel_t<_Base> base() const { return __end_; }
 
   _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const _Iter<_Const>& __lhs, const __sentinel& __rhs) {
     return __lhs.count() == 0 || __lhs.base() == __rhs.__end_;

--- a/libcxx/test/libcxx/ranges/range.adaptors/range.take/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/ranges/range.adaptors/range.take/nodiscard.verify.cpp
@@ -1,0 +1,143 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++20
+
+// <ranges>
+
+// Check that functions are marked [[nodiscard]]
+
+#include <ranges>
+#include <vector>
+#include <utility>
+
+#include "test_macros.h"
+#include "test_iterators.h"
+
+void test() {
+  // [range.take.view]
+
+  {
+    std::vector<int> range;
+
+    auto v = std::views::take(range, 0);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    v.base();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::move(v).base();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    v.begin();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::as_const(v).begin();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    v.end();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::as_const(v).end();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    v.size();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::as_const(v).size();
+  }
+
+  // [range.take.sentinel]
+
+  {
+    struct MoveOnlyView : std::ranges::view_base {
+      int* ptr_;
+
+      constexpr explicit MoveOnlyView(int* ptr) : ptr_(ptr) {}
+      MoveOnlyView(MoveOnlyView&&)            = default;
+      MoveOnlyView& operator=(MoveOnlyView&&) = default;
+
+      constexpr int* begin() const { return ptr_; }
+      constexpr sentinel_wrapper<int*> end() const { return sentinel_wrapper<int*>{ptr_ + 8}; }
+    };
+
+    int arr[]{94, 82, 49};
+    auto v = std::views::take(MoveOnlyView{arr}, 0);
+
+    auto st = v.end();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::as_const(st).base();
+  }
+
+  // [range.take.overview]
+
+  { // The `empty_view` case.
+    auto emptyView = std::views::empty<int>;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::take(emptyView, 0);
+  }
+
+  { // The `span | basic_string_view | subrange` case.
+    int arr[]{94, 82, 49};
+    auto subrange = std::ranges::subrange(arr, arr + 3);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::take(subrange, 3);
+  }
+
+  { // The `iota_view` case.
+    auto iota = std::views::iota(94, 47);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::take(iota, 3);
+  }
+
+#if TEST_STD_VER >= 23
+  { // The `repeat_view` "_RawRange models sized_range" case.
+    auto repeat = std::ranges::repeat_view<int, int>(94, 8);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::take(repeat, 3);
+  }
+
+  { // The `repeat_view` "otherwise" case.
+
+    auto repeat = std::ranges::repeat_view<int>(94);
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::take(repeat, 3);
+  }
+#endif // TEST_STD_VER >= 23
+
+  { // The "otherwise" case.
+    struct SizedView : std::ranges::view_base {
+      int* begin_ = nullptr;
+      int* end_   = nullptr;
+      constexpr SizedView(int* begin, int* end) : begin_(begin), end_(end) {}
+
+      constexpr auto begin() const { return forward_iterator<int*>(begin_); }
+      constexpr auto end() const { return sized_sentinel<forward_iterator<int*>>(forward_iterator<int*>(end_)); }
+    };
+    static_assert(std::ranges::forward_range<SizedView>);
+    static_assert(std::ranges::sized_range<SizedView>);
+    static_assert(std::ranges::view<SizedView>);
+
+    int arr[]{94, 82, 49};
+
+    SizedView view{arr, arr + 3};
+    auto subrange = std::ranges::subrange(view.begin(), view.end());
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::take(subrange, 3);
+  }
+
+  {
+    struct X {};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    std::views::take(X{});
+  }
+}


### PR DESCRIPTION
`[[nodiscard]]` should be applied to functions where discarding the return value is most likely a correctness issue.

- https://libcxx.llvm.org/CodingGuidelines.html
- https://wg21.link/range.take

Towards #172124