### PR TITLE
[Github] Make LLVMbot trigger on changes to itself, the docs in general, and vectorization docs in particular

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -618,6 +618,12 @@ github:workflow:
   - changed-files:
     - any-glob-to-any-file:
       - .github/workflows/**
+      - .github/new-prs-labeler.yml
+
+github-prs:
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/new-prs-labeler.yml
 
 cmake:
   - changed-files:

--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -111,6 +111,7 @@ vectorizers:
     - any-glob-to-any-file:
       - llvm/lib/Transforms/Vectorize/**/*
       - llvm/include/llvm/Transforms/Vectorize/**/*
+      - llvm/docs/Vectorizers.rst
 
 # IMPORTED FROM CODEOWNERS
 LTO:
@@ -1447,3 +1448,8 @@ infrastructure:
   - changed-files:
     - any-glob-to-any-file:
       - .ci/**
+
+documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - llvm/docs/**


### PR DESCRIPTION
Changes to `llvm/docs` should trigger @llvmbot to add labels and make notifications.
Changes to `llvm/docs/Vectorizers.rst` should be treated as a change to vectorizers by llvmbot.
When the PR labeler config (.github/new-prs-labeler.yml) itself changes, that too should trigger tagging.
This PR makes it so.