### PR TITLE
[MLIR][CAPI] Fix duplicate output from mlirOperationPrintWithState

### DIFF
--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -835,7 +835,8 @@ void mlirOperationPrintWithState(MlirOperation op, MlirAsmState state,
   detail::CallbackOstream stream(callback, userData);
   if (state.ptr)
     unwrap(op)->print(stream, *unwrap(state));
-  unwrap(op)->print(stream);
+  else
+    unwrap(op)->print(stream);
 }
 
 void mlirOperationWriteBytecode(MlirOperation op, MlirStringCallback callback,


### PR DESCRIPTION
Fixes an issue where, when supplied with an `MlirAsmState`, `mlirOperationPrintWithState` prints the output twice, once with and once without using the state.

@ftynse @jpienaar @joker-eph