### PR TITLE
[.gitignore] Ignore .clangd config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ pythonenv*
 # clangd index. (".clangd" is a config file now, thus trailing slash)
 .clangd/
 .cache
+.clangd
 # static analyzer regression testing project files
 /clang/utils/analyzer/projects/*/CachedSource
 /clang/utils/analyzer/projects/*/PatchedSource


### PR DESCRIPTION
If anyone wants to use a custom `.clangd` config in the repo, they will need to manually "git ignore it". Since clangd is a popular tool and `.clangd` config is usually set up per-person, it's beneficial to add it to gitignore.

As a matter of fact, I wanted to enable diagnostics from all clang-tidy checks in IDE, with such config:

```
Diagnostics:
    ClangTidy:
        FastCheckFilter: None
```

(By default, clangd will skip some "expensive" checks like const-correctness)