### PR TITLE
[IR] Fix canReplacePointersIfEqual to properly validate vector pointers

### DIFF
--- a/llvm/lib/Analysis/Loads.cpp
+++ b/llvm/lib/Analysis/Loads.cpp
@@ -847,7 +847,7 @@ bool llvm::canReplacePointersInUseIfEqual(const Use &U, const Value *To,
   Type *Ty = To->getType();
   assert(U->getType() == Ty && "values must have matching types");
   // Not a pointer, just return true.
-  if (!Ty->isPointerTy())
+  if (!Ty->isPtrOrPtrVectorTy())
     return true;
 
   // Do not perform replacements in lifetime intrinsic arguments.
@@ -866,7 +866,7 @@ bool llvm::canReplacePointersIfEqual(const Value *From, const Value *To,
                                      const DataLayout &DL) {
   assert(From->getType() == To->getType() && "values must have matching types");
   // Not a pointer, just return true.
-  if (!From->getType()->isPointerTy())
+  if (!From->getType()->isPtrOrPtrVectorTy())
     return true;
 
   return isPointerAlwaysReplaceable(From, To, DL);

--- a/llvm/lib/Analysis/Loads.cpp
+++ b/llvm/lib/Analysis/Loads.cpp
@@ -835,7 +835,7 @@ static bool isPointerAlwaysReplaceable(const Value *From, const Value *To,
   // optimizations.
   if (isa<ConstantPointerNull>(To))
     return true;
-  if (isa<Constant>(To) &&
+  if (isa<Constant>(To) && To->getType()->isPointerTy() &&
       isDereferenceablePointer(To, Type::getInt8Ty(To->getContext()), DL))
     return true;
   return getUnderlyingObjectAggressive(From) ==

--- a/llvm/test/Transforms/GVN/condprop.ll
+++ b/llvm/test/Transforms/GVN/condprop.ll
@@ -864,6 +864,16 @@ bb5:
   br label %bb5
 }
 
+define <2 x ptr> @select_vector_eq(<2 x ptr> %a, <2 x ptr> %b) {
+; CHECK-LABEL: @select_vector_eq(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x ptr> [[A:%.*]], [[B:%.*]]
+; CHECK-NEXT:    ret <2 x ptr> [[B]]
+;
+  %cmp = icmp eq <2 x ptr> %a, %b
+  %sel = select <2 x i1> %cmp, <2 x ptr> %a, <2 x ptr> %b
+  ret <2 x ptr> %sel
+}
+
 define void @select_same_obj(i1 %c, ptr %p, i64 %x) {
 ; CHECK-LABEL: @select_same_obj(
 ; CHECK-NEXT:  entry:

--- a/llvm/test/Transforms/GVN/condprop.ll
+++ b/llvm/test/Transforms/GVN/condprop.ll
@@ -867,7 +867,8 @@ bb5:
 define <2 x ptr> @select_vector_eq(<2 x ptr> %a, <2 x ptr> %b) {
 ; CHECK-LABEL: @select_vector_eq(
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x ptr> [[A:%.*]], [[B:%.*]]
-; CHECK-NEXT:    ret <2 x ptr> [[B]]
+; CHECK-NEXT:    [[SEL:%.*]] = select <2 x i1> [[CMP]], <2 x ptr> [[A]], <2 x ptr> [[B]]
+; CHECK-NEXT:    ret <2 x ptr> [[SEL]]
 ;
   %cmp = icmp eq <2 x ptr> %a, %b
   %sel = select <2 x i1> %cmp, <2 x ptr> %a, <2 x ptr> %b

--- a/llvm/test/Transforms/InstSimplify/select-icmp.ll
+++ b/llvm/test/Transforms/InstSimplify/select-icmp.ll
@@ -287,3 +287,25 @@ define ptr @ptr_eq_replace_same_underlying_object(ptr %st, i64 %i, i64 %j) {
   %sel = select i1 %cmp, ptr %a, ptr %b
   ret ptr %sel
 }
+
+define ptr @ptr_eq_replace_constant(ptr %a) {
+; CHECK-LABEL: @ptr_eq_replace_constant(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq ptr [[A:%.*]], inttoptr (i64 42 to ptr)
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], ptr inttoptr (i64 42 to ptr), ptr [[A]]
+; CHECK-NEXT:    ret ptr [[SEL]]
+;
+  %cmp = icmp eq ptr %a, inttoptr (i64 42 to ptr)
+  %sel = select i1 %cmp, ptr inttoptr (i64 42 to ptr), ptr %a
+  ret ptr %sel
+}
+
+define <2 x ptr> @ptr_eq_replace_vector_constant(<2 x ptr> %a) {
+; CHECK-LABEL: @ptr_eq_replace_vector_constant(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x ptr> [[A:%.*]], <ptr inttoptr (i64 42 to ptr), ptr inttoptr (i64 88 to ptr)>
+; CHECK-NEXT:    [[SEL:%.*]] = select <2 x i1> [[CMP]], <2 x ptr> [[A]], <2 x ptr> <ptr inttoptr (i64 42 to ptr), ptr inttoptr (i64 88 to ptr)>
+; CHECK-NEXT:    ret <2 x ptr> [[SEL]]
+;
+  %cmp = icmp eq <2 x ptr> %a, <ptr inttoptr (i64 42 to ptr), ptr inttoptr (i64 88 to ptr)>
+  %sel = select <2 x i1> %cmp, <2 x ptr> %a, <2 x ptr> <ptr inttoptr (i64 42 to ptr), ptr inttoptr (i64 88 to ptr)>
+  ret <2 x ptr> %sel
+}

--- a/llvm/test/Transforms/InstSimplify/select-icmp.ll
+++ b/llvm/test/Transforms/InstSimplify/select-icmp.ll
@@ -256,6 +256,15 @@ define ptr @icmp_ptr_eq_replace(ptr %a, ptr %b) {
   ret ptr %sel
 }
 
+define <2 x ptr> @icmp_vector_ptr_eq_replace(<2 x ptr> %a, <2 x ptr> %b) {
+; CHECK-LABEL: @icmp_vector_ptr_eq_replace(
+; CHECK-NEXT:    ret <2 x ptr> [[B:%.*]]
+;
+  %cmp = icmp eq <2 x ptr> %a, %b
+  %sel = select <2 x i1> %cmp, <2 x ptr> %a, <2 x ptr> %b
+  ret <2 x ptr> %sel
+}
+
 define ptr @icmp_ptr_eq_replace_null(ptr %a) {
 ; CHECK-LABEL: @icmp_ptr_eq_replace_null(
 ; CHECK-NEXT:    ret ptr [[A:%.*]]

--- a/llvm/test/Transforms/InstSimplify/select-icmp.ll
+++ b/llvm/test/Transforms/InstSimplify/select-icmp.ll
@@ -258,7 +258,9 @@ define ptr @icmp_ptr_eq_replace(ptr %a, ptr %b) {
 
 define <2 x ptr> @icmp_vector_ptr_eq_replace(<2 x ptr> %a, <2 x ptr> %b) {
 ; CHECK-LABEL: @icmp_vector_ptr_eq_replace(
-; CHECK-NEXT:    ret <2 x ptr> [[B:%.*]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq <2 x ptr> [[A:%.*]], [[B1:%.*]]
+; CHECK-NEXT:    [[B:%.*]] = select <2 x i1> [[CMP]], <2 x ptr> [[A]], <2 x ptr> [[B1]]
+; CHECK-NEXT:    ret <2 x ptr> [[B]]
 ;
   %cmp = icmp eq <2 x ptr> %a, %b
   %sel = select <2 x i1> %cmp, <2 x ptr> %a, <2 x ptr> %b


### PR DESCRIPTION
Previously, `canReplacePointersIfEqual` unconditionally returned
`true` for vectors of pointers (e.g., `<2 x ptr>`) because it only
checked for scalar pointer types.

This resulted in a failure to perform appropriate verification for
these types. This patch fixes the logic to ensure they are properly
validated.

Fixes https://github.com/llvm/llvm-project/issues/174045