### PR TITLE
[clang][bytecode] Check if block is initialized before invoking destructor

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -4801,7 +4801,8 @@ VarCreationState Compiler<Emitter>::visitDecl(const VarDecl *VD,
       auto &GD = GlobalBlock->getBlockDesc<GlobalInlineDescriptor>();
 
       GD.InitState = GlobalInitState::InitializerFailed;
-      GlobalBlock->invokeDtor();
+      if (GlobalBlock->isInitialized())
+        GlobalBlock->invokeDtor();
     }
   }
 
@@ -4862,7 +4863,8 @@ bool Compiler<Emitter>::visitDeclAndReturn(const VarDecl *VD, const Expr *Init,
       auto &GD = GlobalBlock->getBlockDesc<GlobalInlineDescriptor>();
 
       GD.InitState = GlobalInitState::InitializerFailed;
-      GlobalBlock->invokeDtor();
+      if (GlobalBlock->isInitialized())
+        GlobalBlock->invokeDtor();
     }
     return false;
   }

--- a/clang/test/AST/ByteCode/typeid.cpp
+++ b/clang/test/AST/ByteCode/typeid.cpp
@@ -72,3 +72,16 @@ namespace TypeidPtrRegression {
   }
 }
 
+
+// Regression test for assertion failure in invokeDtor(). GH-173950
+namespace GH173950 {
+  struct A {
+    virtual void f();
+  };
+
+  static A &a = *new A;
+  extern A &a;
+
+  // This used to crash with: Assertion `IsInitialized' failed in invokeDtor()
+  const std::type_info &a_ti = typeid(a);
+}


### PR DESCRIPTION
Fixes #173950. 

The bytecode interpreter was crashing when evaluating typeid() on references to dynamically allocated objects. For example, this would cause an assertion failure:

static A &a = *new A;
const std::type_info &a_ti = typeid(a);

The problem was that when initialization failed, the code tried to call invokeDtor() on blocks that were never marked as initialized. This caused the assertion "IsInitialized" to fail. With this fix, we first check if the block is actually initialized before trying to invoke its destructor. 

The test case I added reproduces the original crash and with the fix, it now passes.
