### PR TITLE
[flang] Disable new -Wused-undefined-variable warning by default

### DIFF
--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -152,7 +152,6 @@ LanguageFeatureControl::LanguageFeatureControl() {
   // New warnings, on by default
   warnLanguage_.set(LanguageFeature::SavedLocalInSpecExpr);
   warnLanguage_.set(LanguageFeature::NullActualForAllocatable);
-  warnUsage_.set(UsageWarning::UsedUndefinedVariable);
   warnUsage_.set(UsageWarning::BadValueInDeadCode);
 }
 


### PR DESCRIPTION
The new warning about local variables that are used without possible being defined or initialized may be generating some false positives; disable it by default for now.