### PR TITLE
[TableGen] Fix TypeSetByHwMode::getValueTypeByHwMode.

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -102,7 +102,7 @@ ValueTypeByHwMode TypeSetByHwMode::getValueTypeByHwMode() const {
 
   for (const auto &I : *this) {
     MVT T = I.second.empty() ? MVT::Other : *I.second.begin();
-    VVT.getOrCreateTypeForMode(I.first, T);
+    VVT.insertTypeForMode(I.first, T);
   }
   return VVT;
 }

--- a/llvm/utils/TableGen/Common/InfoByHwMode.cpp
+++ b/llvm/utils/TableGen/Common/InfoByHwMode.cpp
@@ -67,19 +67,6 @@ bool ValueTypeByHwMode::operator<(const ValueTypeByHwMode &T) const {
   return Map < T.Map;
 }
 
-MVT &ValueTypeByHwMode::getOrCreateTypeForMode(unsigned Mode, MVT Type) {
-  auto F = Map.find(Mode);
-  if (F != Map.end())
-    return F->second;
-  // If Mode is not in the map, look up the default mode. If it exists,
-  // make a copy of it for Mode and return it.
-  auto D = Map.begin();
-  if (D != Map.end() && D->first == DefaultMode)
-    return Map.try_emplace(Mode, D->second).first->second;
-  // If default mode is not present either, use provided Type.
-  return Map.try_emplace(Mode, Type).first->second;
-}
-
 StringRef ValueTypeByHwMode::getMVTName(MVT T) {
   StringRef N = llvm::getEnumName(T.SimpleTy);
   N.consume_front("MVT::");

--- a/llvm/utils/TableGen/Common/InfoByHwMode.h
+++ b/llvm/utils/TableGen/Common/InfoByHwMode.h
@@ -168,7 +168,9 @@ struct ValueTypeByHwMode : public InfoByHwMode<MVT> {
 
   bool isValid() const { return !Map.empty(); }
   MVT getType(unsigned Mode) const { return get(Mode); }
-  MVT &getOrCreateTypeForMode(unsigned Mode, MVT Type);
+  void insertTypeForMode(unsigned Mode, MVT Type) {
+    Map.try_emplace(Mode, Type);
+  }
 
   static StringRef getMVTName(MVT T);
   void writeToStream(raw_ostream &OS) const;


### PR DESCRIPTION
This should convert the type set for each HwMode to an MVT for that HwMode. Instead, if a single type existed for the DefaultMode, that was used for the MVT of every other mode.

This didn't cause an issue because there is only one place this function is used before HwModes are expanded. That's just verifying that constants are small enough for the MVT for each mode. So you would need a large constant and a HwMode with a smaller VT than the default mode.