### PR TITLE
[clang-tidy] Correct fix-it range for function pointer-like typedef in `modernize-use-using`

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.cpp
@@ -130,13 +130,16 @@ void UseUsingCheck::check(const MatchFinder::MatchResult &Result) {
 
   const TypeLoc TL = MatchedDecl->getTypeSourceInfo()->getTypeLoc();
 
-  auto [Type, QualifierStr] = [MatchedDecl, this, &TL, &SM,
+  bool FunctionPointerCase = false;
+  auto [Type, QualifierStr] = [MatchedDecl, this, &TL, &FunctionPointerCase,
+                               &SM,
                                &LO]() -> std::pair<std::string, std::string> {
     SourceRange TypeRange = TL.getSourceRange();
 
     // Function pointer case, get the left and right side of the identifier
     // without the identifier.
     if (TypeRange.fullyContains(MatchedDecl->getLocation())) {
+      FunctionPointerCase = true;
       const auto RangeLeftOfIdentifier = CharSourceRange::getCharRange(
           TypeRange.getBegin(), MatchedDecl->getLocation());
       const auto RangeRightOfIdentifier = CharSourceRange::getCharRange(
@@ -205,8 +208,7 @@ void UseUsingCheck::check(const MatchFinder::MatchResult &Result) {
   }
 
   if (!ReplaceRange.getEnd().isMacroID()) {
-    const SourceLocation::IntTy Offset =
-        MatchedDecl->getFunctionType() ? 0 : Name.size();
+    const SourceLocation::IntTy Offset = FunctionPointerCase ? 0 : Name.size();
     LastReplacementEnd = ReplaceRange.getEnd().getLocWithOffset(Offset);
   }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -583,6 +583,10 @@ Changes in existing checks
   constructor call, and fixed a crash when handling format strings
   containing non-ASCII characters.
 
+- Improved :doc:`modernize-use-using
+  <clang-tidy/checks/modernize/use-using>` check to correctly provide fix-its
+  for typedefs of pointers or references to array types.
+
 - Improved :doc:`performance-unnecessary-copy-initialization
   <clang-tidy/checks/performance/unnecessary-copy-initialization>` by printing
   the type of the diagnosed variable.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
@@ -437,3 +437,22 @@ namespace GH97009 {
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
 // CHECK-FIXES: using Function = bool (*)(PointType, PointType);
 }
+
+namespace GH173732 {
+  // reference to array
+  typedef char (&refarray)[2];
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
+  // CHECK-FIXES: using refarray = char (&)[2];
+  typedef char &ref;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
+  // CHECK-FIXES: using ref = char &;
+
+
+  // pointer to array
+  typedef char (*ptrarray)[2];
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use
+  // CHECK-FIXES: using ptrarray = char (*)[2];
+  typedef char *ptr;
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use
+  // CHECK-FIXES: using ptr = char *;
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
@@ -450,9 +450,9 @@ namespace GH173732 {
 
   // pointer to array
   typedef char (*ptrarray)[2];
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
   // CHECK-FIXES: using ptrarray = char (*)[2];
   typedef char *ptr;
-  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
   // CHECK-FIXES: using ptr = char *;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
@@ -455,4 +455,9 @@ namespace GH173732 {
   typedef char *ptr;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
   // CHECK-FIXES: using ptr = char *;
+
+  // multiple in one typedef
+  typedef char (&refArray)[2], (*ptrArray)[2];
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
+  // CHECK-MESSAGES: :[[@LINE-2]]:29: warning: use 'using' instead of 'typedef' [modernize-use-using]
 }


### PR DESCRIPTION
Extends the function case to all function pointer-like cases, because their source range contains name.
see more in https://github.com/llvm/llvm-project/pull/65558


Closes [#173732](https://github.com/llvm/llvm-project/issues/173732)