### PR TITLE
[clang-doc] Serialize type info for function parameters

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -448,7 +448,11 @@ static void serializeInfo(const TypeInfo &I, Object &Obj) {
 
 static void serializeInfo(const FieldTypeInfo &I, Object &Obj) {
   Obj["Name"] = I.Name;
-  Obj["Type"] = I.Type.Name;
+  insertNonEmpty("DefaultValue", I.DefaultValue, Obj);
+  json::Value ReferenceVal = Object();
+  Object &ReferenceObj = *ReferenceVal.getAsObject();
+  serializeReference(I.Type, ReferenceObj);
+  Obj["Type"] = ReferenceVal;
 }
 
 static void serializeInfo(const FunctionInfo &F, json::Object &Obj,

--- a/clang-tools-extra/clang-doc/assets/class-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/class-template.mustache
@@ -243,7 +243,7 @@
                         <pre><code class="language-cpp code-clang-doc">class {{Reference.Name}}</code></pre>
                         {{/IsClass}}
                         {{^IsClass}}
-                        <pre><code class="language-cpp code-clang-doc">{{ReturnType.Name}} {{Name}}{{#Template}}{{#Specialization}}&lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;{{/Specialization}}{{/Template}} ({{#Params}}{{^End}}{{Type}} {{Name}}, {{/End}}{{#End}}{{Type}} {{Name}}{{/End}}{{/Params}})</code></pre>
+                        <pre><code class="language-cpp code-clang-doc">{{ReturnType.Name}} {{Name}}{{#Template}}{{#Specialization}}&lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;{{/Specialization}}{{/Template}} ({{#Params}}{{Type.QualName}} {{Name}}{{^End}}, {{/End}}{{/Params}})</code></pre>
                         {{/IsClass}}
                         {{#.Description}}
                         {{>Comments}}

--- a/clang-tools-extra/clang-doc/assets/function-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/function-template.mustache
@@ -11,7 +11,7 @@
         <pre><code class="language-cpp code-clang-doc">template &lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;</code></pre>
         {{/Template}}
         {{! Function Prototype }}
-        <pre><code class="language-cpp code-clang-doc">{{ReturnType.Name}} {{Name}}{{#Template}}{{#Specialization}}&lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;{{/Specialization}}{{/Template}} ({{#Params}}{{^End}}{{Type}} {{Name}}, {{/End}}{{#End}}{{Type}} {{Name}}{{/End}}{{/Params}})</code></pre>
+        <pre><code class="language-cpp code-clang-doc">{{ReturnType.QualName}} {{Name}}{{#Template}}{{#Specialization}}&lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;{{/Specialization}}{{/Template}} ({{#Params}}{{Type.QualName}} {{Name}}{{^End}}, {{/End}}{{/Params}})</code></pre>
         {{! Function Comments }}
         {{#Description}}
         <div>

--- a/clang-tools-extra/test/clang-doc/json/class-template.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class-template.cpp
@@ -13,7 +13,11 @@ template<typename T> struct MyClass {
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "End": true,
 // CHECK-NEXT:        "Name": "Param",
-// CHECK-NEXT:        "Type": "T"
+// CHECK-NEXT:        "Type": {
+// CHECK-NEXT:          "Name": "T",
+// CHECK-NEXT:          "QualName": "T",
+// CHECK-NEXT:          "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:        }
 // CHECK-NEXT:      } 
 // CHECK-NEXT:    ], 
 // CHECK-NEXT:    "ReturnType": {

--- a/clang-tools-extra/test/clang-doc/json/class.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class.cpp
@@ -104,7 +104,11 @@ private:
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "End": true,
 // CHECK-NEXT:            "Name": "",
-// CHECK-NEXT:            "Type": "int"
+// CHECK-NEXT:            "Type": {
+// CHECK-NEXT:              "Name": "int",
+// CHECK-NEXT:              "QualName": "int",
+// CHECK-NEXT:              "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:            }
 // CHECK-NEXT:          }
 // CHECK-NEXT:        ],
 // CHECK-NEXT:        "Reference": {
@@ -217,7 +221,11 @@ private:
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "End": true,
 // CHECK-NEXT:            "Name": "MyParam",
-// CHECK-NEXT:            "Type": "int"
+// CHECK-NEXT:            "Type": {
+// CHECK-NEXT:              "Name": "int",
+// CHECK-NEXT:              "QualName": "int",
+// CHECK-NEXT:              "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:            }
 // CHECK-NEXT:          }
 // CHECK-NEXT:        ],
 // CHECK-NEXT:        "ReturnType": {

--- a/clang-tools-extra/test/clang-doc/json/function-requires.cpp
+++ b/clang-tools-extra/test/clang-doc/json/function-requires.cpp
@@ -21,7 +21,11 @@ template<Incrementable T> Incrementable auto incrementTwo(T t);
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "End": true,
 // CHECK-NEXT:          "Name": "t",
-// CHECK-NEXT:          "Type": "T"
+// CHECK-NEXT:          "Type": {
+// CHECK-NEXT:            "Name": "T",
+// CHECK-NEXT:            "QualName": "T",
+// CHECK-NEXT:            "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:          }
 // CHECK-NEXT:        }
 // CHECK-NEXT:      ],
 // CHECK-NEXT:      "ReturnType": {
@@ -59,7 +63,11 @@ template<Incrementable T> Incrementable auto incrementTwo(T t);
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "End": true,
 // CHECK-NEXT:          "Name": "t",
-// CHECK-NEXT:          "Type": "T"
+// CHECK-NEXT:          "Type": {
+// CHECK-NEXT:            "Name": "T",
+// CHECK-NEXT:            "QualName": "T",
+// CHECK-NEXT:            "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:          }
 // CHECK-NEXT:        }
 // CHECK-NEXT:      ],
 // CHECK-NEXT:      "ReturnType": {

--- a/clang-tools-extra/test/clang-doc/json/method-template.cpp
+++ b/clang-tools-extra/test/clang-doc/json/method-template.cpp
@@ -24,7 +24,11 @@ struct MyClass {
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "End": true,
 // CHECK-NEXT:              "Name": "param",
-// CHECK-NEXT:              "Type": "T"
+// CHECK-NEXT:              "Type": {
+// CHECK-NEXT:                "Name": "T",
+// CHECK-NEXT:                "QualName": "T",
+// CHECK-NEXT:                "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:              }
 // CHECK-NEXT:            }
 // CHECK-NEXT:          ],
 // CHECK-NEXT:          "ReturnType": {

--- a/clang-tools-extra/test/clang-doc/json/namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/json/namespace.cpp
@@ -59,7 +59,11 @@ typedef int MyTypedef;
 // CHECK-NEXT:         {
 // CHECK-NEXT:           "End": true,
 // CHECK-NEXT:           "Name": "Param",
-// CHECK-NEXT:           "Type": "int"
+// CHECK-NEXT:           "Type": {
+// CHECK-NEXT:             "Name": "int",
+// CHECK-NEXT:             "QualName": "int",
+// CHECK-NEXT:             "USR": "0000000000000000000000000000000000000000"
+// CHECK-NEXT:           }
 // CHECK-NEXT:         }
 // CHECK-NEXT:       ],
 // CHECK-NEXT:       "ReturnType": {

--- a/clang-tools-extra/test/clang-doc/templates.cpp
+++ b/clang-tools-extra/test/clang-doc/templates.cpp
@@ -54,7 +54,11 @@ void ParamPackFunction(T... args);
 // JSON-NEXT:        {
 // JSON-NEXT:          "End": true,
 // JSON-NEXT:          "Name": "args",
-// JSON-NEXT:          "Type": "T..."
+// JSON-NEXT:          "Type": {
+// JSON-NEXT:            "Name": "T...",
+// JSON-NEXT:            "QualName": "T...",
+// JSON-NEXT:            "USR": "0000000000000000000000000000000000000000"
+// JSON-NEXT:          }
 // JSON-NEXT:        }
 // JSON-NEXT:      ],
 // JSON-NEXT:      "ReturnType": {
@@ -113,7 +117,11 @@ void function(T x) {}
 // JSON-NEXT:        {
 // JSON-NEXT:          "End": true,
 // JSON-NEXT:          "Name": "x",
-// JSON-NEXT:          "Type": "T"
+// JSON-NEXT:          "Type": {
+// JSON-NEXT:            "Name": "T",
+// JSON-NEXT:            "QualName": "T",
+// JSON-NEXT:            "USR": "0000000000000000000000000000000000000000"
+// JSON-NEXT:          }
 // JSON-NEXT:        }
 // JSON-NEXT:      ],
 // JSON-NEXT:      "ReturnType": {
@@ -139,7 +147,7 @@ void function(T x) {}
 // HTML-NEXT:      <div id="{{([0-9A-F]{40})}}">
 // HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">template &lt;typename T, int U = 1&gt;</code></pre>
 // HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">void function (T x)</code></pre>
-// HTML-NEXT:          <p>Defined at line [[# @LINE - 56]] of file {{.*}}templates.cpp</p>
+// HTML-NEXT:          <p>Defined at line [[# @LINE - 60]] of file {{.*}}templates.cpp</p>
 // HTML-NEXT:      </div>
 // HTML-NEXT:  </div>
 
@@ -177,7 +185,11 @@ void function<bool, 0>(bool x) {}
 // JSON-NEXT:        {
 // JSON-NEXT:          "End": true,
 // JSON-NEXT:          "Name": "x",
-// JSON-NEXT:          "Type": "bool"
+// JSON-NEXT:          "Type": {
+// JSON-NEXT:            "Name": "bool",
+// JSON-NEXT:            "QualName": "bool",
+// JSON-NEXT:            "USR": "0000000000000000000000000000000000000000"
+// JSON-NEXT:          }
 // JSON-NEXT:        }
 // JSON-NEXT:      ],
 // JSON-NEXT:      "ReturnType": {
@@ -206,7 +218,7 @@ void function<bool, 0>(bool x) {}
 // HTML-NEXT:      <div id="{{([0-9A-F]{40})}}">
 // HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">template &lt;&gt;</code></pre>
 // HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">void function&lt;bool, 0&gt; (bool x)</code></pre>
-// HTML-NEXT:          <p>Defined at line [[# @LINE - 62]] of file {{.*}}templates.cpp</p>
+// HTML-NEXT:          <p>Defined at line [[# @LINE - 66]] of file {{.*}}templates.cpp</p>
 // HTML-NEXT:      </div>
 // HTML-NEXT:  </div>
 
@@ -284,12 +296,16 @@ tuple<int, int, bool> func_with_tuple_param(tuple<int, int, bool> t) { return t;
 // MD: **t** The input to func_with_tuple_param
 
 // JSON:           "Name": "func_with_tuple_param",
-// COM:            FIXME: Add type info to parameters
 // JSON-NEXT:      "Params": [
 // JSON-NEXT:        {
 // JSON-NEXT:          "End": true,
 // JSON-NEXT:          "Name": "t",
-// JSON-NEXT:          "Type": "tuple"
+// JSON-NEXT:          "Type": {
+// JSON-NEXT:            "Name": "tuple",
+// JSON-NEXT:            "Path": "GlobalNamespace",
+// JSON-NEXT:            "QualName": "tuple<int, int, bool>",
+// JSON-NEXT:            "USR": "{{([0-9A-F]{40})}}"
+// JSON-NEXT:          }
 // JSON-NEXT:        }
 // JSON-NEXT:      ],
 // JSON-NEXT:      "ReturnType": {
@@ -302,7 +318,7 @@ tuple<int, int, bool> func_with_tuple_param(tuple<int, int, bool> t) { return t;
 
 // HTML:       <div class="delimiter-container">
 // HTML-NEXT:      <div id="{{([0-9A-F]{40})}}">
-// HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">tuple func_with_tuple_param (tuple t)</code></pre>
+// HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">tuple&lt;int, int, bool&gt; func_with_tuple_param (tuple&lt;int, int, bool&gt; t)</code></pre>
 // HTML-NEXT:          <div>
 // HTML-NEXT:              <div>
 // HTML-NEXT:                  <p> A function with a tuple parameter</p>
@@ -312,6 +328,6 @@ tuple<int, int, bool> func_with_tuple_param(tuple<int, int, bool> t) { return t;
 // HTML-NEXT:                  <b>t</b>   The input to func_with_tuple_param
 // HTML-NEXT:              </div> 
 // HTML-NEXT:          </div>
-// HTML-NEXT:          <p>Defined at line [[# @LINE - 77]] of file {{.*}}templates.cpp</p>
+// HTML-NEXT:          <p>Defined at line [[# @LINE - 81]] of file {{.*}}templates.cpp</p>
 // HTML-NEXT:      </div>
 // HTML-NEXT:  </div>


### PR DESCRIPTION
Only the type name of function parameters were serialized, which was
left over from the old Mustache generator. Without the type info, the
fully qualified name of templated parameters wouldn't serialized.