### PR TITLE
[mlir][Interfaces] Add `RegionBranchOpInterface::getSuccessorOperands` helper

### DIFF
--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
@@ -350,6 +350,15 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
     /// Return `true` if there is a loop in the region branching graph. Only
     /// reachable regions (starting from the entry regions) are considered.
     bool hasLoop();
+
+    /// Return the successor operands from the source branch point to the
+    /// destination region successor.
+    ///
+    /// If the branch point is the parent op, this function returns entry
+    /// successor operands of this op. Otherwise, it returns successor operands
+    /// of the respective terminator.
+    ::mlir::OperandRange getSuccessorOperands(
+        ::mlir::RegionBranchPoint src, ::mlir::RegionSuccessor dest);
   }];
 }
 

--- a/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
+++ b/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
@@ -479,6 +479,16 @@ bool RegionBranchOpInterface::hasLoop() {
   return false;
 }
 
+OperandRange
+RegionBranchOpInterface::getSuccessorOperands(RegionBranchPoint src,
+                                              RegionSuccessor dest) {
+  if (src.isParent())
+    return getEntrySuccessorOperands(dest);
+  auto terminator = cast<RegionBranchTerminatorOpInterface>(
+      src.getTerminatorPredecessorOrNull());
+  return terminator.getSuccessorOperands(dest);
+}
+
 Region *mlir::getEnclosingRepetitiveRegion(Operation *op) {
   LDBG() << "Finding enclosing repetitive region for operation "
          << op->getName();


### PR DESCRIPTION
Add a helper for querying the successor operands for a region branch `src -> dst`. Both `src` and `dst` may be the region branch op itself or a terminator.

This helper allows users to query successor operands for the region branch op and the terminators in a uniform way. This is similar to `getSuccessorRegions(RegionBranchPoint)`, which works both for region branch ops and terminators.
