### PR TITLE
InstCombine: Introduce nsz flag on minimum/maximum in SimplifyDemandedFPClass

### DIFF
--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-maximum.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-maximum.ll
@@ -58,7 +58,7 @@ define nofpclass(inf norm sub zero) float @ret_only_nan(float %x, float %y) {
 define nofpclass(inf norm sub zero qnan) float @ret_only_snan(float %x, float %y) {
 ; CHECK-LABEL: define nofpclass(qnan inf zero sub norm) float @ret_only_snan(
 ; CHECK-SAME: float [[X:%.*]], float [[Y:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[X]], float [[Y]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %x, float %y)
@@ -68,7 +68,7 @@ define nofpclass(inf norm sub zero qnan) float @ret_only_snan(float %x, float %y
 define nofpclass(inf norm sub zero snan) float @ret_only_qnan(float %x, float %y) {
 ; CHECK-LABEL: define nofpclass(snan inf zero sub norm) float @ret_only_qnan(
 ; CHECK-SAME: float [[X:%.*]], float [[Y:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[X]], float [[Y]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %x, float %y)
@@ -78,7 +78,7 @@ define nofpclass(inf norm sub zero snan) float @ret_only_qnan(float %x, float %y
 define nofpclass(nan norm sub zero) float @ret_only_inf(float %x, float %y) {
 ; CHECK-LABEL: define nofpclass(nan zero sub norm) float @ret_only_inf(
 ; CHECK-SAME: float [[X:%.*]], float [[Y:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[X]], float [[Y]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.maximum.f32(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %x, float %y)
@@ -412,7 +412,7 @@ define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_1() {
 define nofpclass(nsub) float @lhs_must_be_pinf_or_nan(float %unknown, float nofpclass(ninf norm zero sub) %must.be.pinf.or.nan) {
 ; CHECK-LABEL: define nofpclass(nsub) float @lhs_must_be_pinf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(ninf zero sub norm) [[MUST_BE_PINF_OR_NAN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[MUST_BE_PINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[MUST_BE_PINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %must.be.pinf.or.nan, float %unknown)
@@ -422,7 +422,7 @@ define nofpclass(nsub) float @lhs_must_be_pinf_or_nan(float %unknown, float nofp
 define nofpclass(nsub) float @rhs_must_be_pinf_or_nan(float nofpclass(ninf norm zero sub) %must.be.pinf.or.nan, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nsub) float @rhs_must_be_pinf_or_nan(
 ; CHECK-SAME: float nofpclass(ninf zero sub norm) [[MUST_BE_PINF_OR_NAN:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN]], float [[MUST_BE_PINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN]], float [[MUST_BE_PINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %unknown, float %must.be.pinf.or.nan)
@@ -432,7 +432,7 @@ define nofpclass(nsub) float @rhs_must_be_pinf_or_nan(float nofpclass(ninf norm 
 define nofpclass(nsub) float @lhs_must_be_pinf(float %unknown, float nofpclass(nan ninf norm zero sub) %must.be.pinf) {
 ; CHECK-LABEL: define nofpclass(nsub) float @lhs_must_be_pinf(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(nan ninf zero sub norm) [[MUST_BE_PINF:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %must.be.pinf, float %unknown)
@@ -442,7 +442,7 @@ define nofpclass(nsub) float @lhs_must_be_pinf(float %unknown, float nofpclass(n
 define nofpclass(nsub) float @rhs_must_be_pinf(float nofpclass(nan ninf norm zero sub) %must.be.pinf, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nsub) float @rhs_must_be_pinf(
 ; CHECK-SAME: float nofpclass(nan ninf zero sub norm) [[MUST_BE_PINF:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %unknown, float %must.be.pinf)
@@ -472,7 +472,7 @@ define nofpclass(nsub) float @rhs_must_be_pinf_lhs_non_nan(float nofpclass(nan n
 define nofpclass(nsub) float @lhs_must_be_ninf_or_nan(float %unknown, float nofpclass(pinf norm zero sub) %must.be.ninf.or.nan) {
 ; CHECK-LABEL: define nofpclass(nsub) float @lhs_must_be_ninf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(pinf zero sub norm) [[MUST_BE_NINF_OR_NAN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[MUST_BE_NINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[MUST_BE_NINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %must.be.ninf.or.nan, float %unknown)
@@ -482,7 +482,7 @@ define nofpclass(nsub) float @lhs_must_be_ninf_or_nan(float %unknown, float nofp
 define nofpclass(nsub) float @rhs_must_be_ninf_or_nan(float nofpclass(pinf norm zero sub) %must.be.ninf.or.nan, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nsub) float @rhs_must_be_ninf_or_nan(
 ; CHECK-SAME: float nofpclass(pinf zero sub norm) [[MUST_BE_NINF_OR_NAN:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN]], float [[MUST_BE_NINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN]], float [[MUST_BE_NINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %unknown, float %must.be.ninf.or.nan)
@@ -551,7 +551,7 @@ define nofpclass(pzero) float @result_not_pzero(float %unknown0, float %unknown1
 define nofpclass(zero) float @result_not_zero(float %unknown0, float %unknown1) {
 ; CHECK-LABEL: define nofpclass(zero) float @result_not_zero(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %unknown0, float %unknown1)
@@ -581,7 +581,7 @@ define nofpclass(zero) float @result_not_zero__dynamic(float %unknown0, float %u
 define nofpclass(zero) float @result_not_zero_or_sub(float %unknown0, float %unknown1) {
 ; CHECK-LABEL: define nofpclass(zero) float @result_not_zero_or_sub(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %unknown0, float %unknown1)
@@ -591,7 +591,7 @@ define nofpclass(zero) float @result_not_zero_or_sub(float %unknown0, float %unk
 define nofpclass(zero sub) float @result_not_zero_or_sub__daz(float %unknown0, float %unknown1) #0 {
 ; CHECK-LABEL: define nofpclass(zero sub) float @result_not_zero_or_sub__daz(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) #[[ATTR0]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %unknown0, float %unknown1)
@@ -601,7 +601,7 @@ define nofpclass(zero sub) float @result_not_zero_or_sub__daz(float %unknown0, f
 define nofpclass(zero sub) float @result_not_zero_or_sub__dynamic(float %unknown0, float %unknown1) #1 {
 ; CHECK-LABEL: define nofpclass(zero sub) float @result_not_zero_or_sub__dynamic(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %unknown0, float %unknown1)
@@ -611,7 +611,7 @@ define nofpclass(zero sub) float @result_not_zero_or_sub__dynamic(float %unknown
 define nofpclass(snan) float @lhs_not_zero(float nofpclass(zero) %not.zero, float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @lhs_not_zero(
 ; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_ZERO]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_ZERO]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %not.zero, float %unknown)
@@ -621,7 +621,7 @@ define nofpclass(snan) float @lhs_not_zero(float nofpclass(zero) %not.zero, floa
 define nofpclass(snan) float @rhs_not_zero(float %unknown, float nofpclass(zero) %not.zero) {
 ; CHECK-LABEL: define nofpclass(snan) float @rhs_not_zero(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN]], float [[NOT_ZERO]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN]], float [[NOT_ZERO]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %unknown, float %not.zero)
@@ -631,7 +631,7 @@ define nofpclass(snan) float @rhs_not_zero(float %unknown, float nofpclass(zero)
 define nofpclass(snan) float @sources_not_zero(float nofpclass(zero) %not.zero0, float nofpclass(zero) %not.zero1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero(
 ; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO0:%.*]], float nofpclass(zero) [[NOT_ZERO1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_ZERO0]], float [[NOT_ZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_ZERO0]], float [[NOT_ZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %not.zero0, float %not.zero1)
@@ -648,9 +648,9 @@ define nofpclass(snan) float @sources_not_zero__daz(float nofpclass(zero) %not.z
   ret float %result
 }
 
-define nofpclass(snan) float @sources_not_zero__dynamic(float nofpclass(zero) %not.zero0, float nofpclass(zero) %not.zero1) #2 {
+define nofpclass(snan) float @sources_not_zero__dynamic(float nofpclass(zero) %not.zero0, float nofpclass(zero) %not.zero1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero__dynamic(
-; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO0:%.*]], float nofpclass(zero) [[NOT_ZERO1:%.*]]) {
+; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO0:%.*]], float nofpclass(zero) [[NOT_ZERO1:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_ZERO0]], float [[NOT_ZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
@@ -661,7 +661,7 @@ define nofpclass(snan) float @sources_not_zero__dynamic(float nofpclass(zero) %n
 define nofpclass(snan) float @sources_not_zero_or_sub(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero_or_sub(
 ; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %not.zero.sub.0, float %not.zero.sub.1)
@@ -671,17 +671,17 @@ define nofpclass(snan) float @sources_not_zero_or_sub(float nofpclass(zero sub) 
 define nofpclass(snan) float @sources_not_zero_or_sub__daz(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero_or_sub__daz(
 ; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %not.zero.sub.0, float %not.zero.sub.1)
   ret float %result
 }
 
-define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) #2 {
+define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(
-; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
+; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %not.zero.sub.0, float %not.zero.sub.1)
@@ -691,7 +691,7 @@ define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(float nofpclass(z
 define nofpclass(snan) float @sources_not_nzero(float nofpclass(nzero) %not.nzero0, float nofpclass(nzero) %not.nzero1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_nzero(
 ; CHECK-SAME: float nofpclass(nzero) [[NOT_NZERO0:%.*]], float nofpclass(nzero) [[NOT_NZERO1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %not.nzero0, float %not.nzero1)
@@ -701,7 +701,7 @@ define nofpclass(snan) float @sources_not_nzero(float nofpclass(nzero) %not.nzer
 define nofpclass(snan) float @sources_not_pzero(float nofpclass(pzero) %not.pzero0, float nofpclass(pzero) %not.pzero1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_pzero(
 ; CHECK-SAME: float nofpclass(pzero) [[NOT_PZERO0:%.*]], float nofpclass(pzero) [[NOT_PZERO1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_PZERO0]], float [[NOT_PZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_PZERO0]], float [[NOT_PZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %not.pzero0, float %not.pzero1)
@@ -771,7 +771,7 @@ define nofpclass(snan) float @rhs_not_nzero_lhs_not_pzero__dynamic(float nofpcla
 define nofpclass(snan) float @sources_not_nzero_nsub__dynamic(float nofpclass(nzero nsub) %not.nzero0, float nofpclass(nzero nsub) %not.nzero1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_nzero_nsub__dynamic(
 ; CHECK-SAME: float nofpclass(nzero nsub) [[NOT_NZERO0:%.*]], float nofpclass(nzero nsub) [[NOT_NZERO1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximum.f32(float %not.nzero0, float %not.nzero1)
@@ -1159,7 +1159,7 @@ define nofpclass(pinf pnorm psub) float @ret_always_positive_nonzero__maximum__n
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
 ; CHECK-NEXT:    [[ALWAYS_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[SELECT_RHS:%.*]] = select i1 [[COND]], float [[ALWAYS_POSITIVE]], float [[UNKNOWN]]
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %always.positive = call float @returns_positive()
@@ -1173,7 +1173,7 @@ define nofpclass(pinf pnorm psub) float @ret_always_positive_nonzero__maximum__n
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
 ; CHECK-NEXT:    [[ALWAYS_NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[SELECT_RHS:%.*]] = select i1 [[COND]], float [[ALWAYS_NEGATIVE]], float [[UNKNOWN]]
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %always.negative = call float @returns_negative()
@@ -1186,7 +1186,7 @@ define nofpclass(snan) float @known_positive__maximum__only_pzero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive__maximum__only_pzero_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[KNOWN_PZERO_OR_NAN:%.*]] = call float @returns_pzero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[KNOWN_POSITIVE]], float [[KNOWN_PZERO_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[KNOWN_POSITIVE]], float [[KNOWN_PZERO_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %known.positive = call float @returns_positive()
@@ -1345,7 +1345,7 @@ define nofpclass(snan) float @pinf__maximum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @pinf__maximum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PINF:%.*]] = call float @returns_pinf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf = call float @returns_pinf()
@@ -1357,7 +1357,7 @@ define nofpclass(snan) float @unknown__maximum__pinf(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__maximum__pinf(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PINF:%.*]] = call float @returns_pinf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf = call float @returns_pinf()
@@ -1369,7 +1369,7 @@ define nofpclass(snan) float @pinf_or_nan__maximum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @pinf_or_nan__maximum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PINF_OR_NAN:%.*]] = call float @returns_pinf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[PINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[PINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf.or.nan = call float @returns_pinf_or_nan()
@@ -1381,7 +1381,7 @@ define nofpclass(snan) float @unknown__maximum__pinf_or_nan(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__maximum__pinf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PINF_OR_NAN:%.*]] = call float @returns_pinf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN]], float [[PINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN]], float [[PINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf.or.nan = call float @returns_pinf_or_nan()
@@ -1415,7 +1415,7 @@ define nofpclass(snan) float @ninf_or_nan__maximum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @ninf_or_nan__maximum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NINF_OR_NAN:%.*]] = call float @returns_ninf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf.or.nan = call float @returns_ninf_or_nan()
@@ -1427,7 +1427,7 @@ define nofpclass(snan) float @unknown__maximum__ninf_or_nan(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__maximum__ninf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NINF_OR_NAN:%.*]] = call float @returns_ninf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN]], float [[NINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN]], float [[NINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf.or.nan = call float @returns_ninf_or_nan()
@@ -1439,7 +1439,7 @@ define nofpclass(snan) float @inf__maximum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @inf__maximum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[INF]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[INF]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf = call float @returns_inf()
@@ -1451,7 +1451,7 @@ define nofpclass(snan) float @unknown__maximum__inf(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__maximum__inf(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN]], float [[INF]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN]], float [[INF]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf = call float @returns_inf()
@@ -1463,7 +1463,7 @@ define nofpclass(snan) float @inf_or_nan__maximum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @inf_or_nan__maximum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[INF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[INF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1475,7 +1475,7 @@ define nofpclass(snan) float @unknown__maximum__inf_or_nan(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__maximum__inf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[UNKNOWN]], float [[INF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[UNKNOWN]], float [[INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1487,7 +1487,7 @@ define nofpclass(snan) float @ninf_or_nan__maximum__not_nan(float nofpclass(nan)
 ; CHECK-LABEL: define nofpclass(snan) float @ninf_or_nan__maximum__not_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[NINF_OR_NAN:%.*]] = call float @returns_ninf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NINF_OR_NAN]], float [[NOT_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NINF_OR_NAN]], float [[NOT_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf.or.nan = call float @returns_ninf_or_nan()
@@ -1499,7 +1499,7 @@ define nofpclass(snan) float @not_nan__maximum__ninf_or_nan(float nofpclass(nan)
 ; CHECK-LABEL: define nofpclass(snan) float @not_nan__maximum__ninf_or_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[NINF_OR_NAN:%.*]] = call float @returns_ninf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_NAN]], float [[NINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_NAN]], float [[NINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf.or.nan = call float @returns_ninf_or_nan()
@@ -1533,7 +1533,7 @@ define nofpclass(snan) float @inf_or_nan__maximum__not_nan(float nofpclass(nan) 
 ; CHECK-LABEL: define nofpclass(snan) float @inf_or_nan__maximum__not_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1545,7 +1545,7 @@ define nofpclass(snan) float @not_nan__maximum__inf_or_nan(float nofpclass(nan) 
 ; CHECK-LABEL: define nofpclass(snan) float @not_nan__maximum__inf_or_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1601,7 +1601,7 @@ define nofpclass(snan) float @inf__maximum__not_nan(float nofpclass(nan) %not.na
 ; CHECK-LABEL: define nofpclass(snan) float @inf__maximum__not_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.maximum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf()
@@ -1613,7 +1613,7 @@ define nofpclass(snan) float @not_nan__maximum__inf(float nofpclass(nan) %not.na
 ; CHECK-LABEL: define nofpclass(snan) float @not_nan__maximum__inf(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.maximum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf()
@@ -1758,7 +1758,7 @@ define nofpclass(snan) float @select_is_positive_or_0__maximum__nnorm_or_nan_0(f
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    [[NNORM_OR_NAN:%.*]] = call float @returns_nnorm_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[SELECT]], float [[NNORM_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[SELECT]], float [[NNORM_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %is.pos.or.zero = fcmp oge float %arg, 0.0
@@ -1774,7 +1774,7 @@ define nofpclass(snan) float @select_is_positive_or_0__maximum__nnorm_or_nan_1(f
 ; CHECK-NEXT:    [[NNORM_OR_NAN:%.*]] = call float @returns_nnorm_or_nan()
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NNORM_OR_NAN]], float [[SELECT]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NNORM_OR_NAN]], float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %nnorm.or.nan = call float @returns_nnorm_or_nan()
@@ -1922,7 +1922,7 @@ define nofpclass(snan) float @positive_or_zero__maximum__negative_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @positive_or_zero__maximum__negative_or_nan() {
 ; CHECK-NEXT:    [[POS_NONZERO:%.*]] = call float @returns_positive_nonzero()
 ; CHECK-NEXT:    [[NEGATIVE_OR_NAN:%.*]] = call float @returns_negative_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[POS_NONZERO]], float [[NEGATIVE_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[POS_NONZERO]], float [[NEGATIVE_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pos.nonzero = call float @returns_positive_nonzero()
@@ -1935,7 +1935,7 @@ define nofpclass(snan) float @negative_or_nan__maximum__positive_or_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @negative_or_nan__maximum__positive_or_zero() {
 ; CHECK-NEXT:    [[NEGATIVE_OR_NAN:%.*]] = call float @returns_negative_or_nan()
 ; CHECK-NEXT:    [[POS_NONZERO:%.*]] = call float @returns_positive_nonzero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[NEGATIVE_OR_NAN]], float [[POS_NONZERO]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximum.f32(float [[NEGATIVE_OR_NAN]], float [[POS_NONZERO]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %negative.or.nan = call float @returns_negative_or_nan()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-maximumnum.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-maximumnum.ll
@@ -57,7 +57,7 @@ define nofpclass(inf norm sub zero) float @ret_only_nan(float %x, float %y) {
 define nofpclass(inf norm sub zero qnan) float @ret_only_snan(float %x, float %y) {
 ; CHECK-LABEL: define nofpclass(qnan inf zero sub norm) float @ret_only_snan(
 ; CHECK-SAME: float [[X:%.*]], float [[Y:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[X]], float [[Y]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %x, float %y)
@@ -67,7 +67,7 @@ define nofpclass(inf norm sub zero qnan) float @ret_only_snan(float %x, float %y
 define nofpclass(inf norm sub zero snan) float @ret_only_qnan(float %x, float %y) {
 ; CHECK-LABEL: define nofpclass(snan inf zero sub norm) float @ret_only_qnan(
 ; CHECK-SAME: float [[X:%.*]], float [[Y:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[X]], float [[Y]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %x, float %y)
@@ -77,7 +77,7 @@ define nofpclass(inf norm sub zero snan) float @ret_only_qnan(float %x, float %y
 define nofpclass(nan norm sub zero) float @ret_only_inf(float %x, float %y) {
 ; CHECK-LABEL: define nofpclass(nan zero sub norm) float @ret_only_inf(
 ; CHECK-SAME: float [[X:%.*]], float [[Y:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[X]], float [[Y]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %x, float %y)
@@ -413,7 +413,7 @@ define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_1() {
 define nofpclass(nsub) float @lhs_must_be_pinf_or_nan(float %unknown, float nofpclass(ninf norm zero sub) %must.be.pinf.or.nan) {
 ; CHECK-LABEL: define nofpclass(nsub) float @lhs_must_be_pinf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(ninf zero sub norm) [[MUST_BE_PINF_OR_NAN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[MUST_BE_PINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[MUST_BE_PINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %must.be.pinf.or.nan, float %unknown)
@@ -423,7 +423,7 @@ define nofpclass(nsub) float @lhs_must_be_pinf_or_nan(float %unknown, float nofp
 define nofpclass(nsub) float @rhs_must_be_pinf_or_nan(float nofpclass(ninf norm zero sub) %must.be.pinf.or.nan, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nsub) float @rhs_must_be_pinf_or_nan(
 ; CHECK-SAME: float nofpclass(ninf zero sub norm) [[MUST_BE_PINF_OR_NAN:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[MUST_BE_PINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[MUST_BE_PINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %unknown, float %must.be.pinf.or.nan)
@@ -471,7 +471,7 @@ define nofpclass(nsub) float @rhs_must_be_pinf_lhs_non_nan(float nofpclass(nan n
 define nofpclass(nsub) float @lhs_must_be_ninf_or_nan(float %unknown, float nofpclass(pinf norm zero sub) %must.be.ninf.or.nan) {
 ; CHECK-LABEL: define nofpclass(nsub) float @lhs_must_be_ninf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(pinf zero sub norm) [[MUST_BE_NINF_OR_NAN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[MUST_BE_NINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[MUST_BE_NINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %must.be.ninf.or.nan, float %unknown)
@@ -481,7 +481,7 @@ define nofpclass(nsub) float @lhs_must_be_ninf_or_nan(float %unknown, float nofp
 define nofpclass(nsub) float @rhs_must_be_ninf_or_nan(float nofpclass(pinf norm zero sub) %must.be.ninf.or.nan, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nsub) float @rhs_must_be_ninf_or_nan(
 ; CHECK-SAME: float nofpclass(pinf zero sub norm) [[MUST_BE_NINF_OR_NAN:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[MUST_BE_NINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[MUST_BE_NINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %unknown, float %must.be.ninf.or.nan)
@@ -491,7 +491,7 @@ define nofpclass(nsub) float @rhs_must_be_ninf_or_nan(float nofpclass(pinf norm 
 define nofpclass(nsub) float @lhs_must_be_ninf(float %unknown, float nofpclass(nan pinf norm zero sub) %must.be.ninf) {
 ; CHECK-LABEL: define nofpclass(nsub) float @lhs_must_be_ninf(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(nan pinf zero sub norm) [[MUST_BE_NINF:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %must.be.ninf, float %unknown)
@@ -501,7 +501,7 @@ define nofpclass(nsub) float @lhs_must_be_ninf(float %unknown, float nofpclass(n
 define nofpclass(nsub) float @rhs_must_be_ninf(float nofpclass(nan pinf norm zero sub) %must.be.ninf, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nsub) float @rhs_must_be_ninf(
 ; CHECK-SAME: float nofpclass(nan pinf zero sub norm) [[MUST_BE_NINF:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %unknown, float %must.be.ninf)
@@ -552,7 +552,7 @@ define nofpclass(pzero) float @result_not_pzero(float %unknown0, float %unknown1
 define nofpclass(zero) float @result_not_zero(float %unknown0, float %unknown1) {
 ; CHECK-LABEL: define nofpclass(zero) float @result_not_zero(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %unknown0, float %unknown1)
@@ -582,7 +582,7 @@ define nofpclass(zero) float @result_not_zero__dynamic(float %unknown0, float %u
 define nofpclass(zero) float @result_not_zero_or_sub(float %unknown0, float %unknown1) {
 ; CHECK-LABEL: define nofpclass(zero) float @result_not_zero_or_sub(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %unknown0, float %unknown1)
@@ -592,7 +592,7 @@ define nofpclass(zero) float @result_not_zero_or_sub(float %unknown0, float %unk
 define nofpclass(zero sub) float @result_not_zero_or_sub__daz(float %unknown0, float %unknown1) #0 {
 ; CHECK-LABEL: define nofpclass(zero sub) float @result_not_zero_or_sub__daz(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) #[[ATTR0]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %unknown0, float %unknown1)
@@ -602,7 +602,7 @@ define nofpclass(zero sub) float @result_not_zero_or_sub__daz(float %unknown0, f
 define nofpclass(zero sub) float @result_not_zero_or_sub__dynamic(float %unknown0, float %unknown1) #1 {
 ; CHECK-LABEL: define nofpclass(zero sub) float @result_not_zero_or_sub__dynamic(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %unknown0, float %unknown1)
@@ -612,7 +612,7 @@ define nofpclass(zero sub) float @result_not_zero_or_sub__dynamic(float %unknown
 define nofpclass(snan) float @lhs_not_zero(float nofpclass(zero) %not.zero, float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @lhs_not_zero(
 ; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_ZERO]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NOT_ZERO]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %not.zero, float %unknown)
@@ -622,7 +622,7 @@ define nofpclass(snan) float @lhs_not_zero(float nofpclass(zero) %not.zero, floa
 define nofpclass(snan) float @rhs_not_zero(float %unknown, float nofpclass(zero) %not.zero) {
 ; CHECK-LABEL: define nofpclass(snan) float @rhs_not_zero(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[NOT_ZERO]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[NOT_ZERO]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %unknown, float %not.zero)
@@ -632,7 +632,7 @@ define nofpclass(snan) float @rhs_not_zero(float %unknown, float nofpclass(zero)
 define nofpclass(snan) float @sources_not_zero(float nofpclass(zero) %not.zero0, float nofpclass(zero) %not.zero1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero(
 ; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO0:%.*]], float nofpclass(zero) [[NOT_ZERO1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_ZERO0]], float [[NOT_ZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NOT_ZERO0]], float [[NOT_ZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %not.zero0, float %not.zero1)
@@ -649,9 +649,9 @@ define nofpclass(snan) float @sources_not_zero__daz(float nofpclass(zero) %not.z
   ret float %result
 }
 
-define nofpclass(snan) float @sources_not_zero__dynamic(float nofpclass(zero) %not.zero0, float nofpclass(zero) %not.zero1) #2 {
+define nofpclass(snan) float @sources_not_zero__dynamic(float nofpclass(zero) %not.zero0, float nofpclass(zero) %not.zero1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero__dynamic(
-; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO0:%.*]], float nofpclass(zero) [[NOT_ZERO1:%.*]]) {
+; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO0:%.*]], float nofpclass(zero) [[NOT_ZERO1:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_ZERO0]], float [[NOT_ZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
@@ -662,7 +662,7 @@ define nofpclass(snan) float @sources_not_zero__dynamic(float nofpclass(zero) %n
 define nofpclass(snan) float @sources_not_zero_or_sub(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero_or_sub(
 ; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %not.zero.sub.0, float %not.zero.sub.1)
@@ -672,17 +672,17 @@ define nofpclass(snan) float @sources_not_zero_or_sub(float nofpclass(zero sub) 
 define nofpclass(snan) float @sources_not_zero_or_sub__daz(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero_or_sub__daz(
 ; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %not.zero.sub.0, float %not.zero.sub.1)
   ret float %result
 }
 
-define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) #2 {
+define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(
-; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
+; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %not.zero.sub.0, float %not.zero.sub.1)
@@ -692,7 +692,7 @@ define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(float nofpclass(z
 define nofpclass(snan) float @sources_not_nzero(float nofpclass(nzero) %not.nzero0, float nofpclass(nzero) %not.nzero1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_nzero(
 ; CHECK-SAME: float nofpclass(nzero) [[NOT_NZERO0:%.*]], float nofpclass(nzero) [[NOT_NZERO1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %not.nzero0, float %not.nzero1)
@@ -702,7 +702,7 @@ define nofpclass(snan) float @sources_not_nzero(float nofpclass(nzero) %not.nzer
 define nofpclass(snan) float @sources_not_pzero(float nofpclass(pzero) %not.pzero0, float nofpclass(pzero) %not.pzero1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_pzero(
 ; CHECK-SAME: float nofpclass(pzero) [[NOT_PZERO0:%.*]], float nofpclass(pzero) [[NOT_PZERO1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_PZERO0]], float [[NOT_PZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NOT_PZERO0]], float [[NOT_PZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %not.pzero0, float %not.pzero1)
@@ -772,7 +772,7 @@ define nofpclass(snan) float @rhs_not_nzero_lhs_not_pzero__dynamic(float nofpcla
 define nofpclass(snan) float @sources_not_nzero_nsub__dynamic(float nofpclass(nzero nsub) %not.nzero0, float nofpclass(nzero nsub) %not.nzero1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_nzero_nsub__dynamic(
 ; CHECK-SAME: float nofpclass(nzero nsub) [[NOT_NZERO0:%.*]], float nofpclass(nzero nsub) [[NOT_NZERO1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.maximumnum.f32(float %not.nzero0, float %not.nzero1)
@@ -1059,7 +1059,7 @@ define nofpclass(snan) float @known_negative__maximumnum__only_nzero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_negative__maximumnum__only_nzero_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[KNOWN_NZERO_OR_NAN:%.*]] = call float @returns_nzero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[KNOWN_NEGATIVE]], float [[KNOWN_NZERO_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[KNOWN_NEGATIVE]], float [[KNOWN_NZERO_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %known.negative = call float @returns_negative()
@@ -1072,7 +1072,7 @@ define nofpclass(snan) float @only_nzero_or_nan__maximumnum__known_negative() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_nzero_or_nan__maximumnum__known_negative() {
 ; CHECK-NEXT:    [[KNOWN_NZERO_OR_NAN:%.*]] = call float @returns_nzero_or_nan()
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[KNOWN_NZERO_OR_NAN]], float [[KNOWN_NEGATIVE]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[KNOWN_NZERO_OR_NAN]], float [[KNOWN_NEGATIVE]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %known.nzero.or.nan = call float @returns_nzero_or_nan()
@@ -1164,7 +1164,7 @@ define nofpclass(pinf pnorm psub) float @ret_always_positive_nonzero__maximumnum
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
 ; CHECK-NEXT:    [[ALWAYS_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[SELECT_RHS:%.*]] = select i1 [[COND]], float [[ALWAYS_POSITIVE]], float [[UNKNOWN]]
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %always.positive = call float @returns_positive()
@@ -1178,7 +1178,7 @@ define nofpclass(pinf pnorm psub) float @ret_always_positive_nonzero__maximumnum
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
 ; CHECK-NEXT:    [[ALWAYS_NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[SELECT_RHS:%.*]] = select i1 [[COND]], float [[ALWAYS_NEGATIVE]], float [[UNKNOWN]]
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %always.negative = call float @returns_negative()
@@ -1375,7 +1375,7 @@ define nofpclass(snan) float @pinf_or_nan__maximumnum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @pinf_or_nan__maximumnum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PINF_OR_NAN:%.*]] = call float @returns_pinf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[PINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[PINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf.or.nan = call float @returns_pinf_or_nan()
@@ -1387,7 +1387,7 @@ define nofpclass(snan) float @unknown__maximumnum__pinf_or_nan(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__maximumnum__pinf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PINF_OR_NAN:%.*]] = call float @returns_pinf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[PINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[PINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf.or.nan = call float @returns_pinf_or_nan()
@@ -1399,7 +1399,7 @@ define nofpclass(snan) float @ninf__maximumnum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @ninf__maximumnum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NINF:%.*]] = call float @returns_ninf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf = call float @returns_ninf()
@@ -1411,7 +1411,7 @@ define nofpclass(snan) float @unknown__maximumnum__ninf(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__maximumnum__ninf(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NINF:%.*]] = call float @returns_ninf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf = call float @returns_ninf()
@@ -1423,7 +1423,7 @@ define nofpclass(snan) float @ninf_or_nan__maximumnum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @ninf_or_nan__maximumnum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NINF_OR_NAN:%.*]] = call float @returns_ninf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf.or.nan = call float @returns_ninf_or_nan()
@@ -1435,7 +1435,7 @@ define nofpclass(snan) float @unknown__maximumnum__ninf_or_nan(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__maximumnum__ninf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NINF_OR_NAN:%.*]] = call float @returns_ninf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[NINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[NINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf.or.nan = call float @returns_ninf_or_nan()
@@ -1447,7 +1447,7 @@ define nofpclass(snan) float @inf__maximumnum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @inf__maximumnum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[INF]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[INF]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf = call float @returns_inf()
@@ -1459,7 +1459,7 @@ define nofpclass(snan) float @unknown__maximumnum__inf(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__maximumnum__inf(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[INF]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[INF]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf = call float @returns_inf()
@@ -1471,7 +1471,7 @@ define nofpclass(snan) float @inf_or_nan__maximumnum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @inf_or_nan__maximumnum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[INF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[INF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1483,7 +1483,7 @@ define nofpclass(snan) float @unknown__maximumnum__inf_or_nan(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__maximumnum__inf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[INF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[UNKNOWN]], float [[INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1517,7 +1517,7 @@ define nofpclass(snan) float @pinf_or_nan__maximumnum__not_nan(float nofpclass(n
 ; CHECK-LABEL: define nofpclass(snan) float @pinf_or_nan__maximumnum__not_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[PINF_OR_NAN:%.*]] = call float @returns_pinf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[PINF_OR_NAN]], float [[NOT_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[PINF_OR_NAN]], float [[NOT_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf.or.nan = call float @returns_pinf_or_nan()
@@ -1529,7 +1529,7 @@ define nofpclass(snan) float @not_nan__maximumnum__pinf_or_nan(float nofpclass(n
 ; CHECK-LABEL: define nofpclass(snan) float @not_nan__maximumnum__pinf_or_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[PINF_OR_NAN:%.*]] = call float @returns_pinf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_NAN]], float [[PINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NOT_NAN]], float [[PINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf.or.nan = call float @returns_pinf_or_nan()
@@ -1541,7 +1541,7 @@ define nofpclass(snan) float @inf_or_nan__maximumnum__not_nan(float nofpclass(na
 ; CHECK-LABEL: define nofpclass(snan) float @inf_or_nan__maximumnum__not_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1553,7 +1553,7 @@ define nofpclass(snan) float @not_nan__maximumnum__inf_or_nan(float nofpclass(na
 ; CHECK-LABEL: define nofpclass(snan) float @not_nan__maximumnum__inf_or_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1609,7 +1609,7 @@ define nofpclass(snan) float @inf__maximumnum__not_nan(float nofpclass(nan) %not
 ; CHECK-LABEL: define nofpclass(snan) float @inf__maximumnum__not_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.maximumnum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf()
@@ -1621,7 +1621,7 @@ define nofpclass(snan) float @not_nan__maximumnum__inf(float nofpclass(nan) %not
 ; CHECK-LABEL: define nofpclass(snan) float @not_nan__maximumnum__inf(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.maximumnum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf()
@@ -1951,7 +1951,7 @@ define nofpclass(snan) float @positive_or_zero_or_nan__maximumnum__negative() {
 ; CHECK-LABEL: define nofpclass(snan) float @positive_or_zero_or_nan__maximumnum__negative() {
 ; CHECK-NEXT:    [[POS_NONZERO_OR_NAN:%.*]] = call float @returns_positive_nonzero_or_nan()
 ; CHECK-NEXT:    [[NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[POS_NONZERO_OR_NAN]], float [[NEGATIVE]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[POS_NONZERO_OR_NAN]], float [[NEGATIVE]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pos.nonzero.or.nan = call float @returns_positive_nonzero_or_nan()
@@ -1964,7 +1964,7 @@ define nofpclass(snan) float @negative__maximumnum__positive_or_zero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @negative__maximumnum__positive_or_zero_or_nan() {
 ; CHECK-NEXT:    [[NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[POS_NONZERO_OR_NAN:%.*]] = call float @returns_positive_nonzero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NEGATIVE]], float [[POS_NONZERO_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.maximumnum.f32(float [[NEGATIVE]], float [[POS_NONZERO_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %negative = call float @returns_negative()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-minimum.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-minimum.ll
@@ -57,7 +57,7 @@ define nofpclass(inf norm sub zero) float @ret_only_nan(float %x, float %y) {
 define nofpclass(inf norm sub zero qnan) float @ret_only_snan(float %x, float %y) {
 ; CHECK-LABEL: define nofpclass(qnan inf zero sub norm) float @ret_only_snan(
 ; CHECK-SAME: float [[X:%.*]], float [[Y:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[X]], float [[Y]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %x, float %y)
@@ -67,7 +67,7 @@ define nofpclass(inf norm sub zero qnan) float @ret_only_snan(float %x, float %y
 define nofpclass(inf norm sub zero snan) float @ret_only_qnan(float %x, float %y) {
 ; CHECK-LABEL: define nofpclass(snan inf zero sub norm) float @ret_only_qnan(
 ; CHECK-SAME: float [[X:%.*]], float [[Y:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[X]], float [[Y]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %x, float %y)
@@ -77,7 +77,7 @@ define nofpclass(inf norm sub zero snan) float @ret_only_qnan(float %x, float %y
 define nofpclass(nan norm sub zero) float @ret_only_inf(float %x, float %y) {
 ; CHECK-LABEL: define nofpclass(nan zero sub norm) float @ret_only_inf(
 ; CHECK-SAME: float [[X:%.*]], float [[Y:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[X]], float [[Y]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.minimum.f32(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %x, float %y)
@@ -413,7 +413,7 @@ define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_1() {
 define nofpclass(nsub) float @lhs_must_be_pinf_or_nan(float %unknown, float nofpclass(ninf norm zero sub) %must.be.pinf.or.nan) {
 ; CHECK-LABEL: define nofpclass(nsub) float @lhs_must_be_pinf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(ninf zero sub norm) [[MUST_BE_PINF_OR_NAN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[MUST_BE_PINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[MUST_BE_PINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %must.be.pinf.or.nan, float %unknown)
@@ -423,7 +423,7 @@ define nofpclass(nsub) float @lhs_must_be_pinf_or_nan(float %unknown, float nofp
 define nofpclass(nsub) float @rhs_must_be_pinf_or_nan(float nofpclass(ninf norm zero sub) %must.be.pinf.or.nan, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nsub) float @rhs_must_be_pinf_or_nan(
 ; CHECK-SAME: float nofpclass(ninf zero sub norm) [[MUST_BE_PINF_OR_NAN:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN]], float [[MUST_BE_PINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN]], float [[MUST_BE_PINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %unknown, float %must.be.pinf.or.nan)
@@ -471,7 +471,7 @@ define nofpclass(nsub) float @rhs_must_be_pinf_lhs_non_nan(float nofpclass(nan n
 define nofpclass(nsub) float @lhs_must_be_ninf_or_nan(float %unknown, float nofpclass(pinf norm zero sub) %must.be.ninf.or.nan) {
 ; CHECK-LABEL: define nofpclass(nsub) float @lhs_must_be_ninf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(pinf zero sub norm) [[MUST_BE_NINF_OR_NAN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[MUST_BE_NINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[MUST_BE_NINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %must.be.ninf.or.nan, float %unknown)
@@ -481,7 +481,7 @@ define nofpclass(nsub) float @lhs_must_be_ninf_or_nan(float %unknown, float nofp
 define nofpclass(nsub) float @rhs_must_be_ninf_or_nan(float nofpclass(pinf norm zero sub) %must.be.ninf.or.nan, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nsub) float @rhs_must_be_ninf_or_nan(
 ; CHECK-SAME: float nofpclass(pinf zero sub norm) [[MUST_BE_NINF_OR_NAN:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN]], float [[MUST_BE_NINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN]], float [[MUST_BE_NINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %unknown, float %must.be.ninf.or.nan)
@@ -491,7 +491,7 @@ define nofpclass(nsub) float @rhs_must_be_ninf_or_nan(float nofpclass(pinf norm 
 define nofpclass(nsub) float @lhs_must_be_ninf(float %unknown, float nofpclass(nan pinf norm zero sub) %must.be.ninf) {
 ; CHECK-LABEL: define nofpclass(nsub) float @lhs_must_be_ninf(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(nan pinf zero sub norm) [[MUST_BE_NINF:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %must.be.ninf, float %unknown)
@@ -501,7 +501,7 @@ define nofpclass(nsub) float @lhs_must_be_ninf(float %unknown, float nofpclass(n
 define nofpclass(nsub) float @rhs_must_be_ninf(float nofpclass(nan pinf norm zero sub) %must.be.ninf, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nsub) float @rhs_must_be_ninf(
 ; CHECK-SAME: float nofpclass(nan pinf zero sub norm) [[MUST_BE_NINF:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %unknown, float %must.be.ninf)
@@ -552,7 +552,7 @@ define nofpclass(pzero) float @result_not_pzero(float %unknown0, float %unknown1
 define nofpclass(zero) float @result_not_zero(float %unknown0, float %unknown1) {
 ; CHECK-LABEL: define nofpclass(zero) float @result_not_zero(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %unknown0, float %unknown1)
@@ -582,7 +582,7 @@ define nofpclass(zero) float @result_not_zero__dynamic(float %unknown0, float %u
 define nofpclass(zero) float @result_not_zero_or_sub(float %unknown0, float %unknown1) {
 ; CHECK-LABEL: define nofpclass(zero) float @result_not_zero_or_sub(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %unknown0, float %unknown1)
@@ -592,7 +592,7 @@ define nofpclass(zero) float @result_not_zero_or_sub(float %unknown0, float %unk
 define nofpclass(zero sub) float @result_not_zero_or_sub__daz(float %unknown0, float %unknown1) #0 {
 ; CHECK-LABEL: define nofpclass(zero sub) float @result_not_zero_or_sub__daz(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) #[[ATTR0]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %unknown0, float %unknown1)
@@ -602,7 +602,7 @@ define nofpclass(zero sub) float @result_not_zero_or_sub__daz(float %unknown0, f
 define nofpclass(zero sub) float @result_not_zero_or_sub__dynamic(float %unknown0, float %unknown1) #1 {
 ; CHECK-LABEL: define nofpclass(zero sub) float @result_not_zero_or_sub__dynamic(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %unknown0, float %unknown1)
@@ -612,7 +612,7 @@ define nofpclass(zero sub) float @result_not_zero_or_sub__dynamic(float %unknown
 define nofpclass(snan) float @lhs_not_zero(float nofpclass(zero) %not.zero, float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @lhs_not_zero(
 ; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_ZERO]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NOT_ZERO]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %not.zero, float %unknown)
@@ -622,7 +622,7 @@ define nofpclass(snan) float @lhs_not_zero(float nofpclass(zero) %not.zero, floa
 define nofpclass(snan) float @rhs_not_zero(float %unknown, float nofpclass(zero) %not.zero) {
 ; CHECK-LABEL: define nofpclass(snan) float @rhs_not_zero(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN]], float [[NOT_ZERO]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN]], float [[NOT_ZERO]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %unknown, float %not.zero)
@@ -632,7 +632,7 @@ define nofpclass(snan) float @rhs_not_zero(float %unknown, float nofpclass(zero)
 define nofpclass(snan) float @sources_not_zero(float nofpclass(zero) %not.zero0, float nofpclass(zero) %not.zero1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero(
 ; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO0:%.*]], float nofpclass(zero) [[NOT_ZERO1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_ZERO0]], float [[NOT_ZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NOT_ZERO0]], float [[NOT_ZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %not.zero0, float %not.zero1)
@@ -649,9 +649,9 @@ define nofpclass(snan) float @sources_not_zero__daz(float nofpclass(zero) %not.z
   ret float %result
 }
 
-define nofpclass(snan) float @sources_not_zero__dynamic(float nofpclass(zero) %not.zero0, float nofpclass(zero) %not.zero1) #2 {
+define nofpclass(snan) float @sources_not_zero__dynamic(float nofpclass(zero) %not.zero0, float nofpclass(zero) %not.zero1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero__dynamic(
-; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO0:%.*]], float nofpclass(zero) [[NOT_ZERO1:%.*]]) {
+; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO0:%.*]], float nofpclass(zero) [[NOT_ZERO1:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_ZERO0]], float [[NOT_ZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
@@ -662,7 +662,7 @@ define nofpclass(snan) float @sources_not_zero__dynamic(float nofpclass(zero) %n
 define nofpclass(snan) float @sources_not_zero_or_sub(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero_or_sub(
 ; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %not.zero.sub.0, float %not.zero.sub.1)
@@ -672,17 +672,17 @@ define nofpclass(snan) float @sources_not_zero_or_sub(float nofpclass(zero sub) 
 define nofpclass(snan) float @sources_not_zero_or_sub__daz(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero_or_sub__daz(
 ; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %not.zero.sub.0, float %not.zero.sub.1)
   ret float %result
 }
 
-define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) #2 {
+define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(
-; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
+; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %not.zero.sub.0, float %not.zero.sub.1)
@@ -692,7 +692,7 @@ define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(float nofpclass(z
 define nofpclass(snan) float @sources_not_nzero(float nofpclass(nzero) %not.nzero0, float nofpclass(nzero) %not.nzero1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_nzero(
 ; CHECK-SAME: float nofpclass(nzero) [[NOT_NZERO0:%.*]], float nofpclass(nzero) [[NOT_NZERO1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %not.nzero0, float %not.nzero1)
@@ -702,7 +702,7 @@ define nofpclass(snan) float @sources_not_nzero(float nofpclass(nzero) %not.nzer
 define nofpclass(snan) float @sources_not_pzero(float nofpclass(pzero) %not.pzero0, float nofpclass(pzero) %not.pzero1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_pzero(
 ; CHECK-SAME: float nofpclass(pzero) [[NOT_PZERO0:%.*]], float nofpclass(pzero) [[NOT_PZERO1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_PZERO0]], float [[NOT_PZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NOT_PZERO0]], float [[NOT_PZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %not.pzero0, float %not.pzero1)
@@ -772,7 +772,7 @@ define nofpclass(snan) float @rhs_not_nzero_lhs_not_pzero__dynamic(float nofpcla
 define nofpclass(snan) float @sources_not_nzero_nsub__dynamic(float nofpclass(nzero nsub) %not.nzero0, float nofpclass(nzero nsub) %not.nzero1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_nzero_nsub__dynamic(
 ; CHECK-SAME: float nofpclass(nzero nsub) [[NOT_NZERO0:%.*]], float nofpclass(nzero nsub) [[NOT_NZERO1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimum.f32(float %not.nzero0, float %not.nzero1)
@@ -1059,7 +1059,7 @@ define nofpclass(snan) float @known_negative__minimum__only_nzero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_negative__minimum__only_nzero_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[KNOWN_NZERO_OR_NAN:%.*]] = call float @returns_nzero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[KNOWN_NEGATIVE]], float [[KNOWN_NZERO_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[KNOWN_NEGATIVE]], float [[KNOWN_NZERO_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %known.negative = call float @returns_negative()
@@ -1072,7 +1072,7 @@ define nofpclass(snan) float @only_nzero_or_nan__minimum__known_negative() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_nzero_or_nan__minimum__known_negative() {
 ; CHECK-NEXT:    [[KNOWN_NZERO_OR_NAN:%.*]] = call float @returns_nzero_or_nan()
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[KNOWN_NZERO_OR_NAN]], float [[KNOWN_NEGATIVE]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[KNOWN_NZERO_OR_NAN]], float [[KNOWN_NEGATIVE]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %known.nzero.or.nan = call float @returns_nzero_or_nan()
@@ -1164,7 +1164,7 @@ define nofpclass(pinf pnorm psub) float @ret_always_positive_nonzero__minimum__n
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
 ; CHECK-NEXT:    [[ALWAYS_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[SELECT_RHS:%.*]] = select i1 [[COND]], float [[ALWAYS_POSITIVE]], float [[UNKNOWN]]
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %always.positive = call float @returns_positive()
@@ -1178,7 +1178,7 @@ define nofpclass(pinf pnorm psub) float @ret_always_positive_nonzero__minimum__n
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
 ; CHECK-NEXT:    [[ALWAYS_NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[SELECT_RHS:%.*]] = select i1 [[COND]], float [[ALWAYS_NEGATIVE]], float [[UNKNOWN]]
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %always.negative = call float @returns_negative()
@@ -1369,7 +1369,7 @@ define nofpclass(snan) float @pinf_or_nan__minimum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @pinf_or_nan__minimum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PINF_OR_NAN:%.*]] = call float @returns_pinf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[PINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[PINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf.or.nan = call float @returns_pinf_or_nan()
@@ -1381,7 +1381,7 @@ define nofpclass(snan) float @unknown__minimum__pinf_or_nan(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__minimum__pinf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PINF_OR_NAN:%.*]] = call float @returns_pinf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN]], float [[PINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN]], float [[PINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf.or.nan = call float @returns_pinf_or_nan()
@@ -1393,7 +1393,7 @@ define nofpclass(snan) float @ninf__minimum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @ninf__minimum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NINF:%.*]] = call float @returns_ninf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf = call float @returns_ninf()
@@ -1405,7 +1405,7 @@ define nofpclass(snan) float @unknown__minimum__ninf(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__minimum__ninf(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NINF:%.*]] = call float @returns_ninf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN]], float 0xFFF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf = call float @returns_ninf()
@@ -1417,7 +1417,7 @@ define nofpclass(snan) float @ninf_or_nan__minimum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @ninf_or_nan__minimum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NINF_OR_NAN:%.*]] = call float @returns_ninf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf.or.nan = call float @returns_ninf_or_nan()
@@ -1429,7 +1429,7 @@ define nofpclass(snan) float @unknown__minimum__ninf_or_nan(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__minimum__ninf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NINF_OR_NAN:%.*]] = call float @returns_ninf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN]], float [[NINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN]], float [[NINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf.or.nan = call float @returns_ninf_or_nan()
@@ -1441,7 +1441,7 @@ define nofpclass(snan) float @inf__minimum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @inf__minimum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[INF]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[INF]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf = call float @returns_inf()
@@ -1453,7 +1453,7 @@ define nofpclass(snan) float @unknown__minimum__inf(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__minimum__inf(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN]], float [[INF]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN]], float [[INF]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf = call float @returns_inf()
@@ -1465,7 +1465,7 @@ define nofpclass(snan) float @inf_or_nan__minimum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @inf_or_nan__minimum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[INF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[INF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1477,7 +1477,7 @@ define nofpclass(snan) float @unknown__minimum__inf_or_nan(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__minimum__inf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[UNKNOWN]], float [[INF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[UNKNOWN]], float [[INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1511,7 +1511,7 @@ define nofpclass(snan) float @pinf_or_nan__minimum__not_nan(float nofpclass(nan)
 ; CHECK-LABEL: define nofpclass(snan) float @pinf_or_nan__minimum__not_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[PINF_OR_NAN:%.*]] = call float @returns_pinf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[PINF_OR_NAN]], float [[NOT_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[PINF_OR_NAN]], float [[NOT_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf.or.nan = call float @returns_pinf_or_nan()
@@ -1523,7 +1523,7 @@ define nofpclass(snan) float @not_nan__minimum__pinf_or_nan(float nofpclass(nan)
 ; CHECK-LABEL: define nofpclass(snan) float @not_nan__minimum__pinf_or_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[PINF_OR_NAN:%.*]] = call float @returns_pinf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_NAN]], float [[PINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NOT_NAN]], float [[PINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf.or.nan = call float @returns_pinf_or_nan()
@@ -1535,7 +1535,7 @@ define nofpclass(snan) float @inf_or_nan__minimum__not_nan(float nofpclass(nan) 
 ; CHECK-LABEL: define nofpclass(snan) float @inf_or_nan__minimum__not_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1547,7 +1547,7 @@ define nofpclass(snan) float @not_nan__minimum__inf_or_nan(float nofpclass(nan) 
 ; CHECK-LABEL: define nofpclass(snan) float @not_nan__minimum__inf_or_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1603,7 +1603,7 @@ define nofpclass(snan) float @inf__minimum__not_nan(float nofpclass(nan) %not.na
 ; CHECK-LABEL: define nofpclass(snan) float @inf__minimum__not_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.minimum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf()
@@ -1615,7 +1615,7 @@ define nofpclass(snan) float @not_nan__minimum__inf(float nofpclass(nan) %not.na
 ; CHECK-LABEL: define nofpclass(snan) float @not_nan__minimum__inf(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.minimum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf()
@@ -1934,7 +1934,7 @@ define nofpclass(snan) float @positive_or_zero_or_nan__minimum__negative() {
 ; CHECK-LABEL: define nofpclass(snan) float @positive_or_zero_or_nan__minimum__negative() {
 ; CHECK-NEXT:    [[POS_NONZERO_OR_NAN:%.*]] = call float @returns_positive_nonzero_or_nan()
 ; CHECK-NEXT:    [[NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[POS_NONZERO_OR_NAN]], float [[NEGATIVE]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[POS_NONZERO_OR_NAN]], float [[NEGATIVE]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pos.nonzero.or.nan = call float @returns_positive_nonzero_or_nan()
@@ -1947,7 +1947,7 @@ define nofpclass(snan) float @negative__minimum__positive_or_zero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @negative__minimum__positive_or_zero_or_nan() {
 ; CHECK-NEXT:    [[NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[POS_NONZERO_OR_NAN:%.*]] = call float @returns_positive_nonzero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NEGATIVE]], float [[POS_NONZERO_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimum.f32(float [[NEGATIVE]], float [[POS_NONZERO_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %negative = call float @returns_negative()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-minimumnum.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-minimumnum.ll
@@ -57,7 +57,7 @@ define nofpclass(inf norm sub zero) float @ret_only_nan(float %x, float %y) {
 define nofpclass(inf norm sub zero qnan) float @ret_only_snan(float %x, float %y) {
 ; CHECK-LABEL: define nofpclass(qnan inf zero sub norm) float @ret_only_snan(
 ; CHECK-SAME: float [[X:%.*]], float [[Y:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[X]], float [[Y]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %x, float %y)
@@ -67,7 +67,7 @@ define nofpclass(inf norm sub zero qnan) float @ret_only_snan(float %x, float %y
 define nofpclass(inf norm sub zero snan) float @ret_only_qnan(float %x, float %y) {
 ; CHECK-LABEL: define nofpclass(snan inf zero sub norm) float @ret_only_qnan(
 ; CHECK-SAME: float [[X:%.*]], float [[Y:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[X]], float [[Y]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %x, float %y)
@@ -77,7 +77,7 @@ define nofpclass(inf norm sub zero snan) float @ret_only_qnan(float %x, float %y
 define nofpclass(nan norm sub zero) float @ret_only_inf(float %x, float %y) {
 ; CHECK-LABEL: define nofpclass(nan zero sub norm) float @ret_only_inf(
 ; CHECK-SAME: float [[X:%.*]], float [[Y:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[X]], float [[Y]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[X]], float [[Y]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %x, float %y)
@@ -411,7 +411,7 @@ define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_1() {
 define nofpclass(nsub) float @lhs_must_be_pinf_or_nan(float %unknown, float nofpclass(ninf norm zero sub) %must.be.pinf.or.nan) {
 ; CHECK-LABEL: define nofpclass(nsub) float @lhs_must_be_pinf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(ninf zero sub norm) [[MUST_BE_PINF_OR_NAN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[MUST_BE_PINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[MUST_BE_PINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %must.be.pinf.or.nan, float %unknown)
@@ -421,7 +421,7 @@ define nofpclass(nsub) float @lhs_must_be_pinf_or_nan(float %unknown, float nofp
 define nofpclass(nsub) float @rhs_must_be_pinf_or_nan(float nofpclass(ninf norm zero sub) %must.be.pinf.or.nan, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nsub) float @rhs_must_be_pinf_or_nan(
 ; CHECK-SAME: float nofpclass(ninf zero sub norm) [[MUST_BE_PINF_OR_NAN:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[MUST_BE_PINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[MUST_BE_PINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %unknown, float %must.be.pinf.or.nan)
@@ -431,7 +431,7 @@ define nofpclass(nsub) float @rhs_must_be_pinf_or_nan(float nofpclass(ninf norm 
 define nofpclass(nsub) float @lhs_must_be_pinf(float %unknown, float nofpclass(nan ninf norm zero sub) %must.be.pinf) {
 ; CHECK-LABEL: define nofpclass(nsub) float @lhs_must_be_pinf(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(nan ninf zero sub norm) [[MUST_BE_PINF:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %must.be.pinf, float %unknown)
@@ -441,7 +441,7 @@ define nofpclass(nsub) float @lhs_must_be_pinf(float %unknown, float nofpclass(n
 define nofpclass(nsub) float @rhs_must_be_pinf(float nofpclass(nan ninf norm zero sub) %must.be.pinf, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nsub) float @rhs_must_be_pinf(
 ; CHECK-SAME: float nofpclass(nan ninf zero sub norm) [[MUST_BE_PINF:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %unknown, float %must.be.pinf)
@@ -471,7 +471,7 @@ define nofpclass(nsub) float @rhs_must_be_pinf_lhs_non_nan(float nofpclass(nan n
 define nofpclass(nsub) float @lhs_must_be_ninf_or_nan(float %unknown, float nofpclass(pinf norm zero sub) %must.be.ninf.or.nan) {
 ; CHECK-LABEL: define nofpclass(nsub) float @lhs_must_be_ninf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(pinf zero sub norm) [[MUST_BE_NINF_OR_NAN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[MUST_BE_NINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[MUST_BE_NINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %must.be.ninf.or.nan, float %unknown)
@@ -481,7 +481,7 @@ define nofpclass(nsub) float @lhs_must_be_ninf_or_nan(float %unknown, float nofp
 define nofpclass(nsub) float @rhs_must_be_ninf_or_nan(float nofpclass(pinf norm zero sub) %must.be.ninf.or.nan, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nsub) float @rhs_must_be_ninf_or_nan(
 ; CHECK-SAME: float nofpclass(pinf zero sub norm) [[MUST_BE_NINF_OR_NAN:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[MUST_BE_NINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[MUST_BE_NINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %unknown, float %must.be.ninf.or.nan)
@@ -550,7 +550,7 @@ define nofpclass(pzero) float @result_not_pzero(float %unknown0, float %unknown1
 define nofpclass(zero) float @result_not_zero(float %unknown0, float %unknown1) {
 ; CHECK-LABEL: define nofpclass(zero) float @result_not_zero(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %unknown0, float %unknown1)
@@ -580,7 +580,7 @@ define nofpclass(zero) float @result_not_zero__dynamic(float %unknown0, float %u
 define nofpclass(zero) float @result_not_zero_or_sub(float %unknown0, float %unknown1) {
 ; CHECK-LABEL: define nofpclass(zero) float @result_not_zero_or_sub(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %unknown0, float %unknown1)
@@ -590,7 +590,7 @@ define nofpclass(zero) float @result_not_zero_or_sub(float %unknown0, float %unk
 define nofpclass(zero sub) float @result_not_zero_or_sub__daz(float %unknown0, float %unknown1) #0 {
 ; CHECK-LABEL: define nofpclass(zero sub) float @result_not_zero_or_sub__daz(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) #[[ATTR0]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %unknown0, float %unknown1)
@@ -600,7 +600,7 @@ define nofpclass(zero sub) float @result_not_zero_or_sub__daz(float %unknown0, f
 define nofpclass(zero sub) float @result_not_zero_or_sub__dynamic(float %unknown0, float %unknown1) #1 {
 ; CHECK-LABEL: define nofpclass(zero sub) float @result_not_zero_or_sub__dynamic(
 ; CHECK-SAME: float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN0]], float [[UNKNOWN1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %unknown0, float %unknown1)
@@ -610,7 +610,7 @@ define nofpclass(zero sub) float @result_not_zero_or_sub__dynamic(float %unknown
 define nofpclass(snan) float @lhs_not_zero(float nofpclass(zero) %not.zero, float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @lhs_not_zero(
 ; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_ZERO]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NOT_ZERO]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %not.zero, float %unknown)
@@ -620,7 +620,7 @@ define nofpclass(snan) float @lhs_not_zero(float nofpclass(zero) %not.zero, floa
 define nofpclass(snan) float @rhs_not_zero(float %unknown, float nofpclass(zero) %not.zero) {
 ; CHECK-LABEL: define nofpclass(snan) float @rhs_not_zero(
 ; CHECK-SAME: float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[NOT_ZERO]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[NOT_ZERO]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %unknown, float %not.zero)
@@ -630,7 +630,7 @@ define nofpclass(snan) float @rhs_not_zero(float %unknown, float nofpclass(zero)
 define nofpclass(snan) float @sources_not_zero(float nofpclass(zero) %not.zero0, float nofpclass(zero) %not.zero1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero(
 ; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO0:%.*]], float nofpclass(zero) [[NOT_ZERO1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_ZERO0]], float [[NOT_ZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NOT_ZERO0]], float [[NOT_ZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %not.zero0, float %not.zero1)
@@ -647,9 +647,9 @@ define nofpclass(snan) float @sources_not_zero__daz(float nofpclass(zero) %not.z
   ret float %result
 }
 
-define nofpclass(snan) float @sources_not_zero__dynamic(float nofpclass(zero) %not.zero0, float nofpclass(zero) %not.zero1) #2 {
+define nofpclass(snan) float @sources_not_zero__dynamic(float nofpclass(zero) %not.zero0, float nofpclass(zero) %not.zero1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero__dynamic(
-; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO0:%.*]], float nofpclass(zero) [[NOT_ZERO1:%.*]]) {
+; CHECK-SAME: float nofpclass(zero) [[NOT_ZERO0:%.*]], float nofpclass(zero) [[NOT_ZERO1:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_ZERO0]], float [[NOT_ZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
@@ -660,7 +660,7 @@ define nofpclass(snan) float @sources_not_zero__dynamic(float nofpclass(zero) %n
 define nofpclass(snan) float @sources_not_zero_or_sub(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero_or_sub(
 ; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %not.zero.sub.0, float %not.zero.sub.1)
@@ -670,17 +670,17 @@ define nofpclass(snan) float @sources_not_zero_or_sub(float nofpclass(zero sub) 
 define nofpclass(snan) float @sources_not_zero_or_sub__daz(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero_or_sub__daz(
 ; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %not.zero.sub.0, float %not.zero.sub.1)
   ret float %result
 }
 
-define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) #2 {
+define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(float nofpclass(zero sub) %not.zero.sub.0, float nofpclass(zero sub) %not.zero.sub.1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(
-; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
+; CHECK-SAME: float nofpclass(zero sub) [[NOT_ZERO_SUB_0:%.*]], float nofpclass(zero sub) [[NOT_ZERO_SUB_1:%.*]]) #[[ATTR1]] {
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NOT_ZERO_SUB_0]], float [[NOT_ZERO_SUB_1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %not.zero.sub.0, float %not.zero.sub.1)
@@ -690,7 +690,7 @@ define nofpclass(snan) float @sources_not_zero_or_sub__dynamic(float nofpclass(z
 define nofpclass(snan) float @sources_not_nzero(float nofpclass(nzero) %not.nzero0, float nofpclass(nzero) %not.nzero1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_nzero(
 ; CHECK-SAME: float nofpclass(nzero) [[NOT_NZERO0:%.*]], float nofpclass(nzero) [[NOT_NZERO1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %not.nzero0, float %not.nzero1)
@@ -700,7 +700,7 @@ define nofpclass(snan) float @sources_not_nzero(float nofpclass(nzero) %not.nzer
 define nofpclass(snan) float @sources_not_pzero(float nofpclass(pzero) %not.pzero0, float nofpclass(pzero) %not.pzero1) {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_pzero(
 ; CHECK-SAME: float nofpclass(pzero) [[NOT_PZERO0:%.*]], float nofpclass(pzero) [[NOT_PZERO1:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_PZERO0]], float [[NOT_PZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NOT_PZERO0]], float [[NOT_PZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %not.pzero0, float %not.pzero1)
@@ -770,7 +770,7 @@ define nofpclass(snan) float @rhs_not_nzero_lhs_not_pzero__dynamic(float nofpcla
 define nofpclass(snan) float @sources_not_nzero_nsub__dynamic(float nofpclass(nzero nsub) %not.nzero0, float nofpclass(nzero nsub) %not.nzero1) #1 {
 ; CHECK-LABEL: define nofpclass(snan) float @sources_not_nzero_nsub__dynamic(
 ; CHECK-SAME: float nofpclass(nzero nsub) [[NOT_NZERO0:%.*]], float nofpclass(nzero nsub) [[NOT_NZERO1:%.*]]) #[[ATTR1]] {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NOT_NZERO0]], float [[NOT_NZERO1]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %result = call float @llvm.minimumnum.f32(float %not.nzero0, float %not.nzero1)
@@ -1158,7 +1158,7 @@ define nofpclass(pinf pnorm psub) float @ret_always_positive_nonzero__minimumnum
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
 ; CHECK-NEXT:    [[ALWAYS_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[SELECT_RHS:%.*]] = select i1 [[COND]], float [[ALWAYS_POSITIVE]], float [[UNKNOWN]]
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %always.positive = call float @returns_positive()
@@ -1172,7 +1172,7 @@ define nofpclass(pinf pnorm psub) float @ret_always_positive_nonzero__minimumnum
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN:%.*]], float nofpclass(zero) [[NOT_ZERO:%.*]]) {
 ; CHECK-NEXT:    [[ALWAYS_NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[SELECT_RHS:%.*]] = select i1 [[COND]], float [[ALWAYS_NEGATIVE]], float [[UNKNOWN]]
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NOT_ZERO]], float [[SELECT_RHS]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %always.negative = call float @returns_negative()
@@ -1185,7 +1185,7 @@ define nofpclass(snan) float @known_positive__minimumnum__only_pzero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive__minimumnum__only_pzero_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[KNOWN_PZERO_OR_NAN:%.*]] = call float @returns_pzero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[KNOWN_POSITIVE]], float [[KNOWN_PZERO_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[KNOWN_POSITIVE]], float [[KNOWN_PZERO_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %known.positive = call float @returns_positive()
@@ -1350,7 +1350,7 @@ define nofpclass(snan) float @pinf__minimumnum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @pinf__minimumnum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PINF:%.*]] = call float @returns_pinf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf = call float @returns_pinf()
@@ -1362,7 +1362,7 @@ define nofpclass(snan) float @unknown__minimumnum__pinf(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__minimumnum__pinf(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PINF:%.*]] = call float @returns_pinf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN]], float 0x7FF0000000000000)
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf = call float @returns_pinf()
@@ -1374,7 +1374,7 @@ define nofpclass(snan) float @pinf_or_nan__minimumnum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @pinf_or_nan__minimumnum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PINF_OR_NAN:%.*]] = call float @returns_pinf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[PINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[PINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf.or.nan = call float @returns_pinf_or_nan()
@@ -1386,7 +1386,7 @@ define nofpclass(snan) float @unknown__minimumnum__pinf_or_nan(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__minimumnum__pinf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PINF_OR_NAN:%.*]] = call float @returns_pinf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[PINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[PINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pinf.or.nan = call float @returns_pinf_or_nan()
@@ -1420,7 +1420,7 @@ define nofpclass(snan) float @ninf_or_nan__minimumnum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @ninf_or_nan__minimumnum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NINF_OR_NAN:%.*]] = call float @returns_ninf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NINF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NINF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf.or.nan = call float @returns_ninf_or_nan()
@@ -1432,7 +1432,7 @@ define nofpclass(snan) float @unknown__minimumnum__ninf_or_nan(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__minimumnum__ninf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NINF_OR_NAN:%.*]] = call float @returns_ninf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[NINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[NINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf.or.nan = call float @returns_ninf_or_nan()
@@ -1444,7 +1444,7 @@ define nofpclass(snan) float @inf__minimumnum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @inf__minimumnum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[INF]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[INF]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf = call float @returns_inf()
@@ -1456,7 +1456,7 @@ define nofpclass(snan) float @unknown__minimumnum__inf(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__minimumnum__inf(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[INF]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[INF]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf = call float @returns_inf()
@@ -1468,7 +1468,7 @@ define nofpclass(snan) float @inf_or_nan__minimumnum__unknown(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @inf_or_nan__minimumnum__unknown(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[INF_OR_NAN]], float [[UNKNOWN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[INF_OR_NAN]], float [[UNKNOWN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1480,7 +1480,7 @@ define nofpclass(snan) float @unknown__minimumnum__inf_or_nan(float %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) float @unknown__minimumnum__inf_or_nan(
 ; CHECK-SAME: float [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[INF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[UNKNOWN]], float [[INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1492,7 +1492,7 @@ define nofpclass(snan) float @ninf_or_nan__minimumnum__not_nan(float nofpclass(n
 ; CHECK-LABEL: define nofpclass(snan) float @ninf_or_nan__minimumnum__not_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[NINF_OR_NAN:%.*]] = call float @returns_ninf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NINF_OR_NAN]], float [[NOT_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NINF_OR_NAN]], float [[NOT_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf.or.nan = call float @returns_ninf_or_nan()
@@ -1504,7 +1504,7 @@ define nofpclass(snan) float @not_nan__minimumnum__ninf_or_nan(float nofpclass(n
 ; CHECK-LABEL: define nofpclass(snan) float @not_nan__minimumnum__ninf_or_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[NINF_OR_NAN:%.*]] = call float @returns_ninf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_NAN]], float [[NINF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NOT_NAN]], float [[NINF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %ninf.or.nan = call float @returns_ninf_or_nan()
@@ -1538,7 +1538,7 @@ define nofpclass(snan) float @inf_or_nan__minimumnum__not_nan(float nofpclass(na
 ; CHECK-LABEL: define nofpclass(snan) float @inf_or_nan__minimumnum__not_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1550,7 +1550,7 @@ define nofpclass(snan) float @not_nan__minimumnum__inf_or_nan(float nofpclass(na
 ; CHECK-LABEL: define nofpclass(snan) float @not_nan__minimumnum__inf_or_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf_or_nan()
@@ -1606,7 +1606,7 @@ define nofpclass(snan) float @inf__minimumnum__not_nan(float nofpclass(nan) %not
 ; CHECK-LABEL: define nofpclass(snan) float @inf__minimumnum__not_nan(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.minimumnum.f32(float [[INF_OR_NAN]], float [[NOT_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf()
@@ -1618,7 +1618,7 @@ define nofpclass(snan) float @not_nan__minimumnum__inf(float nofpclass(nan) %not
 ; CHECK-LABEL: define nofpclass(snan) float @not_nan__minimumnum__inf(
 ; CHECK-SAME: float nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call float @returns_inf()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.minimumnum.f32(float [[NOT_NAN]], float [[INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %inf.or.nan = call float @returns_inf()
@@ -1758,7 +1758,7 @@ define nofpclass(snan) float @select_is_positive_or_0__minimumnum__nnorm_or_nan_
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    [[NNORM_OR_NAN:%.*]] = call float @returns_nnorm_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[SELECT]], float [[NNORM_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[SELECT]], float [[NNORM_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %is.pos.or.zero = fcmp oge float %arg, 0.0
@@ -1774,7 +1774,7 @@ define nofpclass(snan) float @select_is_positive_or_0__minimumnum__nnorm_or_nan_
 ; CHECK-NEXT:    [[NNORM_OR_NAN:%.*]] = call float @returns_nnorm_or_nan()
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NNORM_OR_NAN]], float [[SELECT]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NNORM_OR_NAN]], float [[SELECT]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %nnorm.or.nan = call float @returns_nnorm_or_nan()
@@ -1918,7 +1918,7 @@ define nofpclass(snan) float @positive_or_zero__minimumnum__negative_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @positive_or_zero__minimumnum__negative_or_nan() {
 ; CHECK-NEXT:    [[POS_NONZERO:%.*]] = call float @returns_positive_nonzero()
 ; CHECK-NEXT:    [[NEGATIVE_OR_NAN:%.*]] = call float @returns_negative_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[POS_NONZERO]], float [[NEGATIVE_OR_NAN]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[POS_NONZERO]], float [[NEGATIVE_OR_NAN]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %pos.nonzero = call float @returns_positive_nonzero()
@@ -1931,7 +1931,7 @@ define nofpclass(snan) float @negative_or_nan__minimumnum__positive_or_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @negative_or_nan__minimumnum__positive_or_zero() {
 ; CHECK-NEXT:    [[NEGATIVE_OR_NAN:%.*]] = call float @returns_negative_or_nan()
 ; CHECK-NEXT:    [[POS_NONZERO:%.*]] = call float @returns_positive_nonzero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[NEGATIVE_OR_NAN]], float [[POS_NONZERO]])
+; CHECK-NEXT:    [[RESULT:%.*]] = call nsz float @llvm.minimumnum.f32(float [[NEGATIVE_OR_NAN]], float [[POS_NONZERO]])
 ; CHECK-NEXT:    ret float [[RESULT]]
 ;
   %negative.or.nan = call float @returns_negative_or_nan()


### PR DESCRIPTION
Alive isn't particularly happy with this in the case where
one of the inputs could be zero, but I think
it's wrong: https://alive2.llvm.org/ce/z/dF7V6k

nsz shouldn't permit introducing a -0 result where
there wasn't one in the input here.