### PR TITLE
Add lowering for llvm.vector.splice.va

### DIFF
--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -2005,6 +2005,12 @@ public:
                                      cast<VectorType>(Args[0]->getType()), {},
                                      CostKind, Index, cast<VectorType>(RetTy));
     }
+    case Intrinsic::vector_splice_va: {
+      // Conservative estimate: variable splice requires at least one
+      // shift/rotate
+      // TODO: Refine this cost model based on target-specific implementation
+      return 1;
+    }
     case Intrinsic::vector_reduce_add:
     case Intrinsic::vector_reduce_mul:
     case Intrinsic::vector_reduce_and:

--- a/llvm/include/llvm/CodeGen/ISDOpcodes.h
+++ b/llvm/include/llvm/CodeGen/ISDOpcodes.h
@@ -655,6 +655,10 @@ enum NodeType {
   /// is a constant integer.
   VECTOR_SPLICE,
 
+  /// Same as VECTOR_SPLICE but takes variable argument.
+  /// VECTOR_SPLICE(VEC1, VEC2, VAL)
+  VECTOR_SPLICE_VA,
+
   /// SCALAR_TO_VECTOR(VAL) - This represents the operation of loading a
   /// scalar value into element 0 of the resultant vector type.  The top
   /// elements 1 to N-1 of the N-element vector are poison. The type of

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -5789,6 +5789,9 @@ public:
   /// method accepts vectors as its arguments.
   SDValue expandVectorSplice(SDNode *Node, SelectionDAG &DAG) const;
 
+  /// Method for building the DAG expansion of ISD::VECTOR_SPLICE_VA
+  SDValue expandVectorSpliceVA(SDNode *Node, SelectionDAG &DAG) const;
+
   /// Expand a vector VECTOR_COMPRESS into a sequence of extract element, store
   /// temporarily, advance store position, before re-loading the final vector.
   SDValue expandVECTOR_COMPRESS(SDNode *Node, SelectionDAG &DAG) const;

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -2835,6 +2835,12 @@ def int_vector_splice : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
                                                IntrSpeculatable,
                                                ImmArg<ArgIndex<2>>]>;
 
+def int_vector_splice_va : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+                                                 [LLVMMatchType<0>,
+                                                  LLVMMatchType<0>,
+                                                  llvm_i32_ty],
+                                                 [IntrNoMem]>;
+
 //===---------- Intrinsics to query properties of scalable vectors --------===//
 def int_vscale : DefaultAttrsIntrinsic<[llvm_anyint_ty],
                                        [],

--- a/llvm/include/llvm/Target/TargetSelectionDAG.td
+++ b/llvm/include/llvm/Target/TargetSelectionDAG.td
@@ -839,6 +839,7 @@ def ist        : SDNode<"ISD::STORE"      , SDTIStore,
 def vector_shuffle : SDNode<"ISD::VECTOR_SHUFFLE", SDTVecShuffle, []>;
 def vector_reverse : SDNode<"ISD::VECTOR_REVERSE", SDTVecReverse>;
 def vector_splice : SDNode<"ISD::VECTOR_SPLICE", SDTVecSlice, []>;
+def vector_splice_va : SDNode<"ISD::VECTOR_SPLICE_VA", SDTVecSlice, []>;
 def build_vector : SDNode<"ISD::BUILD_VECTOR", SDTypeProfile<1, -1, []>, []>;
 def splat_vector : SDNode<"ISD::SPLAT_VECTOR", SDTypeProfile<1, 1, []>, []>;
 def step_vector : SDNode<"ISD::STEP_VECTOR", SDTypeProfile<1, 1,

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
@@ -3711,6 +3711,10 @@ bool SelectionDAGLegalize::ExpandNode(SDNode *Node) {
     Results.push_back(Tmp1);
     break;
   }
+  case ISD::VECTOR_SPLICE_VA: {
+    Results.push_back(TLI.expandVectorSpliceVA(Node, DAG));
+    break;
+  }
   case ISD::VECTOR_SPLICE: {
     Results.push_back(TLI.expandVectorSplice(Node, DAG));
     break;
@@ -5643,6 +5647,14 @@ void SelectionDAGLegalize::PromoteNode(SDNode *Node) {
     Tmp1 = ShuffleWithNarrowerEltType(NVT, OVT, dl, Tmp1, Tmp2, Mask);
     Tmp1 = DAG.getNode(ISD::BITCAST, dl, OVT, Tmp1);
     Results.push_back(Tmp1);
+    break;
+  }
+  case ISD::VECTOR_SPLICE_VA: {
+    Tmp1 = DAG.getNode(ISD::ANY_EXTEND, dl, NVT, Node->getOperand(0));
+    Tmp2 = DAG.getNode(ISD::ANY_EXTEND, dl, NVT, Node->getOperand(1));
+    Tmp3 = DAG.getNode(ISD::VECTOR_SPLICE_VA, dl, NVT, Tmp1, Tmp2,
+                       Node->getOperand(2));
+    Results.push_back(DAG.getNode(ISD::TRUNCATE, dl, OVT, Tmp3));
     break;
   }
   case ISD::VECTOR_SPLICE: {

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -135,6 +135,9 @@ void DAGTypeLegalizer::PromoteIntegerResult(SDNode *N, unsigned ResNo) {
                          Res = PromoteIntRes_VECTOR_SHUFFLE(N); break;
   case ISD::VECTOR_SPLICE:
                          Res = PromoteIntRes_VECTOR_SPLICE(N); break;
+  case ISD::VECTOR_SPLICE_VA:
+    Res = PromoteIntRes_VECTOR_SPLICE_VA(N);
+    break;
   case ISD::VECTOR_INTERLEAVE:
   case ISD::VECTOR_DEINTERLEAVE:
     Res = PromoteIntRes_VECTOR_INTERLEAVE_DEINTERLEAVE(N);
@@ -5918,6 +5921,16 @@ SDValue DAGTypeLegalizer::PromoteIntRes_VECTOR_SPLICE(SDNode *N) {
   EVT OutVT = V0.getValueType();
 
   return DAG.getNode(ISD::VECTOR_SPLICE, dl, OutVT, V0, V1, N->getOperand(2));
+}
+
+SDValue DAGTypeLegalizer::PromoteIntRes_VECTOR_SPLICE_VA(SDNode *N) {
+  SDLoc dl(N);
+  SDValue V0 = GetPromotedInteger(N->getOperand(0));
+  SDValue V1 = GetPromotedInteger(N->getOperand(1));
+  EVT OutVT = V0.getValueType();
+
+  return DAG.getNode(ISD::VECTOR_SPLICE_VA, dl, OutVT, V0, V1,
+                     N->getOperand(2));
 }
 
 SDValue DAGTypeLegalizer::PromoteIntRes_VECTOR_INTERLEAVE_DEINTERLEAVE(SDNode *N) {

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeTypes.h
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeTypes.h
@@ -313,6 +313,7 @@ private:
   SDValue PromoteIntRes_VECTOR_REVERSE(SDNode *N);
   SDValue PromoteIntRes_VECTOR_SHUFFLE(SDNode *N);
   SDValue PromoteIntRes_VECTOR_SPLICE(SDNode *N);
+  SDValue PromoteIntRes_VECTOR_SPLICE_VA(SDNode *N);
   SDValue PromoteIntRes_VECTOR_INTERLEAVE_DEINTERLEAVE(SDNode *N);
   SDValue PromoteIntRes_BUILD_VECTOR(SDNode *N);
   SDValue PromoteIntRes_ScalarOp(SDNode *N);
@@ -998,6 +999,7 @@ private:
   void SplitVecRes_VECTOR_SHUFFLE(ShuffleVectorSDNode *N, SDValue &Lo,
                                   SDValue &Hi);
   void SplitVecRes_VECTOR_SPLICE(SDNode *N, SDValue &Lo, SDValue &Hi);
+  void SplitVecRes_VECTOR_SPLICE_VA(SDNode *N, SDValue &Lo, SDValue &Hi);
   void SplitVecRes_VECTOR_DEINTERLEAVE(SDNode *N);
   void SplitVecRes_VECTOR_INTERLEAVE(SDNode *N);
   void SplitVecRes_VAARG(SDNode *N, SDValue &Lo, SDValue &Hi);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -8367,6 +8367,9 @@ void SelectionDAGBuilder::visitIntrinsicCall(const CallInst &I,
   case Intrinsic::vector_splice:
     visitVectorSplice(I);
     return;
+  case Intrinsic::vector_splice_va:
+    visitVectorSpliceVA(I);
+    return;
   case Intrinsic::callbr_landingpad:
     visitCallBrLandingPad(I);
     return;
@@ -12863,6 +12866,30 @@ void SelectionDAGBuilder::visitVectorSplice(const CallInst &I) {
   for (unsigned i = 0; i < NumElts; ++i)
     Mask.push_back(Idx + i);
   setValue(&I, DAG.getVectorShuffle(VT, DL, V1, V2, Mask));
+}
+
+void SelectionDAGBuilder::visitVectorSpliceVA(const CallInst &I) {
+  // Validate operand types
+  const TargetLowering &TLI = DAG.getTargetLoweringInfo();
+  EVT VT = TLI.getValueType(DAG.getDataLayout(), I.getType());
+
+  if (!VT.isVector()) {
+    // Invalid type, report error or fall back
+    return;
+  }
+
+  // Fall back to ISD::VECTOR_SPLICE just in case.
+  if (isa<ConstantInt>(I.getOperand(2))) {
+    visitVectorSplice(I);
+    return;
+  }
+
+  SDLoc DL = getCurSDLoc();
+  SDValue V1 = getValue(I.getOperand(0));
+  SDValue V2 = getValue(I.getOperand(1));
+  SDValue V3 = getValue(I.getOperand(2));
+
+  setValue(&I, DAG.getNode(ISD::VECTOR_SPLICE_VA, DL, VT, V1, V2, V3));
 }
 
 // Consider the following MIR after SelectionDAG, which produces output in

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.h
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.h
@@ -684,6 +684,7 @@ private:
   void visitVectorReduce(const CallInst &I, unsigned Intrinsic);
   void visitVectorReverse(const CallInst &I);
   void visitVectorSplice(const CallInst &I);
+  void visitVectorSpliceVA(const CallInst &I);
   void visitVectorInterleave(const CallInst &I, unsigned Factor);
   void visitVectorDeinterleave(const CallInst &I, unsigned Factor);
   void visitStepVector(const CallInst &I);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGDumper.cpp
@@ -349,6 +349,7 @@ std::string SDNode::getOperationName(const SelectionDAG *G) const {
   case ISD::SCALAR_TO_VECTOR:           return "scalar_to_vector";
   case ISD::VECTOR_SHUFFLE:             return "vector_shuffle";
   case ISD::VECTOR_SPLICE:              return "vector_splice";
+  case ISD::VECTOR_SPLICE_VA:           return "vector_splice_va";
   case ISD::SPLAT_VECTOR:               return "splat_vector";
   case ISD::SPLAT_VECTOR_PARTS:         return "splat_vector_parts";
   case ISD::VECTOR_REVERSE:             return "vector_reverse";

--- a/llvm/lib/CodeGen/TargetLoweringBase.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringBase.cpp
@@ -1163,6 +1163,7 @@ void TargetLoweringBase::initActions() {
 
     // Named vector shuffles default to expand.
     setOperationAction(ISD::VECTOR_SPLICE, VT, Expand);
+    setOperationAction(ISD::VECTOR_SPLICE_VA, VT, Expand);
 
     // Only some target support this vector operation. Most need to expand it.
     setOperationAction(ISD::VECTOR_COMPRESS, VT, Expand);

--- a/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
@@ -124,6 +124,7 @@ HexagonTargetLowering::initializeHVXLowering() {
   setOperationAction(ISD::VECTOR_SHUFFLE,          ByteV, Legal);
   setOperationAction(ISD::VECTOR_SHUFFLE,          ByteW, Legal);
   setOperationAction(ISD::INTRINSIC_WO_CHAIN, MVT::Other, Custom);
+  setOperationAction(ISD::VECTOR_SPLICE_VA, WordV, Legal);
 
   if (Subtarget.useHVX128BOps()) {
     setOperationAction(ISD::BITCAST, MVT::v32i1, Custom);

--- a/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
@@ -545,6 +545,8 @@ private:
                    SmallPtrSet<Value *, 16> &Visited) const;
   std::optional<uint64_t> getPHIBaseMinAlignment(Instruction &In,
                                                  PHINode *PN) const;
+  bool matchVectorSplice(Instruction &In) const;
+  Value *processVectorSplice(Instruction &In) const;
 
   // Vector manipulations for Ripple
   bool matchScatter(Instruction &In) const;
@@ -1876,6 +1878,13 @@ auto HvxIdioms::processFxpMul(Instruction &In, const FxpOp &Op) const
   return Ext;
 }
 
+bool HvxIdioms::matchVectorSplice(Instruction &In) const {
+  IntrinsicInst *II = dyn_cast<IntrinsicInst>(&In);
+  if (!II)
+    return false;
+  return II->getIntrinsicID() == Intrinsic::vector_splice_va;
+}
+
 inline bool HvxIdioms::matchScatter(Instruction &In) const {
   IntrinsicInst *II = dyn_cast<IntrinsicInst>(&In);
   if (!II)
@@ -1902,6 +1911,77 @@ inline bool HvxIdioms::matchMStore(Instruction &In) const {
   if (!II)
     return false;
   return (II->getIntrinsicID() == Intrinsic::masked_store);
+Value *HvxIdioms::processVectorSplice(Instruction &In) const {
+  IRBuilder Builder(In.getParent(), In.getIterator(),
+                    InstSimplifyFolder(HVC.DL));
+
+  auto *InpTy = cast<VectorType>(In.getOperand(0)->getType());
+  unsigned InpSize = HVC.getSizeOf(InpTy);
+  if (!InpTy) {
+    LLVM_DEBUG(
+        dbgs() << "Cannot handle non-vector type for llvm.vector.splice.va\n");
+    return nullptr;
+  }
+
+  LLVM_DEBUG(dbgs() << "Process vector splice " << In << "\n");
+  LLVM_DEBUG(dbgs() << "  Input type(" << *InpTy << ") elements("
+                    << HVC.length(InpTy) << ") VecLen(" << InpSize << ")\n");
+
+  auto *ElemTy = cast<IntegerType>(InpTy->getElementType());
+  if (!ElemTy) {
+    LLVM_DEBUG(
+        dbgs() << "Cannot handle FP element for llvm.vector.splice.va\n");
+    return nullptr;
+  }
+
+  unsigned ElemWidth = ElemTy->getBitWidth() >> 3;
+  LLVM_DEBUG(dbgs() << "  Element type(" << *ElemTy << ") with(" << ElemWidth
+                    << ")bytes\n");
+
+  if (In.getOperand(0) != In.getOperand(1)) {
+    LLVM_DEBUG(dbgs() << "Only support same arg for llvm.vector.splice.va\n");
+    return nullptr;
+  }
+
+  if (!HVC.HST.isTypeForHVX(InpTy)) {
+    LLVM_DEBUG(
+        dbgs() << "Non HVX type not supported for llvm.vector.splice.va\n");
+    return nullptr;
+  }
+
+  // We need to scale the rotate amound by number of bytes in a vector element;
+  Value *ShiftAmount = In.getOperand(2);
+  if (ElemWidth > 1)
+    ShiftAmount = Builder.CreateShl(
+        ShiftAmount, HVC.getConstInt(Log2_32(ElemWidth)), "ripple.scale");
+
+  if (HVC.HST.getVectorLength() == InpSize) {
+    // Native width cast to default type and vror
+    Type *NT = HVC.getHvxTy(HVC.getIntTy(ElemTy->getBitWidth()), false);
+    auto V6_vror = HVC.HST.getIntrinsicId(Hexagon::V6_vror);
+    return HVC.createHvxIntrinsic(Builder, V6_vror, NT,
+                                  {In.getOperand(0), ShiftAmount});
+  } else if (HVC.HST.getVectorLength() == InpSize * 2) {
+    // This is half of the reg width, duplicate low in high
+    Value *Pair = HVC.concat(Builder, {In.getOperand(0), In.getOperand(0)});
+    Value *Shift = HVC.vralignb(Builder, Pair, Pair, ShiftAmount);
+    return Builder.CreateExtractVector(InpTy, Shift, Builder.getInt64(0));
+  } else if (HVC.HST.getVectorLength() * 2 == InpSize) {
+    // Double vec length
+    Type *NT = HVC.getHvxTy(HVC.getIntTy(ElemTy->getBitWidth()), false);
+    auto V6_hi = HVC.HST.getIntrinsicId(Hexagon::V6_hi);
+    auto V6_lo = HVC.HST.getIntrinsicId(Hexagon::V6_lo);
+
+    Value *Hi = HVC.createHvxIntrinsic(Builder, V6_hi, NT, {In.getOperand(0)});
+    Value *Lo = HVC.createHvxIntrinsic(Builder, V6_lo, NT, {In.getOperand(0)});
+
+    Value *ShiftHiLo = HVC.vralignb(Builder, Hi, Lo, ShiftAmount);
+    Value *ShiftLoHi = HVC.vralignb(Builder, Lo, Hi, ShiftAmount);
+
+    return HVC.concat(Builder, {ShiftLoHi, ShiftHiLo});
+  }
+  // All other cases are not yet implemented.
+  llvm_unreachable("Underimplemented llvm.vector.splice.va");
 }
 
 Instruction *locateDestination(Instruction *In, HvxIdioms::DstQualifier &Qual);
@@ -3254,6 +3334,15 @@ auto HvxIdioms::run() -> bool {
         It = StartOver ? B.rbegin()
                        : cast<Instruction>(New)->getReverseIterator();
         Changed = true;
+      } else if (matchVectorSplice(*It)) {
+        Value *New = processVectorSplice(*It);
+        if (!New)
+          continue;
+        LLVM_DEBUG(dbgs() << "  Vsplice : " << *New << "\n");
+        It->replaceAllUsesWith(New);
+        RecursivelyDeleteTriviallyDeadInstructions(&*It, &HVC.TLI);
+        It = cast<Instruction>(New)->getReverseIterator();
+        Changed = true;
       } else if (matchGather(*It)) {
         Value *New = processVGather(*It);
         if (!New)
@@ -3289,7 +3378,6 @@ auto HvxIdioms::run() -> bool {
       }
     }
   }
-
   return Changed;
 }
 

--- a/llvm/test/CodeGen/Hexagon/va-vector-shuffles.ll
+++ b/llvm/test/CodeGen/Hexagon/va-vector-shuffles.ll
@@ -1,0 +1,52 @@
+; RUN: llc -march=hexagon -mcpu=hexagonv73 -mattr=+hvxv73,+hvx-length128b < %s | FileCheck %s
+
+; CHECK: splice.va.v64i16:
+; CHECK: r{{[0-9]+}} = asl(r0,#1)
+; CHECK: v0 = vror(v0,r{{[0-9]+}})
+define <64 x i16> @splice.va.v64i16(<64 x i16> %a, <64 x i16> %b, i32 %c) #0 {
+  %res = tail call <64 x i16> @llvm.vector.splice.va.v64i16(<64 x i16> %a, <64 x i16> %a, i32 %c)
+  ret <64 x i16> %res
+}
+
+; CHECK: splice.va.v64i32:
+; CHECK: r{{[0-9]+}} = asl(r0,#2)
+; CHECK: v{{[0-9]+}} = valign(v0,v1,r{{[0-9]+}})
+; CHECK: v{{[0-9]+}} = valign(v1,v0,r{{[0-9]+}})
+; CHECK: v1:0 = vcombine(v{{[0-9]+}},v{{[0-9]+}})
+define <64 x i32> @splice.va.v64i32(<64 x i32> %a, <64 x i32> %b, i32 %c) #0 {
+  %res = tail call <64 x i32> @llvm.vector.splice.va.v64i32(<64 x i32> %a, <64 x i32> %a, i32 %c)
+  ret <64 x i32> %res
+}
+
+; CHECK: splice.va.v32i32:
+; CHECK: r{{[0-9]+}} = asl(r0,#2)
+; CHECK: v0 = vror(v0,r{{[0-9]+}})
+define <32 x i32> @splice.va.v32i32(<32 x i32> %a, <32 x i32> %b, i32 %c) #0 {
+  %res = tail call <32 x i32> @llvm.vector.splice.va.v32i32(<32 x i32> %a, <32 x i32> %a, i32 %c)
+  ret <32 x i32> %res
+}
+
+; CHECK: splice.va.v16i32:
+; CHECK: r0 = asl(r0,#2)
+; CHECK: r{{[0-9]+}} = #64
+; CHECK: v1:0 = vshuff(v0,v0,r{{[0-9]+}})
+; CHECK: v0 = valign(v0,v0,r0)
+define <16 x i32> @splice.va.v16i32(<16 x i32> %a, <16 x i32> %b, i32 %c) #0 {
+  %res = tail call <16 x i32> @llvm.vector.splice.va.v16i32(<16 x i32> %a, <16 x i32> %a, i32 %c)
+  ret <16 x i32> %res
+}
+
+; CHECK: splice.va.v128i8:
+; CHECK: v0 = vror(v0,r0)
+define <128 x i8> @splice.va.v128i8(<128 x i8> %a, <128 x i8> %b, i32 %c) #0 {
+  %res = tail call <128 x i8> @llvm.vector.splice.va.v128i8(<128 x i8> %a, <128 x i8> %a, i32 %c)
+  ret <128 x i8> %res
+}
+
+declare <16 x i32> @llvm.vector.splice.va.v16i32(<16 x i32>, <16 x i32>, i32)
+declare <32 x i32> @llvm.vector.splice.va.v32i32(<32 x i32>, <32 x i32>, i32)
+declare <64 x i32> @llvm.vector.splice.va.v64i32(<64 x i32>, <64 x i32>, i32)
+declare <64 x i16> @llvm.vector.splice.va.v64i16(<64 x i16>, <64 x i16>, i32)
+declare <128 x i8> @llvm.vector.splice.va.v128i8(<128 x i8>, <128 x i8>, i32)
+
+attributes #0 = { nounwind "target-cpu"="hexagonv73" "target-features"="+hvxv73,+hvx-length128b" }


### PR DESCRIPTION
This is initial patch that handles most common cases. Generic implementation is still needed.

Patch By: Fateme Hosseini