### PR TITLE
[TableGen] Use TreePatternNode::getSimpleType instead of getType. NFC

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
@@ -681,9 +681,6 @@ public:
 
   // Type accessors.
   unsigned getNumTypes() const { return Types.size(); }
-  ValueTypeByHwMode getType(unsigned ResNo) const {
-    return Types[ResNo].getValueTypeByHwMode();
-  }
   const std::vector<TypeSetByHwMode> &getExtTypes() const { return Types; }
   const TypeSetByHwMode &getExtType(unsigned ResNo) const {
     return Types[ResNo];

--- a/llvm/utils/TableGen/FastISelEmitter.cpp
+++ b/llvm/utils/TableGen/FastISelEmitter.cpp
@@ -175,10 +175,8 @@ struct OperandsSignature {
 
       // Emit the type check.
       TreePattern *TP = PredFn.getOrigPatFragRecord();
-      ValueTypeByHwMode VVT = TP->getTree(0)->getType(0);
-      assert(VVT.isSimple() &&
-             "Cannot use variable value types with fast isel");
-      OS << LS << "VT == " << getEnumName(VVT.getSimple().SimpleTy) << " && ";
+      MVT VT = TP->getTree(0)->getSimpleType(0);
+      OS << LS << "VT == " << getEnumName(VT) << " && ";
 
       OS << PredFn.getFnName() << "(imm" << Idx << ')';
     }

--- a/llvm/utils/TableGen/GlobalISelEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelEmitter.cpp
@@ -2412,11 +2412,9 @@ void GlobalISelEmitter::emitRunCustomAction(raw_ostream &OS) {
 
 bool hasBFloatType(const TreePatternNode &Node) {
   for (unsigned I = 0, E = Node.getNumTypes(); I < E; I++) {
-    auto Ty = Node.getType(I);
-    for (auto T : Ty)
-      if (T.second == MVT::bf16 ||
-          (T.second.isVector() && T.second.getScalarType() == MVT::bf16))
-        return true;
+    MVT VT = Node.getSimpleType(I);
+    if (VT.getScalarType() == MVT::bf16)
+      return true;
   }
   for (const TreePatternNode &C : Node.children())
     if (hasBFloatType(C))


### PR DESCRIPTION
These were the only uses of getType. Both of these calls are after HwMode has been expanded so we can use getSimpleType like other code.

Remove getType since it is now unused.

While there, simplify the hasBFloatType to use getScalarType for the scalar and vector case.