### PR TITLE
[InstCombine] Fold values to 0 on eq-dominated paths

### DIFF
--- a/llvm/test/Transforms/GVN/fold-on-eq-branch.ll
+++ b/llvm/test/Transforms/GVN/fold-on-eq-branch.ll
@@ -1,0 +1,18 @@
+; RUN: opt -passes='default<O2>' -S < %s | FileCheck %s
+; RUN: opt -passes='default<O3>' -S < %s | FileCheck %s
+
+declare void @use(i64)
+
+define i64 @ftp_state_list(i64 %0, i64 %1) {
+  %3 = sub i64 %0, %1
+  %4 = icmp eq i64 %0, %1
+  br i1 %4, label %5, label %common.ret
+
+5:
+; CHECK: tail call void @use(i64 0)
+  tail call void @use(i64 %3)
+  br label %common.ret
+
+common.ret:
+  ret i64 %3
+}


### PR DESCRIPTION
InstCombine can miss simplifications when an instruction is only used in a block that is reachable only if `Op0 == Op1`. This patch folds such values to 0.

Fixes: #143658