### PR TITLE
[Flang-rt][build] fixes building warnings under gcc:

### DIFF
--- a/flang-rt/include/flang-rt/runtime/numeric-templates.h
+++ b/flang-rt/include/flang-rt/runtime/numeric-templates.h
@@ -67,7 +67,7 @@ struct MaxOrMinIdentity<TypeCategory::Real, 16, IS_MAXVAL,
     // Create a buffer to store binary representation of __float128 constant.
     constexpr std::size_t alignment =
         std::max(alignof(Type), alignof(std::uint64_t));
-    alignas(alignment) char data[sizeof(Type)];
+    alignas(alignment) char data[sizeof(Type)]{};
 
     // First, verify that our interpretation of __float128 format is correct,
     // e.g. by checking at least one known constant.
@@ -104,7 +104,7 @@ template <> struct MinValue<113, CppTypeFor<TypeCategory::Real, 16>> {
     // Create a buffer to store binary representation of __float128 constant.
     constexpr std::size_t alignment =
         std::max(alignof(Type), alignof(std::uint64_t));
-    alignas(alignment) char data[sizeof(Type)];
+    alignas(alignment) char data[sizeof(Type)]{};
 
     // First, verify that our interpretation of __float128 format is correct,
     // e.g. by checking at least one known constant.

--- a/flang-rt/lib/runtime/character.cpp
+++ b/flang-rt/lib/runtime/character.cpp
@@ -159,7 +159,7 @@ template <typename CHAR, bool ADJUSTR>
 static RT_API_ATTRS void AdjustLRHelper(Descriptor &result,
     const Descriptor &string, const Terminator &terminator) {
   int rank{string.rank()};
-  SubscriptValue ub[maxRank], stringAt[maxRank];
+  SubscriptValue ub[maxRank]{}, stringAt[maxRank];
   SubscriptValue elements{1};
   for (int j{0}; j < rank; ++j) {
     ub[j] = string.GetDimension(j).Extent();
@@ -215,7 +215,7 @@ template <typename INT, typename CHAR>
 static RT_API_ATTRS void LenTrim(Descriptor &result, const Descriptor &string,
     const Terminator &terminator) {
   int rank{string.rank()};
-  SubscriptValue ub[maxRank], stringAt[maxRank];
+  SubscriptValue ub[maxRank]{}, stringAt[maxRank];
   SubscriptValue elements{1};
   for (int j{0}; j < rank; ++j) {
     ub[j] = string.GetDimension(j).Extent();

--- a/flang-rt/lib/runtime/extensions.cpp
+++ b/flang-rt/lib/runtime/extensions.cpp
@@ -452,7 +452,13 @@ float RTNAME(Rand)(int *i, const char *sourceFile, int line) {
   if (radix == 2) {
     mask = ~(unsigned)0u << (32 - digits + 1);
   } else if (radix == 16) {
-    mask = ~(unsigned)0u << ((8 - digits) * 4 + 1);
+    int shift_val = ((8 - digits) * 4 + 1);
+    if (shift_val < 0) {
+      Terminator terminator{sourceFile, line};
+      terminator.Crash("Radix 16: negative shift for mask. digits value maybe invalid.");
+    } else {
+      mask = ~(unsigned)0u << shift_val;
+    }
   } else {
     Terminator terminator{sourceFile, line};
     terminator.Crash("Radix unknown value.");


### PR DESCRIPTION
This PR fixes some building warning messages, primarily related to logical ambiguities during variable initialization and undefined behavior when the result of a shift operation is negative.

The files that were fixed are as follows:
1. flang-rt/runtime/numeric-templates.h

2. flang-rt/lib/runtime/character.cpp

3. flang-rt/lib/runtime/extensions.cpp
