### PR TITLE
[MemProf] Include matching calls in the dot graph node label

### DIFF
--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -3411,6 +3411,11 @@ struct DOTGraphTraits<const CallsiteContextGraph<DerivedCCG, FuncTy, CallTy> *>
       assert(Func != G->NodeToCallingFunc.end());
       LabelString +=
           G->getLabel(Func->second, Node->Call.call(), Node->Call.cloneNo());
+      for (auto &MatchingCall : Node->MatchingCalls) {
+        LabelString += "\n";
+        LabelString += G->getLabel(Func->second, MatchingCall.call(),
+                                   MatchingCall.cloneNo());
+      }
     } else {
       LabelString += "null call";
       if (Node->Recursive)

--- a/llvm/test/ThinLTO/X86/memprof-icp.ll
+++ b/llvm/test/ThinLTO/X86/memprof-icp.ll
@@ -116,11 +116,17 @@
 ; RUN:	-thinlto-threads=1 \
 ; RUN:  -memprof-verify-ccg -memprof-verify-nodes -stats \
 ; RUN:  -pass-remarks=. -save-temps \
+; RUN:	-memprof-export-to-dot -memprof-dot-file-path-prefix=%t. \
 ; RUN:  -o %t.out 2>&1 | FileCheck %s --check-prefix=STATS \
 ; RUN:  --check-prefix=STATS-BE --check-prefix=REMARKS-MAIN \
 ; RUN:  --check-prefix=REMARKS-FOO --check-prefix=REMARKS-FOO-IMPORT
 
 ; RUN: llvm-dis %t.out.2.4.opt.bc -o - | FileCheck %s --check-prefix=IR --check-prefix=IR-IMPORT
+
+;; We should print both potential indirect callees after initially matching
+;; stack nodes to the summary.
+; RUN: cat %t.ccg.poststackupdate.dot | FileCheck %s --check-prefix=DOT
+; DOT: {OrigId: 0 NodeId: 10\n_Z3fooR2B0j -\> _ZN1B3barEj\n_Z3fooR2B0j -\> _ZN2B03barEj}
 
 ;; Try again but with distributed ThinLTO
 ; RUN: llvm-lto2 run %t/main.o %t/foo.o -enable-memprof-context-disambiguation \


### PR DESCRIPTION
After initially matching stack nodes to summary we may have multiple
calls per node, e.g. in the case of indirect calls with multiple
profiled callee targets. It is useful to see all of these calls, which
will show up in the poststackupdate dot graph.
