### PR TITLE
[ADT] Allow `TypeSwitch::Default` for `FailureOr<T>`

### DIFF
--- a/llvm/include/llvm/ADT/TypeSwitch.h
+++ b/llvm/include/llvm/ADT/TypeSwitch.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/LogicalResult.h"
 #include <optional>
 
 namespace llvm {
@@ -133,6 +134,16 @@ public:
                 std::enable_if_t<std::is_constructible_v<ArgT, std::nullopt_t>>>
   [[nodiscard]] ResultT Default(std::nullopt_t) {
     return Default(ResultT(std::nullopt));
+  }
+
+  /// Default for result types constructible from `LogicalResult` (e.g.,
+  /// `FailureOr<T>`).
+  template <typename ArgT = ResultT,
+            typename =
+                std::enable_if_t<std::is_constructible_v<ArgT, LogicalResult> &&
+                                 !std::is_same_v<ArgT, LogicalResult>>>
+  [[nodiscard]] ResultT Default(LogicalResult result) {
+    return Default(ResultT(result));
   }
 
   /// Declare default as unreachable, making sure that all cases were handled.

--- a/llvm/unittests/ADT/TypeSwitchTest.cpp
+++ b/llvm/unittests/ADT/TypeSwitchTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/LogicalResult.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;
@@ -182,4 +183,25 @@ TEST(TypeSwitchTest, DefaultNullptrForPointerLike) {
   };
   EXPECT_EQ(&foo, translate(DerivedA()).ptr);
   EXPECT_EQ(nullptr, translate(DerivedD()).ptr);
+}
+
+TEST(TypeSwitchTest, DefaultLogicalResultSuccess) {
+  auto translate = [](auto value) {
+    return TypeSwitch<Base *, LogicalResult>(&value)
+        .Case([](DerivedA *) { return success(); })
+        .Default(failure());
+  };
+  EXPECT_TRUE(succeeded(translate(DerivedA())));
+  EXPECT_TRUE(failed(translate(DerivedD())));
+}
+
+TEST(TypeSwitchTest, DefaultFailureOr) {
+  auto translate = [](auto value) {
+    return TypeSwitch<Base *, FailureOr<int>>(&value)
+        .Case([](DerivedA *) { return 42; })
+        .Default(failure());
+  };
+  EXPECT_TRUE(succeeded(translate(DerivedA())));
+  EXPECT_EQ(42, *translate(DerivedA()));
+  EXPECT_TRUE(failed(translate(DerivedD())));
 }

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -4314,7 +4314,7 @@ DiagnosedSilenceableFailure transform::TransposeMatmulOp::applyToOne(
           .Case([&](linalg::BatchMatmulOp op) {
             return transposeBatchMatmul(rewriter, op, transposeLHS);
           })
-          .Default([&](Operation *op) { return failure(); });
+          .Default(failure());
   if (failed(maybeTransformed))
     return emitSilenceableFailure(target->getLoc()) << "not supported";
   // Handle to the new Matmul operation with transposed filters

--- a/mlir/lib/Dialect/Linalg/Transforms/DataLayoutPropagation.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/DataLayoutPropagation.cpp
@@ -972,7 +972,7 @@ public:
         .Case([&](tensor::ExpandShapeOp op) {
           return bubbleUpPackOpThroughExpandShape(op, packOp, rewriter);
         })
-        .Default([](Operation *) { return failure(); });
+        .Default(failure());
   }
 
 private:
@@ -1090,7 +1090,7 @@ public:
           return pushDownUnPackOpThroughExpandShape(unPackOp, op, rewriter,
                                                     controlFn);
         })
-        .Default([](Operation *) { return failure(); });
+        .Default(failure());
   }
 
 private:

--- a/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
@@ -2676,7 +2676,7 @@ LogicalResult mlir::linalg::vectorizeOpPrecondition(
       .Case<tensor::InsertSliceOp>([&](auto sliceOp) {
         return vectorizeInsertSliceOpPrecondition(sliceOp, inputVectorSizes);
       })
-      .Default([](auto) { return failure(); });
+      .Default(failure());
 }
 
 /// Converts affine.apply Ops to arithmetic operations.
@@ -2783,7 +2783,7 @@ FailureOr<VectorizationResult> mlir::linalg::vectorize(
             return vectorizeAsInsertSliceOp(rewriter, sliceOp, inputVectorSizes,
                                             results);
           })
-          .Default([](auto) { return failure(); });
+          .Default(failure());
 
   if (failed(vectorizeResult)) {
     LDBG() << "Vectorization failed";

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMIRToLLVMTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMIRToLLVMTranslation.cpp
@@ -277,7 +277,7 @@ static LogicalResult setLoopAttr(const llvm::MDNode *node, Operation *op,
         branchOp.setLoopAnnotationAttr(attr);
         return success();
       })
-      .Default([](auto) { return failure(); });
+      .Default(failure());
 }
 
 /// Looks up all the alias scope attributes that map to the alias scope nodes


### PR DESCRIPTION
Support specifying the default value without having to write a lambda, e.g.: `.Default(failure());`.