### PR TITLE
[RISCV] Update Andes45 vector load/stores scheduling info

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedAndes45.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedAndes45.td
@@ -462,10 +462,11 @@ foreach mx = SchedMxList in {
 // The latency for loads is (4+VLSU_MEM_LATENCY+(DLEN/EEW)).
 // The throughput for loads and stores is VL.
 foreach mx = SchedMxList in {
-  defvar Cycles = Andes45GetCyclesOnePerElement<mx, 8>.c;
   defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
 
   foreach eew = [8, 16, 32, 64] in {
+    defvar Cycles = Andes45GetCyclesOnePerElement<mx, eew>.c;
+
     let Latency = !add(4, !add(VLSU_MEM_LATENCY, !div(Andes45DLEN, eew))),
         ReleaseAtCycles = [Cycles] in
       defm "" : LMULWriteResMX<"WriteVLDS"  # eew, [Andes45VLSU], mx, IsWorstCase>;
@@ -482,10 +483,11 @@ foreach mx = SchedMxList in {
 // The latency for loads is (5+VLSU_MEM_LATENCY+(DLEN/EEW)).
 // The throughput for loads and stores is (VL+EMUL-1).
 foreach mx = SchedMxList in {
-  defvar Cycles = Andes45GetCyclesOnePerElement<mx, 8>.c;
   defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
 
   foreach eew = [8, 16, 32, 64] in {
+    defvar Cycles = Andes45GetCyclesOnePerElement<mx, eew>.c;
+
     let Latency = !add(5, !add(VLSU_MEM_LATENCY, !div(Andes45DLEN, eew))),
         ReleaseAtCycles = [!add(Cycles, !sub(Andes45GetLMULValue<mx>.c, 1))] in {
       defm "" : LMULWriteResMX<"WriteVLDUX" # eew, [Andes45VLSU], mx, IsWorstCase>;

--- a/llvm/lib/Target/RISCV/RISCVSchedAndes45.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedAndes45.td
@@ -501,7 +501,7 @@ foreach mx = SchedMxList in {
 
 // Unit-Stride Segmented Loads and Stores
 
-// The latency for loads is (4+VLSU_MEM_LATENCY+EMUL* NFIELDS+2)
+// The latency for loads is (4+VLSU_MEM_LATENCY+EMUL*NFIELDS+2)
 // The throughput for loads and stores is (VLEN/VLSU_MEM_DW)*EMUL*NFIELDS.
 foreach mx = SchedMxList in {
   foreach nf=2-8 in {
@@ -517,8 +517,7 @@ foreach mx = SchedMxList in {
         defm "" : LMULWriteResMX<"WriteVLSEGFF" # nf # "e" # eew,
                                  [Andes45VLSU], mx, IsWorstCase>;
       }
-      // TODO
-      let ReleaseAtCycles = [Cycles] in
+      let ReleaseAtCycles = [!mul(Cycles, nf)] in
       defm "" : LMULWriteResMX<"WriteVSSEG" # nf # "e" # eew,
                                [Andes45VLSU], mx, IsWorstCase>;
     }
@@ -527,19 +526,19 @@ foreach mx = SchedMxList in {
 
 // Strided Segmented Loads and Stores
 
-// The latency for loads is (5+VLSU_MEM_LATENCY+(DLEN/EEW))
-// The throughput for loads and stores is VL.
+// The latency for loads is (5+VLSU_MEM_LATENCY+(DLEN/EEW)*NFIELDS)
+// The throughput for loads and stores is VL*NFIELDS.
 foreach mx = SchedMxList in {
   foreach nf=2-8 in {
     foreach eew = [8, 16, 32, 64] in {
       defvar Cycles = Andes45GetCyclesOnePerElement<mx, eew>.c;
       defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
 
-      let Latency = !add(5, !add(VLSU_MEM_LATENCY, !div(Andes45DLEN, eew))),
-          ReleaseAtCycles = [Cycles] in
+      let Latency = !add(5, !add(VLSU_MEM_LATENCY, !mul(!div(Andes45DLEN, eew), nf))),
+          ReleaseAtCycles = [!mul(Cycles, nf)] in
         defm "" : LMULWriteResMX<"WriteVLSSEG" # nf # "e" # eew,
                                  [Andes45VLSU], mx, IsWorstCase>;
-      let ReleaseAtCycles = [Cycles] in
+      let ReleaseAtCycles = [!mul(Cycles, nf)] in
         defm "" : LMULWriteResMX<"WriteVSSSEG" # nf # "e" # eew,
                                  [Andes45VLSU], mx, IsWorstCase>;
     }
@@ -548,22 +547,24 @@ foreach mx = SchedMxList in {
 
 // Indexed Segmented Loads and Stores
 
-// The latency for loads is (6+VLSU_MEM_LATENCY+(DLEN/EEW))
-// The throughput for loads and stores is (VL+EMUL-1).
+// The latency for loads is (6+VLSU_MEM_LATENCY+(DLEN/EEW)*NFIELDS)
+// The throughput for loads and stores is (VL*NFIELDS+EMUL-1).
 foreach mx = SchedMxList in {
   foreach nf=2-8 in {
     foreach eew = [8, 16, 32, 64] in {
       defvar Cycles = Andes45GetCyclesOnePerElement<mx, eew>.c;
       defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
 
-      let Latency = !add(6, !add(VLSU_MEM_LATENCY, !div(Andes45DLEN, eew))),
-          ReleaseAtCycles = [!add(Cycles, !sub(Andes45GetLMULValue<mx>.c, 1))] in {
+      let Latency = !add(6, !add(VLSU_MEM_LATENCY, !mul(!div(Andes45DLEN, eew), nf))),
+          ReleaseAtCycles = [!add(!mul(Cycles, nf),
+                                  !sub(Andes45GetLMULValue<mx>.c, 1))] in {
         defm "" : LMULWriteResMX<"WriteVLUXSEG" # nf # "e" # eew,
                                  [Andes45VLSU], mx, IsWorstCase>;
         defm "" : LMULWriteResMX<"WriteVLOXSEG" # nf # "e" # eew,
                                  [Andes45VLSU], mx, IsWorstCase>;
       }
-      let ReleaseAtCycles = [!add(Cycles, !sub(Andes45GetLMULValue<mx>.c, 1))] in {
+      let ReleaseAtCycles = [!add(!mul(Cycles, nf),
+                                  !sub(Andes45GetLMULValue<mx>.c, 1))] in {
         defm "" : LMULWriteResMX<"WriteVSUXSEG" # nf # "e" # eew,
                                  [Andes45VLSU], mx, IsWorstCase>;
         defm "" : LMULWriteResMX<"WriteVSOXSEG" # nf # "e" # eew,

--- a/llvm/lib/Target/RISCV/RISCVSchedAndes45.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedAndes45.td
@@ -8,6 +8,27 @@
 
 //===----------------------------------------------------------------------===//
 
+defvar Andes45VLEN = 512;
+defvar Andes45DLEN = 512;
+defvar Andes45VLEN_DLEN_RATIO = !div(Andes45VLEN, Andes45DLEN);
+
+assert !or(!eq(Andes45VLEN_DLEN_RATIO, 1), !eq(Andes45VLEN_DLEN_RATIO, 2)),
+       "Andes45VLEN / Andes45DLEN should be 1 or 2";
+
+defvar Andes45BIU_DATA_WIDTH = 512;
+defvar Andes45DLEN_BIU_DATA_WIDTH_RATIO = !div(Andes45DLEN, Andes45BIU_DATA_WIDTH);
+
+assert !or(!eq(Andes45DLEN_BIU_DATA_WIDTH_RATIO, 1), !eq(Andes45DLEN_BIU_DATA_WIDTH_RATIO, 2)),
+       "Andes45DLEN / Andes45DLEN_BIU_DATA_WIDTH_RATIO should be 1 or 2";
+
+// HVM region: VLSU_MEM_DW equals DLEN
+// Cachable/Non-cachable region: VLSU_MEM_DW equals BIU_DATA_WIDTH
+defvar Andes45VLSU_MEM_DW = Andes45BIU_DATA_WIDTH;
+defvar Andes45VLEN_VLSU_MEM_DW_RATIO = !div(Andes45VLEN, Andes45VLSU_MEM_DW);
+
+// There are various latency depending on its memory type and status.
+defvar VLSU_MEM_LATENCY = 13;
+
 // The worst case LMUL is the largest LMUL.
 class Andes45IsWorstCaseMX<string mx, list<string> MxList> {
   defvar LLMUL = LargestLMUL<MxList>.r;
@@ -20,6 +41,45 @@ class Andes45IsWorstCaseMXSEW<string mx, int sew, list<string> MxList,
   defvar LLMUL = LargestLMUL<MxList>.r;
   defvar SSEW = SmallestSEW<mx, isF>.r;
   bit c = !and(!eq(mx, LLMUL), !eq(sew, SSEW));
+}
+
+// (VLEN/VLSU_MEM_DW)*EMUL
+class Andes45GetCyclesLoadStore<string mx> {
+  int c = !cond(
+    !eq(mx, "M1") : !mul(Andes45VLEN_VLSU_MEM_DW_RATIO, 1),
+    !eq(mx, "M2") : !mul(Andes45VLEN_VLSU_MEM_DW_RATIO, 2),
+    !eq(mx, "M4") : !mul(Andes45VLEN_VLSU_MEM_DW_RATIO, 4),
+    !eq(mx, "M8") : !mul(Andes45VLEN_VLSU_MEM_DW_RATIO, 8),
+    !eq(mx, "MF2") : !mul(Andes45VLEN_VLSU_MEM_DW_RATIO, 1),
+    !eq(mx, "MF4") : !mul(Andes45VLEN_VLSU_MEM_DW_RATIO, 1),
+    !eq(mx, "MF8") : !mul(Andes45VLEN_VLSU_MEM_DW_RATIO, 1)
+  );
+}
+
+class Andes45GetCyclesOnePerElement<string mx, int sew> {
+  defvar VL = !div(Andes45VLEN, sew);
+  int c = !cond(
+    !eq(mx, "M1")  : VL,
+    !eq(mx, "M2")  : !mul(VL, 2),
+    !eq(mx, "M4")  : !mul(VL, 4),
+    !eq(mx, "M8")  : !mul(VL, 8),
+    !eq(mx, "MF2") : !div(VL, 2),
+    !eq(mx, "MF4") : !div(VL, 4),
+    !eq(mx, "MF8") : !div(VL, 8)
+  );
+}
+
+// When fractional LMUL is used, the LMUL used in calculation is 1.
+class Andes45GetLMULValue<string mx> {
+  int c = !cond(
+    !eq(mx, "M1") : 1,
+    !eq(mx, "M2") : 2,
+    !eq(mx, "M4") : 4,
+    !eq(mx, "M8") : 8,
+    !eq(mx, "MF2") : 1,
+    !eq(mx, "MF4") : 1,
+    !eq(mx, "MF8") : 1
+  );
 }
 
 def Andes45Model : SchedMachineModel {
@@ -372,58 +432,153 @@ def : WriteRes<WriteVSETIVLI, [Andes45CSR]>;
 def : WriteRes<WriteVSETVL, [Andes45CSR]>;
 
 // 7. Vector Loads and Stores
+
+// Unit-stride loads and stores
+
+// The latency for loads is (4+VLSU_MEM_LATENCY).
+// The throughput for loads and stores is (VLEN/VLSU_MEM_DW)*EMUL.
 foreach mx = SchedMxList in {
+  defvar Cycles = Andes45GetCyclesLoadStore<mx>.c;
   defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
 
-  // Unit-stride loads and stores
-  defm "" : LMULWriteResMX<"WriteVLDE", [Andes45VLSU], mx, IsWorstCase>;
-  defm "" : LMULWriteResMX<"WriteVLDFF", [Andes45VLSU], mx, IsWorstCase>;
+  let Latency = !add(4, VLSU_MEM_LATENCY), ReleaseAtCycles = [Cycles] in {
+    defm "" : LMULWriteResMX<"WriteVLDE", [Andes45VLSU], mx, IsWorstCase>;
+    defm "" : LMULWriteResMX<"WriteVLDFF", [Andes45VLSU], mx, IsWorstCase>;
+  }
+  let ReleaseAtCycles = [Cycles] in
   defm "" : LMULWriteResMX<"WriteVSTE", [Andes45VLSU], mx, IsWorstCase>;
 
   // Mask loads and stores
+  let Latency = !add(4, VLSU_MEM_LATENCY), ReleaseAtCycles = [Cycles] in
   defm "" : LMULWriteResMX<"WriteVLDM", [Andes45VLSU], mx, IsWorstCase=!eq(mx, "M1")>;
+  let ReleaseAtCycles = [Cycles] in
   defm "" : LMULWriteResMX<"WriteVSTM", [Andes45VLSU], mx, IsWorstCase=!eq(mx, "M1")>;
+}
 
-  // Strided and indexed loads and stores
+// Strided loads and stores.
+
+// Strided loads and stores operate at one element per cycles.
+// We uses the SEW to compute the number of elements for throughput.
+// The latency for loads is (4+VLSU_MEM_LATENCY+(DLEN/EEW)).
+// The throughput for loads and stores is VL.
+foreach mx = SchedMxList in {
+  defvar Cycles = Andes45GetCyclesOnePerElement<mx, 8>.c;
+  defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
+
   foreach eew = [8, 16, 32, 64] in {
-    defm "" : LMULWriteResMX<"WriteVLDS"  # eew, [Andes45VLSU], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDUX" # eew, [Andes45VLSU], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVLDOX" # eew, [Andes45VLSU], mx, IsWorstCase>;
+    let Latency = !add(4, !add(VLSU_MEM_LATENCY, !div(Andes45DLEN, eew))),
+        ReleaseAtCycles = [Cycles] in
+      defm "" : LMULWriteResMX<"WriteVLDS"  # eew, [Andes45VLSU], mx, IsWorstCase>;
 
-    defm "" : LMULWriteResMX<"WriteVSTS"  # eew, [Andes45VLSU], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTUX" # eew, [Andes45VLSU], mx, IsWorstCase>;
-    defm "" : LMULWriteResMX<"WriteVSTOX" # eew, [Andes45VLSU], mx, IsWorstCase>;
+    let ReleaseAtCycles = [Cycles] in
+      defm "" : LMULWriteResMX<"WriteVSTS"  # eew, [Andes45VLSU], mx, IsWorstCase>;
   }
 }
 
-// Segmented loads and stores
+// Indexed loads and stores
+
+// Indexed loads and stores operate at one element per cycles.
+// We uses the SEW to compute the number of elements for throughput.
+// The latency for loads is (5+VLSU_MEM_LATENCY+(DLEN/EEW)).
+// The throughput for loads and stores is (VL+EMUL-1).
+foreach mx = SchedMxList in {
+  defvar Cycles = Andes45GetCyclesOnePerElement<mx, 8>.c;
+  defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
+
+  foreach eew = [8, 16, 32, 64] in {
+    let Latency = !add(5, !add(VLSU_MEM_LATENCY, !div(Andes45DLEN, eew))),
+        ReleaseAtCycles = [!add(Cycles, !sub(Andes45GetLMULValue<mx>.c, 1))] in {
+      defm "" : LMULWriteResMX<"WriteVLDUX" # eew, [Andes45VLSU], mx, IsWorstCase>;
+      defm "" : LMULWriteResMX<"WriteVLDOX" # eew, [Andes45VLSU], mx, IsWorstCase>;
+    }
+
+    let ReleaseAtCycles = [!add(Cycles, !sub(Andes45GetLMULValue<mx>.c, 1))] in {
+      defm "" : LMULWriteResMX<"WriteVSTUX" # eew, [Andes45VLSU], mx, IsWorstCase>;
+      defm "" : LMULWriteResMX<"WriteVSTOX" # eew, [Andes45VLSU], mx, IsWorstCase>;
+    }
+  }
+}
+
+// Unit-Stride Segmented Loads and Stores
+
+// The latency for loads is (4+VLSU_MEM_LATENCY+EMUL* NFIELDS+2)
+// The throughput for loads and stores is (VLEN/VLSU_MEM_DW)*EMUL*NFIELDS.
 foreach mx = SchedMxList in {
   foreach nf=2-8 in {
     foreach eew = [8, 16, 32, 64] in {
+      defvar Cycles = Andes45GetCyclesLoadStore<mx>.c;
+      defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
+      defvar Size = !mul(Andes45GetLMULValue<mx>.c, nf);
+
+      let Latency = !add(4, !add(VLSU_MEM_LATENCY, !add(Size, 2))),
+          ReleaseAtCycles = [!mul(Cycles, nf)] in {
+        defm "" : LMULWriteResMX<"WriteVLSEG" # nf # "e" # eew,
+                                 [Andes45VLSU], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVLSEGFF" # nf # "e" # eew,
+                                 [Andes45VLSU], mx, IsWorstCase>;
+      }
+      // TODO
+      let ReleaseAtCycles = [Cycles] in
+      defm "" : LMULWriteResMX<"WriteVSSEG" # nf # "e" # eew,
+                               [Andes45VLSU], mx, IsWorstCase>;
+    }
+  }
+}
+
+// Strided Segmented Loads and Stores
+
+// The latency for loads is (5+VLSU_MEM_LATENCY+(DLEN/EEW))
+// The throughput for loads and stores is VL.
+foreach mx = SchedMxList in {
+  foreach nf=2-8 in {
+    foreach eew = [8, 16, 32, 64] in {
+      defvar Cycles = Andes45GetCyclesOnePerElement<mx, eew>.c;
       defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
 
-      // Unit-stride segmented
-      defm "" : LMULWriteResMX<"WriteVLSEG" # nf # "e" #eew, [Andes45VLSU], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVLSEGFF" # nf # "e" #eew, [Andes45VLSU], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVSSEG" # nf # "e" #eew, [Andes45VLSU], mx, IsWorstCase>;
+      let Latency = !add(5, !add(VLSU_MEM_LATENCY, !div(Andes45DLEN, eew))),
+          ReleaseAtCycles = [Cycles] in
+        defm "" : LMULWriteResMX<"WriteVLSSEG" # nf # "e" # eew,
+                                 [Andes45VLSU], mx, IsWorstCase>;
+      let ReleaseAtCycles = [Cycles] in
+        defm "" : LMULWriteResMX<"WriteVSSSEG" # nf # "e" # eew,
+                                 [Andes45VLSU], mx, IsWorstCase>;
+    }
+  }
+}
 
-      // Strided/indexed segmented
-      defm "" : LMULWriteResMX<"WriteVLSSEG" # nf # "e" #eew, [Andes45VLSU], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVSSSEG" # nf # "e" #eew, [Andes45VLSU], mx, IsWorstCase>;
+// Indexed Segmented Loads and Stores
 
-      // Indexed segmented
-      defm "" : LMULWriteResMX<"WriteVLOXSEG" # nf # "e" #eew, [Andes45VLSU], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVLUXSEG" # nf # "e" #eew, [Andes45VLSU], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVSUXSEG" # nf # "e" #eew, [Andes45VLSU], mx, IsWorstCase>;
-      defm "" : LMULWriteResMX<"WriteVSOXSEG" # nf # "e" #eew, [Andes45VLSU], mx, IsWorstCase>;
+// The latency for loads is (6+VLSU_MEM_LATENCY+(DLEN/EEW))
+// The throughput for loads and stores is (VL+EMUL-1).
+foreach mx = SchedMxList in {
+  foreach nf=2-8 in {
+    foreach eew = [8, 16, 32, 64] in {
+      defvar Cycles = Andes45GetCyclesOnePerElement<mx, eew>.c;
+      defvar IsWorstCase = Andes45IsWorstCaseMX<mx, SchedMxList>.c;
+
+      let Latency = !add(6, !add(VLSU_MEM_LATENCY, !div(Andes45DLEN, eew))),
+          ReleaseAtCycles = [!add(Cycles, !sub(Andes45GetLMULValue<mx>.c, 1))] in {
+        defm "" : LMULWriteResMX<"WriteVLUXSEG" # nf # "e" # eew,
+                                 [Andes45VLSU], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVLOXSEG" # nf # "e" # eew,
+                                 [Andes45VLSU], mx, IsWorstCase>;
+      }
+      let ReleaseAtCycles = [!add(Cycles, !sub(Andes45GetLMULValue<mx>.c, 1))] in {
+        defm "" : LMULWriteResMX<"WriteVSUXSEG" # nf # "e" # eew,
+                                 [Andes45VLSU], mx, IsWorstCase>;
+        defm "" : LMULWriteResMX<"WriteVSOXSEG" # nf # "e" # eew,
+                                 [Andes45VLSU], mx, IsWorstCase>;
+      }
     }
   }
 }
 
 // Whole register move/load/store
 foreach LMul = [1, 2, 4, 8] in {
-  def : WriteRes<!cast<SchedWrite>("WriteVLD" # LMul # "R"), [Andes45VLSU]>;
-  def : WriteRes<!cast<SchedWrite>("WriteVST" # LMul # "R"), [Andes45VLSU]>;
+  let Latency = 6, ReleaseAtCycles = [!mul(LMul, 2)] in
+    def : WriteRes<!cast<SchedWrite>("WriteVLD" # LMul # "R"), [Andes45VLSU]>;
+  let ReleaseAtCycles = [!mul(LMul, 2)] in
+    def : WriteRes<!cast<SchedWrite>("WriteVST" # LMul # "R"), [Andes45VLSU]>;
 
   def : WriteRes<!cast<SchedWrite>("WriteVMov" # LMul # "V"), [Andes45VPERMUT]>;
 }

--- a/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vle-vse-vlm.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vle-vse-vlm.s
@@ -210,49 +210,49 @@ vle64ff.v   v8, (a0)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      17    2.00    *                    17    Andes45VLSU[2]                             VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      17    4.00    *                    17    Andes45VLSU[4]                             VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8_V                     vle8.v	v8, (a0)
+# CHECK-NEXT:  1      17    8.00    *                    17    Andes45VLSU[8]                             VLE8_V                     vle8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE16_V                    vle16.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE16_V                    vle16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE16_V                    vle16.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE16_V                    vle16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE16_V                    vle16.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE16_V                    vle16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE16_V                    vle16.v	v8, (a0)
+# CHECK-NEXT:  1      17    2.00    *                    17    Andes45VLSU[2]                             VLE16_V                    vle16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE16_V                    vle16.v	v8, (a0)
+# CHECK-NEXT:  1      17    4.00    *                    17    Andes45VLSU[4]                             VLE16_V                    vle16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE16_V                    vle16.v	v8, (a0)
+# CHECK-NEXT:  1      17    8.00    *                    17    Andes45VLSU[8]                             VLE16_V                    vle16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE32_V                    vle32.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE32_V                    vle32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE32_V                    vle32.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE32_V                    vle32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE32_V                    vle32.v	v8, (a0)
+# CHECK-NEXT:  1      17    2.00    *                    17    Andes45VLSU[2]                             VLE32_V                    vle32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE32_V                    vle32.v	v8, (a0)
+# CHECK-NEXT:  1      17    4.00    *                    17    Andes45VLSU[4]                             VLE32_V                    vle32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE32_V                    vle32.v	v8, (a0)
+# CHECK-NEXT:  1      17    8.00    *                    17    Andes45VLSU[8]                             VLE32_V                    vle32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE64_V                    vle64.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE64_V                    vle64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE64_V                    vle64.v	v8, (a0)
+# CHECK-NEXT:  1      17    2.00    *                    17    Andes45VLSU[2]                             VLE64_V                    vle64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE64_V                    vle64.v	v8, (a0)
+# CHECK-NEXT:  1      17    4.00    *                    17    Andes45VLSU[4]                             VLE64_V                    vle64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE64_V                    vle64.v	v8, (a0)
+# CHECK-NEXT:  1      17    8.00    *                    17    Andes45VLSU[8]                             VLE64_V                    vle64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE8_V                     vse8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
@@ -262,11 +262,11 @@ vle64ff.v   v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE8_V                     vse8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE8_V                     vse8.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSE8_V                     vse8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE8_V                     vse8.v	v8, (a0)
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSE8_V                     vse8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE8_V                     vse8.v	v8, (a0)
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSE8_V                     vse8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE16_V                    vse16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
@@ -274,43 +274,43 @@ vle64ff.v   v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE16_V                    vse16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE16_V                    vse16.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSE16_V                    vse16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE16_V                    vse16.v	v8, (a0)
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSE16_V                    vse16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE16_V                    vse16.v	v8, (a0)
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSE16_V                    vse16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE32_V                    vse32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE32_V                    vse32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE32_V                    vse32.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSE32_V                    vse32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE32_V                    vse32.v	v8, (a0)
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSE32_V                    vse32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE32_V                    vse32.v	v8, (a0)
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSE32_V                    vse32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE64_V                    vse64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE64_V                    vse64.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSE64_V                    vse64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE64_V                    vse64.v	v8, (a0)
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSE64_V                    vse64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSE64_V                    vse64.v	v8, (a0)
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSE64_V                    vse64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLM_V                      vlm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSM_V                      vsm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
@@ -326,49 +326,49 @@ vle64ff.v   v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSM_V                      vsm.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    2.00    *                    17    Andes45VLSU[2]                             VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    4.00    *                    17    Andes45VLSU[4]                             VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE8FF_V                   vle8ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    8.00    *                    17    Andes45VLSU[8]                             VLE8FF_V                   vle8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE16FF_V                  vle16ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE16FF_V                  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE16FF_V                  vle16ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE16FF_V                  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE16FF_V                  vle16ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE16FF_V                  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE16FF_V                  vle16ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    2.00    *                    17    Andes45VLSU[2]                             VLE16FF_V                  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE16FF_V                  vle16ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    4.00    *                    17    Andes45VLSU[4]                             VLE16FF_V                  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE16FF_V                  vle16ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    8.00    *                    17    Andes45VLSU[8]                             VLE16FF_V                  vle16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE32FF_V                  vle32ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE32FF_V                  vle32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE32FF_V                  vle32ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE32FF_V                  vle32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE32FF_V                  vle32ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    2.00    *                    17    Andes45VLSU[2]                             VLE32FF_V                  vle32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE32FF_V                  vle32ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    4.00    *                    17    Andes45VLSU[4]                             VLE32FF_V                  vle32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE32FF_V                  vle32ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    8.00    *                    17    Andes45VLSU[8]                             VLE32FF_V                  vle32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE64FF_V                  vle64ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    1.00    *                    17    Andes45VLSU                                VLE64FF_V                  vle64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE64FF_V                  vle64ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    2.00    *                    17    Andes45VLSU[2]                             VLE64FF_V                  vle64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE64FF_V                  vle64ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    4.00    *                    17    Andes45VLSU[4]                             VLE64FF_V                  vle64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLE64FF_V                  vle64ff.v	v8, (a0)
+# CHECK-NEXT:  1      17    8.00    *                    17    Andes45VLSU[8]                             VLE64FF_V                  vle64ff.v	v8, (a0)
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0.0] - Andes45ALU
@@ -391,7 +391,7 @@ vle64ff.v   v8, (a0)
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -     80.00   -      -      -      -      -      -      -      -      -      -     80.00   -      -      -
+# CHECK-NEXT:  -      -     80.00   -      -      -      -      -      -      -      -      -      -     212.00  -      -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
@@ -404,11 +404,11 @@ vle64ff.v   v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vle8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vle8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vle8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
@@ -416,29 +416,29 @@ vle64ff.v   v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vle16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vle16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vle16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vle32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vle32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vle32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vle64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vle64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vle64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
@@ -448,11 +448,11 @@ vle64ff.v   v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vse8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vse8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vse8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
@@ -460,29 +460,29 @@ vle64ff.v   v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vse16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vse16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vse16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vse32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vse32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vse32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vse64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vse64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vse64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vse64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlm.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
@@ -520,11 +520,11 @@ vle64ff.v   v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vle8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vle8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vle8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
@@ -532,26 +532,26 @@ vle64ff.v   v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vle16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vle16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vle16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vle32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vle32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vle32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vle64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vle64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vle64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vle64ff.v	v8, (a0)

--- a/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vlse-vsse.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vlse-vsse.s
@@ -128,93 +128,93 @@ vsse64.v   v8, (a0), t0
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      81    8.00    *                    81    Andes45VLSU[8]                             VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      81    16.00   *                    81    Andes45VLSU[16]                            VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      81    32.00   *                    81    Andes45VLSU[32]                            VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      81    64.00   *                    81    Andes45VLSU[64]                            VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      81    128.00  *                    81    Andes45VLSU[128]                           VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      81    256.00  *                    81    Andes45VLSU[256]                           VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE8_V                    vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      81    512.00  *                    81    Andes45VLSU[512]                           VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      49    16.00   *                    49    Andes45VLSU[16]                            VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      49    32.00   *                    49    Andes45VLSU[32]                            VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      49    64.00   *                    49    Andes45VLSU[64]                            VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      49    128.00  *                    49    Andes45VLSU[128]                           VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      49    256.00  *                    49    Andes45VLSU[256]                           VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      49    512.00  *                    49    Andes45VLSU[512]                           VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      33    32.00   *                    33    Andes45VLSU[32]                            VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      33    64.00   *                    33    Andes45VLSU[64]                            VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      33    128.00  *                    33    Andes45VLSU[128]                           VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      33    256.00  *                    33    Andes45VLSU[256]                           VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      33    512.00  *                    33    Andes45VLSU[512]                           VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE64_V                   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      25    64.00   *                    25    Andes45VLSU[64]                            VLSE64_V                   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE64_V                   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      25    128.00  *                    25    Andes45VLSU[128]                           VLSE64_V                   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE64_V                   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      25    256.00  *                    25    Andes45VLSU[256]                           VLSE64_V                   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSE64_V                   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      25    512.00  *                    25    Andes45VLSU[512]                           VLSE64_V                   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE8_V                    vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE64_V                   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSE64_V                   vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE64_V                   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSE64_V                   vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE64_V                   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSE64_V                   vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSE64_V                   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSSE64_V                   vsse64.v	v8, (a0), t0
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0.0] - Andes45ALU
@@ -237,95 +237,95 @@ vsse64.v   v8, (a0), t0
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -     44.00   -      -      -      -      -      -      -      -      -      -     44.00   -      -      -
+# CHECK-NEXT:  -      -     44.00   -      -      -      -      -      -      -      -      -      -     7952.00  -     -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse8.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vsse64.v	v8, (a0), t0

--- a/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vlse-vsse.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vlse-vsse.s
@@ -142,35 +142,35 @@ vsse64.v   v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  1      81    512.00  *                    81    Andes45VLSU[512]                           VLSE8_V                    vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      49    16.00   *                    49    Andes45VLSU[16]                            VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      49    8.00    *                    49    Andes45VLSU[8]                             VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      49    32.00   *                    49    Andes45VLSU[32]                            VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      49    16.00   *                    49    Andes45VLSU[16]                            VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      49    64.00   *                    49    Andes45VLSU[64]                            VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      49    32.00   *                    49    Andes45VLSU[32]                            VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      49    128.00  *                    49    Andes45VLSU[128]                           VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      49    64.00   *                    49    Andes45VLSU[64]                            VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      49    256.00  *                    49    Andes45VLSU[256]                           VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      49    128.00  *                    49    Andes45VLSU[128]                           VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      49    512.00  *                    49    Andes45VLSU[512]                           VLSE16_V                   vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      49    256.00  *                    49    Andes45VLSU[256]                           VLSE16_V                   vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      33    32.00   *                    33    Andes45VLSU[32]                            VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      33    8.00    *                    33    Andes45VLSU[8]                             VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      33    64.00   *                    33    Andes45VLSU[64]                            VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      33    16.00   *                    33    Andes45VLSU[16]                            VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      33    128.00  *                    33    Andes45VLSU[128]                           VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      33    32.00   *                    33    Andes45VLSU[32]                            VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      33    256.00  *                    33    Andes45VLSU[256]                           VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      33    64.00   *                    33    Andes45VLSU[64]                            VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      33    512.00  *                    33    Andes45VLSU[512]                           VLSE32_V                   vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      33    128.00  *                    33    Andes45VLSU[128]                           VLSE32_V                   vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      25    64.00   *                    25    Andes45VLSU[64]                            VLSE64_V                   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      25    8.00    *                    25    Andes45VLSU[8]                             VLSE64_V                   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      25    128.00  *                    25    Andes45VLSU[128]                           VLSE64_V                   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      25    16.00   *                    25    Andes45VLSU[16]                            VLSE64_V                   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      25    256.00  *                    25    Andes45VLSU[256]                           VLSE64_V                   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      25    32.00   *                    25    Andes45VLSU[32]                            VLSE64_V                   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      25    512.00  *                    25    Andes45VLSU[512]                           VLSE64_V                   vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      25    64.00   *                    25    Andes45VLSU[64]                            VLSE64_V                   vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
 # CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
@@ -186,35 +186,35 @@ vsse64.v   v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSSE8_V                    vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSSE16_V                   vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSE16_V                   vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSSE32_V                   vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSE32_V                   vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSE64_V                   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSE64_V                   vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSE64_V                   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSE64_V                   vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSE64_V                   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSE64_V                   vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSSE64_V                   vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSE64_V                   vsse64.v	v8, (a0), t0
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0.0] - Andes45ALU
@@ -237,7 +237,7 @@ vsse64.v   v8, (a0), t0
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -     44.00   -      -      -      -      -      -      -      -      -      -     7952.00  -     -      -
+# CHECK-NEXT:  -      -     44.00   -      -      -      -      -      -      -      -      -      -     3776.00  -     -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
@@ -256,35 +256,35 @@ vsse64.v   v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vlse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vlse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vlse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vlse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
@@ -300,32 +300,32 @@ vsse64.v   v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vsse8.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vsse16.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsse16.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vsse32.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsse32.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsse64.v	v8, (a0), t0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vsse64.v	v8, (a0), t0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsse64.v	v8, (a0), t0

--- a/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vlseg-vsseg.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vlseg-vsseg.s
@@ -1807,521 +1807,521 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E64_V                vlseg8e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
 # CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
 # CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E16_V                vsseg2e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E16_V                vsseg2e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E16_V                vsseg2e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
 # CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E16_V                vsseg2e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E16_V                vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E16_V                vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
 # CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG2E16_V                vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG2E16_V                vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E32_V                vsseg2e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E32_V                vsseg2e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
 # CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E32_V                vsseg2e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E32_V                vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
 # CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG2E32_V                vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG2E32_V                vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E64_V                vsseg2e64.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
 # CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E64_V                vsseg2e64.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
 # CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG2E64_V                vsseg2e64.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E16_V                vsseg3e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E16_V                vsseg3e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E16_V                vsseg3e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG3E16_V                vsseg3e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E32_V                vsseg3e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E32_V                vsseg3e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG3E32_V                vsseg3e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E64_V                vsseg3e64.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG3E64_V                vsseg3e64.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E16_V                vsseg4e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E16_V                vsseg4e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E16_V                vsseg4e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG4E16_V                vsseg4e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E32_V                vsseg4e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E32_V                vsseg4e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG4E32_V                vsseg4e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E64_V                vsseg4e64.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG4E64_V                vsseg4e64.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG5E16_V                vsseg5e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG5E16_V                vsseg5e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG5E16_V                vsseg5e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG5E32_V                vsseg5e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG5E32_V                vsseg5e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG5E64_V                vsseg5e64.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG6E16_V                vsseg6e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG6E16_V                vsseg6e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG6E16_V                vsseg6e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG6E32_V                vsseg6e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG6E32_V                vsseg6e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG6E64_V                vsseg6e64.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG7E16_V                vsseg7e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG7E16_V                vsseg7e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG7E16_V                vsseg7e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG7E32_V                vsseg7e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG7E32_V                vsseg7e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG7E64_V                vsseg7e64.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG8E16_V                vsseg8e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG8E16_V                vsseg8e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG8E16_V                vsseg8e16.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG8E32_V                vsseg8e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG8E32_V                vsseg8e32.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG8E64_V                vsseg8e64.v	v8, (a0)
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      82    128.00  *                    82    Andes45VLSU[128]                           VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      82    256.00  *                    82    Andes45VLSU[256]                           VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      50    64.00   *                    50    Andes45VLSU[64]                            VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      50    128.00  *                    50    Andes45VLSU[128]                           VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      34    32.00   *                    34    Andes45VLSU[32]                            VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      34    64.00   *                    34    Andes45VLSU[64]                            VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      26    16.00   *                    26    Andes45VLSU[16]                            VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      26    32.00   *                    26    Andes45VLSU[32]                            VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG2E64_V                vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     3.00           *             1     Andes45VLSU[3]                             VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     3.00           *             1     Andes45VLSU[3]                             VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     3.00           *             1     Andes45VLSU[3]                             VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     3.00           *             1     Andes45VLSU[3]                             VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      82    128.00  *                    82    Andes45VLSU[128]                           VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     3.00           *             1     Andes45VLSU[3]                             VSSEG3E16_V                vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     3.00           *             1     Andes45VLSU[3]                             VSSEG3E16_V                vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     3.00           *             1     Andes45VLSU[3]                             VSSEG3E16_V                vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      50    64.00   *                    50    Andes45VLSU[64]                            VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG3E16_V                vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     3.00           *             1     Andes45VLSU[3]                             VSSEG3E32_V                vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     3.00           *             1     Andes45VLSU[3]                             VSSEG3E32_V                vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      34    32.00   *                    34    Andes45VLSU[32]                            VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG3E32_V                vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG3E64_V               vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     3.00           *             1     Andes45VLSU[3]                             VSSEG3E64_V                vsseg3e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      26    16.00   *                    26    Andes45VLSU[16]                            VLSSEG3E64_V               vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG3E64_V                vsseg3e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      82    128.00  *                    82    Andes45VLSU[128]                           VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG4E16_V                vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG4E16_V                vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG4E16_V                vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      50    64.00   *                    50    Andes45VLSU[64]                            VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG4E16_V                vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG4E32_V                vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG4E32_V                vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      34    32.00   *                    34    Andes45VLSU[32]                            VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG4E32_V                vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG4E64_V               vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG4E64_V                vsseg4e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      26    16.00   *                    26    Andes45VLSU[16]                            VLSSEG4E64_V               vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG4E64_V                vsseg4e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     5.00           *             1     Andes45VLSU[5]                             VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     5.00           *             1     Andes45VLSU[5]                             VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     5.00           *             1     Andes45VLSU[5]                             VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     5.00           *             1     Andes45VLSU[5]                             VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     5.00           *             1     Andes45VLSU[5]                             VSSEG5E16_V                vsseg5e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     5.00           *             1     Andes45VLSU[5]                             VSSEG5E16_V                vsseg5e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     5.00           *             1     Andes45VLSU[5]                             VSSEG5E16_V                vsseg5e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG5E32_V               vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     5.00           *             1     Andes45VLSU[5]                             VSSEG5E32_V                vsseg5e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG5E32_V               vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     5.00           *             1     Andes45VLSU[5]                             VSSEG5E32_V                vsseg5e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG5E64_V               vlsseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     5.00           *             1     Andes45VLSU[5]                             VSSEG5E64_V                vsseg5e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG6E8_V                 vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG6E16_V                vsseg6e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG6E16_V                vsseg6e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG6E16_V                vsseg6e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG6E32_V               vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG6E32_V                vsseg6e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG6E32_V               vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG6E32_V                vsseg6e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG6E64_V               vlsseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     6.00           *             1     Andes45VLSU[6]                             VSSEG6E64_V                vsseg6e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     7.00           *             1     Andes45VLSU[7]                             VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     7.00           *             1     Andes45VLSU[7]                             VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     7.00           *             1     Andes45VLSU[7]                             VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     7.00           *             1     Andes45VLSU[7]                             VSSEG7E8_V                 vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     7.00           *             1     Andes45VLSU[7]                             VSSEG7E16_V                vsseg7e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     7.00           *             1     Andes45VLSU[7]                             VSSEG7E16_V                vsseg7e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     7.00           *             1     Andes45VLSU[7]                             VSSEG7E16_V                vsseg7e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG7E32_V               vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     7.00           *             1     Andes45VLSU[7]                             VSSEG7E32_V                vsseg7e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG7E32_V               vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     7.00           *             1     Andes45VLSU[7]                             VSSEG7E32_V                vsseg7e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG7E64_V               vlsseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     7.00           *             1     Andes45VLSU[7]                             VSSEG7E64_V                vsseg7e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG8E8_V                 vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG8E16_V                vsseg8e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG8E16_V                vsseg8e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG8E16_V                vsseg8e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG8E32_V               vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG8E32_V                vsseg8e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG8E32_V               vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG8E32_V                vsseg8e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG8E64_V               vlsseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSEG8E64_V                vsseg8e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      146   16.00   *                    146   Andes45VLSU[16]                            VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      146   32.00   *                    146   Andes45VLSU[32]                            VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      146   64.00   *                    146   Andes45VLSU[64]                            VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      146   128.00  *                    146   Andes45VLSU[128]                           VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      146   256.00  *                    146   Andes45VLSU[256]                           VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      146   512.00  *                    146   Andes45VLSU[512]                           VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      82    128.00  *                    82    Andes45VLSU[128]                           VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      82    256.00  *                    82    Andes45VLSU[256]                           VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      50    64.00   *                    50    Andes45VLSU[64]                            VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      50    128.00  *                    50    Andes45VLSU[128]                           VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      34    32.00   *                    34    Andes45VLSU[32]                            VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      34    64.00   *                    34    Andes45VLSU[64]                            VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      210   24.00   *                    210   Andes45VLSU[24]                            VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      210   48.00   *                    210   Andes45VLSU[48]                            VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      210   96.00   *                    210   Andes45VLSU[96]                            VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      210   192.00  *                    210   Andes45VLSU[192]                           VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      210   384.00  *                    210   Andes45VLSU[384]                           VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      114   24.00   *                    114   Andes45VLSU[24]                            VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      114   48.00   *                    114   Andes45VLSU[48]                            VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      114   96.00   *                    114   Andes45VLSU[96]                            VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      114   192.00  *                    114   Andes45VLSU[192]                           VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      66    24.00   *                    66    Andes45VLSU[24]                            VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      66    48.00   *                    66    Andes45VLSU[48]                            VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      66    96.00   *                    66    Andes45VLSU[96]                            VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      42    24.00   *                    42    Andes45VLSU[24]                            VLSSEG3E64_V               vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      42    48.00   *                    42    Andes45VLSU[48]                            VLSSEG3E64_V               vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      274   32.00   *                    274   Andes45VLSU[32]                            VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      274   64.00   *                    274   Andes45VLSU[64]                            VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      274   128.00  *                    274   Andes45VLSU[128]                           VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      274   256.00  *                    274   Andes45VLSU[256]                           VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      274   512.00  *                    274   Andes45VLSU[512]                           VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      146   32.00   *                    146   Andes45VLSU[32]                            VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      146   64.00   *                    146   Andes45VLSU[64]                            VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      146   128.00  *                    146   Andes45VLSU[128]                           VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      146   256.00  *                    146   Andes45VLSU[256]                           VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      82    128.00  *                    82    Andes45VLSU[128]                           VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG4E64_V               vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      50    64.00   *                    50    Andes45VLSU[64]                            VLSSEG4E64_V               vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      338   40.00   *                    338   Andes45VLSU[40]                            VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      338   80.00   *                    338   Andes45VLSU[80]                            VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      338   160.00  *                    338   Andes45VLSU[160]                           VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      338   320.00  *                    338   Andes45VLSU[320]                           VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      178   40.00   *                    178   Andes45VLSU[40]                            VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      178   80.00   *                    178   Andes45VLSU[80]                            VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      178   160.00  *                    178   Andes45VLSU[160]                           VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      98    40.00   *                    98    Andes45VLSU[40]                            VLSSEG5E32_V               vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      98    80.00   *                    98    Andes45VLSU[80]                            VLSSEG5E32_V               vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      58    40.00   *                    58    Andes45VLSU[40]                            VLSSEG5E64_V               vlsseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      402   48.00   *                    402   Andes45VLSU[48]                            VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      402   96.00   *                    402   Andes45VLSU[96]                            VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      402   192.00  *                    402   Andes45VLSU[192]                           VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      402   384.00  *                    402   Andes45VLSU[384]                           VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      210   48.00   *                    210   Andes45VLSU[48]                            VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      210   96.00   *                    210   Andes45VLSU[96]                            VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      210   192.00  *                    210   Andes45VLSU[192]                           VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      114   48.00   *                    114   Andes45VLSU[48]                            VLSSEG6E32_V               vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      114   96.00   *                    114   Andes45VLSU[96]                            VLSSEG6E32_V               vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      66    48.00   *                    66    Andes45VLSU[48]                            VLSSEG6E64_V               vlsseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      466   56.00   *                    466   Andes45VLSU[56]                            VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      466   112.00  *                    466   Andes45VLSU[112]                           VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      466   224.00  *                    466   Andes45VLSU[224]                           VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      466   448.00  *                    466   Andes45VLSU[448]                           VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      242   56.00   *                    242   Andes45VLSU[56]                            VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      242   112.00  *                    242   Andes45VLSU[112]                           VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      242   224.00  *                    242   Andes45VLSU[224]                           VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      130   56.00   *                    130   Andes45VLSU[56]                            VLSSEG7E32_V               vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      130   112.00  *                    130   Andes45VLSU[112]                           VLSSEG7E32_V               vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      74    56.00   *                    74    Andes45VLSU[56]                            VLSSEG7E64_V               vlsseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      530   64.00   *                    530   Andes45VLSU[64]                            VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      530   128.00  *                    530   Andes45VLSU[128]                           VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      530   256.00  *                    530   Andes45VLSU[256]                           VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      530   512.00  *                    530   Andes45VLSU[512]                           VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      274   64.00   *                    274   Andes45VLSU[64]                            VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      274   128.00  *                    274   Andes45VLSU[128]                           VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      274   256.00  *                    274   Andes45VLSU[256]                           VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      146   64.00   *                    146   Andes45VLSU[64]                            VLSSEG8E32_V               vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      146   128.00  *                    146   Andes45VLSU[128]                           VLSSEG8E32_V               vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG8E64_V               vlsseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
 # CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
 # CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
 # CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
 # CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     24.00          *             1     Andes45VLSU[24]                            VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     192.00         *             1     Andes45VLSU[192]                           VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     384.00         *             1     Andes45VLSU[384]                           VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     24.00          *             1     Andes45VLSU[24]                            VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     192.00         *             1     Andes45VLSU[192]                           VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     24.00          *             1     Andes45VLSU[24]                            VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG3E64_V               vssseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     24.00          *             1     Andes45VLSU[24]                            VSSSEG3E64_V               vssseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG3E64_V               vssseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSSSEG3E64_V               vssseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG4E64_V               vssseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG4E64_V               vssseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG4E64_V               vssseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG4E64_V               vssseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     40.00          *             1     Andes45VLSU[40]                            VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     80.00          *             1     Andes45VLSU[80]                            VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     160.00         *             1     Andes45VLSU[160]                           VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     320.00         *             1     Andes45VLSU[320]                           VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     40.00          *             1     Andes45VLSU[40]                            VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     80.00          *             1     Andes45VLSU[80]                            VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     160.00         *             1     Andes45VLSU[160]                           VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG5E32_V               vssseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     40.00          *             1     Andes45VLSU[40]                            VSSSEG5E32_V               vssseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG5E32_V               vssseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     80.00          *             1     Andes45VLSU[80]                            VSSSEG5E32_V               vssseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG5E64_V               vssseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     40.00          *             1     Andes45VLSU[40]                            VSSSEG5E64_V               vssseg5e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     192.00         *             1     Andes45VLSU[192]                           VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     384.00         *             1     Andes45VLSU[384]                           VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     192.00         *             1     Andes45VLSU[192]                           VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG6E32_V               vssseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSSSEG6E32_V               vssseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG6E32_V               vssseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSSSEG6E32_V               vssseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG6E64_V               vssseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSSSEG6E64_V               vssseg6e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     56.00          *             1     Andes45VLSU[56]                            VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     112.00         *             1     Andes45VLSU[112]                           VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     224.00         *             1     Andes45VLSU[224]                           VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     448.00         *             1     Andes45VLSU[448]                           VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     56.00          *             1     Andes45VLSU[56]                            VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     112.00         *             1     Andes45VLSU[112]                           VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     224.00         *             1     Andes45VLSU[224]                           VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG7E32_V               vssseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     56.00          *             1     Andes45VLSU[56]                            VSSSEG7E32_V               vssseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG7E32_V               vssseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     112.00         *             1     Andes45VLSU[112]                           VSSSEG7E32_V               vssseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG7E64_V               vssseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     56.00          *             1     Andes45VLSU[56]                            VSSSEG7E64_V               vssseg7e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG8E32_V               vssseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG8E32_V               vssseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG8E32_V               vssseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG8E32_V               vssseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG8E64_V               vssseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG8E64_V               vssseg8e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
@@ -2495,685 +2495,685 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E64FF_V              vlseg8e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   16.00   *                    147   Andes45VLSU[16]                            VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   32.00   *                    147   Andes45VLSU[32]                            VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   64.00   *                    147   Andes45VLSU[64]                            VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   128.00  *                    147   Andes45VLSU[128]                           VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   257.00  *                    147   Andes45VLSU[257]                           VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      83    259.00  *                    83    Andes45VLSU[259]                           VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   515.00  *                    147   Andes45VLSU[515]                           VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      51    131.00  *                    51    Andes45VLSU[131]                           VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    259.00  *                    83    Andes45VLSU[259]                           VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      35    67.00   *                    35    Andes45VLSU[67]                            VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    131.00  *                    51    Andes45VLSU[131]                           VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      27    17.00   *                    27    Andes45VLSU[17]                            VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      27    35.00   *                    27    Andes45VLSU[35]                            VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    67.00   *                    35    Andes45VLSU[67]                            VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   24.00   *                    211   Andes45VLSU[24]                            VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   48.00   *                    211   Andes45VLSU[48]                            VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   96.00   *                    211   Andes45VLSU[96]                            VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   192.00  *                    211   Andes45VLSU[192]                           VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   385.00  *                    211   Andes45VLSU[385]                           VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      115   24.00   *                    115   Andes45VLSU[24]                            VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      115   48.00   *                    115   Andes45VLSU[48]                            VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      115   96.00   *                    115   Andes45VLSU[96]                            VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      115   193.00  *                    115   Andes45VLSU[193]                           VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      67    24.00   *                    67    Andes45VLSU[24]                            VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      67    48.00   *                    67    Andes45VLSU[48]                            VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      67    97.00   *                    67    Andes45VLSU[97]                            VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG3EI64_V             vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      43    24.00   *                    43    Andes45VLSU[24]                            VLUXSEG3EI64_V             vluxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      27    17.00   *                    27    Andes45VLSU[17]                            VLUXSEG3EI64_V             vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      43    49.00   *                    43    Andes45VLSU[49]                            VLUXSEG3EI64_V             vluxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   32.00   *                    275   Andes45VLSU[32]                            VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   64.00   *                    275   Andes45VLSU[64]                            VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   128.00  *                    275   Andes45VLSU[128]                           VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   256.00  *                    275   Andes45VLSU[256]                           VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   513.00  *                    275   Andes45VLSU[513]                           VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   32.00   *                    147   Andes45VLSU[32]                            VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   64.00   *                    147   Andes45VLSU[64]                            VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   128.00  *                    147   Andes45VLSU[128]                           VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   257.00  *                    147   Andes45VLSU[257]                           VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG4EI64_V             vluxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG4EI64_V             vluxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      27    17.00   *                    27    Andes45VLSU[17]                            VLUXSEG4EI64_V             vluxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLUXSEG4EI64_V             vluxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      339   40.00   *                    339   Andes45VLSU[40]                            VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      339   80.00   *                    339   Andes45VLSU[80]                            VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      339   160.00  *                    339   Andes45VLSU[160]                           VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      339   320.00  *                    339   Andes45VLSU[320]                           VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      179   40.00   *                    179   Andes45VLSU[40]                            VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      179   80.00   *                    179   Andes45VLSU[80]                            VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      179   160.00  *                    179   Andes45VLSU[160]                           VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG5EI32_V             vluxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      99    40.00   *                    99    Andes45VLSU[40]                            VLUXSEG5EI32_V             vluxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG5EI32_V             vluxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      99    80.00   *                    99    Andes45VLSU[80]                            VLUXSEG5EI32_V             vluxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG5EI64_V             vluxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      59    40.00   *                    59    Andes45VLSU[40]                            VLUXSEG5EI64_V             vluxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      403   48.00   *                    403   Andes45VLSU[48]                            VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      403   96.00   *                    403   Andes45VLSU[96]                            VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      403   192.00  *                    403   Andes45VLSU[192]                           VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      403   384.00  *                    403   Andes45VLSU[384]                           VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   48.00   *                    211   Andes45VLSU[48]                            VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   96.00   *                    211   Andes45VLSU[96]                            VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   192.00  *                    211   Andes45VLSU[192]                           VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG6EI32_V             vluxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      115   48.00   *                    115   Andes45VLSU[48]                            VLUXSEG6EI32_V             vluxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG6EI32_V             vluxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      115   96.00   *                    115   Andes45VLSU[96]                            VLUXSEG6EI32_V             vluxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG6EI64_V             vluxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      67    48.00   *                    67    Andes45VLSU[48]                            VLUXSEG6EI64_V             vluxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      467   56.00   *                    467   Andes45VLSU[56]                            VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      467   112.00  *                    467   Andes45VLSU[112]                           VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      467   224.00  *                    467   Andes45VLSU[224]                           VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      467   448.00  *                    467   Andes45VLSU[448]                           VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      243   56.00   *                    243   Andes45VLSU[56]                            VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      243   112.00  *                    243   Andes45VLSU[112]                           VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      243   224.00  *                    243   Andes45VLSU[224]                           VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG7EI32_V             vluxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      131   56.00   *                    131   Andes45VLSU[56]                            VLUXSEG7EI32_V             vluxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG7EI32_V             vluxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      131   112.00  *                    131   Andes45VLSU[112]                           VLUXSEG7EI32_V             vluxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG7EI64_V             vluxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      75    56.00   *                    75    Andes45VLSU[56]                            VLUXSEG7EI64_V             vluxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      531   64.00   *                    531   Andes45VLSU[64]                            VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      531   128.00  *                    531   Andes45VLSU[128]                           VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      531   256.00  *                    531   Andes45VLSU[256]                           VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      531   512.00  *                    531   Andes45VLSU[512]                           VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   64.00   *                    275   Andes45VLSU[64]                            VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   128.00  *                    275   Andes45VLSU[128]                           VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   256.00  *                    275   Andes45VLSU[256]                           VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG8EI32_V             vluxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   64.00   *                    147   Andes45VLSU[64]                            VLUXSEG8EI32_V             vluxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG8EI32_V             vluxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   128.00  *                    147   Andes45VLSU[128]                           VLUXSEG8EI32_V             vluxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG8EI64_V             vluxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG8EI64_V             vluxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   16.00   *                    147   Andes45VLSU[16]                            VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   32.00   *                    147   Andes45VLSU[32]                            VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   64.00   *                    147   Andes45VLSU[64]                            VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   128.00  *                    147   Andes45VLSU[128]                           VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   257.00  *                    147   Andes45VLSU[257]                           VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      83    259.00  *                    83    Andes45VLSU[259]                           VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   515.00  *                    147   Andes45VLSU[515]                           VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      51    131.00  *                    51    Andes45VLSU[131]                           VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    259.00  *                    83    Andes45VLSU[259]                           VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      35    67.00   *                    35    Andes45VLSU[67]                            VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    131.00  *                    51    Andes45VLSU[131]                           VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      27    17.00   *                    27    Andes45VLSU[17]                            VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      27    35.00   *                    27    Andes45VLSU[35]                            VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    67.00   *                    35    Andes45VLSU[67]                            VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   24.00   *                    211   Andes45VLSU[24]                            VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   48.00   *                    211   Andes45VLSU[48]                            VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   96.00   *                    211   Andes45VLSU[96]                            VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   192.00  *                    211   Andes45VLSU[192]                           VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   385.00  *                    211   Andes45VLSU[385]                           VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      115   24.00   *                    115   Andes45VLSU[24]                            VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      115   48.00   *                    115   Andes45VLSU[48]                            VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      115   96.00   *                    115   Andes45VLSU[96]                            VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      115   193.00  *                    115   Andes45VLSU[193]                           VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      67    24.00   *                    67    Andes45VLSU[24]                            VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      67    48.00   *                    67    Andes45VLSU[48]                            VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      67    97.00   *                    67    Andes45VLSU[97]                            VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG3EI64_V             vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      43    24.00   *                    43    Andes45VLSU[24]                            VLOXSEG3EI64_V             vloxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      27    17.00   *                    27    Andes45VLSU[17]                            VLOXSEG3EI64_V             vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      43    49.00   *                    43    Andes45VLSU[49]                            VLOXSEG3EI64_V             vloxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   32.00   *                    275   Andes45VLSU[32]                            VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   64.00   *                    275   Andes45VLSU[64]                            VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   128.00  *                    275   Andes45VLSU[128]                           VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   256.00  *                    275   Andes45VLSU[256]                           VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   513.00  *                    275   Andes45VLSU[513]                           VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   32.00   *                    147   Andes45VLSU[32]                            VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   64.00   *                    147   Andes45VLSU[64]                            VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   128.00  *                    147   Andes45VLSU[128]                           VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   257.00  *                    147   Andes45VLSU[257]                           VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG4EI64_V             vloxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG4EI64_V             vloxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      27    17.00   *                    27    Andes45VLSU[17]                            VLOXSEG4EI64_V             vloxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLOXSEG4EI64_V             vloxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      339   40.00   *                    339   Andes45VLSU[40]                            VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      339   80.00   *                    339   Andes45VLSU[80]                            VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      339   160.00  *                    339   Andes45VLSU[160]                           VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      339   320.00  *                    339   Andes45VLSU[320]                           VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      179   40.00   *                    179   Andes45VLSU[40]                            VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      179   80.00   *                    179   Andes45VLSU[80]                            VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      179   160.00  *                    179   Andes45VLSU[160]                           VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG5EI32_V             vloxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      99    40.00   *                    99    Andes45VLSU[40]                            VLOXSEG5EI32_V             vloxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG5EI32_V             vloxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      99    80.00   *                    99    Andes45VLSU[80]                            VLOXSEG5EI32_V             vloxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG5EI64_V             vloxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      59    40.00   *                    59    Andes45VLSU[40]                            VLOXSEG5EI64_V             vloxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      403   48.00   *                    403   Andes45VLSU[48]                            VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      403   96.00   *                    403   Andes45VLSU[96]                            VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      403   192.00  *                    403   Andes45VLSU[192]                           VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      403   384.00  *                    403   Andes45VLSU[384]                           VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   48.00   *                    211   Andes45VLSU[48]                            VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   96.00   *                    211   Andes45VLSU[96]                            VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      211   192.00  *                    211   Andes45VLSU[192]                           VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG6EI32_V             vloxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      115   48.00   *                    115   Andes45VLSU[48]                            VLOXSEG6EI32_V             vloxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG6EI32_V             vloxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      115   96.00   *                    115   Andes45VLSU[96]                            VLOXSEG6EI32_V             vloxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG6EI64_V             vloxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      67    48.00   *                    67    Andes45VLSU[48]                            VLOXSEG6EI64_V             vloxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      467   56.00   *                    467   Andes45VLSU[56]                            VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      467   112.00  *                    467   Andes45VLSU[112]                           VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      467   224.00  *                    467   Andes45VLSU[224]                           VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      467   448.00  *                    467   Andes45VLSU[448]                           VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      243   56.00   *                    243   Andes45VLSU[56]                            VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      243   112.00  *                    243   Andes45VLSU[112]                           VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      243   224.00  *                    243   Andes45VLSU[224]                           VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG7EI32_V             vloxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      131   56.00   *                    131   Andes45VLSU[56]                            VLOXSEG7EI32_V             vloxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG7EI32_V             vloxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      131   112.00  *                    131   Andes45VLSU[112]                           VLOXSEG7EI32_V             vloxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG7EI64_V             vloxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      75    56.00   *                    75    Andes45VLSU[56]                            VLOXSEG7EI64_V             vloxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      531   64.00   *                    531   Andes45VLSU[64]                            VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      531   128.00  *                    531   Andes45VLSU[128]                           VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      531   256.00  *                    531   Andes45VLSU[256]                           VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      531   512.00  *                    531   Andes45VLSU[512]                           VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   64.00   *                    275   Andes45VLSU[64]                            VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   128.00  *                    275   Andes45VLSU[128]                           VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      275   256.00  *                    275   Andes45VLSU[256]                           VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG8EI32_V             vloxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   64.00   *                    147   Andes45VLSU[64]                            VLOXSEG8EI32_V             vloxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG8EI32_V             vloxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      147   128.00  *                    147   Andes45VLSU[128]                           VLOXSEG8EI32_V             vloxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG8EI64_V             vloxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG8EI64_V             vloxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     257.00         *             1     Andes45VLSU[257]                           VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG2EI64_V             vsuxseg2ei64.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSUXSEG2EI64_V             vsuxseg2ei64.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG3EI64_V             vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG2EI64_V             vsuxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSUXSEG3EI64_V             vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSUXSEG2EI64_V             vsuxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     24.00          *             1     Andes45VLSU[24]                            VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     192.00         *             1     Andes45VLSU[192]                           VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      1     385.00         *             1     Andes45VLSU[385]                           VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      1     24.00          *             1     Andes45VLSU[24]                            VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      1     193.00         *             1     Andes45VLSU[193]                           VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      1     24.00          *             1     Andes45VLSU[24]                            VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      1     97.00          *             1     Andes45VLSU[97]                            VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      1     24.00          *             1     Andes45VLSU[24]                            VSUXSEG3EI64_V             vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  1      1     49.00          *             1     Andes45VLSU[49]                            VSUXSEG3EI64_V             vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     513.00         *             1     Andes45VLSU[513]                           VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     257.00         *             1     Andes45VLSU[257]                           VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG4EI64_V             vsuxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG4EI64_V             vsuxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSUXSEG4EI64_V             vsuxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSUXSEG4EI64_V             vsuxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     40.00          *             1     Andes45VLSU[40]                            VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     80.00          *             1     Andes45VLSU[80]                            VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     160.00         *             1     Andes45VLSU[160]                           VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     320.00         *             1     Andes45VLSU[320]                           VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     40.00          *             1     Andes45VLSU[40]                            VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     80.00          *             1     Andes45VLSU[80]                            VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     160.00         *             1     Andes45VLSU[160]                           VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG5EI32_V             vsuxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     40.00          *             1     Andes45VLSU[40]                            VSUXSEG5EI32_V             vsuxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG5EI32_V             vsuxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     80.00          *             1     Andes45VLSU[80]                            VSUXSEG5EI32_V             vsuxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG5EI64_V             vsuxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     40.00          *             1     Andes45VLSU[40]                            VSUXSEG5EI64_V             vsuxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     192.00         *             1     Andes45VLSU[192]                           VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     384.00         *             1     Andes45VLSU[384]                           VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     192.00         *             1     Andes45VLSU[192]                           VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG6EI32_V             vsuxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSUXSEG6EI32_V             vsuxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG6EI32_V             vsuxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSUXSEG6EI32_V             vsuxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG6EI64_V             vsuxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSUXSEG6EI64_V             vsuxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     56.00          *             1     Andes45VLSU[56]                            VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     112.00         *             1     Andes45VLSU[112]                           VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     224.00         *             1     Andes45VLSU[224]                           VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     448.00         *             1     Andes45VLSU[448]                           VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     56.00          *             1     Andes45VLSU[56]                            VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     112.00         *             1     Andes45VLSU[112]                           VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     224.00         *             1     Andes45VLSU[224]                           VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG7EI32_V             vsuxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     56.00          *             1     Andes45VLSU[56]                            VSUXSEG7EI32_V             vsuxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG7EI32_V             vsuxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     112.00         *             1     Andes45VLSU[112]                           VSUXSEG7EI32_V             vsuxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG7EI64_V             vsuxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     56.00          *             1     Andes45VLSU[56]                            VSUXSEG7EI64_V             vsuxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG8EI32_V             vsuxseg8ei32.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG8EI32_V             vsuxseg8ei32.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG8EI64_V             vsuxseg8ei64.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG8EI32_V             vsuxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSUXSEG8EI32_V             vsuxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG8EI64_V             vsuxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     257.00         *             1     Andes45VLSU[257]                           VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     515.00         *             1     Andes45VLSU[515]                           VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     131.00         *             1     Andes45VLSU[131]                           VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     67.00          *             1     Andes45VLSU[67]                            VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     131.00         *             1     Andes45VLSU[131]                           VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     35.00          *             1     Andes45VLSU[35]                            VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     67.00          *             1     Andes45VLSU[67]                            VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     24.00          *             1     Andes45VLSU[24]                            VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     192.00         *             1     Andes45VLSU[192]                           VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     385.00         *             1     Andes45VLSU[385]                           VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     24.00          *             1     Andes45VLSU[24]                            VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     193.00         *             1     Andes45VLSU[193]                           VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     24.00          *             1     Andes45VLSU[24]                            VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     97.00          *             1     Andes45VLSU[97]                            VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG3EI64_V             vsoxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     24.00          *             1     Andes45VLSU[24]                            VSOXSEG3EI64_V             vsoxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSOXSEG3EI64_V             vsoxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     49.00          *             1     Andes45VLSU[49]                            VSOXSEG3EI64_V             vsoxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     513.00         *             1     Andes45VLSU[513]                           VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     257.00         *             1     Andes45VLSU[257]                           VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG4EI64_V             vsoxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG4EI64_V             vsoxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSOXSEG4EI64_V             vsoxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSOXSEG4EI64_V             vsoxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     40.00          *             1     Andes45VLSU[40]                            VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     80.00          *             1     Andes45VLSU[80]                            VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     160.00         *             1     Andes45VLSU[160]                           VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     320.00         *             1     Andes45VLSU[320]                           VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     40.00          *             1     Andes45VLSU[40]                            VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     80.00          *             1     Andes45VLSU[80]                            VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     160.00         *             1     Andes45VLSU[160]                           VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG5EI32_V             vsoxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     40.00          *             1     Andes45VLSU[40]                            VSOXSEG5EI32_V             vsoxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG5EI32_V             vsoxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     80.00          *             1     Andes45VLSU[80]                            VSOXSEG5EI32_V             vsoxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG5EI64_V             vsoxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     40.00          *             1     Andes45VLSU[40]                            VSOXSEG5EI64_V             vsoxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     192.00         *             1     Andes45VLSU[192]                           VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     384.00         *             1     Andes45VLSU[384]                           VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     192.00         *             1     Andes45VLSU[192]                           VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG6EI32_V             vsoxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSOXSEG6EI32_V             vsoxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG6EI32_V             vsoxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     96.00          *             1     Andes45VLSU[96]                            VSOXSEG6EI32_V             vsoxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG6EI64_V             vsoxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     48.00          *             1     Andes45VLSU[48]                            VSOXSEG6EI64_V             vsoxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     56.00          *             1     Andes45VLSU[56]                            VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     112.00         *             1     Andes45VLSU[112]                           VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     224.00         *             1     Andes45VLSU[224]                           VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     448.00         *             1     Andes45VLSU[448]                           VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     56.00          *             1     Andes45VLSU[56]                            VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     112.00         *             1     Andes45VLSU[112]                           VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     224.00         *             1     Andes45VLSU[224]                           VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG7EI32_V             vsoxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     56.00          *             1     Andes45VLSU[56]                            VSOXSEG7EI32_V             vsoxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG7EI32_V             vsoxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     112.00         *             1     Andes45VLSU[112]                           VSOXSEG7EI32_V             vsoxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG7EI64_V             vsoxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     56.00          *             1     Andes45VLSU[56]                            VSOXSEG7EI64_V             vsoxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     512.00         *             1     Andes45VLSU[512]                           VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG8EI32_V             vsoxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG8EI32_V             vsoxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG8EI32_V             vsoxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSOXSEG8EI32_V             vsoxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG8EI64_V             vsoxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG8EI64_V             vsoxseg8ei64.v	v8, (a0), v16
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0.0] - Andes45ALU
@@ -3196,7 +3196,7 @@ vsoxseg8ei64.v  v8, (a0), v16
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -     770.00  -      -      -      -      -      -      -      -      -      -     16558.00  -    -      -
+# CHECK-NEXT:  -      -     770.00  -      -      -      -      -      -      -      -      -      -     62886.00  -    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
@@ -3373,521 +3373,521 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e8.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e8.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e8.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e8.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e8.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e16.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e16.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e16.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e16.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e32.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e32.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e32.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e64.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e64.v	v8, (a0)
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg2e64.v	v8, (a0)
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vsseg3e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg3e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg3e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg4e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg4e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg4e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg5e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vsseg5e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg5e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vsseg5e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg5e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vsseg5e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg5e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vsseg5e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg5e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vsseg5e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg5e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vsseg5e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg6e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg6e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg6e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg6e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg6e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg6e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg6e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg6e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg6e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg6e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg6e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vsseg6e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vsseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg7e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vsseg7e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg7e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vsseg7e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg7e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vsseg7e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg7e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vsseg7e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg7e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vsseg7e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg7e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vsseg7e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg8e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg8e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg8e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg8e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg8e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg8e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg8e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg8e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg8e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg8e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg8e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsseg8e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlsseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg2e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg2e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg2e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg2e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg2e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg2e64.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg2e64.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg2e64.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg3e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg3e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg3e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg3e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg3e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg3e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg3e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg3e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg3e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg3e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg3e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg3e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg3e64.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg3e64.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg4e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg4e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg4e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg4e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg4e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg4e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg4e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg4e64.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg4e64.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg5e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg5e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg5e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg5e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg5e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg5e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg5e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg5e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg5e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg5e64.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg6e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg6e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg6e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg6e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg6e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg6e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg6e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg6e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg6e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg6e64.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg7e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg7e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg7e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg7e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg7e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg7e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg7e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg7e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg7e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg7e64.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg8e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg8e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg8e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg8e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg8e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg8e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg8e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg8e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg8e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg8e64.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg2e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     384.00  -      -      -     vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     160.00  -      -      -     vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     320.00  -      -      -     vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     160.00  -      -      -     vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vlsseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     384.00  -      -      -     vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vlsseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     224.00  -      -      -     vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     448.00  -      -      -     vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     224.00  -      -      -     vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vlsseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     384.00  -      -      -     vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vssseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vssseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg4e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg4e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg4e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg4e16.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg4e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg4e32.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     160.00  -      -      -     vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     320.00  -      -      -     vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     160.00  -      -      -     vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vssseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vssseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vssseg5e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     384.00  -      -      -     vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vssseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vssseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vssseg6e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     224.00  -      -      -     vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     448.00  -      -      -     vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     224.00  -      -      -     vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vssseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vssseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vssseg7e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg8e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg8e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg8e8.v	v8, (a0), a1
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg8e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
@@ -4061,682 +4061,682 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     257.00  -      -      -     vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     515.00  -      -      -     vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg2ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg2ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vluxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vluxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg2ei64.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vluxseg2ei64.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     35.00   -      -      -     vluxseg2ei64.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vluxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     385.00  -      -      -     vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     193.00  -      -      -     vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     97.00   -      -      -     vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     49.00   -      -      -     vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg4ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     513.00  -      -      -     vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg4ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg4ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     257.00  -      -      -     vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vluxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vluxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     160.00  -      -      -     vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     320.00  -      -      -     vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     160.00  -      -      -     vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vluxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vluxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vluxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     384.00  -      -      -     vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vluxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vluxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vluxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     224.00  -      -      -     vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     448.00  -      -      -     vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     224.00  -      -      -     vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vluxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vluxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vluxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg8ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg8ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg8ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg8ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg8ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg8ei64.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vluxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     257.00  -      -      -     vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     515.00  -      -      -     vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg2ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg2ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vloxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vloxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg2ei64.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vloxseg2ei64.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     35.00   -      -      -     vloxseg2ei64.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vloxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     385.00  -      -      -     vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     193.00  -      -      -     vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     97.00   -      -      -     vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     49.00   -      -      -     vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg4ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     513.00  -      -      -     vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg4ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg4ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     257.00  -      -      -     vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vloxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vloxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     160.00  -      -      -     vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     320.00  -      -      -     vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     160.00  -      -      -     vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vloxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vloxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vloxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     384.00  -      -      -     vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vloxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vloxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vloxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     224.00  -      -      -     vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     448.00  -      -      -     vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     224.00  -      -      -     vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vloxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vloxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vloxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg8ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg8ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg8ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg8ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg8ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg8ei64.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vloxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     257.00  -      -      -     vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg2ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg2ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsuxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg2ei64.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsuxseg2ei64.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxseg3ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsuxseg3ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsuxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     385.00  -      -      -     vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     193.00  -      -      -     vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     97.00   -      -      -     vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     49.00   -      -      -     vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg4ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     513.00  -      -      -     vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg4ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg4ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     257.00  -      -      -     vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsuxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsuxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     160.00  -      -      -     vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     320.00  -      -      -     vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     160.00  -      -      -     vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vsuxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vsuxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vsuxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     384.00  -      -      -     vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsuxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vsuxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsuxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     224.00  -      -      -     vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     448.00  -      -      -     vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     224.00  -      -      -     vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vsuxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vsuxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vsuxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg8ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg8ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg8ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg8ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg8ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg8ei64.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsuxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg2ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     257.00  -      -      -     vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     515.00  -      -      -     vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg2ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg2ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg2ei32.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     35.00   -      -      -     vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     385.00  -      -      -     vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     193.00  -      -      -     vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     97.00   -      -      -     vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     24.00   -      -      -     vsoxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsoxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     49.00   -      -      -     vsoxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg4ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg4ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg4ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     513.00  -      -      -     vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg4ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg4ei16.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     257.00  -      -      -     vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsoxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsoxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     160.00  -      -      -     vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     320.00  -      -      -     vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     160.00  -      -      -     vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vsoxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     80.00   -      -      -     vsoxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     40.00   -      -      -     vsoxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     384.00  -      -      -     vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     192.00  -      -      -     vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsoxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     96.00   -      -      -     vsoxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     48.00   -      -      -     vsoxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     224.00  -      -      -     vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     448.00  -      -      -     vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     224.00  -      -      -     vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vsoxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     112.00  -      -      -     vsoxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     56.00   -      -      -     vsoxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg8ei8.v	v8, (a0), v16
-# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     512.00  -      -      -     vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vsoxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg8ei64.v	v8, (a0), v16

--- a/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vlseg-vsseg.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vlseg-vsseg.s
@@ -1635,177 +1635,177 @@ vsoxseg8ei64.v  v8, (a0), v16
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG2E8_V                 vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E16_V                vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E16_V                vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E16_V                vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E16_V                vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E16_V                vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E16_V                vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E16_V                vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG2E16_V                vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E16_V                vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG2E16_V                vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E32_V                vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E32_V                vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E32_V                vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E32_V                vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E32_V                vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG2E32_V                vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E32_V                vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG2E32_V                vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E64_V                vlseg2e64.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E64_V                vlseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E64_V                vlseg2e64.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG2E64_V                vlseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E64_V                vlseg2e64.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG2E64_V                vlseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG3E8_V                 vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E16_V                vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E16_V                vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E16_V                vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E16_V                vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E16_V                vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E16_V                vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E16_V                vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG3E16_V                vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E32_V                vlseg3e32.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E32_V                vlseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E32_V                vlseg3e32.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E32_V                vlseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E32_V                vlseg3e32.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG3E32_V                vlseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E64_V                vlseg3e64.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E64_V                vlseg3e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E64_V                vlseg3e64.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG3E64_V                vlseg3e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG4E8_V                 vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E16_V                vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E16_V                vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E16_V                vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E16_V                vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E16_V                vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E16_V                vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E16_V                vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG4E16_V                vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E32_V                vlseg4e32.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E32_V                vlseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E32_V                vlseg4e32.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E32_V                vlseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E32_V                vlseg4e32.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG4E32_V                vlseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E64_V                vlseg4e64.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E64_V                vlseg4e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E64_V                vlseg4e64.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG4E64_V                vlseg4e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E8_V                 vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E16_V                vlseg5e16.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E16_V                vlseg5e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E16_V                vlseg5e16.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E16_V                vlseg5e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E16_V                vlseg5e16.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E16_V                vlseg5e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E32_V                vlseg5e32.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E32_V                vlseg5e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E32_V                vlseg5e32.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E32_V                vlseg5e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E64_V                vlseg5e64.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E64_V                vlseg5e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E8_V                 vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E16_V                vlseg6e16.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E16_V                vlseg6e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E16_V                vlseg6e16.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E16_V                vlseg6e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E16_V                vlseg6e16.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E16_V                vlseg6e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E32_V                vlseg6e32.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E32_V                vlseg6e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E32_V                vlseg6e32.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E32_V                vlseg6e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E64_V                vlseg6e64.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E64_V                vlseg6e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E8_V                 vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E16_V                vlseg7e16.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E16_V                vlseg7e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E16_V                vlseg7e16.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E16_V                vlseg7e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E16_V                vlseg7e16.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E16_V                vlseg7e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E32_V                vlseg7e32.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E32_V                vlseg7e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E32_V                vlseg7e32.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E32_V                vlseg7e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E64_V                vlseg7e64.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E64_V                vlseg7e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E8_V                 vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E16_V                vlseg8e16.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E16_V                vlseg8e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E16_V                vlseg8e16.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E16_V                vlseg8e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E16_V                vlseg8e16.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E16_V                vlseg8e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E32_V                vlseg8e32.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E32_V                vlseg8e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E32_V                vlseg8e32.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E32_V                vlseg8e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E64_V                vlseg8e64.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E64_V                vlseg8e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
@@ -1815,9 +1815,9 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG2E8_V                 vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E16_V                vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
@@ -1825,23 +1825,23 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E16_V                vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E16_V                vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E16_V                vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E16_V                vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG2E16_V                vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E32_V                vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E32_V                vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E32_V                vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E32_V                vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E32_V                vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG2E32_V                vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E64_V                vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E64_V                vsseg2e64.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG2E64_V                vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG2E64_V                vsseg2e64.v	v8, (a0)
+# CHECK-NEXT:  1      1     4.00           *             1     Andes45VLSU[4]                             VSSEG2E64_V                vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
@@ -1851,7 +1851,7 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG3E8_V                 vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E16_V                vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
@@ -1859,17 +1859,17 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E16_V                vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E16_V                vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG3E16_V                vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E32_V                vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E32_V                vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E32_V                vsseg3e32.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG3E32_V                vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E64_V                vsseg3e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG3E64_V                vsseg3e64.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG3E64_V                vsseg3e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
@@ -1879,7 +1879,7 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG4E8_V                 vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E16_V                vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
@@ -1887,17 +1887,17 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E16_V                vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E16_V                vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG4E16_V                vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E32_V                vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E32_V                vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E32_V                vsseg4e32.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG4E32_V                vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E64_V                vsseg4e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG4E64_V                vsseg4e64.v	v8, (a0)
+# CHECK-NEXT:  1      1     2.00           *             1     Andes45VLSU[2]                             VSSEG4E64_V                vsseg4e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG5E8_V                 vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
@@ -1979,1201 +1979,1201 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSEG8E64_V                vsseg8e64.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    128.00  *                    82    Andes45VLSU[128]                           VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    256.00  *                    82    Andes45VLSU[256]                           VLSSEG2E8_V                vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    64.00   *                    50    Andes45VLSU[64]                            VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    128.00  *                    50    Andes45VLSU[128]                           VLSSEG2E16_V               vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    32.00   *                    34    Andes45VLSU[32]                            VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    64.00   *                    34    Andes45VLSU[64]                            VLSSEG2E32_V               vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      26    16.00   *                    26    Andes45VLSU[16]                            VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      26    32.00   *                    26    Andes45VLSU[32]                            VLSSEG2E64_V               vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    128.00  *                    82    Andes45VLSU[128]                           VLSSEG3E8_V                vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    64.00   *                    50    Andes45VLSU[64]                            VLSSEG3E16_V               vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    32.00   *                    34    Andes45VLSU[32]                            VLSSEG3E32_V               vlsseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E64_V               vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG3E64_V               vlsseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG3E64_V               vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      26    16.00   *                    26    Andes45VLSU[16]                            VLSSEG3E64_V               vlsseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    128.00  *                    82    Andes45VLSU[128]                           VLSSEG4E8_V                vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    64.00   *                    50    Andes45VLSU[64]                            VLSSEG4E16_V               vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    32.00   *                    34    Andes45VLSU[32]                            VLSSEG4E32_V               vlsseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E64_V               vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG4E64_V               vlsseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG4E64_V               vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      26    16.00   *                    26    Andes45VLSU[16]                            VLSSEG4E64_V               vlsseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG5E8_V                vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG5E16_V               vlsseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG5E32_V               vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG5E32_V               vlsseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG5E32_V               vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG5E32_V               vlsseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG5E64_V               vlsseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG5E64_V               vlsseg5e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG6E8_V                vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG6E16_V               vlsseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG6E32_V               vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG6E32_V               vlsseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG6E32_V               vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG6E32_V               vlsseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG6E64_V               vlsseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG6E64_V               vlsseg6e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG7E8_V                vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG7E16_V               vlsseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG7E32_V               vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG7E32_V               vlsseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG7E32_V               vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG7E32_V               vlsseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG7E64_V               vlsseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG7E64_V               vlsseg7e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLSSEG8E8_V                vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLSSEG8E16_V               vlsseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG8E32_V               vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLSSEG8E32_V               vlsseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG8E32_V               vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLSSEG8E32_V               vlsseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSSEG8E64_V               vlsseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLSSEG8E64_V               vlsseg8e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     256.00         *             1     Andes45VLSU[256]                           VSSSEG2E8_V                vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG2E16_V               vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG2E32_V               vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG2E64_V               vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG3E8_V                vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG3E16_V               vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG3E32_V               vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E64_V               vssseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG3E64_V               vssseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG3E64_V               vssseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG3E64_V               vssseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     128.00         *             1     Andes45VLSU[128]                           VSSSEG4E8_V                vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG4E16_V               vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG4E32_V               vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E64_V               vssseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG4E64_V               vssseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG4E64_V               vssseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG4E64_V               vssseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG5E8_V                vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG5E16_V               vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG5E32_V               vssseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG5E32_V               vssseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG5E32_V               vssseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG5E32_V               vssseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG5E64_V               vssseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG5E64_V               vssseg5e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG6E8_V                vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG6E16_V               vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG6E32_V               vssseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG6E32_V               vssseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG6E32_V               vssseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG6E32_V               vssseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG6E64_V               vssseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG6E64_V               vssseg6e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG7E8_V                vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG7E16_V               vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG7E32_V               vssseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG7E32_V               vssseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG7E32_V               vssseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG7E32_V               vssseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG7E64_V               vssseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG7E64_V               vssseg7e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSSSEG8E8_V                vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSSSEG8E16_V               vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG8E32_V               vssseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG8E32_V               vssseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG8E32_V               vssseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSSSEG8E32_V               vssseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSSSEG8E64_V               vssseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSSSEG8E64_V               vssseg8e64.v	v8, (a0), a1
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG2E8FF_V               vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG2E16FF_V              vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG2E32FF_V              vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E64FF_V              vlseg2e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      21    2.00    *                    21    Andes45VLSU[2]                             VLSEG2E64FF_V              vlseg2e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E64FF_V              vlseg2e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG2E64FF_V              vlseg2e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG2E64FF_V              vlseg2e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG2E64FF_V              vlseg2e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG3E8FF_V               vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG3E16FF_V              vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E32FF_V              vlseg3e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E32FF_V              vlseg3e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E32FF_V              vlseg3e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E32FF_V              vlseg3e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E32FF_V              vlseg3e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG3E32FF_V              vlseg3e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E64FF_V              vlseg3e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      22    3.00    *                    22    Andes45VLSU[3]                             VLSEG3E64FF_V              vlseg3e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG3E64FF_V              vlseg3e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG3E64FF_V              vlseg3e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG4E8FF_V               vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG4E16FF_V              vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E32FF_V              vlseg4e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E32FF_V              vlseg4e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E32FF_V              vlseg4e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E32FF_V              vlseg4e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E32FF_V              vlseg4e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG4E32FF_V              vlseg4e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E64FF_V              vlseg4e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      23    4.00    *                    23    Andes45VLSU[4]                             VLSEG4E64FF_V              vlseg4e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG4E64FF_V              vlseg4e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG4E64FF_V              vlseg4e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E8FF_V               vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E16FF_V              vlseg5e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E16FF_V              vlseg5e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E16FF_V              vlseg5e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E16FF_V              vlseg5e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E16FF_V              vlseg5e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E16FF_V              vlseg5e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E32FF_V              vlseg5e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E32FF_V              vlseg5e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E32FF_V              vlseg5e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E32FF_V              vlseg5e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG5E64FF_V              vlseg5e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      24    5.00    *                    24    Andes45VLSU[5]                             VLSEG5E64FF_V              vlseg5e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E8FF_V               vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E16FF_V              vlseg6e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E16FF_V              vlseg6e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E16FF_V              vlseg6e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E16FF_V              vlseg6e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E16FF_V              vlseg6e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E16FF_V              vlseg6e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E32FF_V              vlseg6e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E32FF_V              vlseg6e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E32FF_V              vlseg6e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E32FF_V              vlseg6e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG6E64FF_V              vlseg6e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      25    6.00    *                    25    Andes45VLSU[6]                             VLSEG6E64FF_V              vlseg6e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E8FF_V               vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E16FF_V              vlseg7e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E16FF_V              vlseg7e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E16FF_V              vlseg7e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E16FF_V              vlseg7e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E16FF_V              vlseg7e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E16FF_V              vlseg7e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E32FF_V              vlseg7e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E32FF_V              vlseg7e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E32FF_V              vlseg7e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E32FF_V              vlseg7e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG7E64FF_V              vlseg7e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      26    7.00    *                    26    Andes45VLSU[7]                             VLSEG7E64FF_V              vlseg7e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E8FF_V               vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E16FF_V              vlseg8e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E16FF_V              vlseg8e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E16FF_V              vlseg8e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E16FF_V              vlseg8e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E16FF_V              vlseg8e16ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E16FF_V              vlseg8e16ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E32FF_V              vlseg8e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E32FF_V              vlseg8e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E32FF_V              vlseg8e32ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E32FF_V              vlseg8e32ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLSEG8E64FF_V              vlseg8e64ff.v	v8, (a0)
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLSEG8E64FF_V              vlseg8e64ff.v	v8, (a0)
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    259.00  *                    83    Andes45VLSU[259]                           VLUXSEG2EI8_V              vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    131.00  *                    51    Andes45VLSU[131]                           VLUXSEG2EI16_V             vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    67.00   *                    35    Andes45VLSU[67]                            VLUXSEG2EI32_V             vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    17.00   *                    27    Andes45VLSU[17]                            VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    35.00   *                    27    Andes45VLSU[35]                            VLUXSEG2EI64_V             vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLUXSEG3EI8_V              vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLUXSEG3EI16_V             vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLUXSEG3EI32_V             vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI64_V             vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG3EI64_V             vluxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG3EI64_V             vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    17.00   *                    27    Andes45VLSU[17]                            VLUXSEG3EI64_V             vluxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLUXSEG4EI8_V              vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLUXSEG4EI16_V             vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLUXSEG4EI32_V             vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI64_V             vluxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG4EI64_V             vluxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG4EI64_V             vluxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    17.00   *                    27    Andes45VLSU[17]                            VLUXSEG4EI64_V             vluxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG5EI8_V              vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG5EI16_V             vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG5EI32_V             vluxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG5EI32_V             vluxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG5EI32_V             vluxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG5EI32_V             vluxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG5EI64_V             vluxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG5EI64_V             vluxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG6EI8_V              vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG6EI16_V             vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG6EI32_V             vluxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG6EI32_V             vluxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG6EI32_V             vluxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG6EI32_V             vluxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG6EI64_V             vluxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG6EI64_V             vluxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG7EI8_V              vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG7EI16_V             vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG7EI32_V             vluxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG7EI32_V             vluxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG7EI32_V             vluxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG7EI32_V             vluxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG7EI64_V             vluxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG7EI64_V             vluxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLUXSEG8EI8_V              vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLUXSEG8EI16_V             vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG8EI32_V             vluxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLUXSEG8EI32_V             vluxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG8EI32_V             vluxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLUXSEG8EI32_V             vluxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXSEG8EI64_V             vluxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLUXSEG8EI64_V             vluxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    259.00  *                    83    Andes45VLSU[259]                           VLOXSEG2EI8_V              vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    131.00  *                    51    Andes45VLSU[131]                           VLOXSEG2EI16_V             vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    67.00   *                    35    Andes45VLSU[67]                            VLOXSEG2EI32_V             vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    17.00   *                    27    Andes45VLSU[17]                            VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    35.00   *                    27    Andes45VLSU[35]                            VLOXSEG2EI64_V             vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLOXSEG3EI8_V              vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLOXSEG3EI16_V             vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLOXSEG3EI32_V             vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI64_V             vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG3EI64_V             vloxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG3EI64_V             vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    17.00   *                    27    Andes45VLSU[17]                            VLOXSEG3EI64_V             vloxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    129.00  *                    83    Andes45VLSU[129]                           VLOXSEG4EI8_V              vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    65.00   *                    51    Andes45VLSU[65]                            VLOXSEG4EI16_V             vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    33.00   *                    35    Andes45VLSU[33]                            VLOXSEG4EI32_V             vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI64_V             vloxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG4EI64_V             vloxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG4EI64_V             vloxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    17.00   *                    27    Andes45VLSU[17]                            VLOXSEG4EI64_V             vloxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG5EI8_V              vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG5EI16_V             vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG5EI32_V             vloxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG5EI32_V             vloxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG5EI32_V             vloxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG5EI32_V             vloxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG5EI64_V             vloxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG5EI64_V             vloxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG6EI8_V              vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG6EI16_V             vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG6EI32_V             vloxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG6EI32_V             vloxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG6EI32_V             vloxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG6EI32_V             vloxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG6EI64_V             vloxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG6EI64_V             vloxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG7EI8_V              vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG7EI16_V             vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG7EI32_V             vloxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG7EI32_V             vloxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG7EI32_V             vloxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG7EI32_V             vloxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG7EI64_V             vloxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG7EI64_V             vloxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    8.00    *                    83    Andes45VLSU[8]                             VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    16.00   *                    83    Andes45VLSU[16]                            VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    32.00   *                    83    Andes45VLSU[32]                            VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      83    64.00   *                    83    Andes45VLSU[64]                            VLOXSEG8EI8_V              vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    8.00    *                    51    Andes45VLSU[8]                             VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    16.00   *                    51    Andes45VLSU[16]                            VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      51    32.00   *                    51    Andes45VLSU[32]                            VLOXSEG8EI16_V             vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG8EI32_V             vloxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    8.00    *                    35    Andes45VLSU[8]                             VLOXSEG8EI32_V             vloxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG8EI32_V             vloxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      35    16.00   *                    35    Andes45VLSU[16]                            VLOXSEG8EI32_V             vloxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXSEG8EI64_V             vloxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      27    8.00    *                    27    Andes45VLSU[8]                             VLOXSEG8EI64_V             vloxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXSEG2EI8_V              vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSUXSEG2EI16_V             vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSUXSEG2EI32_V             vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI64_V             vsuxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG2EI64_V             vsuxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG2EI64_V             vsuxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSUXSEG2EI64_V             vsuxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXSEG3EI8_V              vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSUXSEG3EI16_V             vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSUXSEG3EI32_V             vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI64_V             vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG3EI64_V             vsuxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG3EI64_V             vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSUXSEG3EI64_V             vsuxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXSEG4EI8_V              vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSUXSEG4EI16_V             vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSUXSEG4EI32_V             vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI64_V             vsuxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG4EI64_V             vsuxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG4EI64_V             vsuxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSUXSEG4EI64_V             vsuxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG5EI8_V              vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG5EI16_V             vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG5EI32_V             vsuxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG5EI32_V             vsuxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG5EI32_V             vsuxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG5EI32_V             vsuxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG5EI64_V             vsuxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG5EI64_V             vsuxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG6EI8_V              vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG6EI16_V             vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG6EI32_V             vsuxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG6EI32_V             vsuxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG6EI32_V             vsuxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG6EI32_V             vsuxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG6EI64_V             vsuxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG6EI64_V             vsuxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG7EI8_V              vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG7EI16_V             vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG7EI32_V             vsuxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG7EI32_V             vsuxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG7EI32_V             vsuxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG7EI32_V             vsuxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG7EI64_V             vsuxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG7EI64_V             vsuxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXSEG8EI8_V              vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXSEG8EI16_V             vsuxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG8EI32_V             vsuxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG8EI32_V             vsuxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG8EI32_V             vsuxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXSEG8EI32_V             vsuxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXSEG8EI64_V             vsuxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXSEG8EI64_V             vsuxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSOXSEG2EI8_V              vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     131.00         *             1     Andes45VLSU[131]                           VSOXSEG2EI16_V             vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     67.00          *             1     Andes45VLSU[67]                            VSOXSEG2EI32_V             vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     35.00          *             1     Andes45VLSU[35]                            VSOXSEG2EI64_V             vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXSEG3EI8_V              vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSOXSEG3EI16_V             vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSOXSEG3EI32_V             vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI64_V             vsoxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG3EI64_V             vsoxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG3EI64_V             vsoxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSOXSEG3EI64_V             vsoxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXSEG4EI8_V              vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSOXSEG4EI16_V             vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSOXSEG4EI32_V             vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI64_V             vsoxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG4EI64_V             vsoxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG4EI64_V             vsoxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSOXSEG4EI64_V             vsoxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG5EI8_V              vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG5EI16_V             vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG5EI32_V             vsoxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG5EI32_V             vsoxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG5EI32_V             vsoxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG5EI32_V             vsoxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG5EI64_V             vsoxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG5EI64_V             vsoxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG6EI8_V              vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG6EI16_V             vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG6EI32_V             vsoxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG6EI32_V             vsoxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG6EI32_V             vsoxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG6EI32_V             vsoxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG6EI64_V             vsoxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG6EI64_V             vsoxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG7EI8_V              vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG7EI16_V             vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG7EI32_V             vsoxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG7EI32_V             vsoxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG7EI32_V             vsoxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG7EI32_V             vsoxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG7EI64_V             vsoxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG7EI64_V             vsoxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXSEG8EI8_V              vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXSEG8EI16_V             vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG8EI32_V             vsoxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG8EI32_V             vsoxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG8EI32_V             vsoxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXSEG8EI32_V             vsoxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXSEG8EI64_V             vsoxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXSEG8EI64_V             vsoxseg8ei64.v	v8, (a0), v16
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0.0] - Andes45ALU
@@ -3196,182 +3196,182 @@ vsoxseg8ei64.v  v8, (a0), v16
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -     770.00  -      -      -      -      -      -      -      -      -      -     770.00  -      -      -
+# CHECK-NEXT:  -      -     770.00  -      -      -      -      -      -      -      -      -      -     16558.00  -    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg3e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg4e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
@@ -3381,9 +3381,9 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg2e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
@@ -3391,23 +3391,23 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg2e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg2e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg2e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vsseg2e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
@@ -3417,7 +3417,7 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg3e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
@@ -3425,17 +3425,17 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg3e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg3e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg3e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg3e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
@@ -3445,7 +3445,7 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e8.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg4e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
@@ -3453,17 +3453,17 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e16.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg4e16.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e32.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg4e32.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg4e64.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vsseg4e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg5e8.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
@@ -3545,1198 +3545,1198 @@ vsoxseg8ei64.v  v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsseg8e64.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vlsseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vlsseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg5e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg6e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg7e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vlsseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vlsseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vlsseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlsseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlsseg8e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     256.00  -      -      -     vssseg2e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg2e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg2e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg2e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg2e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg3e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg3e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg3e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg3e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg3e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     128.00  -      -      -     vssseg4e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg4e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg4e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg4e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg4e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg5e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg5e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg5e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg5e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg5e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg5e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg5e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg5e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg6e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg6e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg6e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg6e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg6e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg6e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg6e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg6e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg7e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg7e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg7e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg7e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg7e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg7e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg7e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg7e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg8e8.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vssseg8e8.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg8e16.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vssseg8e16.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg8e32.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vssseg8e32.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vssseg8e64.v	v8, (a0), a1
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vssseg8e64.v	v8, (a0), a1
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg2e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg2e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg2e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     2.00    -      -      -     vlseg2e64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg2e64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg2e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg2e64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg3e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg3e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg3e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     3.00    -      -      -     vlseg3e64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg3e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg3e64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg4e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg4e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg4e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     4.00    -      -      -     vlseg4e64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg4e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg4e64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg5e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     5.00    -      -      -     vlseg5e64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg6e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     6.00    -      -      -     vlseg6e64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg7e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     7.00    -      -      -     vlseg7e64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e8ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e8ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e16ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e16ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e32ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e32ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vlseg8e64ff.v	v8, (a0)
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vlseg8e64ff.v	v8, (a0)
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vluxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vluxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vluxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     35.00   -      -      -     vluxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vluxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vluxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vluxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vluxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vluxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vluxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vloxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vloxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vloxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     35.00   -      -      -     vloxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vloxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vloxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vloxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vloxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vloxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vloxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsuxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsuxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsuxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsuxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsuxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsuxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsuxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsuxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsuxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxseg8ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsoxseg2ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vsoxseg2ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vsoxseg2ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg2ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     35.00   -      -      -     vsoxseg2ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxseg3ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsoxseg3ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsoxseg3ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg3ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsoxseg3ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxseg4ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsoxseg4ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsoxseg4ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg4ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsoxseg4ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg5ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg5ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg5ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg5ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg5ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg5ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg5ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg5ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg6ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg6ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg6ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg6ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg6ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg6ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg6ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg6ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg7ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg7ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg7ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg7ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg7ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg7ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg7ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg7ei64.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg8ei8.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxseg8ei8.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg8ei16.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxseg8ei16.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg8ei32.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxseg8ei32.v	v8, (a0), v16
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxseg8ei64.v	v8, (a0), v16
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxseg8ei64.v	v8, (a0), v16

--- a/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vlxe-vsxe.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vlxe-vsxe.s
@@ -224,181 +224,181 @@ vsoxei64.v   v8, (a0), v0
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    129.00  *                    82    Andes45VLSU[129]                           VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    259.00  *                    82    Andes45VLSU[259]                           VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI8_V                  vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    519.00  *                    82    Andes45VLSU[519]                           VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    64.00   *                    50    Andes45VLSU[64]                            VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    129.00  *                    50    Andes45VLSU[129]                           VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    259.00  *                    50    Andes45VLSU[259]                           VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    519.00  *                    50    Andes45VLSU[519]                           VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    32.00   *                    34    Andes45VLSU[32]                            VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    64.00   *                    34    Andes45VLSU[64]                            VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    129.00  *                    34    Andes45VLSU[129]                           VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    259.00  *                    34    Andes45VLSU[259]                           VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    519.00  *                    34    Andes45VLSU[519]                           VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI64_V                 vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    64.00   *                    26    Andes45VLSU[64]                            VLUXEI64_V                 vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI64_V                 vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    129.00  *                    26    Andes45VLSU[129]                           VLUXEI64_V                 vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI64_V                 vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    259.00  *                    26    Andes45VLSU[259]                           VLUXEI64_V                 vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLUXEI64_V                 vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    519.00  *                    26    Andes45VLSU[519]                           VLUXEI64_V                 vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    16.00   *                    82    Andes45VLSU[16]                            VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    32.00   *                    82    Andes45VLSU[32]                            VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    64.00   *                    82    Andes45VLSU[64]                            VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    129.00  *                    82    Andes45VLSU[129]                           VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    259.00  *                    82    Andes45VLSU[259]                           VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI8_V                  vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      82    519.00  *                    82    Andes45VLSU[519]                           VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    64.00   *                    50    Andes45VLSU[64]                            VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    129.00  *                    50    Andes45VLSU[129]                           VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    259.00  *                    50    Andes45VLSU[259]                           VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    519.00  *                    50    Andes45VLSU[519]                           VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    32.00   *                    34    Andes45VLSU[32]                            VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    64.00   *                    34    Andes45VLSU[64]                            VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    129.00  *                    34    Andes45VLSU[129]                           VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    259.00  *                    34    Andes45VLSU[259]                           VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    519.00  *                    34    Andes45VLSU[519]                           VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI64_V                 vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    64.00   *                    26    Andes45VLSU[64]                            VLOXEI64_V                 vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI64_V                 vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    129.00  *                    26    Andes45VLSU[129]                           VLOXEI64_V                 vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI64_V                 vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    259.00  *                    26    Andes45VLSU[259]                           VLOXEI64_V                 vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00    *                    1     Andes45VLSU                                VLOXEI64_V                 vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    519.00  *                    26    Andes45VLSU[519]                           VLOXEI64_V                 vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     1.00           *             1     Andes45VLSU                                VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0.0] - Andes45ALU
@@ -421,183 +421,183 @@ vsoxei64.v   v8, (a0), v0
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -     88.00   -      -      -      -      -      -      -      -      -      -     88.00   -      -      -
+# CHECK-NEXT:  -      -     88.00   -      -      -      -      -      -      -      -      -      -     16080.00  -    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei8.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     1.00    -      -      -     vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsoxei64.v	v8, (a0), v0

--- a/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vlxe-vsxe.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Andes45/rvv-vlxe-vsxe.s
@@ -238,35 +238,35 @@ vsoxei64.v   v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  1      82    519.00  *                    82    Andes45VLSU[519]                           VLUXEI8_V                  vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      50    64.00   *                    50    Andes45VLSU[64]                            VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      50    129.00  *                    50    Andes45VLSU[129]                           VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    65.00   *                    50    Andes45VLSU[65]                            VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      50    259.00  *                    50    Andes45VLSU[259]                           VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    131.00  *                    50    Andes45VLSU[131]                           VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      50    519.00  *                    50    Andes45VLSU[519]                           VLUXEI16_V                 vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    263.00  *                    50    Andes45VLSU[263]                           VLUXEI16_V                 vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      34    32.00   *                    34    Andes45VLSU[32]                            VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      34    64.00   *                    34    Andes45VLSU[64]                            VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      34    129.00  *                    34    Andes45VLSU[129]                           VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    33.00   *                    34    Andes45VLSU[33]                            VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      34    259.00  *                    34    Andes45VLSU[259]                           VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    67.00   *                    34    Andes45VLSU[67]                            VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      34    519.00  *                    34    Andes45VLSU[519]                           VLUXEI32_V                 vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    135.00  *                    34    Andes45VLSU[135]                           VLUXEI32_V                 vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      26    64.00   *                    26    Andes45VLSU[64]                            VLUXEI64_V                 vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLUXEI64_V                 vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      26    129.00  *                    26    Andes45VLSU[129]                           VLUXEI64_V                 vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    17.00   *                    26    Andes45VLSU[17]                            VLUXEI64_V                 vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      26    259.00  *                    26    Andes45VLSU[259]                           VLUXEI64_V                 vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    35.00   *                    26    Andes45VLSU[35]                            VLUXEI64_V                 vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      26    519.00  *                    26    Andes45VLSU[519]                           VLUXEI64_V                 vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    71.00   *                    26    Andes45VLSU[71]                            VLUXEI64_V                 vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
 # CHECK-NEXT:  1      82    8.00    *                    82    Andes45VLSU[8]                             VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
@@ -282,35 +282,35 @@ vsoxei64.v   v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  1      82    519.00  *                    82    Andes45VLSU[519]                           VLOXEI8_V                  vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    8.00    *                    50    Andes45VLSU[8]                             VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    16.00   *                    50    Andes45VLSU[16]                            VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      50    64.00   *                    50    Andes45VLSU[64]                            VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    32.00   *                    50    Andes45VLSU[32]                            VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      50    129.00  *                    50    Andes45VLSU[129]                           VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    65.00   *                    50    Andes45VLSU[65]                            VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      50    259.00  *                    50    Andes45VLSU[259]                           VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    131.00  *                    50    Andes45VLSU[131]                           VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      50    519.00  *                    50    Andes45VLSU[519]                           VLOXEI16_V                 vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      50    263.00  *                    50    Andes45VLSU[263]                           VLOXEI16_V                 vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      34    32.00   *                    34    Andes45VLSU[32]                            VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    8.00    *                    34    Andes45VLSU[8]                             VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      34    64.00   *                    34    Andes45VLSU[64]                            VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    16.00   *                    34    Andes45VLSU[16]                            VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      34    129.00  *                    34    Andes45VLSU[129]                           VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    33.00   *                    34    Andes45VLSU[33]                            VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      34    259.00  *                    34    Andes45VLSU[259]                           VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    67.00   *                    34    Andes45VLSU[67]                            VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      34    519.00  *                    34    Andes45VLSU[519]                           VLOXEI32_V                 vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      34    135.00  *                    34    Andes45VLSU[135]                           VLOXEI32_V                 vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      26    64.00   *                    26    Andes45VLSU[64]                            VLOXEI64_V                 vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    8.00    *                    26    Andes45VLSU[8]                             VLOXEI64_V                 vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      26    129.00  *                    26    Andes45VLSU[129]                           VLOXEI64_V                 vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    17.00   *                    26    Andes45VLSU[17]                            VLOXEI64_V                 vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      26    259.00  *                    26    Andes45VLSU[259]                           VLOXEI64_V                 vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    35.00   *                    26    Andes45VLSU[35]                            VLOXEI64_V                 vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      26    519.00  *                    26    Andes45VLSU[519]                           VLOXEI64_V                 vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      26    71.00   *                    26    Andes45VLSU[71]                            VLOXEI64_V                 vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
 # CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
@@ -326,35 +326,35 @@ vsoxei64.v   v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSUXEI8_V                  vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     131.00         *             1     Andes45VLSU[131]                           VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     263.00         *             1     Andes45VLSU[263]                           VSUXEI16_V                 vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     67.00          *             1     Andes45VLSU[67]                            VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     135.00         *             1     Andes45VLSU[135]                           VSUXEI32_V                 vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     35.00          *             1     Andes45VLSU[35]                            VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     71.00          *             1     Andes45VLSU[71]                            VSUXEI64_V                 vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf8, ta, ma
 # CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, mf4, ta, ma
@@ -370,35 +370,35 @@ vsoxei64.v   v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSOXEI8_V                  vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     65.00          *             1     Andes45VLSU[65]                            VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     131.00         *             1     Andes45VLSU[131]                           VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     263.00         *             1     Andes45VLSU[263]                           VSOXEI16_V                 vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  1      1     32.00          *             1     Andes45VLSU[32]                            VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     16.00          *             1     Andes45VLSU[16]                            VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     33.00          *             1     Andes45VLSU[33]                            VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     67.00          *             1     Andes45VLSU[67]                            VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     135.00         *             1     Andes45VLSU[135]                           VSOXEI32_V                 vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  1      1     64.00          *             1     Andes45VLSU[64]                            VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     8.00           *             1     Andes45VLSU[8]                             VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  1      1     129.00         *             1     Andes45VLSU[129]                           VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     17.00          *             1     Andes45VLSU[17]                            VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  1      1     259.00         *             1     Andes45VLSU[259]                           VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     35.00          *             1     Andes45VLSU[35]                            VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  1      1     1.00                  U      1     Andes45CSR                                 VSETVLI                    vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  1      1     519.00         *             1     Andes45VLSU[519]                           VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  1      1     71.00          *             1     Andes45VLSU[71]                            VSOXEI64_V                 vsoxei64.v	v8, (a0), v0
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0.0] - Andes45ALU
@@ -421,7 +421,7 @@ vsoxei64.v   v8, (a0), v0
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]
-# CHECK-NEXT:  -      -     88.00   -      -      -      -      -      -      -      -      -      -     16080.00  -    -      -
+# CHECK-NEXT:  -      -     88.00   -      -      -      -      -      -      -      -      -      -     7728.00  -     -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0.0]  [0.1]  [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    [9]    [10]   [11]   [12]   [13]   [14]   [15]   Instructions:
@@ -440,35 +440,35 @@ vsoxei64.v   v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vluxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vluxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     263.00  -      -      -     vluxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vluxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     135.00  -      -      -     vluxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     35.00   -      -      -     vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vluxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     71.00   -      -      -     vluxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
@@ -484,35 +484,35 @@ vsoxei64.v   v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vloxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vloxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     263.00  -      -      -     vloxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vloxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     135.00  -      -      -     vloxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     35.00   -      -      -     vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vloxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     71.00   -      -      -     vloxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
@@ -528,35 +528,35 @@ vsoxei64.v   v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsuxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsuxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     263.00  -      -      -     vsuxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsuxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     135.00  -      -      -     vsuxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     35.00   -      -      -     vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsuxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     71.00   -      -      -     vsuxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, ta, ma
@@ -572,32 +572,32 @@ vsoxei64.v   v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, ta, ma
 # CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsoxei8.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     65.00   -      -      -     vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     131.00  -      -      -     vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsoxei16.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     263.00  -      -      -     vsoxei16.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     32.00   -      -      -     vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     16.00   -      -      -     vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     33.00   -      -      -     vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     67.00   -      -      -     vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsoxei32.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     135.00  -      -      -     vsoxei32.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     64.00   -      -      -     vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     8.00    -      -      -     vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     129.00  -      -      -     vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     17.00   -      -      -     vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     259.00  -      -      -     vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     35.00   -      -      -     vsoxei64.v	v8, (a0), v0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -      -      -      -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, ta, ma
-# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     519.00  -      -      -     vsoxei64.v	v8, (a0), v0
+# CHECK-NEXT:  -      -      -      -      -      -      -      -      -      -      -      -      -     71.00   -      -      -     vsoxei64.v	v8, (a0), v0


### PR DESCRIPTION
This PR adds latency/throughput for all RVV load/stores to the Andes45 series scheduling model.