### PR TITLE
[Dexter] Replace DAP "initialized" timeout with a warning

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -782,7 +782,9 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
         initialize_timeout = Timeout(60)
         while self._proc.poll() is None and not self._debugger_state.initialized:
             if initialize_timeout.timed_out():
-                raise TimeoutError("Timed out while waiting for initialized event from DAP")
+                raise TimeoutError(
+                    "Timed out while waiting for initialized event from DAP"
+                )
             time.sleep(0.01)
 
         # Set breakpoints after receiving launch response but before configurationDone.

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -775,16 +775,17 @@ class DAP(DebuggerBase, metaclass=abc.ABCMeta):
 
         # Wait for the initialized event; for LLDB, this will be sent after the launch request has been processed;
         # for other debuggers, it will have been sent some time after the initialize response was sent.
-        # NB: In all current cases this timeout is never hit because the initialized event is received almost
-        # immediately after either the initialize response or the launch request/response; if this starts being hit, we
-        # probably need to parameterize this.
-        initialize_timeout = Timeout(3)
+        # FIXME: It may be possible that Dexter should do something about this timeout, but as we don't know whether
+        # some debuggers/inputs may reasonably trigger the timeout, leave it as a warning for now.
+        initialize_timeout = Timeout(10)
         while not self._debugger_state.initialized:
-            if initialize_timeout.timed_out():
-                raise TimeoutError(
-                    f"Timed out while waiting for initialized event from DAP"
+            if initialize_timeout and initialize_timeout.timed_out():
+                self.context.logger.warning(
+                    "Waiting for 'initialized' event for more than 10 seconds, debugger may be hanging."
                 )
-            time.sleep(0.001)
+                # Only trigger the warning once.
+                initialize_timeout = None
+            time.sleep(0.01)
 
         # Set breakpoints after receiving launch response but before configurationDone.
         self._flush_breakpoints()


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/172893.

In the issue reported above there, it appears that LLDB is hitting a 3s timeout as part of some CI tests; this patch attempts to fix the issue by replacing the 3s timeout with a warning printed after 10s.

This patch is assuming that the issue is that LLDB sometimes takes more than 3s to send the initialized event after the launch request is sent; I'm not sure whether that's actually likely or not, but it looks like the most likely explanation of the issue right now.