### PR TITLE
[mlir][spirv] Allow unrealized casts in scf-to-spirv

### DIFF
--- a/mlir/lib/Conversion/SCFToSPIRV/SCFToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/SCFToSPIRV/SCFToSPIRVPass.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Conversion/SCFToSPIRV/SCFToSPIRV.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
 #include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
+#include "mlir/IR/BuiltinOps.h"
 
 namespace mlir {
 #define GEN_PASS_DEF_SCFTOSPIRV
@@ -40,6 +41,7 @@ void SCFToSPIRVPass::runOnOperation() {
   auto targetAttr = spirv::lookupTargetEnvOrDefault(op);
   std::unique_ptr<ConversionTarget> target =
       SPIRVConversionTarget::get(targetAttr);
+  target->addLegalOp<UnrealizedConversionCastOp>();
 
   SPIRVTypeConverter typeConverter(targetAttr);
   ScfToSPIRVContext scfContext;

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -1018,7 +1018,7 @@ struct FuncOpConversion final : OpConversionPattern<func::FuncOp> {
                                             : TypeRange()));
 
     // Copy over all attributes other than the function name and type.
-    for (const auto &namedAttr : funcOp->getAttrs()) {
+    for (NamedAttribute namedAttr : funcOp->getAttrs()) {
       if (namedAttr.getName() != funcOp.getFunctionTypeAttrName() &&
           namedAttr.getName() != SymbolTable::getSymbolAttrName())
         newFuncOp->setAttr(namedAttr.getName(), namedAttr.getValue());

--- a/mlir/test/Conversion/SCFToSPIRV/func-signature.mlir
+++ b/mlir/test/Conversion/SCFToSPIRV/func-signature.mlir
@@ -1,0 +1,21 @@
+// RUN: mlir-opt --convert-scf-to-spirv --reconcile-unrealized-casts %s | FileCheck %s
+
+// Make sure that this test pass handles function signature conversion properly.
+
+// CHECK-LABEL: spirv.func @add_scalar
+// CHECK-SAME: (%[[ARG0:.+]]: i32) -> i32
+func.func @add_scalar(%arg0: i32) -> i32 {
+  // CHECK-NEXT: %[[RES:.+]] = spirv.IAdd %[[ARG0]], %[[ARG0]] : i32
+  // CHECK-NEXT: spirv.ReturnValue %[[RES]] : i32
+  %0 = arith.addi %arg0, %arg0 : i32
+  return %0 : i32
+}
+
+// CHECK-LABEL: spirv.func @add_index
+// CHECK-SAME: (%[[ARG0:.+]]: i32) -> i32
+func.func @add_index(%arg0: index) -> index {
+  // CHECK-NEXT: %[[RES:.+]] = spirv.IAdd %[[ARG0]], %[[ARG0]] : i32
+  // CHECK-NEXT: spirv.ReturnValue %[[RES]] : i32
+  %0 = arith.addi %arg0, %arg0 : index
+  return %0 : index
+}


### PR DESCRIPTION
This is required for signature conversion to work.

Fixes: https://github.com/llvm/llvm-project/issues/173564