### PR TITLE
InstCombine: Fix another wrong interested mask computeKnownFPClass call

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2266,7 +2266,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Value *V,
       [[fallthrough]];
     }
     default:
-      Known = computeKnownFPClass(I, ~DemandedMask, CxtI, Depth + 1);
+      Known = computeKnownFPClass(I, DemandedMask, CxtI, Depth + 1);
       break;
     }
 


### PR DESCRIPTION
Follow up from c436551d5283a8fc00ae880a5b76660b6f08e37b, this is another
instance of the same problem.