### PR TITLE
[RFC] Use pre-compiled headers to speed up LLVM build (~1.5-2x)

### DIFF
--- a/clang/include/clang/AST/pch.h
+++ b/clang/include/clang/AST/pch.h
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Precompiled header for clangAST.
+///
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/CanonicalType.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclObjC.h"
+#include "clang/AST/DeclOpenMP.h"
+#include "clang/AST/DeclTemplate.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
+#include "clang/AST/ExprObjC.h"
+#include "clang/AST/GlobalDecl.h"
+#include "clang/AST/OpenMPClause.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/Stmt.h"
+#include "clang/AST/StmtOpenMP.h"
+#include "clang/AST/StmtVisitor.h"
+#include "clang/AST/Type.h"
+#include "llvm/Support/pch.h"

--- a/clang/lib/AST/CMakeLists.txt
+++ b/clang/lib/AST/CMakeLists.txt
@@ -136,6 +136,9 @@ add_clang_library(clangAST
   VTableBuilder.cpp
   VTTBuilder.cpp
 
+  PRECOMPILE_HEADERS
+  [["clang/AST/pch.h"]]
+
   LINK_LIBS
   clangBasic
   clangLex

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -18,8 +18,10 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Metadata.h"
 #include <optional>
-using namespace clang::CodeGen;
 using namespace llvm;
+
+// No using namespace to avoid collision with llvm::LoopInfo.
+namespace clang::CodeGen {
 
 MDNode *
 LoopInfo::createFollowupMetadata(const char *FollowupName,
@@ -863,3 +865,4 @@ void LoopInfoStack::InsertHelper(Instruction *I) const {
     return;
   }
 }
+} // end namespace clang::CodeGen

--- a/clang/lib/CodeGen/CMakeLists.txt
+++ b/clang/lib/CodeGen/CMakeLists.txt
@@ -158,6 +158,10 @@ add_clang_library(clangCodeGen
   TrapReasonBuilder.cpp
   VarBypassDetector.cpp
 
+  DISABLE_PCH_REUSE # PCH contains private headers
+  PRECOMPILE_HEADERS
+  [["pch.h"]]
+
   DEPENDS
   vt_gen
   intrinsics_gen

--- a/clang/lib/CodeGen/pch.h
+++ b/clang/lib/CodeGen/pch.h
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Precompiled header for clangCodeGen. Uses private headers.
+///
+//===----------------------------------------------------------------------===//
+
+#include "ABIInfoImpl.h"
+#include "Address.h"
+#include "CGBuilder.h"
+#include "CGCXXABI.h"
+#include "CGValue.h"
+#include "CodeGenFunction.h"
+#include "CodeGenModule.h"
+#include "clang/AST/pch.h"
+#include "llvm/IR/pch.h"
+#include "llvm/Support/pch.h"

--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -37,7 +37,7 @@ static constexpr raw_ostream::Colors SavedColor = raw_ostream::SAVEDCOLOR;
 // is already taken for 'note'. Green is already used to underline
 // source ranges. White and black are bad because of the usual
 // terminal backgrounds. Which leaves us only with TWO options.
-static constexpr raw_ostream::Colors CommentColor = raw_ostream::YELLOW;
+static constexpr raw_ostream::Colors TCommentColor = raw_ostream::YELLOW;
 static constexpr raw_ostream::Colors LiteralColor = raw_ostream::GREEN;
 static constexpr raw_ostream::Colors KeywordColor = raw_ostream::BLUE;
 
@@ -1269,7 +1269,7 @@ highlightLines(StringRef FileData, unsigned StartLineNumber,
       Vec.emplace_back(Start, Start + Length, LiteralColor);
     } else {
       assert(T.is(tok::comment));
-      Vec.emplace_back(Start, Start + Length, CommentColor);
+      Vec.emplace_back(Start, Start + Length, TCommentColor);
     }
   };
 

--- a/clang/tools/c-index-test/CMakeLists.txt
+++ b/clang/tools/c-index-test/CMakeLists.txt
@@ -5,6 +5,8 @@ set(LLVM_LINK_COMPONENTS
 add_clang_executable(c-index-test
   c-index-test.c
   core_main.cpp
+
+  DISABLE_PCH_REUSE # Prevent CMake error with C source files.
   )
 
 if(NOT MSVC)

--- a/clang/tools/clang-fuzzer/dictionary/CMakeLists.txt
+++ b/clang/tools/clang-fuzzer/dictionary/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(CMAKE_CXX_FLAGS ${CXX_FLAGS_NOFUZZ})
 add_clang_executable(clang-fuzzer-dictionary
   dictionary.c
+
+  DISABLE_PCH_REUSE # no C++ files, prevent CMake error.
   )
 

--- a/clang/unittests/Basic/CharInfoTest.cpp
+++ b/clang/unittests/Basic/CharInfoTest.cpp
@@ -9,7 +9,6 @@
 #include "clang/Basic/CharInfo.h"
 #include "gtest/gtest.h"
 
-using namespace llvm;
 using namespace clang;
 
 // Check that the CharInfo table has been constructed reasonably.

--- a/clang/unittests/Interpreter/ExceptionTests/CMakeLists.txt
+++ b/clang/unittests/Interpreter/ExceptionTests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # The interpreter can throw an exception from user input. The test binary needs
 # to be compiled with exception support to catch the thrown exception.
 set(LLVM_REQUIRES_EH ON)
-set(LLVM_REQUIRES_RTTI ON)
+set(LLVM_REQUIRES_RTTI OFF)
 
 add_distinct_clang_unittest(ClangReplInterpreterExceptionTests
   InterpreterExceptionTest.cpp

--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -441,11 +441,6 @@ if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
   if (BUILD_SHARED_LIBS AND NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-semantic-interposition")
   endif()
-
-  # GCC requires this flag in order for precompiled headers to work with ccache
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpch-preprocess")
-  endif()
 endif()
 
 # Clang on Darwin enables non-POSIX extensions by default, which allows the
@@ -454,11 +449,6 @@ endif()
 # Set _POSIX_C_SOURCE to avoid including these extensions.
 if (APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_POSIX_C_SOURCE=200809")
-endif()
-
-# Clang requires this flag in order for precompiled headers to work with ccache
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -fno-pch-timestamp")
 endif()
 
 list(REMOVE_DUPLICATES CMAKE_CXX_FLAGS)

--- a/flang/lib/Evaluate/CMakeLists.txt
+++ b/flang/lib/Evaluate/CMakeLists.txt
@@ -66,15 +66,8 @@ add_flang_library(FortranEvaluate
   ${LIBPGMATH}
   ${QUADMATHLIB}
 
-  LINK_COMPONENTS
-  Support
-
-  DEPENDS
-  acc_gen
-  omp_gen
-)
-
-target_precompile_headers(FortranEvaluate PRIVATE
+  DISABLE_PCH_REUSE
+  PRECOMPILE_HEADERS
   [["flang/Evaluate/common.h"]]
   [["flang/Evaluate/call.h"]]
   [["flang/Evaluate/traverse.h"]]
@@ -86,4 +79,11 @@ target_precompile_headers(FortranEvaluate PRIVATE
   [["flang/Evaluate/integer.h"]]
   [["flang/Evaluate/expression.h"]]
   [["flang/Evaluate/tools.h"]]
+
+  LINK_COMPONENTS
+  Support
+
+  DEPENDS
+  acc_gen
+  omp_gen
 )

--- a/flang/lib/Frontend/CMakeLists.txt
+++ b/flang/lib/Frontend/CMakeLists.txt
@@ -13,6 +13,14 @@ add_flang_library(flangFrontend
   TextDiagnosticBuffer.cpp
   TextDiagnostic.cpp
 
+  DISABLE_PCH_REUSE
+  PRECOMPILE_HEADERS
+  [["flang/Parser/parsing.h"]]
+  [["flang/Parser/parse-tree.h"]]
+  [["flang/Parser/dump-parse-tree.h"]]
+  [["flang/Lower/PFTBuilder.h"]]
+  [["flang/Lower/Bridge.h"]]
+
   DEPENDS
   CUFDialect
   FIRDialect
@@ -77,12 +85,4 @@ add_flang_library(flangFrontend
   CLANG_LIBS
   clangBasic
   clangOptions
-)
-
-target_precompile_headers(flangFrontend PRIVATE
-  [["flang/Parser/parsing.h"]]
-  [["flang/Parser/parse-tree.h"]]
-  [["flang/Parser/dump-parse-tree.h"]]
-  [["flang/Lower/PFTBuilder.h"]]
-  [["flang/Lower/Bridge.h"]]
 )

--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -38,6 +38,17 @@ add_flang_library(FortranLower
   Support/Utils.cpp
   SymbolMap.cpp
   VectorSubscripts.cpp
+
+  DISABLE_PCH_REUSE
+  PRECOMPILE_HEADERS
+  [["flang/Lower/ConvertExpr.h"]]
+  [["flang/Lower/SymbolMap.h"]]
+  [["flang/Lower/AbstractConverter.h"]]
+  [["flang/Lower/IterationSpace.h"]]
+  [["flang/Lower/CallInterface.h"]]
+  [["flang/Lower/BoxAnalyzer.h"]]
+  [["flang/Lower/PFTBuilder.h"]]
+  [["flang/Lower/DirectivesCommon.h"]]
   
   DEPENDS
   CUFAttrs
@@ -78,15 +89,4 @@ add_flang_library(FortranLower
   MLIRFuncDialect
   MLIRLLVMDialect
   MLIRSCFToControlFlow
-)
-
-target_precompile_headers(FortranLower PRIVATE
-  [["flang/Lower/ConvertExpr.h"]]
-  [["flang/Lower/SymbolMap.h"]]
-  [["flang/Lower/AbstractConverter.h"]]
-  [["flang/Lower/IterationSpace.h"]]
-  [["flang/Lower/CallInterface.h"]]
-  [["flang/Lower/BoxAnalyzer.h"]]
-  [["flang/Lower/PFTBuilder.h"]]
-  [["flang/Lower/DirectivesCommon.h"]]
 )

--- a/flang/lib/Parser/CMakeLists.txt
+++ b/flang/lib/Parser/CMakeLists.txt
@@ -25,6 +25,14 @@ add_flang_library(FortranParser
   unparse.cpp
   user-state.cpp
 
+  DISABLE_PCH_REUSE
+  PRECOMPILE_HEADERS
+  [["flang/Parser/parsing.h"]]
+  [["flang/Parser/parse-tree.h"]]
+  [["flang/Parser/provenance.h"]]
+  [["flang/Parser/message.h"]]
+  [["flang/Parser/parse-tree-visitor.h"]]
+
   LINK_LIBS
   FortranSupport
 
@@ -36,12 +44,4 @@ add_flang_library(FortranParser
   DEPENDS
   omp_gen
   acc_gen
-)
-
-target_precompile_headers(FortranParser PRIVATE
-  [["flang/Parser/parsing.h"]]
-  [["flang/Parser/parse-tree.h"]]
-  [["flang/Parser/provenance.h"]]
-  [["flang/Parser/message.h"]]
-  [["flang/Parser/parse-tree-visitor.h"]]
 )

--- a/flang/lib/Semantics/CMakeLists.txt
+++ b/flang/lib/Semantics/CMakeLists.txt
@@ -53,6 +53,15 @@ add_flang_library(FortranSemantics
   type.cpp
   unparse-with-symbols.cpp
 
+  DISABLE_PCH_REUSE
+  PRECOMPILE_HEADERS
+  [["flang/Semantics/semantics.h"]]
+  [["flang/Semantics/type.h"]]
+  [["flang/Semantics/openmp-modifiers.h"]]
+  [["flang/Semantics/expression.h"]]
+  [["flang/Semantics/tools.h"]]
+  [["flang/Semantics/symbol.h"]]
+
   DEPENDS
   acc_gen
   omp_gen
@@ -67,13 +76,4 @@ add_flang_library(FortranSemantics
   FrontendOpenMP
   FrontendOpenACC
   TargetParser
-)
-
-target_precompile_headers(FortranSemantics PRIVATE
-  [["flang/Semantics/semantics.h"]]
-  [["flang/Semantics/type.h"]]
-  [["flang/Semantics/openmp-modifiers.h"]]
-  [["flang/Semantics/expression.h"]]
-  [["flang/Semantics/tools.h"]]
-  [["flang/Semantics/symbol.h"]]
 )

--- a/lld/MachO/Arch/ARM64Common.cpp
+++ b/lld/MachO/Arch/ARM64Common.cpp
@@ -38,7 +38,7 @@ int64_t ARM64Common::getEmbeddedAddend(MemoryBufferRef mb, uint64_t offset,
   }
 }
 
-static void writeValue(uint8_t *loc, const Reloc &r, uint64_t value) {
+static void writeValue(uint8_t *loc, const Relocation &r, uint64_t value) {
   switch (r.length) {
   case 2:
     checkInt(loc, r, value, 32);
@@ -57,7 +57,7 @@ static void writeValue(uint8_t *loc, const Reloc &r, uint64_t value) {
 // instruction has opcode & register-operand bits set, with immediate
 // operands zeroed. We read it from text, OR-in the immediate
 // operands, then write-back the completed instruction.
-void ARM64Common::relocateOne(uint8_t *loc, const Reloc &r, uint64_t value,
+void ARM64Common::relocateOne(uint8_t *loc, const Relocation &r, uint64_t value,
                               uint64_t pc) const {
   auto loc32 = reinterpret_cast<uint32_t *>(loc);
   uint32_t base = ((r.length == 2) ? read32le(loc) : 0);
@@ -110,7 +110,7 @@ void ARM64Common::relaxGotLoad(uint8_t *loc, uint8_t type) const {
   write32le(loc, instruction);
 }
 
-void ARM64Common::handleDtraceReloc(const Symbol *sym, const Reloc &r,
+void ARM64Common::handleDtraceReloc(const Symbol *sym, const Relocation &r,
                                     uint8_t *loc) const {
   assert(r.type == ARM64_RELOC_BRANCH26);
 
@@ -138,8 +138,8 @@ static void reportUnalignedLdrStr(Twine loc, uint64_t va, int align,
         "-byte aligned");
 }
 
-void macho::reportUnalignedLdrStr(void *loc, const lld::macho::Reloc &r,
-                                  uint64_t va, int align) {
+void macho::reportUnalignedLdrStr(void *loc, const Relocation &r, uint64_t va,
+                                  int align) {
   uint64_t off = reinterpret_cast<const uint8_t *>(loc) - in.bufferStart;
   const InputSection *isec = offsetToInputSection(&off);
   std::string locStr = isec ? isec->getLocation(off) : "(invalid location)";

--- a/lld/MachO/Arch/ARM64Common.h
+++ b/lld/MachO/Arch/ARM64Common.h
@@ -23,13 +23,13 @@ struct ARM64Common : TargetInfo {
 
   int64_t getEmbeddedAddend(MemoryBufferRef, uint64_t offset,
                             const llvm::MachO::relocation_info) const override;
-  void relocateOne(uint8_t *loc, const Reloc &, uint64_t va,
+  void relocateOne(uint8_t *loc, const Relocation &, uint64_t va,
                    uint64_t pc) const override;
 
   void relaxGotLoad(uint8_t *loc, uint8_t type) const override;
   uint64_t getPageSize() const override { return 16 * 1024; }
 
-  void handleDtraceReloc(const Symbol *sym, const Reloc &r,
+  void handleDtraceReloc(const Symbol *sym, const Relocation &r,
                          uint8_t *loc) const override;
 };
 
@@ -42,7 +42,7 @@ inline uint64_t bitField(uint64_t value, int right, int width, int left) {
 // |           |                       imm26                       |
 // +-----------+---------------------------------------------------+
 
-inline void encodeBranch26(uint32_t *loc, const Reloc &r, uint32_t base,
+inline void encodeBranch26(uint32_t *loc, const Relocation &r, uint32_t base,
                            uint64_t va) {
   checkInt(loc, r, va, 28);
   // Since branch destinations are 4-byte aligned, the 2 least-
@@ -61,7 +61,7 @@ inline void encodeBranch26(uint32_t *loc, SymbolDiagnostic d, uint32_t base,
 // | |ilo|         |                immhi                |         |
 // +-+---+---------+-------------------------------------+---------+
 
-inline void encodePage21(uint32_t *loc, const Reloc &r, uint32_t base,
+inline void encodePage21(uint32_t *loc, const Relocation &r, uint32_t base,
                          uint64_t va) {
   checkInt(loc, r, va, 35);
   llvm::support::endian::write32le(loc, base | bitField(va, 12, 2, 29) |
@@ -75,7 +75,8 @@ inline void encodePage21(uint32_t *loc, SymbolDiagnostic d, uint32_t base,
                                             bitField(va, 14, 19, 5));
 }
 
-void reportUnalignedLdrStr(void *loc, const Reloc &, uint64_t va, int align);
+void reportUnalignedLdrStr(void *loc, const Relocation &, uint64_t va,
+                           int align);
 void reportUnalignedLdrStr(void *loc, SymbolDiagnostic, uint64_t va, int align);
 
 //                      21                   10

--- a/lld/MachO/Arch/X86_64.cpp
+++ b/lld/MachO/Arch/X86_64.cpp
@@ -28,7 +28,7 @@ struct X86_64 : TargetInfo {
 
   int64_t getEmbeddedAddend(MemoryBufferRef, uint64_t offset,
                             const relocation_info) const override;
-  void relocateOne(uint8_t *loc, const Reloc &, uint64_t va,
+  void relocateOne(uint8_t *loc, const Relocation &, uint64_t va,
                    uint64_t relocVA) const override;
 
   void writeStub(uint8_t *buf, const Symbol &,
@@ -44,7 +44,7 @@ struct X86_64 : TargetInfo {
   void relaxGotLoad(uint8_t *loc, uint8_t type) const override;
   uint64_t getPageSize() const override { return 4 * 1024; }
 
-  void handleDtraceReloc(const Symbol *sym, const Reloc &r,
+  void handleDtraceReloc(const Symbol *sym, const Relocation &r,
                          uint8_t *loc) const override;
 };
 } // namespace
@@ -102,7 +102,7 @@ int64_t X86_64::getEmbeddedAddend(MemoryBufferRef mb, uint64_t offset,
   return addend + pcrelOffset(rel.r_type);
 }
 
-void X86_64::relocateOne(uint8_t *loc, const Reloc &r, uint64_t value,
+void X86_64::relocateOne(uint8_t *loc, const Relocation &r, uint64_t value,
                          uint64_t relocVA) const {
   if (r.pcrel) {
     uint64_t pc = relocVA + (1ull << r.length) + pcrelOffset(r.type);
@@ -241,7 +241,7 @@ TargetInfo *macho::createX86_64TargetInfo() {
   return &t;
 }
 
-void X86_64::handleDtraceReloc(const Symbol *sym, const Reloc &r,
+void X86_64::handleDtraceReloc(const Symbol *sym, const Relocation &r,
                                uint8_t *loc) const {
   assert(r.type == X86_64_RELOC_BRANCH);
 

--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -85,7 +85,7 @@ struct BPOrdererMachO : lld::BPOrderer<BPOrdererMachO> {
 
 private:
   static uint64_t
-  getRelocHash(const macho::Reloc &reloc,
+  getRelocHash(const Relocation &reloc,
                const llvm::DenseMap<const void *, uint64_t> &sectionToIdx) {
     auto *isec = reloc.getReferentInputSection();
     std::optional<uint64_t> sectionIdx;

--- a/lld/MachO/ConcatOutputSection.cpp
+++ b/lld/MachO/ConcatOutputSection.cpp
@@ -148,7 +148,7 @@ bool TextOutputSection::needsThunks() const {
     parent->needsThunks = true;
   }
   for (ConcatInputSection *isec : inputs) {
-    for (Reloc &r : isec->relocs) {
+    for (Relocation &r : isec->relocs) {
       if (!target->hasAttr(r.type, RelocAttrBits::BRANCH))
         continue;
       auto *sym = cast<Symbol *>(r.referent);
@@ -333,12 +333,13 @@ void TextOutputSection::finalize() {
       branchTargetThresholdVA = estimateBranchTargetThresholdVA(callIdx);
     }
     // Process relocs by ascending address, i.e., ascending offset within isec
-    std::vector<Reloc> &relocs = isec->relocs;
+    std::vector<Relocation> &relocs = isec->relocs;
     // FIXME: This property does not hold for object files produced by ld64's
     // `-r` mode.
-    assert(is_sorted(relocs,
-                     [](Reloc &a, Reloc &b) { return a.offset > b.offset; }));
-    for (Reloc &r : reverse(relocs)) {
+    assert(is_sorted(relocs, [](Relocation &a, Relocation &b) {
+      return a.offset > b.offset;
+    }));
+    for (Relocation &r : reverse(relocs)) {
       ++relocCount;
       if (!target->hasAttr(r.type, RelocAttrBits::BRANCH))
         continue;

--- a/lld/MachO/EhFrame.cpp
+++ b/lld/MachO/EhFrame.cpp
@@ -109,16 +109,16 @@ template <bool Invert = false>
 static void createSubtraction(PointerUnion<Symbol *, InputSection *> a,
                               PointerUnion<Symbol *, InputSection *> b,
                               uint64_t off, uint8_t length,
-                              SmallVectorImpl<Reloc> *newRelocs) {
+                              SmallVectorImpl<Relocation> *newRelocs) {
   auto subtrahend = a;
   auto minuend = b;
   if (Invert)
     std::swap(subtrahend, minuend);
   assert(isa<Symbol *>(subtrahend));
-  Reloc subtrahendReloc(target->subtractorRelocType, /*pcrel=*/false, length,
-                        off, /*addend=*/0, subtrahend);
-  Reloc minuendReloc(target->unsignedRelocType, /*pcrel=*/false, length, off,
-                     (Invert ? 1 : -1) * off, minuend);
+  Relocation subtrahendReloc(target->subtractorRelocType, /*pcrel=*/false,
+                             length, off, /*addend=*/0, subtrahend);
+  Relocation minuendReloc(target->unsignedRelocType, /*pcrel=*/false, length,
+                          off, (Invert ? 1 : -1) * off, minuend);
   newRelocs->push_back(subtrahendReloc);
   newRelocs->push_back(minuendReloc);
 }

--- a/lld/MachO/EhFrame.h
+++ b/lld/MachO/EhFrame.h
@@ -108,7 +108,7 @@ private:
   InputSection *isec;
   // Insert new relocs here so that we don't invalidate iterators into the
   // existing relocs vector.
-  SmallVector<Reloc, 6> newRelocs;
+  SmallVector<Relocation, 6> newRelocs;
 };
 
 } // namespace lld::macho

--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -106,7 +106,7 @@ bool ICF::equalsConstant(const ConcatInputSection *ia,
     return false;
   if (ia->relocs.size() != ib->relocs.size())
     return false;
-  auto f = [](const Reloc &ra, const Reloc &rb) {
+  auto f = [](const Relocation &ra, const Relocation &rb) {
     if (ra.type != rb.type)
       return false;
     if (ra.pcrel != rb.pcrel)
@@ -213,7 +213,7 @@ bool ICF::equalsVariable(const ConcatInputSection *ia,
   if (verboseDiagnostics)
     ++equalsVariableCount;
   assert(ia->relocs.size() == ib->relocs.size());
-  auto f = [this](const Reloc &ra, const Reloc &rb) {
+  auto f = [this](const Relocation &ra, const Relocation &rb) {
     // We already filtered out mismatching values/addends in equalsConstant.
     if (ra.referent == rb.referent)
       return true;
@@ -390,7 +390,7 @@ void ICF::run() {
   for (icfPass = 0; icfPass < 2; ++icfPass) {
     parallelForEach(icfInputs, [&](ConcatInputSection *isec) {
       uint32_t hash = isec->icfEqClass[icfPass % 2];
-      for (const Reloc &r : isec->relocs) {
+      for (const Relocation &r : isec->relocs) {
         if (auto *sym = r.referent.dyn_cast<Symbol *>()) {
           if (auto *defined = dyn_cast<Defined>(sym)) {
             if (defined->isec()) {
@@ -520,7 +520,7 @@ void macho::markAddrSigSymbols() {
 
     const InputSection *isec = addrSigSection->subsections[0].isec;
 
-    for (const Reloc &r : isec->relocs) {
+    for (const Relocation &r : isec->relocs) {
       if (auto *sym = r.referent.dyn_cast<Symbol *>())
         markSymAsAddrSig(sym);
       else
@@ -609,7 +609,7 @@ void macho::foldIdenticalSections(bool onlyCfStrings) {
         // We have to do this copying serially as the BumpPtrAllocator is not
         // thread-safe. FIXME: Make a thread-safe allocator.
         MutableArrayRef<uint8_t> copy = isec->data.copy(bAlloc());
-        for (const Reloc &r : isec->relocs)
+        for (const Relocation &r : isec->relocs)
           target->relocateOne(copy.data() + r.offset, r, /*va=*/0,
                               /*relocVA=*/0);
         isec->data = copy;

--- a/lld/MachO/InputFiles.h
+++ b/lld/MachO/InputFiles.h
@@ -45,7 +45,7 @@ class ConcatInputSection;
 class Symbol;
 class Defined;
 class AliasSymbol;
-struct Reloc;
+struct Relocation;
 enum class RefState : uint8_t;
 
 // If --reproduce option is given, all input files are written

--- a/lld/MachO/InputSection.h
+++ b/lld/MachO/InputSection.h
@@ -56,7 +56,7 @@ public:
   // Format: Source.cpp:123 (/path/to/Source.cpp:123)
   std::string getSourceLocation(uint64_t off) const;
   // Return the relocation at \p off, if it exists. This does a linear search.
-  const Reloc *getRelocAt(uint32_t off) const;
+  const Relocation *getRelocAt(uint32_t off) const;
   // Whether the data at \p off in this InputSection is live.
   virtual bool isLive(uint64_t off) const = 0;
   virtual void markLive(uint64_t off) = 0;
@@ -88,7 +88,7 @@ public:
 
   OutputSection *parent = nullptr;
   ArrayRef<uint8_t> data;
-  std::vector<Reloc> relocs;
+  std::vector<Relocation> relocs;
   // The symbols that belong to this InputSection, sorted by value. With
   // .subsections_via_symbols, there is typically only one element here.
   llvm::TinyPtrVector<Defined *> symbols;

--- a/lld/MachO/MarkLive.cpp
+++ b/lld/MachO/MarkLive.cpp
@@ -154,7 +154,7 @@ void MarkLiveImpl<RecordWhyLive>::markTransitively() {
       assert(isec->live && "We mark as live when pushing onto the worklist!");
 
       // Mark all symbols listed in the relocation table for this section.
-      for (const Reloc &r : isec->relocs) {
+      for (const Relocation &r : isec->relocs) {
         if (auto *s = r.referent.dyn_cast<Symbol *>())
           addSym(s, entry);
         else
@@ -172,7 +172,7 @@ void MarkLiveImpl<RecordWhyLive>::markTransitively() {
       if (!(isec->getFlags() & S_ATTR_LIVE_SUPPORT) || isec->live)
         continue;
 
-      for (const Reloc &r : isec->relocs) {
+      for (const Relocation &r : isec->relocs) {
         if (auto *s = r.referent.dyn_cast<Symbol *>()) {
           if (s->isLive()) {
             InputSection *referentIsec = nullptr;

--- a/lld/MachO/Relocations.cpp
+++ b/lld/MachO/Relocations.cpp
@@ -18,10 +18,10 @@ using namespace llvm;
 using namespace lld;
 using namespace lld::macho;
 
-static_assert(sizeof(void *) != 8 || sizeof(Reloc) == 24,
+static_assert(sizeof(void *) != 8 || sizeof(Relocation) == 24,
               "Try to minimize Reloc's size; we create many instances");
 
-InputSection *Reloc::getReferentInputSection() const {
+InputSection *Relocation::getReferentInputSection() const {
   if (const auto *sym = referent.dyn_cast<Symbol *>()) {
     if (const auto *d = dyn_cast<Defined>(sym))
       return d->isec();
@@ -31,7 +31,7 @@ InputSection *Reloc::getReferentInputSection() const {
   }
 }
 
-StringRef Reloc::getReferentString() const {
+StringRef Relocation::getReferentString() const {
   if (auto *isec = dyn_cast<InputSection *>(referent)) {
     const auto *cisec = dyn_cast<CStringInputSection>(isec);
     assert(cisec && "referent must be a CStringInputSection");
@@ -57,7 +57,8 @@ StringRef Reloc::getReferentString() const {
 }
 
 bool macho::validateSymbolRelocation(const Symbol *sym,
-                                     const InputSection *isec, const Reloc &r) {
+                                     const InputSection *isec,
+                                     const Relocation &r) {
   const RelocAttrs &relocAttrs = target->getRelocAttrs(r.type);
   bool valid = true;
   auto message = [&](const Twine &diagnostic) {
@@ -117,7 +118,7 @@ InputSection *macho::offsetToInputSection(uint64_t *off) {
   return nullptr;
 }
 
-void macho::reportRangeError(void *loc, const Reloc &r, const Twine &v,
+void macho::reportRangeError(void *loc, const Relocation &r, const Twine &v,
                              uint8_t bits, int64_t min, uint64_t max) {
   std::string hint;
   uint64_t off = reinterpret_cast<const uint8_t *>(loc) - in.bufferStart;

--- a/lld/MachO/Relocations.h
+++ b/lld/MachO/Relocations.h
@@ -51,7 +51,7 @@ struct RelocAttrs {
   bool hasAttr(RelocAttrBits b) const { return (bits & b) == b; }
 };
 
-struct Reloc {
+struct Relocation {
   uint8_t type = llvm::MachO::GENERIC_RELOC_INVALID;
   bool pcrel = false;
   uint8_t length = 0;
@@ -63,10 +63,11 @@ struct Reloc {
   int64_t addend = 0;
   llvm::PointerUnion<Symbol *, InputSection *> referent = nullptr;
 
-  Reloc() = default;
+  Relocation() = default;
 
-  Reloc(uint8_t type, bool pcrel, uint8_t length, uint32_t offset,
-        int64_t addend, llvm::PointerUnion<Symbol *, InputSection *> referent)
+  Relocation(uint8_t type, bool pcrel, uint8_t length, uint32_t offset,
+             int64_t addend,
+             llvm::PointerUnion<Symbol *, InputSection *> referent)
       : type(type), pcrel(pcrel), length(length), offset(offset),
         addend(addend), referent(referent) {}
 
@@ -78,13 +79,13 @@ struct Reloc {
 };
 
 bool validateSymbolRelocation(const Symbol *, const InputSection *,
-                              const Reloc &);
+                              const Relocation &);
 
 /*
  * v: The value the relocation is attempting to encode
  * bits: The number of bits actually available to encode this relocation
  */
-void reportRangeError(void *loc, const Reloc &, const llvm::Twine &v,
+void reportRangeError(void *loc, const Relocation &, const llvm::Twine &v,
                       uint8_t bits, int64_t min, uint64_t max);
 
 struct SymbolDiagnostic {

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -2010,7 +2010,7 @@ uint64_t InitOffsetsSection::getSize() const {
 void InitOffsetsSection::writeTo(uint8_t *buf) const {
   // FIXME: Add function specified by -init when that argument is implemented.
   for (ConcatInputSection *isec : sections) {
-    for (const Reloc &rel : isec->relocs) {
+    for (const Relocation &rel : isec->relocs) {
       const Symbol *referent = cast<Symbol *>(rel.referent);
       assert(referent && "section relocation should have been rejected");
       uint64_t offset = referent->getVA() - in.header->addr;
@@ -2035,7 +2035,7 @@ void InitOffsetsSection::writeTo(uint8_t *buf) const {
 // not known at link time, stub-indirection has to be used.
 void InitOffsetsSection::setUp() {
   for (const ConcatInputSection *isec : sections) {
-    for (const Reloc &rel : isec->relocs) {
+    for (const Relocation &rel : isec->relocs) {
       RelocAttrs attrs = target->getRelocAttrs(rel.type);
       if (!attrs.hasAttr(RelocAttrBits::UNSIGNED))
         error(isec->getLocation(rel.offset) +
@@ -2076,7 +2076,7 @@ void ObjCMethListSection::setUp() {
 
     // Loop through all methods, and ensure a selref for each of them exists.
     while (methodNameOff < isec->data.size()) {
-      const Reloc *reloc = isec->getRelocAt(methodNameOff);
+      const Relocation *reloc = isec->getRelocAt(methodNameOff);
       assert(reloc && "Relocation expected at method list name slot");
 
       StringRef methname = reloc->getReferentString();
@@ -2177,7 +2177,7 @@ bool ObjCMethListSection::isMethodList(const ConcatInputSection *isec) {
 void ObjCMethListSection::writeRelativeOffsetForIsec(
     const ConcatInputSection *isec, uint8_t *buf, uint32_t &inSecOff,
     uint32_t &outSecOff, bool useSelRef) const {
-  const Reloc *reloc = isec->getRelocAt(inSecOff);
+  const Relocation *reloc = isec->getRelocAt(inSecOff);
   assert(reloc && "Relocation expected at __objc_methlist Offset");
 
   uint32_t symVA = 0;

--- a/lld/MachO/Target.h
+++ b/lld/MachO/Target.h
@@ -58,7 +58,7 @@ public:
   virtual int64_t
   getEmbeddedAddend(llvm::MemoryBufferRef, uint64_t offset,
                     const llvm::MachO::relocation_info) const = 0;
-  virtual void relocateOne(uint8_t *loc, const Reloc &, uint64_t va,
+  virtual void relocateOne(uint8_t *loc, const Relocation &, uint64_t va,
                            uint64_t relocVA) const = 0;
 
   // Write code for lazy binding. See the comments on StubsSection for more
@@ -119,7 +119,7 @@ public:
   // For now, handleDtraceReloc only implements -no_dtrace_dof, and ensures
   // that the linking would not fail even when there are user-provided dtrace
   // symbols. However, unlike ld64, lld currently does not emit __dof sections.
-  virtual void handleDtraceReloc(const Symbol *sym, const Reloc &r,
+  virtual void handleDtraceReloc(const Symbol *sym, const Relocation &r,
                                  uint8_t *loc) const {
     llvm_unreachable("Unsupported architecture for dtrace symbols");
   }

--- a/lld/MachO/UnwindInfoSection.cpp
+++ b/lld/MachO/UnwindInfoSection.cpp
@@ -232,7 +232,7 @@ void UnwindInfoSectionImpl::prepareRelocations(ConcatInputSection *isec) {
   // that are referenced from many places, at least some of them likely
   // live, it wouldn't reduce number of got entries.
   for (size_t i = 0; i < isec->relocs.size(); ++i) {
-    Reloc &r = isec->relocs[i];
+    Relocation &r = isec->relocs[i];
     assert(target->hasAttr(r.type, RelocAttrBits::UNSIGNED));
     // Since compact unwind sections aren't part of the inputSections vector,
     // they don't get canonicalized by scanRelocations(), so we have to do the
@@ -386,7 +386,7 @@ void UnwindInfoSectionImpl::relocateCompactUnwind(
     cu.functionLength =
         support::endian::read32le(buf + cuLayout.functionLengthOffset);
     cu.encoding = support::endian::read32le(buf + cuLayout.encodingOffset);
-    for (const Reloc &r : d->unwindEntry()->relocs) {
+    for (const Relocation &r : d->unwindEntry()->relocs) {
       if (r.offset == cuLayout.personalityOffset)
         cu.personality = cast<Symbol *>(r.referent);
       else if (r.offset == cuLayout.lsdaOffset)

--- a/lld/MachO/Writer.cpp
+++ b/lld/MachO/Writer.cpp
@@ -663,7 +663,7 @@ void Writer::treatSpecialUndefineds() {
 }
 
 static void prepareSymbolRelocation(Symbol *sym, const InputSection *isec,
-                                    const lld::macho::Reloc &r) {
+                                    const Relocation &r) {
   if (!sym->isLive()) {
     if (Defined *defined = dyn_cast<Defined>(sym)) {
       if (config->emitInitOffsets &&
@@ -707,7 +707,7 @@ void Writer::scanRelocations() {
       continue;
 
     for (auto it = isec->relocs.begin(); it != isec->relocs.end(); ++it) {
-      lld::macho::Reloc &r = *it;
+      Relocation &r = *it;
 
       // Canonicalize the referent so that later accesses in Writer won't
       // have to worry about it.

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -73,6 +73,56 @@ function(llvm_update_compile_flags name)
   target_compile_definitions(${name} PRIVATE ${LLVM_COMPILE_DEFINITIONS})
 endfunction()
 
+function(llvm_update_pch name)
+  if(LLVM_REQUIRES_RTTI OR LLVM_REQUIRES_EH)
+    # Non-default RTTI/EH results in incompatible flags, precluding PCH reuse.
+    set(ARG_DISABLE_PCH_REUSE ON)
+  endif()
+
+  # Find PCH with highest priority from dependencies. We reuse the first PCH
+  # with the highest priority. If the target has its own set of PCH, we give it
+  # a higher priority so that dependents will prefer the new PCH. We don't do
+  # transitive PCH reuse, because this causes too many unrelated naming
+  # collisions (e.g., in A -> B -> C{pch}, only B would reuse the PCH of C).
+  set(pch_priority 0)
+  llvm_map_components_to_libnames(libs
+    ${LLVM_LINK_COMPONENTS}
+  )
+  list(APPEND libs ${ARG_LINK_LIBS})
+  foreach(lib ${libs})
+    if(TARGET ${lib})
+      get_target_property(lib_pch_priority ${lib} LLVM_PCH_PRIORITY)
+      if(${lib_pch_priority} GREATER ${pch_priority})
+        set(pch_priority ${lib_pch_priority})
+        set(pch_reuse ${lib})
+      endif()
+    endif()
+  endforeach()
+
+  if(ARG_PRECOMPILE_HEADERS)
+    message(DEBUG "Adding PCH ${ARG_PRECOMPILE_HEADERS} for ${name} (prio ${pch_priority})")
+    target_precompile_headers(${name} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${ARG_PRECOMPILE_HEADERS}>)
+    if(NOT ARG_DISABLE_PCH_REUSE)
+      # Set priority so that dependants can reuse the PCH.
+      math(EXPR pch_priority "${pch_priority} + 1")
+      set_target_properties(${name} PROPERTIES LLVM_PCH_PRIORITY ${pch_priority})
+    endif()
+  elseif(pch_reuse AND NOT ARG_DISABLE_PCH_REUSE)
+    # This loop is purely for debugging to see what the actually used PCH is.
+    while(FALSE)
+      get_target_property(pch_reuse_parent ${pch_reuse} PRECOMPILE_HEADERS_REUSE_FROM)
+      if(${pch_reuse_parent} STREQUAL "pch_reuse_parent-NOTFOUND")
+        break()
+      endif()
+      set(pch_reuse ${pch_reuse_parent})
+    endwhile()
+    message(DEBUG "Using PCH ${pch_reuse} for ${name} (prio ${pch_priority})")
+    target_precompile_headers(${name} REUSE_FROM ${pch_reuse})
+  else()
+    message(DEBUG "Using NO PCH for ${name}")
+  endif()
+endfunction()
+
 function(add_llvm_symbol_exports target_name export_file)
   if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
     set(native_export_file "${target_name}.exports")
@@ -479,6 +529,13 @@ endfunction(set_windows_version_resource_properties)
 #     Corresponds to OUTPUT_NAME in target properties.
 #   DEPENDS targets...
 #     Same semantics as add_dependencies().
+#   PRECOMPILE_HEADERS include_directives...
+#     Pre-compiled C++ headers to use. PCH can be reused by dependants. If
+#     specified, no PCHs from dependencies will be reused.
+#   DISABLE_PCH_REUSE
+#     Disable reuse of pre-compiled headers in both directions: the library will
+#     not reuse the PCH of a dependency and a defined PCH will not be offered
+#     for reuse by dependants.
 #   LINK_COMPONENTS components...
 #     Same as the variable LLVM_LINK_COMPONENTS.
 #   LINK_LIBS lib_targets...
@@ -498,11 +555,12 @@ endfunction(set_windows_version_resource_properties)
 #   )
 function(llvm_add_library name)
   cmake_parse_arguments(ARG
-    "MODULE;SHARED;STATIC;OBJECT;DISABLE_LLVM_LINK_LLVM_DYLIB;SONAME;NO_INSTALL_RPATH;COMPONENT_LIB"
+    "MODULE;SHARED;STATIC;OBJECT;DISABLE_LLVM_LINK_LLVM_DYLIB;SONAME;NO_INSTALL_RPATH;COMPONENT_LIB;DISABLE_PCH_REUSE"
     "OUTPUT_NAME;PLUGIN_TOOL;ENTITLEMENTS;BUNDLE_PATH"
-    "ADDITIONAL_HEADERS;DEPENDS;LINK_COMPONENTS;LINK_LIBS;OBJLIBS"
+    "ADDITIONAL_HEADERS;PRECOMPILE_HEADERS;DEPENDS;LINK_COMPONENTS;LINK_LIBS;OBJLIBS"
     ${ARGN})
   list(APPEND LLVM_COMMON_DEPENDS ${ARG_DEPENDS})
+  list(APPEND LLVM_LINK_COMPONENTS ${ARG_LINK_COMPONENTS})
   if(ARG_ADDITIONAL_HEADERS)
     # Pass through ADDITIONAL_HEADERS.
     set(ARG_ADDITIONAL_HEADERS ADDITIONAL_HEADERS ${ARG_ADDITIONAL_HEADERS})
@@ -544,6 +602,7 @@ function(llvm_add_library name)
       ${ALL_FILES}
       )
     llvm_update_compile_flags(${obj_name})
+    llvm_update_pch(${obj_name})
     if(CMAKE_GENERATOR STREQUAL "Xcode")
       set(DUMMY_FILE ${CMAKE_CURRENT_BINARY_DIR}/Dummy.c)
       file(WRITE ${DUMMY_FILE} "// This file intentionally empty\n")
@@ -598,7 +657,7 @@ function(llvm_add_library name)
       ${output_name}
       OBJLIBS ${ALL_FILES} # objlib
       LINK_LIBS ${ARG_LINK_LIBS}
-      LINK_COMPONENTS ${ARG_LINK_COMPONENTS}
+      LINK_COMPONENTS ${LLVM_LINK_COMPONENTS}
       )
     set_target_properties(${name_static} PROPERTIES FOLDER "${subproject_title}/Libraries")
 
@@ -670,6 +729,11 @@ function(llvm_add_library name)
   # $<TARGET_OBJECTS> doesn't require compile flags.
   if(NOT obj_name)
     llvm_update_compile_flags(${name})
+    llvm_update_pch(${name})
+  else()
+    target_precompile_headers(${name} REUSE_FROM ${obj_name})
+    get_target_property(pch_priority ${obj_name} LLVM_PCH_PRIORITY)
+    set_target_properties(${name} PROPERTIES LLVM_PCH_PRIORITY ${pch_priority})
   endif()
   add_link_opts( ${name} )
   if(ARG_OUTPUT_NAME)
@@ -752,8 +816,7 @@ function(llvm_add_library name)
         target_compile_definitions(${name} PRIVATE LLVM_BUILD_STATIC)
       endif()
       llvm_map_components_to_libnames(llvm_libs
-       ${ARG_LINK_COMPONENTS}
-       ${LLVM_LINK_COMPONENTS}
+        ${LLVM_LINK_COMPONENTS}
        )
     endif()
   else()
@@ -764,7 +827,7 @@ function(llvm_add_library name)
     # It would be nice to verify that we have the dependencies for this library
     # name, but using get_property(... SET) doesn't suffice to determine if a
     # property has been set to an empty value.
-    set_property(TARGET ${name} PROPERTY LLVM_LINK_COMPONENTS ${ARG_LINK_COMPONENTS} ${LLVM_LINK_COMPONENTS})
+    set_property(TARGET ${name} PROPERTY LLVM_LINK_COMPONENTS ${LLVM_LINK_COMPONENTS})
 
     # This property is an internal property only used to make sure the
     # link step applied in LLVMBuildResolveComponentsLink uses the same
@@ -987,6 +1050,7 @@ macro(generate_llvm_objects name)
       ${ALL_FILES}
       )
     llvm_update_compile_flags(${obj_name})
+    llvm_update_pch(${obj_name})
     set(ALL_FILES "$<TARGET_OBJECTS:${obj_name}>")
     if(ARG_DEPENDS)
       add_dependencies(${obj_name} ${ARG_DEPENDS})
@@ -1026,7 +1090,7 @@ endmacro()
 
 macro(add_llvm_executable name)
   cmake_parse_arguments(ARG
-    "DISABLE_LLVM_LINK_LLVM_DYLIB;IGNORE_EXTERNALIZE_DEBUGINFO;NO_INSTALL_RPATH;SUPPORT_PLUGINS;EXPORT_SYMBOLS"
+    "DISABLE_LLVM_LINK_LLVM_DYLIB;IGNORE_EXTERNALIZE_DEBUGINFO;NO_INSTALL_RPATH;SUPPORT_PLUGINS;EXPORT_SYMBOLS;DISABLE_PCH_REUSE"
     "ENTITLEMENTS;BUNDLE_PATH"
     ""
     ${ARGN})
@@ -1067,6 +1131,11 @@ macro(add_llvm_executable name)
   # $<TARGET_OBJECTS> doesn't require compile flags.
   if(NOT LLVM_ENABLE_OBJLIB)
     llvm_update_compile_flags(${name})
+    llvm_update_pch(${name})
+  else()
+    target_precompile_headers(${name} REUSE_FROM ${obj_name})
+    get_target_property(pch_priority ${obj_name} LLVM_PCH_PRIORITY)
+    set_target_properties(${name} PROPERTIES LLVM_PCH_PRIORITY ${pch_priority})
   endif()
 
   if (ARG_SUPPORT_PLUGINS AND NOT "${CMAKE_SYSTEM_NAME}" MATCHES "AIX")
@@ -1774,7 +1843,7 @@ function(add_unittest test_suite test_name)
   endif()
 
   list(APPEND LLVM_LINK_COMPONENTS Support) # gtest needs it for raw_ostream
-  add_llvm_executable(${test_name} IGNORE_EXTERNALIZE_DEBUGINFO NO_INSTALL_RPATH ${ARGN})
+  add_llvm_executable(${test_name} IGNORE_EXTERNALIZE_DEBUGINFO NO_INSTALL_RPATH DISABLE_PCH_REUSE ${ARGN})
   get_subproject_title(subproject_title)
   set_target_properties(${test_name} PROPERTIES FOLDER "${subproject_title}/Tests/Unit")
 

--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -1304,6 +1304,16 @@ if (LLVM_BUILD_INSTRUMENTED AND LLVM_BUILD_INSTRUMENTED_COVERAGE)
   message(FATAL_ERROR "LLVM_BUILD_INSTRUMENTED and LLVM_BUILD_INSTRUMENTED_COVERAGE cannot both be specified")
 endif()
 
+if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Clang requires this flag in order for precompiled headers to work with ccache
+    append("-Xclang -fno-pch-timestamp" CMAKE_CXX_FLAGS)
+  elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # GCC requires this flag in order for precompiled headers to work with ccache
+    append("-fpch-preprocess" CMAKE_CXX_FLAGS)
+  endif()
+endif()
+
 set(LLVM_THINLTO_CACHE_PATH "${PROJECT_BINARY_DIR}/lto.cache" CACHE STRING "Set ThinLTO cache path. This can be used when building LLVM from several different directiories.")
 
 if(LLVM_ENABLE_LTO AND WIN32 AND NOT LINKER_IS_LLD_LINK AND NOT MINGW)

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsAddObjectFile/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsAddObjectFile/CMakeLists.txt
@@ -12,4 +12,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_example(OrcV2CBindingsAddObjectFile
   OrcV2CBindingsAddObjectFile.c
+
+  DISABLE_PCH_REUSE # no C++ files, prevent CMake error.
   )

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsBasicUsage/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsBasicUsage/CMakeLists.txt
@@ -12,4 +12,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_example(OrcV2CBindingsBasicUsage
   OrcV2CBindingsBasicUsage.c
+
+  DISABLE_PCH_REUSE # no C++ files, prevent CMake error.
   )

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsDumpObjects/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsDumpObjects/CMakeLists.txt
@@ -12,4 +12,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_example(OrcV2CBindingsDumpObjects
   OrcV2CBindingsDumpObjects.c
+
+  DISABLE_PCH_REUSE # no C++ files, prevent CMake error.
   )

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsIRTransforms/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsIRTransforms/CMakeLists.txt
@@ -13,4 +13,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_example(OrcV2CBindingsIRTransforms
   OrcV2CBindingsIRTransforms.c
+
+  DISABLE_PCH_REUSE # no C++ files, prevent CMake error.
   )

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsLazy/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsLazy/CMakeLists.txt
@@ -12,4 +12,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_example(OrcV2CBindingsLazy
   OrcV2CBindingsLazy.c
+
+  DISABLE_PCH_REUSE # no C++ files, prevent CMake error.
   )

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsMCJITLikeMemoryManager/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsMCJITLikeMemoryManager/CMakeLists.txt
@@ -12,4 +12,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_example(OrcV2CBindingsMCJITLikeMemoryManager
   OrcV2CBindingsMCJITLikeMemoryManager.c
+
+  DISABLE_PCH_REUSE # no C++ files, prevent CMake error.
   )

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsRemovableCode/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsRemovableCode/CMakeLists.txt
@@ -12,4 +12,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_example(OrcV2CBindingsRemovableCode
   OrcV2CBindingsRemovableCode.c
+
+  DISABLE_PCH_REUSE # no C++ files, prevent CMake error.
   )

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsVeryLazy/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsVeryLazy/CMakeLists.txt
@@ -12,4 +12,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_example(OrcV2CBindingsVeryLazy
   OrcV2CBindingsVeryLazy.c
+
+  DISABLE_PCH_REUSE # no C++ files, prevent CMake error.
   )

--- a/llvm/include/llvm/CodeGen/pch.h
+++ b/llvm/include/llvm/CodeGen/pch.h
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Precompiled header for LLVMCodeGen.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CodeGen/MachineFrameInfo.h"
+#include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/MachineScheduler.h"
+#include "llvm/CodeGen/SelectionDAG.h"
+#include "llvm/CodeGen/SelectionDAGNodes.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/CodeGen/TargetLowering.h"
+#include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/IR/pch.h"
+#include "llvm/Support/pch.h"

--- a/llvm/include/llvm/IR/pch.h
+++ b/llvm/include/llvm/IR/pch.h
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Precompiled header for LLVMCore.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/Constant.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/Dominators.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/Instruction.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/ModuleSummaryIndex.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/IR/PatternMatch.h"
+#include "llvm/IR/Value.h"
+#include "llvm/Support/pch.h"

--- a/llvm/include/llvm/Support/pch.h
+++ b/llvm/include/llvm/Support/pch.h
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Precompiled header for LLVMSupport.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/ADL.h"
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/VersionTuple.h"
+#include "llvm/Support/YAMLTraits.h"
+#include "llvm/Support/raw_ostream.h"
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <bitset>
+#include <cassert>
+#include <chrono>
+#include <climits>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <deque>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <limits>
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <new>
+#include <optional>
+#include <queue>
+#include <set>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+#include <vector>

--- a/llvm/lib/CMakeLists.txt
+++ b/llvm/lib/CMakeLists.txt
@@ -3,8 +3,8 @@ include(LLVM-Build)
 # `Demangle', `Support' and `TableGen' libraries are added on the top-level
 # CMakeLists.txt
 
-add_subdirectory(ABI)
 add_subdirectory(IR)
+add_subdirectory(ABI)
 add_subdirectory(FuzzMutate)
 add_subdirectory(FileCheck)
 add_subdirectory(InterfaceStub)

--- a/llvm/lib/CodeGen/CMakeLists.txt
+++ b/llvm/lib/CodeGen/CMakeLists.txt
@@ -267,6 +267,9 @@ add_llvm_component_library(LLVMCodeGen
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/CodeGen
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/CodeGen/PBQP
 
+  PRECOMPILE_HEADERS
+  [["llvm/CodeGen/pch.h"]]
+
   LINK_LIBS ${LLVM_PTHREAD_LIB} ${MLLinkDeps}
 
   DEPENDS

--- a/llvm/lib/IR/CMakeLists.txt
+++ b/llvm/lib/IR/CMakeLists.txt
@@ -83,6 +83,9 @@ add_llvm_component_library(LLVMCore
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/IR
 
+  PRECOMPILE_HEADERS
+  [["llvm/IR/pch.h"]]
+
   LINK_LIBS
   ${LLVM_PTHREAD_LIB}
 

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -135,7 +135,6 @@ if (UNIX AND "${CMAKE_SYSTEM_NAME}" MATCHES "AIX")
 endif()
 
 add_subdirectory(BLAKE3)
-add_subdirectory(LSP)
 
 add_llvm_component_library(LLVMSupport
   ABIBreak.cpp
@@ -322,6 +321,9 @@ add_llvm_component_library(LLVMSupport
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Support
   ${Backtrace_INCLUDE_DIRS}
 
+  PRECOMPILE_HEADERS
+  [["llvm/Support/pch.h"]]
+
   LINK_LIBS
   ${system_libs} ${imported_libs} ${delayload_flags}
 
@@ -396,3 +398,6 @@ target_include_directories(LLVMSupport
   PRIVATE
   ${LLVM_THIRD_PARTY_DIR}/siphash/include
 )
+
+# SupportLSP depends on Support and therefore must be included afterwards.
+add_subdirectory(LSP)

--- a/llvm/tools/llvm-c-test/CMakeLists.txt
+++ b/llvm/tools/llvm-c-test/CMakeLists.txt
@@ -53,6 +53,8 @@ add_llvm_tool(llvm-c-test
   metadata.c
   object.c
   targets.c
+
+  DISABLE_PCH_REUSE # no C++ files, prevent CMake error.
   )
 
 if(USE_LLVM_DYLIB)

--- a/llvm/unittests/Support/raw_sha1_ostream_test.cpp
+++ b/llvm/unittests/Support/raw_sha1_ostream_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_sha1_ostream.h"
 #include "gtest/gtest.h"
@@ -13,20 +14,6 @@
 #include <string>
 
 using namespace llvm;
-
-static std::string toHex(ArrayRef<uint8_t> Input) {
-  static const char *const LUT = "0123456789ABCDEF";
-  size_t Length = Input.size();
-
-  std::string Output;
-  Output.reserve(2 * Length);
-  for (size_t i = 0; i < Length; ++i) {
-    const unsigned char c = Input[i];
-    Output.push_back(LUT[c >> 4]);
-    Output.push_back(LUT[c & 15]);
-  }
-  return Output;
-}
 
 TEST(raw_sha1_ostreamTest, Basic) {
   llvm::raw_sha1_ostream Sha1Stream;

--- a/llvm/utils/count/CMakeLists.txt
+++ b/llvm/utils/count/CMakeLists.txt
@@ -4,4 +4,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_utility(count
   count.c
+
+  DISABLE_PCH_REUSE # no C++ files, prevent CMake error.
   )

--- a/mlir/test/CAPI/CMakeLists.txt
+++ b/mlir/test/CAPI/CMakeLists.txt
@@ -8,6 +8,7 @@ function(_add_capi_test_executable name)
     )
   add_llvm_executable(${name}
     PARTIAL_SOURCES_INTENDED
+    DISABLE_PCH_REUSE # no C++ files, prevent CMake error.
     ${ARG_UNPARSED_ARGUMENTS})
   set_target_properties(${name} PROPERTIES FOLDER "MLIR/Tests")
   set_target_properties(${name} PROPERTIES EXCLUDE_FROM_ALL ON)

--- a/third-party/unittest/CMakeLists.txt
+++ b/third-party/unittest/CMakeLists.txt
@@ -13,6 +13,8 @@
 
 set(LLVM_SUBPROJECT_TITLE "Third-Party/Google Test")
 
+set(GTEST_PCH [["gtest/gtest.h"]])
+
 if(LLVM_RUNTIMES_BUILD)
   # This instance of GTest is use for unittests for the runtime libraries. It
   # must not link to LLVMSupport (used for llvm::raw_ostream and llvm::cl
@@ -37,6 +39,7 @@ else()
   set(GTEST_LLVM_COMPONENTS "Support")
   set(gtest_name "llvm_gtest")
   set(gtest_main_src UnitTestMain/TestMain.cpp)
+  list(APPEND GTEST_PCH [["llvm/Support/pch.h"]])
 endif()
 
 if(WIN32)
@@ -59,7 +62,6 @@ if(CXX_SUPPORTS_COVERED_SWITCH_DEFAULT_FLAG)
   add_definitions("-Wno-covered-switch-default")
 endif()
 
-set(LLVM_REQUIRES_RTTI 1)
 add_definitions( -DGTEST_HAS_RTTI=0 )
 
 if (HAVE_LIBPTHREAD)
@@ -75,6 +77,9 @@ endif ()
 add_llvm_library("${gtest_name}"
   googletest/src/gtest-all.cc
   googlemock/src/gmock-all.cc
+
+  PRECOMPILE_HEADERS
+  ${GTEST_PCH}
 
   LINK_LIBS
   ${LIBS}


### PR DESCRIPTION
Building LLVM is slow and dominated by the C++ front-end. Most time is spent in (repeatedly) parsing headers. C++ modules build didn't really help, is fragile, and kills parallelism. Therefore, I propose to use PCH for frequently used headers (i.e., C++ stdlib, Support, IR, CodeGen). There shouldn't be much difference for incremental compilation, as many headers I put into the PCHs transitively get included into most source files anyway.

Time breakdown in seconds for building libLLVM.so (collected with -ftime-trace, -O1, -DLLVM_TARGETS_TO_BUILD="X86;AArch64"):

```
Phase                           main main+TPDE+PCH
------------------------------- ---- -------------
ExecuteCompiler                 9913          4084
Frontend                        7842          2773 (PCH difference)
  Source                        5471          1213
  PerformPendingInstantiations  1837           916
  CodeGen Function               248           278
Backend                         2014          1256
  Optimizer                     1332          1243 (probably just measurement noise)
  CodeGenPasses                  675             3 (TPDE fallbacks to LLVM for 10 CUs)
  TPDE                             0             7

wall-time [s] (48c/96t)       126.48         66.04
(AMD EPYC 9454P, 2.75-3.80 GHz, 372 GiB memory)
```
(Edit: new data with idle machine + assertions disabled, individual results are still a bit noisy due to hyper-threading; no substantial change in relative factors.) (NB: on this machine, much larger wall-time reductions are rather unlikely: SLPVectorizer.cpp takes >40s alone.)

The back-end is not really relevant here, but enabling PCH (this PR) reduces the front-end time by 2x. On [c-t-t, this shows up as a 30% wall-time/instructions reduction in stage2-clang](https://llvm-compile-time-tracker.com/compare.php?from=937009a76c6af9799ccbf89d7d8a07dbb4917f86&to=8e38a6f850d685a437a5bf6a8823c7996ba484bd&stat=instructions:u). Further improvements for Clang should also be possible (clang/AST/Decl.h is expensive with 1219s), but is not trivial due to the use of object libraries.

I'm opening this PR for early feedback/direction before spending more time on this:

- Does this extensive PCH use has a reasonable chance of getting merged?
  - How to deal with newly occuring name collisions? (e.g. llvm::Reloc from llvm/Support/CodeGen.h vs. lld::macho::Reloc from lld/MachO/Relocations.h; where e.g. lld/MachO/InputSections.cpp uses both namespaces)
- Enable by default vs. not? E.g., CI should probably not use this to catch missing includes, but CI should also keep it working as PCHs can lead to new errors.
- PCH reuse is currently hard-coded in llvm_add_library, how to make this more elegant?

cc @nikic @rnk @boomanaiden154 (not sure who else is interested in LLVM build times + looking at CMake)