### PR TITLE
[lldb][lldb-dap] Do not expose internal breakpoints to DAP clients

### DIFF
--- a/lldb/tools/lldb-dap/LLDBUtils.cpp
+++ b/lldb/tools/lldb-dap/LLDBUtils.cpp
@@ -143,12 +143,14 @@ bool ThreadHasStopReason(lldb::SBThread &thread) {
   case lldb::eStopReasonHistoryBoundary:
     return true;
   case lldb::eStopReasonBreakpoint: {
-    // Internal breakpoints must not be considered as valid stop reason.
-    uint64_t data_count = thread.GetStopReasonDataCount();
+    // Stop reason data for breakpoints consists of breakpoint ID and location
+    // ID pairs. Internal breakpoints (identified by their ID) are not
+    // considered valid stop reasons.
+    const uint64_t data_count = thread.GetStopReasonDataCount();
     if (data_count == 0)
       return true;
     for (uint64_t i = 0; i < data_count; i += 2) {
-      lldb::break_id_t bp_id = thread.GetStopReasonDataAtIndex(i);
+      const lldb::break_id_t bp_id = thread.GetStopReasonDataAtIndex(i);
       if (!LLDB_BREAK_ID_IS_INTERNAL(bp_id))
         return true;
     }


### PR DESCRIPTION
**This commit fixes the following problem:**

When debugging an APK running on Android, and the Android process stops due to a user breakpoint, sometimes a second breakpoint is hit at the same time, and the corresponding thread is marked as stopped for reason `jit-debug-register`.

This second breakpoint is used by lldb internally, to track code generated by the JIT compiler (JVM).

Instead of displaying the code corresponding to the user breakpoint, the debugger displays the disassembled code corresponding to this internal breakpoint.

**Solution:**

Internal breakpoints must stay internal, not visible by VS Code or any other DAP-based debugger.

**Notes:**

* This is part on an effort to get lldb working for debugging Swift on Android: https://github.com/swiftlang/llvm-project/issues/10831
* Reproducing the problems is not simple because you need an environment allowing to run lldb-server in the Android emulator. See https://github.com/gmondada/swift-on-android/blob/main/Docs/exploring-apk-debugging.md
* The problem has been seen on Android, but `jit-debug-register` is not Android specific and there are probably other scenarios where internal breakpoints are used.