### PR TITLE
[mlir][Pass] Fix pipeline for crashless reproducer

### DIFF
--- a/mlir/lib/Pass/PassCrashRecovery.cpp
+++ b/mlir/lib/Pass/PassCrashRecovery.cpp
@@ -106,8 +106,8 @@ RecoveryReproducerContext::~RecoveryReproducerContext() {
 
 static void appendReproducer(std::string &description, Operation *op,
                              const ReproducerStreamFactory &factory,
-                             const std::string &pipelineElements,
-                             bool disableThreads, bool verifyPasses) {
+                             const std::string &pipeline, bool disableThreads,
+                             bool verifyPasses) {
   llvm::raw_string_ostream descOS(description);
 
   // Try to create a new output stream for this crash reproducer.
@@ -119,8 +119,6 @@ static void appendReproducer(std::string &description, Operation *op,
   }
   descOS << "reproducer generated at `" << stream->description() << "`";
 
-  std::string pipeline =
-      (op->getName().getStringRef() + "(" + pipelineElements + ")").str();
   AsmState state(op);
   state.attachResourcePrinter(
       "mlir_reproducer", [&](Operation *op, AsmResourceBuilder &builder) {
@@ -134,8 +132,11 @@ static void appendReproducer(std::string &description, Operation *op,
 }
 
 void RecoveryReproducerContext::generate(std::string &description) {
-  appendReproducer(description, preCrashOperation, streamFactory,
-                   pipelineElements, disableThreads, verifyPasses);
+  std::string pipeline = (preCrashOperation->getName().getStringRef() + "(" +
+                          pipelineElements + ")")
+                             .str();
+  appendReproducer(description, preCrashOperation, streamFactory, pipeline,
+                   disableThreads, verifyPasses);
 }
 
 void RecoveryReproducerContext::disable() {

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -593,7 +593,7 @@ performActions(raw_ostream &os,
 
   // Generate reproducers if requested
   if (!config.getReproducerFilename().empty()) {
-    StringRef anchorName = pm.getAnyOpAnchorName();
+    StringRef anchorName = pm.getOpAnchorName();
     const auto &passes = pm.getPasses();
     makeReproducer(anchorName, passes, op.get(),
                    config.getReproducerFilename());

--- a/mlir/test/Pass/crashless-reproducer.mlir
+++ b/mlir/test/Pass/crashless-reproducer.mlir
@@ -7,4 +7,4 @@ module @inner_mod1 {
 
 // REPRO: module @inner_mod1
 // REPRO: module @foo {
-// REPRO: pipeline: "builtin.module(any(builtin.module(test-module-pass)))"
+// REPRO: pipeline: "builtin.module(builtin.module(test-module-pass))"


### PR DESCRIPTION
Crashless reproducers currently emit an extra anchor op in the pipeline they print out, because one gets added by `appendReproducer`. Fix this by always adding the anchor op in the caller of `appendReproducer`.

In addition, `mlir-opt` always uses `any` as the anchor op, instead of getting the anchor op from the `PassManager`, fix that as well so we can test that the pipeline is reproduced as it was passed in.