### PR TITLE
[mlir][spirv] Mark `spirv.ReturnValue` as `ReturnLike`

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td
@@ -507,7 +507,7 @@ def SPIRV_MergeOp : SPIRV_Op<"mlir.merge", [
 // -----
 
 def SPIRV_ReturnOp : SPIRV_Op<"Return", [InFunctionScope, Pure,
-                                     Terminator]> {
+                                         ReturnLike, Terminator]> {
   let summary = "Return with no value from a function with void return type.";
 
   let description = [{
@@ -546,7 +546,7 @@ def SPIRV_UnreachableOp : SPIRV_Op<"Unreachable", [InFunctionScope, Terminator]>
 // -----
 
 def SPIRV_ReturnValueOp : SPIRV_Op<"ReturnValue", [InFunctionScope, Pure,
-                                               Terminator]> {
+                                                   ReturnLike, Terminator]> {
   let summary = "Return a value from a function.";
 
   let description = [{

--- a/mlir/test/Dialect/SPIRV/IR/return-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/return-ops.mlir
@@ -1,0 +1,17 @@
+// RUN: mlir-opt %s --remove-dead-values | FileCheck %s
+
+// Make sure that the return value op is considered as a return-like op and
+// remains live.
+
+// CHECK-LABEL: @preserve_return_value
+// CHECK-SAME:    (%[[ARG0:.*]]: vector<2xi32>, %[[ARG1:.*]]: vector<2xi32>) -> vector<2xi32>
+// CHECK-NEXT:    %[[BITCAST0:.*]] = spirv.Bitcast %[[ARG1]] : vector<2xi32> to vector<2xf32>
+// CHECK-NEXT:    %[[BITCAST1:.*]] = spirv.Bitcast %[[BITCAST0]] : vector<2xf32> to vector<2xi32>
+// CHECK-NEXT:    spirv.ReturnValue %[[BITCAST1]] : vector<2xi32>
+
+spirv.func @preserve_return_value(%arg0: vector<2xi32>, %arg1: vector<2xi32>) -> vector<2xi32> "None" {
+  %0 = spirv.Bitcast %arg0 : vector<2xi32> to vector<2xf32>
+  %1 = spirv.Bitcast %arg1 : vector<2xi32> to vector<2xf32>
+  %2 = spirv.Bitcast %1 : vector<2xf32> to vector<2xi32>
+  spirv.ReturnValue %2 : vector<2xi32>
+}


### PR DESCRIPTION
This makes the dead value analysis consider it live.

Fixes: https://github.com/llvm/llvm-project/issues/173563