### PR TITLE
[mlir][llvm] Use the roundtrip flag in test

### DIFF
--- a/mlir/test/Dialect/LLVMIR/debuginfo.mlir
+++ b/mlir/test/Dialect/LLVMIR/debuginfo.mlir
@@ -1,5 +1,4 @@
-// RUN: mlir-opt %s | mlir-opt | FileCheck %s
-// RUN: mlir-opt -emit-bytecode %s | mlir-opt | FileCheck %s
+// RUN: mlir-opt %s --verify-roundtrip | mlir-opt | FileCheck %s
 
 // CHECK-DAG: #[[FILE:.*]] = #llvm.di_file<"debuginfo.mlir" in "/test/">
 #file = #llvm.di_file<"debuginfo.mlir" in "/test/">


### PR DESCRIPTION
This commit changes the debug info test to use the `--verify-roundtrip` flag. The byte code rountrip has been problematic before. Recent changes to the attribute parsing make it possible to use the flag.

This closes https://github.com/llvm/llvm-project/issues/163004