### PR TITLE
[lldb] Avoid unnecessary vector copy for StringList::AppendList

### DIFF
--- a/lldb/include/lldb/Utility/StringList.h
+++ b/lldb/include/lldb/Utility/StringList.h
@@ -49,7 +49,7 @@ public:
 
   void AppendList(const char **strv, int strc);
 
-  void AppendList(StringList strings);
+  void AppendList(const StringList &strings);
 
   size_t GetSize() const;
 

--- a/lldb/source/Utility/StringList.cpp
+++ b/lldb/source/Utility/StringList.cpp
@@ -66,7 +66,7 @@ void StringList::AppendList(const char **strv, int strc) {
   }
 }
 
-void StringList::AppendList(StringList strings) {
+void StringList::AppendList(const StringList &strings) {
   m_strings.reserve(m_strings.size() + strings.GetSize());
   m_strings.insert(m_strings.end(), strings.begin(), strings.end());
 }


### PR DESCRIPTION
Eliminate redundant vector copies in StringList  and its dependent classes.