### PR TITLE
[offload] [test] Mark bug 51781 test as requiring GPU

### DIFF
--- a/offload/test/offloading/bug51781.c
+++ b/offload/test/offloading/bug51781.c
@@ -1,6 +1,7 @@
 // Use the generic state machine.  On some architectures, other threads in the
 // main thread's warp must avoid barrier instructions.
 //
+// REQUIRES: gpu
 // RUN: %libomptarget-compile-run-and-check-generic
 
 // SPMDize.  There is no main thread, so there's no issue.


### PR DESCRIPTION
While the main problem with the test is that it requires LLD, given that it is unlikely to be testing anything meaningful for a CPU-only build, just mark it as requiring GPU.

Fixes #100780