### PR TITLE
InstCombine: Fix wrong interested mask in SimplifyDemandedFPClass

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2281,7 +2281,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Value *V,
     break;
   }
   default:
-    Known = computeKnownFPClass(I, ~DemandedMask, CxtI, Depth + 1);
+    Known = computeKnownFPClass(I, DemandedMask, CxtI, Depth + 1);
     break;
   }
 


### PR DESCRIPTION
We are interested in the values that are still candidates, not ones
that have already been ruled out from the uses. Avoids regressions
when new uses are introduced.