### PR TITLE
[MergeFunc] Do not merge kernel functions

### DIFF
--- a/llvm/lib/Transforms/IPO/MergeFunctions.cpp
+++ b/llvm/lib/Transforms/IPO/MergeFunctions.cpp
@@ -697,6 +697,9 @@ static bool canCreateThunkFor(Function *F) {
   if (F->isVarArg())
     return false;
 
+  if (F->hasKernelCallingConv())
+    return false;
+
   // Don't merge tiny functions using a thunk, since it can just end up
   // making the function larger.
   if (F->size() == 1) {

--- a/llvm/test/Transforms/MergeFunc/merge-calling-conv.ll
+++ b/llvm/test/Transforms/MergeFunc/merge-calling-conv.ll
@@ -1,0 +1,55 @@
+; RUN: opt -S -passes=mergefunc < %s | FileCheck --implicit-check-not=call %s
+
+; Check that no calls are generated for certain calling conventions
+
+@debug = global i32 0
+
+; CHECK: call void @as_normal
+
+define void @normal(i32 %a) unnamed_addr {
+  %b = xor i32 %a, 0
+  store i32 %b, ptr @debug
+  ret void
+}
+
+define void @as_normal(i32 %a) unnamed_addr {
+  %b = xor i32 %a, 0
+  store i32 %b, ptr @debug
+  ret void
+}
+
+define amdgpu_kernel void @amdgpu_kernel(i32 %a) unnamed_addr {
+  %b = xor i32 %a, 1
+  store i32 %b, ptr @debug
+  ret void
+}
+
+define amdgpu_kernel void @as_amdgpu_kernel(i32 %a) unnamed_addr {
+  %b = xor i32 %a, 1
+  store i32 %b, ptr @debug
+  ret void
+}
+
+define ptx_kernel void @ptx_kernel(i32 %a) unnamed_addr {
+  %b = xor i32 %a, 2
+  store i32 %b, ptr @debug
+  ret void
+}
+
+define ptx_kernel void @as_ptx_kernel(i32 %a) unnamed_addr {
+  %b = xor i32 %a, 2
+  store i32 %b, ptr @debug
+  ret void
+}
+
+define spir_kernel void @spir_kernel(i32 %a) unnamed_addr {
+  %b = xor i32 %a, 3
+  store i32 %b, ptr @debug
+  ret void
+}
+
+define spir_kernel void @as_spir_kernel(i32 %a) unnamed_addr {
+  %b = xor i32 %a, 3
+  store i32 %b, ptr @debug
+  ret void
+}


### PR DESCRIPTION
Kernels cannot be called, so we cannot introduce calls to them in MergeFunctions.

The test uses a `--implicit-check-not=call` to make sure that only the function with C calling convention gets merged.

Fixes #39579. Fixes #173355