### PR TITLE
[Clang] Remove 't' from __builtin_amdgcn_flat_atomic_fmin/fmax_f64

### DIFF
--- a/clang/include/clang/Basic/BuiltinsAMDGPU.def
+++ b/clang/include/clang/Basic/BuiltinsAMDGPU.def
@@ -273,8 +273,8 @@ TARGET_BUILTIN(__builtin_amdgcn_global_atomic_fmin_f64, "dd*1d", "t", "gfx90a-in
 TARGET_BUILTIN(__builtin_amdgcn_global_atomic_fmax_f64, "dd*1d", "t", "gfx90a-insts")
 
 TARGET_BUILTIN(__builtin_amdgcn_flat_atomic_fadd_f64, "dd*0d", "", "gfx90a-insts")
-TARGET_BUILTIN(__builtin_amdgcn_flat_atomic_fmin_f64, "dd*0d", "t", "gfx90a-insts")
-TARGET_BUILTIN(__builtin_amdgcn_flat_atomic_fmax_f64, "dd*0d", "t", "gfx90a-insts")
+TARGET_BUILTIN(__builtin_amdgcn_flat_atomic_fmin_f64, "dd*0d", "", "gfx90a-insts")
+TARGET_BUILTIN(__builtin_amdgcn_flat_atomic_fmax_f64, "dd*0d", "", "gfx90a-insts")
 
 TARGET_BUILTIN(__builtin_amdgcn_ds_atomic_fadd_f64, "dd*3d", "", "gfx90a-insts")
 TARGET_BUILTIN(__builtin_amdgcn_ds_atomic_fadd_f32, "ff*3f", "", "gfx8-insts")

--- a/clang/test/CodeGenOpenCL/builtins-fp-atomics-gfx90a.cl
+++ b/clang/test/CodeGenOpenCL/builtins-fp-atomics-gfx90a.cl
@@ -77,10 +77,10 @@ void test_flat_min_flat_f64(__generic double *addr, double x){
 }
 
 // CHECK-LABEL: test_flat_global_min_f64
-// CHECK: = atomicrmw fmin ptr addrspace(1) {{.+}}, double %{{.+}} syncscope("agent") monotonic, align 8, !amdgpu.no.fine.grained.memory !{{[0-9]+$}}
+// CHECK: = atomicrmw fmin ptr {{.+}}, double %{{.+}} syncscope("agent") monotonic, align 8, !amdgpu.no.fine.grained.memory !{{[0-9]+$}}
 
 // GFX90A:  test_flat_global_min_f64$local
-// GFX90A:  global_atomic_min_f64
+// GFX90A:  flat_atomic_min_f64
 void test_flat_global_min_f64(__global double *addr, double x){
   double *rtn;
   *rtn = __builtin_amdgcn_flat_atomic_fmin_f64(addr, x);
@@ -97,10 +97,10 @@ void test_flat_max_flat_f64(__generic double *addr, double x){
 }
 
 // CHECK-LABEL: test_flat_global_max_f64
-// CHECK: = atomicrmw fmax ptr addrspace(1) {{.+}}, double %{{.+}} syncscope("agent") monotonic, align 8, !amdgpu.no.fine.grained.memory !{{[0-9]+$}}
+// CHECK: = atomicrmw fmax ptr {{.+}}, double %{{.+}} syncscope("agent") monotonic, align 8, !amdgpu.no.fine.grained.memory !{{[0-9]+$}}
 
 // GFX90A-LABEL:  test_flat_global_max_f64$local
-// GFX90A:  global_atomic_max_f64
+// GFX90A:  flat_atomic_max_f64
 void test_flat_global_max_f64(__global double *addr, double x){
   double *rtn;
   *rtn = __builtin_amdgcn_flat_atomic_fmax_f64(addr, x);

--- a/clang/test/SemaHIP/amdgpu-flat-atomic-fmax-err.hip
+++ b/clang/test/SemaHIP/amdgpu-flat-atomic-fmax-err.hip
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -triple amdgcn -target-cpu gfx942 -verify %s -fcuda-is-device
 // RUN: %clang_cc1 -fsyntax-only -triple x86_64 -aux-triple amdgcn -verify %s
-// expected-no-diagnostics
 
 #define __device__ __attribute__((device))
 
@@ -12,7 +11,7 @@ __device__ void test_flat_atomic_fmax_f64_valid(double *ptr, double val) {
 __device__ void test_flat_atomic_fmax_f64_errors(double *ptr, double val,
                                                  float *ptr_f) {
   double result;
-  result = __builtin_amdgcn_flat_atomic_fmax_f64(ptr, val, 0);
-  result = __builtin_amdgcn_flat_atomic_fmax_f64(ptr_f, val);
+  result = __builtin_amdgcn_flat_atomic_fmax_f64(ptr, val, 0); // expected-error{{too many arguments to function call, expected 2, have 3}}
+  result = __builtin_amdgcn_flat_atomic_fmax_f64(ptr_f, val); // expected-error{{cannot initialize a parameter of type}}
 }
 

--- a/clang/test/SemaHIP/amdgpu-flat-atomic-fmax-err.hip
+++ b/clang/test/SemaHIP/amdgpu-flat-atomic-fmax-err.hip
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -fsyntax-only -triple amdgcn -target-cpu gfx942 -verify %s -fcuda-is-device
+// RUN: %clang_cc1 -fsyntax-only -triple x86_64 -aux-triple amdgcn -verify %s
+// expected-no-diagnostics
+
+#define __device__ __attribute__((device))
+
+__device__ void test_flat_atomic_fmax_f64_valid(double *ptr, double val) {
+  double result;
+  result = __builtin_amdgcn_flat_atomic_fmax_f64(ptr, val);
+}
+
+__device__ void test_flat_atomic_fmax_f64_errors(double *ptr, double val,
+                                                 float *ptr_f) {
+  double result;
+  result = __builtin_amdgcn_flat_atomic_fmax_f64(ptr, val, 0);
+  result = __builtin_amdgcn_flat_atomic_fmax_f64(ptr_f, val);
+}
+

--- a/clang/test/SemaHIP/amdgpu-flat-atomic-fmin-err.hip
+++ b/clang/test/SemaHIP/amdgpu-flat-atomic-fmin-err.hip
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -fsyntax-only -triple amdgcn -target-cpu gfx942 -verify %s -fcuda-is-device
+// RUN: %clang_cc1 -fsyntax-only -triple x86_64 -aux-triple amdgcn -verify %s
+// expected-no-diagnostics
+
+#define __device__ __attribute__((device))
+
+__device__ void test_flat_atomic_fmin_f64_valid(double *ptr, double val) {
+  double result;
+  result = __builtin_amdgcn_flat_atomic_fmin_f64(ptr, val);
+}
+
+__device__ void test_flat_atomic_fmin_f64_errors(double *ptr, double val,
+                                                 float *ptr_f) {
+  double result;
+  result = __builtin_amdgcn_flat_atomic_fmin_f64(ptr, val, 0);
+  result = __builtin_amdgcn_flat_atomic_fmin_f64(ptr_f, val);
+}
+

--- a/clang/test/SemaHIP/amdgpu-flat-atomic-fmin-err.hip
+++ b/clang/test/SemaHIP/amdgpu-flat-atomic-fmin-err.hip
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -triple amdgcn -target-cpu gfx942 -verify %s -fcuda-is-device
 // RUN: %clang_cc1 -fsyntax-only -triple x86_64 -aux-triple amdgcn -verify %s
-// expected-no-diagnostics
 
 #define __device__ __attribute__((device))
 
@@ -12,7 +11,7 @@ __device__ void test_flat_atomic_fmin_f64_valid(double *ptr, double val) {
 __device__ void test_flat_atomic_fmin_f64_errors(double *ptr, double val,
                                                  float *ptr_f) {
   double result;
-  result = __builtin_amdgcn_flat_atomic_fmin_f64(ptr, val, 0);
-  result = __builtin_amdgcn_flat_atomic_fmin_f64(ptr_f, val);
+  result = __builtin_amdgcn_flat_atomic_fmin_f64(ptr, val, 0); // expected-error{{too many arguments to function call, expected 2, have 3}}
+  result = __builtin_amdgcn_flat_atomic_fmin_f64(ptr_f, val); // expected-error{{cannot initialize a parameter of type}}
 }
 


### PR DESCRIPTION
Allows for type checking depending on the built-in signature.

There is no `f32` version for both builtins