### PR TITLE
[MLIR][Python] Refine the support of `RewritePatternSet.add`

### DIFF
--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -291,7 +291,7 @@ void mlir::python::populateRewriteSubmodule(nb::module_ &m) {
           },
           "root"_a, "fn"_a, "benefit"_a = 1,
           // clang-format off
-          nb::sig("def add(self, root: type | str, fn: Callable[[" MAKE_MLIR_PYTHON_QUALNAME("ir.Operation") ", PatternRewriter], Any], benefit: int = 1) -> None"),
+          nb::sig("def add(self, root: type | str, fn: typing.Callable[[" MAKE_MLIR_PYTHON_QUALNAME("ir.Operation") ", PatternRewriter], typing.Any], benefit: int = 1) -> None"),
           // clang-format on
           R"(
             Add a new rewrite pattern on the given root operation with the

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -294,18 +294,20 @@ void mlir::python::populateRewriteSubmodule(nb::module_ &m) {
           nb::sig("def add(self, root: type | str, fn: typing.Callable[[" MAKE_MLIR_PYTHON_QUALNAME("ir.Operation") ", PatternRewriter], typing.Any], benefit: int = 1) -> None"),
           // clang-format on
           R"(
-            Add a new rewrite pattern on the given root operation with the
-            callable as the matching and rewriting function and the given benefit.
+            Add a new rewrite pattern on the specified root operation, using the provided callable
+            for matching and rewriting, and assign it the given benefit.
 
             Args:
-              root: The root operation to apply the pattern on,
-                    which can be an OpView subclass (e.g. arith.AddIOp)
-                    or an operation name string (e.g. "arith.addi").
+              root: The root operation to which this pattern applies.
+                    This may be either an OpView subclass (e.g., ``arith.AddIOp``) or
+                    an operation name string (e.g., ``"arith.addi"``).
               fn: The callable to use for matching and rewriting,
                   which takes an operation and a pattern rewriter as arguments.
-                  The matching succeeds iff the callable returns
-                  a value castable to False (e.g. None).
-              benefit: The benefit of the pattern, defaults to 1.)")
+                  The match is considered successful iff the callable returns
+                  a value where ``bool(value)`` is ``False`` (e.g. ``None``).
+                  If possible, the operation is cast to its corresponding OpView subclass
+                  before being passed to the callable.
+              benefit: The benefit of the pattern, defaulting to 1.)")
       .def("freeze", &PyRewritePatternSet::freeze,
            "Freeze the pattern set into a frozen one.");
 

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -299,10 +299,12 @@ void mlir::python::populateRewriteSubmodule(nb::module_ &m) {
 
             Args:
               root: The root operation to apply the pattern on,
-                    which can be an OpView class (type) or an operation name (str).
+                    which can be an OpView subclass (e.g. arith.AddIOp)
+                    or an operation name string (e.g. "arith.addi").
               fn: The callable to use for matching and rewriting,
                   which takes an operation and a pattern rewriter as arguments.
-                  The matching succeeds iff the callable returns a value castable to False (e.g. None).
+                  The matching succeeds iff the callable returns
+                  a value castable to False (e.g. None).
               benefit: The benefit of the pattern, defaults to 1.)")
       .def("freeze", &PyRewritePatternSet::freeze,
            "Freeze the pattern set into a frozen one.");

--- a/mlir/test/python/rewrite.py
+++ b/mlir/test/python/rewrite.py
@@ -32,7 +32,7 @@ def testRewritePattern():
     with Context():
         patterns = RewritePatternSet()
         patterns.add(arith.AddIOp, to_muli)
-        patterns.add(arith.ConstantOp, constant_1_to_2)
+        patterns.add("arith.constant", constant_1_to_2)
         frozen = patterns.freeze()
 
         module = ModuleOp.parse(


### PR DESCRIPTION
This patch includes the following changes:
- `RewritePatternSet.add` now accepts op name (e.g. `.add("arith.addi", fn)`) besides op class (e.g. `.add(arith.AddIOp, fn)`)
- add a concrete signature and a more complete docstring to `RewritePatternSet.add`.