### PR TITLE
[libc++][iostream] Applied `[[nodiscard]]`

### DIFF
--- a/libcxx/include/__ostream/basic_ostream.h
+++ b/libcxx/include/__ostream/basic_ostream.h
@@ -174,7 +174,7 @@ public:
   basic_ostream& flush();
 
   // 27.7.2.5 seeks:
-  inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 pos_type tellp();
+  [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 pos_type tellp();
   inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 basic_ostream& seekp(pos_type __pos);
   inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 basic_ostream& seekp(off_type __off, ios_base::seekdir __dir);
 

--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -265,8 +265,8 @@ public:
   basic_istream& operator>>(void*& __p);
 
   // 27.7.1.3 Unformatted input:
-  _LIBCPP_HIDE_FROM_ABI streamsize gcount() const { return __gc_; }
-  int_type get();
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI streamsize gcount() const { return __gc_; }
+  [[__nodiscard__]] int_type get();
 
   inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 basic_istream& get(char_type& __c) {
     int_type __ch = get();
@@ -298,7 +298,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI basic_istream& ignore(streamsize __n, char_type __delim) {
     return ignore(__n, traits_type::to_int_type(__delim));
   }
-  int_type peek();
+  [[__nodiscard__]] int_type peek();
   basic_istream& read(char_type* __s, streamsize __n);
   streamsize readsome(char_type* __s, streamsize __n);
 
@@ -306,7 +306,7 @@ public:
   basic_istream& unget();
   int sync();
 
-  pos_type tellg();
+  [[__nodiscard__]] pos_type tellg();
   basic_istream& seekg(pos_type __pos);
   basic_istream& seekg(off_type __off, ios_base::seekdir __dir);
 };

--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -266,7 +266,7 @@ public:
 
   // 27.7.1.3 Unformatted input:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI streamsize gcount() const { return __gc_; }
-  [[__nodiscard__]] int_type get();
+  int_type get();
 
   inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 basic_istream& get(char_type& __c) {
     int_type __ch = get();

--- a/libcxx/include/streambuf
+++ b/libcxx/include/streambuf
@@ -157,7 +157,7 @@ public:
     return __r;
   }
 
-  inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 locale getloc() const { return __loc_; }
+  [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 locale getloc() const { return __loc_; }
 
   // 27.6.2.2.2 buffer and positioning:
   inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 basic_streambuf* pubsetbuf(char_type* __s, streamsize __n) {
@@ -178,7 +178,7 @@ public:
 
   // Get and put areas:
   // 27.6.2.2.3 Get area:
-  inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 streamsize in_avail() {
+  [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 streamsize in_avail() {
     __check_invariants();
     auto __guard = std::__make_scope_guard([this] { this->__check_invariants(); });
 
@@ -187,7 +187,7 @@ public:
     return showmanyc();
   }
 
-  inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 int_type snextc() {
+  [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 int_type snextc() {
     __check_invariants();
     auto __guard = std::__make_scope_guard([this] { this->__check_invariants(); });
 
@@ -207,7 +207,7 @@ public:
     return __c;
   }
 
-  inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 int_type sgetc() {
+  [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 int_type sgetc() {
     __check_invariants();
     auto __guard = std::__make_scope_guard([this] { this->__check_invariants(); });
 

--- a/libcxx/test/libcxx/input.output/iostream.format/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/nodiscard.verify.cpp
@@ -14,13 +14,20 @@
 
 #include <iostream>
 
+struct testbuf
+    : public std::basic_streambuf<char>
+{};
+
+
 void test() {
+  testbuf sbuf;
+
   // [iostreamclass]
 
   // [istream]
 
   {
-    std::basic_istream<char> stream;
+    std::basic_istream<char> stream(sbuf);
 
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     stream.gcount();
@@ -35,7 +42,7 @@ void test() {
   // [ostream]
 
   {
-    std::basic_ostream<char> stream;
+    std::basic_ostream<char> stream(sbuf);
 
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     stream.tellp();

--- a/libcxx/test/libcxx/input.output/iostream.format/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/nodiscard.verify.cpp
@@ -14,20 +14,16 @@
 
 #include <iostream>
 
-struct testbuf
-    : public std::basic_streambuf<char>
-{};
-
-
 void test() {
-  testbuf sbuf;
+  struct testbuf : public std::basic_streambuf<char> {
+  } sbuf;
 
   // [iostreamclass]
 
   // [istream]
 
   {
-    std::basic_istream<char> stream(sbuf);
+    std::basic_istream<char> stream(&sbuf);
 
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     stream.gcount();
@@ -42,7 +38,7 @@ void test() {
   // [ostream]
 
   {
-    std::basic_ostream<char> stream(sbuf);
+    std::basic_ostream<char> stream(&sbuf);
 
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     stream.tellp();

--- a/libcxx/test/libcxx/input.output/iostream.format/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/nodiscard.verify.cpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <istream>
+// <ostream>
+// <iostream>
+
+// Check that functions are marked [[nodiscard]]
+
+#include <iostream>
+
+void test() {
+  // [iostreamclass]
+
+  // [istream]
+
+  {
+    std::basic_istream<char> stream;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    stream.gcount();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    stream.get();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    stream.peek();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    stream.tellg();
+  }
+
+  // [ostream]
+
+  {
+    std::basic_ostream<char> stream;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    stream.tellp();
+  }
+}

--- a/libcxx/test/libcxx/input.output/iostream.format/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/nodiscard.verify.cpp
@@ -26,9 +26,6 @@ void test() {
     stream.gcount();
 
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-    stream.get();
-
-    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     stream.peek();
 
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}

--- a/libcxx/test/libcxx/input.output/stream.buffers/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/input.output/stream.buffers/nodiscard.verify.cpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <streambuf>
+
+// Check that functions are marked [[nodiscard]]
+
+#include <streambuf>
+
+void test() {
+  std::basic_streambuf<char> sbuf;
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  sbuf.getloc();
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  sbuf.in_avail();
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  sbuf.snextc();
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  sbuf.sgetc();
+}

--- a/libcxx/test/libcxx/input.output/stream.buffers/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/input.output/stream.buffers/nodiscard.verify.cpp
@@ -13,7 +13,8 @@
 #include <streambuf>
 
 void test() {
-  std::basic_streambuf<char> sbuf;
+  struct testbuf : public std::basic_streambuf<char> {
+  } sbuf;
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   sbuf.getloc();

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/peek.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/peek.pass.cpp
@@ -77,7 +77,7 @@ int main(int, char**)
         is.exceptions(std::ios_base::eofbit);
         bool threw = false;
         try {
-            (void)is.peek();
+          (void)is.peek();
         } catch (std::ios_base::failure&) {
             threw = true;
         }
@@ -93,7 +93,7 @@ int main(int, char**)
         is.exceptions(std::ios_base::eofbit);
         bool threw = false;
         try {
-            (void)is.peek();
+          (void)is.peek();
         } catch (std::ios_base::failure&) {
             threw = true;
         }

--- a/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/peek.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/input.streams/istream.unformatted/peek.pass.cpp
@@ -77,7 +77,7 @@ int main(int, char**)
         is.exceptions(std::ios_base::eofbit);
         bool threw = false;
         try {
-            is.peek();
+            (void)is.peek();
         } catch (std::ios_base::failure&) {
             threw = true;
         }
@@ -93,7 +93,7 @@ int main(int, char**)
         is.exceptions(std::ios_base::eofbit);
         bool threw = false;
         try {
-            is.peek();
+            (void)is.peek();
         } catch (std::ios_base::failure&) {
             threw = true;
         }


### PR DESCRIPTION
`[[nodiscard]]` should be applied to functions where discarding the return value is most likely a correctness issue.

- Applied to (if applicable):
  - [x] `basic_streambuf`
  - [x] `basic_istream`
  - [x] `basic_ostream`
  - [x] `basic_iostream` (none)

- https://libcxx.llvm.org/CodingGuidelines.html
- https://wg21.link/stream.buffers
- https://wg21.link/iostreamclass
- https://wg21.link/istream
- https://wg21.link/ostream

Towards #172124