### PR TITLE
[clang][bytecode] Check isActive() in EvalEmitter::speculate()

### DIFF
--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -155,6 +155,8 @@ bool EvalEmitter::fallthrough(const LabelTy &Label) {
 }
 
 bool EvalEmitter::speculate(const CallExpr *E, const LabelTy &EndLabel) {
+  if (!isActive())
+    return true;
   size_t StackSizeBefore = S.Stk.size();
   const Expr *Arg = E->getArg(0);
   if (!this->visit(Arg)) {

--- a/clang/test/AST/ByteCode/builtin-constant-p.cpp
+++ b/clang/test/AST/ByteCode/builtin-constant-p.cpp
@@ -148,3 +148,15 @@ static void foo(int i) __attribute__((__diagnose_if__(!__builtin_constant_p(i), 
 static void bar(int i) {
   foo(15); // expected-error {{not constant}}
 }
+
+namespace Inactive {
+  int foo() {
+    if ((__extension__(
+            0 ? __extension__({ (1 ? 0 : (__builtin_constant_p("plane"))); })
+              : 0)) == 0) {
+    }
+
+    return 0;
+  }
+
+}


### PR DESCRIPTION
If this opcode is being jumped-over, we have to ignore it.

Fixes #172191