### PR TITLE
[NOMERGE][mlir] python on default

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -198,7 +198,7 @@ set(MLIR_PYTHON_PACKAGE_PREFIX "mlir"
   CACHE STRING "Specifies that all MLIR packages are co-located under the
   `MLIR_PYTHON_PACKAGE_PREFIX` top level package (the API has been
   embedded in a relocatable way).")
-set(MLIR_ENABLE_BINDINGS_PYTHON 0 CACHE BOOL
+set(MLIR_ENABLE_BINDINGS_PYTHON 1 CACHE BOOL
        "Enables building of Python bindings.")
 set(MLIR_BINDINGS_PYTHON_INSTALL_PREFIX "python_packages/mlir_core/mlir" CACHE STRING
        "Prefix under install directory to place python bindings")


### PR DESCRIPTION
flang-arm64-windows-msvc-testsuite: https://lab.llvm.org/buildbot/#/builders/222/builds/1566
flang-arm64-windows-msvc: https://lab.llvm.org/buildbot/#/builders/207/builds/11607
flang-aarch64-out-of-tree: https://lab.llvm.org/buildbot/#/builders/53/builds/24734