### PR TITLE
[llvm] Fix LLVMOrcTargetProcess symbol export with MinGW/Cygwin shared libs

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/CMakeLists.txt
@@ -44,3 +44,13 @@ add_llvm_component_library(LLVMOrcTargetProcess
   Support
   TargetParser
   )
+
+if ((MINGW OR CYGWIN) AND BUILD_SHARED_LIBS)
+  # This library contains symbols marked with LLVM_ALWAYS_EXPORT (__declspec(
+  # dllexport)) so that they can be found via GetProcAddress from a statically
+  # linked exe. When any symbol in a DLL carries dllexport, the MinGW/Cygwin
+  # linker switches to exclusive-export mode and omits all other symbols from
+  # the export table. Add --export-all-symbols to restore full export of all
+  # symbols despite the targeted dllexports.
+  target_link_options(LLVMOrcTargetProcess PRIVATE LINKER:--export-all-symbols)
+endif()


### PR DESCRIPTION
When any symbol in a DLL carries dllexport, the MinGW/Cygwin linker
switches to exclusive-export mode and omits all other symbols from the
export table. LLVMOrcTargetProcess uses LLVM_ALWAYS_EXPORT (__declspec(
dllexport)) so its symbols can be found via GetProcAddress from a
statically linked executable, which triggers this behaviour.

Add --export-all-symbols to LLVMOrcTargetProcess for MinGW/Cygwin
BUILD_SHARED_LIBS builds to restore full symbol export.