### PR TITLE
[flang] Fix two bugs with new warnings

### DIFF
--- a/flang/include/flang/Parser/message.h
+++ b/flang/include/flang/Parser/message.h
@@ -44,6 +44,15 @@ enum class Severity {
   None // everything else, common for attachments with source locations
 };
 
+inline constexpr bool IsFatalSeverity(Severity severity) {
+  return severity == Severity::Error ||
+      severity == Severity::ErrorUnlessDeadCode || severity == Severity::Todo;
+}
+
+inline constexpr bool IsWarningSeverity(Severity severity) {
+  return severity == Severity::Warning || severity == Severity::Portability;
+}
+
 class MessageFixedText {
 public:
   constexpr MessageFixedText() {}
@@ -62,11 +71,7 @@ public:
     severity_ = severity;
     return *this;
   }
-  bool IsFatal() const {
-    return severity_ == Severity::Error ||
-        severity_ == Severity::ErrorUnlessDeadCode ||
-        severity_ == Severity::Todo;
-  }
+  bool IsFatal() const { return IsFatalSeverity(severity_); }
 
   static const MessageFixedText endOfFileMessage; // "end of file"_err_en_US
 
@@ -122,9 +127,7 @@ public:
   MessageFormattedText &operator=(const MessageFormattedText &) = default;
   MessageFormattedText &operator=(MessageFormattedText &&) = default;
   const std::string &string() const { return string_; }
-  bool IsFatal() const {
-    return severity_ == Severity::Error || severity_ == Severity::Todo;
-  }
+  bool IsFatal() const { return IsFatalSeverity(severity_); }
   Severity severity() const { return severity_; }
   MessageFormattedText &set_severity(Severity severity) {
     severity_ = severity;

--- a/flang/lib/Evaluate/check-expression.cpp
+++ b/flang/lib/Evaluate/check-expression.cpp
@@ -1376,7 +1376,7 @@ public:
   Result Return(parser::Message &&msg) const {
     if (severity_) {
       msg.set_severity(*severity_);
-      if (*severity_ != parser::Severity::Error) {
+      if (parser::IsWarningSeverity(*severity_)) {
         msg.set_languageFeature(feature);
       }
     }

--- a/flang/lib/Parser/message.cpp
+++ b/flang/lib/Parser/message.cpp
@@ -165,9 +165,7 @@ bool Message::SortBefore(const Message &that) const {
       location_, that.location_);
 }
 
-bool Message::IsFatal() const {
-  return severity() == Severity::Error || severity() == Severity::Todo;
-}
+bool Message::IsFatal() const { return IsFatalSeverity(severity()); }
 
 Severity Message::severity() const {
   return common::visit(
@@ -277,18 +275,13 @@ static std::string Prefix(Severity severity) {
 }
 
 static llvm::raw_ostream::Colors PrefixColor(Severity severity) {
-  switch (severity) {
-  case Severity::Error:
-  case Severity::Todo:
+  if (IsFatalSeverity(severity)) {
     return llvm::raw_ostream::RED;
-  case Severity::Warning:
-  case Severity::Portability:
+  } else if (IsWarningSeverity(severity)) {
     return llvm::raw_ostream::MAGENTA;
-  default:
-    // TODO: Set the color.
-    break;
+  } else {
+    return llvm::raw_ostream::SAVEDCOLOR;
   }
-  return llvm::raw_ostream::SAVEDCOLOR;
 }
 
 static std::string HintLanguageControlFlag(

--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -57,10 +57,7 @@ static void CheckImplicitInterfaceArg(evaluate::ActualArgument &arg,
   }
   if (const auto *expr{arg.UnwrapExpr()}) {
     if (const Symbol *base{GetFirstSymbol(*expr)}) {
-      const Symbol &symbol{GetAssociationRoot(*base)};
-      if (IsFunctionResult(symbol)) {
-        context.NoteDefinedSymbol(symbol);
-      }
+      context.NoteDefinedSymbol(GetAssociationRoot(*base));
     }
     if (IsBOZLiteral(*expr)) {
       messages.Say("BOZ argument %s requires an explicit interface"_err_en_US,
@@ -781,10 +778,7 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
     } else if (dummy.intent != common::Intent::In ||
         (dummyIsPointer && !actualIsPointer)) {
       if (auto named{evaluate::ExtractNamedEntity(actual)}) {
-        if (const Symbol & base{named->GetFirstSymbol()};
-            IsFunctionResult(base)) {
-          context.NoteDefinedSymbol(base);
-        }
+        context.NoteDefinedSymbol(named->GetFirstSymbol());
       }
     }
   }

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -7744,7 +7744,7 @@ bool DeclarationVisitor::OkToAddComponent(
       if (msg) {
         auto &said{Say2(name, std::move(*msg), *prev,
             "Previous declaration of '%s'"_en_US)};
-        if (msg->severity() == parser::Severity::Error) {
+        if (msg->IsFatal()) {
           Resolve(name, *prev);
           return false;
         }

--- a/flang/test/Semantics/bug171844.f90
+++ b/flang/test/Semantics/bug171844.f90
@@ -1,5 +1,5 @@
-! RUN: %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck --check-prefix=CHECK-WARNING %s
-! RUN: %flang_fc1 -fsyntax-only -Wno-bad-value-in-dead-code %s 2>&1 | FileCheck %s
+! RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck --check-prefix=CHECK-WARNING %s
+! RUN: not %flang_fc1 -fsyntax-only -Wno-bad-value-in-dead-code %s 2>&1 | FileCheck %s
 
 real a(2)
 


### PR DESCRIPTION
The new Severity::ErrorUnlessDeadCode message severity isn't always considered to be fatal.  Consolidate the "is this severity fatal?" logic into one place.

Some instances in semantics that note variable definitions were conditional on the symbol being a function result, since only the "function result was never defined" warning needed to know about them.  Make them note all defined symbols.