### PR TITLE
[CMake] Drop per-target LLVM_REQUIRES_RTTI

### DIFF
--- a/clang/examples/LLVMPrintFunctionNames/CMakeLists.txt
+++ b/clang/examples/LLVMPrintFunctionNames/CMakeLists.txt
@@ -1,13 +1,5 @@
-# If we don't need RTTI or EH, there's no reason to export anything
-# from the plugin.
-if(NOT MSVC) # MSVC mangles symbols differently, and
-    # PrintLLVMFunctionNames.export contains C++ symbols.
-  if(NOT LLVM_REQUIRES_RTTI)
-    if(NOT LLVM_REQUIRES_EH)
-      set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/LLVMPrintFunctionNames.exports)
-    endif()
-  endif()
-endif()
+# There's no reason to export anything from the plugin.
+set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/LLVMPrintFunctionNames.exports)
 
 add_llvm_library(LLVMPrintFunctionNames MODULE LLVMPrintFunctionNames.cpp PLUGIN_TOOL clang)
 

--- a/clang/examples/PrintFunctionNames/CMakeLists.txt
+++ b/clang/examples/PrintFunctionNames/CMakeLists.txt
@@ -1,13 +1,5 @@
-# If we don't need RTTI or EH, there's no reason to export anything
-# from the plugin.
-if( NOT MSVC ) # MSVC mangles symbols differently, and
-               # PrintFunctionNames.export contains C++ symbols.
-  if( NOT LLVM_REQUIRES_RTTI )
-    if( NOT LLVM_REQUIRES_EH )
-      set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/PrintFunctionNames.exports)
-    endif()
-  endif()
-endif()
+# There's no reason to export anything from the plugin.
+set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/PrintFunctionNames.exports)
 
 add_llvm_library(PrintFunctionNames MODULE PrintFunctionNames.cpp PLUGIN_TOOL clang)
 

--- a/clang/unittests/Interpreter/ExceptionTests/CMakeLists.txt
+++ b/clang/unittests/Interpreter/ExceptionTests/CMakeLists.txt
@@ -1,7 +1,10 @@
 # The interpreter can throw an exception from user input. The test binary needs
 # to be compiled with exception support to catch the thrown exception.
+#
+# NOTE: we compile with exceptions enabled, but (possibly) with RTTI disabled.
+# This only works in these limited circumstances where all exception-related
+# code is in the same library/executable.
 set(LLVM_REQUIRES_EH ON)
-set(LLVM_REQUIRES_RTTI ON)
 
 add_distinct_clang_unittest(ClangReplInterpreterExceptionTests
   InterpreterExceptionTest.cpp

--- a/flang/unittests/Evaluate/CMakeLists.txt
+++ b/flang/unittests/Evaluate/CMakeLists.txt
@@ -45,8 +45,9 @@ add_flang_nongtest_unittest(logical
 # IEEE exception flags (different use of the word "exception")
 # in the actual hardware floating-point status register, so ensure that
 # C++ exceptions are enabled for this test.
+# TODO: add_flang_nongtest_unittest never disables RTTI/exceptions, this should
+# not be required at all.
 set(LLVM_REQUIRES_EH ON)
-set(LLVM_REQUIRES_RTTI ON)
 add_flang_nongtest_unittest(real
   NonGTestTesting
   FortranEvaluate

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -25,10 +25,6 @@ function(llvm_update_compile_flags name)
   # LLVM_REQUIRES_EH is an internal flag that individual targets can use to
   # force EH
   if(LLVM_REQUIRES_EH OR LLVM_ENABLE_EH)
-    if(NOT (LLVM_REQUIRES_RTTI OR LLVM_ENABLE_RTTI))
-      message(AUTHOR_WARNING "Exception handling requires RTTI. Enabling RTTI for ${name}")
-      set(LLVM_REQUIRES_RTTI ON)
-    endif()
     if(MSVC)
       list(APPEND LLVM_COMPILE_CXXFLAGS "/EHsc")
     endif()
@@ -49,12 +45,7 @@ function(llvm_update_compile_flags name)
     endif()
   endif()
 
-  # LLVM_REQUIRES_RTTI is an internal flag that individual
-  # targets can use to force RTTI
-  if(NOT (LLVM_REQUIRES_RTTI OR LLVM_ENABLE_RTTI))
-    # TODO: GTEST_HAS_RTTI should be determined automatically, evaluate whether
-    # the explicit definition is actually required.
-    list(APPEND LLVM_COMPILE_DEFINITIONS GTEST_HAS_RTTI=0)
+  if(NOT LLVM_ENABLE_RTTI)
     list(APPEND LLVM_COMPILE_CXXFLAGS ${LLVM_CXXFLAGS_RTTI_DISABLE})
   else()
     list(APPEND LLVM_COMPILE_CXXFLAGS ${LLVM_CXXFLAGS_RTTI_ENABLE})
@@ -1758,10 +1749,6 @@ function(add_unittest test_suite test_name)
   # Some parts of gtest rely on this GNU extension, don't warn on it.
   if(SUPPORTS_GNU_ZERO_VARIADIC_MACRO_ARGUMENTS_FLAG)
     list(APPEND LLVM_COMPILE_FLAGS "-Wno-gnu-zero-variadic-macro-arguments")
-  endif()
-
-  if (NOT DEFINED LLVM_REQUIRES_RTTI)
-    set(LLVM_REQUIRES_RTTI OFF)
   endif()
 
   list(APPEND LLVM_LINK_COMPONENTS Support) # gtest needs it for raw_ostream

--- a/llvm/tools/bugpoint-passes/CMakeLists.txt
+++ b/llvm/tools/bugpoint-passes/CMakeLists.txt
@@ -2,13 +2,8 @@ if( NOT LLVM_BUILD_TOOLS )
   set(EXCLUDE_FROM_ALL ON)
 endif()
 
-# If we don't need RTTI or EH, there's no reason to export anything
-# from this plugin.
-if( NOT LLVM_REQUIRES_RTTI )
-  if( NOT LLVM_REQUIRES_EH )
-    set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/bugpoint.exports)
-  endif()
-endif()
+# There's no reason to export anything from the plugin.
+set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/bugpoint.exports)
 
 if(WIN32 OR CYGWIN OR ZOS)
   set(LLVM_LINK_COMPONENTS Core Support)

--- a/offload/unittests/Conformance/lib/CMakeLists.txt
+++ b/offload/unittests/Conformance/lib/CMakeLists.txt
@@ -3,9 +3,5 @@ add_library(MathTest STATIC
 
 target_include_directories(MathTest PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include")
 
-if(NOT LLVM_REQUIRES_RTTI)
-  target_compile_options(MathTest PUBLIC -fno-rtti)
-endif()
-
 include(FindLibcCommonUtils)
 target_link_libraries(MathTest PUBLIC LLVMOffload LLVMSupport LLVMDemangle llvm-libc-common-utilities)

--- a/third-party/unittest/CMakeLists.txt
+++ b/third-party/unittest/CMakeLists.txt
@@ -59,9 +59,6 @@ if(CXX_SUPPORTS_COVERED_SWITCH_DEFAULT_FLAG)
   add_definitions("-Wno-covered-switch-default")
 endif()
 
-set(LLVM_REQUIRES_RTTI 1)
-add_definitions( -DGTEST_HAS_RTTI=0 )
-
 if (HAVE_LIBPTHREAD)
   list(APPEND LIBS pthread)
 endif()


### PR DESCRIPTION
If we compile with RTTI disabled, don't override it again for any target. This reduces the number of different build flags. Mixing RTTI and non-RTTI objects is problematic anyway on some platforms, e.g. MSVC.

- LLVM_REQUIRES_* are per-target flags that are never set globally. Yet, some files used these (undefined) flags for some logic. This patch removes these dead checks/unconditionally executes the logic. Note that the references *.exports files are empty, so there is no need to make related logic conditional on MSVC.

- gtest automatically determines GTEST_HAS_RTTI from pre-defined compiler macros, there is no need to explicitly define this and especially no need to define this for every single source file.

- add_flang_nongtest_unittest never disables RTTI/exceptions and just uses whatever the compiler defaults to (typically both enabled). There should be no difference in removing the forced RTTI enabling, especially given that the test doesn't use exceptions/RTTI at all.

- The *only* (non-runtime) user of exceptions in-tree is clang/unittests/Interpreter/ExceptionTests. This test only uses catch(...), which should work fine without RTTI on all platforms.

After this, we could move the RTTI enable/disable flag to the general CMAKE_CXX_FLAGS.

This is preliminary work for using pre-compiled headers for unit tests, where llvm_gtest and the gtest PCH should be compiled without RTTI to permit PCH reuse for most (all-but-one) executables.