### PR TITLE
[NFC][Clang] Remove unused include <tuple> in Lexer.cpp

### DIFF
--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -44,7 +44,6 @@
 #include <limits>
 #include <optional>
 #include <string>
-#include <tuple>
 
 #ifdef __SSE4_2__
 #include <nmmintrin.h>


### PR DESCRIPTION
This header was not being used, as found by `Ctrl + F`-ing all the declarations from `tuple` (found at https://en.cppreference.com/w/cpp/header/tuple.html).