### PR TITLE
[clang][CodeGen] Remove redundant bitcast(NFC)

### DIFF
--- a/clang/lib/CodeGen/CGCoroutine.cpp
+++ b/clang/lib/CodeGen/CGCoroutine.cpp
@@ -975,12 +975,9 @@ void CodeGenFunction::EmitCoroutineBody(const CoroutineBodyStmt &S) {
     EmitStmt(S.getPromiseDeclStmt());
 
     Address PromiseAddr = GetAddrOfLocalVar(S.getPromiseDecl());
-    auto *PromiseAddrVoidPtr =
-        new llvm::BitCastInst(PromiseAddr.emitRawPointer(*this), VoidPtrTy, "",
-                              CoroId->getIterator());
     // Update CoroId to refer to the promise. We could not do it earlier because
     // promise local variable was not emitted yet.
-    CoroId->setArgOperand(1, PromiseAddrVoidPtr);
+    CoroId->setArgOperand(1, PromiseAddr.emitRawPointer(*this));
 
     // Now we have the promise, initialize the GRO
     GroManager.EmitGroAlloca();

--- a/clang/test/CodeGenCoroutines/coro-gro.cpp
+++ b/clang/test/CodeGenCoroutines/coro-gro.cpp
@@ -56,7 +56,7 @@ int f() {
   // types mismatch (see cwg2563).
 
   // CHECK: pre.gvo.conv:
-  // CHECK-NEXT: %10 = phi i1 [ true, %cleanup8 ], [ false, %final.suspend ], [ false, %init.suspend ]
+  // CHECK-NEXT: %[[IsFinalExit:.+]] = phi i1 [ true, %cleanup8 ], [ false, %final.suspend ], [ false, %init.suspend ]
   // CHECK-NEXT: %InRamp = call i1 @llvm.coro.is_in_ramp()
   // CHECK-NEXT: br i1 %InRamp, label %[[GroConv:.+]], label %[[AfterGroConv:.+]]
 
@@ -66,7 +66,7 @@ int f() {
   // CHECK-NEXT: br label %[[AfterGroConv]]
 
   // CHECK: [[AfterGroConv]]:
-  // CHECK-NEXT: br i1 %10, label %cleanup.cont10, label %[[CoroRet:.+]]
+  // CHECK-NEXT: br i1  %[[IsFinalExit]], label %cleanup.cont10, label %[[CoroRet:.+]]
 
   // CHECK: cleanup.cont10:
   // CHECK-NEXT: br label %[[Cleanup:.+]]


### PR DESCRIPTION
Since opaque pointers have been adopted for years, this bitcast is no longer necessary.