### PR TITLE
[flang] Unify return value of memcpy and memmove

### DIFF
--- a/flang/include/flang/Runtime/freestanding-tools.h
+++ b/flang/include/flang/Runtime/freestanding-tools.h
@@ -158,7 +158,6 @@ static inline RT_API_ATTRS void *memmove(
   }
   if (to + count <= from || from + count <= to) {
     memcpy(dest, src, count);
-    return dest;
   } else if (to < from) {
     while (count--) {
       *to++ = *from++;

--- a/flang/include/flang/Runtime/freestanding-tools.h
+++ b/flang/include/flang/Runtime/freestanding-tools.h
@@ -117,9 +117,10 @@ using std::memset;
 #endif
 
 #if STD_MEMCPY_USE_BUILTIN
-static inline RT_API_ATTRS void memcpy(
+static inline RT_API_ATTRS void *memcpy(
     void *dest, const void *src, std::size_t count) {
   __builtin_memcpy(dest, src, count);
+  return dest;
 }
 #elif STD_MEMCPY_UNSUPPORTED
 static inline RT_API_ATTRS void *memcpy(
@@ -127,7 +128,7 @@ static inline RT_API_ATTRS void *memcpy(
   char *to{reinterpret_cast<char *>(dest)};
   const char *from{reinterpret_cast<const char *>(src)};
   if (to == from) {
-    return;
+    return dest;
   }
   while (count--) {
     *to++ = *from++;
@@ -139,9 +140,10 @@ using std::memcpy;
 #endif
 
 #if STD_MEMMOVE_USE_BUILTIN
-static inline RT_API_ATTRS void memmove(
+static inline RT_API_ATTRS void *memmove(
     void *dest, const void *src, std::size_t count) {
   __builtin_memmove(dest, src, count);
+  return dest;
 }
 #elif STD_MEMMOVE_UNSUPPORTED
 // Provides alternative implementation for std::memmove(), if
@@ -156,6 +158,7 @@ static inline RT_API_ATTRS void *memmove(
   }
   if (to + count <= from || from + count <= to) {
     memcpy(dest, src, count);
+    return dest;
   } else if (to < from) {
     while (count--) {
       *to++ = *from++;


### PR DESCRIPTION
memcpy and memmove functions are not all returning a void*. Unify this so it doesn't make other errors like in #172568