### PR TITLE
Revert "[AMDGPU] Fix excessive stack usage in SIInsertWaitcnts::run (#134835)"

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -2915,15 +2915,10 @@ bool SIInsertWaitcnts::run(MachineFunction &MF) {
         else
           *Brackets = *BI.Incoming;
       } else {
-        if (!Brackets) {
+        if (!Brackets)
           Brackets = std::make_unique<WaitcntBrackets>(this);
-        } else {
-          // Reinitialize in-place. N.B. do not do this by assigning from a
-          // temporary because the WaitcntBrackets class is large and it could
-          // cause this function to use an unreasonable amount of stack space.
-          Brackets->~WaitcntBrackets();
-          new (Brackets.get()) WaitcntBrackets(this);
-        }
+        else
+          *Brackets = WaitcntBrackets(this);
       }
 
       Modified |= insertWaitcntInBlock(MF, *MBB, *Brackets);


### PR DESCRIPTION
This reverts commit 008c875be85732f72c4df4671167f5be79f449eb.

PR #162077 / #171779 shrunk the WaitcntBrackets class by using DenseMaps
instead of large arrays, so the size of a temporary WaitcntBrackets
allocated on the stack is no longer a concern.

With this patch on Linux I measured the stack size of
SIInsertWaitcnts::run increasing from 456 bytes to 632 bytes.
