### PR TITLE
[lldb][lldb-dap] Correctly format lldb warnings in the debug console

### DIFF
--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -566,7 +566,7 @@ static void HandleDiagnosticEvent(const lldb::SBEvent &event, Log &log) {
     std::string type = GetStringValue(data.GetValueForKey("type"));
     std::string message = GetStringValue(data.GetValueForKey("message"));
     dap_instance->SendOutput(OutputType::Important,
-                             llvm::formatv("{0}: {1}", type, message).str());
+                             llvm::formatv("{0}: {1}\n", type, message).str());
   }
 }
 


### PR DESCRIPTION
Trivial change to prevent all warnings from being printed on a single line in the VS Code debug console.