### PR TITLE
[clang-tidy] Fix some false negatives in `bugprone-throw-keyword-missing`

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/ThrowKeywordMissingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ThrowKeywordMissingCheck.cpp
@@ -11,24 +11,28 @@
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 
 using namespace clang::ast_matchers;
+using namespace clang::ast_matchers::internal;
 
 namespace clang::tidy::bugprone {
 
 void ThrowKeywordMissingCheck::registerMatchers(MatchFinder *Finder) {
+  const VariadicDynCastAllOfMatcher<Stmt, AttributedStmt> AttributedStmt;
+  // Matches an 'expression-statement' (not to be confused with a statement
+  // expression, the GNU extension!), as defined in [stmt.expr]/1.
+  const auto ExprStmt = [&](const Matcher<Expr> &InnerMatcher) {
+    return expr(hasParent(stmt(anyOf(doStmt(), whileStmt(), forStmt(),
+                                     compoundStmt(), ifStmt(), switchStmt(),
+                                     labelStmt(), AttributedStmt()))),
+                InnerMatcher);
+  };
+
   Finder->addMatcher(
-      cxxConstructExpr(
-          hasType(cxxRecordDecl(anyOf(
+      ExprStmt(
+          cxxConstructExpr(hasType(cxxRecordDecl(anyOf(
               matchesName("[Ee]xception|EXCEPTION"),
               hasAnyBase(hasType(hasCanonicalType(recordType(hasDeclaration(
                   cxxRecordDecl(matchesName("[Ee]xception|EXCEPTION"))
-                      .bind("base"))))))))),
-          unless(anyOf(
-              hasAncestor(
-                  stmt(anyOf(cxxThrowExpr(), callExpr(), returnStmt()))),
-              hasAncestor(decl(anyOf(varDecl(), fieldDecl()))),
-              hasAncestor(expr(cxxNewExpr(hasAnyPlacementArg(anything())))),
-              allOf(hasAncestor(cxxConstructorDecl()),
-                    unless(hasAncestor(cxxCatchStmt()))))))
+                      .bind("base")))))))))))
           .bind("temporary-exception-not-thrown"),
       this);
 }

--- a/clang-tools-extra/clang-tidy/bugprone/ThrowKeywordMissingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ThrowKeywordMissingCheck.cpp
@@ -17,8 +17,9 @@ namespace clang::tidy::bugprone {
 
 void ThrowKeywordMissingCheck::registerMatchers(MatchFinder *Finder) {
   const VariadicDynCastAllOfMatcher<Stmt, AttributedStmt> AttributedStmt;
-  // Matches an 'expression-statement' (not to be confused with a statement
-  // expression, the GNU extension!), as defined in [stmt.expr]/1.
+  // Matches an 'expression-statement', as defined in [stmt.expr]/1.
+  // Not to be confused with the similarly-named GNU extension, the
+  // statement expression.
   const auto ExprStmt = [&](const Matcher<Expr> &InnerMatcher) {
     return expr(hasParent(stmt(anyOf(doStmt(), whileStmt(), forStmt(),
                                      compoundStmt(), ifStmt(), switchStmt(),

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -426,8 +426,8 @@ Changes in existing checks
 - Improved :doc:`bugprone-throw-keyword-missing
   <clang-tidy/checks/bugprone/throw-keyword-missing>` check by only considering
   the canonical types of base classes as written and adding a note on the base
-  class that triggered the warning. Also, fixed some false negatives in the
-  check.
+  class that triggered the warning. Also, fixed an issue where the check
+  wouldn't fire in constructors or (in certain contexts) lambdas.
 
 - Improved :doc:`bugprone-unchecked-optional-access
   <clang-tidy/checks/bugprone/unchecked-optional-access>` check by supporting

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -426,7 +426,8 @@ Changes in existing checks
 - Improved :doc:`bugprone-throw-keyword-missing
   <clang-tidy/checks/bugprone/throw-keyword-missing>` check by only considering
   the canonical types of base classes as written and adding a note on the base
-  class that triggered the warning.
+  class that triggered the warning. Also, fixed some false negatives in the
+  check.
 
 - Improved :doc:`bugprone-unchecked-optional-access
   <clang-tidy/checks/bugprone/unchecked-optional-access>` check by supporting

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/throw-keyword-missing.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/throw-keyword-missing.cpp
@@ -49,7 +49,7 @@ struct RegularException {
 
 // --------------
 
-void stdExceptionNotTrownTest(int i) {
+void stdExceptionNotThrownTest(int i) {
   if (i < 0)
     // CHECK-MESSAGES-DAG: :[[@LINE+1]]:5: warning: suspicious exception object created but not thrown; did you mean 'throw {{.*}}'? [bugprone-throw-keyword-missing]
     std::exception();
@@ -205,3 +205,17 @@ void placeMentNewTest() {
   alignas(RegularException) unsigned char expr[sizeof(RegularException)];
   new (expr) RegularException{};
 }
+
+void foo() {
+  const auto var = [] {
+    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious exception
+    RegularException{0};
+  };
+}
+
+struct Bar {
+  Bar() {
+    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious exception
+    RegularException{0};
+  }
+};

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/throw-keyword-missing.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/throw-keyword-missing.cpp
@@ -206,15 +206,22 @@ void placeMentNewTest() {
   new (expr) RegularException{};
 }
 
-void foo() {
+void lambdaAsVariableInitializerTest() {
   const auto var = [] {
     // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious exception
     RegularException{0};
   };
 }
 
-struct Bar {
-  Bar() {
+void lambdaInReturnTest() {
+  return [] {
+    // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious exception
+    RegularException{0};
+  }();
+}
+
+struct ExceptionInConstructorTest {
+  ExceptionInConstructorTest() {
     // CHECK-MESSAGES: :[[@LINE+1]]:5: warning: suspicious exception
     RegularException{0};
   }


### PR DESCRIPTION
Fixes #115540.