### PR TITLE
InstCombine: Compute fp class when simplifying with multiple uses

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2053,8 +2053,10 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Value *V,
     return FoldedToConst == V ? nullptr : FoldedToConst;
   }
 
-  if (!I->hasOneUse())
+  if (!I->hasOneUse()) {
+    Known = computeKnownFPClass(V, DemandedMask, CxtI, Depth + 1);
     return nullptr;
+  }
 
   if (auto *FPOp = dyn_cast<FPMathOperator>(I)) {
     if (FPOp->hasNoNaNs())


### PR DESCRIPTION
Fall back on reporting the known fp class even if we aren't simplifying
the value.