### PR TITLE
[CodeGen][NewPM] Consistently preserve IR analyses in MF passes

### DIFF
--- a/llvm/lib/CodeGen/MachineInstrBundle.cpp
+++ b/llvm/lib/CodeGen/MachineInstrBundle.cpp
@@ -393,5 +393,5 @@ llvm::FinalizeBundleTestPass::run(MachineFunction &MF,
   // except for terminators.
   for (MachineBasicBlock &MBB : MF)
     finalizeBundle(MBB, MBB.instr_begin(), MBB.getFirstInstrTerminator());
-  return PreservedAnalyses::none();
+  return getMachineFunctionPassPreservedAnalyses();
 }


### PR DESCRIPTION
This was the only pass that did not do this in the generic codegen
infra. Update it to be consistent.
