### PR TITLE
[LLVM][ADT] Migrate users of `make_scope_exit` to CTAD

### DIFF
--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -347,7 +347,7 @@ bool DataAggregator::checkPerfDataMagic(StringRef FileName) {
 
   char Buf[7] = {0, 0, 0, 0, 0, 0, 0};
 
-  auto Close = make_scope_exit([&] { sys::fs::closeFile(*FD); });
+  llvm::scope_exit Close([&] { sys::fs::closeFile(*FD); });
   Expected<size_t> BytesRead = sys::fs::readNativeFileSlice(
       *FD, MutableArrayRef(Buf, sizeof(Buf)), 0);
   if (!BytesRead) {

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -433,7 +433,7 @@ private:
     // When the request ends, we can clean up the entry we just added.
     // The cookie lets us check that it hasn't been overwritten due to ID
     // reuse.
-    return Task.first.derive(llvm::make_scope_exit([this, StrID, Cookie] {
+    return Task.first.derive(llvm::scope_exit([this, StrID, Cookie] {
       std::lock_guard<std::mutex> Lock(RequestCancelersMutex);
       auto It = RequestCancelers.find(StrID);
       if (It != RequestCancelers.end() && It->second.second == Cookie)

--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -880,7 +880,7 @@ void StoreDiags::HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
 void StoreDiags::flushLastDiag() {
   if (!LastDiag)
     return;
-  auto Finish = llvm::make_scope_exit([&, NDiags(Output.size())] {
+  llvm::scope_exit Finish([&, NDiags(Output.size())] {
     if (Output.size() == NDiags) // No new diag emitted.
       vlog("Dropped diagnostic: {0}: {1}", LastDiag->File, LastDiag->Message);
     LastDiag.reset();

--- a/clang-tools-extra/clangd/GlobalCompilationDatabase.cpp
+++ b/clang-tools-extra/clangd/GlobalCompilationDatabase.cpp
@@ -174,7 +174,7 @@ public:
     }
 
     std::lock_guard<std::mutex> Lock(Mu);
-    auto RequestBroadcast = llvm::make_scope_exit([&, OldCDB(CDB.get())] {
+    llvm::scope_exit RequestBroadcast([&, OldCDB(CDB.get())] {
       // If we loaded a new CDB, it should be broadcast at some point.
       if (CDB != nullptr && CDB.get() != OldCDB)
         NeedsBroadcast = true;

--- a/clang-tools-extra/clangd/SystemIncludeExtractor.cpp
+++ b/clang-tools-extra/clangd/SystemIncludeExtractor.cpp
@@ -332,7 +332,7 @@ std::optional<std::string> run(llvm::ArrayRef<llvm::StringRef> Argv,
          EC.message());
     return std::nullopt;
   }
-  auto CleanUp = llvm::make_scope_exit(
+  llvm::scope_exit CleanUp(
       [&OutputPath]() { llvm::sys::fs::remove(OutputPath); });
 
   std::optional<llvm::StringRef> Redirects[] = {{""}, {""}, {""}};

--- a/clang-tools-extra/clangd/TUScheduler.cpp
+++ b/clang-tools-extra/clangd/TUScheduler.cpp
@@ -1003,8 +1003,7 @@ void ASTWorker::runWithAST(
       AST = NewAST ? std::make_unique<ParsedAST>(std::move(*NewAST)) : nullptr;
     }
     // Make sure we put the AST back into the LRU cache.
-    auto _ = llvm::make_scope_exit(
-        [&AST, this]() { IdleASTs.put(this, std::move(*AST)); });
+    llvm::scope_exit _([&AST, this]() { IdleASTs.put(this, std::move(*AST)); });
     // Run the user-provided action.
     if (!*AST)
       return Action(error(llvm::errc::invalid_argument, "invalid AST"));
@@ -1057,7 +1056,7 @@ void PreambleThread::build(Request Req) {
   Status.update([&](TUStatus &Status) {
     Status.PreambleActivity = PreambleAction::Building;
   });
-  auto _ = llvm::make_scope_exit([this, &Req, &ReusedPreamble] {
+  llvm::scope_exit _([this, &Req, &ReusedPreamble] {
     ASTPeer.updatePreamble(std::move(Req.CI), std::move(Req.Inputs),
                            LatestBuild, std::move(Req.CIDiags),
                            std::move(Req.WantDiags));

--- a/clang-tools-extra/clangd/XRefs.cpp
+++ b/clang-tools-extra/clangd/XRefs.cpp
@@ -1097,7 +1097,7 @@ class FindControlFlow : public RecursiveASTVisitor<FindControlFlow> {
   // Traverses the subtree using Delegate() if any targets remain.
   template <typename Func>
   bool filterAndTraverse(DynTypedNode D, const Func &Delegate) {
-    auto RestoreIgnore = llvm::make_scope_exit(
+    llvm::scope_exit RestoreIgnore(
         [OldIgnore(Ignore), this] { Ignore = OldIgnore; });
     if (getFunctionBody(D))
       Ignore = All;

--- a/clang-tools-extra/clangd/index/dex/dexp/Dexp.cpp
+++ b/clang-tools-extra/clangd/index/dex/dexp/Dexp.cpp
@@ -107,7 +107,7 @@ public:
     bool Ok = llvm::cl::ParseCommandLineOptions(Argv.size(), Argv.data(),
                                                 Overview, &OS);
     // must do this before opts are destroyed
-    auto Cleanup = llvm::make_scope_exit(llvm::cl::ResetCommandLineParser);
+    llvm::scope_exit Cleanup(llvm::cl::ResetCommandLineParser);
     if (Help.getNumOccurrences() > 0) {
       // Avoid printing parse errors in this case.
       // (Well, in theory. A bunch get printed to llvm::errs() regardless!)

--- a/clang-tools-extra/clangd/support/FileCache.cpp
+++ b/clang-tools-extra/clangd/support/FileCache.cpp
@@ -35,7 +35,7 @@ void FileCache::read(
 
   std::lock_guard<std::mutex> Lock(Mu);
   // We're going to update the cache and return whatever's in it.
-  auto Return = llvm::make_scope_exit(Read);
+  llvm::scope_exit Return(Read);
 
   // Return any sufficiently recent result without doing any further work.
   if (ValidTime > FreshTime)
@@ -43,7 +43,7 @@ void FileCache::read(
 
   // Ensure we always bump ValidTime, so that FreshTime imposes a hard limit on
   // how often we do IO.
-  auto BumpValidTime = llvm::make_scope_exit(
+  llvm::scope_exit BumpValidTime(
       [&] { ValidTime = std::chrono::steady_clock::now(); });
 
   // stat is cheaper than opening the file. It's usually unchanged.

--- a/clang-tools-extra/clangd/support/Threading.cpp
+++ b/clang-tools-extra/clangd/support/Threading.cpp
@@ -85,7 +85,7 @@ void AsyncTaskRunner::runAsync(const llvm::Twine &Name,
     ++InFlightTasks;
   }
 
-  auto CleanupTask = llvm::make_scope_exit([this]() {
+  llvm::scope_exit CleanupTask([this]() {
     std::lock_guard<std::mutex> Lock(Mutex);
     int NewTasksCnt = --InFlightTasks;
     if (NewTasksCnt == 0) {

--- a/clang-tools-extra/clangd/support/Trace.cpp
+++ b/clang-tools-extra/clangd/support/Trace.cpp
@@ -289,7 +289,7 @@ makeSpanContext(llvm::Twine Name, const Metric &LatencyMetric) {
     return std::make_pair(Context::current().clone(), nullptr);
   std::optional<WithContextValue> WithLatency;
   using Clock = std::chrono::high_resolution_clock;
-  WithLatency.emplace(llvm::make_scope_exit(
+  WithLatency.emplace(llvm::scope_exit(
       [StartTime = Clock::now(), Name = Name.str(), &LatencyMetric] {
         LatencyMetric.record(
             std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() -

--- a/clang-tools-extra/clangd/unittests/CompileCommandsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CompileCommandsTests.cpp
@@ -140,7 +140,7 @@ TEST(CommandMangler, ClangPathResolve) {
               ok());
   // /var/tmp is a symlink on Mac. Resolve it so we're asserting the right path.
   ASSERT_THAT(llvm::sys::fs::real_path(TempDir.str(), TempDir), ok());
-  auto CleanDir = llvm::make_scope_exit(
+  llvm::scope_exit CleanDir(
       [&] { llvm::sys::fs::remove_directories(TempDir); });
   ASSERT_THAT(llvm::sys::fs::create_directory(TempDir + "/bin"), ok());
   ASSERT_THAT(llvm::sys::fs::create_directory(TempDir + "/lib"), ok());
@@ -163,10 +163,9 @@ TEST(CommandMangler, ClangPathResolve) {
 
   // Set PATH to point to temp/bin so we can find 'foo' on it.
   ASSERT_TRUE(::getenv("PATH"));
-  auto RestorePath =
-      llvm::make_scope_exit([OldPath = std::string(::getenv("PATH"))] {
-        ::setenv("PATH", OldPath.c_str(), 1);
-      });
+  llvm::scope_exit RestorePath([OldPath = std::string(::getenv("PATH"))] {
+    ::setenv("PATH", OldPath.c_str(), 1);
+  });
   ::setenv("PATH", (TempDir + "/bin").str().c_str(), /*overwrite=*/1);
 
   // Test the case where the driver is a $PATH-relative path to a symlink.

--- a/clang-tools-extra/clangd/unittests/TUSchedulerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/TUSchedulerTests.cpp
@@ -113,7 +113,7 @@ protected:
   void updateWithCallback(TUScheduler &S, PathRef File, ParseInputs Inputs,
                           WantDiagnostics WD,
                           llvm::unique_function<void()> CB) {
-    WithContextValue Ctx(llvm::make_scope_exit(std::move(CB)));
+    WithContextValue Ctx(llvm::scope_exit(std::move(CB)));
     S.update(File, Inputs, WD);
   }
 

--- a/clang-tools-extra/clangd/unittests/TestTU.cpp
+++ b/clang-tools-extra/clangd/unittests/TestTU.cpp
@@ -106,7 +106,7 @@ TestTU::preamble(PreambleParsedCallback PreambleCallback) const {
   assert(CI && "Failed to build compilation invocation.");
   if (OverlayRealFileSystemForModules)
     initializeModuleCache(*CI);
-  auto ModuleCacheDeleter = llvm::make_scope_exit(
+  llvm::scope_exit ModuleCacheDeleter(
       std::bind(deleteModuleCache, CI->getHeaderSearchOpts().ModuleCachePath));
   return clang::clangd::buildPreamble(testPath(Filename), *CI, Inputs,
                                       /*StoreInMemory=*/true, PreambleCallback);
@@ -121,7 +121,7 @@ ParsedAST TestTU::build() const {
   assert(CI && "Failed to build compilation invocation.");
   if (OverlayRealFileSystemForModules)
     initializeModuleCache(*CI);
-  auto ModuleCacheDeleter = llvm::make_scope_exit(
+  llvm::scope_exit ModuleCacheDeleter(
       std::bind(deleteModuleCache, CI->getHeaderSearchOpts().ModuleCachePath));
 
   auto Preamble = clang::clangd::buildPreamble(testPath(Filename), *CI, Inputs,

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -1298,7 +1298,7 @@ auto ASTImporter::FunctionDeclImportCycleDetector::makeScopedCycleDetection(
     FunctionDeclsWithImportInProgress.insert(D);
     LambdaD = D;
   }
-  return llvm::make_scope_exit([this, LambdaD]() {
+  return llvm::scope_exit([this, LambdaD]() {
     if (LambdaD) {
       FunctionDeclsWithImportInProgress.erase(LambdaD);
     }
@@ -2547,8 +2547,7 @@ Error ASTNodeImporter::ImportDefinition(
   // Complete the definition even if error is returned.
   // The RecordDecl may be already part of the AST so it is better to
   // have it in complete state even if something is wrong with it.
-  auto DefinitionCompleterScopeExit =
-      llvm::make_scope_exit(DefinitionCompleter);
+  llvm::scope_exit DefinitionCompleterScopeExit(DefinitionCompleter);
 
   if (Error Err = setTypedefNameForAnonDecl(From, To, Importer))
     return Err;
@@ -9799,8 +9798,7 @@ Expected<Decl *> ASTImporter::Import(Decl *FromD) {
 
   // Push FromD to the stack, and remove that when we return.
   ImportPath.push(FromD);
-  auto ImportPathBuilder =
-      llvm::make_scope_exit([this]() { ImportPath.pop(); });
+  llvm::scope_exit ImportPathBuilder([this]() { ImportPath.pop(); });
 
   // Check whether there was a previous failed import.
   // If yes return the existing error.

--- a/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowEnvironment.cpp
@@ -1018,7 +1018,7 @@ Environment::createLocAndMaybeValue(QualType Ty,
                                     int Depth, int &CreatedValuesCount) {
   if (!Visited.insert(Ty.getCanonicalType()).second)
     return createStorageLocation(Ty.getNonReferenceType());
-  auto EraseVisited = llvm::make_scope_exit(
+  llvm::scope_exit EraseVisited(
       [&Visited, Ty] { Visited.erase(Ty.getCanonicalType()); });
 
   Ty = Ty.getNonReferenceType();

--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.cpp
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.cpp
@@ -539,12 +539,10 @@ llvm::Expected<std::string> renderSVG(llvm::StringRef DotGraph) {
                                                    Input))
     return llvm::createStringError(EC, "failed to create `dot` temp input");
   llvm::raw_fd_ostream(InputFD, /*shouldClose=*/true) << DotGraph;
-  auto DeleteInput =
-      llvm::make_scope_exit([&] { llvm::sys::fs::remove(Input); });
+  llvm::scope_exit DeleteInput([&] { llvm::sys::fs::remove(Input); });
   if (auto EC = llvm::sys::fs::createTemporaryFile("analysis", ".svg", Output))
     return llvm::createStringError(EC, "failed to create `dot` temp output");
-  auto DeleteOutput =
-      llvm::make_scope_exit([&] { llvm::sys::fs::remove(Output); });
+  llvm::scope_exit DeleteOutput([&] { llvm::sys::fs::remove(Output); });
 
   std::vector<std::optional<llvm::StringRef>> Redirects = {
       Input, Output,

--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -1682,7 +1682,7 @@ void ThreadSafetyAnalyzer::getEdgeLockset(FactSet& Result,
           return LocalVarMap.lookupExpr(D, Ctx);
         });
   }
-  auto Cleanup = llvm::make_scope_exit(
+  llvm::scope_exit Cleanup(
       [this] { SxBuilder.setLookupLocalVarExpr(nullptr); });
 
   const auto *Exp = getTrylockCallExpr(Cond, LVarCtx, Negate);

--- a/clang/lib/Analysis/ThreadSafetyCommon.cpp
+++ b/clang/lib/Analysis/ThreadSafetyCommon.cpp
@@ -251,13 +251,13 @@ til::SExpr *SExprBuilder::translateVariable(const VarDecl *VD,
 
   // The closure captures state that is updated to correctly translate chains of
   // aliases. Restore it when we are done with recursive translation.
-  auto Cleanup = llvm::make_scope_exit(
-      [&, RestoreClosure =
-              VarsBeingTranslated.empty() ? LookupLocalVarExpr : nullptr] {
-        VarsBeingTranslated.erase(VD->getCanonicalDecl());
-        if (VarsBeingTranslated.empty())
-          LookupLocalVarExpr = RestoreClosure;
-      });
+  llvm::scope_exit Cleanup([&, RestoreClosure = VarsBeingTranslated.empty()
+                                                    ? LookupLocalVarExpr
+                                                    : nullptr] {
+    VarsBeingTranslated.erase(VD->getCanonicalDecl());
+    if (VarsBeingTranslated.empty())
+      LookupLocalVarExpr = RestoreClosure;
+  });
   VarsBeingTranslated.insert(VD->getCanonicalDecl());
 
   QualType Ty = VD->getType();

--- a/clang/lib/CodeGen/CGCoroutine.cpp
+++ b/clang/lib/CodeGen/CGCoroutine.cpp
@@ -230,8 +230,7 @@ static LValueOrRValue emitSuspendExpression(CodeGenFunction &CGF, CGCoroData &Co
 
   auto CommonBinder =
       CodeGenFunction::OpaqueValueMappingData::bind(CGF, S.getOpaqueValue(), E);
-  auto UnbindCommonOnExit =
-      llvm::make_scope_exit([&] { CommonBinder.unbind(CGF); });
+  llvm::scope_exit UnbindCommonOnExit([&] { CommonBinder.unbind(CGF); });
 
   auto Prefix = buildSuspendPrefixStr(Coro, Kind);
   BasicBlock *ReadyBlock = CGF.createBasicBlock(Prefix + Twine(".ready"));
@@ -464,8 +463,7 @@ CodeGenFunction::generateAwaitSuspendWrapper(Twine const &CoroName,
 
   auto *SuspendRet = EmitScalarExpr(S.getSuspendExpr());
 
-  auto UnbindCommonOnExit =
-      llvm::make_scope_exit([&] { AwaiterBinder.unbind(*this); });
+  llvm::scope_exit UnbindCommonOnExit([&] { AwaiterBinder.unbind(*this); });
   if (SuspendRet != nullptr) {
     Fn->addRetAttr(llvm::Attribute::AttrKind::NoUndef);
     Builder.CreateStore(SuspendRet, ReturnValue);

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -5874,8 +5874,7 @@ LValue CodeGenFunction::EmitConditionalOperatorLValue(
 /// are permitted with aggregate result, including noop aggregate casts, and
 /// cast from scalar to union.
 LValue CodeGenFunction::EmitCastLValue(const CastExpr *E) {
-  auto RestoreCurCast =
-      llvm::make_scope_exit([this, Prev = CurCast] { CurCast = Prev; });
+  llvm::scope_exit RestoreCurCast([this, Prev = CurCast] { CurCast = Prev; });
   CurCast = E;
   switch (E->getCastKind()) {
   case CK_ToVoid:
@@ -6172,7 +6171,7 @@ RValue CodeGenFunction::EmitCallExpr(const CallExpr *E,
     CallOrInvoke = &CallOrInvokeStorage;
   }
 
-  auto AddCoroElideSafeOnExit = llvm::make_scope_exit([&] {
+  llvm::scope_exit AddCoroElideSafeOnExit([&] {
     if (E->isCoroElideSafe()) {
       auto *I = *CallOrInvoke;
       if (I)

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2503,8 +2503,8 @@ static Value *EmitHLSLElementwiseCast(CodeGenFunction &CGF, LValue SrcVal,
 // have to handle a more broad range of conversions than explicit casts, as they
 // handle things like function to ptr-to-function decay etc.
 Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
-  auto RestoreCurCast =
-      llvm::make_scope_exit([this, Prev = CGF.CurCast] { CGF.CurCast = Prev; });
+  llvm::scope_exit RestoreCurCast(
+      [this, Prev = CGF.CurCast] { CGF.CurCast = Prev; });
   CGF.CurCast = CE;
 
   Expr *E = CE->getSubExpr();

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -1418,7 +1418,7 @@ class HLSLBufferCopyEmitter {
                          llvm::ConstantInt *LoadIndex) {
     CurStoreIndices.push_back(StoreIndex);
     CurLoadIndices.push_back(LoadIndex);
-    auto RestoreIndices = llvm::make_scope_exit([&]() {
+    llvm::scope_exit RestoreIndices([&]() {
       CurStoreIndices.pop_back();
       CurLoadIndices.pop_back();
     });

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1515,7 +1515,7 @@ void CodeGenFunction::GenerateCode(GlobalDecl GD, llvm::Function *Fn,
     DebugInfo = nullptr;
   }
   // Finalize function debug info on exit.
-  auto Cleanup = llvm::make_scope_exit([this] {
+  llvm::scope_exit Cleanup([this] {
     if (CGDebugInfo *DI = getDebugInfo())
       DI->completeFunction();
   });

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -779,7 +779,7 @@ bool CompilerInstanceWithContext::computeDependencies(
 
   // We create this cleanup object because computeDependencies may exit
   // early with errors.
-  auto CleanUp = llvm::make_scope_exit([&]() {
+  llvm::scope_exit CleanUp([&]() {
     CI.clearDependencyCollectors();
     // The preprocessor may not be created at the entry of this method,
     // but it must have been created when this method returns, whether

--- a/clang/lib/DirectoryWatcher/linux/DirectoryWatcher-linux.cpp
+++ b/clang/lib/DirectoryWatcher/linux/DirectoryWatcher-linux.cpp
@@ -191,7 +191,7 @@ void DirectoryWatcherLinux::InotifyPollingLoop() {
     StopWork();
     return;
   }
-  auto EpollFDGuard = llvm::make_scope_exit([EpollFD]() { close(EpollFD); });
+  llvm::scope_exit EpollFDGuard([EpollFD]() { close(EpollFD); });
 
   struct epoll_event EventSpec;
   EventSpec.events = EPOLLIN;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2817,8 +2817,8 @@ static void RenderFloatingPointOptions(const ToolChain &TC, const Driver &D,
   }
 
   for (const Arg *A : Args) {
-    auto CheckMathErrnoForVecLib =
-        llvm::make_scope_exit([&, MathErrnoBeforeArg = MathErrno] {
+    llvm::scope_exit CheckMathErrnoForVecLib(
+        [&, MathErrnoBeforeArg = MathErrno] {
           if (NoMathErrnoWasImpliedByVecLib && !MathErrnoBeforeArg && MathErrno)
             ArgThatEnabledMathErrnoAfterVecLib = A;
         });

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -1133,7 +1133,7 @@ bool ASTUnit::Parse(std::shared_ptr<PCHContainerOperations> PCHContainerOps,
                                                   std::move(PCHContainerOps));
 
   // Clean up on error, disengage it if the function returns successfully.
-  auto CleanOnError = llvm::make_scope_exit([&]() {
+  llvm::scope_exit CleanOnError([&]() {
     // Remove the overridden buffer we used for the preamble.
     SavedMainFileBuffer = nullptr;
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -963,7 +963,7 @@ bool CompilerInstance::ExecuteAction(FrontendAction &Act) {
   // DesiredStackSpace available.
   noteBottomOfStack();
 
-  auto FinishDiagnosticClient = llvm::make_scope_exit([&]() {
+  llvm::scope_exit FinishDiagnosticClient([&]() {
     // Notify the diagnostic client that all files were processed.
     getDiagnosticClient().finish();
   });

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -836,7 +836,7 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
 
   // If we fail, reset state since the client will not end up calling the
   // matching EndSourceFile(). All paths that return true should release this.
-  auto FailureCleanup = llvm::make_scope_exit([&]() {
+  llvm::scope_exit FailureCleanup([&]() {
     if (HasBegunSourceFile)
       CI.getDiagnosticClient().EndSourceFile();
     CI.setASTConsumer(nullptr);

--- a/clang/lib/Index/IndexTypeSourceInfo.cpp
+++ b/clang/lib/Index/IndexTypeSourceInfo.cpp
@@ -183,8 +183,8 @@ public:
     // so clear them while visiting the args.
     SmallVector<SymbolRelation, 3> SavedRelations = Relations;
     Relations.clear();
-    auto ResetSavedRelations =
-        llvm::make_scope_exit([&] { this->Relations = SavedRelations; });
+    llvm::scope_exit ResetSavedRelations(
+        [&] { this->Relations = SavedRelations; });
     for (unsigned I = 0, E = TL.getNumArgs(); I != E; ++I) {
       if (!TraverseTemplateArgumentLoc(TL.getArgLoc(I)))
         return false;

--- a/clang/lib/Lex/DependencyDirectivesScanner.cpp
+++ b/clang/lib/Lex/DependencyDirectivesScanner.cpp
@@ -904,7 +904,7 @@ bool Scanner::lexPPLine(const char *&First, const char *const End) {
 
   TheLexer.seek(getOffsetAt(First), /*IsAtStartOfLine*/ true);
 
-  auto ScEx1 = make_scope_exit([&]() {
+  llvm::scope_exit ScEx1([&]() {
     /// Clear Scanner's CurDirToks before returning, in case we didn't push a
     /// new directive.
     CurDirToks.clear();
@@ -919,7 +919,7 @@ bool Scanner::lexPPLine(const char *&First, const char *const End) {
   // Handle preprocessing directives.
 
   TheLexer.setParsingPreprocessorDirective(true);
-  auto ScEx2 = make_scope_exit(
+  llvm::scope_exit ScEx2(
       [&]() { TheLexer.setParsingPreprocessorDirective(false); });
 
   // Handle "@import".

--- a/clang/lib/Lex/LiteralSupport.cpp
+++ b/clang/lib/Lex/LiteralSupport.cpp
@@ -1448,7 +1448,7 @@ void NumericLiteralParser::ParseNumberStartingWithZero(SourceLocation TokLoc) {
     return;
   }
 
-  auto _ = llvm::make_scope_exit([&] {
+  llvm::scope_exit _([&] {
     // If we still have an octal value but we did not see an octal prefix,
     // diagnose as being an obsolescent feature starting in C2y.
     if (radix == 8 && LangOpts.C2y && !hadError && !IsSingleZero)

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2973,7 +2973,7 @@ MacroInfo *Preprocessor::ReadOptionalMacroParameterListAndBody(
   LexUnexpandedToken(Tok);
 
   // Ensure we consume the rest of the macro body if errors occur.
-  auto _ = llvm::make_scope_exit([&]() {
+  llvm::scope_exit _([&]() {
     // The flag indicates if we are still waiting for 'eod'.
     if (CurLexer->ParsingPreprocessorDirective)
       DiscardUntilEndOfDirective();

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -603,7 +603,7 @@ void Parser::ParseLexedMethodDef(LexedMethod &LM) {
 
   Actions.ActOnStartOfFunctionDef(getCurScope(), LM.D);
 
-  auto _ = llvm::make_scope_exit([&]() {
+  llvm::scope_exit _([&]() {
     while (Tok.isNot(tok::eof))
       ConsumeAnyToken();
 

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -2379,8 +2379,7 @@ StmtResult Parser::ParseDeferStatement(SourceLocation *TrailingElseLoc) {
 
   Actions.ActOnStartOfDeferStmt(DeferLoc, getCurScope());
 
-  auto OnError = llvm::make_scope_exit(
-      [&] { Actions.ActOnDeferStmtError(getCurScope()); });
+  llvm::scope_exit OnError([&] { Actions.ActOnDeferStmtError(getCurScope()); });
 
   StmtResult Res = ParseStatement(TrailingElseLoc);
   if (!Res.isUsable())

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13787,7 +13787,7 @@ void Sema::DiagnoseUniqueObjectDuplication(const VarDecl *VD) {
 }
 
 void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
-  auto ResetDeclForInitializer = llvm::make_scope_exit([this]() {
+  llvm::scope_exit ResetDeclForInitializer([this]() {
     if (this->ExprEvalContexts.empty())
       this->ExprEvalContexts.back().DeclForInitializer = nullptr;
   });

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -12723,7 +12723,7 @@ static void NoteFunctionCandidate(Sema &S, OverloadCandidate *Cand,
   // We prefer adding such notes at the end of the deduction failure because
   // duplicate code snippets appearing in the diagnostic would likely become
   // noisy.
-  auto _ = llvm::make_scope_exit([&] { NoteImplicitDeductionGuide(S, Fn); });
+  llvm::scope_exit _([&] { NoteImplicitDeductionGuide(S, Fn); });
 
   switch (Cand->FailureKind) {
   case ovl_fail_too_many_arguments:

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5166,7 +5166,7 @@ ASTReader::ReadASTCore(StringRef FileName,
   assert(M && "Missing module file");
 
   bool ShouldFinalizePCM = false;
-  auto FinalizeOrDropPCM = llvm::make_scope_exit([&]() {
+  llvm::scope_exit FinalizeOrDropPCM([&]() {
     auto &MC = getModuleManager().getModuleCache().getInMemoryModuleCache();
     if (ShouldFinalizePCM)
       MC.finalizePCM(FileName);

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -3516,7 +3516,7 @@ void ASTWriter::WriteFileDeclIDsMap() {
 
 void ASTWriter::WriteComments(ASTContext &Context) {
   Stream.EnterSubblock(COMMENTS_BLOCK_ID, 3);
-  auto _ = llvm::make_scope_exit([this] { Stream.ExitBlock(); });
+  llvm::scope_exit _([this] { Stream.ExitBlock(); });
   if (!PP->getPreprocessorOpts().WriteCommentListToPCH)
     return;
 

--- a/clang/lib/StaticAnalyzer/Core/ConstraintManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ConstraintManager.cpp
@@ -59,8 +59,7 @@ ConstraintManager::assumeDualImpl(ProgramStateRef &State,
   if (LLVM_UNLIKELY(AssumeStack.contains(RawSt)))
     return {State, State};
   AssumeStack.push(RawSt);
-  auto AssumeStackBuilder =
-      llvm::make_scope_exit([this]() { AssumeStack.pop(); });
+  llvm::scope_exit AssumeStackBuilder([this]() { AssumeStack.pop(); });
 
   ProgramStateRef StTrue = Assume(true);
 

--- a/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+++ b/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
@@ -637,8 +637,7 @@ void AnalysisConsumer::HandleTranslationUnit(ASTContext &C) {
   // FIXME: This should be replaced with something that doesn't rely on
   // side-effects in PathDiagnosticConsumer's destructor. This is required when
   // used with option -disable-free.
-  const auto DiagFlusherScopeExit =
-      llvm::make_scope_exit([this] { Mgr.reset(); });
+  const llvm::scope_exit DiagFlusherScopeExit([this] { Mgr.reset(); });
 
   if (Opts.ShouldIgnoreBisonGeneratedFiles &&
       fileContainsString("/* A Bison parser, made by", C)) {

--- a/clang/lib/Testing/TestAST.cpp
+++ b/clang/lib/Testing/TestAST.cpp
@@ -80,8 +80,8 @@ TestAST::TestAST(const TestInputs &In) {
   Clang = std::make_unique<CompilerInstance>();
   // If we don't manage to finish parsing, create CompilerInstance components
   // anyway so that the test will see an empty AST instead of crashing.
-  auto RecoverFromEarlyExit =
-      llvm::make_scope_exit([&] { createMissingComponents(*Clang); });
+  llvm::scope_exit RecoverFromEarlyExit(
+      [&] { createMissingComponents(*Clang); });
 
   std::string Filename = In.FileName;
   if (Filename.empty())

--- a/clang/unittests/StaticAnalyzer/UnsignedStatDemo.cpp
+++ b/clang/unittests/StaticAnalyzer/UnsignedStatDemo.cpp
@@ -119,7 +119,7 @@ TEST(UnsignedStat, ExplicitlySetUnsignedStatistic) {
       std::string("dump-entry-point-stats-to-csv=") +
           TempMetricsCsvPath.str().str()};
   // Clean up on exit
-  auto Cleanup = llvm::make_scope_exit(
+  llvm::scope_exit Cleanup(
       [&]() { llvm::sys::fs::remove(TempMetricsCsvPath); });
   EXPECT_TRUE(runCheckerOnCodeWithArgs<addUnsignedStatTesterChecker>(
       R"cpp(

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2355,8 +2355,7 @@ private:
     if (Fortran::lower::isInsideOpenACCComputeConstruct(*builder)) {
       // Open up a new scope for the loop variables.
       localSymbols.pushScope();
-      auto scopeGuard =
-          llvm::make_scope_exit([&]() { localSymbols.popScope(); });
+      llvm::scope_exit scopeGuard([&]() { localSymbols.popScope(); });
 
       mlir::Operation *loopOp = Fortran::lower::genOpenACCLoopFromDoConstruct(
           *this, bridge.getSemanticsContext(), localSymbols, doConstruct, eval);

--- a/flang/lib/Optimizer/CodeGen/TypeConverter.cpp
+++ b/flang/lib/Optimizer/CodeGen/TypeConverter.cpp
@@ -163,8 +163,8 @@ LLVMTypeConverter::convertRecordType(fir::RecordType derived,
     return mlir::success();
   }
   callStack.push_back(derived);
-  auto popConversionCallStack =
-      llvm::make_scope_exit([&callStack]() { callStack.pop_back(); });
+  llvm::scope_exit popConversionCallStack(
+      [&callStack]() { callStack.pop_back(); });
 
   llvm::SmallVector<mlir::Type> members;
   for (auto mem : derived.getTypeList()) {

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -308,7 +308,7 @@ protected:
         return;
       }
 
-      auto on_error = llvm::make_scope_exit(
+      llvm::scope_exit on_error(
           [&target_list = debugger.GetTargetList(), &target_sp]() {
             target_list.DeleteTarget(target_sp);
           });

--- a/lldb/source/Host/common/MemoryMonitor.cpp
+++ b/lldb/source/Host/common/MemoryMonitor.cpp
@@ -42,7 +42,7 @@ public:
       return {};
     fds.events = POLLPRI;
 
-    auto cleanup = llvm::make_scope_exit([&]() { close(fds.fd); });
+    llvm::scope_exit cleanup([&]() { close(fds.fd); });
 
     // Detect a 50ms stall in a 2 second time window.
     const char trig[] = "some 50000 2000000";

--- a/lldb/source/Host/macosx/objcxx/Host.mm
+++ b/lldb/source/Host/macosx/objcxx/Host.mm
@@ -399,7 +399,7 @@ llvm::Error Host::OpenFileInExternalEditor(llvm::StringRef editor,
                       error));
 
   // Deallocate the descriptor on exit.
-  auto on_exit = llvm::make_scope_exit(
+  llvm::scope_exit on_exit(
       [&]() { AEDisposeDesc(&(file_and_line_desc.descContent)); });
 
   if (editor.empty()) {
@@ -1175,8 +1175,7 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
   }
 
   // Make sure we clean up the posix spawn attributes before exiting this scope.
-  auto cleanup_attr =
-      llvm::make_scope_exit([&]() { posix_spawnattr_destroy(&attr); });
+  llvm::scope_exit cleanup_attr([&]() { posix_spawnattr_destroy(&attr); });
 
   sigset_t no_signals;
   sigset_t all_signals;
@@ -1349,7 +1348,7 @@ static Status LaunchProcessPosixSpawn(const char *exe_path,
     }
 
     // Make sure we clean up the posix file actions before exiting this scope.
-    auto cleanup_fileact = llvm::make_scope_exit(
+    llvm::scope_exit cleanup_fileact(
         [&]() { posix_spawn_file_actions_destroy(&file_actions); });
 
     for (size_t i = 0; i < num_file_actions; ++i) {

--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -677,16 +677,16 @@ bool SharedCacheInfo::CreateSharedCacheInfoWithInstrospectionSPIs() {
   if (!dyld_process)
     return false;
 
-  auto cleanup_process_on_exit =
-      llvm::make_scope_exit([&]() { dyld_process_dispose(dyld_process); });
+  llvm::scope_exit cleanup_process_on_exit(
+      [&]() { dyld_process_dispose(dyld_process); });
 
   dyld_process_snapshot_t snapshot =
       dyld_process_snapshot_create_for_process(dyld_process, nullptr);
   if (!snapshot)
     return false;
 
-  auto cleanup_snapshot_on_exit =
-      llvm::make_scope_exit([&]() { dyld_process_snapshot_dispose(snapshot); });
+  llvm::scope_exit cleanup_snapshot_on_exit(
+      [&]() { dyld_process_snapshot_dispose(snapshot); });
 
   dyld_shared_cache_t shared_cache =
       dyld_process_snapshot_get_shared_cache(snapshot);

--- a/lldb/source/Host/windows/ProcessLauncherWindows.cpp
+++ b/lldb/source/Host/windows/ProcessLauncherWindows.cpp
@@ -100,7 +100,7 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
   HANDLE stdin_handle = GetStdioHandle(launch_info, STDIN_FILENO);
   HANDLE stdout_handle = GetStdioHandle(launch_info, STDOUT_FILENO);
   HANDLE stderr_handle = GetStdioHandle(launch_info, STDERR_FILENO);
-  auto close_handles = llvm::make_scope_exit([&] {
+  llvm::scope_exit close_handles([&] {
     if (stdin_handle)
       ::CloseHandle(stdin_handle);
     if (stdout_handle)
@@ -116,15 +116,15 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
 
   startupinfoex.lpAttributeList =
       static_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(malloc(attributelist_size));
-  auto free_attributelist =
-      llvm::make_scope_exit([&] { free(startupinfoex.lpAttributeList); });
+  llvm::scope_exit free_attributelist(
+      [&] { free(startupinfoex.lpAttributeList); });
   if (!InitializeProcThreadAttributeList(startupinfoex.lpAttributeList,
                                          /*dwAttributeCount=*/1, /*dwFlags=*/0,
                                          &attributelist_size)) {
     error = Status(::GetLastError(), eErrorTypeWin32);
     return HostProcess();
   }
-  auto delete_attributelist = llvm::make_scope_exit(
+  llvm::scope_exit delete_attributelist(
       [&] { DeleteProcThreadAttributeList(startupinfoex.lpAttributeList); });
 
   std::vector<HANDLE> inherited_handles;

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -3390,7 +3390,7 @@ void CommandInterpreter::IOHandlerInputComplete(IOHandler &io_handler,
     OverrideExecutionContext(exe_ctx);
     pushed_exe_ctx = true;
   }
-  auto finalize = llvm::make_scope_exit([this, pushed_exe_ctx]() {
+  llvm::scope_exit finalize([this, pushed_exe_ctx]() {
     if (pushed_exe_ctx)
       RestoreExecutionContext();
   });

--- a/lldb/source/Interpreter/CommandObject.cpp
+++ b/lldb/source/Interpreter/CommandObject.cpp
@@ -272,7 +272,7 @@ void CommandObject::Cleanup() {
 void CommandObject::HandleCompletion(CompletionRequest &request) {
 
   m_exe_ctx = m_interpreter.GetExecutionContext();
-  auto reset_ctx = llvm::make_scope_exit([this]() { Cleanup(); });
+  llvm::scope_exit reset_ctx([this]() { Cleanup(); });
 
   // Default implementation of WantsCompletion() is !WantsRawCommandString().
   // Subclasses who want raw command string but desire, for example, argument

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionSourceCode.cpp
@@ -149,9 +149,8 @@ static void AddMacros(const DebugMacros *dm, CompileUnit *comp_unit,
   stream << "#pragma clang diagnostic push\n";
   stream << "#pragma clang diagnostic ignored \"-Wmacro-redefined\"\n";
   stream << "#pragma clang diagnostic ignored \"-Wbuiltin-macro-redefined\"\n";
-  auto pop_warning = llvm::make_scope_exit([&stream](){
-    stream << "#pragma clang diagnostic pop\n";
-  });
+  llvm::scope_exit pop_warning(
+      [&stream]() { stream << "#pragma clang diagnostic pop\n"; });
 
   for (size_t i = 0; i < dm->GetNumMacroEntries(); i++) {
     const DebugMacroEntry &entry = dm->GetMacroEntryAtIndex(i);

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -553,7 +553,7 @@ bool ClangUserExpression::TryParse(
 
   ResetDeclMap(exe_ctx, m_result_delegate, keep_result_in_memory);
 
-  auto on_exit = llvm::make_scope_exit([this]() { ResetDeclMap(); });
+  llvm::scope_exit on_exit([this]() { ResetDeclMap(); });
 
   if (!DeclMap()->WillParse(exe_ctx, GetMaterializer())) {
     diagnostic_manager.PutString(
@@ -797,7 +797,7 @@ bool ClangUserExpression::Complete(ExecutionContext &exe_ctx,
 
   ResetDeclMap(exe_ctx, m_result_delegate, /*keep result in memory*/ true);
 
-  auto on_exit = llvm::make_scope_exit([this]() { ResetDeclMap(); });
+  llvm::scope_exit on_exit([this]() { ResetDeclMap(); });
 
   if (!DeclMap()->WillParse(exe_ctx, GetMaterializer())) {
     diagnostic_manager.PutString(

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -2119,7 +2119,7 @@ AppleObjCRuntimeV2::DynamicClassInfoExtractor::UpdateISAToDescriptorMap(
     return DescriptorMapUpdateResult::Fail();
   }
 
-  auto deallocate_class_infos = llvm::make_scope_exit([&] {
+  llvm::scope_exit deallocate_class_infos([&] {
     // Deallocate the memory we allocated for the ClassInfo array
     if (class_infos_addr != LLDB_INVALID_ADDRESS)
       process->DeallocateMemory(class_infos_addr);
@@ -2142,7 +2142,7 @@ AppleObjCRuntimeV2::DynamicClassInfoExtractor::UpdateISAToDescriptorMap(
     }
   }
 
-  auto deallocate_class_buffer = llvm::make_scope_exit([&] {
+  llvm::scope_exit deallocate_class_buffer([&] {
     // Deallocate the memory we allocated for the Class array
     if (class_buffer_addr != LLDB_INVALID_ADDRESS)
       process->DeallocateMemory(class_buffer_addr);

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -2706,7 +2706,7 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     __block vm_offset_t vm_string_memory = 0;
     __block mach_msg_type_number_t vm_string_bytes_read = 0;
 
-    auto _ = llvm::make_scope_exit(^{
+    llvm::scope_exit _(^{
       if (vm_nlist_memory)
         vm_deallocate(mach_task_self(), vm_nlist_memory, vm_nlist_bytes_read);
       if (vm_string_memory)

--- a/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
+++ b/lldb/source/Plugins/Platform/POSIX/PlatformPOSIX.cpp
@@ -741,7 +741,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
   }
 
   // Make sure we deallocate the input string memory:
-  auto path_cleanup = llvm::make_scope_exit([process, path_addr] {
+  llvm::scope_exit path_cleanup([process, path_addr] {
     // Deallocate the buffer.
     process->DeallocateMemory(path_addr);
   });
@@ -768,7 +768,7 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
   }
   
   // Make sure we deallocate the result structure memory
-  auto return_cleanup = llvm::make_scope_exit([process, return_addr] {
+  llvm::scope_exit return_cleanup([process, return_addr] {
     // Deallocate the buffer
     process->DeallocateMemory(return_addr);
   });
@@ -872,10 +872,9 @@ uint32_t PlatformPOSIX::DoLoadImage(lldb_private::Process *process,
   // Make sure we clean up the args structure.  We can't reuse it because the
   // Platform lives longer than the process and the Platforms don't get a
   // signal to clean up cached data when a process goes away.
-  auto args_cleanup =
-      llvm::make_scope_exit([do_dlopen_function, &exe_ctx, func_args_addr] {
-        do_dlopen_function->DeallocateFunctionResults(exe_ctx, func_args_addr);
-      });
+  llvm::scope_exit args_cleanup([do_dlopen_function, &exe_ctx, func_args_addr] {
+    do_dlopen_function->DeallocateFunctionResults(exe_ctx, func_args_addr);
+  });
 
   // Now run the caller:
   EvaluateExpressionOptions options;

--- a/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
+++ b/lldb/source/Plugins/Platform/Windows/PlatformWindows.cpp
@@ -217,9 +217,8 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
-  auto name_cleanup = llvm::make_scope_exit([process, injected_name]() {
-    process->DeallocateMemory(injected_name);
-  });
+  llvm::scope_exit name_cleanup(
+      [process, injected_name]() { process->DeallocateMemory(injected_name); });
 
   process->WriteMemory(injected_name, name.data(),
                        name.size() * sizeof(llvm::UTF16), status);
@@ -289,10 +288,10 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
-  auto injected_module_path_cleanup =
-      llvm::make_scope_exit([process, injected_module_path]() {
-    process->DeallocateMemory(injected_module_path);
-  });
+  llvm::scope_exit injected_module_path_cleanup(
+      [process, injected_module_path]() {
+        process->DeallocateMemory(injected_module_path);
+      });
 
   /* Inject __lldb_LoadLibraryResult into inferior */
   const uint32_t word_size = process->GetAddressByteSize();
@@ -307,7 +306,7 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
-  auto result_cleanup = llvm::make_scope_exit([process, injected_result]() {
+  llvm::scope_exit result_cleanup([process, injected_result]() {
     process->DeallocateMemory(injected_result);
   });
 
@@ -347,8 +346,8 @@ uint32_t PlatformWindows::DoLoadImage(Process *process,
     return LLDB_INVALID_IMAGE_TOKEN;
   }
 
-  auto parameter_cleanup =
-      llvm::make_scope_exit([invocation, &context, injected_parameters]() {
+  llvm::scope_exit parameter_cleanup(
+      [invocation, &context, injected_parameters]() {
         invocation->DeallocateFunctionResults(context, injected_parameters);
       });
 

--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -1366,7 +1366,7 @@ NativeProcessLinux::Syscall(llvm::ArrayRef<uint64_t> args) {
   WritableDataBufferSP registers_sp;
   if (llvm::Error Err = reg_ctx.ReadAllRegisterValues(registers_sp).ToError())
     return std::move(Err);
-  auto restore_regs = llvm::make_scope_exit(
+  llvm::scope_exit restore_regs(
       [&] { reg_ctx.WriteAllRegisterValues(registers_sp); });
 
   llvm::SmallVector<uint8_t, 8> memory(syscall_data.Insn.size());
@@ -1377,7 +1377,7 @@ NativeProcessLinux::Syscall(llvm::ArrayRef<uint64_t> args) {
     return std::move(Err);
   }
 
-  auto restore_mem = llvm::make_scope_exit(
+  llvm::scope_exit restore_mem(
       [&] { WriteMemory(exe_addr, memory.data(), memory.size(), bytes_read); });
 
   if (llvm::Error Err = reg_ctx.SetPC(exe_addr).ToError())

--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
@@ -128,14 +128,13 @@ void PythonObject::Dump(Stream &strm) const {
   if (!py_str)
     return;
 
-  auto release_py_str = llvm::make_scope_exit([py_str] { Py_DECREF(py_str); });
+  llvm::scope_exit release_py_str([py_str] { Py_DECREF(py_str); });
 
   PyObject *py_bytes = PyUnicode_AsEncodedString(py_str, "utf-8", "replace");
   if (!py_bytes)
     return;
 
-  auto release_py_bytes =
-      llvm::make_scope_exit([py_bytes] { Py_DECREF(py_bytes); });
+  llvm::scope_exit release_py_bytes([py_bytes] { Py_DECREF(py_bytes); });
 
   char *buffer = nullptr;
   Py_ssize_t length = 0;
@@ -414,8 +413,7 @@ Expected<llvm::StringRef> PythonString::AsUTF8() const {
   PyObject *py_bytes = PyUnicode_AsUTF8String(m_py_obj);
   if (!py_bytes)
     return exception();
-  auto release_py_str =
-      llvm::make_scope_exit([py_bytes] { Py_DECREF(py_bytes); });
+  llvm::scope_exit release_py_str([py_bytes] { Py_DECREF(py_bytes); });
   Py_ssize_t size = PyBytes_Size(py_bytes);
   const char *str = PyBytes_AsString(py_bytes);
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2783,7 +2783,7 @@ Status Process::LaunchPrivate(ProcessLaunchInfo &launch_info, StateType &state,
   // Listen and queue events that are broadcasted during the process launch.
   ListenerSP listener_sp(Listener::MakeListener("LaunchEventHijack"));
   HijackProcessEvents(listener_sp);
-  auto on_exit = llvm::make_scope_exit([this]() { RestoreProcessEvents(); });
+  llvm::scope_exit on_exit([this]() { RestoreProcessEvents(); });
 
   if (PrivateStateThreadIsValid())
     PausePrivateStateThread();

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2864,7 +2864,7 @@ ExpressionResults Target::EvaluateExpression(
   // We shouldn't run stop hooks in expressions.
   bool old_suppress_value = m_suppress_stop_hooks;
   m_suppress_stop_hooks = true;
-  auto on_exit = llvm::make_scope_exit([this, old_suppress_value]() {
+  llvm::scope_exit on_exit([this, old_suppress_value]() {
     m_suppress_stop_hooks = old_suppress_value;
   });
 
@@ -3200,7 +3200,7 @@ bool Target::RunStopHooks(bool at_initial_stop) {
   }
 
   StreamSP output_sp = m_debugger.GetAsyncOutputStream();
-  auto on_exit = llvm::make_scope_exit([output_sp] { output_sp->Flush(); });
+  llvm::scope_exit on_exit([output_sp] { output_sp->Flush(); });
 
   size_t num_hooks_with_output = llvm::count_if(
       active_hooks, [](auto h) { return !h->GetSuppressOutput(); });

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -831,7 +831,7 @@ bool DAP::HandleObject(const Message &M) {
         debugger.CancelInterruptRequest();
     }
 
-    auto cleanup = llvm::make_scope_exit([&]() {
+    llvm::scope_exit cleanup([&]() {
       std::scoped_lock<std::mutex> active_request_lock(m_active_request_mutex);
       m_active_request = nullptr;
     });
@@ -1034,7 +1034,7 @@ void DAP::TerminateLoop(bool failed) {
 }
 
 void DAP::TransportHandler() {
-  auto scope_guard = llvm::make_scope_exit([this] {
+  llvm::scope_exit scope_guard([this] {
     std::lock_guard<std::mutex> guard(m_queue_mutex);
     // Ensure we're marked as disconnecting when the reader exits.
     m_disconnecting = true;
@@ -1067,7 +1067,7 @@ llvm::Error DAP::Loop() {
 
   auto thread = std::thread(std::bind(&DAP::TransportHandler, this));
 
-  auto cleanup = llvm::make_scope_exit([this]() {
+  llvm::scope_exit cleanup([this]() {
     // FIXME: Merge these into the MainLoop handler.
     out.Stop();
     err.Stop();

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -675,7 +675,7 @@ int main(int argc, char *argv[]) {
     memory_monitor->Start();
 
   // Terminate the debugger before the C++ destructor chain kicks in.
-  auto terminate_debugger = llvm::make_scope_exit([&] {
+  llvm::scope_exit terminate_debugger([&] {
     if (memory_monitor)
       memory_monitor->Stop();
     lldb::SBDebugger::Terminate();

--- a/lldb/tools/lldb-mcp/lldb-mcp.cpp
+++ b/lldb/tools/lldb-mcp/lldb-mcp.cpp
@@ -217,7 +217,7 @@ int main(int argc, char *argv[]) {
           std::make_unique<lldb_private::SystemInitializerCommon>(nullptr)))
     exitWithError(std::move(err));
 
-  auto cleanup = make_scope_exit([] { g_debugger_lifetime->Terminate(); });
+  llvm::scope_exit cleanup([] { g_debugger_lifetime->Terminate(); });
 
   IOObjectSP input_sp = std::make_shared<NativeFile>(
       fileno(stdin), File::eOpenOptionReadOnly, NativeFile::Unowned);

--- a/lldb/tools/lldb-test/lldb-test.cpp
+++ b/lldb/tools/lldb-test/lldb-test.cpp
@@ -1254,8 +1254,7 @@ int main(int argc, const char *argv[]) {
     return 1;
   }
 
-  auto TerminateDebugger =
-      llvm::make_scope_exit([&] { DebuggerLifetime.Terminate(); });
+  llvm::scope_exit TerminateDebugger([&] { DebuggerLifetime.Terminate(); });
 
   auto Dbg = lldb_private::Debugger::CreateInstance();
   ModuleList::GetGlobalModuleListProperties().SetEnableExternalLookup(false);

--- a/lldb/unittests/Host/HostTest.cpp
+++ b/lldb/unittests/Host/HostTest.cpp
@@ -125,7 +125,7 @@ TEST(Host, FindProcesses) {
     }
   }
   ASSERT_TRUE(foundPID);
-  auto clean_up = llvm::make_scope_exit([&] {
+  llvm::scope_exit clean_up([&] {
     Host::Kill(info.GetProcessID(), SIGKILL);
     exit_status.get_future().get();
   });

--- a/llvm/include/llvm/ADT/ScopeExit.h
+++ b/llvm/include/llvm/ADT/ScopeExit.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_ADT_SCOPEEXIT_H
 #define LLVM_ADT_SCOPEEXIT_H
 
+#include "llvm/Support/Compiler.h"
 #include <utility>
 
 namespace llvm {
@@ -50,7 +51,13 @@ template <typename Callable> scope_exit(Callable) -> scope_exit<Callable>;
 // returned object is kept).
 //
 // Interface is specified by p0052r2.
-template <typename Callable> [[nodiscard]] auto make_scope_exit(Callable &&F) {
+template <typename Callable>
+[[nodiscard]]
+LLVM_DEPRECATED(
+    "llvm::make_scope_exit is deprecated and will be removed in LLVM 24. "
+    "Prefer calling the constructor of llvm::scope_exit directly.",
+    "scope_exit") auto make_scope_exit(Callable &&F) {
+  // TODO(LLVM 24): Remove this function.
   return scope_exit(std::forward<Callable>(F));
 }
 

--- a/llvm/include/llvm/ADT/ScopeExit.h
+++ b/llvm/include/llvm/ADT/ScopeExit.h
@@ -15,7 +15,6 @@
 #ifndef LLVM_ADT_SCOPEEXIT_H
 #define LLVM_ADT_SCOPEEXIT_H
 
-#include "llvm/Support/Compiler.h"
 #include <utility>
 
 namespace llvm {
@@ -51,13 +50,7 @@ template <typename Callable> scope_exit(Callable) -> scope_exit<Callable>;
 // returned object is kept).
 //
 // Interface is specified by p0052r2.
-template <typename Callable>
-[[nodiscard]]
-LLVM_DEPRECATED(
-    "llvm::make_scope_exit is deprecated and will be removed in LLVM 24. "
-    "Prefer calling the constructor of llvm::scope_exit directly.",
-    "scope_exit") auto make_scope_exit(Callable &&F) {
-  // TODO(LLVM 24): Remove this function.
+template <typename Callable> [[nodiscard]] auto make_scope_exit(Callable &&F) {
   return scope_exit(std::forward<Callable>(F));
 }
 

--- a/llvm/include/llvm/Transforms/Utils/SSAUpdaterImpl.h
+++ b/llvm/include/llvm/Transforms/Utils/SSAUpdaterImpl.h
@@ -427,7 +427,7 @@ public:
   bool CheckIfPHIMatches(PhiT *PHI, BlockListTy &TaggedBlocks) {
     // Match failed: clear all the PHITag values. Only need to clear visited
     // blocks.
-    auto Cleanup = make_scope_exit([&]() {
+    scope_exit Cleanup([&]() {
       for (BBInfo *TaggedBlock : TaggedBlocks)
         TaggedBlock->PHITag = nullptr;
       TaggedBlocks.clear();

--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -757,7 +757,7 @@ ModRefInfo BasicAAResult::getModRefInfoMask(const MemoryLocation &Loc,
                                             AAQueryInfo &AAQI,
                                             bool IgnoreLocals) {
   assert(Visited.empty() && "Visited must be cleared after use!");
-  auto _ = make_scope_exit([&] { Visited.clear(); });
+  llvm::scope_exit _([&] { Visited.clear(); });
 
   unsigned MaxLookup = 8;
   SmallVector<const Value *, 16> Worklist;

--- a/llvm/lib/Analysis/LazyCallGraph.cpp
+++ b/llvm/lib/Analysis/LazyCallGraph.cpp
@@ -591,7 +591,7 @@ bool LazyCallGraph::RefSCC::switchInternalEdgeToCall(
 
 #ifdef EXPENSIVE_CHECKS
   verify();
-  auto VerifyOnExit = make_scope_exit([&]() { verify(); });
+  llvm::scope_exit VerifyOnExit([&]() { verify(); });
 #endif
 
   SCC &SourceSCC = *G->lookupSCC(SourceN);
@@ -736,7 +736,7 @@ void LazyCallGraph::RefSCC::switchTrivialInternalEdgeToRef(Node &SourceN,
 
 #ifdef EXPENSIVE_CHECKS
   verify();
-  auto VerifyOnExit = make_scope_exit([&]() { verify(); });
+  llvm::scope_exit VerifyOnExit([&]() { verify(); });
 #endif
 
   assert(G->lookupRefSCC(SourceN) == this && "Source must be in this RefSCC.");
@@ -754,7 +754,7 @@ LazyCallGraph::RefSCC::switchInternalEdgeToRef(Node &SourceN, Node &TargetN) {
 
 #ifdef EXPENSIVE_CHECKS
   verify();
-  auto VerifyOnExit = make_scope_exit([&]() { verify(); });
+  llvm::scope_exit VerifyOnExit([&]() { verify(); });
 #endif
 
   assert(G->lookupRefSCC(SourceN) == this && "Source must be in this RefSCC.");
@@ -1016,7 +1016,7 @@ LazyCallGraph::RefSCC::insertIncomingRefEdge(Node &SourceN, Node &TargetN) {
 
 #ifdef EXPENSIVE_CHECKS
   verify();
-  auto VerifyOnExit = make_scope_exit([&]() { verify(); });
+  llvm::scope_exit VerifyOnExit([&]() { verify(); });
 #endif
 
   int SourceIdx = G->RefSCCIndices[&SourceC];
@@ -1152,7 +1152,7 @@ void LazyCallGraph::RefSCC::removeOutgoingEdge(Node &SourceN, Node &TargetN) {
 
 #ifdef EXPENSIVE_CHECKS
   verify();
-  auto VerifyOnExit = make_scope_exit([&]() { verify(); });
+  llvm::scope_exit VerifyOnExit([&]() { verify(); });
 #endif
 
   // First remove it from the node.
@@ -1172,7 +1172,7 @@ LazyCallGraph::RefSCC::removeInternalRefEdges(
   // list of result RefSCCs and this RefSCC remains valid, or we return new
   // RefSCCs and this RefSCC is dead.
   verify();
-  auto VerifyOnExit = make_scope_exit([&]() {
+  llvm::scope_exit VerifyOnExit([&]() {
     // If we didn't replace our RefSCC with new ones, check that this one
     // remains valid.
     if (G)
@@ -1395,7 +1395,7 @@ LazyCallGraph::RefSCC::removeInternalRefEdges(
 void LazyCallGraph::RefSCC::insertTrivialCallEdge(Node &SourceN,
                                                   Node &TargetN) {
 #ifdef EXPENSIVE_CHECKS
-  auto ExitVerifier = make_scope_exit([this] { verify(); });
+  llvm::scope_exit ExitVerifier([this] { verify(); });
 
   // Check that we aren't breaking some invariants of the SCC graph. Note that
   // this is quadratic in the number of edges in the call graph!
@@ -1423,7 +1423,7 @@ void LazyCallGraph::RefSCC::insertTrivialCallEdge(Node &SourceN,
 
 void LazyCallGraph::RefSCC::insertTrivialRefEdge(Node &SourceN, Node &TargetN) {
 #ifdef EXPENSIVE_CHECKS
-  auto ExitVerifier = make_scope_exit([this] { verify(); });
+  llvm::scope_exit ExitVerifier([this] { verify(); });
 
   // Check that we aren't breaking some invariants of the RefSCC graph.
   RefSCC &SourceRC = *G->lookupRefSCC(SourceN);
@@ -1449,7 +1449,7 @@ void LazyCallGraph::RefSCC::replaceNodeFunction(Node &N, Function &NewF) {
   Function &OldF = N.getFunction();
 
 #ifdef EXPENSIVE_CHECKS
-  auto ExitVerifier = make_scope_exit([this] { verify(); });
+  llvm::scope_exit ExitVerifier([this] { verify(); });
 
   assert(G->lookupRefSCC(N) == this &&
          "Cannot replace the function of a node outside this RefSCC.");
@@ -1629,7 +1629,7 @@ void LazyCallGraph::addSplitFunction(Function &OriginalFunction,
 
 #ifdef EXPENSIVE_CHECKS
   OriginalRC->verify();
-  auto VerifyOnExit = make_scope_exit([&]() { OriginalRC->verify(); });
+  llvm::scope_exit VerifyOnExit([&]() { OriginalRC->verify(); });
 #endif
 
   assert(!lookup(NewFunction) &&
@@ -1708,7 +1708,7 @@ void LazyCallGraph::addSplitRefRecursiveFunctions(
 
 #ifdef EXPENSIVE_CHECKS
   OriginalRC->verify();
-  auto VerifyOnExit = make_scope_exit([&]() {
+  llvm::scope_exit VerifyOnExit([&]() {
     OriginalRC->verify();
     for (Function *NewFunction : NewFunctions)
       lookupRefSCC(get(*NewFunction))->verify();

--- a/llvm/lib/Analysis/LoopInfo.cpp
+++ b/llvm/lib/Analysis/LoopInfo.cpp
@@ -887,7 +887,7 @@ bool LoopInfo::invalidate(Function &F, const PreservedAnalyses &PA,
 void LoopInfo::erase(Loop *Unloop) {
   assert(!Unloop->isInvalid() && "Loop has already been erased!");
 
-  auto InvalidateOnExit = make_scope_exit([&]() { destroy(Unloop); });
+  llvm::scope_exit InvalidateOnExit([&]() { destroy(Unloop); });
 
   // First handle the special case of no parent loop to simplify the algorithm.
   if (Unloop->isOutermost()) {

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -11879,8 +11879,8 @@ bool ScalarEvolution::isImpliedCond(CmpPredicate Pred, const SCEV *LHS,
   if (!PendingLoopPredicates.insert(FoundCondValue).second)
     return false;
 
-  auto ClearOnExit =
-      make_scope_exit([&]() { PendingLoopPredicates.erase(FoundCondValue); });
+  llvm::scope_exit ClearOnExit(
+      [&]() { PendingLoopPredicates.erase(FoundCondValue); });
 
   // Recursively handle And and Or conditions.
   const Value *Op0, *Op1;
@@ -12427,7 +12427,7 @@ bool ScalarEvolution::isImpliedViaMerge(CmpPredicate Pred, const SCEV *LHS,
                                         const SCEV *FoundRHS, unsigned Depth) {
   const PHINode *LPhi = nullptr, *RPhi = nullptr;
 
-  auto ClearOnExit = make_scope_exit([&]() {
+  llvm::scope_exit ClearOnExit([&]() {
     if (LPhi) {
       bool Erased = PendingMerges.erase(LPhi);
       assert(Erased && "Failed to erase LPhi!");

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -4999,7 +4999,7 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
   // assume this from flags/attributes.
   InterestedClasses &= ~KnownNotFromFlags;
 
-  auto ClearClassesFromFlags = make_scope_exit([=, &Known] {
+  llvm::scope_exit ClearClassesFromFlags([=, &Known] {
     Known.knownNot(KnownNotFromFlags);
     if (!Known.SignBit && AssumedClasses.SignBit) {
       if (*AssumedClasses.SignBit)

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -2584,7 +2584,7 @@ std::optional<MemoryEffects> LLParser::parseMemoryAttr() {
   // We use syntax like memory(argmem: read), so the colon should not be
   // interpreted as a label terminator.
   Lex.setIgnoreColonInIdentifiers(true);
-  auto _ = make_scope_exit([&] { Lex.setIgnoreColonInIdentifiers(false); });
+  llvm::scope_exit _([&] { Lex.setIgnoreColonInIdentifiers(false); });
 
   Lex.Lex();
   if (!EatIfPresent(lltok::lparen)) {
@@ -3244,7 +3244,7 @@ bool LLParser::parseCapturesAttr(AttrBuilder &B) {
   // We use syntax like captures(ret: address, provenance), so the colon
   // should not be interpreted as a label terminator.
   Lex.setIgnoreColonInIdentifiers(true);
-  auto _ = make_scope_exit([&] { Lex.setIgnoreColonInIdentifiers(false); });
+  llvm::scope_exit _([&] { Lex.setIgnoreColonInIdentifiers(false); });
 
   Lex.Lex();
   if (parseToken(lltok::lparen, "expected '('"))

--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -1233,7 +1233,7 @@ OnDiskGraphDB::load(ObjectID ExternalRef) {
   if (!File)
     return createFileError(Path, File.takeError());
 
-  auto CloseFile = make_scope_exit([&]() { sys::fs::closeFile(*File); });
+  llvm::scope_exit CloseFile([&]() { sys::fs::closeFile(*File); });
 
   sys::fs::file_status Status;
   if (std::error_code EC = sys::fs::status(*File, Status))

--- a/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/GISelValueTracking.cpp
@@ -852,8 +852,8 @@ void GISelValueTracking::computeKnownFPClass(Register R,
   // assume this from flags/attributes.
   InterestedClasses &= ~KnownNotFromFlags;
 
-  auto ClearClassesFromFlags =
-      make_scope_exit([=, &Known] { Known.knownNot(KnownNotFromFlags); });
+  llvm::scope_exit ClearClassesFromFlags(
+      [=, &Known] { Known.knownNot(KnownNotFromFlags); });
 
   // All recursive calls that increase depth must come after this.
   if (Depth == MaxAnalysisRecursionDepth)

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -4196,7 +4196,7 @@ bool IRTranslator::runOnMachineFunction(MachineFunction &CurMF) {
   }
 
   // Release the per-function state when we return, whether we succeeded or not.
-  auto FinalizeOnReturn = make_scope_exit([this]() { finalizeFunction(); });
+  llvm::scope_exit FinalizeOnReturn([this]() { finalizeFunction(); });
 
   // Setup a separate basic-block for the arguments and constants
   MachineBasicBlock *EntryBB = MF->CreateMachineBasicBlock();

--- a/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
@@ -140,7 +140,7 @@ bool InstructionSelect::runOnMachineFunction(MachineFunction &MF) {
 
   // FIXME: Properly override OptLevel in TargetMachine. See OptLevelChanger
   CodeGenOptLevel OldOptLevel = OptLevel;
-  auto RestoreOptLevel = make_scope_exit([=]() { OptLevel = OldOptLevel; });
+  llvm::scope_exit RestoreOptLevel([=]() { OptLevel = OldOptLevel; });
   OptLevel = MF.getFunction().hasOptNone() ? CodeGenOptLevel::None
                                            : MF.getTarget().getOptLevel();
 

--- a/llvm/lib/CodeGen/IfConversion.cpp
+++ b/llvm/lib/CodeGen/IfConversion.cpp
@@ -940,7 +940,7 @@ bool IfConverter::ValidForkedDiamond(
     FalseReversed = true;
     reverseBranchCondition(FalseBBI);
   }
-  auto UnReverseOnExit = make_scope_exit([&]() {
+  llvm::scope_exit UnReverseOnExit([&]() {
     if (FalseReversed)
       reverseBranchCondition(FalseBBI);
   });

--- a/llvm/lib/CodeGen/ResetMachineFunctionPass.cpp
+++ b/llvm/lib/CodeGen/ResetMachineFunctionPass.cpp
@@ -57,8 +57,8 @@ namespace {
       // No matter what happened, whether we successfully selected the function
       // or not, nothing is going to use the vreg types after us. Make sure they
       // disappear.
-      auto ClearVRegTypesOnReturn =
-          make_scope_exit([&MF]() { MF.getRegInfo().clearVirtRegTypes(); });
+      llvm::scope_exit ClearVRegTypesOnReturn(
+          [&MF]() { MF.getRegInfo().clearVirtRegTypes(); });
 
       if (MF.getProperties().hasFailedISel()) {
         if (AbortOnFailedISel)

--- a/llvm/lib/ExecutionEngine/Orc/LoadLinkableFile.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LoadLinkableFile.cpp
@@ -49,7 +49,7 @@ loadLinkableFile(StringRef Path, const Triple &TT, LoadArchives LA,
   if (!FDOrErr)
     return createFileError(Path, FDOrErr.takeError());
   sys::fs::file_t FD = *FDOrErr;
-  auto CloseFile = make_scope_exit([&]() { sys::fs::closeFile(FD); });
+  llvm::scope_exit CloseFile([&]() { sys::fs::closeFile(FD); });
 
   auto Buf =
       MemoryBuffer::getOpenFile(FD, *IdentifierOverride, /*FileSize=*/-1);

--- a/llvm/lib/ExecutionEngine/Orc/MachO.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MachO.cpp
@@ -112,7 +112,7 @@ loadMachORelocatableObject(StringRef Path, const Triple &TT, LoadArchives LA,
   if (!FDOrErr)
     return createFileError(Path, FDOrErr.takeError());
   sys::fs::file_t FD = *FDOrErr;
-  auto CloseFile = make_scope_exit([&]() { sys::fs::closeFile(FD); });
+  llvm::scope_exit CloseFile([&]() { sys::fs::closeFile(FD); });
 
   auto Buf =
       MemoryBuffer::getOpenFile(FD, *IdentifierOverride, /*FileSize=*/-1);

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.cpp
@@ -49,7 +49,7 @@ SimpleExecutorMemoryManager::initialize(tpctypes::FinalizeRequest &FR) {
   ExecutorAddrRange RR(FR.Segments.front().Addr, FR.Segments.front().Addr);
 
   std::vector<sys::MemoryBlock> MBsToReset;
-  auto ResetMBs = make_scope_exit([&]() {
+  llvm::scope_exit ResetMBs([&]() {
     for (auto &MB : MBsToReset)
       sys::Memory::protectMappedMemory(MB, sys::Memory::MF_READ |
                                                sys::Memory::MF_WRITE);

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -1900,7 +1900,7 @@ Error LTO::runThinLTO(AddStreamFn AddStream, FileCache Cache,
   LLVM_DEBUG(dbgs() << "Running ThinLTO\n");
   ThinLTO.CombinedIndex.releaseTemporaryMemory();
   timeTraceProfilerBegin("ThinLink", StringRef(""));
-  auto TimeTraceScopeExit = llvm::make_scope_exit([]() {
+  llvm::scope_exit TimeTraceScopeExit([]() {
     if (llvm::timeTraceProfilerEnabled())
       llvm::timeTraceProfilerEnd();
   });
@@ -2533,7 +2533,7 @@ public:
     if (Err)
       return std::move(*Err);
 
-    auto CleanPerJobFiles = llvm::make_scope_exit([&] {
+    llvm::scope_exit CleanPerJobFiles([&] {
       llvm::TimeTraceScope TimeScope("Remove DTLTO temporary files");
       if (!SaveTemps)
         for (auto &Job : Jobs) {
@@ -2560,7 +2560,7 @@ public:
             BCError + "failed to generate distributor JSON script: " + JsonFile,
             inconvertibleErrorCode());
     }
-    auto CleanJson = llvm::make_scope_exit([&] {
+    llvm::scope_exit CleanJson([&] {
       if (!SaveTemps)
         removeFile(JsonFile);
     });

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -956,7 +956,7 @@ ThinLTOCodeGenerator::writeGeneratedObject(int count, StringRef CacheEntryPath,
 // Main entry point for the ThinLTO processing
 void ThinLTOCodeGenerator::run() {
   timeTraceProfilerBegin("ThinLink", StringRef(""));
-  auto TimeTraceScopeExit = llvm::make_scope_exit([]() {
+  llvm::scope_exit TimeTraceScopeExit([]() {
     if (llvm::timeTraceProfilerEnabled())
       llvm::timeTraceProfilerEnd();
   });

--- a/llvm/lib/MC/MCExpr.cpp
+++ b/llvm/lib/MC/MCExpr.cpp
@@ -485,7 +485,7 @@ bool MCExpr::evaluateAsRelocatableImpl(MCValue &Res, const MCAssembler *Asm,
     }
     if (Sym.isVariable() && (Kind == 0 || Layout) && !Sym.isWeakExternal()) {
       Sym.setIsResolving(true);
-      auto _ = make_scope_exit([&] { Sym.setIsResolving(false); });
+      llvm::scope_exit _([&] { Sym.setIsResolving(false); });
       bool IsMachO =
           Asm && Asm->getContext().getAsmInfo()->hasSubsectionsViaSymbols();
       if (!Sym.getVariableValue()->evaluateAsRelocatableImpl(Res, Asm,

--- a/llvm/lib/MC/MCParser/ELFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/ELFAsmParser.cpp
@@ -720,8 +720,7 @@ bool ELFAsmParser::parseDirectiveType(StringRef, SMLoc) {
   if (!AllowAt &&
       !getContext().getAsmInfo()->getCommentString().starts_with("@"))
     getLexer().setAllowAtInIdentifier(true);
-  auto _ =
-      make_scope_exit([&]() { getLexer().setAllowAtInIdentifier(AllowAt); });
+  llvm::scope_exit _([&]() { getLexer().setAllowAtInIdentifier(AllowAt); });
 
   // NOTE the comma is optional in all cases.  It is only documented as being
   // optional in the first case, however, GAS will silently treat the comma as

--- a/llvm/lib/ObjectYAML/DXContainerYAML.cpp
+++ b/llvm/lib/ObjectYAML/DXContainerYAML.cpp
@@ -366,7 +366,7 @@ void MappingTraits<DXContainerYAML::PSVInfo>::mapping(
   IO.setContext(&Version);
 
   // Restore the YAML context on function exit.
-  auto RestoreContext = make_scope_exit([&]() { IO.setContext(OldContext); });
+  llvm::scope_exit RestoreContext([&]() { IO.setContext(OldContext); });
 
   // Shader stage is only included in binaries for v1 and later, but we always
   // include it since it simplifies parsing and file construction.

--- a/llvm/lib/Remarks/BitstreamRemarkSerializer.cpp
+++ b/llvm/lib/Remarks/BitstreamRemarkSerializer.cpp
@@ -198,7 +198,7 @@ void BitstreamRemarkSerializerHelper::setupBlockInfo() {
     Bitstream.Emit(static_cast<unsigned>(C), 8);
 
   Bitstream.EnterBlockInfoBlock();
-  auto ExitBlock = make_scope_exit([&] { Bitstream.ExitBlock(); });
+  llvm::scope_exit ExitBlock([&] { Bitstream.ExitBlock(); });
 
   // Setup the main metadata. Depending on the container type, we'll setup the
   // required records next.
@@ -225,7 +225,7 @@ void BitstreamRemarkSerializerHelper::emitMetaBlock(
     std::optional<StringRef> Filename) {
   // Emit the meta block
   Bitstream.EnterSubblock(META_BLOCK_ID, 3);
-  auto ExitBlock = make_scope_exit([&] { Bitstream.ExitBlock(); });
+  llvm::scope_exit ExitBlock([&] { Bitstream.ExitBlock(); });
 
   // The container version and type.
   R.clear();

--- a/llvm/lib/Support/Parallel.cpp
+++ b/llvm/lib/Support/Parallel.cpp
@@ -152,7 +152,7 @@ private:
             break;
         } while (Backoff.waitForNextAttempt());
 
-        auto SlotReleaser = llvm::make_scope_exit(
+        llvm::scope_exit SlotReleaser(
             [&] { TheJobserver->release(std::move(Slot)); });
 
         while (true) {

--- a/llvm/lib/Support/Path.cpp
+++ b/llvm/lib/Support/Path.cpp
@@ -1196,7 +1196,7 @@ Error readNativeFileToEOF(file_t FileHandle, SmallVectorImpl<char> &Buffer,
 
   // Install a handler to truncate the buffer to the correct size on exit.
   size_t Size = Buffer.size();
-  auto TruncateOnExit = make_scope_exit([&]() { Buffer.truncate(Size); });
+  llvm::scope_exit TruncateOnExit([&]() { Buffer.truncate(Size); });
 
   // Read into Buffer until we hit EOF.
   for (;;) {

--- a/llvm/lib/Support/ThreadPool.cpp
+++ b/llvm/lib/Support/ThreadPool.cpp
@@ -189,8 +189,8 @@ void StdThreadPool::processTasksWithJobserver() {
 
     // `make_scope_exit` guarantees the job slot is released, even if the
     // task throws or we exit early. This prevents deadlocking the build.
-    auto SlotReleaser =
-        make_scope_exit([&] { TheJobserver->release(std::move(Slot)); });
+    llvm::scope_exit SlotReleaser(
+        [&] { TheJobserver->release(std::move(Slot)); });
 
     // While we hold a job slot, process tasks from the internal queue.
     while (true) {

--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -82,7 +82,7 @@ llvm_execute_on_thread_impl(void *(*ThreadFunc)(void *), void *Arg,
     ReportErrnumFatal("pthread_attr_init failed", errnum);
   }
 
-  auto AttrGuard = llvm::make_scope_exit([&] {
+  llvm::scope_exit AttrGuard([&] {
     if ((errnum = ::pthread_attr_destroy(&Attr)) != 0) {
       ReportErrnumFatal("pthread_attr_destroy failed", errnum);
     }

--- a/llvm/lib/Support/VirtualOutputBackends.cpp
+++ b/llvm/lib/Support/VirtualOutputBackends.cpp
@@ -473,7 +473,7 @@ Error OnDiskOutputFile::keep() {
     return E;
 
   // Close the file descriptor and remove crash cleanup before exit.
-  auto RemoveDiscardOnSignal = make_scope_exit([&]() {
+  llvm::scope_exit RemoveDiscardOnSignal([&]() {
     if (Config.getDiscardOnSignal())
       sys::DontRemoveFileOnSignal(TempPath ? *TempPath : OutputPath);
   });

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -1468,23 +1468,23 @@ std::error_code remove_directories(const Twine &path, bool IgnoreErrors) {
         CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
     if (FAILED(HR))
       break;
-    auto Uninitialize = make_scope_exit([] { CoUninitialize(); });
+    llvm::scope_exit Uninitialize([] { CoUninitialize(); });
     IFileOperation *FileOp = NULL;
     HR = CoCreateInstance(CLSID_FileOperation, NULL, CLSCTX_ALL,
                           IID_PPV_ARGS(&FileOp));
     if (FAILED(HR))
       break;
-    auto FileOpRelease = make_scope_exit([&FileOp] { FileOp->Release(); });
+    llvm::scope_exit FileOpRelease([&FileOp] { FileOp->Release(); });
     HR = FileOp->SetOperationFlags(FOF_NO_UI | FOFX_NOCOPYHOOKS);
     if (FAILED(HR))
       break;
     PIDLIST_ABSOLUTE PIDL = ILCreateFromPathW(Path16.data());
-    auto FreePIDL = make_scope_exit([&PIDL] { ILFree(PIDL); });
+    llvm::scope_exit FreePIDL([&PIDL] { ILFree(PIDL); });
     IShellItem *ShItem = NULL;
     HR = SHCreateItemFromIDList(PIDL, IID_PPV_ARGS(&ShItem));
     if (FAILED(HR))
       break;
-    auto ShItemRelease = make_scope_exit([&ShItem] { ShItem->Release(); });
+    llvm::scope_exit ShItemRelease([&ShItem] { ShItem->Release(); });
     HR = FileOp->DeleteItem(ShItem, NULL);
     if (FAILED(HR))
       break;

--- a/llvm/lib/Support/Z3Solver.cpp
+++ b/llvm/lib/Support/Z3Solver.cpp
@@ -957,7 +957,7 @@ std::unique_ptr<SMTSolverStatistics> Z3Solver::getStatistics() const {
   auto const &C = Context.Context;
   Z3_stats S = Z3_solver_get_statistics(C, Solver);
   Z3_stats_inc_ref(C, S);
-  auto StatsGuard = llvm::make_scope_exit([&C, &S] { Z3_stats_dec_ref(C, S); });
+  llvm::scope_exit StatsGuard([&C, &S] { Z3_stats_dec_ref(C, S); });
   Z3Statistics Result;
 
   unsigned NumKeys = Z3_stats_size(C, S);

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -3047,7 +3047,7 @@ void AArch64AsmPrinter::emitInstruction(const MachineInstr *MI) {
 
 #ifndef NDEBUG
   InstsEmitted = 0;
-  auto CheckMISize = make_scope_exit([&]() {
+  llvm::scope_exit CheckMISize([&]() {
     assert(STI->getInstrInfo()->getInstSizeInBytes(*MI) >= InstsEmitted * 4);
   });
 #endif

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -2017,7 +2017,7 @@ bool AArch64FrameLowering::spillCalleeSavedRegisters(
     }
 
     Register X0Scratch;
-    auto RestoreX0 = make_scope_exit([&] {
+    llvm::scope_exit RestoreX0([&] {
       if (X0Scratch != AArch64::NoRegister)
         BuildMI(MBB, MI, DL, TII.get(TargetOpcode::COPY), AArch64::X0)
             .addReg(X0Scratch)

--- a/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULegalizerInfo.cpp
@@ -6882,7 +6882,7 @@ bool AMDGPULegalizerInfo::legalizeImageIntrinsic(
   }
 
   Observer.changingInstr(MI);
-  auto ChangedInstr = make_scope_exit([&] { Observer.changedInstr(MI); });
+  scope_exit ChangedInstr([&] { Observer.changedInstr(MI); });
 
   const unsigned StoreOpcode = IsD16 ? AMDGPU::G_AMDGPU_INTRIN_IMAGE_STORE_D16
                                      : AMDGPU::G_AMDGPU_INTRIN_IMAGE_STORE;

--- a/llvm/lib/Target/M68k/M68kInstrInfo.cpp
+++ b/llvm/lib/Target/M68k/M68kInstrInfo.cpp
@@ -94,7 +94,7 @@ bool M68kInstrInfo::AnalyzeBranchImpl(MachineBasicBlock &MBB,
 
   // Erase any instructions if allowed at the end of the scope.
   std::vector<std::reference_wrapper<llvm::MachineInstr>> EraseList;
-  auto FinalizeOnReturn = llvm::make_scope_exit([&EraseList] {
+  llvm::scope_exit FinalizeOnReturn([&EraseList] {
     for (auto &Ref : EraseList)
       Ref.get().eraseFromParent();
   });

--- a/llvm/lib/Target/X86/X86FlagsCopyLowering.cpp
+++ b/llvm/lib/Target/X86/X86FlagsCopyLowering.cpp
@@ -424,7 +424,7 @@ bool X86FlagsCopyLoweringPass::runOnMachineFunction(MachineFunction &MF) {
           "Cannot lower EFLAGS copy unless it is defined in turn by a copy!");
     }
 
-    auto Cleanup = make_scope_exit([&] {
+    llvm::scope_exit Cleanup([&] {
       // All uses of the EFLAGS copy are now rewritten, kill the copy into
       // eflags and if dead the copy from.
       CopyI->eraseFromParent();

--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -341,7 +341,7 @@ void FrameTypeBuilder::addFieldForAllocas(const Function &F,
   SmallVector<AllocaSetType, 4> NonOverlapedAllocas;
 
   // We need to add field for allocas at the end of this function.
-  auto AddFieldForAllocasAtExit = make_scope_exit([&]() {
+  llvm::scope_exit AddFieldForAllocasAtExit([&]() {
     for (auto AllocaList : NonOverlapedAllocas) {
       auto *LargestAI = *AllocaList.begin();
       FieldIDType Id = addFieldForAlloca(LargestAI);

--- a/llvm/lib/Transforms/IPO/ArgumentPromotion.cpp
+++ b/llvm/lib/Transforms/IPO/ArgumentPromotion.cpp
@@ -336,7 +336,7 @@ doPromotion(Function *F, FunctionAnalysisManager &FAM,
 
     // There potentially are metadata uses for things like llvm.dbg.value.
     // Replace them with poison, after handling the other regular uses.
-    auto RauwPoisonMetadata = make_scope_exit(
+    llvm::scope_exit RauwPoisonMetadata(
         [&]() { Arg.replaceAllUsesWith(PoisonValue::get(Arg.getType())); });
 
     if (Arg.use_empty())

--- a/llvm/lib/Transforms/IPO/Inliner.cpp
+++ b/llvm/lib/Transforms/IPO/Inliner.cpp
@@ -279,7 +279,7 @@ PreservedAnalyses InlinerPass::run(LazyCallGraph::SCC &InitialC,
   // Capture updatable variable for the current SCC.
   auto *C = &InitialC;
 
-  auto AdvisorOnExit = make_scope_exit([&] { Advisor.onPassExit(C); });
+  llvm::scope_exit AdvisorOnExit([&] { Advisor.onPassExit(C); });
 
   if (Calls.empty())
     return PreservedAnalyses::all();

--- a/llvm/lib/Transforms/IPO/ModuleInliner.cpp
+++ b/llvm/lib/Transforms/IPO/ModuleInliner.cpp
@@ -137,7 +137,7 @@ PreservedAnalyses ModuleInlinerPass::run(Module &M,
   InlineAdvisor &Advisor = getAdvisor(MAM, FAM, M);
   Advisor.onPassEntry();
 
-  auto AdvisorOnExit = make_scope_exit([&] { Advisor.onPassExit(); });
+  llvm::scope_exit AdvisorOnExit([&] { Advisor.onPassExit(); });
 
   // In the module inliner, a priority-based worklist is used for calls across
   // the entire Module. With this module inliner, the inline order is not

--- a/llvm/lib/Transforms/Instrumentation/PGOCtxProfFlattening.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOCtxProfFlattening.cpp
@@ -152,7 +152,7 @@ PreservedAnalyses PGOCtxProfFlatteningPass::run(Module &M,
   // Note: in such cases we leave as-is any other profile info (if present -
   // e.g. synthetic weights, etc) because it wouldn't interfere with the
   // contextual - based one (which would be in other modules)
-  auto OnExit = llvm::make_scope_exit([&]() {
+  llvm::scope_exit OnExit([&]() {
     if (IsPreThinlink)
       return;
     for (auto &F : M)

--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -1512,7 +1512,7 @@ static std::optional<bool> checkCondition(CmpInst::Predicate Pred, Value *A,
   // about the constraint.
   for (auto &Row : R.ExtraInfo)
     CSToUse.addVariableRow(Row);
-  auto InfoRestorer = make_scope_exit([&]() {
+  llvm::scope_exit InfoRestorer([&]() {
     for (unsigned I = 0; I < R.ExtraInfo.size(); ++I)
       CSToUse.popLastConstraint();
   });
@@ -1683,7 +1683,7 @@ static bool checkOrAndOpImpliedByOther(
     return false;
 
   unsigned OldSize = DFSInStack.size();
-  auto InfoRestorer = make_scope_exit([&]() {
+  llvm::scope_exit InfoRestorer([&]() {
     // Remove entries again.
     while (OldSize < DFSInStack.size()) {
       StackEntry E = DFSInStack.back();

--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -1513,7 +1513,7 @@ Constant *JumpThreadingPass::evaluateOnPredecessorEdge(
     SmallPtrSet<Value *, 8> &Visited) {
   if (!Visited.insert(V).second)
     return nullptr;
-  auto _ = make_scope_exit([&Visited, V]() { Visited.erase(V); });
+  llvm::scope_exit _([&Visited, V]() { Visited.erase(V); });
 
   BasicBlock *PredBB = BB->getSinglePredecessor();
   assert(PredBB && "Expected a single predecessor");

--- a/llvm/lib/Transforms/Scalar/LowerMatrixIntrinsics.cpp
+++ b/llvm/lib/Transforms/Scalar/LowerMatrixIntrinsics.cpp
@@ -2211,7 +2211,7 @@ public:
                                    LoadOp1->getParent() == StoreParent;
       for (unsigned Idx = 0; Idx != LifetimeEnds.size();) {
         IntrinsicInst *End = LifetimeEnds[Idx];
-        auto Inc = make_scope_exit([&Idx]() { Idx++; });
+        llvm::scope_exit Inc([&Idx]() { Idx++; });
         // If the lifetime.end is guaranteed to be before the loads or after the
         // store, it won't interfere with fusion.
         if (DT->dominates(End, LoadOp0) && DT->dominates(End, LoadOp1))

--- a/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -1160,7 +1160,7 @@ bool MemCpyOptPass::processMemCpyMemCpyDependence(MemCpyInst *M,
   IRBuilder<> Builder(M);
   auto *CopySource = MDep->getSource();
   Instruction *NewCopySource = nullptr;
-  auto CleanupOnRet = llvm::make_scope_exit([&] {
+  llvm::scope_exit CleanupOnRet([&] {
     if (NewCopySource && NewCopySource->use_empty())
       // Safety: It's safe here because we will only allocate more instructions
       // after finishing all BatchAA queries, but we have to be careful if we

--- a/llvm/lib/Transforms/Utils/LoopUtils.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUtils.cpp
@@ -66,7 +66,7 @@ bool llvm::formDedicatedExitBlocks(Loop *L, DominatorTree *DT, LoopInfo *LI,
   auto RewriteExit = [&](BasicBlock *BB) {
     assert(InLoopPredecessors.empty() &&
            "Must start with an empty predecessors list!");
-    auto Cleanup = make_scope_exit([&] { InLoopPredecessors.clear(); });
+    llvm::scope_exit Cleanup([&] { InLoopPredecessors.clear(); });
 
     // See if there are any non-loop predecessors of this exit block and
     // keep track of the in-loop predecessors.

--- a/llvm/lib/Transforms/Utils/ScalarEvolutionExpander.cpp
+++ b/llvm/lib/Transforms/Utils/ScalarEvolutionExpander.cpp
@@ -2332,8 +2332,7 @@ Value *SCEVExpander::fixupLCSSAFormFor(Value *V) {
     ToTy = Type::getInt32Ty(DefI->getContext());
   Instruction *User =
       CastInst::CreateBitOrPointerCast(DefI, ToTy, "tmp.lcssa.user", InsertPt);
-  auto RemoveUserOnExit =
-      make_scope_exit([User]() { User->eraseFromParent(); });
+  llvm::scope_exit RemoveUserOnExit([User]() { User->eraseFromParent(); });
 
   SmallVector<Instruction *, 1> ToUpdate;
   ToUpdate.push_back(DefI);

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -8314,7 +8314,7 @@ void BoUpSLP::reorderTopToBottom() {
     // mostly used order.
     ArrayRef<TreeEntry *> OrderedEntries = It->second.getArrayRef();
     // Delete VF entry upon exit.
-    auto Cleanup = make_scope_exit([&]() { VFToOrderedEntries.erase(It); });
+    llvm::scope_exit Cleanup([&]() { VFToOrderedEntries.erase(It); });
 
     // All operands are reordered and used only in this node - propagate the
     // most used order to the user node.
@@ -15973,7 +15973,7 @@ InstructionCost BoUpSLP::getSpillCost() {
     SmallDenseSet<std::pair<const BasicBlock *, const BasicBlock *>>
         ParentsPairsToAdd;
     bool Res = false;
-    auto Cleanup = make_scope_exit([&]() {
+    llvm::scope_exit Cleanup([&]() {
       for (const auto &KeyPair : ParentsPairsToAdd) {
         assert(!ParentOpParentToPreds.contains(KeyPair) &&
                "Should not have been added before.");
@@ -23398,7 +23398,7 @@ bool SLPVectorizerPass::vectorizeStores(
         if (Idx != StoreSeq.size() - 1)
           continue;
       }
-      auto E = make_scope_exit([&, &Dist = Dist, &InstIdx = InstIdx]() {
+      llvm::scope_exit E([&, &Dist = Dist, &InstIdx = InstIdx]() {
         Operands.clear();
         Operands.push_back(Stores[InstIdx]);
         PrevDist = Dist;

--- a/llvm/lib/Transforms/Vectorize/VPlanUnroll.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUnroll.cpp
@@ -425,7 +425,7 @@ void UnrollState::unrollBlock(VPBlockBase *VPB) {
 void VPlanTransforms::unrollByUF(VPlan &Plan, unsigned UF) {
   assert(UF > 0 && "Unroll factor must be positive");
   Plan.setUF(UF);
-  auto Cleanup = make_scope_exit([&Plan]() {
+  llvm::scope_exit Cleanup([&Plan]() {
     auto Iter = vp_depth_first_deep(Plan.getEntry());
     // Remove recipes that are redundant after unrolling.
     for (VPBasicBlock *VPBB : VPBlockUtils::blocksOnly<VPBasicBlock>(Iter)) {

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -1919,7 +1919,7 @@ bool VectorCombine::scalarizeLoadExtract(LoadInst *LI, VectorType *VecTy,
     return false;
 
   DenseMap<ExtractElementInst *, ScalarizationResult> NeedFreeze;
-  auto FailureGuard = make_scope_exit([&]() {
+  llvm::scope_exit FailureGuard([&]() {
     // If the transform is aborted, discard the ScalarizationResults.
     for (auto &Pair : NeedFreeze)
       Pair.second.discard();

--- a/llvm/tools/gold/gold-plugin.cpp
+++ b/llvm/tools/gold/gold-plugin.cpp
@@ -1156,7 +1156,7 @@ static ld_plugin_status allSymbolsReadHook() {
     llvm::timeTraceProfilerInitialize(options::time_trace_granularity,
                                       options::extra.size() ? options::extra[0]
                                                             : "LLVMgold");
-  auto FinalizeTimeTrace = llvm::make_scope_exit([&]() {
+  llvm::scope_exit FinalizeTimeTrace([&]() {
     if (!llvm::timeTraceProfilerEnabled())
       return;
     assert(!options::time_trace_file.empty());

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -424,7 +424,7 @@ int main(int argc, char **argv) {
 
   if (TimeTrace)
     timeTraceProfilerInitialize(TimeTraceGranularity, argv[0]);
-  auto TimeTraceScopeExit = make_scope_exit([]() {
+  llvm::scope_exit TimeTraceScopeExit([]() {
     if (TimeTrace) {
       if (auto E = timeTraceProfilerWrite(TimeTraceFile, OutputFilename)) {
         handleAllErrors(std::move(E), [&](const StringError &SE) {

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkResult.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkResult.cpp
@@ -394,7 +394,7 @@ Expected<std::vector<Benchmark>> Benchmark::readYamls(const LLVMState &State,
 }
 
 Error Benchmark::writeYamlTo(const LLVMState &State, raw_ostream &OS) {
-  auto Cleanup = make_scope_exit([&] { OS.flush(); });
+  llvm::scope_exit Cleanup([&] { OS.flush(); });
   yaml::Output Yout(OS, nullptr /*Ctx*/, 200 /*WrapColumn*/);
   YamlContext Context(State);
   Yout.beginDocuments();

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkRunner.cpp
@@ -292,7 +292,7 @@ private:
                    SmallVectorImpl<int64_t> &CounterValues,
                    ArrayRef<const char *> ValidationCounters,
                    SmallVectorImpl<int64_t> &ValidationCounterValues) const {
-    auto WriteFDClose = make_scope_exit([WriteFD]() { close(WriteFD); });
+    scope_exit WriteFDClose([WriteFD]() { close(WriteFD); });
     const ExegesisTarget &ET = State.getExegesisTarget();
     auto CounterOrError =
         ET.createCounter(CounterName, State, ValidationCounters, ChildPID);

--- a/llvm/tools/llvm-exegesis/lib/SubprocessMemory.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SubprocessMemory.cpp
@@ -57,8 +57,8 @@ Error SubprocessMemory::initializeSubprocessMemory(pid_t ProcessID) {
     return make_error<Failure>(
         "Failed to create shared memory object for auxiliary memory: " +
         Twine(strerror(errno)));
-  auto AuxiliaryMemoryFDClose =
-      make_scope_exit([AuxiliaryMemoryFD]() { close(AuxiliaryMemoryFD); });
+  scope_exit AuxiliaryMemoryFDClose(
+      [AuxiliaryMemoryFD]() { close(AuxiliaryMemoryFD); });
   if (ftruncate(AuxiliaryMemoryFD, AuxiliaryMemorySize) != 0) {
     return make_error<Failure>("Truncating the auxiliary memory failed: " +
                                Twine(strerror(errno)));
@@ -81,8 +81,8 @@ Error SubprocessMemory::addMemoryDefinition(
       return make_error<Failure>(
           "Failed to create shared memory object for memory definition: " +
           Twine(strerror(errno)));
-    auto SharedMemoryFDClose =
-        make_scope_exit([SharedMemoryFD]() { close(SharedMemoryFD); });
+    scope_exit SharedMemoryFDClose(
+        [SharedMemoryFD]() { close(SharedMemoryFD); });
     if (ftruncate(SharedMemoryFD, MemVal.SizeBytes) != 0) {
       return make_error<Failure>("Truncating a memory definiton failed: " +
                                  Twine(strerror(errno)));

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -284,7 +284,7 @@ static int run(int argc, char **argv) {
 
   if (TimeTrace)
     timeTraceProfilerInitialize(TimeTraceGranularity, argv[0]);
-  auto TimeTraceScopeExit = make_scope_exit([]() {
+  llvm::scope_exit TimeTraceScopeExit([]() {
     if (TimeTrace) {
       check(timeTraceProfilerWrite(TimeTraceFile, OutputFilename),
             "timeTraceProfilerWrite failed");

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -395,7 +395,7 @@ int main(int argc, char **argv) {
   if (TimeTrace)
     timeTraceProfilerInitialize(TimeTraceGranularity, argv[0]);
 
-  auto TimeTraceScopeExit = make_scope_exit([]() {
+  llvm::scope_exit TimeTraceScopeExit([]() {
     if (!TimeTrace)
       return;
     if (auto E = timeTraceProfilerWrite(TimeTraceFile, OutputFilename)) {

--- a/llvm/tools/llvm-profdata/llvm-profdata.cpp
+++ b/llvm/tools/llvm-profdata/llvm-profdata.cpp
@@ -779,7 +779,7 @@ loadInput(const WeightedFile &Input, SymbolRemapper *Remapper,
   // we have more non-fatal errors from InstrProfReader in the future. How
   // should this interact with different -failure-mode?
   std::optional<std::pair<Error, std::string>> ReaderWarning;
-  auto ReaderWarningScope = llvm::make_scope_exit([&] {
+  llvm::scope_exit ReaderWarningScope([&] {
     // If we hit a different error we may still have an error in ReaderWarning.
     // Consume it now to avoid an assert
     if (ReaderWarning)

--- a/llvm/unittests/ADT/ScopeExitTest.cpp
+++ b/llvm/unittests/ADT/ScopeExitTest.cpp
@@ -22,7 +22,7 @@ TEST(ScopeExitTest, Basic) {
   };
   bool Called = false;
   {
-    auto g = make_scope_exit(Callable(Called));
+    llvm::scope_exit g((Callable(Called)));
     EXPECT_FALSE(Called);
   }
   EXPECT_TRUE(Called);
@@ -32,14 +32,14 @@ TEST(ScopeExitTest, Release) {
   int Count = 0;
   auto Increment = [&] { ++Count; };
   {
-    auto G = make_scope_exit(Increment);
+    llvm::scope_exit G(Increment);
     auto H = std::move(G);
     auto I = std::move(G);
     EXPECT_EQ(0, Count);
   }
   EXPECT_EQ(1, Count);
   {
-    auto G = make_scope_exit(Increment);
+    llvm::scope_exit G(Increment);
     G.release();
   }
   EXPECT_EQ(1, Count);

--- a/llvm/unittests/ExecutionEngine/Orc/CoreAPIsTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/CoreAPIsTest.cpp
@@ -1718,7 +1718,7 @@ TEST(JITDylibTest, GetDFSLinkOrderTree) {
   // form a tree.
 
   ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
-  auto _ = make_scope_exit([&]() { cantFail(ES.endSession()); });
+  llvm::scope_exit _([&]() { cantFail(ES.endSession()); });
 
   auto &LibA = ES.createBareJITDylib("A");
   auto &LibB = ES.createBareJITDylib("B");
@@ -1760,7 +1760,7 @@ TEST(JITDylibTest, GetDFSLinkOrderDiamond) {
   // contain a diamond.
 
   ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
-  auto _ = make_scope_exit([&]() { cantFail(ES.endSession()); });
+  llvm::scope_exit _([&]() { cantFail(ES.endSession()); });
 
   auto &LibA = ES.createBareJITDylib("A");
   auto &LibB = ES.createBareJITDylib("B");
@@ -1784,7 +1784,7 @@ TEST(JITDylibTest, GetDFSLinkOrderCycle) {
   // contain a cycle.
 
   ExecutionSession ES{std::make_unique<UnsupportedExecutorProcessControl>()};
-  auto _ = make_scope_exit([&]() { cantFail(ES.endSession()); });
+  llvm::scope_exit _([&]() { cantFail(ES.endSession()); });
 
   auto &LibA = ES.createBareJITDylib("A");
   auto &LibB = ES.createBareJITDylib("B");

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -1799,7 +1799,7 @@ TEST_F(FileSystemTest, OpenDirectoryAsFileForRead) {
   EXPECT_EQ(errorToErrorCode(FD.takeError()), errc::is_a_directory);
 #else
   ASSERT_THAT_EXPECTED(FD, Succeeded());
-  auto Close = make_scope_exit([&] { fs::closeFile(*FD); });
+  scope_exit Close([&] { fs::closeFile(*FD); });
   Expected<size_t> BytesRead =
       fs::readNativeFile(*FD, MutableArrayRef(&*Buf.begin(), Buf.size()));
   EXPECT_EQ(errorToErrorCode(BytesRead.takeError()), errc::is_a_directory);
@@ -2025,7 +2025,7 @@ TEST_F(FileSystemTest, readNativeFile) {
     Expected<fs::file_t> FD = fs::openNativeFileForRead(NonExistantFile);
     if (!FD)
       return FD.takeError();
-    auto Close = make_scope_exit([&] { fs::closeFile(*FD); });
+    llvm::scope_exit Close([&] { fs::closeFile(*FD); });
     if (Expected<size_t> BytesRead = fs::readNativeFile(
             *FD, MutableArrayRef(&*Buf.begin(), Buf.size())))
       return Buf.substr(0, *BytesRead);
@@ -2046,7 +2046,7 @@ TEST_F(FileSystemTest, readNativeFileToEOF) {
     Expected<fs::file_t> FD = fs::openNativeFileForRead(NonExistantFile);
     if (!FD)
       return FD.takeError();
-    auto Close = make_scope_exit([&] { fs::closeFile(*FD); });
+    llvm::scope_exit Close([&] { fs::closeFile(*FD); });
     if (ChunkSize)
       return fs::readNativeFileToEOF(*FD, V, *ChunkSize);
     return fs::readNativeFileToEOF(*FD, V);
@@ -2089,7 +2089,7 @@ TEST_F(FileSystemTest, readNativeFileSlice) {
   FileRemover Cleanup(NonExistantFile);
   Expected<fs::file_t> FD = fs::openNativeFileForRead(NonExistantFile);
   ASSERT_THAT_EXPECTED(FD, Succeeded());
-  auto Close = make_scope_exit([&] { fs::closeFile(*FD); });
+  llvm::scope_exit Close([&] { fs::closeFile(*FD); });
   const auto &Read = [&](size_t Offset,
                          size_t ToRead) -> Expected<std::string> {
     std::string Buf(ToRead, '?');

--- a/llvm/unittests/Support/SignalsTest.cpp
+++ b/llvm/unittests/Support/SignalsTest.cpp
@@ -38,8 +38,7 @@ using testing::Not;
 // not. See https://github.com/llvm/llvm-project/issues/168891.
 #if 0
 TEST(SignalsTest, PrintsSymbolizerMarkup) {
-  auto Exit =
-      make_scope_exit([]() { unsetenv("LLVM_ENABLE_SYMBOLIZER_MARKUP"); });
+  scope_exit Exit([]() { unsetenv("LLVM_ENABLE_SYMBOLIZER_MARKUP"); });
   setenv("LLVM_ENABLE_SYMBOLIZER_MARKUP", "1", 1);
   std::string Res;
   raw_string_ostream RawStream(Res);
@@ -59,7 +58,7 @@ TEST(SignalsTest, PrintsSymbolizerMarkup) {
 #endif
 
 TEST(SignalsTest, SymbolizerMarkupDisabled) {
-  auto Exit = make_scope_exit([]() { unsetenv("LLVM_DISABLE_SYMBOLIZATION"); });
+  scope_exit Exit([]() { unsetenv("LLVM_DISABLE_SYMBOLIZATION"); });
   setenv("LLVM_DISABLE_SYMBOLIZATION", "1", 1);
   std::string Res;
   raw_string_ostream RawStream(Res);

--- a/llvm/unittests/Support/ThreadPool.cpp
+++ b/llvm/unittests/Support/ThreadPool.cpp
@@ -211,7 +211,7 @@ TYPED_TEST(ThreadPoolTest, AsyncRAIICaptures) {
   // Create an RAII object that when destroyed schedules more work. This makes
   // it easy to check that the RAII is resolved at the same point as a task runs
   // on the thread pool.
-  auto schedule_next = llvm::make_scope_exit([&Group, &value] {
+  llvm::scope_exit schedule_next([&Group, &value] {
     // We sleep before scheduling the final task to make it much more likely
     // that an incorrect implementation actually exbitits a bug. Without the
     // sleep, we may get "lucky" and have the second task finish before the

--- a/llvm/unittests/Support/VirtualFileSystemTest.cpp
+++ b/llvm/unittests/Support/VirtualFileSystemTest.cpp
@@ -545,8 +545,7 @@ TEST(VirtualFileSystemTest, PhysicalFileSystemWorkingDirFailure) {
   ASSERT_EQ(sys::fs::current_path(PrevWD), std::error_code());
   ASSERT_EQ(sys::fs::createUniqueDirectory("d1", WD), std::error_code());
   ASSERT_EQ(sys::fs::set_current_path(WD), std::error_code());
-  auto Restore =
-      llvm::make_scope_exit([&] { sys::fs::set_current_path(PrevWD); });
+  llvm::scope_exit Restore([&] { sys::fs::set_current_path(PrevWD); });
 
   // Delete the working directory to create an error.
   if (sys::fs::remove_directories(WD, /*IgnoreErrors=*/false))

--- a/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
@@ -267,8 +267,8 @@ LogicalResult DeadCodeAnalysis::initializeRecursively(Operation *op) {
     // has one. If so, update the flag to allow for resolving callables in
     // nested regions.
     bool savedHasSymbolTable = hasSymbolTable;
-    auto restoreHasSymbolTable =
-        llvm::make_scope_exit([&]() { hasSymbolTable = savedHasSymbolTable; });
+    llvm::scope_exit restoreHasSymbolTable(
+        [&]() { hasSymbolTable = savedHasSymbolTable; });
     if (!hasSymbolTable && op->hasTrait<OpTrait::SymbolTable>())
       hasSymbolTable = true;
 

--- a/mlir/lib/Analysis/DataFlowFramework.cpp
+++ b/mlir/lib/Analysis/DataFlowFramework.cpp
@@ -112,10 +112,10 @@ Location LatticeAnchor::getLoc() const {
 LogicalResult DataFlowSolver::initializeAndRun(Operation *top) {
   // Enable enqueue to the worklist.
   isRunning = true;
-  auto guard = llvm::make_scope_exit([&]() { isRunning = false; });
+  llvm::scope_exit guard([&]() { isRunning = false; });
 
   bool isInterprocedural = config.isInterprocedural();
-  auto restoreInterprocedural = llvm::make_scope_exit(
+  llvm::scope_exit restoreInterprocedural(
       [&]() { config.setInterprocedural(isInterprocedural); });
   if (isInterprocedural && !top->hasTrait<OpTrait::SymbolTable>())
     config.setInterprocedural(false);

--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -2131,7 +2131,7 @@ OperationParser::parseCustomOperation(ArrayRef<ResultRecord> resultIDs) {
     parseAssemblyFn = *dialectHook;
   }
   getState().defaultDialectStack.push_back(defaultDialect);
-  auto restoreDefaultDialect = llvm::make_scope_exit(
+  llvm::scope_exit restoreDefaultDialect(
       [&]() { getState().defaultDialectStack.pop_back(); });
 
   // If the custom op parser crashes, produce some indication to help
@@ -2277,7 +2277,7 @@ ParseResult OperationParser::parseRegionBody(Region &region, SMLoc startLoc,
 
   // Parse the first block directly to allow for it to be unnamed.
   auto owningBlock = std::make_unique<Block>();
-  auto failureCleanup = llvm::make_scope_exit([&] {
+  llvm::scope_exit failureCleanup([&] {
     if (owningBlock) {
       // If parsing failed, as indicated by the fact that `owningBlock` still
       // owns the block, drop all forward references from preceding operations
@@ -2382,7 +2382,7 @@ ParseResult OperationParser::parseBlock(Block *&block) {
   // only in the case of a successful parse. This ensures that the Block
   // allocated is released if the parse fails and control returns early.
   std::unique_ptr<Block> inflightBlock;
-  auto cleanupOnFailure = llvm::make_scope_exit([&] {
+  llvm::scope_exit cleanupOnFailure([&] {
     if (inflightBlock)
       inflightBlock->dropAllDefinedValueUses();
   });

--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -867,7 +867,7 @@ public:
     if (PyObject_GetBuffer(array.ptr(), &view, flags) != 0) {
       throw nb::python_error();
     }
-    auto freeBuffer = llvm::make_scope_exit([&]() { PyBuffer_Release(&view); });
+    llvm::scope_exit freeBuffer([&]() { PyBuffer_Release(&view); });
 
     MlirContext context = contextWrapper->get();
     MlirAttribute attr = getAttributeFromBuffer(
@@ -1447,7 +1447,7 @@ public:
 
     // This scope releaser will only release if we haven't yet transferred
     // ownership.
-    auto freeBuffer = llvm::make_scope_exit([&]() {
+    llvm::scope_exit freeBuffer([&]() {
       if (view)
         PyBuffer_Release(view.get());
     });

--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -1355,8 +1355,7 @@ T AttrTypeReader::resolveEntry(SmallVectorImpl<Entry<T>> &entries,
                                uint64_t depth) {
   bool oldResolving = resolving;
   resolving = true;
-  auto restoreResolving =
-      llvm::make_scope_exit([&]() { resolving = oldResolving; });
+  llvm::scope_exit restoreResolving([&]() { resolving = oldResolving; });
 
   if (index >= entries.size()) {
     emitError(fileLoc) << "invalid " << entryType << " index: " << index;
@@ -1578,8 +1577,8 @@ public:
   materialize(Operation *op,
               llvm::function_ref<bool(Operation *)> lazyOpsCallback) {
     this->lazyOpsCallback = lazyOpsCallback;
-    auto resetlazyOpsCallback =
-        llvm::make_scope_exit([&] { this->lazyOpsCallback = nullptr; });
+    llvm::scope_exit resetlazyOpsCallback(
+        [&] { this->lazyOpsCallback = nullptr; });
     auto it = lazyLoadableOpsMap.find(op);
     assert(it != lazyLoadableOpsMap.end() &&
            "materialize called on non-materializable op");
@@ -1890,8 +1889,8 @@ LogicalResult BytecodeReader::Impl::read(
     Block *block, llvm::function_ref<bool(Operation *)> lazyOpsCallback) {
   EncodingReader reader(buffer.getBuffer(), fileLoc);
   this->lazyOpsCallback = lazyOpsCallback;
-  auto resetlazyOpsCallback =
-      llvm::make_scope_exit([&] { this->lazyOpsCallback = nullptr; });
+  llvm::scope_exit resetlazyOpsCallback(
+      [&] { this->lazyOpsCallback = nullptr; });
 
   // Skip over the bytecode header, this should have already been checked.
   if (failed(reader.skipBytes(StringRef("ML\xefR").size())))

--- a/mlir/lib/CAPI/Interfaces/Interfaces.cpp
+++ b/mlir/lib/CAPI/Interfaces/Interfaces.cpp
@@ -61,7 +61,7 @@ SmallVector<std::unique_ptr<Region>> unwrapRegions(intptr_t nRegions,
   unwrappedRegions.reserve(nRegions);
   for (intptr_t i = 0; i < nRegions; ++i)
     unwrappedRegions.emplace_back(unwrap(*(regions + i)));
-  auto cleaner = llvm::make_scope_exit([&]() {
+  llvm::scope_exit cleaner([&]() {
     for (auto &region : unwrappedRegions)
       region.release();
   });

--- a/mlir/lib/Conversion/ArmSMEToLLVM/ArmSMEToLLVM.cpp
+++ b/mlir/lib/Conversion/ArmSMEToLLVM/ArmSMEToLLVM.cpp
@@ -863,7 +863,7 @@ static void mergeConsecutiveTileZerosInBlock(Block *block) {
   uint32_t mergedZeroMask = 0;
   SmallVector<arm_sme::aarch64_sme_zero, 16> zeroOpsToMerge;
   auto replaceMergedZeroOps = [&] {
-    auto cleanup = llvm::make_scope_exit([&] {
+    llvm::scope_exit cleanup([&] {
       mergedZeroMask = 0;
       zeroOpsToMerge.clear();
     });

--- a/mlir/lib/Conversion/LLVMCommon/TypeConverter.cpp
+++ b/mlir/lib/Conversion/LLVMCommon/TypeConverter.cpp
@@ -161,7 +161,7 @@ LLVMTypeConverter::LLVMTypeConverter(MLIRContext *ctx,
         return success();
       }
       recursiveStack.push_back(type);
-      auto popConversionCallStack = llvm::make_scope_exit(
+      llvm::scope_exit popConversionCallStack(
           [&recursiveStack]() { recursiveStack.pop_back(); });
 
       SmallVector<Type> convertedElemTypes;

--- a/mlir/lib/Debug/ExecutionContext.cpp
+++ b/mlir/lib/Debug/ExecutionContext.cpp
@@ -60,7 +60,7 @@ void ExecutionContext::operator()(llvm::function_ref<void()> transform,
     depth = actionStack->getDepth() + 1;
   ActionActiveStack info{actionStack, action, depth};
   actionStack = &info;
-  auto raii = llvm::make_scope_exit([&]() { actionStack = info.getParent(); });
+  llvm::scope_exit raii([&]() { actionStack = info.getParent(); });
   Breakpoint *breakpoint = nullptr;
 
   // Invoke the callback here and handles control requests here.

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
@@ -720,8 +720,7 @@ bufferization::getBufferType(Value value, const BufferizationOptions &options,
   assert(llvm::isa<TensorLikeType>(value.getType()) &&
          "unexpected non-tensor type");
   invocationStack.push_back(value);
-  auto popFromStack =
-      llvm::make_scope_exit([&]() { invocationStack.pop_back(); });
+  llvm::scope_exit popFromStack([&]() { invocationStack.pop_back(); });
 
   // Try querying BufferizableOpInterface.
   Operation *op = getOwnerOfValue(value);

--- a/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp
@@ -295,7 +295,7 @@ static void createNewAliasScopesFromNoAliasParameter(
 
   // Scope exit block to make it impossible to forget to get rid of the
   // intrinsics.
-  auto exit = llvm::make_scope_exit([&] {
+  llvm::scope_exit exit([&] {
     for (LLVM::SSACopyOp ssaCopyOp : ssaCopies) {
       ssaCopyOp.replaceAllUsesWith(ssaCopyOp.getOperand());
       ssaCopyOp->erase();

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -310,8 +310,8 @@ DiagnosedSilenceableFailure transform::BufferizeToAllocationOp::apply(
     transform::TransformResults &results, transform::TransformState &state) {
   // Attach listener to keep track of newly created ops.
   OpBuilder::Listener *previousListener = rewriter.getListener();
-  auto resetListener =
-      llvm::make_scope_exit([&]() { rewriter.setListener(previousListener); });
+  llvm::scope_exit resetListener(
+      [&]() { rewriter.setListener(previousListener); });
   NewOpsListener newOpsListener(previousListener);
   rewriter.setListener(&newOpsListener);
 
@@ -1149,8 +1149,8 @@ tileAndFuseFirstExtractUseThroughContainingOpBlockArgument(
   bvm.map(destinationTensors[resultNumber], bbArg);
   auto tileableProducerClone =
       cast<TilingInterface>(rewriter.clone(*tileableProducer, bvm));
-  auto scopeGuard =
-      llvm::make_scope_exit([&]() { rewriter.eraseOp(tileableProducerClone); });
+  llvm::scope_exit scopeGuard(
+      [&]() { rewriter.eraseOp(tileableProducerClone); });
 
   // Tile the producer.
   FailureOr<TilingResult> tileAndFuseResult =

--- a/mlir/lib/Dialect/Linalg/Transforms/Interchange.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Interchange.cpp
@@ -56,8 +56,7 @@ mlir::linalg::interchangeGenericOp(RewriterBase &rewriter, GenericOp genericOp,
 
   // Start a guarded inplace update.
   rewriter.startOpModification(genericOp);
-  auto guard = llvm::make_scope_exit(
-      [&]() { rewriter.finalizeOpModification(genericOp); });
+  llvm::scope_exit guard([&]() { rewriter.finalizeOpModification(genericOp); });
 
   // 2. Compute the interchanged indexing maps.
   SmallVector<AffineMap> newIndexingMaps;

--- a/mlir/lib/Dialect/SCF/Transforms/TileUsingInterface.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/TileUsingInterface.cpp
@@ -1754,8 +1754,8 @@ mlir::scf::tileConsumerAndFuseProducersUsingSCF(
   // the mutation of replacement values. To do this, we attach a listener to
   // update the replacements as they happen.
   OpBuilder::Listener *previousListener = rewriter.getListener();
-  auto resetListener =
-      llvm::make_scope_exit([&]() { rewriter.setListener(previousListener); });
+  llvm::scope_exit resetListener(
+      [&]() { rewriter.setListener(previousListener); });
   ReplacementListener replaceListener(replacements, previousListener);
   rewriter.setListener(&replaceListener);
 

--- a/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
@@ -170,7 +170,7 @@ transform::AlternativesOp::apply(transform::TransformRewriter &rewriter,
     auto scope = state.make_region_scope(reg);
     auto clones = llvm::to_vector(
         llvm::map_range(originals, [](Operation *op) { return op->clone(); }));
-    auto deleteClones = llvm::make_scope_exit([&] {
+    llvm::scope_exit deleteClones([&] {
       for (Operation *clone : clones)
         clone->erase();
     });

--- a/mlir/lib/Dialect/Transform/Interfaces/TransformInterfaces.cpp
+++ b/mlir/lib/Dialect/Transform/Interfaces/TransformInterfaces.cpp
@@ -810,7 +810,7 @@ transform::TransformState::applyTransform(TransformOpInterface transform) {
   LDBG() << "applying: "
          << OpWithFlags(transform, OpPrintingFlags().skipRegions());
   FULL_LDBG() << "Top-level payload before application:\n" << *getTopLevel();
-  auto printOnFailureRAII = llvm::make_scope_exit([this] {
+  llvm::scope_exit printOnFailureRAII([this] {
     (void)this;
     LDBG() << "Failing Top-level payload:\n"
            << OpWithFlags(getTopLevel(),

--- a/mlir/lib/Dialect/Transform/PDLExtension/PDLExtensionOps.cpp
+++ b/mlir/lib/Dialect/Transform/PDLExtension/PDLExtensionOps.cpp
@@ -174,7 +174,7 @@ transform::WithPDLPatternsOp::apply(transform::TransformRewriter &rewriter,
   }
 
   state.addExtension<PatternApplicatorExtension>(getOperation());
-  auto guard = llvm::make_scope_exit(
+  llvm::scope_exit guard(
       [&]() { state.removeExtension<PatternApplicatorExtension>(); });
 
   auto scope = state.make_region_scope(getBody());

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -3872,8 +3872,8 @@ void OperationPrinter::printRegion(Region &region, bool printEntryBlockArgs,
   }
   os << "{" << newLine;
   if (!region.empty()) {
-    auto restoreDefaultDialect =
-        llvm::make_scope_exit([&]() { defaultDialectStack.pop_back(); });
+    llvm::scope_exit restoreDefaultDialect(
+        [&]() { defaultDialectStack.pop_back(); });
     if (auto iface = dyn_cast<OpAsmOpInterface>(region.getParentOp()))
       defaultDialectStack.push_back(iface.getDefaultDialect());
     else

--- a/mlir/lib/Pass/Pass.cpp
+++ b/mlir/lib/Pass/Pass.cpp
@@ -670,7 +670,7 @@ LogicalResult OpToOpPassAdaptor::runPipeline(
   });
   assert((!instrumentor || parentInfo) &&
          "expected parent info if instrumentor is provided");
-  auto scopeExit = llvm::make_scope_exit([&] {
+  llvm::scope_exit scopeExit([&] {
     // Clear out any computed operation analyses. These analyses won't be used
     // any more in this pipeline, and this helps reduce the current working set
     // of memory. If preserving these analyses becomes important in the future

--- a/mlir/lib/Pass/PassRegistry.cpp
+++ b/mlir/lib/Pass/PassRegistry.cpp
@@ -614,7 +614,7 @@ LogicalResult TextualPipeline::addToPipeline(
   // it's preferrable to just error out if implicit nesting would be required.
   OpPassManager::Nesting nesting = pm.getNesting();
   pm.setNesting(OpPassManager::Nesting::Explicit);
-  auto restore = llvm::make_scope_exit([&]() { pm.setNesting(nesting); });
+  llvm::scope_exit restore([&]() { pm.setNesting(nesting); });
 
   return addToPipeline(pipeline, pm, errorHandler);
 }

--- a/mlir/lib/Rewrite/PatternApplicator.cpp
+++ b/mlir/lib/Rewrite/PatternApplicator.cpp
@@ -217,7 +217,7 @@ LogicalResult PatternApplicator::matchAndRewrite(
                 std::make_unique<RewriterBase::PatternLoggingListener>(
                     oldListener, pattern->getDebugName());
             rewriter.setListener(loggingListener.get());
-            auto resetListenerCallback = llvm::make_scope_exit(
+            llvm::scope_exit resetListenerCallback(
                 [&] { rewriter.setListener(oldListener); });
 #endif
             result = pattern->matchAndRewrite(op, rewriter);

--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -664,7 +664,7 @@ NVPTXSerializer::moduleToObject(llvm::Module &llvmModule) {
   llvm::Timer moduleToObjectTimer(
       "moduleToObjectTimer",
       "Timer for perf llvm-ir -> isa and isa -> binary.");
-  auto clear = llvm::make_scope_exit([&]() { moduleToObjectTimer.clear(); });
+  llvm::scope_exit clear([&]() { moduleToObjectTimer.clear(); });
   // Return LLVM IR if the compilation target is `offload`.
 #define DEBUG_TYPE "serialize-to-llvm"
   LLVM_DEBUG({

--- a/mlir/lib/Target/LLVMIR/Dialect/GPU/SelectObjectAttr.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GPU/SelectObjectAttr.cpp
@@ -428,7 +428,7 @@ llvm::LaunchKernel::createKernelLaunch(mlir::gpu::LaunchFuncOp op,
   // a stream to make a synchronous kernel launch.
   Value *stream = nullptr;
   // Sync & destroy the stream, for synchronous launches.
-  auto destroyStream = make_scope_exit([&]() {
+  llvm::scope_exit destroyStream([&]() {
     builder.CreateCall(getStreamSyncFn(), {stream});
     builder.CreateCall(getStreamDestroyFn(), {stream});
   });

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -1749,7 +1749,7 @@ FailureOr<Value> ModuleImport::convertConstant(llvm::Constant *constant) {
     // since later calls to `getAsInstruction` may return the same address
     // resulting in a conflicting `valueMapping` entry.
     llvm::Instruction *inst = constExpr->getAsInstruction();
-    auto guard = llvm::make_scope_exit([&]() {
+    llvm::scope_exit guard([&]() {
       assert(!noResultOpMapping.contains(inst) &&
              "expected constant expression to return a result");
       valueMapping.erase(inst);

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2644,7 +2644,7 @@ LogicalResult OperationLegalizer::legalizeWithFold(Operation *op) {
 
   // Clear pattern state, so that the next pattern application starts with a
   // clean slate. (The op/block sets are populated by listener notifications.)
-  auto cleanup = llvm::make_scope_exit([&]() {
+  llvm::scope_exit cleanup([&]() {
     rewriterImpl.patternNewOps.clear();
     rewriterImpl.patternModifiedOps.clear();
   });

--- a/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+++ b/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
@@ -612,8 +612,7 @@ bool GreedyPatternRewriteDriver::processWorklist() {
     if (config.getScope()) {
       expensiveChecks.computeFingerPrints(config.getScope()->getParentOp());
     }
-    auto clearFingerprints =
-        llvm::make_scope_exit([&]() { expensiveChecks.clear(); });
+    llvm::scope_exit clearFingerprints([&]() { expensiveChecks.clear(); });
 #endif // MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS
 
     LogicalResult matchResult =

--- a/mlir/test/lib/Dialect/Test/TestPatterns.cpp
+++ b/mlir/test/lib/Dialect/Test/TestPatterns.cpp
@@ -2092,7 +2092,7 @@ struct TestTypeConversionDriver
           }
 
           conversionCallStack.push_back(type);
-          auto popConversionCallStack = llvm::make_scope_exit(
+          llvm::scope_exit popConversionCallStack(
               [&conversionCallStack]() { conversionCallStack.pop_back(); });
 
           // If the type is on the call stack more than once (it is there at


### PR DESCRIPTION
This is a followup to #173131. ~~`llvm/include/llvm/ADT/ScopeExit.h` has a nontrivial change (the deprecation message)~~ (split out into separate PR), everything else is a mechanical replacement.