### PR TITLE
[clang-tidy] Fix false positive in `bugprone-std-namespace-modification` when opening subnamespaces of `std::`

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -413,6 +413,12 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/sizeof-expression>` check by fixing
   a crash on ``sizeof`` of an array of dependent type.
 
+- Improved :doc:`bugprone-std-namespace-modification
+  <clang-tidy/checks/bugprone/std-namespace-modification>`. It now:
+
+  - No longer diagnoses simply opening subnamespaces of ``std::``
+    such as ``std::chrono``.
+
 - Improved :doc:`bugprone-suspicious-include
   <clang-tidy/checks/bugprone/suspicious-include>` check by adding
   `IgnoredRegex` option.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -417,7 +417,7 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/std-namespace-modification>`. It now:
 
   - No longer diagnoses simply opening subnamespaces of ``std::``
-    such as ``std::chrono``.
+    such as ``std::ranges``.
 
 - Improved :doc:`bugprone-suspicious-include
   <clang-tidy/checks/bugprone/suspicious-include>` check by adding

--- a/clang-tools-extra/test/clang-tidy/checkers/Inputs/Headers/system-header-simulation.h
+++ b/clang-tools-extra/test/clang-tidy/checkers/Inputs/Headers/system-header-simulation.h
@@ -56,6 +56,14 @@ namespace detail {
 struct X {};
 } // namespace detail
 
+
+namespace ranges {
+
+template <typename T>
+inline constexpr bool enable_view = false;
+
+} // namespace ranges
+
 } // namespace std
 
 // Template specializations that are in a system-header file.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/std-namespace-modification.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/std-namespace-modification.cpp
@@ -281,3 +281,15 @@ template<typename> struct T {};
 
 T<B> b;
 }
+
+struct MyView {};
+
+namespace std::ranges {
+
+template<> constexpr bool enable_view<MyView> = true;
+
+} // namespace std::ranges
+
+struct MyOtherView {};
+
+template<> constexpr bool std::ranges::enable_view<MyOtherView> = true;


### PR DESCRIPTION
Adding new namespaces inside `std` is a no-no, but opening existing ones like `std::ranges` is perfectly fine. [Godbolt.](https://godbolt.org/z/93f65KxPf)

This is the first of a series of changes to improve `bugprone-std-namespace-modification`.