### PR TITLE
[flang] Recognize IARGC and GETARG as aliases for F2003 intrinsics

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -381,6 +381,9 @@ end
 * Legacy names `AND`, `OR`, and `XOR` are accepted as aliases for
   the standard intrinsic functions `IAND`, `IOR`, and `IEOR`
   respectively.
+* Legacy GNU intrinsics `IARGC` and `GETARG` are accepted as aliases for
+  the standard intrinsics `COMMAND_ARGUMENT_COUNT` and
+  `GET_COMMAND_ARGUMENT`, respectively.
 * A digit count of d=0 is accepted in Ew.0, Dw.0, and Gw.0 output
   editing if no nonzero scale factor (kP) is in effect.
 * The name `IMAG` is accepted as an alias for the generic intrinsic

--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -1164,6 +1164,7 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
 // Aliases for a few generic procedures for legacy compatibility and builtins.
 static const std::pair<const char *, const char *> genericAlias[]{
     {"and", "iand"},
+    {"getarg", "get_command_argument"}, 
     {"getenv", "get_environment_variable"},
     {"fseek64", "fseek"},
     {"fseeko64", "fseek"}, // SUN
@@ -1172,6 +1173,7 @@ static const std::pair<const char *, const char *> genericAlias[]{
     {"ftello64", "ftell"}, // SUN
     {"ftelli8", "ftell"}, // Intel
     {"imag", "aimag"},
+    {"iargc", "command_argument_count"}, 
     {"lshift", "shiftl"},
     {"or", "ior"},
     {"rshift", "shifta"},

--- a/flang/test/Semantics/intrinsic-alias-implicit-none.f90
+++ b/flang/test/Semantics/intrinsic-alias-implicit-none.f90
@@ -1,0 +1,17 @@
+! RUN: %flang_fc1 -fsyntax-only %s
+!
+! Check that GNU Fortran compatibility intrinsics IARGC and GETARG
+! are recognized as intrinsic procedures under IMPLICIT NONE.
+
+program test_intrinsic_aliases
+  implicit none
+
+  integer :: n
+  character(len=100) :: arg
+
+  ! IARGC is an alias for COMMAND_ARGUMENT_COUNT
+  n = iargc()
+
+  ! GETARG is an alias for GET_COMMAND_ARGUMENT
+  call getarg(1, arg)
+end program


### PR DESCRIPTION
This patch fixes a semantic issue where the GNU Fortran compatibility
intrinsics IARGC and GETARG were not recognized under IMPLICIT NONE,
despite being available in the Flang runtime.

The change registers both names as aliases for their Fortran 2003
standard equivalents, restoring compatibility with legacy code
without changing lowering or runtime behavior.

Fixes #158438.