### PR TITLE
[Clang] Honor '#pragma STDC FENV_ROUND' in __builtin_store_half/halff

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -6199,6 +6199,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   }
   case Builtin::BI__builtin_store_half:
   case Builtin::BI__builtin_store_halff: {
+    CodeGenFunction::CGFPOptionsRAII FPOptsRAII(*this, E);
     Value *Val = EmitScalarExpr(E->getArg(0));
     Address Address = EmitPointerWithAlignment(E->getArg(1));
     Value *HalfVal = Builder.CreateFPTrunc(Val, Builder.getHalfTy());

--- a/clang/test/CodeGenOpenCL/builtin-store-half-rounding-constrained.cl
+++ b/clang/test/CodeGenOpenCL/builtin-store-half-rounding-constrained.cl
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 %s -cl-std=cl3.0 -emit-llvm -o - -triple x86_64-unknown-unknown | FileCheck %s
+// RUN: %clang_cc1 %s -cl-std=cl3.0 -triple x86_64-unknown-unknown -disable-llvm-passes -emit-llvm -o - | FileCheck %s
 
 // CHECK-LABEL: @test_store_float(
-// CHECK:         [[TMP0:%.*]] = tail call half @llvm.experimental.constrained.fptrunc.f16.f32(float {{.*}}, metadata !"round.upward", metadata !"fpexcept.ignore")
+// CHECK:         [[TMP0:%.*]] = call half @llvm.experimental.constrained.fptrunc.f16.f32(float {{.*}}, metadata !"round.upward", metadata !"fpexcept.ignore")
 // CHECK-NEXT:    store half [[TMP0]], ptr {{.*}}, align 2
 // CHECK-NEXT:    ret void
 //
@@ -11,7 +11,7 @@ __kernel void test_store_float(float foo, __global half* bar) {
 }
 
 // CHECK-LABEL: @test_store_double(
-// CHECK:         [[TMP0:%.*]] = tail call half @llvm.experimental.constrained.fptrunc.f16.f64(double {{.*}}, metadata !"round.downward", metadata !"fpexcept.ignore")
+// CHECK:         [[TMP0:%.*]] = call half @llvm.experimental.constrained.fptrunc.f16.f64(double {{.*}}, metadata !"round.downward", metadata !"fpexcept.ignore")
 // CHECK-NEXT:    store half [[TMP0]], ptr {{.*}}, align 2
 // CHECK-NEXT:    ret void
 //

--- a/clang/test/CodeGenOpenCL/builtin-store-half-rounding-constrained.cl
+++ b/clang/test/CodeGenOpenCL/builtin-store-half-rounding-constrained.cl
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 %s -cl-std=cl3.0 -emit-llvm -o - -triple x86_64-unknown-unknown | FileCheck %s
+
+// CHECK-LABEL: @test_store_float(
+// CHECK:         [[TMP0:%.*]] = tail call half @llvm.experimental.constrained.fptrunc.f16.f32(float {{.*}}, metadata !"round.upward", metadata !"fpexcept.ignore")
+// CHECK-NEXT:    store half [[TMP0]], ptr {{.*}}, align 2
+// CHECK-NEXT:    ret void
+//
+__kernel void test_store_float(float foo, __global half* bar) {
+  #pragma STDC FENV_ROUND FE_UPWARD
+  __builtin_store_halff(foo, bar);
+}
+
+// CHECK-LABEL: @test_store_double(
+// CHECK:         [[TMP0:%.*]] = tail call half @llvm.experimental.constrained.fptrunc.f16.f64(double {{.*}}, metadata !"round.downward", metadata !"fpexcept.ignore")
+// CHECK-NEXT:    store half [[TMP0]], ptr {{.*}}, align 2
+// CHECK-NEXT:    ret void
+//
+__kernel void test_store_double(double foo, __global half* bar) {
+  #pragma STDC FENV_ROUND FE_DOWNWARD
+  __builtin_store_half(foo, bar);
+}


### PR DESCRIPTION
Before this change, constrained fptrunc for __builtin_store_half/halff always used round.tonearest, ignoring the active pragma STDC FENV_ROUND.
This PR guards builtin emission with CGFPOptionsRAII so the current rounding mode is propagated to the generated constrained intrinsic.