### PR TITLE
[lldb] Add libstdcpp atomic data formatters

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/CPlusPlus/CMakeLists.txt
@@ -31,6 +31,7 @@ add_lldb_library(lldbPluginCPlusPlusLanguage PLUGIN
   LibCxxValarray.cpp
   LibCxxVector.cpp
   LibStdcpp.cpp
+  LibStdcppAtomic.cpp
   LibStdcppSpan.cpp
   LibStdcppTuple.cpp
   LibStdcppUniquePointer.cpp

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -403,6 +403,7 @@ lldb_private::formatters::LibStdcppSharedPtrSyntheticFrontEndCreator(
   return (valobj_sp ? new LibStdcppSharedPtrSyntheticFrontEnd(valobj_sp)
                     : nullptr);
 }
+
 static ValueObjectSP GetReferenceCountPointer(ValueObject &parent,
                                               bool is_atomic_child) {
   auto refcount = parent.GetChildMemberWithName("_M_refcount");

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.h
@@ -32,9 +32,9 @@ bool LibStdcppWStringViewSummaryProvider(
     const TypeSummaryOptions &options); // libstdc++ std::wstring_view
 
 bool LibStdcppSmartPointerSummaryProvider(
-    ValueObject &valobj, Stream &stream,
-    const TypeSummaryOptions
-        &options); // libstdc++ std::shared_ptr<> and std::weak_ptr<>
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options,
+    bool is_atomic_child =
+        false); // libstdc++ std::shared_ptr<> and std::weak_ptr<>
 
 bool LibStdcppUniquePointerSummaryProvider(
     ValueObject &valobj, Stream &stream,

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.h
@@ -44,6 +44,9 @@ bool LibStdcppVariantSummaryProvider(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &options); // libstdc++ std::variant<>
 
+bool LibStdcppAtomicSummaryProvider(ValueObject &valobj, Stream &stream,
+                                    const TypeSummaryOptions &options);
+
 bool LibStdcppPartialOrderingSummaryProvider(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &options); // libstdc++ std::partial_ordering
@@ -55,6 +58,10 @@ bool LibStdcppWeakOrderingSummaryProvider(
 bool LibStdcppStrongOrderingSummaryProvider(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &options); // libstdc++ std::strong_ordering
+
+SyntheticChildrenFrontEnd *
+LibStdcppAtomicSyntheticFrontEndCreator(CXXSyntheticChildren *,
+                                        const lldb::ValueObjectSP &);
 
 SyntheticChildrenFrontEnd *
 LibstdcppMapIteratorSyntheticFrontEndCreator(CXXSyntheticChildren *,

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppAtomic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppAtomic.cpp
@@ -21,13 +21,12 @@ namespace lldb_private::formatters {
 class LibStdcppAtomicSyntheticFrontEnd final
     : public SyntheticChildrenFrontEnd {
 public:
-  explicit LibStdcppAtomicSyntheticFrontEnd(ValueObject &valobj_sp)
-      : SyntheticChildrenFrontEnd(valobj_sp),
-        m_inner_name(ConstString("Value")) {}
+  explicit LibStdcppAtomicSyntheticFrontEnd(ValueObject &valobj)
+      : SyntheticChildrenFrontEnd(valobj), m_inner_name(ConstString("Value")) {}
 
   llvm::Expected<uint32_t> CalculateNumChildren() final {
     if (!m_inner)
-      return llvm::createStringError("invalide atomic ValueObject");
+      return llvm::createStringError("Invalid atomic ValueObject.");
     return 1;
   }
 
@@ -75,7 +74,7 @@ public:
       return backend.GetChildAtNamePath({"_M_base", "_M_i"});
 
     const uint32_t float_mask = lldb::eTypeIsFloat | lldb::eTypeIsBuiltIn;
-    if (first_type.GetTypeInfo() & float_mask) {
+    if ((first_type.GetTypeInfo() & float_mask) == float_mask) {
       // added float types specialization in c++17
       if (const auto child = backend.GetChildMemberWithName("_M_fp"))
         return child;
@@ -125,7 +124,7 @@ bool LibStdcppAtomicSummaryProvider(ValueObject &valobj, Stream &stream,
       return true;
     }
 
-    auto aparent = atomic_value->GetParent();
+    ValueObject *aparent = atomic_value->GetParent();
     if (aparent && aparent->GetName().GetStringRef() == "_M_impl") {
       return LibStdcppSmartPointerSummaryProvider(*aparent, stream, options,
                                                   /*is_atomic_child=*/true);

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppAtomic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppAtomic.cpp
@@ -22,7 +22,7 @@ class LibStdcppAtomicSyntheticFrontEnd final
     : public SyntheticChildrenFrontEnd {
 public:
   explicit LibStdcppAtomicSyntheticFrontEnd(ValueObject &valobj)
-      : SyntheticChildrenFrontEnd(valobj), m_inner_name(ConstString("Value")) {}
+      : SyntheticChildrenFrontEnd(valobj) {}
 
   llvm::Expected<uint32_t> CalculateNumChildren() final {
     if (!m_inner)
@@ -32,7 +32,7 @@ public:
 
   ValueObjectSP GetChildAtIndex(uint32_t idx) final {
     if (idx == 0 && m_inner)
-      return m_inner->GetSP()->Clone(m_inner_name);
+      return m_inner->GetSP()->Clone(k_inner_name);
 
     return {};
   }
@@ -48,7 +48,7 @@ public:
   }
 
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) final {
-    if (name == m_inner_name)
+    if (name == k_inner_name)
       return 0;
 
     return llvm::createStringError("Type has no child named '%s'",
@@ -94,7 +94,7 @@ public:
   }
 
 private:
-  ConstString m_inner_name;
+  inline static const ConstString k_inner_name = ConstString("Value");
   ValueObject *m_inner = nullptr;
 };
 
@@ -104,7 +104,7 @@ LibStdcppAtomicSyntheticFrontEndCreator(CXXSyntheticChildren * /*unused*/,
   if (!valobj_sp)
     return nullptr;
 
-  const lldb::ValueObjectSP member =
+  const ValueObjectSP member =
       LibStdcppAtomicSyntheticFrontEnd::ContainerFieldName(*valobj_sp);
   if (!member)
     return nullptr;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppAtomic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppAtomic.cpp
@@ -1,0 +1,124 @@
+//===---------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "LibStdcpp.h"
+
+#include "lldb/DataFormatters/TypeSynthetic.h"
+#include "lldb/Utility/ConstString.h"
+#include "lldb/ValueObject/ValueObject.h"
+#include "lldb/lldb-enumerations.h"
+#include "llvm/Support/Error.h"
+
+using namespace lldb;
+
+namespace lldb_private::formatters {
+
+class LibStdcppAtomicSyntheticFrontEnd final
+    : public SyntheticChildrenFrontEnd {
+public:
+  explicit LibStdcppAtomicSyntheticFrontEnd(ValueObject &valobj_sp)
+      : SyntheticChildrenFrontEnd(valobj_sp),
+        m_inner_name(ConstString("Value")) {}
+
+  llvm::Expected<uint32_t> CalculateNumChildren() final {
+    if (!m_inner)
+      return llvm::createStringError("invalide atomic ValueObject");
+    return 1;
+  }
+
+  ValueObjectSP GetChildAtIndex(uint32_t idx) final {
+    if (idx == 0 && m_inner)
+      return m_inner->GetSP()->Clone(m_inner_name);
+
+    return {};
+  }
+
+  lldb::ChildCacheState Update() final {
+    if (ValueObjectSP value = ContainerFieldName(m_backend)) {
+      // show the Type, instead of std::__atomic_base<Type>::__Type_type.
+      value = value->Cast(value->GetCompilerType().GetCanonicalType());
+      m_inner = value.get();
+    }
+
+    return lldb::ChildCacheState::eRefetch;
+  }
+
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) final {
+    if (name == m_inner_name)
+      return 0;
+
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
+
+  static ValueObjectSP ContainerFieldName(ValueObject &backend_syn) {
+    const ValueObjectSP non_synthetic = backend_syn.GetNonSyntheticValue();
+    if (!non_synthetic)
+      return {};
+    ValueObject &backend = *non_synthetic;
+
+    const CompilerType type = backend.GetCompilerType();
+    if (!type.IsValid() || type.GetNumTemplateArguments() < 1)
+      return {};
+
+    const CompilerType first_type = type.GetTypeTemplateArgument(0);
+    const lldb::BasicType basic_type = first_type.GetBasicTypeEnumeration();
+    if (basic_type == eBasicTypeBool)
+      return backend.GetChildAtNamePath({"_M_base", "_M_i"});
+
+    const uint32_t float_mask = lldb::eTypeIsFloat | lldb::eTypeIsBuiltIn;
+    if (first_type.GetTypeInfo() & float_mask) {
+      // added float types specialization in c++17
+      if (const auto child = backend.GetChildMemberWithName("_M_fp"))
+        return child;
+
+      return backend.GetChildMemberWithName("_M_i");
+    }
+
+    if (first_type.IsPointerType())
+      return backend.GetChildAtNamePath({"_M_b", "_M_p"});
+
+    return backend.GetChildMemberWithName("_M_i");
+  }
+
+private:
+  ConstString m_inner_name;
+  ValueObject *m_inner = nullptr;
+};
+
+SyntheticChildrenFrontEnd *
+LibStdcppAtomicSyntheticFrontEndCreator(CXXSyntheticChildren * /*unused*/,
+                                        const lldb::ValueObjectSP &valobj_sp) {
+  if (!valobj_sp)
+    return nullptr;
+
+  const lldb::ValueObjectSP member =
+      LibStdcppAtomicSyntheticFrontEnd::ContainerFieldName(*valobj_sp);
+  if (!member)
+    return nullptr;
+
+  return new LibStdcppAtomicSyntheticFrontEnd(*valobj_sp);
+}
+
+bool LibStdcppAtomicSummaryProvider(ValueObject &valobj, Stream &stream,
+                                    const TypeSummaryOptions &options) {
+
+  if (const ValueObjectSP atomic_value =
+          LibStdcppAtomicSyntheticFrontEnd::ContainerFieldName(valobj)) {
+    std::string summary;
+    if (atomic_value->GetSummaryAsCString(summary, options) &&
+        !summary.empty()) {
+      stream << summary;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+} // namespace lldb_private::formatters

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/atomic/TestDataFormatterStdAtomic.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/atomic/TestDataFormatterStdAtomic.py
@@ -56,6 +56,35 @@ class StdAtomicTestCase(TestBase):
         self.assertEqual(s.GetChildAtIndex(0).GetValueAsUnsigned(0), 1, "s.x == 1")
         self.assertEqual(s.GetChildAtIndex(1).GetValueAsUnsigned(0), 2, "s.y == 2")
 
+        # float
+        atomic_float = self.get_variable("atomic_float")
+        val_float = atomic_float.child[0]
+        self.assertIsNotNone(val_float, msg="atomic_float child is None.")
+        self.assertAlmostEqual(float(val_float.value), 3.14, places=2)
+        # double
+        atomic_double = self.get_variable("atomic_double")
+        val_float = atomic_double.child[0]
+        self.assertIsNotNone(val_float, msg="atomic_double child is None.")
+        self.assertAlmostEqual(float(val_float.value), 6.28, places=2)
+
+        # bool
+        atomic_bool = self.get_variable("atomic_bool")
+        val_bool = atomic_bool.child[0]
+        self.assertIsNotNone(val_bool, msg="atomic_bool child is None.")
+        self.assertEqual(bool(val_bool.unsigned), True)
+
+        # func
+        atomic_func = self.get_variable("atomic_func")
+        val_func = atomic_func.child[0]
+        self.assertIsNotNone(val_func, msg="atomic_func child is None.")
+        self.assertNotEqual(val_func.unsigned, 0)
+
+        # pointer
+        atomic_pointer = self.get_variable("atomic_pointer")
+        val_pointer = atomic_pointer.child[0]
+        self.assertIsNotNone(val_pointer, msg="atomic_pointer child is None.")
+        self.assertNotEqual(val_pointer.unsigned, 0)
+
         # Try printing the child that points to its own parent object.
         # This should just treat the atomic pointer as a normal pointer.
         self.expect("frame var p.child", substrs=["Value = 0x"])
@@ -64,10 +93,29 @@ class StdAtomicTestCase(TestBase):
             "frame var p.child.parent", substrs=["p.child.parent = {\n  Value = 0x"]
         )
 
+    def verify_floating_point_equal(self, value: str, expected: float):
+        self.assertAlmostEqual(float(value), float(expected), places=4)
+
     @skipIf(compiler=["gcc"])
     @add_test_categories(["libc++"])
     def test_libcxx(self):
         self.build(dictionary={"USE_LIBCPP": 1})
+        self.do_test()
+
+    @add_test_categories(["libstdcxx"])
+    def test_libstdcxx(self):
+        self.build(dictionary={"USE_LIBSTDCPP": 1})
+        self.do_test()
+
+    # the data layout is different in new libstdc++ versions
+    @add_test_categories(["libstdcxx"])
+    def test_libstdcxx_11(self):
+        self.build(dictionary={"USE_LIBSTDCPP": 1, "CXXFLAGS_EXTRAS": "-std=c++11"})
+        self.do_test()
+
+    @add_test_categories(["libstdcxx"])
+    def test_libstdcxx_17(self):
+        self.build(dictionary={"USE_LIBSTDCPP": 1, "CXXFLAGS_EXTRAS": "-std=c++17"})
         self.do_test()
 
     @add_test_categories(["msvcstl"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/atomic/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/atomic/main.cpp
@@ -1,4 +1,9 @@
 #include <atomic>
+#include <version>
+
+#if __cpp_lib_atomic_shared_ptr
+#include <memory>
+#endif // __cpp_lib_atomic_shared_ptr
 
 // Define a Parent and Child struct that can point to each other.
 class Parent;
@@ -39,6 +44,13 @@ int main() {
 
   S data;
   std::atomic<S *> atomic_pointer{&data};
+
+  // smart atomic shared pointer was added in c++20
+#if __cpp_lib_atomic_shared_ptr
+  std::shared_ptr<int> s_value = std::make_shared<int>(300);
+  std::atomic<std::shared_ptr<int>> atomic_shared{s_value};
+  std::atomic<std::weak_ptr<int>> atomic_weak{s_value};
+#endif // __cpp_lib_atomic_shared_ptr
 
   return 0; // Set break point at this line.
 }

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/atomic/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/atomic/main.cpp
@@ -17,6 +17,9 @@ struct S {
   int y = 2;
 };
 
+static void func() {}
+using func_t = void (*)();
+
 int main() {
   std::atomic<S> s;
   s.store(S());
@@ -26,6 +29,16 @@ int main() {
   Parent p;
   // Let the child node know what its parent is.
   p.child.parent = &p;
+
+  // libstdcpp has different layout depending on the data structure
+  std::atomic<bool> atomic_bool{true};
+  std::atomic<float> atomic_float{3.14};
+  std::atomic<double> atomic_double{6.28};
+
+  std::atomic<func_t> atomic_func(func);
+
+  S data;
+  std::atomic<S *> atomic_pointer{&data};
 
   return 0; // Set break point at this line.
 }


### PR DESCRIPTION
 This patch adds a new synthetic child provider and a summary formatter for the libstdc++ implementation of std::atomic<>.