### PR TITLE
[libc++] Fix std modules compile errors caused by <ctime> functions on Windows

### DIFF
--- a/libcxx/modules/std.compat/ctime.inc
+++ b/libcxx/modules/std.compat/ctime.inc
@@ -17,6 +17,12 @@ export {
 
   using ::asctime _LIBCPP_USING_IF_EXISTS;
   using ::clock _LIBCPP_USING_IF_EXISTS;
+
+// NOTE: UCRT before Windows SDK 10.0.26100.6901 defines the <ctime> functions
+// with 'static' so we cannot export them, but later versions fixed it and now
+// define a macro we can use to detect older UCRT without the fix and we use it
+// to avoid exporting them in order to compile without errors
+#if !defined(_MSC_VER) || (defined(_STATIC_INLINE_UCRT_FUNCTIONS) && _STATIC_INLINE_UCRT_FUNCTIONS == 0)
   using ::ctime _LIBCPP_USING_IF_EXISTS;
   using ::difftime _LIBCPP_USING_IF_EXISTS;
   using ::gmtime _LIBCPP_USING_IF_EXISTS;
@@ -25,4 +31,5 @@ export {
   using ::strftime _LIBCPP_USING_IF_EXISTS;
   using ::time _LIBCPP_USING_IF_EXISTS;
   using ::timespec_get _LIBCPP_USING_IF_EXISTS;
+#endif
 } // export

--- a/libcxx/modules/std/ctime.inc
+++ b/libcxx/modules/std/ctime.inc
@@ -17,6 +17,12 @@ export namespace std {
 
   using std::asctime _LIBCPP_USING_IF_EXISTS;
   using std::clock _LIBCPP_USING_IF_EXISTS;
+
+// NOTE: UCRT before Windows SDK 10.0.26100.6901 defines the <ctime> functions
+// with 'static' so we cannot export them, but later versions fixed it and now
+// define a macro we can use to detect older UCRT without the fix and we use it
+// to avoid exporting them in order to compile without errors
+#if !defined(_MSC_VER) || (defined(_STATIC_INLINE_UCRT_FUNCTIONS) && _STATIC_INLINE_UCRT_FUNCTIONS == 0)
   using std::ctime _LIBCPP_USING_IF_EXISTS;
   using std::difftime _LIBCPP_USING_IF_EXISTS;
   using std::gmtime _LIBCPP_USING_IF_EXISTS;
@@ -25,4 +31,5 @@ export namespace std {
   using std::strftime _LIBCPP_USING_IF_EXISTS;
   using std::time _LIBCPP_USING_IF_EXISTS;
   using std::timespec_get _LIBCPP_USING_IF_EXISTS;
+#endif
 } // namespace std


### PR DESCRIPTION
**Issue**:
Before `Windows SDK 10.0.26100.6901` the UCRT was defining some functions in `<ctime>` as `static inline` which caused compilation errors when compiling std modules, but later versions introduced a fix and defined a macro that can be used to detect the availability of the fix.

**Fixes**:
- Fixes https://github.com/llvm/llvm-project/issues/64812 by allowing std modules to compile by not exporting the problematic `<ctime>` functions when using older UCRT than `Windows SDK 10.0.26100.6901` which introduced the fix.

**Related** (for context):
This PR https://github.com/llvm/llvm-project/pull/148992 included a fix similar to the one used by MSVC's STL at the time (UCRT did not have the fix at that time), but since it did not land, and this issue was discussed there, we can now just skip exporting those functions for older UCRT versions.
