### PR TITLE
[IRBuilder] Introduce CreateSelectFMFWithUnknownProfile

### DIFF
--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -2553,6 +2553,12 @@ public:
                                                  StringRef PassName,
                                                  const Twine &Name = "");
 
+  LLVM_ABI Value *CreateSelectFMFWithUnknownProfile(Value *C, Value *True,
+                                                    Value *False,
+                                                    FMFSource FMFSource,
+                                                    StringRef PassName,
+                                                    const Twine &Name = "");
+
   LLVM_ABI Value *CreateSelect(Value *C, Value *True, Value *False,
                                const Twine &Name = "",
                                Instruction *MDFrom = nullptr);

--- a/llvm/lib/IR/IRBuilder.cpp
+++ b/llvm/lib/IR/IRBuilder.cpp
@@ -1014,6 +1014,18 @@ Value *IRBuilderBase::CreateSelectWithUnknownProfile(Value *C, Value *True,
   return Ret;
 }
 
+Value *IRBuilderBase::CreateSelectFMFWithUnknownProfile(Value *C, Value *True,
+                                                        Value *False,
+                                                        FMFSource FMFSource,
+                                                        StringRef PassName,
+                                                        const Twine &Name) {
+  Value *Ret = CreateSelectFMF(C, True, False, FMFSource, Name);
+  if (auto *SI = dyn_cast<SelectInst>(Ret)) {
+    setExplicitlyUnknownBranchWeightsIfProfiled(*SI, PassName);
+  }
+  return Ret;
+}
+
 Value *IRBuilderBase::CreateSelect(Value *C, Value *True, Value *False,
                                    const Twine &Name, Instruction *MDFrom) {
   return CreateSelectFMF(C, True, False, {}, Name, MDFrom);

--- a/llvm/lib/IR/IRBuilder.cpp
+++ b/llvm/lib/IR/IRBuilder.cpp
@@ -1020,9 +1020,8 @@ Value *IRBuilderBase::CreateSelectFMFWithUnknownProfile(Value *C, Value *True,
                                                         StringRef PassName,
                                                         const Twine &Name) {
   Value *Ret = CreateSelectFMF(C, True, False, FMFSource, Name);
-  if (auto *SI = dyn_cast<SelectInst>(Ret)) {
+  if (auto *SI = dyn_cast<SelectInst>(Ret))
     setExplicitlyUnknownBranchWeightsIfProfiled(*SI, PassName);
-  }
   return Ret;
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2202,12 +2202,10 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Value *V,
         Value *X = CI->getArgOperand(0);
         Value *IsPosInfOrNan = Builder.CreateFCmpFMF(
             FCmpInst::FCMP_UEQ, X, ConstantFP::getInfinity(VTy), FMF);
-        Value *ZeroOrInf = Builder.CreateSelectFMF(
-            IsPosInfOrNan, X, ConstantFP::getZero(VTy), FMF);
         // We do not know whether an infinity or a NaN is more likely here,
         // so mark the branch weights as unkown.
-        if (auto *SI = dyn_cast<SelectInst>(ZeroOrInf))
-          setExplicitlyUnknownBranchWeightsIfProfiled(*SI, DEBUG_TYPE);
+        Value *ZeroOrInf = Builder.CreateSelectFMFWithUnknownProfile(
+            IsPosInfOrNan, X, ConstantFP::getZero(VTy), FMF, DEBUG_TYPE);
         return ZeroOrInf;
       }
 


### PR DESCRIPTION
This came up in review feedback in
c163e7a72249cbc8105fbc5cc6a772e5dc90c94d. This function makes it easier to create select instructions that propagate fast math flags with unknown profile info, which is a common case. This mirrors the already existing CreateSelectWithUknownProfile helper.