### PR TITLE
[PAC][libunwind] Pass ptrauth-qualified values as const references

### DIFF
--- a/libunwind/src/AddressSpace.hpp
+++ b/libunwind/src/AddressSpace.hpp
@@ -202,10 +202,12 @@ public:
 
   pint_t getEncodedP(pint_t &addr, pint_t end, uint8_t encoding,
                      pint_t datarelBase = 0, pint_t *resultAddr = nullptr);
-  bool findFunctionName(pint_t addr, char *buf, size_t bufLen,
+  template <typename T>
+  bool findFunctionName(const T &addr, char *buf, size_t bufLen,
                         unw_word_t *offset);
-  bool findUnwindSections(pint_t targetAddr, UnwindInfoSections &info);
-  bool findOtherFDE(pint_t targetAddr, pint_t &fde);
+  template <typename T>
+  bool findUnwindSections(const T &targetAddr, UnwindInfoSections &info);
+  template <typename T> bool findOtherFDE(const T &targetAddr, pint_t &fde);
 
   static LocalAddressSpace sThisAddressSpace;
 };
@@ -497,8 +499,8 @@ static int findUnwindSectionsByPhdr(struct dl_phdr_info *pinfo,
 
 #endif  // defined(_LIBUNWIND_USE_DL_ITERATE_PHDR)
 
-
-inline bool LocalAddressSpace::findUnwindSections(pint_t targetAddr,
+template <typename T>
+inline bool LocalAddressSpace::findUnwindSections(const T &targetAddr,
                                                   UnwindInfoSections &info) {
 #ifdef __APPLE__
   dyld_unwind_sections dyldInfo;
@@ -669,14 +671,16 @@ inline bool LocalAddressSpace::findUnwindSections(pint_t targetAddr,
   return false;
 }
 
-inline bool LocalAddressSpace::findOtherFDE(pint_t targetAddr, pint_t &fde) {
+template <typename T>
+inline bool LocalAddressSpace::findOtherFDE(const T &targetAddr, pint_t &fde) {
   // TO DO: if OS has way to dynamically register FDEs, check that.
   (void)targetAddr;
   (void)fde;
   return false;
 }
 
-inline bool LocalAddressSpace::findFunctionName(pint_t addr, char *buf,
+template <typename T>
+inline bool LocalAddressSpace::findFunctionName(const T &addr, char *buf,
                                                 size_t bufLen,
                                                 unw_word_t *offset) {
 #if _LIBUNWIND_USE_DLADDR

--- a/libunwind/src/AddressSpace.hpp
+++ b/libunwind/src/AddressSpace.hpp
@@ -202,17 +202,15 @@ public:
 
   pint_t getEncodedP(pint_t &addr, pint_t end, uint8_t encoding,
                      pint_t datarelBase = 0, pint_t *resultAddr = nullptr);
-  // Note: R::link_reg_arg_t is used intentionally instead of `pint_t` to keep
-  // signature of `__ptrauth`-qualified values of `link_reg_t` type on AArch64
-  // PAuth-enabled ABI intact. See corresponding typedefs in `Registers_arm64`.
   template <typename R>
-  bool findFunctionName(typename R::link_reg_arg_t addr, char *buf,
+  bool findFunctionName(typename R::link_hardened_reg_arg_t addr, char *buf,
                         size_t bufLen, unw_word_t *offset);
   template <typename R>
-  bool findUnwindSections(typename R::link_reg_arg_t targetAddr,
+  bool findUnwindSections(typename R::link_hardened_reg_arg_t targetAddr,
                           UnwindInfoSections &info);
   template <typename R>
-  bool findOtherFDE(typename R::link_reg_arg_t targetAddr, pint_t &fde);
+  bool findOtherFDE(typename R::link_hardened_reg_arg_t targetAddr,
+                    pint_t &fde);
 
   static LocalAddressSpace sThisAddressSpace;
 };
@@ -505,9 +503,8 @@ static int findUnwindSectionsByPhdr(struct dl_phdr_info *pinfo,
 #endif  // defined(_LIBUNWIND_USE_DL_ITERATE_PHDR)
 
 template <typename R>
-inline bool
-LocalAddressSpace::findUnwindSections(typename R::link_reg_arg_t targetAddr,
-                                      UnwindInfoSections &info) {
+inline bool LocalAddressSpace::findUnwindSections(
+    typename R::link_hardened_reg_arg_t targetAddr, UnwindInfoSections &info) {
 #ifdef __APPLE__
   dyld_unwind_sections dyldInfo;
   if (_dyld_find_unwind_sections((void *)targetAddr, &dyldInfo)) {
@@ -679,7 +676,7 @@ LocalAddressSpace::findUnwindSections(typename R::link_reg_arg_t targetAddr,
 
 template <typename R>
 inline bool
-LocalAddressSpace::findOtherFDE(typename R::link_reg_arg_t targetAddr,
+LocalAddressSpace::findOtherFDE(typename R::link_hardened_reg_arg_t targetAddr,
                                 pint_t &fde) {
   // TO DO: if OS has way to dynamically register FDEs, check that.
   (void)targetAddr;
@@ -688,9 +685,10 @@ LocalAddressSpace::findOtherFDE(typename R::link_reg_arg_t targetAddr,
 }
 
 template <typename R>
-inline bool LocalAddressSpace::findFunctionName(typename R::link_reg_arg_t addr,
-                                                char *buf, size_t bufLen,
-                                                unw_word_t *offset) {
+inline bool
+LocalAddressSpace::findFunctionName(typename R::link_hardened_reg_arg_t addr,
+                                    char *buf, size_t bufLen,
+                                    unw_word_t *offset) {
 #if _LIBUNWIND_USE_DLADDR
   Dl_info dyldInfo;
   if (dladdr((void *)addr, &dyldInfo)) {

--- a/libunwind/src/AddressSpace.hpp
+++ b/libunwind/src/AddressSpace.hpp
@@ -202,12 +202,17 @@ public:
 
   pint_t getEncodedP(pint_t &addr, pint_t end, uint8_t encoding,
                      pint_t datarelBase = 0, pint_t *resultAddr = nullptr);
-  template <typename T>
-  bool findFunctionName(const T &addr, char *buf, size_t bufLen,
-                        unw_word_t *offset);
-  template <typename T>
-  bool findUnwindSections(const T &targetAddr, UnwindInfoSections &info);
-  template <typename T> bool findOtherFDE(const T &targetAddr, pint_t &fde);
+  // Note: R::link_reg_arg_t is used intentionally instead of `pint_t` to keep
+  // signature of `__ptrauth`-qualified values of `link_reg_t` type on AArch64
+  // PAuth-enabled ABI intact. See corresponding typedefs in `Registers_arm64`.
+  template <typename R>
+  bool findFunctionName(typename R::link_reg_arg_t addr, char *buf,
+                        size_t bufLen, unw_word_t *offset);
+  template <typename R>
+  bool findUnwindSections(typename R::link_reg_arg_t targetAddr,
+                          UnwindInfoSections &info);
+  template <typename R>
+  bool findOtherFDE(typename R::link_reg_arg_t targetAddr, pint_t &fde);
 
   static LocalAddressSpace sThisAddressSpace;
 };
@@ -499,9 +504,10 @@ static int findUnwindSectionsByPhdr(struct dl_phdr_info *pinfo,
 
 #endif  // defined(_LIBUNWIND_USE_DL_ITERATE_PHDR)
 
-template <typename T>
-inline bool LocalAddressSpace::findUnwindSections(const T &targetAddr,
-                                                  UnwindInfoSections &info) {
+template <typename R>
+inline bool
+LocalAddressSpace::findUnwindSections(typename R::link_reg_arg_t targetAddr,
+                                      UnwindInfoSections &info) {
 #ifdef __APPLE__
   dyld_unwind_sections dyldInfo;
   if (_dyld_find_unwind_sections((void *)targetAddr, &dyldInfo)) {
@@ -671,17 +677,19 @@ inline bool LocalAddressSpace::findUnwindSections(const T &targetAddr,
   return false;
 }
 
-template <typename T>
-inline bool LocalAddressSpace::findOtherFDE(const T &targetAddr, pint_t &fde) {
+template <typename R>
+inline bool
+LocalAddressSpace::findOtherFDE(typename R::link_reg_arg_t targetAddr,
+                                pint_t &fde) {
   // TO DO: if OS has way to dynamically register FDEs, check that.
   (void)targetAddr;
   (void)fde;
   return false;
 }
 
-template <typename T>
-inline bool LocalAddressSpace::findFunctionName(const T &addr, char *buf,
-                                                size_t bufLen,
+template <typename R>
+inline bool LocalAddressSpace::findFunctionName(typename R::link_reg_arg_t addr,
+                                                char *buf, size_t bufLen,
                                                 unw_word_t *offset) {
 #if _LIBUNWIND_USE_DLADDR
   Dl_info dyldInfo;

--- a/libunwind/src/DwarfInstructions.hpp
+++ b/libunwind/src/DwarfInstructions.hpp
@@ -33,10 +33,8 @@ public:
   typedef typename A::pint_t pint_t;
   typedef typename A::sint_t sint_t;
 
-  // Note: R::link_reg_arg_t is used intentionally instead of `pint_t` to keep
-  // signature of `__ptrauth`-qualified values of `link_reg_t` type on AArch64
-  // PAuth-enabled ABI intact. See corresponding typedefs in `Registers_arm64`.
-  static int stepWithDwarf(A &addressSpace, typename R::link_reg_arg_t pc,
+  static int stepWithDwarf(A &addressSpace,
+                           typename R::link_hardened_reg_arg_t pc,
                            pint_t fdeStart, R &registers, bool &isSignalFrame,
                            bool stage2);
 
@@ -211,10 +209,9 @@ bool DwarfInstructions<A, R>::isReturnAddressSignedWithPC(A &addressSpace,
 #endif
 
 template <typename A, typename R>
-int DwarfInstructions<A, R>::stepWithDwarf(A &addressSpace,
-                                           typename R::link_reg_arg_t pc,
-                                           pint_t fdeStart, R &registers,
-                                           bool &isSignalFrame, bool stage2) {
+int DwarfInstructions<A, R>::stepWithDwarf(
+    A &addressSpace, typename R::link_hardened_reg_arg_t pc, pint_t fdeStart,
+    R &registers, bool &isSignalFrame, bool stage2) {
   FDE_Info fdeInfo;
   CIE_Info cieInfo;
   if (CFI_Parser<A>::decodeFDE(addressSpace, fdeStart, &fdeInfo,

--- a/libunwind/src/DwarfParser.hpp
+++ b/libunwind/src/DwarfParser.hpp
@@ -160,22 +160,18 @@ public:
     }
   };
 
-  // Note: R::link_reg_arg_t is used intentionally instead of `pint_t` to keep
-  // signature of `__ptrauth`-qualified values of `link_reg_t` type on AArch64
-  // PAuth-enabled ABI intact. See corresponding typedefs in `Registers_arm64`.
   template <typename R>
-  static bool findFDE(A &addressSpace, typename R::link_reg_arg_t pc,
+  static bool findFDE(A &addressSpace, typename R::link_hardened_reg_arg_t pc,
                       pint_t ehSectionStart, size_t sectionLength,
                       pint_t fdeHint, FDE_Info *fdeInfo, CIE_Info *cieInfo);
-  template <typename R>
-  static bool parseFDEInstructions(A &addressSpace, const FDE_Info &fdeInfo,
-                                   const CIE_Info &cieInfo,
-                                   typename R::link_reg_arg_t upToPC, int arch,
-                                   PrologInfo *results);
-
   static const char *decodeFDE(A &addressSpace, pint_t fdeStart,
                                FDE_Info *fdeInfo, CIE_Info *cieInfo,
                                bool useCIEInfo = false);
+  template <typename R>
+  static bool parseFDEInstructions(A &addressSpace, const FDE_Info &fdeInfo,
+                                   const CIE_Info &cieInfo,
+                                   typename R::link_hardened_reg_arg_t upToPC,
+                                   int arch, PrologInfo *results);
 
   static const char *parseCIE(A &addressSpace, pint_t cie, CIE_Info *cieInfo);
 };
@@ -247,7 +243,8 @@ const char *CFI_Parser<A>::decodeFDE(A &addressSpace, pint_t fdeStart,
 /// Scan an eh_frame section to find an FDE for a pc
 template <typename A>
 template <typename R>
-bool CFI_Parser<A>::findFDE(A &addressSpace, typename R::link_reg_arg_t pc,
+bool CFI_Parser<A>::findFDE(A &addressSpace,
+                            typename R::link_hardened_reg_arg_t pc,
                             pint_t ehSectionStart, size_t sectionLength,
                             pint_t fdeHint, FDE_Info *fdeInfo,
                             CIE_Info *cieInfo) {
@@ -461,11 +458,9 @@ const char *CFI_Parser<A>::parseCIE(A &addressSpace, pint_t cie,
 /// "run" the DWARF instructions and create the abstract PrologInfo for an FDE
 template <typename A>
 template <typename R>
-bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
-                                         const FDE_Info &fdeInfo,
-                                         const CIE_Info &cieInfo,
-                                         typename R::link_reg_arg_t upToPC,
-                                         int arch, PrologInfo *results) {
+bool CFI_Parser<A>::parseFDEInstructions(
+    A &addressSpace, const FDE_Info &fdeInfo, const CIE_Info &cieInfo,
+    typename R::link_hardened_reg_arg_t upToPC, int arch, PrologInfo *results) {
   // Alloca is used for the allocation of the rememberStack entries. It removes
   // the dependency on new/malloc but the below for loop can not be refactored
   // into functions. Entry could be saved during the processing of a CIE and

--- a/libunwind/src/DwarfParser.hpp
+++ b/libunwind/src/DwarfParser.hpp
@@ -160,14 +160,16 @@ public:
     }
   };
 
-  static bool findFDE(A &addressSpace, pint_t pc, pint_t ehSectionStart,
+  template <typename T>
+  static bool findFDE(A &addressSpace, const T &pc, pint_t ehSectionStart,
                       size_t sectionLength, pint_t fdeHint, FDE_Info *fdeInfo,
                       CIE_Info *cieInfo);
   static const char *decodeFDE(A &addressSpace, pint_t fdeStart,
                                FDE_Info *fdeInfo, CIE_Info *cieInfo,
                                bool useCIEInfo = false);
+  template <typename T>
   static bool parseFDEInstructions(A &addressSpace, const FDE_Info &fdeInfo,
-                                   const CIE_Info &cieInfo, pint_t upToPC,
+                                   const CIE_Info &cieInfo, const T &upToPC,
                                    int arch, PrologInfo *results);
 
   static const char *parseCIE(A &addressSpace, pint_t cie, CIE_Info *cieInfo);
@@ -239,7 +241,8 @@ const char *CFI_Parser<A>::decodeFDE(A &addressSpace, pint_t fdeStart,
 
 /// Scan an eh_frame section to find an FDE for a pc
 template <typename A>
-bool CFI_Parser<A>::findFDE(A &addressSpace, pint_t pc, pint_t ehSectionStart,
+template <typename T>
+bool CFI_Parser<A>::findFDE(A &addressSpace, const T &pc, pint_t ehSectionStart,
                             size_t sectionLength, pint_t fdeHint,
                             FDE_Info *fdeInfo, CIE_Info *cieInfo) {
   //fprintf(stderr, "findFDE(0x%llX)\n", (long long)pc);
@@ -451,10 +454,12 @@ const char *CFI_Parser<A>::parseCIE(A &addressSpace, pint_t cie,
 
 /// "run" the DWARF instructions and create the abstract PrologInfo for an FDE
 template <typename A>
+template <typename T>
 bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
                                          const FDE_Info &fdeInfo,
-                                         const CIE_Info &cieInfo, pint_t upToPC,
-                                         int arch, PrologInfo *results) {
+                                         const CIE_Info &cieInfo,
+                                         const T &upToPC, int arch,
+                                         PrologInfo *results) {
   // Alloca is used for the allocation of the rememberStack entries. It removes
   // the dependency on new/malloc but the below for loop can not be refactored
   // into functions. Entry could be saved during the processing of a CIE and

--- a/libunwind/src/DwarfParser.hpp
+++ b/libunwind/src/DwarfParser.hpp
@@ -160,17 +160,22 @@ public:
     }
   };
 
-  template <typename T>
-  static bool findFDE(A &addressSpace, const T &pc, pint_t ehSectionStart,
-                      size_t sectionLength, pint_t fdeHint, FDE_Info *fdeInfo,
-                      CIE_Info *cieInfo);
+  // Note: R::link_reg_arg_t is used intentionally instead of `pint_t` to keep
+  // signature of `__ptrauth`-qualified values of `link_reg_t` type on AArch64
+  // PAuth-enabled ABI intact. See corresponding typedefs in `Registers_arm64`.
+  template <typename R>
+  static bool findFDE(A &addressSpace, typename R::link_reg_arg_t pc,
+                      pint_t ehSectionStart, size_t sectionLength,
+                      pint_t fdeHint, FDE_Info *fdeInfo, CIE_Info *cieInfo);
+  template <typename R>
+  static bool parseFDEInstructions(A &addressSpace, const FDE_Info &fdeInfo,
+                                   const CIE_Info &cieInfo,
+                                   typename R::link_reg_arg_t upToPC, int arch,
+                                   PrologInfo *results);
+
   static const char *decodeFDE(A &addressSpace, pint_t fdeStart,
                                FDE_Info *fdeInfo, CIE_Info *cieInfo,
                                bool useCIEInfo = false);
-  template <typename T>
-  static bool parseFDEInstructions(A &addressSpace, const FDE_Info &fdeInfo,
-                                   const CIE_Info &cieInfo, const T &upToPC,
-                                   int arch, PrologInfo *results);
 
   static const char *parseCIE(A &addressSpace, pint_t cie, CIE_Info *cieInfo);
 };
@@ -241,10 +246,11 @@ const char *CFI_Parser<A>::decodeFDE(A &addressSpace, pint_t fdeStart,
 
 /// Scan an eh_frame section to find an FDE for a pc
 template <typename A>
-template <typename T>
-bool CFI_Parser<A>::findFDE(A &addressSpace, const T &pc, pint_t ehSectionStart,
-                            size_t sectionLength, pint_t fdeHint,
-                            FDE_Info *fdeInfo, CIE_Info *cieInfo) {
+template <typename R>
+bool CFI_Parser<A>::findFDE(A &addressSpace, typename R::link_reg_arg_t pc,
+                            pint_t ehSectionStart, size_t sectionLength,
+                            pint_t fdeHint, FDE_Info *fdeInfo,
+                            CIE_Info *cieInfo) {
   //fprintf(stderr, "findFDE(0x%llX)\n", (long long)pc);
   pint_t p = (fdeHint != 0) ? fdeHint : ehSectionStart;
   const pint_t ehSectionEnd = (sectionLength == SIZE_MAX)
@@ -454,12 +460,12 @@ const char *CFI_Parser<A>::parseCIE(A &addressSpace, pint_t cie,
 
 /// "run" the DWARF instructions and create the abstract PrologInfo for an FDE
 template <typename A>
-template <typename T>
+template <typename R>
 bool CFI_Parser<A>::parseFDEInstructions(A &addressSpace,
                                          const FDE_Info &fdeInfo,
                                          const CIE_Info &cieInfo,
-                                         const T &upToPC, int arch,
-                                         PrologInfo *results) {
+                                         typename R::link_reg_arg_t upToPC,
+                                         int arch, PrologInfo *results) {
   // Alloca is used for the allocation of the rememberStack entries. It removes
   // the dependency on new/malloc but the below for loop can not be refactored
   // into functions. Entry could be saved during the processing of a CIE and

--- a/libunwind/src/EHHeaderParser.hpp
+++ b/libunwind/src/EHHeaderParser.hpp
@@ -37,12 +37,8 @@ public:
 
   static bool decodeEHHdr(A &addressSpace, pint_t ehHdrStart, pint_t ehHdrEnd,
                           EHHeaderInfo &ehHdrInfo);
-
-  // Note: R::link_reg_arg_t is used intentionally instead of `pint_t` to keep
-  // signature of `__ptrauth`-qualified values of `link_reg_t` type on AArch64
-  // PAuth-enabled ABI intact. See corresponding typedefs in `Registers_arm64`.
   template <typename R>
-  static bool findFDE(A &addressSpace, typename R::link_reg_arg_t pc,
+  static bool findFDE(A &addressSpace, typename R::link_hardened_reg_arg_t pc,
                       pint_t ehHdrStart, uint32_t sectionLength,
                       typename CFI_Parser<A>::FDE_Info *fdeInfo,
                       typename CFI_Parser<A>::CIE_Info *cieInfo);
@@ -118,7 +114,8 @@ bool EHHeaderParser<A>::decodeTableEntry(
 
 template <typename A>
 template <typename R>
-bool EHHeaderParser<A>::findFDE(A &addressSpace, typename R::link_reg_arg_t pc,
+bool EHHeaderParser<A>::findFDE(A &addressSpace,
+                                typename R::link_hardened_reg_arg_t pc,
                                 pint_t ehHdrStart, uint32_t sectionLength,
                                 typename CFI_Parser<A>::FDE_Info *fdeInfo,
                                 typename CFI_Parser<A>::CIE_Info *cieInfo) {

--- a/libunwind/src/EHHeaderParser.hpp
+++ b/libunwind/src/EHHeaderParser.hpp
@@ -37,9 +37,13 @@ public:
 
   static bool decodeEHHdr(A &addressSpace, pint_t ehHdrStart, pint_t ehHdrEnd,
                           EHHeaderInfo &ehHdrInfo);
-  template <typename T>
-  static bool findFDE(A &addressSpace, const T &pc, pint_t ehHdrStart,
-                      uint32_t sectionLength,
+
+  // Note: R::link_reg_arg_t is used intentionally instead of `pint_t` to keep
+  // signature of `__ptrauth`-qualified values of `link_reg_t` type on AArch64
+  // PAuth-enabled ABI intact. See corresponding typedefs in `Registers_arm64`.
+  template <typename R>
+  static bool findFDE(A &addressSpace, typename R::link_reg_arg_t pc,
+                      pint_t ehHdrStart, uint32_t sectionLength,
                       typename CFI_Parser<A>::FDE_Info *fdeInfo,
                       typename CFI_Parser<A>::CIE_Info *cieInfo);
 
@@ -113,9 +117,9 @@ bool EHHeaderParser<A>::decodeTableEntry(
 }
 
 template <typename A>
-template <typename T>
-bool EHHeaderParser<A>::findFDE(A &addressSpace, const T &pc, pint_t ehHdrStart,
-                                uint32_t sectionLength,
+template <typename R>
+bool EHHeaderParser<A>::findFDE(A &addressSpace, typename R::link_reg_arg_t pc,
+                                pint_t ehHdrStart, uint32_t sectionLength,
                                 typename CFI_Parser<A>::FDE_Info *fdeInfo,
                                 typename CFI_Parser<A>::CIE_Info *cieInfo) {
   pint_t ehHdrEnd = ehHdrStart + sectionLength;

--- a/libunwind/src/EHHeaderParser.hpp
+++ b/libunwind/src/EHHeaderParser.hpp
@@ -37,7 +37,8 @@ public:
 
   static bool decodeEHHdr(A &addressSpace, pint_t ehHdrStart, pint_t ehHdrEnd,
                           EHHeaderInfo &ehHdrInfo);
-  static bool findFDE(A &addressSpace, pint_t pc, pint_t ehHdrStart,
+  template <typename T>
+  static bool findFDE(A &addressSpace, const T &pc, pint_t ehHdrStart,
                       uint32_t sectionLength,
                       typename CFI_Parser<A>::FDE_Info *fdeInfo,
                       typename CFI_Parser<A>::CIE_Info *cieInfo);
@@ -112,7 +113,8 @@ bool EHHeaderParser<A>::decodeTableEntry(
 }
 
 template <typename A>
-bool EHHeaderParser<A>::findFDE(A &addressSpace, pint_t pc, pint_t ehHdrStart,
+template <typename T>
+bool EHHeaderParser<A>::findFDE(A &addressSpace, const T &pc, pint_t ehHdrStart,
                                 uint32_t sectionLength,
                                 typename CFI_Parser<A>::FDE_Info *fdeInfo,
                                 typename CFI_Parser<A>::CIE_Info *cieInfo) {

--- a/libunwind/src/Registers.hpp
+++ b/libunwind/src/Registers.hpp
@@ -68,7 +68,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -290,7 +290,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint64_t    getRegister(int num) const;
@@ -613,7 +613,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -1189,7 +1189,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint64_t    getRegister(int num) const;
@@ -1856,13 +1856,13 @@ public:
   typedef uint64_t reg_t;
   typedef uint64_t __ptrauth_unwind_registers_arm64_link_reg link_reg_t;
 
-  // Use `link_reg_arg_t` to pass values of `link_reg_t` type as function
-  // arguments. We need to use a const l-value reference to keep signature of
-  // `__ptrauth`-qualified values of `link_reg_t` type on AArch64 PAuth-enabled
-  // ABI intact. Passing the raw pointer by value would cause authentication on
-  // the caller side and make the pointer prone to substitution if spilled to
-  // the stack in the callee.
-  typedef const link_reg_t &link_reg_arg_t;
+  // Use `link_hardened_reg_arg_t` to pass values of `link_reg_t` type as
+  // function arguments. We need to use a const l-value reference to keep
+  // signature of `__ptrauth`-qualified values of `link_reg_t` type on AArch64
+  // PAuth-enabled ABI intact. Passing the raw pointer by value would cause
+  // authentication on the caller side and make the pointer prone to
+  // substitution if spilled to the stack in the callee.
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint64_t    getRegister(int num) const;
@@ -2269,7 +2269,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -2778,7 +2778,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -2981,7 +2981,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -3320,7 +3320,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint64_t    getRegister(int num) const;
@@ -3627,7 +3627,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -3817,7 +3817,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool validRegister(int num) const;
   uint64_t getRegister(int num) const;
@@ -4006,7 +4006,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -4225,7 +4225,7 @@ public:
 
   typedef ::libunwind::reg_t reg_t;
   typedef ::libunwind::reg_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   reg_t       getRegister(int num) const;
@@ -4526,7 +4526,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint64_t    getRegister(int num) const;
@@ -4973,7 +4973,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint64_t    getRegister(int num) const;
@@ -5265,7 +5265,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
-  typedef const link_reg_t &link_reg_arg_t;
+  typedef const link_reg_t &link_hardened_reg_arg_t;
 
   bool validRegister(int num) const;
   uint64_t getRegister(int num) const;

--- a/libunwind/src/Registers.hpp
+++ b/libunwind/src/Registers.hpp
@@ -68,6 +68,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -289,6 +290,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint64_t    getRegister(int num) const;
@@ -611,6 +613,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -1186,6 +1189,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint64_t    getRegister(int num) const;
@@ -1852,6 +1856,14 @@ public:
   typedef uint64_t reg_t;
   typedef uint64_t __ptrauth_unwind_registers_arm64_link_reg link_reg_t;
 
+  // Use `link_reg_arg_t` to pass values of `link_reg_t` type as function
+  // arguments. We need to use a const l-value reference to keep signature of
+  // `__ptrauth`-qualified values of `link_reg_t` type on AArch64 PAuth-enabled
+  // ABI intact. Passing the raw pointer by value would cause authentication on
+  // the caller side and make the pointer prone to substitution if spilled to
+  // the stack in the callee.
+  typedef const link_reg_t &link_reg_arg_t;
+
   bool        validRegister(int num) const;
   uint64_t    getRegister(int num) const;
   void        setRegister(int num, uint64_t value);
@@ -2257,6 +2269,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -2765,6 +2778,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -2967,6 +2981,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -3305,6 +3320,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint64_t    getRegister(int num) const;
@@ -3611,6 +3627,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -3800,6 +3817,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool validRegister(int num) const;
   uint64_t getRegister(int num) const;
@@ -3988,6 +4006,7 @@ public:
 
   typedef uint32_t reg_t;
   typedef uint32_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint32_t    getRegister(int num) const;
@@ -4206,6 +4225,7 @@ public:
 
   typedef ::libunwind::reg_t reg_t;
   typedef ::libunwind::reg_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   reg_t       getRegister(int num) const;
@@ -4506,6 +4526,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint64_t    getRegister(int num) const;
@@ -4952,6 +4973,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool        validRegister(int num) const;
   uint64_t    getRegister(int num) const;
@@ -5243,6 +5265,7 @@ public:
 
   typedef uint64_t reg_t;
   typedef uint64_t link_reg_t;
+  typedef const link_reg_t &link_reg_arg_t;
 
   bool validRegister(int num) const;
   uint64_t getRegister(int num) const;

--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -121,7 +121,7 @@ class _LIBUNWIND_HIDDEN DwarfFDECache {
   typedef typename A::pint_t pint_t;
 public:
   static constexpr pint_t kSearchAll = static_cast<pint_t>(-1);
-  static pint_t findFDE(pint_t mh, pint_t pc);
+  template <typename T> static pint_t findFDE(pint_t mh, const T &pc);
   static void add(pint_t mh, pint_t ip_start, pint_t ip_end, pint_t fde);
   static void removeAllIn(pint_t mh);
   static void iterateCacheEntries(void (*func)(unw_word_t ip_start,
@@ -174,8 +174,9 @@ bool DwarfFDECache<A>::_registeredForDyldUnloads = false;
 #endif
 
 template <typename A>
+template <typename T>
 typename DwarfFDECache<A>::pint_t DwarfFDECache<A>::findFDE(pint_t mh,
-                                                            pint_t pc) {
+                                                            const T &pc) {
   pint_t result = 0;
   _LIBUNWIND_LOG_IF_FALSE(_lock.lock_shared());
   for (entry *p = _buffer; p < _bufferUsed; ++p) {
@@ -1060,7 +1061,7 @@ private:
 #if defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND)
   bool getInfoFromFdeCie(const typename CFI_Parser<A>::FDE_Info &fdeInfo,
                          const typename CFI_Parser<A>::CIE_Info &cieInfo,
-                         pint_t pc, uintptr_t dso_base);
+                         const typename R::link_reg_t &pc, uintptr_t dso_base);
   bool getInfoFromDwarfSection(const typename R::link_reg_t &pc,
                                const UnwindInfoSections &sects,
                                uint32_t fdeSectionOffsetHint = 0);
@@ -1730,8 +1731,8 @@ bool UnwindCursor<A, R>::getInfoFromEHABISection(
 template <typename A, typename R>
 bool UnwindCursor<A, R>::getInfoFromFdeCie(
     const typename CFI_Parser<A>::FDE_Info &fdeInfo,
-    const typename CFI_Parser<A>::CIE_Info &cieInfo, pint_t pc,
-    uintptr_t dso_base) {
+    const typename CFI_Parser<A>::CIE_Info &cieInfo,
+    const typename R::link_reg_t &pc, uintptr_t dso_base) {
   typename CFI_Parser<A>::PrologInfo prolog;
   if (CFI_Parser<A>::parseFDEInstructions(_addressSpace, fdeInfo, cieInfo, pc,
                                           R::getArch(), &prolog)) {


### PR DESCRIPTION
For Apple's arm64e or Linux's pauthtest, `Registers_arm64::link_reg_t` type is `__ptrauth`-qualified. When passing a value of such a type to a function accepting non-`__ptrauth`-qualified parameter with `pint_t` type, an authentication is performed. So, the corresponding callee argument does not contain an embedded signature, making it prone to substitution if spilled to the stack.

This patch prevents early authentication of signed values of `link_reg_t` type by passing them as const l-value references instead of passing by value with type `pint_t`. This way, the callee would operate with a `__ptrauth`-qualified value containing a signature, allowing to detect a substitution if the value is spilled to the stack.

Note that this approach was introduced previously in #143230 for some other functions. In this patch, we apply the approach to the functions which were not considered previously.