### PR TITLE
[mlir][vector] Add 1:N vector to llvm conversion

### DIFF
--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -1578,6 +1578,8 @@ def ConvertVectorToLLVMPass : Pass<"convert-vector-to-llvm"> {
            clEnumValN(::mlir::vector::VectorTransposeLowering::Shuffle16x16, "shuffle16x16",
             "Lower 2-D transpose to `vector.shuffle` on 16x16 vector.")
           )}]>,
+    Option<"enableOneToNConversion", "enable-one-to-n-conversion",
+           "bool", /*default=*/"false", "1:N conversion">,
   ];
 }
 

--- a/mlir/include/mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h
+++ b/mlir/include/mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h
@@ -15,9 +15,9 @@ class LLVMTypeConverter;
 
 /// Collect a set of patterns to convert from the Vector dialect to LLVM.
 void populateVectorToLLVMConversionPatterns(
-    const LLVMTypeConverter &converter, RewritePatternSet &patterns,
+    LLVMTypeConverter &converter, RewritePatternSet &patterns,
     bool reassociateFPReductions = false, bool force32BitVectorIndices = false,
-    bool useVectorAlignment = false);
+    bool useVectorAlignment = false, bool enableOneToNConversion = false);
 
 namespace vector {
 void registerConvertVectorToLLVMInterface(DialectRegistry &registry);

--- a/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.cpp
+++ b/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.cpp
@@ -115,75 +115,11 @@ void ConvertVectorToLLVMPass::runOnOperation() {
   LowerToLLVMOptions options(&getContext());
   LLVMTypeConverter converter(&getContext(), options);
 
-  if (enableOneToNConversion) {
-
-    converter.addConversion(
-        [&](VectorType type,
-            SmallVectorImpl<Type> &result) -> std::optional<LogicalResult> {
-          auto elementType = converter.convertType(type.getElementType());
-          if (!elementType)
-            return failure();
-          if (type.getShape().empty()) {
-            result.push_back(VectorType::get({1}, elementType));
-            return success();
-          }
-          Type vectorType = VectorType::get(type.getShape().back(), elementType,
-                                            type.getScalableDims().back());
-          assert(LLVM::isCompatibleVectorType(vectorType) &&
-                 "expected vector type compatible with the LLVM dialect");
-          // For n-D vector types for which a _non-trailing_ dim is scalable,
-          // return a failure. Supporting such cases would require LLVM
-          // to support something akin "scalable arrays" of vectors.
-          if (llvm::is_contained(type.getScalableDims().drop_back(), true))
-            return failure();
-
-          ArrayRef<int64_t> shapeLeadingDims = type.getShape().drop_back();
-          int64_t numVectors = ShapedType::getNumElements(shapeLeadingDims);
-          for (int64_t i = 0; i < numVectors; i++)
-            result.push_back(vectorType);
-
-          return success();
-        });
-
-    converter.addTargetMaterialization(
-        [&](OpBuilder &builder, TypeRange resultTypes, ValueRange inputs,
-            Location loc) -> SmallVector<Value> {
-          // from ('vector<4x4xf32>')
-          // to ('vector<4xf32>', 'vector<4xf32>', 'vector<4xf32>',
-          // 'vector<4xf32>')
-          Type ty = resultTypes[0];
-          for (Type ithTy : resultTypes)
-            if (ithTy != ty)
-              return {};
-
-          if (!isa<VectorType>(ty))
-            return {};
-
-          if (inputs.size() != 1)
-            return {};
-
-          Type inputTy = inputs[0].getType();
-          if (!isa<VectorType>(inputTy))
-            return {};
-
-          VectorType inputVectorTy = cast<VectorType>(inputTy);
-          ArrayRef<int64_t> inputShape = inputVectorTy.getShape();
-          size_t numElements =
-              ShapedType::getNumElements(inputShape.drop_back());
-          if (numElements != resultTypes.size())
-            return {};
-
-          return UnrealizedConversionCastOp::create(builder, loc, resultTypes,
-                                                    inputs)
-              .getResults();
-        });
-  }
-
   RewritePatternSet patterns(&getContext());
   populateVectorTransferLoweringPatterns(patterns);
   populateVectorToLLVMConversionPatterns(
       converter, patterns, reassociateFPReductions, force32BitVectorIndices,
-      useVectorAlignment);
+      useVectorAlignment, enableOneToNConversion);
 
   // Architecture specific augmentations.
   LLVMConversionTarget target(getContext());

--- a/mlir/test/Conversion/VectorToLLVM/vector-to-llvm-one-to-n.mlir
+++ b/mlir/test/Conversion/VectorToLLVM/vector-to-llvm-one-to-n.mlir
@@ -1,0 +1,140 @@
+// RUN: mlir-opt  --convert-vector-to-llvm="enable-one-to-n-conversion=true" --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func @vector_extract_vector(
+// CHECK-SAME: %[[ARG0:.+]]: vector<4x4xf32>
+func.func @vector_extract_vector(%arg0: vector<4x4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
+    // CHECK-NEXT: %[[CAST:.+]]:4 = builtin.unrealized_conversion_cast %[[ARG0]] : vector<4x4xf32> to vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>
+    %0 = vector.extract %arg0[0] : vector<4xf32> from vector<4x4xf32>
+    %1 = vector.extract %arg0[1] : vector<4xf32> from vector<4x4xf32>
+    %2 = vector.extract %arg0[2] : vector<4xf32> from vector<4x4xf32>
+    %3 = vector.extract %arg0[3] : vector<4xf32> from vector<4x4xf32>
+    // CHECK-NEXT: return %[[CAST]]#3, %[[CAST]]#2, %[[CAST]]#1, %[[CAST]]#0
+    return %3, %2, %1, %0 : vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @vector_extract_linearize(
+// CHECK-SAME: %[[ARG0:.+]]: vector<5x4x3xf32>
+func.func @vector_extract_linearize(%arg0: vector<5x4x3xf32>) -> (vector<3xf32>, vector<3xf32>, vector<3xf32>) {
+    // CHECK-NEXT: %[[CAST:.+]]:20 = builtin.unrealized_conversion_cast %[[ARG0]] : vector<5x4x3xf32> to vector<3xf32>
+    %0 = vector.extract %arg0[0, 0] : vector<3xf32> from vector<5x4x3xf32>
+    %1 = vector.extract %arg0[0, 1] : vector<3xf32> from vector<5x4x3xf32>
+    %2 = vector.extract %arg0[1, 1] : vector<3xf32> from vector<5x4x3xf32>
+    // CHECK-NEXT: return %[[CAST]]#0, %[[CAST]]#1, %[[CAST]]#5
+    return %0, %1, %2 : vector<3xf32>, vector<3xf32>, vector<3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @vector_extract_scalar(
+// CHECK-SAME: %[[ARG0:.+]]: vector<2x2xf32>
+func.func @vector_extract_scalar(%arg0: vector<2x2xf32>) -> (f32) {
+  // CHECK: %[[CAST:.+]]:2 = builtin.unrealized_conversion_cast %[[ARG0]] : vector<2x2xf32> to vector<2xf32>, vector<2xf32>
+  // CHECK: %[[C0:.+]] = llvm.mlir.constant(0 : i64)
+  // CHECK: %[[EXTRACTED:.+]] = llvm.extractelement %[[CAST]]#0[%[[C0]] : i64]
+  %0 = vector.extract %arg0[0, 0] : f32 from vector<2x2xf32>
+  // CHECK: return %[[EXTRACTED]]
+  return %0 : f32
+}
+
+// -----
+
+// CHECK-LABEL: func @vector_extract_lhs_multiple(
+// CHECK-SAME: %[[ARG0:.+]]: vector<2x2x2xf32>)
+func.func @vector_extract_lhs_multiple(%arg0: vector<2x2x2xf32>) -> vector<2x2xf32> {
+  // CHECK: %[[CAST:.+]]:4 = builtin.unrealized_conversion_cast %[[ARG0]] : vector<2x2x2xf32> to vector<2xf32>
+  // CHECK: %[[SELECTED:.+]] = builtin.unrealized_conversion_cast %[[CAST]]#0, %[[CAST]]#1 : vector<2xf32>, vector<2xf32>
+  %0 = vector.extract %arg0[0] : vector<2x2xf32> from vector<2x2x2xf32>
+  // CHECK: return %[[SELECTED]]
+  return %0 : vector<2x2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @vector_extract_rank_0(
+// CHECK-SAME: %[[ARG0:.+]]: vector<f32>)
+func.func @vector_extract_rank_0(%arg0: vector<f32>) -> f32 {
+  // CHECK: %[[CAST:.+]] = builtin.unrealized_conversion_cast %[[ARG0]] : vector<f32> to vector<1xf32>
+  // CHECK: %[[C0:.+]] = llvm.mlir.constant(0 : i64)
+  // CHECK: %[[ELEM:.+]] = llvm.extractelement %[[CAST]][%[[C0]] : i64]
+  %0 = vector.extract %arg0[] : f32 from vector<f32>
+  // CHECK: return %[[ELEM]]
+  return %0 : f32
+}
+
+// -----
+
+// CHECK-LABEL: func @vector_insert_vector(
+// CHECK-SAME: %[[VAL0:.+]]: vector<4xf32>, %[[VAL1:.+]]: vector<4xf32>, %[[VAL2:.+]]: vector<4xf32>, %[[AGG:.+]]: vector<4x4xf32>)
+func.func @vector_insert_vector(%val0: vector<4xf32>, %val1: vector<4xf32>, %val2: vector<4xf32>, %agg: vector<4x4xf32>) -> (vector<4x4xf32>) {
+  // CHECK: %[[CAST:.+]]:4 = builtin.unrealized_conversion_cast %[[AGG]] : vector<4x4xf32> to vector<4xf32>
+  %0 = vector.insert %val0, %agg[0] : vector<4xf32> into vector<4x4xf32>
+  %1 = vector.insert %val1, %0[1] : vector<4xf32> into vector<4x4xf32>
+  %2 = vector.insert %val2, %1[2] : vector<4xf32> into vector<4x4xf32>
+
+  // CHECK: %[[INSERTION_CAST:.+]] = builtin.unrealized_conversion_cast %[[VAL0]], %[[VAL1]], %[[VAL2]], %[[CAST]]#3
+  // CHECK: return %[[INSERTION_CAST]]
+  return %2 : vector<4x4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @vector_insert_linearize(
+// CHECK-SAME: %[[VAL:.+]]: vector<3xf32>, %[[AGG:.+]]: vector<5x4x3xf32>)
+func.func @vector_insert_linearize(%val: vector<3xf32>, %agg: vector<5x4x3xf32>) -> (vector<5x4x3xf32>) {
+  // CHECK: %[[CAST:.+]]:20 = builtin.unrealized_conversion_cast %[[AGG]] : vector<5x4x3xf32> to vector<3xf32>
+
+  %0 = vector.insert %val, %agg[0, 0] : vector<3xf32> into vector<5x4x3xf32>
+  %1 = vector.insert %val, %0[0, 1] : vector<3xf32> into vector<5x4x3xf32>
+  %2 = vector.insert %val, %1[1, 1] : vector<3xf32> into vector<5x4x3xf32>
+
+  // CHECK: %[[INSERTION_CAST:.+]] = builtin.unrealized_conversion_cast %[[VAL]], %[[VAL]], %[[CAST]]#2, %[[CAST]]#3, %[[CAST]]#4, %[[VAL]]
+  // CHECK: return %[[INSERTION_CAST]]
+  return %2 : vector<5x4x3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @vector_insert_scalar(
+// CHECK-SAME: %[[VAL:.+]]: f32, %[[AGG:.+]]: vector<2x2xf32>)
+func.func @vector_insert_scalar(%val: f32, %agg: vector<2x2xf32>) -> (vector<2x2xf32>) {
+  // CHECK-DAG: %[[CAST:.+]]:2 = builtin.unrealized_conversion_cast %[[AGG]] : vector<2x2xf32> to vector<2xf32>
+  // CHECK-DAG: %[[C1:.+]] = llvm.mlir.constant(1 : i64)
+  // CHECK: %[[MODIFIED_VECTOR:.+]] = llvm.insertelement %[[VAL]], %[[CAST]]#0[%[[C1]] : i64]
+  // CHECK: %[[INSERTION_CAST:.+]] = builtin.unrealized_conversion_cast %[[MODIFIED_VECTOR]], %[[CAST]]#1
+  %0 = vector.insert %val, %agg[0, 1] : f32 into vector<2x2xf32>
+
+  // CHECK: return %[[INSERTION_CAST]]
+  return %0 : vector<2x2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @vector_insert_sources_multiple(
+// CHECK-SAME: %[[TO_STORE:.+]]: vector<2x2xf32>,
+// CHECK-SAME: %[[DEST:.+]]: vector<2x2x2xf32>
+func.func @vector_insert_sources_multiple(%val: vector<2x2xf32>, %dest: vector<2x2x2xf32>) -> (vector<2x2x2xf32>) {
+  // CHECK: %[[CAST_DEST:.+]]:4 = builtin.unrealized_conversion_cast %[[DEST]] : vector<2x2x2xf32> to vector<2xf32>
+  // CHECK: %[[CAST_TO_STORE:.+]]:2 = builtin.unrealized_conversion_cast %[[TO_STORE]] : vector<2x2xf32> to vector<2xf32>
+  // CHECK: %[[INSERT:.+]] = builtin.unrealized_conversion_cast %[[CAST_TO_STORE]]#0, %[[CAST_TO_STORE]]#1, %[[CAST_DEST]]#2, %[[CAST_DEST]]#3
+
+  %0 = vector.insert %val, %dest[0] : vector<2x2xf32> into vector<2x2x2xf32>
+  // CHECK: return %[[INSERT]]
+  return %0 : vector<2x2x2xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @vector_insert_rank_0(
+// CHECK-SAME: %[[TO_STORE:.+]]: f32,
+// CHECK-SAME: %[[DEST:.+]]: vector<f32>
+func.func @vector_insert_rank_0(%val: f32, %dest: vector<f32>) -> (vector<f32>) {
+  // CHECK: %[[CAST_DEST:.+]] = builtin.unrealized_conversion_cast %[[DEST]] : vector<f32> to vector<1xf32>
+  // CHECK: %[[C0:.+]] = llvm.mlir.constant(0 : i64)
+  // CHECK: %[[INSERT:.+]] = llvm.insertelement %[[TO_STORE]], %[[CAST_DEST]][%[[C0]] : i64]
+  // CHECK: %[[INSERT_CAST:.+]] = builtin.unrealized_conversion_cast %[[INSERT]] : vector<1xf32> to vector<f32>
+  %0 = vector.insert %val, %dest[] : f32 into vector<f32>
+  // CHECK: return %[[INSERT_CAST]]
+  return %0 : vector<f32>
+}

--- a/mlir/test/lib/Dialect/Vector/TestVectorTransforms.cpp
+++ b/mlir/test/lib/Dialect/Vector/TestVectorTransforms.cpp
@@ -51,8 +51,8 @@ struct TestVectorToVectorLowering
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<affine::AffineDialect>();
-    registry.insert<vector::VectorDialect>();
+    registry.insert<affine::AffineDialect, arith::ArithDialect,
+                    vector::VectorDialect>();
   }
 
   Option<bool> unroll{*this, "unroll", llvm::cl::desc("Include unrolling"),
@@ -149,6 +149,9 @@ struct TestVectorUnrollingPatterns
   StringRef getDescription() const final {
     return "Test lowering patterns to unroll contract ops in the vector "
            "dialect";
+  }
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<vector::VectorDialect>();
   }
   TestVectorUnrollingPatterns() = default;
   TestVectorUnrollingPatterns(const TestVectorUnrollingPatterns &pass)


### PR DESCRIPTION
Add 1:N vector to LLVM conversion.

This PR adds the option `enable-one-to-n-conversion` to `--convert-vector-to-llvm`. When this option is selected, the current `VectorInsertOpConversion` and `VectorExtractOpConversion` patterns are not used, and instead `VectorInsertOneToNOpConversion` and `VectorExtractOneToNOpConversion` are used and new conversions and materializations are added to implement 1:N conversion of multidimensional vectors into a collection of vectors. E.g.,

Instead of the usual conversion of

```mlir
vector<2x2xf32> -> !llvm.array<2 x vector<2xf32>>
```

The following conversion is used:

```mlir
vector<2x2xf32> -> vector<2xf32>, vector<2xf32>
```

This is useful because vector unrolling will heavily use vector.extract_strided_slice and vector.insert_strided_slice on multidimensional vectors creating nested arrays. However, these nested arrays are temporary as other unrolled operations will extract 1-dimensional vectors from their inputs. This new option avoids insertions of these temporary insertions and extractions.

The next step is to add this option to `--convert-to-llvm` itself and potentially others. For example, `--convert-arith-to-llvm` some arith operations can operate on vectors (e.g., `%a = arith.addf %0, %1 : vector<3x7x8xf32>`)