### PR TITLE
[DAG]Add ISD::SPLAT_VECTOR to TargetLowering::getNegatedExpression

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18038,19 +18038,6 @@ SDValue DAGCombiner::visitFADD(SDNode *N) {
             N0, DAG, LegalOperations, ForCodeSize))
       return DAG.getNode(ISD::FSUB, DL, VT, N1, NegN0);
 
-  // fold (fadd A, Splat(fneg(B))) -> (fsub A, Splat(B))
-  if (VT.isVector() &&
-      (!LegalOperations || TLI.isOperationLegalOrCustom(ISD::FSUB, VT))) {
-    if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
-      SDValue SplatN0 = N1->getOperand(0);
-      if (SplatN0.getOpcode() == ISD::FNEG && SplatN0.hasOneUse()) {
-        SDValue Splat =
-            DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
-        return DAG.getNode(ISD::FSUB, DL, VT, N0, Splat);
-      }
-    }
-  }
-
   auto isFMulNegTwo = [](SDValue FMul) {
     if (!FMul.hasOneUse() || FMul.getOpcode() != ISD::FMUL)
       return false;

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18038,19 +18038,6 @@ SDValue DAGCombiner::visitFADD(SDNode *N) {
             N0, DAG, LegalOperations, ForCodeSize))
       return DAG.getNode(ISD::FSUB, DL, VT, N1, NegN0);
 
-  // fold (fadd A, Splat(fneg(B))) -> (fsub A, Splat(B))
-  if (VT.isVector() &&
-      (!LegalOperations || TLI.isOperationLegalOrCustom(ISD::FSUB, VT))) {
-    if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
-      SDValue SplatN0 = N1->getOperand(0);
-      if (SplatN0.getOpcode() == ISD::FNEG && SplatN0.hasOneUse()) {
-        SDValue Splat =
-            DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
-        return DAG.getNode(ISD::FSUB, DL, VT, N0, Splat);
-      }
-    }
-  }
-
   auto isFMulNegTwo = [](SDValue FMul) {
     if (!FMul.hasOneUse() || FMul.getOpcode() != ISD::FMUL)
       return false;
@@ -18291,18 +18278,6 @@ SDValue DAGCombiner::visitFSUB(SDNode *N) {
           TLI.getNegatedExpression(N1, DAG, LegalOperations, ForCodeSize))
     return DAG.getNode(ISD::FADD, DL, VT, N0, NegN1);
 
-  // fold (fsub A, Splat(fneg(B))) -> (fadd A, Splat(B))
-  if (VT.isVector() &&
-      (!LegalOperations || TLI.isOperationLegalOrCustom(ISD::FADD, VT))) {
-    if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
-      SDValue SplatN0 = N1->getOperand(0);
-      if (SplatN0.getOpcode() == ISD::FNEG && SplatN0.hasOneUse()) {
-        SDValue Splat =
-            DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
-        return DAG.getNode(ISD::FADD, DL, VT, N0, Splat);
-      }
-    }
-  }
   // FSUB -> FMA combines:
   if (SDValue Fused = visitFSUBForFMACombine<EmptyMatchContext>(N)) {
     AddToWorklist(Fused.getNode());

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18043,7 +18043,8 @@ SDValue DAGCombiner::visitFADD(SDNode *N) {
       (!LegalOperations || TLI.isOperationLegalOrCustom(ISD::FSUB, VT))) {
     if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
       SDValue SplatN0 = N1->getOperand(0);
-      if (SplatN0.getOpcode() == ISD::FNEG && SplatN0.hasOneUse()) {
+      if (SplatN0.getOpcode() == ISD::FNEG &&
+          (TLI.isFNegFree(VT) || SplatN0.hasOneUse())) {
         SDValue Splat =
             DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
         return DAG.getNode(ISD::FSUB, DL, VT, N0, Splat);
@@ -18296,7 +18297,8 @@ SDValue DAGCombiner::visitFSUB(SDNode *N) {
       (!LegalOperations || TLI.isOperationLegalOrCustom(ISD::FADD, VT))) {
     if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
       SDValue SplatN0 = N1->getOperand(0);
-      if (SplatN0.getOpcode() == ISD::FNEG && SplatN0.hasOneUse()) {
+      if (SplatN0.getOpcode() == ISD::FNEG &&
+          (TLI.isFNegFree(VT) || SplatN0.hasOneUse())) {
         SDValue Splat =
             DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
         return DAG.getNode(ISD::FADD, DL, VT, N0, Splat);

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18039,6 +18039,7 @@ SDValue DAGCombiner::visitFADD(SDNode *N) {
       return DAG.getNode(ISD::FSUB, DL, VT, N1, NegN0);
 
   // fold (fadd A, Splat(fneg(B))) -> (fsub A, Splat(B))
+  // TODO: move ISD::SPLAT_VECTOR handling inside getCheaperNegatedExpression
   if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
     SDValue SplatN0 = N1->getOperand(0);
     if (SDValue NegN0 = TLI.getCheaperNegatedExpression(
@@ -18290,6 +18291,7 @@ SDValue DAGCombiner::visitFSUB(SDNode *N) {
     return DAG.getNode(ISD::FADD, DL, VT, N0, NegN1);
 
   // fold (fsub A, Splat(fneg(B))) -> (fadd A, Splat(B))
+  // TODO: move ISD::SPLAT_VECTOR handling inside getCheaperNegatedExpression
   if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
     SDValue SplatN0 = N1->getOperand(0);
     if (SDValue NegN0 = TLI.getCheaperNegatedExpression(

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18038,18 +18038,6 @@ SDValue DAGCombiner::visitFADD(SDNode *N) {
             N0, DAG, LegalOperations, ForCodeSize))
       return DAG.getNode(ISD::FSUB, DL, VT, N1, NegN0);
 
-  // fold (fadd A, Splat(fneg(B))) -> (fsub A, Splat(B))
-  // TODO: move ISD::SPLAT_VECTOR handling inside getCheaperNegatedExpression
-  if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
-    SDValue SplatN0 = N1->getOperand(0);
-    if (SDValue NegN0 = TLI.getCheaperNegatedExpression(
-            SplatN0, DAG, LegalOperations, ForCodeSize)) {
-      SDValue Splat =
-          DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
-      return DAG.getNode(ISD::FSUB, DL, VT, N0, Splat);
-    }
-  }
-
   auto isFMulNegTwo = [](SDValue FMul) {
     if (!FMul.hasOneUse() || FMul.getOpcode() != ISD::FMUL)
       return false;
@@ -18289,18 +18277,6 @@ SDValue DAGCombiner::visitFSUB(SDNode *N) {
   if (SDValue NegN1 =
           TLI.getNegatedExpression(N1, DAG, LegalOperations, ForCodeSize))
     return DAG.getNode(ISD::FADD, DL, VT, N0, NegN1);
-
-  // fold (fsub A, Splat(fneg(B))) -> (fadd A, Splat(B))
-  // TODO: move ISD::SPLAT_VECTOR handling inside getCheaperNegatedExpression
-  if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
-    SDValue SplatN0 = N1->getOperand(0);
-    if (SDValue NegN0 = TLI.getCheaperNegatedExpression(
-            SplatN0, DAG, LegalOperations, ForCodeSize)) {
-      SDValue Splat =
-          DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
-      return DAG.getNode(ISD::FADD, DL, VT, N0, Splat);
-    }
-  }
 
   // FSUB -> FMA combines:
   if (SDValue Fused = visitFSUBForFMACombine<EmptyMatchContext>(N)) {

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18038,6 +18038,19 @@ SDValue DAGCombiner::visitFADD(SDNode *N) {
             N0, DAG, LegalOperations, ForCodeSize))
       return DAG.getNode(ISD::FSUB, DL, VT, N1, NegN0);
 
+  // fold (fadd A, Splat(fneg(B))) -> (fsub A, Splat(B))
+  if (VT.isVector() &&
+      (!LegalOperations || TLI.isOperationLegalOrCustom(ISD::FSUB, VT))) {
+    if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
+      SDValue SplatN0 = N1->getOperand(0);
+      if (SplatN0.getOpcode() == ISD::FNEG && SplatN0.hasOneUse()) {
+        SDValue Splat =
+            DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
+        return DAG.getNode(ISD::FSUB, DL, VT, N0, Splat);
+      }
+    }
+  }
+
   auto isFMulNegTwo = [](SDValue FMul) {
     if (!FMul.hasOneUse() || FMul.getOpcode() != ISD::FMUL)
       return false;

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18038,6 +18038,17 @@ SDValue DAGCombiner::visitFADD(SDNode *N) {
             N0, DAG, LegalOperations, ForCodeSize))
       return DAG.getNode(ISD::FSUB, DL, VT, N1, NegN0);
 
+  // fold (fadd A, Splat(fneg(B))) -> (fsub A, Splat(B))
+  if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
+    SDValue SplatN0 = N1->getOperand(0);
+    if (SDValue NegN0 = TLI.getCheaperNegatedExpression(
+            SplatN0, DAG, LegalOperations, ForCodeSize)) {
+      SDValue Splat =
+          DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
+      return DAG.getNode(ISD::FSUB, DL, VT, N0, Splat);
+    }
+  }
+
   auto isFMulNegTwo = [](SDValue FMul) {
     if (!FMul.hasOneUse() || FMul.getOpcode() != ISD::FMUL)
       return false;
@@ -18277,6 +18288,17 @@ SDValue DAGCombiner::visitFSUB(SDNode *N) {
   if (SDValue NegN1 =
           TLI.getNegatedExpression(N1, DAG, LegalOperations, ForCodeSize))
     return DAG.getNode(ISD::FADD, DL, VT, N0, NegN1);
+
+  // fold (fsub A, Splat(fneg(B))) -> (fadd A, Splat(B))
+  if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
+    SDValue SplatN0 = N1->getOperand(0);
+    if (SDValue NegN0 = TLI.getCheaperNegatedExpression(
+            SplatN0, DAG, LegalOperations, ForCodeSize)) {
+      SDValue Splat =
+          DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
+      return DAG.getNode(ISD::FADD, DL, VT, N0, Splat);
+    }
+  }
 
   // FSUB -> FMA combines:
   if (SDValue Fused = visitFSUBForFMACombine<EmptyMatchContext>(N)) {

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18043,8 +18043,7 @@ SDValue DAGCombiner::visitFADD(SDNode *N) {
       (!LegalOperations || TLI.isOperationLegalOrCustom(ISD::FSUB, VT))) {
     if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
       SDValue SplatN0 = N1->getOperand(0);
-      if (SplatN0.getOpcode() == ISD::FNEG &&
-          (TLI.isFNegFree(VT) || SplatN0.hasOneUse())) {
+      if (SplatN0.getOpcode() == ISD::FNEG && SplatN0.hasOneUse()) {
         SDValue Splat =
             DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
         return DAG.getNode(ISD::FSUB, DL, VT, N0, Splat);
@@ -18297,8 +18296,7 @@ SDValue DAGCombiner::visitFSUB(SDNode *N) {
       (!LegalOperations || TLI.isOperationLegalOrCustom(ISD::FADD, VT))) {
     if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
       SDValue SplatN0 = N1->getOperand(0);
-      if (SplatN0.getOpcode() == ISD::FNEG &&
-          (TLI.isFNegFree(VT) || SplatN0.hasOneUse())) {
+      if (SplatN0.getOpcode() == ISD::FNEG && SplatN0.hasOneUse()) {
         SDValue Splat =
             DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
         return DAG.getNode(ISD::FADD, DL, VT, N0, Splat);

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18038,6 +18038,19 @@ SDValue DAGCombiner::visitFADD(SDNode *N) {
             N0, DAG, LegalOperations, ForCodeSize))
       return DAG.getNode(ISD::FSUB, DL, VT, N1, NegN0);
 
+  // fold (fadd A, Splat(fneg(B))) -> (fsub A, Splat(B))
+  if (VT.isVector() &&
+      (!LegalOperations || TLI.isOperationLegalOrCustom(ISD::FSUB, VT))) {
+    if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
+      SDValue SplatN0 = N1->getOperand(0);
+      if (SplatN0.getOpcode() == ISD::FNEG && SplatN0.hasOneUse()) {
+        SDValue Splat =
+            DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
+        return DAG.getNode(ISD::FSUB, DL, VT, N0, Splat);
+      }
+    }
+  }
+
   auto isFMulNegTwo = [](SDValue FMul) {
     if (!FMul.hasOneUse() || FMul.getOpcode() != ISD::FMUL)
       return false;
@@ -18278,6 +18291,18 @@ SDValue DAGCombiner::visitFSUB(SDNode *N) {
           TLI.getNegatedExpression(N1, DAG, LegalOperations, ForCodeSize))
     return DAG.getNode(ISD::FADD, DL, VT, N0, NegN1);
 
+  // fold (fsub A, Splat(fneg(B))) -> (fadd A, Splat(B))
+  if (VT.isVector() &&
+      (!LegalOperations || TLI.isOperationLegalOrCustom(ISD::FADD, VT))) {
+    if (N1.getOpcode() == ISD::SPLAT_VECTOR) {
+      SDValue SplatN0 = N1->getOperand(0);
+      if (SplatN0.getOpcode() == ISD::FNEG && SplatN0.hasOneUse()) {
+        SDValue Splat =
+            DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, SplatN0->getOperand(0));
+        return DAG.getNode(ISD::FADD, DL, VT, N0, Splat);
+      }
+    }
+  }
   // FSUB -> FMA combines:
   if (SDValue Fused = visitFSUBForFMACombine<EmptyMatchContext>(N)) {
     AddToWorklist(Fused.getNode());

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -7554,6 +7554,18 @@ SDValue TargetLowering::getNegatedExpression(SDValue Op, SelectionDAG &DAG,
     Cost = NegatibleCost::Neutral;
     return CFP;
   }
+  case ISD::SPLAT_VECTOR: {
+    // fold splat_vector(fneg(X)) -> splat_vector(-X)
+    SDValue X = Op.getOperand(0);
+    if (!isOperationLegal(ISD::SPLAT_VECTOR, VT))
+      break;
+
+    SDValue NegX = getCheaperNegatedExpression(X, DAG, LegalOps, OptForSize);
+    if (!NegX)
+      break;
+    Cost = NegatibleCost::Cheaper;
+    return DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, NegX);
+  }
   case ISD::BUILD_VECTOR: {
     // Only permit BUILD_VECTOR of constants.
     if (llvm::any_of(Op->op_values(), [&](SDValue N) {

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -7554,19 +7554,6 @@ SDValue TargetLowering::getNegatedExpression(SDValue Op, SelectionDAG &DAG,
     Cost = NegatibleCost::Neutral;
     return CFP;
   }
-  case ISD::SPLAT_VECTOR: {
-    SDValue X = Op.getOperand(0);
-    if (!isOperationLegal(ISD::SPLAT_VECTOR, VT))
-      break;
-
-    NegatibleCost CostX = NegatibleCost::Expensive;
-    SDValue NegX =
-        getNegatedExpression(X, DAG, LegalOps, OptForSize, CostX, Depth);
-    if (!NegX || CostX >= NegatibleCost::Neutral)
-      break;
-    Cost = CostX;
-    return DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, NegX);
-  }
   case ISD::BUILD_VECTOR: {
     // Only permit BUILD_VECTOR of constants.
     if (llvm::any_of(Op->op_values(), [&](SDValue N) {

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -7554,6 +7554,19 @@ SDValue TargetLowering::getNegatedExpression(SDValue Op, SelectionDAG &DAG,
     Cost = NegatibleCost::Neutral;
     return CFP;
   }
+  case ISD::SPLAT_VECTOR: {
+    SDValue X = Op.getOperand(0);
+    if (!isOperationLegal(ISD::SPLAT_VECTOR, VT))
+      break;
+
+    NegatibleCost CostX = NegatibleCost::Expensive;
+    SDValue NegX =
+        getNegatedExpression(X, DAG, LegalOps, OptForSize, CostX, Depth);
+    if (!NegX || CostX >= NegatibleCost::Neutral)
+      break;
+    Cost = CostX;
+    return DAG.getNode(ISD::SPLAT_VECTOR, DL, VT, NegX);
+  }
   case ISD::BUILD_VECTOR: {
     // Only permit BUILD_VECTOR of constants.
     if (llvm::any_of(Op->op_values(), [&](SDValue N) {

--- a/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
@@ -84,8 +84,9 @@ define <vscale x 8 x float> @vfsub_vf_nxv8f32(<vscale x 8 x float> %va) {
 ; CHECK-LABEL: vfsub_vf_nxv8f32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    fli.s fa5, 2.0
+; CHECK-NEXT:    fneg.s fa5, fa5
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
-; CHECK-NEXT:    vfsub.vf v8, v8, fa5
+; CHECK-NEXT:    vfadd.vf v8, v8, fa5
 ; CHECK-NEXT:    ret
   %vd = fadd <vscale x 8 x float> %va, splat (float -2.000000e+00)
   ret <vscale x 8 x float> %vd

--- a/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
@@ -80,8 +80,8 @@ define <vscale x 8 x float> @vfnmadd(<vscale x 8 x float> %va, <vscale x 8 x flo
   ret <vscale x 8 x float> %vd
 }
 
-define <vscale x 8 x float> @vfsub_vf_nxv8f32(<vscale x 8 x float> %va) {
-; CHECK-LABEL: vfsub_vf_nxv8f32:
+define <vscale x 8 x float> @vfadd_vf_neg(<vscale x 8 x float> %va) {
+; CHECK-LABEL: vfadd_vf_neg:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    fli.s fa5, 2.0
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
@@ -92,13 +92,36 @@ define <vscale x 8 x float> @vfsub_vf_nxv8f32(<vscale x 8 x float> %va) {
 }
 
 
-define <vscale x 8 x float> @vfsub_vf(<vscale x 8 x float> %va) {
-; CHECK-LABEL: vfsub_vf:
+define <vscale x 8 x float> @vfsub_vf_neg(<vscale x 8 x float> %va) {
+; CHECK-LABEL: vfsub_vf_neg:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    fli.s fa5, 2.0
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
 ; CHECK-NEXT:    vfadd.vf v8, v8, fa5
 ; CHECK-NEXT:    ret
   %vd = fsub <vscale x 8 x float> %va, splat (float -2.000000e+00)
+  ret <vscale x 8 x float> %vd
+}
+
+
+define <vscale x 8 x float> @vfsub_vf(<vscale x 8 x float> %va) {
+; CHECK-LABEL: vfsub_vf:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fli.s fa5, 2.0
+; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
+; CHECK-NEXT:    vfsub.vf v8, v8, fa5
+; CHECK-NEXT:    ret
+  %vd = fsub <vscale x 8 x float> %va, splat (float 2.000000e+00)
+  ret <vscale x 8 x float> %vd
+}
+
+define <vscale x 8 x float> @vfadd_vf(<vscale x 8 x float> %va) {
+; CHECK-LABEL: vfadd_vf:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fli.s fa5, 2.0
+; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
+; CHECK-NEXT:    vfadd.vf v8, v8, fa5
+; CHECK-NEXT:    ret
+  %vd = fadd <vscale x 8 x float> %va, splat (float 2.000000e+00)
   ret <vscale x 8 x float> %vd
 }

--- a/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
@@ -84,10 +84,21 @@ define <vscale x 8 x float> @vfsub_vf_nxv8f32(<vscale x 8 x float> %va) {
 ; CHECK-LABEL: vfsub_vf_nxv8f32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    fli.s fa5, 2.0
-; CHECK-NEXT:    fneg.s fa5, fa5
+; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
+; CHECK-NEXT:    vfsub.vf v8, v8, fa5
+; CHECK-NEXT:    ret
+  %vd = fadd <vscale x 8 x float> %va, splat (float -2.000000e+00)
+  ret <vscale x 8 x float> %vd
+}
+
+
+define <vscale x 8 x float> @vfsub_vf(<vscale x 8 x float> %va) {
+; CHECK-LABEL: vfsub_vf:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fli.s fa5, 2.0
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
 ; CHECK-NEXT:    vfadd.vf v8, v8, fa5
 ; CHECK-NEXT:    ret
-  %vd = fadd <vscale x 8 x float> %va, splat (float -2.000000e+00)
+  %vd = fsub <vscale x 8 x float> %va, splat (float -2.000000e+00)
   ret <vscale x 8 x float> %vd
 }

--- a/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
@@ -84,20 +84,10 @@ define <vscale x 8 x float> @vfsub_vf_nxv8f32(<vscale x 8 x float> %va) {
 ; CHECK-LABEL: vfsub_vf_nxv8f32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    fli.s fa5, 2.0
-; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
-; CHECK-NEXT:    vfsub.vf v8, v8, fa5
-; CHECK-NEXT:    ret
-  %vd = fadd <vscale x 8 x float> %va, splat (float -2.000000e+00)
-  ret <vscale x 8 x float> %vd
-}
-
-define <vscale x 8 x float> @vfsub_vf(<vscale x 8 x float> %va) {
-; CHECK-LABEL: vfsub_vf:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    fli.s fa5, 2.0
+; CHECK-NEXT:    fneg.s fa5, fa5
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
 ; CHECK-NEXT:    vfadd.vf v8, v8, fa5
 ; CHECK-NEXT:    ret
-  %vd = fsub <vscale x 8 x float> %va, splat (float -2.000000e+00)
+  %vd = fadd <vscale x 8 x float> %va, splat (float -2.000000e+00)
   ret <vscale x 8 x float> %vd
 }

--- a/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
@@ -79,3 +79,15 @@ define <vscale x 8 x float> @vfnmadd(<vscale x 8 x float> %va, <vscale x 8 x flo
   %vd = call <vscale x 8 x float> @llvm.fma.v8f32(<vscale x 8 x float> %va, <vscale x 8 x float> splat (float -2.000000e+00), <vscale x 8 x float> %neg)
   ret <vscale x 8 x float> %vd
 }
+
+define <vscale x 8 x float> @vfsub_vf_nxv8f32(<vscale x 8 x float> %va) {
+; CHECK-LABEL: vfsub_vf_nxv8f32:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fli.s fa5, 2.0
+; CHECK-NEXT:    fneg.s fa5, fa5
+; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
+; CHECK-NEXT:    vfadd.vf v8, v8, fa5
+; CHECK-NEXT:    ret
+  %vd = fadd <vscale x 8 x float> %va, splat (float -2.000000e+00)
+  ret <vscale x 8 x float> %vd
+}

--- a/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
@@ -84,10 +84,20 @@ define <vscale x 8 x float> @vfsub_vf_nxv8f32(<vscale x 8 x float> %va) {
 ; CHECK-LABEL: vfsub_vf_nxv8f32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    fli.s fa5, 2.0
-; CHECK-NEXT:    fneg.s fa5, fa5
+; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
+; CHECK-NEXT:    vfsub.vf v8, v8, fa5
+; CHECK-NEXT:    ret
+  %vd = fadd <vscale x 8 x float> %va, splat (float -2.000000e+00)
+  ret <vscale x 8 x float> %vd
+}
+
+define <vscale x 8 x float> @vfsub_vf(<vscale x 8 x float> %va) {
+; CHECK-LABEL: vfsub_vf:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fli.s fa5, 2.0
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
 ; CHECK-NEXT:    vfadd.vf v8, v8, fa5
 ; CHECK-NEXT:    ret
-  %vd = fadd <vscale x 8 x float> %va, splat (float -2.000000e+00)
+  %vd = fsub <vscale x 8 x float> %va, splat (float -2.000000e+00)
   ret <vscale x 8 x float> %vd
 }

--- a/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
@@ -84,9 +84,8 @@ define <vscale x 8 x float> @vfsub_vf_nxv8f32(<vscale x 8 x float> %va) {
 ; CHECK-LABEL: vfsub_vf_nxv8f32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    fli.s fa5, 2.0
-; CHECK-NEXT:    fneg.s fa5, fa5
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
-; CHECK-NEXT:    vfadd.vf v8, v8, fa5
+; CHECK-NEXT:    vfsub.vf v8, v8, fa5
 ; CHECK-NEXT:    ret
   %vd = fadd <vscale x 8 x float> %va, splat (float -2.000000e+00)
   ret <vscale x 8 x float> %vd

--- a/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vsplats-zfa.ll
@@ -84,21 +84,10 @@ define <vscale x 8 x float> @vfsub_vf_nxv8f32(<vscale x 8 x float> %va) {
 ; CHECK-LABEL: vfsub_vf_nxv8f32:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    fli.s fa5, 2.0
-; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
-; CHECK-NEXT:    vfsub.vf v8, v8, fa5
-; CHECK-NEXT:    ret
-  %vd = fadd <vscale x 8 x float> %va, splat (float -2.000000e+00)
-  ret <vscale x 8 x float> %vd
-}
-
-
-define <vscale x 8 x float> @vfsub_vf(<vscale x 8 x float> %va) {
-; CHECK-LABEL: vfsub_vf:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    fli.s fa5, 2.0
+; CHECK-NEXT:    fneg.s fa5, fa5
 ; CHECK-NEXT:    vsetvli a0, zero, e32, m4, ta, ma
 ; CHECK-NEXT:    vfadd.vf v8, v8, fa5
 ; CHECK-NEXT:    ret
-  %vd = fsub <vscale x 8 x float> %va, splat (float -2.000000e+00)
+  %vd = fadd <vscale x 8 x float> %va, splat (float -2.000000e+00)
   ret <vscale x 8 x float> %vd
 }


### PR DESCRIPTION
Fold splat_vector(fneg(X)) -> splat_vector(-X)
Call the getCheaperNegatedExpression function, and ISD::SPLAT_VECTOR return NegatibleCost::Cheaper. 
This optimization is applied only to the fneg instruction.
