### PR TITLE
[clang][analyzer] Extend CallAndMessageChecker argument initializedness check

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/CallAndMessageChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CallAndMessageChecker.cpp
@@ -80,9 +80,11 @@ public:
 
   bool ChecksEnabled[CK_NumCheckKinds] = {false};
 
-  /// When checking a struct value for uninitialized data, should all the fields
-  /// be un-initialized or only find one uninitialized field.
-  bool StructInitializednessComplete = true;
+  /// When checking a struct value for uninitialized data and this setting is
+  /// true, all members should be completely uninitialized to get a checker
+  /// warning. When the value is false, the warning is emitted for partially
+  // initialized structures too.
+  bool ArgPointeeInitializednessComplete = true;
 
   void checkPreObjCMessage(const ObjCMethodCall &msg, CheckerContext &C) const;
 
@@ -292,7 +294,7 @@ bool CallAndMessageChecker::uninitRefOrPointer(CheckerContext &C, SVal V,
   if (!ParamT->isPointerOrReferenceType())
     return false;
 
-  bool AllowPartialInitializedness = StructInitializednessComplete;
+  bool AllowPartialInitializedness = ArgPointeeInitializednessComplete;
   QualType PointeeT = ParamT->getPointeeType();
   if (!PointeeT.isConstQualified()) {
     if (const int *PI = FunctionsWithInOutPtrParam.lookup(Call)) {
@@ -765,7 +767,7 @@ void ento::registerCallAndMessageChecker(CheckerManager &Mgr) {
   QUERY_CHECKER_OPTION(NilReceiver)
   QUERY_CHECKER_OPTION(UndefReceiver)
 
-  Chk->StructInitializednessComplete =
+  Chk->ArgPointeeInitializednessComplete =
       Mgr.getAnalyzerOptions().getCheckerBooleanOption(
           Mgr.getCurrentCheckerName(), "ArgPointeeInitializednessComplete");
 }

--- a/clang/test/Analysis/call-and-message-argpointeeinitializedness.c
+++ b/clang/test/Analysis/call-and-message-argpointeeinitializedness.c
@@ -1,0 +1,57 @@
+// RUN: %clang_analyze_cc1 -verify %s \
+// RUN:   -analyzer-checker=core \
+// RUN:   -analyzer-config core.CallAndMessage:ArgPointeeInitializedness=true \
+// RUN:   -analyzer-config core.CallAndMessage:ArgPointeeInitializednessComplete=true \
+// RUN:   -analyzer-config core.CallAndMessage:ArgInitializedness=false
+
+// RUN: %clang_analyze_cc1 -verify %s \
+// RUN:   -analyzer-checker=core \
+// RUN:   -analyzer-config core.CallAndMessage:ArgPointeeInitializedness=true \
+// RUN:   -analyzer-config core.CallAndMessage:ArgInitializedness=false
+
+typedef __typeof(sizeof(int)) size_t;
+typedef __WCHAR_TYPE__ wchar_t;
+typedef __CHAR16_TYPE__ char16_t;
+typedef long time_t;
+typedef struct {
+  int x;
+  int y;
+} mbstate_t;
+struct tm {
+  int x;
+  int y;
+};
+extern size_t mbrlen(const char *restrict, size_t, mbstate_t *restrict);
+extern size_t wcsnrtombs(char *restrict dst, const wchar_t **restrict src,
+       size_t nwc, size_t len, mbstate_t *restrict ps);
+extern size_t mbrtoc16(char16_t *restrict pc16, const char *restrict s,
+       size_t n, mbstate_t *restrict ps);
+extern time_t mktime(struct tm *timeptr);
+
+void uninit_mbrlen(const char *mbs) {
+  mbstate_t state;
+  mbrlen(mbs, 1, &state); // expected-warning{{3rd function call argument points to an uninitialized value}}
+}
+
+void init_mbrlen(const char *mbs) {
+  mbstate_t state;
+  state.x = 0;
+  mbrlen(mbs, 1, &state);
+}
+
+void uninit_wcsnrtombs(const wchar_t *src) {
+  char dst[10];
+  mbstate_t state;
+  wcsnrtombs(dst, &src, 1, 2, &state); // expected-warning{{5th function call argument points to an uninitialized value}}
+}
+
+void uninit_mbrtoc16(const char *s) {
+  char16_t pc16[10];
+  mbstate_t state;
+  mbrtoc16(pc16, s, 1, &state); // expected-warning{{4th function call argument points to an uninitialized value}}
+}
+
+void uninit_mktime() {
+  struct tm time;
+  mktime(&time); // expected-warning{{1st function call argument points to an uninitialized value}}
+}


### PR DESCRIPTION
Add extra check to `CallAndMessageChecker` to find uninitialized non-const values passed through parameters. This check is used only at a specific list of C library functions which have non-const pointer parameters and the value should be initialized before the call.