### PR TITLE
[RISCV] Convert ORI with SingleBitSetMaskImm12 to BSETI when Xqcibm is enabled

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -221,6 +221,10 @@ def AddLike: PatFrags<(ops node:$A, node:$B),
     return CurDAG->isBaseWithConstantOffset(SDValue(N, 0));
 }]>;
 
+def SingleBitSetMaskImm12 : RISCVOp<XLenVT>, ImmLeaf<XLenVT, [{
+  return isPowerOf2_32(Imm) && isInt<12>(Imm) && Imm != 1;
+}], SingleBitSetMaskToIndex>;
+
 //===----------------------------------------------------------------------===//
 // Instruction Formats
 //===----------------------------------------------------------------------===//
@@ -1738,6 +1742,11 @@ def: Pat<(i32 (qc_e_li tblockaddress:$A)), (QC_E_LI bare_simm32:$A)>;
 def: Pat<(i32 (qc_e_li tjumptable:$A)), (QC_E_LI bare_simm32:$A)>;
 def: Pat<(i32 (qc_e_li tconstpool:$A)), (QC_E_LI bare_simm32:$A)>;
 } // Predicates = [HasVendorXqcili, IsRV32]
+
+let Predicates = [HasVendorXqcibm, HasStdExtZbs, IsRV32], AddedComplexity = 1 in {
+def : Pat<(XLenVT (or GPR:$rs1, SingleBitSetMaskImm12:$mask)),
+          (BSETI GPR:$rs1, SingleBitSetMaskImm12:$mask)>;
+} // Predicates = [HasVendorXqcibm, HasStdExtZbs, IsRV32]
 
 //===----------------------------------------------------------------------===/i
 // Compress Instruction tablegen backend.

--- a/llvm/test/CodeGen/RISCV/xqcibm-insert.ll
+++ b/llvm/test/CodeGen/RISCV/xqcibm-insert.ll
@@ -344,3 +344,60 @@ define i64 @test8(i64 %a) {
   %2 = or i64 %1, 157601565442048     ; 0x00008f5679530000
   ret i64 %2
 }
+
+define i32 @no_bseti_1(i32 %a, i32 %b, i32 %c) nounwind {
+; RV32I-LABEL: no_bseti_1:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    ori a0, a1, 1
+; RV32I-NEXT:    ret
+;
+; RV32IXQCIBM-LABEL: no_bseti_1:
+; RV32IXQCIBM:       # %bb.0:
+; RV32IXQCIBM-NEXT:    ori a0, a1, 1
+; RV32IXQCIBM-NEXT:    ret
+;
+; RV32IXQCIBMZBS-LABEL: no_bseti_1:
+; RV32IXQCIBMZBS:       # %bb.0:
+; RV32IXQCIBMZBS-NEXT:    ori a0, a1, 1
+; RV32IXQCIBMZBS-NEXT:    ret
+  %or = or i32 %b, 1
+  ret i32 %or
+}
+
+define i32 @bseti_2(i32 %a, i32 %b, i32 %c) nounwind {
+; RV32I-LABEL: bseti_2:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    ori a0, a1, 2
+; RV32I-NEXT:    ret
+;
+; RV32IXQCIBM-LABEL: bseti_2:
+; RV32IXQCIBM:       # %bb.0:
+; RV32IXQCIBM-NEXT:    ori a0, a1, 2
+; RV32IXQCIBM-NEXT:    ret
+;
+; RV32IXQCIBMZBS-LABEL: bseti_2:
+; RV32IXQCIBMZBS:       # %bb.0:
+; RV32IXQCIBMZBS-NEXT:    ori a0, a1, 2
+; RV32IXQCIBMZBS-NEXT:    ret
+  %or = or i32 %b, 2
+  ret i32 %or
+}
+
+define i32 @bseti_i32_10(i32 %a) nounwind {
+; RV32I-LABEL: bseti_i32_10:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    ori a0, a0, 1024
+; RV32I-NEXT:    ret
+;
+; RV32IXQCIBM-LABEL: bseti_i32_10:
+; RV32IXQCIBM:       # %bb.0:
+; RV32IXQCIBM-NEXT:    ori a0, a0, 1024
+; RV32IXQCIBM-NEXT:    ret
+;
+; RV32IXQCIBMZBS-LABEL: bseti_i32_10:
+; RV32IXQCIBMZBS:       # %bb.0:
+; RV32IXQCIBMZBS-NEXT:    ori a0, a0, 1024
+; RV32IXQCIBMZBS-NEXT:    ret
+  %or = or i32 %a, 1024
+  ret i32 %or
+}

--- a/llvm/test/CodeGen/RISCV/xqcibm-insert.ll
+++ b/llvm/test/CodeGen/RISCV/xqcibm-insert.ll
@@ -377,7 +377,7 @@ define i32 @bseti_2(i32 %a, i32 %b, i32 %c) nounwind {
 ;
 ; RV32IXQCIBMZBS-LABEL: bseti_2:
 ; RV32IXQCIBMZBS:       # %bb.0:
-; RV32IXQCIBMZBS-NEXT:    ori a0, a1, 2
+; RV32IXQCIBMZBS-NEXT:    bseti a0, a1, 1
 ; RV32IXQCIBMZBS-NEXT:    ret
   %or = or i32 %b, 2
   ret i32 %or
@@ -396,7 +396,7 @@ define i32 @bseti_i32_10(i32 %a) nounwind {
 ;
 ; RV32IXQCIBMZBS-LABEL: bseti_i32_10:
 ; RV32IXQCIBMZBS:       # %bb.0:
-; RV32IXQCIBMZBS-NEXT:    ori a0, a0, 1024
+; RV32IXQCIBMZBS-NEXT:    bseti a0, a0, 10
 ; RV32IXQCIBMZBS-NEXT:    ret
   %or = or i32 %a, 1024
   ret i32 %or


### PR DESCRIPTION
`BSETI` can be compressed to `QC_C_BSETI` when `Xqcibm` is enabled.