### PR TITLE
[mlir][Interfaces][NFC] Add `RegionBranchOpInterface` helper for forwarded values

### DIFF
--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
@@ -176,6 +176,19 @@ namespace detail {
 LogicalResult verifyTypesAlongControlFlowEdges(Operation *op);
 } //  namespace detail
 
+/// A mapping from successor operands to successor inputs.
+///
+/// * A successor operand is an operand of a region branch op or region
+///   branch terminator, that is forwarded to a successor input.
+/// * A successor input is a block argument of a region or a result of the
+///   region branch op, that is populated by a successor operand.
+///
+/// The mapping is 1:N. Each successor operand may be forwarded to multiple
+/// successor inputs. (Because the control flow can dispatch to multiple
+/// possible successors.) Operands that not forwarded at all are not present in
+/// the mapping.
+using RegionBranchSuccessorMapping = DenseMap<OpOperand *, SmallVector<Value>>;
+
 /// This class represents a successor of a region. A region successor can either
 /// be another region, or the parent operation. If the successor is a region,
 /// this class represents the destination region, as well as a set of arguments

--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
@@ -251,30 +251,16 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
            "::llvm::SmallVectorImpl<::mlir::RegionBranchPoint> &":$predecessors),
       [{}],
       /*defaultImplementation=*/[{
-        ::llvm::SmallVector<::mlir::RegionSuccessor> successors;
-        $_op.getSuccessorRegions(RegionBranchPoint::parent(),
-                                 successors);
-        if (llvm::any_of(successors, [&] (const RegionSuccessor & succ) {
+        auto op = cast<RegionBranchOpInterface>($_op.getOperation());
+        for (::mlir::RegionBranchPoint point : op.getAllRegionBranchPoints()) {
+          ::llvm::SmallVector<::mlir::RegionSuccessor> successors;
+          op.getSuccessorRegions(point, successors);
+          bool isPred = llvm::any_of(successors, [&] (const auto &succ) {
             return succ.getSuccessor() == successor.getSuccessor() ||
-              (succ.isParent() && successor.isParent());
-          }))
-          predecessors.push_back(RegionBranchPoint::parent());
-        for (Region &region : $_op->getRegions()) {
-          for (::mlir::Block &block : region) {
-            if (block.empty())
-              continue;
-            if (auto terminator =
-                    dyn_cast<RegionBranchTerminatorOpInterface>(block.back())) {
-              ::llvm::SmallVector<::mlir::RegionSuccessor> successors;
-              $_op.getSuccessorRegions(RegionBranchPoint(terminator),
-                                       successors);
-              if (llvm::any_of(successors, [&] (const RegionSuccessor & succ) {
-                  return succ.getSuccessor() == successor.getSuccessor() ||
-                    (succ.isParent() && successor.isParent());
-                }))
-                predecessors.push_back(terminator);
-            }
-          }
+                   (succ.isParent() && successor.isParent());
+            });
+          if (isPred)
+            predecessors.push_back(point);
         }
       }]>,
     InterfaceMethod<[{
@@ -359,6 +345,19 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
     /// of the respective terminator.
     ::mlir::OperandRange getSuccessorOperands(
         ::mlir::RegionBranchPoint src, ::mlir::RegionSuccessor dest);
+
+    /// Build a mapping from successor operands to successor input. Each
+    /// successor operand could be forwarded to multiple successor inputs.
+    /// Operands that are not forwarded are not added to the map. Unless a
+    /// specific region branch point is specified, this function takes into
+    /// account all possible region branch points.
+    void getSuccessorOperandInputMapping(
+        ::mlir::RegionBranchSuccessorMapping &mapping,
+        std::optional<::mlir::RegionBranchPoint> src = std::nullopt);
+
+    /// Return all possible region branch points: the region branch op itself
+    /// and all region branch terminators.
+    ::llvm::SmallVector<::mlir::RegionBranchPoint> getAllRegionBranchPoints();
   }];
 }
 

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPropagateLayout.cpp
@@ -1248,20 +1248,15 @@ updateControlFlowOps(mlir::OpBuilder &builder,
                      mlir::RegionBranchTerminatorOpInterface terminator,
                      GetLayoutFnTy getLayoutOfValue) {
   // Only process if the terminator is inside a region branch op.
-  if (!mlir::isa<mlir::RegionBranchOpInterface>(terminator->getParentOp()))
+  auto branchOp = dyn_cast<RegionBranchOpInterface>(terminator->getParentOp());
+  if (!branchOp)
     return success();
 
-  llvm::SmallVector<mlir::RegionSuccessor> successors;
-  llvm::SmallVector<mlir::Attribute> operands(terminator->getNumOperands(),
-                                              nullptr);
-  terminator.getSuccessorRegions(operands, successors);
-
-  for (mlir::RegionSuccessor &successor : successors) {
-    mlir::OperandRange successorOperands =
-        terminator.getSuccessorOperands(successor);
-    mlir::ValueRange successorInputs = successor.getSuccessorInputs();
-    for (auto [successorOperand, successorInput] :
-         llvm::zip(successorOperands, successorInputs)) {
+  RegionBranchSuccessorMapping mapping;
+  branchOp.getSuccessorOperandInputMapping(mapping,
+                                           RegionBranchPoint(terminator));
+  for (const auto &[successorOperand, successorInputs] : mapping) {
+    for (Value successorInput : successorInputs) {
       Type inputType = successorInput.getType();
       // We only need to operate on tensor descriptor or vector types.
       if (!isa<xegpu::TensorDescType, VectorType>(inputType))
@@ -1269,13 +1264,13 @@ updateControlFlowOps(mlir::OpBuilder &builder,
       xegpu::DistributeLayoutAttr successorInputLayout =
           getLayoutOfValue(successorInput);
       xegpu::DistributeLayoutAttr successorOperandLayout =
-          getLayoutOfValue(successorOperand);
+          getLayoutOfValue(successorOperand->get());
 
       // If either of the layouts is not assigned, we cannot proceed.
       if (!successorOperandLayout) {
         LLVM_DEBUG(DBGS() << "No layout assigned for forwarded operand in "
                              "branch terminator: "
-                          << successorOperand << "\n");
+                          << successorOperand->get() << "\n");
         return failure();
       }
       // We expect the layouts to match.


### PR DESCRIPTION
Add a helper function to compute a mapping of successor operands to successor inputs. This mapping is computed in various places. Also add a helper function to gather all region branch points.

This commit is in preparation of a bug fix / partial redesign of `-remove-dead-values`. This commit also removes some duplicate code in various places.
