### PR TITLE
[flang] Catch misuse of assumed-rank dummy argument

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3760,6 +3760,8 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::Expr::Parentheses &x) {
   if (MaybeExpr operand{Analyze(x.v.value())}) {
     if (IsNullPointerOrAllocatable(&*operand)) {
       Say("NULL() may not be parenthesized"_err_en_US);
+    } else if (semantics::IsAssumedRank(*operand)) {
+      Say("An assumed-rank dummy argument may not be parenthesized"_err_en_US);
     } else if (const semantics::Symbol *symbol{GetLastSymbol(*operand)}) {
       if (const semantics::Symbol *result{FindFunctionResult(*symbol)}) {
         if (semantics::IsProcedurePointer(*result)) {

--- a/flang/test/Semantics/bug173593.f90
+++ b/flang/test/Semantics/bug173593.f90
@@ -1,0 +1,12 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1
+module m
+ contains
+  subroutine s1(x)
+    integer :: x(..)
+    !ERROR: An assumed-rank dummy argument may not be parenthesized
+    call s2((x))
+  end
+  subroutine s2(y)
+    integer :: y(..)
+  end
+end


### PR DESCRIPTION
Assumed-rank dummy arguments can't be parenthesized.

Fixes https://github.com/llvm/llvm-project/issues/173593.