### PR TITLE
[clang][bytecode] Check builtin_memchr for non-block pointers earlier

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -2078,6 +2078,9 @@ static bool interp__builtin_memchr(InterpState &S, CodePtr OpPC,
     return false;
   }
 
+  if (!Ptr.isBlockPointer())
+    return false;
+
   QualType ElemTy = Ptr.getFieldDesc()->isArray()
                         ? Ptr.getFieldDesc()->getElemQualType()
                         : Ptr.getFieldDesc()->getType();

--- a/clang/test/AST/ByteCode/builtins.c
+++ b/clang/test/AST/ByteCode/builtins.c
@@ -18,3 +18,4 @@ int structStrlen(void) {
 }
 
 void f() { __builtin_memcpy(f, f, 1); }
+void f2()  { __builtin_memchr(f2, 0, 1); }


### PR DESCRIPTION
The getType() call might fail. We can't pull the isReadable() check up though because that creates different diagnostic output compared to the current interpreter.

Fixes #172202