### PR TITLE
[InstCombine] Fold ((X + AddC) & Mask) ^ Mask to (~AddC - X) & Mask

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -5185,10 +5185,11 @@ static Instruction *foldAndWithMask(BinaryOperator &I,
   Value *InnerVal;
   const APInt *AndMask, *XorMask, *AddC;
 
-  if (match(&I, m_Xor(m_And(m_Add(m_Value(InnerVal), m_APInt(AddC)),
-                            m_APInt(AndMask)),
+  if (match(&I, m_Xor(m_OneUse(m_And(
+                          m_OneUse(m_Add(m_Value(InnerVal), m_APInt(AddC))),
+                          m_LowBitMask(AndMask))),
                       m_APInt(XorMask))) &&
-      *AndMask == *XorMask && AndMask->isMask()) {
+      *AndMask == *XorMask) {
     APInt NewConst = *AndMask - *AddC;
     Value *NewSub =
         Builder.CreateSub(ConstantInt::get(I.getType(), NewConst), InnerVal);

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -5191,7 +5191,7 @@ static Instruction *foldMaskedAddXorPattern(BinaryOperator &I,
                                      m_Add(m_Value(X), m_ImmConstant(AddC)))),
                                  m_Value(Mask))),
                   m_Deferred(Mask)))) {
-    Constant *NotC = ConstantExpr::getNot(AddC);
+    Value *NotC = Builder.CreateNot(AddC);
     Value *NewSub = Builder.CreateSub(NotC, X, "", AddInst->hasNoUnsignedWrap(),
                                       AddInst->hasNoSignedWrap());
     return BinaryOperator::CreateAnd(NewSub, Mask);

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -5181,7 +5181,8 @@ Instruction *InstCombinerImpl::foldNot(BinaryOperator &I) {
 
 // ((X + C) & M) ^ M --> ((M − C) − X) & M
 static Instruction *foldMaskedAddXorPattern(BinaryOperator &I,
-                                            InstCombiner::BuilderTy &Builder) {
+                                            InstCombiner::BuilderTy &Builder,
+                                            InstCombinerImpl &IC) {
   Value *InnerVal;
   const APInt *AndMask, *XorMask, *AddC;
 
@@ -5191,6 +5192,16 @@ static Instruction *foldMaskedAddXorPattern(BinaryOperator &I,
                       m_APInt(XorMask))) &&
       *AndMask == *XorMask) {
     APInt NewConst = *AndMask - *AddC;
+    unsigned BitWidth = I.getType()->getScalarSizeInBits();
+    ConstantRange Range =
+        computeConstantRange(InnerVal, /*signed*/ true,
+                             /*UseInstrInfo=*/true, &IC.getAssumptionCache(),
+                             &I, &IC.getDominatorTree(), 0);
+    // Since C <= (X + C) <= M always holds, 'nuw' check is unnecessary.
+    // Bail out if 'nsw' is implied to avoid creating poison for X=INT_MIN.
+    if (!Range.contains(APInt::getSignedMinValue(BitWidth)))
+      return nullptr;
+
     Value *NewSub =
         Builder.CreateSub(ConstantInt::get(I.getType(), NewConst), InnerVal);
 
@@ -5537,7 +5548,7 @@ Instruction *InstCombinerImpl::visitXor(BinaryOperator &I) {
   if (Instruction *Res = foldBitwiseLogicWithIntrinsics(I, Builder))
     return Res;
 
-  if (Instruction *Res = foldMaskedAddXorPattern(I, Builder))
+  if (Instruction *Res = foldMaskedAddXorPattern(I, Builder, *this))
     return Res;
 
   return nullptr;

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -5184,26 +5184,23 @@ static Instruction *foldMaskedAddXorPattern(BinaryOperator &I,
                                             InstCombiner::BuilderTy &Builder,
                                             InstCombinerImpl &IC) {
   Value *InnerVal;
+  Value *AddOpVal;
   const APInt *AndMask, *XorMask, *AddC;
-
-  if (match(&I, m_Xor(m_OneUse(m_And(
-                          m_OneUse(m_Add(m_Value(InnerVal), m_APInt(AddC))),
-                          m_LowBitMask(AndMask))),
-                      m_APInt(XorMask))) &&
+  if (match(&I,
+            m_Xor(m_OneUse(m_And(m_OneUse(m_CombineAnd(
+                                     m_Value(AddOpVal),
+                                     m_Add(m_Value(InnerVal), m_APInt(AddC)))),
+                                 m_LowBitMask(AndMask))),
+                  m_APInt(XorMask))) &&
       *AndMask == *XorMask) {
     APInt NewConst = *AndMask - *AddC;
-    unsigned BitWidth = I.getType()->getScalarSizeInBits();
-    ConstantRange Range =
-        computeConstantRange(InnerVal, /*signed*/ true,
-                             /*UseInstrInfo=*/true, &IC.getAssumptionCache(),
-                             &I, &IC.getDominatorTree(), 0);
-    // Since C <= (X + C) <= M always holds, 'nuw' check is unnecessary.
-    // Bail out if 'nsw' is implied to avoid creating poison for X=INT_MIN.
-    if (!Range.contains(APInt::getSignedMinValue(BitWidth)))
-      return nullptr;
-
-    Value *NewSub =
-        Builder.CreateSub(ConstantInt::get(I.getType(), NewConst), InnerVal);
+    ConstantRange XRange = computeConstantRange(
+        InnerVal, /*signed*/ true, /*UseInstrInfo=*/true,
+        &IC.getAssumptionCache(), &I, &IC.getDominatorTree(), 0);
+    ConstantRange SubRange = ConstantRange(NewConst).sub(XRange);
+    bool InfersNSW = !SubRange.isSignWrappedSet();
+    Value *NewSub = Builder.CreateSub(ConstantInt::get(I.getType(), NewConst),
+                                      InnerVal, "", false, InfersNSW);
 
     return BinaryOperator::CreateAnd(NewSub,
                                      ConstantInt::get(I.getType(), *AndMask));

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -5180,8 +5180,8 @@ Instruction *InstCombinerImpl::foldNot(BinaryOperator &I) {
 }
 
 // ((X + C) & M) ^ M --> ((M − C) − X) & M
-static Instruction *foldAndWithMask(BinaryOperator &I,
-                                    InstCombiner::BuilderTy &Builder) {
+static Instruction *foldMaskedAddXorPattern(BinaryOperator &I,
+                                            InstCombiner::BuilderTy &Builder) {
   Value *InnerVal;
   const APInt *AndMask, *XorMask, *AddC;
 
@@ -5537,7 +5537,7 @@ Instruction *InstCombinerImpl::visitXor(BinaryOperator &I) {
   if (Instruction *Res = foldBitwiseLogicWithIntrinsics(I, Builder))
     return Res;
 
-  if (Instruction *Res = foldAndWithMask(I, Builder))
+  if (Instruction *Res = foldMaskedAddXorPattern(I, Builder))
     return Res;
 
   return nullptr;

--- a/llvm/test/Transforms/InstCombine/and-xor-merge.ll
+++ b/llvm/test/Transforms/InstCombine/and-xor-merge.ll
@@ -79,3 +79,116 @@ define i32 @PR75692_3(i32 %x, i32 %y) {
   %t4 = and i32 %t2, %t3
   ret i32 %t4
 }
+
+; ((X + C) & M) ^ M --> ((M − C) − X) & M
+define i8 @add_and_xor_basic(i8 %x) {
+; CHECK-LABEL: @add_and_xor_basic(
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[X:%.*]], 5
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[ADD]], 15
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], 15
+; CHECK-NEXT:    ret i8 [[XOR]]
+;
+  %add = add i8 %x, 5
+  %and = and i8 %add, 15
+  %xor = xor i8 %and, 15
+  ret i8 %xor
+}
+
+define <4 x i32> @add_and_xor_vector_splat(<4 x i32> %x) {
+; CHECK-LABEL: @add_and_xor_vector_splat(
+; CHECK-NEXT:    [[ADD:%.*]] = add <4 x i32> [[X:%.*]], splat (i32 10)
+; CHECK-NEXT:    [[AND:%.*]] = and <4 x i32> [[ADD]], splat (i32 63)
+; CHECK-NEXT:    [[XOR:%.*]] = xor <4 x i32> [[AND]], splat (i32 63)
+; CHECK-NEXT:    ret <4 x i32> [[XOR]]
+;
+  %add = add <4 x i32> %x, <i32 10, i32 10, i32 10, i32 10>
+  %and = and <4 x i32> %add, <i32 63, i32 63, i32 63, i32 63>
+  %xor = xor <4 x i32> %and, <i32 63, i32 63, i32 63, i32 63>
+  ret <4 x i32> %xor
+}
+
+define i32 @add_and_xor_overflow_addc(i32 %x) {
+; CHECK-LABEL: @add_and_xor_overflow_addc(
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X:%.*]], 4
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 31
+; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 31
+; CHECK-NEXT:    ret i32 [[XOR]]
+;
+  %add = add i32 %x, 100
+  %and = and i32 %add, 31
+  %xor = xor i32 %and, 31
+  ret i32 %xor
+}
+
+define i32 @add_and_xor_negative_addc(i32 %x) {
+; CHECK-LABEL: @add_and_xor_negative_addc(
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X:%.*]], 254
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 255
+; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 255
+; CHECK-NEXT:    ret i32 [[XOR]]
+;
+  %add = add i32 %x, -2
+  %and = and i32 %add, 255
+  %xor = xor i32 %and, 255
+  ret i32 %xor
+}
+
+; This test is trasformed to 'xor(and(add x, 11), 15), 15)' and being applied.
+define i8 @add_and_xor_sub_op(i8 %x) {
+; CHECK-LABEL: @add_and_xor_sub_op(
+; CHECK-NEXT:    [[SUB:%.*]] = add i8 [[X:%.*]], 11
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[SUB]], 15
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], 15
+; CHECK-NEXT:    ret i8 [[XOR]]
+;
+  %sub = sub i8 %x, 5
+  %and = and i8 %sub, 15
+  %xor = xor i8 %and, 15
+  ret i8 %xor
+}
+
+
+; and_xor_mask negative tests
+
+define i8 @neg_add_and_xor_mask_mismatch(i8 %x) {
+; CHECK-LABEL: @neg_add_and_xor_mask_mismatch(
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[X:%.*]], 5
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[ADD]], 15
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], 7
+; CHECK-NEXT:    ret i8 [[XOR]]
+;
+  %add = add i8 %x, 5
+  %and = and i8 %add, 15
+  %xor = xor i8 %and, 7
+  ret i8 %xor
+}
+
+define i8 @neg_add_and_xor_not_low_mask(i8 %x) {
+; CHECK-LABEL: @neg_add_and_xor_not_low_mask(
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[X:%.*]], 5
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[ADD]], 16
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], 16
+; CHECK-NEXT:    ret i8 [[XOR]]
+;
+  %add = add i8 %x, 5
+  %and = and i8 %add, 16
+  %xor = xor i8 %and, 16
+  ret i8 %xor
+}
+
+define i8 @neg_add_and_xor_multi_use(i8 %x) {
+; CHECK-LABEL: @neg_add_and_xor_multi_use(
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[X:%.*]], 5
+; CHECK-NEXT:    call void @use(i8 [[ADD]])
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[ADD]], 15
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], 15
+; CHECK-NEXT:    ret i8 [[XOR]]
+;
+  %add = add i8 %x, 5
+  call void @use(i8 %add)
+  %and = and i8 %add, 15
+  %xor = xor i8 %and, 15
+  ret i8 %xor
+}
+
+declare void @use(i8)

--- a/llvm/test/Transforms/InstCombine/and-xor-merge.ll
+++ b/llvm/test/Transforms/InstCombine/and-xor-merge.ll
@@ -175,8 +175,8 @@ define i8 @neg_add_and_xor_multi_use(i8 %x) {
 ; CHECK-LABEL: @neg_add_and_xor_multi_use(
 ; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[X:%.*]], 5
 ; CHECK-NEXT:    call void @use(i8 [[ADD]])
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i8 10, [[X]]
-; CHECK-NEXT:    [[XOR:%.*]] = and i8 [[TMP1]], 15
+; CHECK-NEXT:    [[AND:%.*]] = and i8 [[ADD]], 15
+; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], 15
 ; CHECK-NEXT:    ret i8 [[XOR]]
 ;
   %add = add i8 %x, 5

--- a/llvm/test/Transforms/InstCombine/and-xor-merge.ll
+++ b/llvm/test/Transforms/InstCombine/and-xor-merge.ll
@@ -93,43 +93,6 @@ define i8 @add_and_xor_basic(i8 %x) {
   ret i8 %xor
 }
 
-; Negative test
-; Should not optimize Cases where `nsw` is added to the sub.
-define i32 @add_and_xor_nsw(i32 %x) {
-; CHECK-LABEL: @add_and_xor_nsw(
-; CHECK-NEXT:    [[IS_POS:%.*]] = icmp sgt i32 [[X:%.*]], -1
-; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_POS]])
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[X]], 63
-; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 63
-; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 63
-; CHECK-NEXT:    ret i32 [[XOR]]
-;
-  %is_pos = icmp sgt i32 %x, -1
-  call void @llvm.assume(i1 %is_pos)
-  %add = add nuw nsw i32 %x, 63
-  %and = and i32 %add, 63
-  %xor = xor i32 %and, 63
-  ret i32 %xor
-}
-
-; Should not optimize Cases where `nsw` `nuw` is added to the sub.
-define i32 @add_and_xor_nsw_nuw(i32 %x) {
-; CHECK-LABEL: @add_and_xor_nsw_nuw(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X:%.*]], 10
-; CHECK-NEXT:    call void @llvm.assume(i1 [[CMP]])
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[X]], 54
-; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 63
-; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 63
-; CHECK-NEXT:    ret i32 [[XOR]]
-;
-  %cmp = icmp ult i32 %x, 10
-  call void @llvm.assume(i1 %cmp)
-  %add = add i32 %x, 4294967286
-  %and = and i32 %add, 63
-  %xor = xor i32 %and, 63
-  ret i32 %xor
-}
-
 define <4 x i32> @add_and_xor_vector_splat(<4 x i32> %x) {
 ; CHECK-LABEL: @add_and_xor_vector_splat(
 ; CHECK-NEXT:    [[ADD:%.*]] = sub <4 x i32> splat (i32 53), [[X:%.*]]

--- a/llvm/test/Transforms/InstCombine/and-xor-merge.ll
+++ b/llvm/test/Transforms/InstCombine/and-xor-merge.ll
@@ -83,7 +83,7 @@ define i32 @PR75692_3(i32 %x, i32 %y) {
 ; ((X + C) & M) ^ M --> ((M − C) − X) & M
 define i8 @add_and_xor_basic(i8 %x) {
 ; CHECK-LABEL: @add_and_xor_basic(
-; CHECK-NEXT:    [[ADD:%.*]] = sub i8 10, [[X:%.*]]
+; CHECK-NEXT:    [[ADD:%.*]] = sub nsw i8 10, [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[ADD]], 15
 ; CHECK-NEXT:    ret i8 [[AND]]
 ;
@@ -93,16 +93,13 @@ define i8 @add_and_xor_basic(i8 %x) {
   ret i8 %xor
 }
 
-; Negative test
-; Should not optimize Cases where `nsw` is added to the sub.
 define i32 @add_and_xor_nsw(i32 %x) {
 ; CHECK-LABEL: @add_and_xor_nsw(
 ; CHECK-NEXT:    [[IS_POS:%.*]] = icmp sgt i32 [[X:%.*]], -1
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_POS]])
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[X]], 63
+; CHECK-NEXT:    [[ADD:%.*]] = sub nsw i32 0, [[X]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 63
-; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 63
-; CHECK-NEXT:    ret i32 [[XOR]]
+; CHECK-NEXT:    ret i32 [[AND]]
 ;
   %is_pos = icmp sgt i32 %x, -1
   call void @llvm.assume(i1 %is_pos)
@@ -112,15 +109,13 @@ define i32 @add_and_xor_nsw(i32 %x) {
   ret i32 %xor
 }
 
-; Should not optimize Cases where `nsw` `nuw` is added to the sub.
 define i32 @add_and_xor_nsw_nuw(i32 %x) {
 ; CHECK-LABEL: @add_and_xor_nsw_nuw(
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X:%.*]], 10
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[CMP]])
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[X]], 54
+; CHECK-NEXT:    [[ADD:%.*]] = sub nsw i32 9, [[X]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 63
-; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 63
-; CHECK-NEXT:    ret i32 [[XOR]]
+; CHECK-NEXT:    ret i32 [[AND]]
 ;
   %cmp = icmp ult i32 %x, 10
   call void @llvm.assume(i1 %cmp)
@@ -132,7 +127,7 @@ define i32 @add_and_xor_nsw_nuw(i32 %x) {
 
 define <4 x i32> @add_and_xor_vector_splat(<4 x i32> %x) {
 ; CHECK-LABEL: @add_and_xor_vector_splat(
-; CHECK-NEXT:    [[ADD:%.*]] = sub <4 x i32> splat (i32 53), [[X:%.*]]
+; CHECK-NEXT:    [[ADD:%.*]] = sub nsw <4 x i32> splat (i32 53), [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and <4 x i32> [[ADD]], splat (i32 63)
 ; CHECK-NEXT:    ret <4 x i32> [[AND]]
 ;
@@ -144,7 +139,7 @@ define <4 x i32> @add_and_xor_vector_splat(<4 x i32> %x) {
 
 define i32 @add_and_xor_overflow_addc(i32 %x) {
 ; CHECK-LABEL: @add_and_xor_overflow_addc(
-; CHECK-NEXT:    [[ADD:%.*]] = sub i32 27, [[X:%.*]]
+; CHECK-NEXT:    [[ADD:%.*]] = sub nsw i32 27, [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 31
 ; CHECK-NEXT:    ret i32 [[AND]]
 ;
@@ -156,7 +151,7 @@ define i32 @add_and_xor_overflow_addc(i32 %x) {
 
 define i32 @add_and_xor_negative_addc(i32 %x) {
 ; CHECK-LABEL: @add_and_xor_negative_addc(
-; CHECK-NEXT:    [[ADD:%.*]] = sub i32 1, [[X:%.*]]
+; CHECK-NEXT:    [[ADD:%.*]] = sub nsw i32 1, [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 255
 ; CHECK-NEXT:    ret i32 [[AND]]
 ;
@@ -169,7 +164,7 @@ define i32 @add_and_xor_negative_addc(i32 %x) {
 ; This test is trasformed to 'xor(and(add x, 11), 15), 15)' and being applied.
 define i8 @add_and_xor_sub_op(i8 %x) {
 ; CHECK-LABEL: @add_and_xor_sub_op(
-; CHECK-NEXT:    [[SUB:%.*]] = sub i8 4, [[X:%.*]]
+; CHECK-NEXT:    [[SUB:%.*]] = sub nsw i8 4, [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[SUB]], 15
 ; CHECK-NEXT:    ret i8 [[AND]]
 ;

--- a/llvm/test/Transforms/InstCombine/and-xor-merge.ll
+++ b/llvm/test/Transforms/InstCombine/and-xor-merge.ll
@@ -81,56 +81,52 @@ define i32 @PR75692_3(i32 %x, i32 %y) {
 }
 
 ; ((X + C) & M) ^ M --> (~C − X) & M
-define i32 @add_and_xor_fomula_basic(i32 %x, i32 %AddC, i32 %M) {
+define i32 @add_and_xor_fomula_basic(i32 %x, i32 %M) {
 ; CHECK-LABEL: @add_and_xor_fomula_basic(
-; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X:%.*]], [[ADDC:%.*]]
-; CHECK-NEXT:    [[AND1:%.*]] = xor i32 [[ADD]], -1
+; CHECK-NEXT:    [[AND1:%.*]] = sub i32 0, [[X:%.*]]
 ; CHECK-NEXT:    [[XOR:%.*]] = and i32 [[M:%.*]], [[AND1]]
 ; CHECK-NEXT:    ret i32 [[XOR]]
 ;
-  %add = add i32 %x, %AddC
+  %add = add i32 %x, -1
   %and = and i32 %add, %M
   %xor = xor i32 %and, %M
   ret i32 %xor
 }
 
-define i32 @add_and_xor_fomula_nsw(i32 %x, i32 %AddC, i32 %M) {
+define i64 @add_and_xor_fomula_nsw(i64 %x, i64 %M) {
 ; CHECK-LABEL: @add_and_xor_fomula_nsw(
-; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[X:%.*]], [[ADDC:%.*]]
-; CHECK-NEXT:    [[AND1:%.*]] = xor i32 [[ADD]], -1
-; CHECK-NEXT:    [[XOR:%.*]] = and i32 [[M:%.*]], [[AND1]]
-; CHECK-NEXT:    ret i32 [[XOR]]
+; CHECK-NEXT:    [[AND1:%.*]] = sub i64 0, [[X:%.*]]
+; CHECK-NEXT:    [[XOR:%.*]] = and i64 [[M:%.*]], [[AND1]]
+; CHECK-NEXT:    ret i64 [[XOR]]
 ;
-  %add = add nsw i32 %x, %AddC
-  %and = and i32 %add, %M
-  %xor = xor i32 %and, %M
-  ret i32 %xor
+  %add = add nsw i64 %x, -1
+  %and = and i64 %add, %M
+  %xor = xor i64 %and, %M
+  ret i64 %xor
 }
 
-define i32 @add_and_xor_fomula_nuw(i32 %x, i32 %AddC, i32 %M) {
+define i32 @add_and_xor_fomula_nuw(i32 %x, i32 %M) {
 ; CHECK-LABEL: @add_and_xor_fomula_nuw(
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw i32 [[X:%.*]], [[ADDC:%.*]]
-; CHECK-NEXT:    [[AND1:%.*]] = xor i32 [[ADD]], -1
-; CHECK-NEXT:    [[XOR:%.*]] = and i32 [[M:%.*]], [[AND1]]
+; CHECK-NEXT:    [[M:%.*]] = sub i32 -2147483648, [[X:%.*]]
+; CHECK-NEXT:    [[XOR:%.*]] = and i32 [[M]], [[AND1:%.*]]
 ; CHECK-NEXT:    ret i32 [[XOR]]
 ;
-  %add = add nuw i32 %x, %AddC
+  %add = add nuw i32 %x, 2147483647
   %and = and i32 %add, %M
   %xor = xor i32 %and, %M
   ret i32 %xor
 }
 
-define i32 @add_and_xor_fomula_nsw_nuw(i32 %x, i32 %AddC, i32 %M) {
+define i64 @add_and_xor_fomula_nsw_nuw(i64 %x, i64 %M) {
 ; CHECK-LABEL: @add_and_xor_fomula_nsw_nuw(
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[X:%.*]], [[ADDC:%.*]]
-; CHECK-NEXT:    [[AND1:%.*]] = xor i32 [[ADD]], -1
-; CHECK-NEXT:    [[XOR:%.*]] = and i32 [[M:%.*]], [[AND1]]
-; CHECK-NEXT:    ret i32 [[XOR]]
+; CHECK-NEXT:    [[AND1:%.*]] = sub i64 -4191968325751275520, [[X:%.*]]
+; CHECK-NEXT:    [[XOR:%.*]] = and i64 [[AND1]], [[M:%.*]]
+; CHECK-NEXT:    ret i64 [[XOR]]
 ;
-  %add = add nuw nsw i32 %x, %AddC
-  %and = and i32 %add, %M
-  %xor = xor i32 %and, %M
-  ret i32 %xor
+  %add = add nuw nsw i64 %x, 21474836479223372036854775807
+  %and = and i64 %add, %M
+  %xor = xor i64 %and, %M
+  ret i64 %xor
 }
 
 define i8 @add_and_xor_basic(i8 %x) {

--- a/llvm/test/Transforms/InstCombine/and-xor-merge.ll
+++ b/llvm/test/Transforms/InstCombine/and-xor-merge.ll
@@ -93,6 +93,43 @@ define i8 @add_and_xor_basic(i8 %x) {
   ret i8 %xor
 }
 
+; Negative test
+; Should not optimize Cases where `nsw` is added to the sub.
+define i32 @add_and_xor_nsw(i32 %x) {
+; CHECK-LABEL: @add_and_xor_nsw(
+; CHECK-NEXT:    [[IS_POS:%.*]] = icmp sgt i32 [[X:%.*]], -1
+; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_POS]])
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[X]], 63
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 63
+; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 63
+; CHECK-NEXT:    ret i32 [[XOR]]
+;
+  %is_pos = icmp sgt i32 %x, -1
+  call void @llvm.assume(i1 %is_pos)
+  %add = add nuw nsw i32 %x, 63
+  %and = and i32 %add, 63
+  %xor = xor i32 %and, 63
+  ret i32 %xor
+}
+
+; Should not optimize Cases where `nsw` `nuw` is added to the sub.
+define i32 @add_and_xor_nsw_nuw(i32 %x) {
+; CHECK-LABEL: @add_and_xor_nsw_nuw(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X:%.*]], 10
+; CHECK-NEXT:    call void @llvm.assume(i1 [[CMP]])
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[X]], 54
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 63
+; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 63
+; CHECK-NEXT:    ret i32 [[XOR]]
+;
+  %cmp = icmp ult i32 %x, 10
+  call void @llvm.assume(i1 %cmp)
+  %add = add i32 %x, 4294967286
+  %and = and i32 %add, 63
+  %xor = xor i32 %and, 63
+  ret i32 %xor
+}
+
 define <4 x i32> @add_and_xor_vector_splat(<4 x i32> %x) {
 ; CHECK-LABEL: @add_and_xor_vector_splat(
 ; CHECK-NEXT:    [[ADD:%.*]] = sub <4 x i32> splat (i32 53), [[X:%.*]]

--- a/llvm/test/Transforms/InstCombine/and-xor-merge.ll
+++ b/llvm/test/Transforms/InstCombine/and-xor-merge.ll
@@ -83,10 +83,9 @@ define i32 @PR75692_3(i32 %x, i32 %y) {
 ; ((X + C) & M) ^ M --> ((M − C) − X) & M
 define i8 @add_and_xor_basic(i8 %x) {
 ; CHECK-LABEL: @add_and_xor_basic(
-; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[X:%.*]], 5
+; CHECK-NEXT:    [[ADD:%.*]] = sub i8 10, [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[ADD]], 15
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], 15
-; CHECK-NEXT:    ret i8 [[XOR]]
+; CHECK-NEXT:    ret i8 [[AND]]
 ;
   %add = add i8 %x, 5
   %and = and i8 %add, 15
@@ -96,10 +95,9 @@ define i8 @add_and_xor_basic(i8 %x) {
 
 define <4 x i32> @add_and_xor_vector_splat(<4 x i32> %x) {
 ; CHECK-LABEL: @add_and_xor_vector_splat(
-; CHECK-NEXT:    [[ADD:%.*]] = add <4 x i32> [[X:%.*]], splat (i32 10)
+; CHECK-NEXT:    [[ADD:%.*]] = sub <4 x i32> splat (i32 53), [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and <4 x i32> [[ADD]], splat (i32 63)
-; CHECK-NEXT:    [[XOR:%.*]] = xor <4 x i32> [[AND]], splat (i32 63)
-; CHECK-NEXT:    ret <4 x i32> [[XOR]]
+; CHECK-NEXT:    ret <4 x i32> [[AND]]
 ;
   %add = add <4 x i32> %x, <i32 10, i32 10, i32 10, i32 10>
   %and = and <4 x i32> %add, <i32 63, i32 63, i32 63, i32 63>
@@ -109,10 +107,9 @@ define <4 x i32> @add_and_xor_vector_splat(<4 x i32> %x) {
 
 define i32 @add_and_xor_overflow_addc(i32 %x) {
 ; CHECK-LABEL: @add_and_xor_overflow_addc(
-; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X:%.*]], 4
+; CHECK-NEXT:    [[ADD:%.*]] = sub i32 27, [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 31
-; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 31
-; CHECK-NEXT:    ret i32 [[XOR]]
+; CHECK-NEXT:    ret i32 [[AND]]
 ;
   %add = add i32 %x, 100
   %and = and i32 %add, 31
@@ -122,10 +119,9 @@ define i32 @add_and_xor_overflow_addc(i32 %x) {
 
 define i32 @add_and_xor_negative_addc(i32 %x) {
 ; CHECK-LABEL: @add_and_xor_negative_addc(
-; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X:%.*]], 254
+; CHECK-NEXT:    [[ADD:%.*]] = sub i32 1, [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 255
-; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 255
-; CHECK-NEXT:    ret i32 [[XOR]]
+; CHECK-NEXT:    ret i32 [[AND]]
 ;
   %add = add i32 %x, -2
   %and = and i32 %add, 255
@@ -136,10 +132,9 @@ define i32 @add_and_xor_negative_addc(i32 %x) {
 ; This test is trasformed to 'xor(and(add x, 11), 15), 15)' and being applied.
 define i8 @add_and_xor_sub_op(i8 %x) {
 ; CHECK-LABEL: @add_and_xor_sub_op(
-; CHECK-NEXT:    [[SUB:%.*]] = add i8 [[X:%.*]], 11
+; CHECK-NEXT:    [[SUB:%.*]] = sub i8 4, [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[SUB]], 15
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], 15
-; CHECK-NEXT:    ret i8 [[XOR]]
+; CHECK-NEXT:    ret i8 [[AND]]
 ;
   %sub = sub i8 %x, 5
   %and = and i8 %sub, 15
@@ -180,8 +175,8 @@ define i8 @neg_add_and_xor_multi_use(i8 %x) {
 ; CHECK-LABEL: @neg_add_and_xor_multi_use(
 ; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[X:%.*]], 5
 ; CHECK-NEXT:    call void @use(i8 [[ADD]])
-; CHECK-NEXT:    [[AND:%.*]] = and i8 [[ADD]], 15
-; CHECK-NEXT:    [[XOR:%.*]] = xor i8 [[AND]], 15
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i8 10, [[X]]
+; CHECK-NEXT:    [[XOR:%.*]] = and i8 [[TMP1]], 15
 ; CHECK-NEXT:    ret i8 [[XOR]]
 ;
   %add = add i8 %x, 5

--- a/llvm/test/Transforms/InstCombine/and-xor-merge.ll
+++ b/llvm/test/Transforms/InstCombine/and-xor-merge.ll
@@ -81,54 +81,6 @@ define i32 @PR75692_3(i32 %x, i32 %y) {
 }
 
 ; ((X + C) & M) ^ M --> (~C − X) & M
-define i32 @add_and_xor_fomula_basic(i32 %x, i32 %M) {
-; CHECK-LABEL: @add_and_xor_fomula_basic(
-; CHECK-NEXT:    [[AND1:%.*]] = sub i32 0, [[X:%.*]]
-; CHECK-NEXT:    [[XOR:%.*]] = and i32 [[M:%.*]], [[AND1]]
-; CHECK-NEXT:    ret i32 [[XOR]]
-;
-  %add = add i32 %x, -1
-  %and = and i32 %add, %M
-  %xor = xor i32 %and, %M
-  ret i32 %xor
-}
-
-define i64 @add_and_xor_fomula_nsw(i64 %x, i64 %M) {
-; CHECK-LABEL: @add_and_xor_fomula_nsw(
-; CHECK-NEXT:    [[AND1:%.*]] = sub i64 0, [[X:%.*]]
-; CHECK-NEXT:    [[XOR:%.*]] = and i64 [[M:%.*]], [[AND1]]
-; CHECK-NEXT:    ret i64 [[XOR]]
-;
-  %add = add nsw i64 %x, -1
-  %and = and i64 %add, %M
-  %xor = xor i64 %and, %M
-  ret i64 %xor
-}
-
-define i32 @add_and_xor_fomula_nuw(i32 %x, i32 %M) {
-; CHECK-LABEL: @add_and_xor_fomula_nuw(
-; CHECK-NEXT:    [[M:%.*]] = sub i32 -2147483648, [[X:%.*]]
-; CHECK-NEXT:    [[XOR:%.*]] = and i32 [[M]], [[AND1:%.*]]
-; CHECK-NEXT:    ret i32 [[XOR]]
-;
-  %add = add nuw i32 %x, 2147483647
-  %and = and i32 %add, %M
-  %xor = xor i32 %and, %M
-  ret i32 %xor
-}
-
-define i64 @add_and_xor_fomula_nsw_nuw(i64 %x, i64 %M) {
-; CHECK-LABEL: @add_and_xor_fomula_nsw_nuw(
-; CHECK-NEXT:    [[AND1:%.*]] = sub i64 -4191968325751275520, [[X:%.*]]
-; CHECK-NEXT:    [[XOR:%.*]] = and i64 [[AND1]], [[M:%.*]]
-; CHECK-NEXT:    ret i64 [[XOR]]
-;
-  %add = add nuw nsw i64 %x, 21474836479223372036854775807
-  %and = and i64 %add, %M
-  %xor = xor i64 %and, %M
-  ret i64 %xor
-}
-
 define i8 @add_and_xor_basic(i8 %x) {
 ; CHECK-LABEL: @add_and_xor_basic(
 ; CHECK-NEXT:    [[ADD:%.*]] = sub i8 10, [[X:%.*]]
@@ -179,38 +131,50 @@ define i32 @add_and_xor_negative_addc(i32 %x) {
 
 define i8 @add_and_xor_not_low_mask(i8 %x) {
 ; CHECK-LABEL: @add_and_xor_not_low_mask(
-; CHECK-NEXT:    [[TMP1:%.*]] = sub i8 26, [[X:%.*]]
-; CHECK-NEXT:    [[XOR:%.*]] = and i8 [[TMP1]], 16
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i8 1, [[X:%.*]]
+; CHECK-NEXT:    [[XOR:%.*]] = and i8 [[TMP1]], -18
 ; CHECK-NEXT:    ret i8 [[XOR]]
 ;
-  %add = add i8 %x, 5
-  %and = and i8 %add, 16
-  %xor = xor i8 %and, 16
+  %add = add i8 %x, -2
+  %and = and i8 %add, 238
+  %xor = xor i8 %and, 238
   ret i8 %xor
 }
 
-define i64 @add_and_xor_nsw(i32 %x) {
-; CHECK-LABEL: @add_and_xor_nsw(
-; CHECK-NEXT:    [[ASSUME_COND:%.*]] = icmp ult i32 [[X:%.*]], 65
-; CHECK-NEXT:    call void @llvm.assume(i1 [[ASSUME_COND]])
-; CHECK-NEXT:    [[TMP1:%.*]] = sub nsw i32 0, [[X]]
-; CHECK-NEXT:    [[XOR:%.*]] = and i32 [[TMP1]], 63
-; CHECK-NEXT:    [[EXT:%.*]] = zext nneg i32 [[XOR]] to i64
-; CHECK-NEXT:    [[SHR:%.*]] = lshr i64 -1, [[EXT]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[X]], 0
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i64 0, i64 [[SHR]]
-; CHECK-NEXT:    ret i64 [[SEL]]
+define i8 @add_and_xor_not_low_mask2(i8 %x) {
+; CHECK-LABEL: @add_and_xor_not_low_mask2(
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i8 1, [[X:%.*]]
+; CHECK-NEXT:    [[XOR:%.*]] = and i8 [[TMP1]], 119
+; CHECK-NEXT:    ret i8 [[XOR]]
 ;
-  %assume_cond = icmp ult i32 %x, 65
-  call void @llvm.assume(i1 %assume_cond)
-  %add = add nuw nsw i32 %x, 63
-  %and = and i32 %add, 63
-  %xor = xor i32 %and, 63
-  %ext = zext nneg i32 %xor to i64
-  %shr = lshr i64 -1, %ext
-  %cmp = icmp eq i32 %x, 0
-  %sel = select i1 %cmp, i64 0, i64 %shr
-  ret i64 %sel
+  %add = add i8 %x, -2
+  %and = and i8 %add, 119
+  %xor = xor i8 %and, 119
+  ret i8 %xor
+}
+
+define i8 @add_and_xor_not_low_mask3(i8 %x) {
+; CHECK-LABEL: @add_and_xor_not_low_mask3(
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i8 1, [[X:%.*]]
+; CHECK-NEXT:    [[XOR:%.*]] = and i8 [[TMP1]], -91
+; CHECK-NEXT:    ret i8 [[XOR]]
+;
+  %add = add i8 %x, -2
+  %and = and i8 %add, 165
+  %xor = xor i8 %and, 165
+  ret i8 %xor
+}
+
+define i8 @add_and_xor_not_low_mask4(i8 %x) {
+; CHECK-LABEL: @add_and_xor_not_low_mask4(
+; CHECK-NEXT:    [[TMP1:%.*]] = sub i8 1, [[X:%.*]]
+; CHECK-NEXT:    [[XOR:%.*]] = and i8 [[TMP1]], -86
+; CHECK-NEXT:    ret i8 [[XOR]]
+;
+  %add = add i8 %x, -2
+  %and = and i8 %add, 170
+  %xor = xor i8 %and, 170
+  ret i8 %xor
 }
 
 ; This test is trasformed to 'xor(and(add x, 11), 15), 15)' and being applied.

--- a/llvm/test/Transforms/InstCombine/and-xor-merge.ll
+++ b/llvm/test/Transforms/InstCombine/and-xor-merge.ll
@@ -83,7 +83,7 @@ define i32 @PR75692_3(i32 %x, i32 %y) {
 ; ((X + C) & M) ^ M --> ((M − C) − X) & M
 define i8 @add_and_xor_basic(i8 %x) {
 ; CHECK-LABEL: @add_and_xor_basic(
-; CHECK-NEXT:    [[ADD:%.*]] = sub nsw i8 10, [[X:%.*]]
+; CHECK-NEXT:    [[ADD:%.*]] = sub i8 10, [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[ADD]], 15
 ; CHECK-NEXT:    ret i8 [[AND]]
 ;
@@ -93,13 +93,16 @@ define i8 @add_and_xor_basic(i8 %x) {
   ret i8 %xor
 }
 
+; Negative test
+; Should not optimize Cases where `nsw` is added to the sub.
 define i32 @add_and_xor_nsw(i32 %x) {
 ; CHECK-LABEL: @add_and_xor_nsw(
 ; CHECK-NEXT:    [[IS_POS:%.*]] = icmp sgt i32 [[X:%.*]], -1
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_POS]])
-; CHECK-NEXT:    [[ADD:%.*]] = sub nsw i32 0, [[X]]
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[X]], 63
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 63
-; CHECK-NEXT:    ret i32 [[AND]]
+; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 63
+; CHECK-NEXT:    ret i32 [[XOR]]
 ;
   %is_pos = icmp sgt i32 %x, -1
   call void @llvm.assume(i1 %is_pos)
@@ -109,13 +112,15 @@ define i32 @add_and_xor_nsw(i32 %x) {
   ret i32 %xor
 }
 
+; Should not optimize Cases where `nsw` `nuw` is added to the sub.
 define i32 @add_and_xor_nsw_nuw(i32 %x) {
 ; CHECK-LABEL: @add_and_xor_nsw_nuw(
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X:%.*]], 10
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[CMP]])
-; CHECK-NEXT:    [[ADD:%.*]] = sub nsw i32 9, [[X]]
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[X]], 54
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 63
-; CHECK-NEXT:    ret i32 [[AND]]
+; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 63
+; CHECK-NEXT:    ret i32 [[XOR]]
 ;
   %cmp = icmp ult i32 %x, 10
   call void @llvm.assume(i1 %cmp)
@@ -127,7 +132,7 @@ define i32 @add_and_xor_nsw_nuw(i32 %x) {
 
 define <4 x i32> @add_and_xor_vector_splat(<4 x i32> %x) {
 ; CHECK-LABEL: @add_and_xor_vector_splat(
-; CHECK-NEXT:    [[ADD:%.*]] = sub nsw <4 x i32> splat (i32 53), [[X:%.*]]
+; CHECK-NEXT:    [[ADD:%.*]] = sub <4 x i32> splat (i32 53), [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and <4 x i32> [[ADD]], splat (i32 63)
 ; CHECK-NEXT:    ret <4 x i32> [[AND]]
 ;
@@ -139,7 +144,7 @@ define <4 x i32> @add_and_xor_vector_splat(<4 x i32> %x) {
 
 define i32 @add_and_xor_overflow_addc(i32 %x) {
 ; CHECK-LABEL: @add_and_xor_overflow_addc(
-; CHECK-NEXT:    [[ADD:%.*]] = sub nsw i32 27, [[X:%.*]]
+; CHECK-NEXT:    [[ADD:%.*]] = sub i32 27, [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 31
 ; CHECK-NEXT:    ret i32 [[AND]]
 ;
@@ -151,7 +156,7 @@ define i32 @add_and_xor_overflow_addc(i32 %x) {
 
 define i32 @add_and_xor_negative_addc(i32 %x) {
 ; CHECK-LABEL: @add_and_xor_negative_addc(
-; CHECK-NEXT:    [[ADD:%.*]] = sub nsw i32 1, [[X:%.*]]
+; CHECK-NEXT:    [[ADD:%.*]] = sub i32 1, [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], 255
 ; CHECK-NEXT:    ret i32 [[AND]]
 ;
@@ -164,7 +169,7 @@ define i32 @add_and_xor_negative_addc(i32 %x) {
 ; This test is trasformed to 'xor(and(add x, 11), 15), 15)' and being applied.
 define i8 @add_and_xor_sub_op(i8 %x) {
 ; CHECK-LABEL: @add_and_xor_sub_op(
-; CHECK-NEXT:    [[SUB:%.*]] = sub nsw i8 4, [[X:%.*]]
+; CHECK-NEXT:    [[SUB:%.*]] = sub i8 4, [[X:%.*]]
 ; CHECK-NEXT:    [[AND:%.*]] = and i8 [[SUB]], 15
 ; CHECK-NEXT:    ret i8 [[AND]]
 ;


### PR DESCRIPTION
This patch optimizes specific pattern.

((X + AddC) & Mask) ^ Mask
-> (~AddC - X) & Mask

Proof: https://alive2.llvm.org/ce/z/XFHfnD
Fixed: https://github.com/llvm/llvm-project/issues/128475