### PR TITLE
[clang][Tooling] Fix assertion failure when processing CUDA files

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -730,7 +730,10 @@ CUDA/HIP Language Changes
 CUDA Support
 ^^^^^^^^^^^^
 
-Support calling `consteval` function between different target.
+- Fixed an assertion failure when processing CUDA files with `-fsyntax-only` or
+  device architecture flags.
+
+- Support calling `consteval` function between different target.
 
 AIX Support
 ^^^^^^^^^^^

--- a/clang/lib/Tooling/Tooling.cpp
+++ b/clang/lib/Tooling/Tooling.cpp
@@ -102,19 +102,10 @@ static bool ignoreExtraCC1Commands(const driver::Compilation *Compilation) {
       if (isa<driver::BindArchAction>(A))
         A = *A->input_begin();
       if (isa<driver::OffloadAction>(A)) {
-        // Offload compilation has 2 top-level actions, one (at the front) is
-        // the original host compilation and the other is offload action
-        // composed of at least one device compilation. For such case, general
-        // tooling will consider host-compilation only. For tooling on device
-        // compilation, device compilation only option, such as
-        // `--cuda-device-only`, needs specifying.
-        assert(Actions.size() > 1);
-        assert(
-            isa<driver::CompileJobAction>(Actions.front()) ||
-            // On MacOSX real actions may end up being wrapped in
-            // BindArchAction.
-            (isa<driver::BindArchAction>(Actions.front()) &&
-             isa<driver::CompileJobAction>(*Actions.front()->input_begin())));
+        // For offload compilation, general tooling will consider host
+        // compilation only. For tooling on device compilation, device
+        // compilation only option, such as `--cuda-device-only`, needs
+        // specifying.
         OffloadCompilation = true;
         break;
       }

--- a/clang/lib/Tooling/Tooling.cpp
+++ b/clang/lib/Tooling/Tooling.cpp
@@ -116,9 +116,6 @@ static bool ignoreExtraCC1Commands(const driver::Compilation *Compilation) {
               (isa<driver::BindArchAction>(Actions.front()) &&
                isa<driver::CompileJobAction>(*Actions.front()->input_begin())));
         }
-        // FIXME: CUDA/HIP can produce a single top-level OffloadAction (e.g.
-        // -fsyntax-only, -E, -M), which contradicts the expectation of at least
-        // two top-level actions.
         OffloadCompilation = true;
         break;
       }

--- a/clang/unittests/Tooling/ToolingTest.cpp
+++ b/clang/unittests/Tooling/ToolingTest.cpp
@@ -85,6 +85,13 @@ TEST(runToolOnCode, CudaSyntaxOnly) {
        "-nocudainc"}));
 }
 
+TEST(runToolOnCode, CudaMultipleArchs) {
+  EXPECT_TRUE(runToolOnCodeWithArgs(
+      std::make_unique<TestAction>(std::make_unique<clang::ASTConsumer>()), "",
+      {"-fsyntax-only", "-x", "cuda", "--offload-arch=sm_70,sm_80",
+       "-nocudalib", "-nocudainc"}));
+}
+
 namespace {
 class FindClassDeclXConsumer : public clang::ASTConsumer {
  public:

--- a/clang/unittests/Tooling/ToolingTest.cpp
+++ b/clang/unittests/Tooling/ToolingTest.cpp
@@ -80,9 +80,9 @@ TEST(runToolOnCode, FindsNoTopLevelDeclOnEmptyCode) {
 
 TEST(runToolOnCode, CudaSyntaxOnly) {
   EXPECT_TRUE(runToolOnCodeWithArgs(
-      std::make_unique<TestAction>(std::make_unique<clang::ASTConsumer>()),
-      "__global__ void k() {}",
-      {"-fsyntax-only", "-x", "cuda", "--offload-arch=sm_70"}));
+      std::make_unique<TestAction>(std::make_unique<clang::ASTConsumer>()), "",
+      {"-fsyntax-only", "-x", "cuda", "--offload-arch=sm_70", "-nocudalib",
+       "-nocudainc"}));
 }
 
 namespace {

--- a/clang/unittests/Tooling/ToolingTest.cpp
+++ b/clang/unittests/Tooling/ToolingTest.cpp
@@ -78,6 +78,13 @@ TEST(runToolOnCode, FindsNoTopLevelDeclOnEmptyCode) {
   EXPECT_FALSE(FoundTopLevelDecl);
 }
 
+TEST(runToolOnCode, CudaSyntaxOnly) {
+  EXPECT_TRUE(runToolOnCodeWithArgs(
+      std::make_unique<TestAction>(std::make_unique<clang::ASTConsumer>()),
+      "__global__ void k() {}",
+      {"-fsyntax-only", "-x", "cuda", "--offload-arch=sm_70"}));
+}
+
 namespace {
 class FindClassDeclXConsumer : public clang::ASTConsumer {
  public:


### PR DESCRIPTION
Running clang-tidy on CUDA files without specifying `--cuda-host-only` or `--cuda-device-only` would trigger an assertion failure in `Actions.size() > 1`, a related discussion: https://github.com/llvm/llvm-project/pull/173699#discussion_r2649279975.

This occurred because the Clang Driver generates a single top-level `OffloadAction` in `-fsyntax-only`, `-E`, `-M`. This commit removes the overly strict assertions.

Closes #173777