### PR TITLE
[clang][bytecode] Check builtin_memcpy() for non-block pointers

### DIFF
--- a/clang/test/AST/ByteCode/builtins.c
+++ b/clang/test/AST/ByteCode/builtins.c
@@ -17,3 +17,4 @@ int structStrlen(void) {
   return 1;
 }
 
+void f() { __builtin_memcpy(f, f, 1); }


### PR DESCRIPTION
This pretty hard to produce in C++ but easy in C.

Fixes #171609