### PR TITLE
[NFC][CIR] Fix unused variable warning

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -710,7 +710,7 @@ void CIRGenTypes::updateCompletedType(const TagDecl *td) {
   // If this is an enum being completed, then we flush all non-struct types
   // from the cache. This allows function types and other things that may be
   // derived from the enum to be recomputed.
-  if (const auto *ed = dyn_cast<EnumDecl>(td)) {
+  if ([[maybe_unused]] const auto *ed = dyn_cast<EnumDecl>(td)) {
     // Classic codegen clears the type cache if it contains an entry for this
     // enum type that doesn't use i32 as the underlying type, but I can't find
     // a test case that meets that condition. C++ doesn't allow forward


### PR DESCRIPTION
This fixes the clang warning when compiling with CIR enabled and assertions ignored:
```cpp
llvm-project/clang/lib/CIR/CodeGen/CIRGenTypes.cpp:713:19: warning: variable 'ed' set but not used [-Wunused-but-set-variable]
  713 |   if (const auto *ed = dyn_cast<EnumDecl>(td)) {
      |                   ^
```