### PR TITLE
[Flang][VecLib] Ensure TargetMachine->VecLib is set for flang invocations.

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -466,36 +466,8 @@ static bool initTargetOptions(const CompilerInstance &CI,
   Options.Hotpatch = CodeGenOpts.HotPatch;
   Options.JMCInstrument = CodeGenOpts.JMCInstrument;
   Options.XCOFFReadOnlyPointers = CodeGenOpts.XCOFFReadOnlyPointers;
-
-  switch (CodeGenOpts.getVecLib()) {
-  case llvm::driver::VectorLibrary::NoLibrary:
-    Options.VecLib = llvm::VectorLibrary::NoLibrary;
-    break;
-  case llvm::driver::VectorLibrary::Accelerate:
-    Options.VecLib = llvm::VectorLibrary::Accelerate;
-    break;
-  case llvm::driver::VectorLibrary::Darwin_libsystem_m:
-    Options.VecLib = llvm::VectorLibrary::DarwinLibSystemM;
-    break;
-  case llvm::driver::VectorLibrary::LIBMVEC:
-    Options.VecLib = llvm::VectorLibrary::LIBMVEC;
-    break;
-  case llvm::driver::VectorLibrary::MASSV:
-    Options.VecLib = llvm::VectorLibrary::MASSV;
-    break;
-  case llvm::driver::VectorLibrary::SVML:
-    Options.VecLib = llvm::VectorLibrary::SVML;
-    break;
-  case llvm::driver::VectorLibrary::SLEEF:
-    Options.VecLib = llvm::VectorLibrary::SLEEFGNUABI;
-    break;
-  case llvm::driver::VectorLibrary::ArmPL:
-    Options.VecLib = llvm::VectorLibrary::ArmPL;
-    break;
-  case llvm::driver::VectorLibrary::AMDLIBM:
-    Options.VecLib = llvm::VectorLibrary::AMDLIBM;
-    break;
-  }
+  Options.VecLib =
+      convertDriverVectorLibraryToVectorLibrary(CodeGenOpts.getVecLib());
 
   switch (CodeGenOpts.getSwiftAsyncFramePointer()) {
   case CodeGenOptions::SwiftAsyncFramePointerKind::Auto:

--- a/flang/lib/Frontend/CompilerInstance.cpp
+++ b/flang/lib/Frontend/CompilerInstance.cpp
@@ -364,6 +364,7 @@ bool CompilerInstance::setUpTargetMachine() {
 
   llvm::TargetOptions tOpts = llvm::TargetOptions();
   tOpts.EnableAIXExtendedAltivecABI = targetOpts.EnableAIXExtendedAltivecABI;
+  tOpts.VecLib = convertDriverVectorLibraryToVectorLibrary(CGOpts.getVecLib());
 
   targetMachine.reset(theTarget->createTargetMachine(
       triple, /*CPU=*/targetOpts.cpu,

--- a/flang/test/Driver/veclib-frem.f90
+++ b/flang/test/Driver/veclib-frem.f90
@@ -1,0 +1,23 @@
+! RUN: %flang %s -O3 -ffast-math -fveclib=ArmPL --target=aarch64 -mcpu=neoverse-v1 -S -o - | FileCheck %s
+! REQUIRES: aarch64-registered-target
+
+! This test checks that veclib works from flang through the pipeline:
+!  The modulo is turned into a loop with double frem.
+!  The frem is vectorized in the loop vectorizer using fveclib=ArmPL to a
+!    <vscale x 2 x double> frem.
+!  The <vscale x 2 x double> frem is converted to a call to armpl_svfmod_f64_x
+!    in the backend.
+
+! CHECK-LABEL: frem_kernel_
+! CHECK: bl armpl_svfmod_f64_x
+
+  subroutine frem_kernel(a, b, c, n)
+    integer, intent(in) :: n
+    real(8), intent(in)  :: a(n), b(n)
+    real(8), intent(out) :: c(n)
+    integer :: i
+
+    do i = 1, n
+       c(i) = modulo(a(i), b(i))
+    end do
+  end subroutine frem_kernel

--- a/llvm/include/llvm/Frontend/Driver/CodeGenOptions.h
+++ b/llvm/include/llvm/Frontend/Driver/CodeGenOptions.h
@@ -19,6 +19,7 @@
 namespace llvm {
 class Triple;
 class TargetLibraryInfoImpl;
+enum class VectorLibrary;
 } // namespace llvm
 
 namespace llvm::driver {
@@ -48,6 +49,9 @@ enum class VectorLibrary {
   ArmPL,              // Arm Performance Libraries.
   AMDLIBM             // AMD vector math library.
 };
+
+LLVM_ABI llvm::VectorLibrary
+convertDriverVectorLibraryToVectorLibrary(llvm::driver::VectorLibrary VecLib);
 
 LLVM_ABI TargetLibraryInfoImpl *createTLII(const llvm::Triple &TargetTriple,
                                            VectorLibrary Veclib);

--- a/llvm/lib/Frontend/Driver/CodeGenOptions.cpp
+++ b/llvm/lib/Frontend/Driver/CodeGenOptions.cpp
@@ -19,48 +19,35 @@ extern llvm::cl::opt<llvm::InstrProfCorrelator::ProfCorrelatorKind>
 
 namespace llvm::driver {
 
+llvm::VectorLibrary
+convertDriverVectorLibraryToVectorLibrary(llvm::driver::VectorLibrary VecLib) {
+  switch (VecLib) {
+  case llvm::driver::VectorLibrary::NoLibrary:
+    return llvm::VectorLibrary::NoLibrary;
+  case llvm::driver::VectorLibrary::Accelerate:
+    return llvm::VectorLibrary::Accelerate;
+  case llvm::driver::VectorLibrary::Darwin_libsystem_m:
+    return llvm::VectorLibrary::DarwinLibSystemM;
+  case llvm::driver::VectorLibrary::LIBMVEC:
+    return llvm::VectorLibrary::LIBMVEC;
+  case llvm::driver::VectorLibrary::MASSV:
+    return llvm::VectorLibrary::MASSV;
+  case llvm::driver::VectorLibrary::SVML:
+    return llvm::VectorLibrary::SVML;
+  case llvm::driver::VectorLibrary::SLEEF:
+    return llvm::VectorLibrary::SLEEFGNUABI;
+  case llvm::driver::VectorLibrary::ArmPL:
+    return llvm::VectorLibrary::ArmPL;
+  case llvm::driver::VectorLibrary::AMDLIBM:
+    return llvm::VectorLibrary::AMDLIBM;
+  }
+  llvm_unreachable("Unexpected driver::VectorLibrary");
+}
+
 TargetLibraryInfoImpl *createTLII(const llvm::Triple &TargetTriple,
                                   driver::VectorLibrary Veclib) {
-  TargetLibraryInfoImpl *TLII = new TargetLibraryInfoImpl(TargetTriple);
-
-  using VectorLibrary = llvm::driver::VectorLibrary;
-  switch (Veclib) {
-  case VectorLibrary::Accelerate:
-    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::Accelerate,
-                                             TargetTriple);
-    break;
-  case VectorLibrary::LIBMVEC:
-    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::LIBMVEC,
-                                             TargetTriple);
-    break;
-  case VectorLibrary::MASSV:
-    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::MASSV,
-                                             TargetTriple);
-    break;
-  case VectorLibrary::SVML:
-    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::SVML,
-                                             TargetTriple);
-    break;
-  case VectorLibrary::SLEEF:
-    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::SLEEFGNUABI,
-                                             TargetTriple);
-    break;
-  case VectorLibrary::Darwin_libsystem_m:
-    TLII->addVectorizableFunctionsFromVecLib(
-        llvm::VectorLibrary::DarwinLibSystemM, TargetTriple);
-    break;
-  case VectorLibrary::ArmPL:
-    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::ArmPL,
-                                             TargetTriple);
-    break;
-  case VectorLibrary::AMDLIBM:
-    TLII->addVectorizableFunctionsFromVecLib(llvm::VectorLibrary::AMDLIBM,
-                                             TargetTriple);
-    break;
-  default:
-    break;
-  }
-  return TLII;
+  return new TargetLibraryInfoImpl(
+      TargetTriple, convertDriverVectorLibraryToVectorLibrary(Veclib));
 }
 
 std::string getDefaultProfileGenName() {


### PR DESCRIPTION
This ensures that both the midend and backend see consistent values for VecLib, so that for example frem can be selected correctly.

The test involves running the front-end, midend (to vectorize) and backend to prove it can lower the vector frem call.

Fixes #172483