### PR TITLE
[clang][bytecode] Check builtin_memchr() for one-past-end pointers

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -73,6 +73,8 @@ static bool isReadable(const Pointer &P) {
     return false;
   if (!P.isLive())
     return false;
+  if (P.isOnePastEnd())
+    return false;
   return true;
 }
 
@@ -2088,6 +2090,9 @@ static bool interp__builtin_memchr(InterpState &S, CodePtr OpPC,
         << S.getASTContext().BuiltinInfo.getQuotedName(ID) << ElemTy;
     return false;
   }
+
+  if (!isReadable(Ptr))
+    return false;
 
   if (ID == Builtin::BIstrchr || ID == Builtin::BI__builtin_strchr) {
     int64_t DesiredTrunc;

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1649,6 +1649,10 @@ namespace Memchr {
     return __builtin_char_memchr(c + 1, 'f', 1) == nullptr;
   }
   static_assert(f());
+
+
+  extern const char char_memchr_arg[0l];
+  char *memchr_result = __builtin_char_memchr(char_memchr_arg, 123, 32);
 }
 
 namespace Strchr {


### PR DESCRIPTION
We can't read from them and this fails later.

Fixes https://github.com/llvm/llvm-project/issues/173942