### PR TITLE
[NFC][lldb-dap] Format typescript files

### DIFF
--- a/lldb/tools/lldb-dap/.prettierrc.json
+++ b/lldb/tools/lldb-dap/.prettierrc.json
@@ -3,5 +3,5 @@
   "tabWidth": 2,
   "semi": true,
   "singleQuote": false,
-  "plugins": ["prettier-plugin-curly"]
+  "plugins": ["prettier-plugin-curly", "prettier-plugin-organize-imports"]
 }

--- a/lldb/tools/lldb-dap/package-lock.json
+++ b/lldb/tools/lldb-dap/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lldb-dap",
-  "version": "0.2.16",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lldb-dap",
-      "version": "0.2.16",
+      "version": "0.4.1",
       "license": "Apache 2.0 License with LLVM exceptions",
       "dependencies": {
         "chokidar": "^4.0.3"
@@ -21,6 +21,7 @@
         "esbuild": "^0.25.9",
         "prettier": "^3.4.2",
         "prettier-plugin-curly": "^0.3.1",
+        "prettier-plugin-organize-imports": "^4.3.0",
         "tabulator-tables": "^6.3.1",
         "typescript": "^5.7.3"
       },
@@ -767,6 +768,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1074,9 +1098,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1744,13 +1768,13 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -1841,15 +1865,15 @@
       "optional": true
     },
     "node_modules/glob": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
-      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^4.0.1",
-        "minimatch": "^10.0.0",
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
@@ -1864,24 +1888,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "@isaacs/brace-expansion": "^5.0.0"
       },
       "engines": {
         "node": "20 || >=22"
@@ -2105,9 +2119,9 @@
       "license": "ISC"
     },
     "node_modules/jackspeak": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
-      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -2170,48 +2184,48 @@
       }
     },
     "node_modules/jsonwebtoken/node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jsonwebtoken/node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jwa": "^2.0.0",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -2656,6 +2670,7 @@
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2682,6 +2697,23 @@
       },
       "peerDependencies": {
         "prettier": "^2 || ^3"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.3.0.tgz",
+      "integrity": "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": ">=2.0",
+        "typescript": ">=2.9",
+        "vue-tsc": "^2.1.0 || 3"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
       }
     },
     "node_modules/pump": {
@@ -3063,9 +3095,9 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3220,6 +3252,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3406,9 +3439,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -40,6 +40,7 @@
     "esbuild": "^0.25.9",
     "prettier": "^3.4.2",
     "prettier-plugin-curly": "^0.3.1",
+    "prettier-plugin-organize-imports": "^4.3.0",
     "tabulator-tables": "^6.3.1",
     "typescript": "^5.7.3"
   },

--- a/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
@@ -1,11 +1,11 @@
+import * as child_process from "child_process";
+import * as fs from "node:fs/promises";
 import * as path from "path";
 import * as util from "util";
 import * as vscode from "vscode";
-import * as child_process from "child_process";
-import * as fs from "node:fs/promises";
-import { ConfigureButton, OpenSettingsButton } from "./ui/show-error-message";
-import { ErrorWithNotification } from "./ui/error-with-notification";
 import { LogFilePathProvider, LogType } from "./logging";
+import { ErrorWithNotification } from "./ui/error-with-notification";
+import { ConfigureButton, OpenSettingsButton } from "./ui/show-error-message";
 import { expandUser } from "./utils";
 
 const exec = util.promisify(child_process.execFile);
@@ -92,8 +92,7 @@ function validateDAPEnv(debugConfigEnv: any): boolean {
   if (
     Array.isArray(debugConfigEnv) &&
     debugConfigEnv.findIndex(
-      (entry) =>
-        typeof entry !== "string" || !/^\w+(=.*)?$/.test(entry),
+      (entry) => typeof entry !== "string" || !/^\w+(=.*)?$/.test(entry),
     ) !== -1
   ) {
     return false;

--- a/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
@@ -1,11 +1,11 @@
-import * as vscode from "vscode";
 import * as child_process from "child_process";
 import * as util from "util";
-import { LLDBDapServer } from "./lldb-dap-server";
+import * as vscode from "vscode";
 import { createDebugAdapterExecutable } from "./debug-adapter-factory";
-import { ConfigureButton, showErrorMessage } from "./ui/show-error-message";
-import { ErrorWithNotification } from "./ui/error-with-notification";
+import { LLDBDapServer } from "./lldb-dap-server";
 import { LogFilePathProvider } from "./logging";
+import { ErrorWithNotification } from "./ui/error-with-notification";
+import { ConfigureButton } from "./ui/show-error-message";
 
 const exec = util.promisify(child_process.execFile);
 
@@ -69,7 +69,9 @@ const configurations: Record<string, DefaultConfig> = {
   terminateCommands: { type: "stringArray", default: [] },
 };
 
-export function getDefaultConfigKey(key: string): string | number | boolean | string[] | undefined {
+export function getDefaultConfigKey(
+  key: string,
+): string | number | boolean | string[] | undefined {
   return configurations[key]?.default;
 }
 

--- a/lldb/tools/lldb-dap/src-ts/debug-session-tracker.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-session-tracker.ts
@@ -45,8 +45,9 @@ export class DebugSessionTracker
   private modulesChanged = new vscode.EventEmitter<
     vscode.DebugSession | undefined
   >();
-  private sessionReceivedCapabilities =
-      new vscode.EventEmitter<[ vscode.DebugSession, LLDBDapCapabilities ]>();
+  private sessionReceivedCapabilities = new vscode.EventEmitter<
+    [vscode.DebugSession, LLDBDapCapabilities]
+  >();
   private sessionExited = new vscode.EventEmitter<vscode.DebugSession>();
 
   /**
@@ -58,9 +59,9 @@ export class DebugSessionTracker
     this.modulesChanged.event;
 
   /** Fired when a debug session is initialized. */
-  onDidReceiveSessionCapabilities:
-      vscode.Event<[ vscode.DebugSession, LLDBDapCapabilities ]> =
-      this.sessionReceivedCapabilities.event;
+  onDidReceiveSessionCapabilities: vscode.Event<
+    [vscode.DebugSession, LLDBDapCapabilities]
+  > = this.sessionReceivedCapabilities.event;
 
   /** Fired when a debug session is exiting. */
   onDidExitSession: vscode.Event<vscode.DebugSession> =
@@ -167,7 +168,10 @@ export class DebugSessionTracker
 
       this.sessionExited.fire(session);
     } else if (isEvent(message, "capabilities")) {
-      this.sessionReceivedCapabilities.fire([ session, message.body.capabilities ]);
+      this.sessionReceivedCapabilities.fire([
+        session,
+        message.body.capabilities,
+      ]);
     }
   }
 }

--- a/lldb/tools/lldb-dap/src-ts/extension.ts
+++ b/lldb/tools/lldb-dap/src-ts/extension.ts
@@ -1,18 +1,17 @@
-import * as path from "path";
 import * as vscode from "vscode";
 
 import { LLDBDapDescriptorFactory } from "./debug-adapter-factory";
-import { DisposableContext } from "./disposable-context";
-import { LaunchUriHandler } from "./uri-launch-handler";
 import { LLDBDapConfigurationProvider } from "./debug-configuration-provider";
-import { LLDBDapServer } from "./lldb-dap-server";
 import { DebugSessionTracker } from "./debug-session-tracker";
-import {
-  ModulesDataProvider,
-  ModuleProperty,
-} from "./ui/modules-data-provider";
+import { DisposableContext } from "./disposable-context";
+import { LLDBDapServer } from "./lldb-dap-server";
 import { LogFilePathProvider } from "./logging";
+import {
+  ModuleProperty,
+  ModulesDataProvider,
+} from "./ui/modules-data-provider";
 import { SymbolsProvider } from "./ui/symbols-provider";
+import { LaunchUriHandler } from "./uri-launch-handler";
 
 /**
  * This class represents the extension and manages its life cycle. Other extensions
@@ -54,10 +53,12 @@ export class LLDBDapExtension extends DisposableContext {
       vscode.window.registerUriHandler(new LaunchUriHandler()),
     );
 
-    this.pushSubscription(vscode.commands.registerCommand(
-      "lldb-dap.modules.copyProperty",
-      (node: ModuleProperty) => vscode.env.clipboard.writeText(node.value),
-    ));
+    this.pushSubscription(
+      vscode.commands.registerCommand(
+        "lldb-dap.modules.copyProperty",
+        (node: ModuleProperty) => vscode.env.clipboard.writeText(node.value),
+      ),
+    );
 
     this.pushSubscription(new SymbolsProvider(sessionTracker, context));
   }
@@ -67,7 +68,9 @@ export class LLDBDapExtension extends DisposableContext {
  * This is the entry point when initialized by VS Code.
  */
 export async function activate(context: vscode.ExtensionContext) {
-  const outputChannel = vscode.window.createOutputChannel("LLDB-DAP", { log: true });
+  const outputChannel = vscode.window.createOutputChannel("LLDB-DAP", {
+    log: true,
+  });
   outputChannel.info("LLDB-DAP extension activating...");
   const logFilePath = new LogFilePathProvider(context, outputChannel);
   context.subscriptions.push(

--- a/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
@@ -1,6 +1,5 @@
-import { FSWatcher, watch as chokidarWatch } from 'chokidar';
+import { FSWatcher, watch as chokidarWatch } from "chokidar";
 import * as child_process from "node:child_process";
-import * as path from "path";
 import { isDeepStrictEqual } from "util";
 import * as vscode from "vscode";
 
@@ -92,8 +91,8 @@ export class LLDBDapServer implements vscode.Disposable {
       this.serverFileChanged = false;
       this.serverFileWatcher = chokidarWatch(dapPath);
       this.serverFileWatcher
-        .on('change', () => this.serverFileChanged = true)
-        .on('unlink', () => this.serverFileChanged = true);
+        .on("change", () => (this.serverFileChanged = true))
+        .on("unlink", () => (this.serverFileChanged = true));
     });
     return this.serverInfo;
   }
@@ -139,8 +138,7 @@ ${this.serverSpawnInfo.join(" ")}
 The new lldb-dap server will be started with:
 
 ${newSpawnInfo.join(" ")}
-`
-      );
+`);
     }
 
     // If the server hasn't changed, continue startup without killing it.
@@ -153,7 +151,7 @@ ${newSpawnInfo.join(" ")}
       "The lldb-dap server has changed. Would you like to restart the server?",
       {
         modal: true,
-        detail: `An existing lldb-dap server (${this.serverProcess.pid}) is running with ${changeTLDR.map(s => `*${s}*`).join(" and ")}.
+        detail: `An existing lldb-dap server (${this.serverProcess.pid}) is running with ${changeTLDR.map((s) => `*${s}*`).join(" and ")}.
 ${changeDetails.join("\n")}
 Restarting the server will interrupt any existing debug sessions and start a new server.`,
       },

--- a/lldb/tools/lldb-dap/src-ts/logging.ts
+++ b/lldb/tools/lldb-dap/src-ts/logging.ts
@@ -30,21 +30,22 @@ export class LogFilePathProvider {
   ) {
     this.updateLogFolder();
     context.subscriptions.push(
-        vscode.workspace.onDidChangeConfiguration(e => {
-            if (
-                e.affectsConfiguration("lldb-dap.logFolder")
-            ) {
-                this.updateLogFolder();
-            }
-        })
+      vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration("lldb-dap.logFolder")) {
+          this.updateLogFolder();
+        }
+      }),
     );
   }
 
   get(type: LogType): string {
     const logFolder = this.logFolder || this.context.logUri.fsPath;
-    switch(type) {
-    case LogType.DEBUG_SESSION:
-        return path.join(logFolder, `lldb-dap-${formatDate(new Date())}-${vscode.env.sessionId.split("-")[0]}.log`);
+    switch (type) {
+      case LogType.DEBUG_SESSION:
+        return path.join(
+          logFolder,
+          `lldb-dap-${formatDate(new Date())}-${vscode.env.sessionId.split("-")[0]}.log`,
+        );
         break;
     }
   }

--- a/lldb/tools/lldb-dap/src-ts/ui/modules-data-provider.ts
+++ b/lldb/tools/lldb-dap/src-ts/ui/modules-data-provider.ts
@@ -1,5 +1,5 @@
-import * as vscode from "vscode";
 import { DebugProtocol } from "@vscode/debugprotocol";
+import * as vscode from "vscode";
 import { DebugSessionTracker } from "../debug-session-tracker";
 
 export interface ModuleProperty {

--- a/lldb/tools/lldb-dap/src-ts/ui/symbols-webview-html.ts
+++ b/lldb/tools/lldb-dap/src-ts/ui/symbols-webview-html.ts
@@ -1,7 +1,11 @@
 import * as vscode from "vscode";
 
-export function getSymbolsTableHTMLContent(tabulatorJsPath: vscode.Uri, tabulatorCssPath: vscode.Uri, symbolsTableScriptPath: vscode.Uri): string {
-    return `<!DOCTYPE html>
+export function getSymbolsTableHTMLContent(
+  tabulatorJsPath: vscode.Uri,
+  tabulatorCssPath: vscode.Uri,
+  symbolsTableScriptPath: vscode.Uri,
+): string {
+  return `<!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">

--- a/lldb/tools/lldb-dap/src-ts/webview/symbols-table-view.ts
+++ b/lldb/tools/lldb-dap/src-ts/webview/symbols-table-view.ts
@@ -1,24 +1,34 @@
 import type { CellComponent, ColumnDefinition } from "tabulator-tables";
-import type { SymbolType } from ".."
+import type { SymbolType } from "..";
 
 /// SVG from https://github.com/olifolkerd/tabulator/blob/master/src/js/modules/Format/defaults/formatters/tickCross.js
 /// but with the default font color.
 /// hopefully in the future we can set the color as parameter: https://github.com/olifolkerd/tabulator/pull/4791
 const TICK_ELEMENT = `<svg enable-background="new 0 0 24 24" height="14" width="14" viewBox="0 0 24 24" xml:space="preserve" ><path fill="var(--vscode-editor-foreground)" clip-rule="evenodd" d="M21.652,3.211c-0.293-0.295-0.77-0.295-1.061,0L9.41,14.34  c-0.293,0.297-0.771,0.297-1.062,0L3.449,9.351C3.304,9.203,3.114,9.13,2.923,9.129C2.73,9.128,2.534,9.201,2.387,9.351  l-2.165,1.946C0.078,11.445,0,11.63,0,11.823c0,0.194,0.078,0.397,0.223,0.544l4.94,5.184c0.292,0.296,0.771,0.776,1.062,1.07  l2.124,2.141c0.292,0.293,0.769,0.293,1.062,0l14.366-14.34c0.293-0.294,0.293-0.777,0-1.071L21.652,3.211z" fill-rule="evenodd"/></svg>`;
 
-function getTabulatorHexaFormatter(padding: number): (cell: CellComponent) => string {
+function getTabulatorHexaFormatter(
+  padding: number,
+): (cell: CellComponent) => string {
   return (cell: CellComponent) => {
     const val = cell.getValue();
     if (val === undefined || val === null) {
       return "";
     }
 
-    return val !== undefined ? "0x" + val.toString(16).toLowerCase().padStart(padding, "0") : "";
+    return val !== undefined
+      ? "0x" + val.toString(16).toLowerCase().padStart(padding, "0")
+      : "";
   };
 }
 
 const SYMBOL_TABLE_COLUMNS: ColumnDefinition[] = [
-  { title: "ID", field: "id", headerTooltip: true, sorter: "number", widthGrow: 0.6 },
+  {
+    title: "ID",
+    field: "id",
+    headerTooltip: true,
+    sorter: "number",
+    widthGrow: 0.6,
+  },
   {
     title: "Name",
     field: "name",
@@ -26,10 +36,10 @@ const SYMBOL_TABLE_COLUMNS: ColumnDefinition[] = [
     sorter: "string",
     widthGrow: 2.5,
     minWidth: 200,
-    tooltip : (_event: MouseEvent, cell: CellComponent) => {
+    tooltip: (_event: MouseEvent, cell: CellComponent) => {
       const rowData = cell.getRow().getData();
       return rowData.name;
-    }
+    },
   },
   {
     title: "Debug",
@@ -41,7 +51,7 @@ const SYMBOL_TABLE_COLUMNS: ColumnDefinition[] = [
     formatterParams: {
       tickElement: TICK_ELEMENT,
       crossElement: false,
-    }
+    },
   },
   {
     title: "Synthetic",
@@ -53,7 +63,7 @@ const SYMBOL_TABLE_COLUMNS: ColumnDefinition[] = [
     formatterParams: {
       tickElement: TICK_ELEMENT,
       crossElement: false,
-    }
+    },
   },
   {
     title: "External",
@@ -65,7 +75,7 @@ const SYMBOL_TABLE_COLUMNS: ColumnDefinition[] = [
     formatterParams: {
       tickElement: TICK_ELEMENT,
       crossElement: false,
-    }
+    },
   },
   { title: "Type", field: "type", sorter: "string" },
   {
@@ -73,7 +83,7 @@ const SYMBOL_TABLE_COLUMNS: ColumnDefinition[] = [
     field: "fileAddress",
     headerTooltip: true,
     sorter: "number",
-    widthGrow : 1.25,
+    widthGrow: 1.25,
     formatter: getTabulatorHexaFormatter(16),
   },
   {
@@ -81,10 +91,16 @@ const SYMBOL_TABLE_COLUMNS: ColumnDefinition[] = [
     field: "loadAddress",
     headerTooltip: true,
     sorter: "number",
-    widthGrow : 1.25,
+    widthGrow: 1.25,
     formatter: getTabulatorHexaFormatter(16),
   },
-  { title: "Size", field: "size", headerTooltip: true, sorter: "number", formatter: getTabulatorHexaFormatter(8) },
+  {
+    title: "Size",
+    field: "size",
+    headerTooltip: true,
+    sorter: "number",
+    formatter: getTabulatorHexaFormatter(8),
+  },
 ];
 
 const vscode = acquireVsCodeApi();
@@ -112,4 +128,3 @@ window.addEventListener("message", (event: MessageEvent<any>) => {
       break;
   }
 });
-

--- a/lldb/tools/lldb-dap/src-ts/webview/tsconfig.json
+++ b/lldb/tools/lldb-dap/src-ts/webview/tsconfig.json
@@ -1,15 +1,13 @@
 {
-	"compilerOptions": {
-		"moduleResolution": "node",
-		"module": "esnext",
-		"outDir": "out",
-		"rootDir": ".",
-		"sourceMap": true,
-		"strict": true,
-		"noEmit": true,
-		"target": "es2017"
-	},
-	"include": [
-		"./"
-	],
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "esnext",
+    "outDir": "out",
+    "rootDir": ".",
+    "sourceMap": true,
+    "strict": true,
+    "noEmit": true,
+    "target": "es2017"
+  },
+  "include": ["./"]
 }


### PR DESCRIPTION
This patch was generated by following commands:
1. `npm install --save-dev prettier-plugin-organize-imports`
2. `npm run format`
3. `npm audit fix`

It partially addresses [issue](https://github.com/llvm/llvm-project/issues/151598) and improves quality of  ts code (formatting and unused imports).