### PR TITLE
[mlir][SPIRV] Move getDecorationString to SPIRVEnums utilities (NFC).

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVEnums.h
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVEnums.h
@@ -52,6 +52,10 @@ ArrayRef<Capability> getDirectImpliedCapabilities(Capability cap);
 /// third one will also be returned.
 SmallVector<Capability, 0> getRecursiveImpliedCapabilities(Capability cap);
 
+/// Converts a SPIR-V Decoration enum value to its snake_case string
+/// representation for use in MLIR attributes.
+std::string getDecorationString(Decoration decoration);
+
 } // namespace spirv
 } // namespace mlir
 

--- a/mlir/lib/Conversion/SPIRVCommon/Pattern.h
+++ b/mlir/lib/Conversion/SPIRVCommon/Pattern.h
@@ -13,22 +13,12 @@
 #include "mlir/Dialect/SPIRV/IR/SPIRVOpTraits.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/FormatVariadic.h"
-#include <string>
 
 namespace mlir {
 namespace spirv {
 
-//===----------------------------------------------------------------------===//
-// Utility Functions
-//===----------------------------------------------------------------------===//
-
-/// Converts a SPIR-V Decoration enum value to its snake_case string
-/// representation for use in MLIR attributes.
-inline std::string getDecorationString(spirv::Decoration decor) {
-  return llvm::convertToSnakeFromCamelCase(stringifyDecoration(decor));
-}
+// Note: spirv::getDecorationString() is defined in SPIRVEnums.h
 
 /// Converts elementwise unary, binary and ternary standard operations to SPIR-V
 /// operations.

--- a/mlir/lib/Conversion/SPIRVCommon/Pattern.h
+++ b/mlir/lib/Conversion/SPIRVCommon/Pattern.h
@@ -18,7 +18,6 @@
 namespace mlir {
 namespace spirv {
 
-// Note: spirv::getDecorationString() is defined in SPIRVEnums.h
 
 /// Converts elementwise unary, binary and ternary standard operations to SPIR-V
 /// operations.

--- a/mlir/lib/Conversion/SPIRVCommon/Pattern.h
+++ b/mlir/lib/Conversion/SPIRVCommon/Pattern.h
@@ -18,7 +18,6 @@
 namespace mlir {
 namespace spirv {
 
-
 /// Converts elementwise unary, binary and ternary standard operations to SPIR-V
 /// operations.
 template <typename Op, typename SPIRVOp>

--- a/mlir/lib/Dialect/SPIRV/IR/MemoryOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/MemoryOps.cpp
@@ -657,8 +657,7 @@ LogicalResult VariableOp::verify() {
   }
 
   auto getDecorationAttr = [op = getOperation()](spirv::Decoration decoration) {
-    return op->getAttr(
-        llvm::convertToSnakeFromCamelCase(stringifyDecoration(decoration)));
+    return op->getAttr(spirv::getDecorationString(decoration));
   };
 
   // TODO: generate these strings using ODS.
@@ -667,8 +666,7 @@ LogicalResult VariableOp::verify() {
         spirv::Decoration::BuiltIn}) {
     if (auto attr = getDecorationAttr(decoration))
       return emitOpError("cannot have '")
-             << llvm::convertToSnakeFromCamelCase(
-                    stringifyDecoration(decoration))
+             << spirv::getDecorationString(decoration)
              << "' attribute (only allowed in spirv.GlobalVariable)";
   }
 

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
@@ -141,7 +141,7 @@ void SPIRVDialect::initialize() {
 }
 
 std::string SPIRVDialect::getAttributeName(Decoration decoration) {
-  return llvm::convertToSnakeFromCamelCase(stringifyDecoration(decoration));
+  return getDecorationString(decoration);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVEnums.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVEnums.cpp
@@ -101,3 +101,7 @@ spirv::getRecursiveImpliedCapabilities(spirv::Capability cap) {
 
   return allCaps.takeVector();
 }
+
+std::string spirv::getDecorationString(spirv::Decoration decoration) {
+  return llvm::convertToSnakeFromCamelCase(stringifyDecoration(decoration));
+}


### PR DESCRIPTION
Moves the getDecorationString() helper from the conversion layer's SPIRVCommon/Pattern.h to the public SPIRVEnums.h header. This makes the utility accessible to both the SPIRV dialect and conversion layers, following proper architectural layering.

This continues the refactoring started in #174145.