### PR TITLE
[AArch64] Let LoadStoreOptimizer handle renamable implicit-defs.

### DIFF
--- a/llvm/test/CodeGen/AArch64/ldst-implicitop.mir
+++ b/llvm/test/CodeGen/AArch64/ldst-implicitop.mir
@@ -78,3 +78,32 @@ body:             |
     $q1 = ORRv16i8 $q5, killed $q5
     RET_ReallyLR
 ...
+# Test that when the implicit-def is renamable, the loads/stores can still be
+# bundled together.
+---
+name:            impdef_renamable
+tracksRegLiveness: true
+stack:
+  - { id: 0, name: '', type: default, offset: -8, size: 8, alignment: 8,
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+      local-offset: -8, debug-info-variable: '', debug-info-expression: '',
+      debug-info-location: '' }
+  - { id: 1, name: '', type: default, offset: -16, size: 8, alignment: 8,
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+      local-offset: -16, debug-info-variable: '', debug-info-expression: '',
+      debug-info-location: '' }
+body:             |
+  bb.0:
+    ; CHECK-LABEL: name: impdef_renamable
+    ; CHECK: early-clobber $sp, renamable $w8, $w9 = frame-setup LDPWpre $sp, -4 :: (load (s32) from %stack.1 + 4), (load (s32) from %stack.1, align 8)
+    ; CHECK-NEXT: STPWi killed renamable $w8, killed $w9, $sp, 2 :: (store (s32) into %stack.0 + 4), (store (s32) into %stack.0, align 8)
+    ; CHECK-NEXT: $sp = frame-destroy ADDXri $sp, 16, 0
+    ; CHECK-NEXT: RET undef $lr
+    $sp = frame-setup SUBXri $sp, 16, 0
+    renamable $w8 = LDRWui $sp, 1, implicit-def renamable $x8 :: (load (s32) from %stack.1 + 4)
+    STRWui killed renamable $w8, $sp, 3 :: (store (s32) into %stack.0 + 4)
+    renamable $w8 = LDRWui $sp, 0, implicit-def renamable $x8 :: (load (s32) from %stack.1, align 8)
+    STRWui killed renamable $w8, $sp, 2 :: (store (s32) into %stack.0, align 8)
+    $sp = frame-destroy ADDXri $sp, 16, 0
+    RET undef $lr
+...


### PR DESCRIPTION
The LoadStoreOptimizer is very conservative with handling instructions that have implicit-def operands and only support them for 2 instructions. However, they can be considered when a MachineOperand is marked explicitly as 'renamable'.