### PR TITLE
[mlir][Tensor] Add rank-reducing slice in generatedSlices

### DIFF
--- a/mlir/lib/Dialect/SCF/Transforms/TileUsingInterface.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/TileUsingInterface.cpp
@@ -1328,7 +1328,7 @@ getUntiledProducerFromSliceSource(OpOperand *source,
   if (loopIt == loops.rend())
     destinationIterArg = source;
 
-  OpResult result = dyn_cast<OpResult>(source->get());
+  auto result = dyn_cast<OpResult>(source->get());
   if (result) {
     Operation *producer = result.getOwner();
     Operation *innermostLoop = loops.back();

--- a/mlir/lib/Dialect/SCF/Transforms/TileUsingInterface.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/TileUsingInterface.cpp
@@ -1327,7 +1327,18 @@ getUntiledProducerFromSliceSource(OpOperand *source,
   }
   if (loopIt == loops.rend())
     destinationIterArg = source;
-  return {dyn_cast<OpResult>(source->get()), destinationIterArg};
+
+  OpResult result = dyn_cast<OpResult>(source->get());
+  if (result) {
+    Operation *producer = result.getOwner();
+    Operation *innermostLoop = loops.back();
+    // If the producer is already inside the innermost loop (where the slice
+    // is), it has already been fused. Skip it to avoid infinite loops.
+    if (innermostLoop->isProperAncestor(producer))
+      return {OpResult(), std::nullopt};
+  }
+
+  return {result, destinationIterArg};
 }
 
 /// Implementation of fusing producer of a single slice by computing the

--- a/mlir/lib/Dialect/Tensor/Transforms/SwapExtractSliceWithProducerPatterns.cpp
+++ b/mlir/lib/Dialect/Tensor/Transforms/SwapExtractSliceWithProducerPatterns.cpp
@@ -53,6 +53,7 @@ FailureOr<TilingResult> tensor::replaceExtractSliceWithTiledProducer(
         builder, sliceOp.getLoc(), sliceOp.getType(),
         tiledResult->tiledValues[0], offsets, sliceOp.getMixedSizes(), strides);
     tiledResult->tiledValues[0] = newSliceOp;
+    tiledResult->generatedSlices.push_back(newSliceOp);
   }
 
   return *tiledResult;

--- a/mlir/test/Interfaces/TilingInterface/tile-and-fuse-with-reduction-tiling.mlir
+++ b/mlir/test/Interfaces/TilingInterface/tile-and-fuse-with-reduction-tiling.mlir
@@ -1,6 +1,9 @@
 // RUN: mlir-opt -transform-interpreter -cse -mlir-print-local-scope -split-input-file -verify-diagnostics %s | FileCheck %s
 
-// Check tile+ fuse works with partial reduction outer parallel strategy.
+// Check tile + fuse works with partial reduction outer parallel strategy.
+// This also tests that the fusion logic correctly skips producers that are
+// already inside the innermost loop (e.g., the rank-reducing slice of the
+// fused fill), avoiding infinite loops in the fusion worklist.
 
 module{
   func.func @tile_and_fuse_with_partial_reduction_outer_parallel(


### PR DESCRIPTION
 When `replaceExtractSliceWithTiledProducer `creates a rank-reducing slice to handle type mismatches, it should be tracked in `generatedSlices `so downstream cleanup patterns (like IREE's FoldExtractSliceOfBroadcast) can process it. 
 
This PR also fixes an infinite loop in getUntiledProducerFromSliceSource where adding the slice to generatedSlices caused the fusion worklist to repeatedly try to re-fuse producers already inside the innermost loop; the fix skips producers that are already inside the innermost loop via an isProperAncestor check.

Added a lit test (@fuse_through_rank_reducing_slice) demonstrating correct fusion through rank-reducing slices. Note that demonstrating the generatedSlices tracking benefit requires a cleanup pattern (SwapExtractSliceWithFillPatterns) to consume the slice; IREE's full CI suite (iree-org/iree#23012) validates this works correctly in practice with patterns like FoldExtractSliceOfBroadcast.