### PR TITLE
[clang-tidy][NFC] Prefer `llvm::split` over `StringRef::split`

### DIFF
--- a/clang-tools-extra/clang-tidy/android/ComparisonInTempFailureRetryCheck.cpp
+++ b/clang-tools-extra/clang-tidy/android/ComparisonInTempFailureRetryCheck.cpp
@@ -18,9 +18,8 @@ namespace clang::tidy::android {
 ComparisonInTempFailureRetryCheck::ComparisonInTempFailureRetryCheck(
     StringRef Name, ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
-      RawRetryList(Options.get("RetryMacros", "TEMP_FAILURE_RETRY")) {
-  RawRetryList.split(RetryMacros, ",", -1, false);
-}
+      RawRetryList(Options.get("RetryMacros", "TEMP_FAILURE_RETRY")),
+      RetryMacros(llvm::split(RawRetryList, ',')) {}
 
 void ComparisonInTempFailureRetryCheck::storeOptions(
     ClangTidyOptions::OptionMap &Opts) {

--- a/clang-tools-extra/clang-tidy/bugprone/AssertSideEffectCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/AssertSideEffectCheck.cpp
@@ -90,9 +90,8 @@ AssertSideEffectCheck::AssertSideEffectCheck(StringRef Name,
       CheckFunctionCalls(Options.get("CheckFunctionCalls", false)),
       RawAssertList(Options.get("AssertMacros", "assert,NSAssert,NSCAssert")),
       IgnoredFunctions(utils::options::parseListPair(
-          "__builtin_expect;", Options.get("IgnoredFunctions", ""))) {
-  RawAssertList.split(AssertMacros, ",", -1, false);
-}
+          "__builtin_expect;", Options.get("IgnoredFunctions", ""))),
+      AssertMacros(llvm::split(RawAssertList, ',')) {}
 
 // The options are explained in AssertSideEffectCheck.h.
 void AssertSideEffectCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {

--- a/clang-tools-extra/clang-tidy/bugprone/AssertSideEffectCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/AssertSideEffectCheck.cpp
@@ -89,9 +89,9 @@ AssertSideEffectCheck::AssertSideEffectCheck(StringRef Name,
     : ClangTidyCheck(Name, Context),
       CheckFunctionCalls(Options.get("CheckFunctionCalls", false)),
       RawAssertList(Options.get("AssertMacros", "assert,NSAssert,NSCAssert")),
+      AssertMacros(llvm::split(RawAssertList, ',')),
       IgnoredFunctions(utils::options::parseListPair(
-          "__builtin_expect;", Options.get("IgnoredFunctions", ""))),
-      AssertMacros(llvm::split(RawAssertList, ',')) {}
+          "__builtin_expect;", Options.get("IgnoredFunctions", ""))) {}
 
 // The options are explained in AssertSideEffectCheck.h.
 void AssertSideEffectCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {

--- a/clang-tools-extra/clang-tidy/bugprone/ExceptionEscapeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ExceptionEscapeCheck.cpp
@@ -42,20 +42,13 @@ ExceptionEscapeCheck::ExceptionEscapeCheck(StringRef Name,
       CheckDestructors(Options.get("CheckDestructors", true)),
       CheckMoveMemberFunctions(Options.get("CheckMoveMemberFunctions", true)),
       CheckMain(Options.get("CheckMain", true)),
-      CheckNothrowFunctions(Options.get("CheckNothrowFunctions", true)) {
-  llvm::SmallVector<StringRef, 8> FunctionsThatShouldNotThrowVec,
-      IgnoredExceptionsVec, CheckedSwapFunctionsVec;
-  RawFunctionsThatShouldNotThrow.split(FunctionsThatShouldNotThrowVec, ",", -1,
-                                       false);
-  FunctionsThatShouldNotThrow.insert_range(FunctionsThatShouldNotThrowVec);
-
-  RawCheckedSwapFunctions.split(CheckedSwapFunctionsVec, ",", -1, false);
-  CheckedSwapFunctions.insert_range(CheckedSwapFunctionsVec);
-
-  llvm::StringSet<> IgnoredExceptions;
-  RawIgnoredExceptions.split(IgnoredExceptionsVec, ",", -1, false);
-  IgnoredExceptions.insert_range(IgnoredExceptionsVec);
-  Tracer.ignoreExceptions(std::move(IgnoredExceptions));
+      CheckNothrowFunctions(Options.get("CheckNothrowFunctions", true)),
+      FunctionsThatShouldNotThrow(
+          llvm::from_range, llvm::split(RawFunctionsThatShouldNotThrow, ',')),
+      CheckedSwapFunctions(llvm::from_range,
+                           llvm::split(RawCheckedSwapFunctions, ',')) {
+  Tracer.ignoreExceptions(
+      {llvm::from_range, llvm::split(RawIgnoredExceptions, ',')});
   Tracer.ignoreBadAlloc(true);
 }
 

--- a/clang-tools-extra/clang-tidy/bugprone/RandomGeneratorSeedCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/RandomGeneratorSeedCheck.cpp
@@ -19,9 +19,8 @@ RandomGeneratorSeedCheck::RandomGeneratorSeedCheck(StringRef Name,
                                                    ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       RawDisallowedSeedTypes(
-          Options.get("DisallowedSeedTypes", "time_t,std::time_t")) {
-  RawDisallowedSeedTypes.split(DisallowedSeedTypes, ',');
-}
+          Options.get("DisallowedSeedTypes", "time_t,std::time_t")),
+      DisallowedSeedTypes(llvm::split(RawDisallowedSeedTypes, ',')) {}
 
 void RandomGeneratorSeedCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "DisallowedSeedTypes", RawDisallowedSeedTypes);

--- a/clang-tools-extra/clang-tidy/modernize/UseNullptrCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseNullptrCheck.cpp
@@ -495,9 +495,8 @@ UseNullptrCheck::UseNullptrCheck(StringRef Name, ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       NullMacrosStr(Options.get("NullMacros", "NULL")),
       IgnoredTypes(utils::options::parseStringList(Options.get(
-          "IgnoredTypes", "_CmpUnspecifiedParam;^std::__cmp_cat::__unspec"))) {
-  NullMacrosStr.split(NullMacros, ",");
-}
+          "IgnoredTypes", "_CmpUnspecifiedParam;^std::__cmp_cat::__unspec"))),
+      NullMacros(llvm::split(NullMacrosStr, ',')) {}
 
 void UseNullptrCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "NullMacros", NullMacrosStr);

--- a/clang-tools-extra/clang-tidy/modernize/UseNullptrCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseNullptrCheck.cpp
@@ -494,9 +494,9 @@ private:
 UseNullptrCheck::UseNullptrCheck(StringRef Name, ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       NullMacrosStr(Options.get("NullMacros", "NULL")),
+      NullMacros(llvm::split(NullMacrosStr, ',')),
       IgnoredTypes(utils::options::parseStringList(Options.get(
-          "IgnoredTypes", "_CmpUnspecifiedParam;^std::__cmp_cat::__unspec"))),
-      NullMacros(llvm::split(NullMacrosStr, ',')) {}
+          "IgnoredTypes", "_CmpUnspecifiedParam;^std::__cmp_cat::__unspec"))) {}
 
 void UseNullptrCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "NullMacros", NullMacrosStr);

--- a/clang-tools-extra/clang-tidy/openmp/ExceptionEscapeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/openmp/ExceptionEscapeCheck.cpp
@@ -20,13 +20,9 @@ ExceptionEscapeCheck::ExceptionEscapeCheck(StringRef Name,
                                            ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       RawIgnoredExceptions(Options.get("IgnoredExceptions", "")) {
-  llvm::SmallVector<StringRef, 8> IgnoredExceptionsVec;
-
   llvm::StringSet<> IgnoredExceptions;
-  RawIgnoredExceptions.split(IgnoredExceptionsVec, ",", -1, false);
-  llvm::transform(IgnoredExceptionsVec, IgnoredExceptionsVec.begin(),
-                  [](StringRef S) { return S.trim(); });
-  IgnoredExceptions.insert_range(IgnoredExceptionsVec);
+  for (const StringRef S : llvm::split(RawIgnoredExceptions, ','))
+    IgnoredExceptions.insert(S.trim());
   Tracer.ignoreExceptions(std::move(IgnoredExceptions));
   Tracer.ignoreBadAlloc(true);
 }

--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -660,13 +660,9 @@ std::string IdentifierNamingCheck::HungarianNotation::getEnumPrefix(
   static const llvm::Regex Splitter(
       "([a-z0-9A-Z]*)(_+)|([A-Z]?[a-z0-9]+)([A-Z]|$)|([A-Z]+)([A-Z]|$)");
 
-  const StringRef EnumName(Name);
-  SmallVector<StringRef, 8> Substrs;
-  EnumName.split(Substrs, "_", -1, false);
-
   SmallVector<StringRef, 8> Words;
   SmallVector<StringRef, 8> Groups;
-  for (auto Substr : Substrs) {
+  for (StringRef Substr : llvm::split(Name, '_')) {
     while (!Substr.empty()) {
       Groups.clear();
       if (!Splitter.match(Substr, &Groups))
@@ -910,12 +906,9 @@ std::string IdentifierNamingCheck::fixupWithCase(
   static const llvm::Regex Splitter(
       "([a-z0-9A-Z]*)(_+)|([A-Z]?[a-z0-9]+)([A-Z]|$)|([A-Z]+)([A-Z]|$)");
 
-  SmallVector<StringRef, 8> Substrs;
-  Name.split(Substrs, "_", -1, false);
-
   SmallVector<StringRef, 8> Words;
   SmallVector<StringRef, 8> Groups;
-  for (auto Substr : Substrs) {
+  for (auto Substr : llvm::split(Name, '_')) {
     while (!Substr.empty()) {
       Groups.clear();
       if (!Splitter.match(Substr, &Groups))

--- a/clang-tools-extra/clang-tidy/utils/OptionsUtils.cpp
+++ b/clang-tools-extra/clang-tidy/utils/OptionsUtils.cpp
@@ -11,7 +11,7 @@
 
 namespace clang::tidy::utils::options {
 
-static constexpr char StringsDelimiter[] = ";";
+static constexpr char StringsDelimiter = ';';
 
 std::vector<StringRef> parseStringList(StringRef Option) {
   Option = Option.trim().trim(StringsDelimiter);
@@ -19,16 +19,11 @@ std::vector<StringRef> parseStringList(StringRef Option) {
     return {};
   std::vector<StringRef> Result;
   Result.reserve(Option.count(StringsDelimiter) + 1);
-  StringRef Cur;
-  while (std::tie(Cur, Option) = Option.split(StringsDelimiter),
-         !Option.empty()) {
-    Cur = Cur.trim();
-    if (!Cur.empty())
-      Result.push_back(Cur);
+  for (StringRef SubStr : llvm::split(Option, StringsDelimiter)) {
+    SubStr = SubStr.trim();
+    if (!SubStr.empty())
+      Result.push_back(SubStr);
   }
-  Cur = Cur.trim();
-  if (!Cur.empty())
-    Result.push_back(Cur);
   return Result;
 }
 
@@ -57,7 +52,7 @@ std::vector<StringRef> parseListPair(StringRef L, StringRef R) {
 }
 
 std::string serializeStringList(ArrayRef<StringRef> Strings) {
-  return llvm::join(Strings, StringsDelimiter);
+  return llvm::join(Strings, {&StringsDelimiter, 1});
 }
 
 } // namespace clang::tidy::utils::options

--- a/clang-tools-extra/unittests/clang-tidy/DeclRefExprUtilsTest.cpp
+++ b/clang-tools-extra/unittests/clang-tidy/DeclRefExprUtilsTest.cpp
@@ -102,9 +102,7 @@ template <int Indirections> void RunTest(StringRef Snippet) {
     )";
 
   std::string Code = (CommonCode + Snippet).str();
-
-  llvm::SmallVector<StringRef, 1> Parts;
-  StringRef(Code).split(Parts, "/*const*/");
+  llvm::SmallVector<StringRef, 1> Parts(llvm::split(Code, "/*const*/"));
 
   EXPECT_EQ(Code,
             runCheckOnCode<ConstReferenceDeclRefExprsTransform<Indirections>>(


### PR DESCRIPTION
`llvm::split` is compatible with all containers (not just `SmallVector`), doesn't use out parameters, and is lazy, making it the more ergonomic option in basically all scenarios.