### PR TITLE
[mlir][Shape] Fix Yoda condition in OutlineShapeComputation

### DIFF
--- a/mlir/lib/Dialect/Shape/Transforms/OutlineShapeComputation.cpp
+++ b/mlir/lib/Dialect/Shape/Transforms/OutlineShapeComputation.cpp
@@ -290,7 +290,7 @@ void OutlineShapeComputationPass::getClusterFromValue(
       cluster.insert(op);
       for (Value inp : op->getOperands()) {
         Operation *inpDefOp = inp.getDefiningOp();
-        if (nullptr != inpDefOp && visited.insert(inpDefOp).second)
+        if (inpDefOp != nullptr && visited.insert(inpDefOp).second)
           queue.push(inpDefOp);
       }
     }


### PR DESCRIPTION
Change `nullptr != inpDefOp` to `inpDefOp != nullptr` for better readability and consistency with LLVM coding standards.