### PR TITLE
[clangd] Do not skip Attr nodes in SelectionTree traversal

### DIFF
--- a/clang-tools-extra/clangd/Selection.cpp
+++ b/clang-tools-extra/clangd/Selection.cpp
@@ -817,6 +817,11 @@ private:
     if (llvm::any_of(getAttributes(N),
                      [](const Attr *A) { return !A->isImplicit(); }))
       return false;
+    // Attributes themselves also often have bad source ranges.
+    if (const auto *A = N.get<Attr>()) {
+      if (!A->isImplicit())
+        return false;
+    }
     if (!SelChecker.mayHit(S)) {
       dlog("{2}skip: {0} {1}", printNodeToString(N, PrintPolicy),
            S.printToString(SM), indent());

--- a/clang-tools-extra/clangd/unittests/SelectionTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SelectionTests.cpp
@@ -608,6 +608,11 @@ TEST(SelectionTest, CommonAncestor) {
         template <typename T> void g(D<[[^T]]> auto abc) {}
       )cpp",
        "TemplateTypeParmTypeLoc"},
+      {R"cpp(
+        const unsigned WALDO = 64;
+        struct alignas([[WA^LDO]]) foo {};
+      )cpp",
+       "DeclRefExpr"},
   };
 
   for (const Case &C : Cases) {


### PR DESCRIPTION
SelectionTree attempts to skip nodes that don't intersect with the selection for performance. However, Attr nodes (like AlignedAttr) often have inaccurate source ranges (e.g. pointing to a single location).

Previously, canSafelySkipNode handled nodes that *have* attributes attached, but failed to account for the case where the node being visited *is* the attribute itself. This caused `alignas(WALDO)` to be skipped, breaking features like go-to-definition on WALDO.

This commit adds a check to ensure explicit Attr nodes are visited, fixing the issue.

Fixes https://github.com/clangd/clangd/issues/2502