### PR TITLE
Fix #174158: Overly strict warning ‘Unrecognized parameter passing direction’

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCommentKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommentKinds.td
@@ -64,7 +64,7 @@ def note_doc_block_command_previous_alias : Note<
 
 def warn_doc_param_invalid_direction : Warning<
   "unrecognized parameter passing direction, "
-  "valid directions are '[in]', '[out]', '[in,out]', '[out,in]', '[inout]', and '[outin]'">,
+  "valid directions are '[in]', '[out]', '[in,out]', '[out,in]', '[in out]', '[out in]', '[inout]', and '[outin]'">,
   InGroup<Documentation>, DefaultIgnore;
 
 def warn_doc_param_spaces_in_direction : Warning<

--- a/clang/include/clang/Basic/DiagnosticCommentKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommentKinds.td
@@ -64,7 +64,7 @@ def note_doc_block_command_previous_alias : Note<
 
 def warn_doc_param_invalid_direction : Warning<
   "unrecognized parameter passing direction, "
-  "valid directions are '[in]', '[out]' and '[in,out]'">,
+  "valid directions are '[in]', '[out]', '[in,out]', '[out,in]', '[inout]', and '[outin]'">,
   InGroup<Documentation>, DefaultIgnore;
 
 def warn_doc_param_spaces_in_direction : Warning<

--- a/clang/lib/AST/CommentSema.cpp
+++ b/clang/lib/AST/CommentSema.cpp
@@ -225,7 +225,8 @@ static ParamCommandPassDirection getParamPassDirection(StringRef Arg) {
   return llvm::StringSwitch<ParamCommandPassDirection>(Arg)
       .Case("[in]", ParamCommandPassDirection::In)
       .Case("[out]", ParamCommandPassDirection::Out)
-      .Cases({"[in,out]", "[out,in]", "[inout]", "[outin]"},
+      .Cases({"[in,out]", "[out,in]", "[in out]", "[out in]", "[inout]",
+              "[outin]"},
              ParamCommandPassDirection::InOut)
       .Default(static_cast<ParamCommandPassDirection>(-1));
 }

--- a/clang/lib/AST/CommentSema.cpp
+++ b/clang/lib/AST/CommentSema.cpp
@@ -225,7 +225,8 @@ static ParamCommandPassDirection getParamPassDirection(StringRef Arg) {
   return llvm::StringSwitch<ParamCommandPassDirection>(Arg)
       .Case("[in]", ParamCommandPassDirection::In)
       .Case("[out]", ParamCommandPassDirection::Out)
-      .Cases({"[in,out]", "[out,in]"}, ParamCommandPassDirection::InOut)
+      .Cases({"[in,out]", "[out,in]", "[inout]", "[outin]"},
+             ParamCommandPassDirection::InOut)
       .Default(static_cast<ParamCommandPassDirection>(-1));
 }
 

--- a/clang/test/Sema/warn-documentation.cpp
+++ b/clang/test/Sema/warn-documentation.cpp
@@ -245,11 +245,17 @@ int test_param7(int a);
 /// \param [out,in] a Blah blah.
 int test_param7b(int a);
 
-/// \param [inout] a Blah blah.
+/// \param [in out] a Blah blah.
 int test_param7c(int a);
 
-/// \param [outin] a Blah blah.
+/// \param [out in] a Blah blah.
 int test_param7d(int a);
+
+/// \param [inout] a Blah blah.
+int test_param7e(int a);
+
+/// \param [outin] a Blah blah.
+int test_param7f(int a);
 
 // expected-warning@+1 {{whitespace is not allowed in parameter passing direction}}
 /// \param [ in ] a Blah blah.
@@ -259,7 +265,7 @@ int test_param8(int a);
 /// \param [in, out] a Blah blah.
 int test_param9(int a);
 
-// expected-warning@+1 {{unrecognized parameter passing direction, valid directions are '[in]', '[out]', '[in,out]', '[out,in]', '[inout]', and '[outin]'}}
+// expected-warning@+1 {{unrecognized parameter passing direction, valid directions are '[in]', '[out]', '[in,out]', '[out,in]', '[in out]', '[out in]', '[inout]', and '[outin]'}}
 /// \param [ junk] a Blah blah.
 int test_param10(int a);
 

--- a/clang/test/Sema/warn-documentation.cpp
+++ b/clang/test/Sema/warn-documentation.cpp
@@ -242,6 +242,15 @@ int test_param6(int a);
 /// \param [in,out] a Blah blah.
 int test_param7(int a);
 
+/// \param [out,in] a Blah blah.
+int test_param7b(int a);
+
+/// \param [inout] a Blah blah.
+int test_param7c(int a);
+
+/// \param [outin] a Blah blah.
+int test_param7d(int a);
+
 // expected-warning@+1 {{whitespace is not allowed in parameter passing direction}}
 /// \param [ in ] a Blah blah.
 int test_param8(int a);
@@ -250,7 +259,7 @@ int test_param8(int a);
 /// \param [in, out] a Blah blah.
 int test_param9(int a);
 
-// expected-warning@+1 {{unrecognized parameter passing direction, valid directions are '[in]', '[out]' and '[in,out]'}}
+// expected-warning@+1 {{unrecognized parameter passing direction, valid directions are '[in]', '[out]', '[in,out]', '[out,in]', '[inout]', and '[outin]'}}
 /// \param [ junk] a Blah blah.
 int test_param10(int a);
 


### PR DESCRIPTION
Allow '[out,in]', '[in out]', '[out in]', '[inout]', and '[outin]' as doc passing directions.

Fix #174158: Overly strict warning ‘Unrecognized parameter passing direction’.