### PR TITLE
[InstCombine] Honor rewrite semantics of fast-math flags in InstCombineMulDivRem.cpp

### DIFF
--- a/llvm/include/llvm/IR/FMF.h
+++ b/llvm/include/llvm/IR/FMF.h
@@ -105,6 +105,10 @@ public:
     return Flags != OtherFlags.Flags;
   }
 
+  bool operator==(const FastMathFlags &OtherFlags) const {
+    return Flags == OtherFlags.Flags;
+  }
+
   /// Print fast-math flags to \p O.
   LLVM_ABI void print(raw_ostream &O) const;
 

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -81,19 +81,49 @@ template <typename T> inline OneUse_match<T> m_OneUse(const T &SubPattern) {
   return SubPattern;
 }
 
-template <typename SubPattern_t> struct AllowReassoc_match {
+template <typename SubPattern_t, int Flag> struct AllowFmf_match {
   SubPattern_t SubPattern;
 
-  AllowReassoc_match(const SubPattern_t &SP) : SubPattern(SP) {}
+  AllowFmf_match(const SubPattern_t &SP) : SubPattern(SP) {}
 
   template <typename OpTy> bool match(OpTy *V) const {
     auto *I = dyn_cast<FPMathOperator>(V);
-    return I && I->hasAllowReassoc() && SubPattern.match(I);
+    return I && (I->getFastMathFlags() & Flag) && SubPattern.match(I);
   }
 };
 
 template <typename T>
-inline AllowReassoc_match<T> m_AllowReassoc(const T &SubPattern) {
+inline AllowFmf_match<T, FastMathFlags::AllowReassoc> m_AllowReassoc(const T &SubPattern) {
+  return SubPattern;
+}
+
+template <typename T>
+inline AllowFmf_match<T, FastMathFlags::AllowReciprocal> m_AllowReciprocal(const T &SubPattern) {
+  return SubPattern;
+}
+
+template <typename T>
+inline AllowFmf_match<T, FastMathFlags::AllowContract> m_AllowContract(const T &SubPattern) {
+  return SubPattern;
+}
+
+template <typename T>
+inline AllowFmf_match<T, FastMathFlags::ApproxFunc> m_ApproxFunc(const T &SubPattern) {
+  return SubPattern;
+}
+
+template <typename T>
+inline AllowFmf_match<T, FastMathFlags::NoNaNs> m_NoNaNs(const T &SubPattern) {
+  return SubPattern;
+}
+
+template <typename T>
+inline AllowFmf_match<T, FastMathFlags::NoInfs> m_NoInfs(const T &SubPattern) {
+  return SubPattern;
+}
+
+template <typename T>
+inline AllowFmf_match<T, FastMathFlags::NoSignedZeros> m_NoSignedZeros(const T &SubPattern) {
   return SubPattern;
 }
 

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -28,6 +28,7 @@
 #ifndef LLVM_IR_PATTERNMATCH_H
 #define LLVM_IR_PATTERNMATCH_H
 
+#include "FMF.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/IR/Constant.h"
@@ -83,32 +84,52 @@ template <typename T> inline OneUse_match<T> m_OneUse(const T &SubPattern) {
 
 template <typename SubPattern_t, int Flag> struct AllowFmf_match {
   SubPattern_t SubPattern;
+  FastMathFlags FMF;
 
-  AllowFmf_match(const SubPattern_t &SP) : SubPattern(SP) {}
+  AllowFmf_match(const SubPattern_t &SP) : SubPattern(SP) {
+    if (Flag == FastMathFlags::AllowReassoc)
+      FMF.setAllowReassoc();
+    if (Flag == FastMathFlags::AllowReciprocal)
+      FMF.setAllowReciprocal();
+    if (Flag == FastMathFlags::AllowContract)
+      FMF.setAllowContract();
+    if (Flag == FastMathFlags::ApproxFunc)
+      FMF.setApproxFunc();
+    if (Flag == FastMathFlags::NoNaNs)
+      FMF.setNoNaNs();
+    if (Flag == FastMathFlags::NoInfs)
+      FMF.setNoInfs();
+    if (Flag == FastMathFlags::NoSignedZeros)
+      FMF.setNoSignedZeros();
+  }
 
   template <typename OpTy> bool match(OpTy *V) const {
     auto *I = dyn_cast<FPMathOperator>(V);
-    return I && (I->getFastMathFlags() & Flag) && SubPattern.match(I);
+    return I && ((I->getFastMathFlags() & FMF) == FMF) && SubPattern.match(I);
   }
 };
 
 template <typename T>
-inline AllowFmf_match<T, FastMathFlags::AllowReassoc> m_AllowReassoc(const T &SubPattern) {
+inline AllowFmf_match<T, FastMathFlags::AllowReassoc>
+m_AllowReassoc(const T &SubPattern) {
   return SubPattern;
 }
 
 template <typename T>
-inline AllowFmf_match<T, FastMathFlags::AllowReciprocal> m_AllowReciprocal(const T &SubPattern) {
+inline AllowFmf_match<T, FastMathFlags::AllowReciprocal>
+m_AllowReciprocal(const T &SubPattern) {
   return SubPattern;
 }
 
 template <typename T>
-inline AllowFmf_match<T, FastMathFlags::AllowContract> m_AllowContract(const T &SubPattern) {
+inline AllowFmf_match<T, FastMathFlags::AllowContract>
+m_AllowContract(const T &SubPattern) {
   return SubPattern;
 }
 
 template <typename T>
-inline AllowFmf_match<T, FastMathFlags::ApproxFunc> m_ApproxFunc(const T &SubPattern) {
+inline AllowFmf_match<T, FastMathFlags::ApproxFunc>
+m_ApproxFunc(const T &SubPattern) {
   return SubPattern;
 }
 
@@ -123,7 +144,14 @@ inline AllowFmf_match<T, FastMathFlags::NoInfs> m_NoInfs(const T &SubPattern) {
 }
 
 template <typename T>
-inline AllowFmf_match<T, FastMathFlags::NoSignedZeros> m_NoSignedZeros(const T &SubPattern) {
+inline AllowFmf_match<T, FastMathFlags::NoSignedZeros>
+m_NoSignedZeros(const T &SubPattern) {
+  return SubPattern;
+}
+
+template <typename T>
+inline AllowFmf_match<T, FastMathFlags::AllFlagsMask>
+m_IsFast(const T &SubPattern) {
   return SubPattern;
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -97,8 +97,8 @@ public:
   Instruction *visitSub(BinaryOperator &I);
   Instruction *visitFSub(BinaryOperator &I);
   Instruction *visitMul(BinaryOperator &I);
-  Instruction *foldPowiReassoc(BinaryOperator &I);
-  Instruction *foldFMulReassoc(BinaryOperator &I);
+  Instruction *foldPowi(BinaryOperator &I);
+  Instruction *foldFMul(BinaryOperator &I);
   Instruction *visitFMul(BinaryOperator &I);
   Instruction *visitURem(BinaryOperator &I);
   Instruction *visitSRem(BinaryOperator &I);

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -1936,7 +1936,7 @@ Instruction *InstCombinerImpl::foldFDivConstantDivisor(BinaryOperator &I) {
   // If the constant divisor has an exact inverse, this is always safe. If not,
   // then we can still create a reciprocal if fast-math-flags allow it and the
   // constant is a regular number (not zero, infinite, or denormal).
-  if (!C->hasExactInverseFP() && !(I.hasAllowReciprocal() && C->isNormalFP()))
+  if (!(C->hasExactInverseFP() || (I.hasAllowReciprocal() && C->isNormalFP())))
     return nullptr;
 
   // Disallow denormal constants because we don't know what would happen

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -801,27 +801,6 @@ Instruction *InstCombinerImpl::foldFMul(BinaryOperator &I) {
   if (!I.hasAllowReassoc())
     return nullptr;
 
-  // (X * Y) * X => (X * X) * Y,
-  // X * (X * Y) => (X * X) * Y where Y != X
-  //  The purpose is two-fold:
-  //   1) to form a power expression (of X).
-  //   2) potentially shorten the critical path: After transformation, the
-  //  latency of the instruction Y is amortized by the expression of X*X,
-  //  and therefore Y is in a "less critical" position compared to what it
-  //  was before the transformation.
-  if (match(Op0,
-            m_OneUse(m_AllowReassoc(m_c_FMul(m_Specific(Op1), m_Value(Y))))) &&
-      Op1 != Y) {
-    Value *XX = Builder.CreateFMulFMF(Op1, Op1, &I);
-    return BinaryOperator::CreateFMulFMF(XX, Y, &I);
-  }
-  if (match(Op1,
-            m_OneUse(m_AllowReassoc(m_c_FMul(m_Specific(Op0), m_Value(Y))))) &&
-      Op0 != Y) {
-    Value *XX = Builder.CreateFMulFMF(Op0, Op0, &I);
-    return BinaryOperator::CreateFMulFMF(XX, Y, &I);
-  }
-
   // Reassociate constant RHS with another constant to form constant
   // expression.
   if (match(Op1, m_Constant(C)) && C->isFiniteNonZeroFP() &&
@@ -962,6 +941,27 @@ Instruction *InstCombinerImpl::foldFMul(BinaryOperator &I) {
       Value *Exp2 = Builder.CreateUnaryIntrinsic(Intrinsic::exp2, XY, &I);
       return replaceInstUsesWith(I, Exp2);
     }
+  }
+
+  // (X * Y) * X => (X * X) * Y,
+  // X * (X * Y) => (X * X) * Y where Y != X
+  //  The purpose is two-fold:
+  //   1) to form a power expression (of X).
+  //   2) potentially shorten the critical path: After transformation, the
+  //  latency of the instruction Y is amortized by the expression of X*X,
+  //  and therefore Y is in a "less critical" position compared to what it
+  //  was before the transformation.
+  if (match(Op0,
+            m_OneUse(m_AllowReassoc(m_c_FMul(m_Specific(Op1), m_Value(Y))))) &&
+      Op1 != Y) {
+    Value *XX = Builder.CreateFMulFMF(Op1, Op1, &I);
+    return BinaryOperator::CreateFMulFMF(XX, Y, &I);
+  }
+  if (match(Op1,
+            m_OneUse(m_AllowReassoc(m_c_FMul(m_Specific(Op0), m_Value(Y))))) &&
+      Op0 != Y) {
+    Value *XX = Builder.CreateFMulFMF(Op0, Op0, &I);
+    return BinaryOperator::CreateFMulFMF(XX, Y, &I);
   }
 
   return nullptr;

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -614,7 +614,7 @@ Instruction *InstCombinerImpl::foldFPSignBitOps(BinaryOperator &I) {
   return nullptr;
 }
 
-Instruction *InstCombinerImpl::foldPowiReassoc(BinaryOperator &I) {
+Instruction *InstCombinerImpl::foldPowi(BinaryOperator &I) {
   auto createPowiExpr = [](BinaryOperator &I, InstCombinerImpl &IC, Value *X,
                            Value *Y, Value *Z) {
     InstCombiner::BuilderTy &Builder = IC.Builder;
@@ -630,17 +630,8 @@ Instruction *InstCombinerImpl::foldPowiReassoc(BinaryOperator &I) {
   assert((Opcode == Instruction::FMul || Opcode == Instruction::FDiv) &&
          "Unexpected opcode");
 
-  // powi(X, Y) * X --> powi(X, Y+1)
-  // X * powi(X, Y) --> powi(X, Y+1)
-  if (match(&I, m_c_FMul(m_OneUse(m_AllowReassoc(m_Intrinsic<Intrinsic::powi>(
-                             m_Value(X), m_Value(Y)))),
-                         m_Deferred(X)))) {
-    Constant *One = ConstantInt::get(Y->getType(), 1);
-    if (willNotOverflowSignedAdd(Y, One, I)) {
-      Instruction *NewPow = createPowiExpr(I, *this, X, Y, One);
-      return replaceInstUsesWith(I, NewPow);
-    }
-  }
+  if (!I.hasAllowReassoc())
+    return nullptr;
 
   // powi(x, y) * powi(x, z) -> powi(x, y + z)
   Value *Op0 = I.getOperand(0);
@@ -655,7 +646,19 @@ Instruction *InstCombinerImpl::foldPowiReassoc(BinaryOperator &I) {
     return replaceInstUsesWith(I, NewPow);
   }
 
-  if (Opcode == Instruction::FDiv && I.hasAllowReassoc() && I.hasNoNaNs()) {
+  // powi(X, Y) * X --> powi(X, Y+1)
+  // X * powi(X, Y) --> powi(X, Y+1)
+  if (match(&I, m_c_FMul(m_OneUse(m_AllowReassoc(m_Intrinsic<Intrinsic::powi>(
+                             m_Value(X), m_Value(Y)))),
+                         m_Deferred(X)))) {
+    Constant *One = ConstantInt::get(Y->getType(), 1);
+    if (willNotOverflowSignedAdd(Y, One, I)) {
+      Instruction *NewPow = createPowiExpr(I, *this, X, Y, One);
+      return replaceInstUsesWith(I, NewPow);
+    }
+  }
+
+  if (Opcode == Instruction::FDiv && I.hasNoNaNs()) {
     // powi(X, Y) / X --> powi(X, Y-1)
     // This is legal when (Y - 1) can't wraparound, in which case reassoc and
     // nnan are required.
@@ -773,12 +776,51 @@ static bool isFSqrtDivToFMulLegal(Instruction *X,
   });
 }
 
-Instruction *InstCombinerImpl::foldFMulReassoc(BinaryOperator &I) {
+Instruction *InstCombinerImpl::foldFMul(BinaryOperator &I) {
   Value *Op0 = I.getOperand(0);
   Value *Op1 = I.getOperand(1);
   Value *X, *Y;
   Constant *C;
   BinaryOperator *Op0BinOp;
+
+  // The following transforms are done irrespective of the number of uses
+  // for the expression "1.0/sqrt(X)".
+  //  1) 1.0/sqrt(X) * X -> X/sqrt(X)
+  //  2) X * 1.0/sqrt(X) -> X/sqrt(X)
+  // We always expect the backend to reduce X/sqrt(X) to sqrt(X), if it
+  // has the necessary (reassoc) fast-math-flags.
+  if (I.hasNoSignedZeros() && I.hasAllowReciprocal() &&
+      match(Op0, (m_AllowReciprocal(m_FDiv(m_SpecificFP(1.0), m_Value(Y))))) &&
+      match(Y, m_Sqrt(m_Value(X))) && Op1 == X)
+    return BinaryOperator::CreateFDivFMF(X, Y, &I);
+  if (I.hasNoSignedZeros() && I.hasAllowReciprocal() &&
+      match(Op1, (m_AllowReciprocal(m_FDiv(m_SpecificFP(1.0), m_Value(Y))))) &&
+      match(Y, m_Sqrt(m_Value(X))) && Op0 == X)
+    return BinaryOperator::CreateFDivFMF(X, Y, &I);
+
+  if (!I.hasAllowReassoc())
+    return nullptr;
+
+  // (X * Y) * X => (X * X) * Y,
+  // X * (X * Y) => (X * X) * Y where Y != X
+  //  The purpose is two-fold:
+  //   1) to form a power expression (of X).
+  //   2) potentially shorten the critical path: After transformation, the
+  //  latency of the instruction Y is amortized by the expression of X*X,
+  //  and therefore Y is in a "less critical" position compared to what it
+  //  was before the transformation.
+  if (match(Op0,
+            m_OneUse(m_AllowReassoc(m_c_FMul(m_Specific(Op1), m_Value(Y))))) &&
+      Op1 != Y) {
+    Value *XX = Builder.CreateFMulFMF(Op1, Op1, &I);
+    return BinaryOperator::CreateFMulFMF(XX, Y, &I);
+  }
+  if (match(Op1,
+            m_OneUse(m_AllowReassoc(m_c_FMul(m_Specific(Op0), m_Value(Y))))) &&
+      Op0 != Y) {
+    Value *XX = Builder.CreateFMulFMF(Op0, Op0, &I);
+    return BinaryOperator::CreateFMulFMF(XX, Y, &I);
+  }
 
   // Reassociate constant RHS with another constant to form constant
   // expression.
@@ -794,16 +836,15 @@ Instruction *InstCombinerImpl::foldFMulReassoc(BinaryOperator &I) {
       if (CC1 && CC1->isNormalFP())
         return BinaryOperator::CreateFDivFMF(CC1, X, FMF);
     }
-    if (match(Op0, m_FDiv(m_Value(X), m_Constant(C1)))) {
-      // FIXME: This seems like it should also be checking for arcp
-      // (X / C1) * C --> X * (C / C1)
+    if (match(Op0, m_AllowReciprocal(m_FDiv(m_Value(X), m_Constant(C1))))) {
+      // (X / C1) * C --> (X * (1 / C1)) * C --> X * (C / C1)
       Constant *CDivC1 =
           ConstantFoldBinaryOpOperands(Instruction::FDiv, C, C1, DL);
       if (CDivC1 && CDivC1->isNormalFP())
         return BinaryOperator::CreateFMulFMF(X, CDivC1, FMF);
 
       // If the constant was a denormal, try reassociating differently.
-      // (X / C1) * C --> X / (C1 / C)
+      // (X / C1) * C --> (X * (1 / C1)) * C --> X * (C / C1) --> X / (C1 / C)
       Constant *C1DivC =
           ConstantFoldBinaryOpOperands(Instruction::FDiv, C1, C, DL);
       if (C1DivC && Op0->hasOneUse() && C1DivC->isNormalFP())
@@ -833,8 +874,7 @@ Instruction *InstCombinerImpl::foldFMulReassoc(BinaryOperator &I) {
 
   Value *Z;
   if (match(&I,
-            m_c_FMul(m_AllowReassoc(m_OneUse(m_FDiv(m_Value(X), m_Value(Y)))),
-                     m_Value(Z)))) {
+            m_c_FMul(m_OneUse(m_FDiv(m_Value(X), m_Value(Y))), m_Value(Z)))) {
     BinaryOperator *DivOp = cast<BinaryOperator>(((Z == Op0) ? Op1 : Op0));
     FastMathFlags FMF = I.getFastMathFlags() & DivOp->getFastMathFlags();
     if (FMF.allowReassoc()) {
@@ -847,39 +887,27 @@ Instruction *InstCombinerImpl::foldFMulReassoc(BinaryOperator &I) {
   // sqrt(X) * sqrt(Y) -> sqrt(X * Y)
   // nnan disallows the possibility of returning a number if both operands are
   // negative (in that case, we should return NaN).
-  if (I.hasNoNaNs() && match(Op0, m_OneUse(m_Sqrt(m_Value(X)))) &&
-      match(Op1, m_OneUse(m_Sqrt(m_Value(Y))))) {
+  if (I.hasNoNaNs() &&
+      match(Op0, m_OneUse(m_AllowReassoc(m_Sqrt(m_Value(X))))) &&
+      match(Op1, m_OneUse(m_AllowReassoc(m_Sqrt(m_Value(Y)))))) {
     Value *XY = Builder.CreateFMulFMF(X, Y, &I);
     Value *Sqrt = Builder.CreateUnaryIntrinsic(Intrinsic::sqrt, XY, &I);
     return replaceInstUsesWith(I, Sqrt);
   }
-
-  // The following transforms are done irrespective of the number of uses
-  // for the expression "1.0/sqrt(X)".
-  //  1) 1.0/sqrt(X) * X -> X/sqrt(X)
-  //  2) X * 1.0/sqrt(X) -> X/sqrt(X)
-  // We always expect the backend to reduce X/sqrt(X) to sqrt(X), if it
-  // has the necessary (reassoc) fast-math-flags.
-  if (I.hasNoSignedZeros() &&
-      match(Op0, (m_FDiv(m_SpecificFP(1.0), m_Value(Y)))) &&
-      match(Y, m_Sqrt(m_Value(X))) && Op1 == X)
-    return BinaryOperator::CreateFDivFMF(X, Y, &I);
-  if (I.hasNoSignedZeros() &&
-      match(Op1, (m_FDiv(m_SpecificFP(1.0), m_Value(Y)))) &&
-      match(Y, m_Sqrt(m_Value(X))) && Op0 == X)
-    return BinaryOperator::CreateFDivFMF(X, Y, &I);
 
   // Like the similar transform in instsimplify, this requires 'nsz' because
   // sqrt(-0.0) = -0.0, and -0.0 * -0.0 does not simplify to -0.0.
   if (I.hasNoNaNs() && I.hasNoSignedZeros() && Op0 == Op1 && Op0->hasNUses(2)) {
     // Peek through fdiv to find squaring of square root:
     // (X / sqrt(Y)) * (X / sqrt(Y)) --> (X * X) / Y
-    if (match(Op0, m_FDiv(m_Value(X), m_Sqrt(m_Value(Y))))) {
+    if (match(Op0, m_AllowReassoc(m_FDiv(
+                       m_Value(X), m_AllowReassoc(m_Sqrt(m_Value(Y))))))) {
       Value *XX = Builder.CreateFMulFMF(X, X, &I);
       return BinaryOperator::CreateFDivFMF(XX, Y, &I);
     }
     // (sqrt(Y) / X) * (sqrt(Y) / X) --> Y / (X * X)
-    if (match(Op0, m_FDiv(m_Sqrt(m_Value(Y)), m_Value(X)))) {
+    if (match(Op0, m_AllowReassoc(m_FDiv(m_AllowReassoc(m_Sqrt(m_Value(Y))),
+                                         m_Value(X))))) {
       Value *XX = Builder.CreateFMulFMF(X, X, &I);
       return BinaryOperator::CreateFDivFMF(Y, XX, &I);
     }
@@ -887,64 +915,53 @@ Instruction *InstCombinerImpl::foldFMulReassoc(BinaryOperator &I) {
 
   // pow(X, Y) * X --> pow(X, Y+1)
   // X * pow(X, Y) --> pow(X, Y+1)
-  if (match(&I, m_c_FMul(m_OneUse(m_Intrinsic<Intrinsic::pow>(m_Value(X),
-                                                              m_Value(Y))),
-                         m_Deferred(X)))) {
+  if (match(&I, m_AllowReassoc(m_c_FMul(
+                    m_OneUse(m_AllowReassoc(
+                        m_Intrinsic<Intrinsic::pow>(m_Value(X), m_Value(Y)))),
+                    m_Deferred(X))))) {
     Value *Y1 = Builder.CreateFAddFMF(Y, ConstantFP::get(I.getType(), 1.0), &I);
     Value *Pow = Builder.CreateBinaryIntrinsic(Intrinsic::pow, X, Y1, &I);
     return replaceInstUsesWith(I, Pow);
   }
 
-  if (Instruction *FoldedPowi = foldPowiReassoc(I))
+  if (Instruction *FoldedPowi = foldPowi(I))
     return FoldedPowi;
 
   if (I.isOnlyUserOfAnyOperand()) {
     // pow(X, Y) * pow(X, Z) -> pow(X, Y + Z)
-    if (match(Op0, m_Intrinsic<Intrinsic::pow>(m_Value(X), m_Value(Y))) &&
-        match(Op1, m_Intrinsic<Intrinsic::pow>(m_Specific(X), m_Value(Z)))) {
+    if (match(Op0, m_AllowReassoc(
+                       m_Intrinsic<Intrinsic::pow>(m_Value(X), m_Value(Y)))) &&
+        match(Op1, m_AllowReassoc(m_Intrinsic<Intrinsic::pow>(m_Specific(X),
+                                                              m_Value(Z))))) {
       auto *YZ = Builder.CreateFAddFMF(Y, Z, &I);
       auto *NewPow = Builder.CreateBinaryIntrinsic(Intrinsic::pow, X, YZ, &I);
       return replaceInstUsesWith(I, NewPow);
     }
     // pow(X, Y) * pow(Z, Y) -> pow(X * Z, Y)
-    if (match(Op0, m_Intrinsic<Intrinsic::pow>(m_Value(X), m_Value(Y))) &&
-        match(Op1, m_Intrinsic<Intrinsic::pow>(m_Value(Z), m_Specific(Y)))) {
+    if (match(Op0, m_AllowReassoc(
+                       m_Intrinsic<Intrinsic::pow>(m_Value(X), m_Value(Y)))) &&
+        match(Op1, m_AllowReassoc(m_Intrinsic<Intrinsic::pow>(
+                       m_Value(Z), m_Specific(Y))))) {
       auto *XZ = Builder.CreateFMulFMF(X, Z, &I);
       auto *NewPow = Builder.CreateBinaryIntrinsic(Intrinsic::pow, XZ, Y, &I);
       return replaceInstUsesWith(I, NewPow);
     }
 
     // exp(X) * exp(Y) -> exp(X + Y)
-    if (match(Op0, m_Intrinsic<Intrinsic::exp>(m_Value(X))) &&
-        match(Op1, m_Intrinsic<Intrinsic::exp>(m_Value(Y)))) {
+    if (match(Op0, m_AllowReassoc(m_Intrinsic<Intrinsic::exp>(m_Value(X)))) &&
+        match(Op1, m_AllowReassoc(m_Intrinsic<Intrinsic::exp>(m_Value(Y))))) {
       Value *XY = Builder.CreateFAddFMF(X, Y, &I);
       Value *Exp = Builder.CreateUnaryIntrinsic(Intrinsic::exp, XY, &I);
       return replaceInstUsesWith(I, Exp);
     }
 
     // exp2(X) * exp2(Y) -> exp2(X + Y)
-    if (match(Op0, m_Intrinsic<Intrinsic::exp2>(m_Value(X))) &&
-        match(Op1, m_Intrinsic<Intrinsic::exp2>(m_Value(Y)))) {
+    if (match(Op0, m_AllowReassoc(m_Intrinsic<Intrinsic::exp2>(m_Value(X)))) &&
+        match(Op1, m_AllowReassoc(m_Intrinsic<Intrinsic::exp2>(m_Value(Y))))) {
       Value *XY = Builder.CreateFAddFMF(X, Y, &I);
       Value *Exp2 = Builder.CreateUnaryIntrinsic(Intrinsic::exp2, XY, &I);
       return replaceInstUsesWith(I, Exp2);
     }
-  }
-
-  // (X*Y) * X => (X*X) * Y where Y != X
-  //  The purpose is two-fold:
-  //   1) to form a power expression (of X).
-  //   2) potentially shorten the critical path: After transformation, the
-  //  latency of the instruction Y is amortized by the expression of X*X,
-  //  and therefore Y is in a "less critical" position compared to what it
-  //  was before the transformation.
-  if (match(Op0, m_OneUse(m_c_FMul(m_Specific(Op1), m_Value(Y)))) && Op1 != Y) {
-    Value *XX = Builder.CreateFMulFMF(Op1, Op1, &I);
-    return BinaryOperator::CreateFMulFMF(XX, Y, &I);
-  }
-  if (match(Op1, m_OneUse(m_c_FMul(m_Specific(Op0), m_Value(Y)))) && Op0 != Y) {
-    Value *XX = Builder.CreateFMulFMF(Op0, Op0, &I);
-    return BinaryOperator::CreateFMulFMF(XX, Y, &I);
   }
 
   return nullptr;
@@ -1025,20 +1042,21 @@ Instruction *InstCombinerImpl::visitFMul(BinaryOperator &I) {
   if (Value *V = SimplifySelectsFeedingBinaryOp(I, Op0, Op1))
     return replaceInstUsesWith(I, V);
 
-  if (I.hasAllowReassoc())
-    if (Instruction *FoldedMul = foldFMulReassoc(I))
-      return FoldedMul;
+  if (Instruction *FoldedMul = foldFMul(I))
+    return FoldedMul;
 
   // log2(X * 0.5) * Y = log2(X) * Y - Y
-  if (I.isFast()) {
+  if (I.hasAllowReassoc()) {
     IntrinsicInst *Log2 = nullptr;
-    if (match(Op0, m_OneUse(m_Intrinsic<Intrinsic::log2>(
-            m_OneUse(m_FMul(m_Value(X), m_SpecificFP(0.5))))))) {
+    if (match(Op0,
+              m_OneUse(m_AllowReassoc(m_Intrinsic<Intrinsic::log2>(m_OneUse(
+                  m_AllowReassoc(m_FMul(m_Value(X), m_SpecificFP(0.5))))))))) {
       Log2 = cast<IntrinsicInst>(Op0);
       Y = Op1;
     }
-    if (match(Op1, m_OneUse(m_Intrinsic<Intrinsic::log2>(
-            m_OneUse(m_FMul(m_Value(X), m_SpecificFP(0.5))))))) {
+    if (match(Op1,
+              m_OneUse(m_AllowReassoc(m_Intrinsic<Intrinsic::log2>(m_OneUse(
+                  m_AllowReassoc(m_FMul(m_Value(X), m_SpecificFP(0.5))))))))) {
       Log2 = cast<IntrinsicInst>(Op1);
       Y = Op0;
     }
@@ -1073,10 +1091,11 @@ Instruction *InstCombinerImpl::visitFMul(BinaryOperator &I) {
   }
 
   // tan(X) * cos(X) -> sin(X)
-  if (I.hasAllowContract() &&
-      match(&I,
-            m_c_FMul(m_OneUse(m_Intrinsic<Intrinsic::tan>(m_Value(X))),
-                     m_OneUse(m_Intrinsic<Intrinsic::cos>(m_Deferred(X)))))) {
+  if (match(&I, m_AllowContract(m_c_FMul(
+                    m_OneUse(m_AllowContract(
+                        m_Intrinsic<Intrinsic::tan>(m_Value(X)))),
+                    m_OneUse(m_AllowContract(
+                        m_Intrinsic<Intrinsic::cos>(m_Deferred(X)))))))) {
     auto *Sin = Builder.CreateUnaryIntrinsic(Intrinsic::sin, X, &I);
     if (auto *Metadata = I.getMetadata(LLVMContext::MD_fpmath)) {
       Sin->setMetadata(LLVMContext::MD_fpmath, Metadata);
@@ -1917,7 +1936,7 @@ Instruction *InstCombinerImpl::foldFDivConstantDivisor(BinaryOperator &I) {
   // If the constant divisor has an exact inverse, this is always safe. If not,
   // then we can still create a reciprocal if fast-math-flags allow it and the
   // constant is a regular number (not zero, infinite, or denormal).
-  if (!(C->hasExactInverseFP() || (I.hasAllowReciprocal() && C->isNormalFP())))
+  if (!C->hasExactInverseFP() && !(I.hasAllowReciprocal() && C->isNormalFP()))
     return nullptr;
 
   // Disallow denormal constants because we don't know what would happen
@@ -1951,11 +1970,15 @@ static Instruction *foldFDivConstantDividend(BinaryOperator &I) {
 
   // Try to reassociate C / X expressions where X includes another constant.
   Constant *C2, *NewC = nullptr;
-  if (match(I.getOperand(1), m_FMul(m_Value(X), m_Constant(C2)))) {
-    // C / (X * C2) --> (C / C2) / X
+  if (match(I.getOperand(1),
+            m_AllowReassoc(m_FMul(m_Value(X), m_Constant(C2))))) {
+    // C / (X * C2) --> C * (1 / (X * C2)) --> C * ((1 / X) * (1 / C2)) -->
+    // (C / C2) * (1 / X)  --> (C / C2) / X
     NewC = ConstantFoldBinaryOpOperands(Instruction::FDiv, C, C2, DL);
-  } else if (match(I.getOperand(1), m_FDiv(m_Value(X), m_Constant(C2)))) {
-    // C / (X / C2) --> (C * C2) / X
+  } else if (match(I.getOperand(1), m_AllowReassoc(m_AllowReciprocal(
+                                        m_FDiv(m_Value(X), m_Constant(C2)))))) {
+    // C / (X / C2) --> C * (1 / (X / C2)) --> C * ((1 / X) * (1 / C2)) -->
+    // (C * C2) * (1 / X) --> (C * C2) / X
     NewC = ConstantFoldBinaryOpOperands(Instruction::FMul, C, C2, DL);
   }
   // Disallow denormal constants because we don't know what would happen
@@ -1974,11 +1997,11 @@ static Instruction *foldFDivPowDivisor(BinaryOperator &I,
   Value *Op0 = I.getOperand(0), *Op1 = I.getOperand(1);
   auto *II = dyn_cast<IntrinsicInst>(Op1);
   if (!II || !II->hasOneUse() || !I.hasAllowReassoc() ||
-      !I.hasAllowReciprocal())
+      !I.hasAllowReciprocal() || !II->hasAllowReassoc())
     return nullptr;
 
-  // Z / pow(X, Y) --> Z * pow(X, -Y)
-  // Z / exp{2}(Y) --> Z * exp{2}(-Y)
+  // Z / pow(X, Y) --> Z  * (1 / pow(X, Y)) --> Z * pow(X, -Y)
+  // Z / exp{2}(Y) --> Z * (1 / exp{2}(Y)) --> Z * exp{2}(-Y)
   // In the general case, this creates an extra instruction, but fmul allows
   // for better canonicalization and optimization than fdiv.
   Intrinsic::ID IID = II->getIntrinsicID();
@@ -2017,22 +2040,21 @@ static Instruction *foldFDivPowDivisor(BinaryOperator &I,
 /// instruction.
 static Instruction *foldFDivSqrtDivisor(BinaryOperator &I,
                                         InstCombiner::BuilderTy &Builder) {
-  // X / sqrt(Y / Z) -->  X * sqrt(Z / Y)
+  // X / sqrt(Y / Z) --> X * (1 / (sqrt(Y / Z))) -->
+  // X * (1 / sqrt(Y * (1 / Z))) -> X * (1 / (sqrt(Y) * sqrt(1 / Z))) -->
+  // X * ((1 / sqrt(Y)) * (1 / sqrt(1 / Z))) --> X * sqrt(Z / Y)
   if (!I.hasAllowReassoc() || !I.hasAllowReciprocal())
     return nullptr;
   Value *Op0 = I.getOperand(0), *Op1 = I.getOperand(1);
   auto *II = dyn_cast<IntrinsicInst>(Op1);
   if (!II || II->getIntrinsicID() != Intrinsic::sqrt || !II->hasOneUse() ||
-      !II->hasAllowReassoc() || !II->hasAllowReciprocal())
+      !II->hasAllowReassoc())
     return nullptr;
 
   Value *Y, *Z;
   auto *DivOp = dyn_cast<Instruction>(II->getOperand(0));
-  if (!DivOp)
-    return nullptr;
-  if (!match(DivOp, m_FDiv(m_Value(Y), m_Value(Z))))
-    return nullptr;
-  if (!DivOp->hasAllowReassoc() || !I.hasAllowReciprocal() ||
+  if (!DivOp || !match(DivOp, m_FDiv(m_Value(Y), m_Value(Z))) ||
+      !DivOp->hasAllowReciprocal() || !DivOp->hasAllowReassoc() ||
       !DivOp->hasOneUse())
     return nullptr;
   Value *SwapDiv = Builder.CreateFDivFMF(Z, Y, DivOp);
@@ -2163,37 +2185,44 @@ Instruction *InstCombinerImpl::visitFDiv(BinaryOperator &I) {
 
   if (I.hasAllowReassoc() && I.hasAllowReciprocal()) {
     Value *X, *Y;
-    if (match(Op0, m_OneUse(m_FDiv(m_Value(X), m_Value(Y)))) &&
+    if (match(Op0, m_OneUse(m_AllowReassoc(
+                       m_AllowReciprocal(m_FDiv(m_Value(X), m_Value(Y)))))) &&
         (!isa<Constant>(Y) || !isa<Constant>(Op1))) {
-      // (X / Y) / Z => X / (Y * Z)
+      // (X / Y) / Z => (X * (1 / Y)) * (1 / Z) =>  X / (Y * Z)
       Value *YZ = Builder.CreateFMulFMF(Y, Op1, &I);
       return BinaryOperator::CreateFDivFMF(X, YZ, &I);
     }
-    if (match(Op1, m_OneUse(m_FDiv(m_Value(X), m_Value(Y)))) &&
+    if (match(Op1, m_OneUse(m_AllowReassoc(
+                       m_AllowReciprocal(m_FDiv(m_Value(X), m_Value(Y)))))) &&
         (!isa<Constant>(Y) || !isa<Constant>(Op0))) {
       // Z / (X / Y) => (Y * Z) / X
       Value *YZ = Builder.CreateFMulFMF(Y, Op0, &I);
       return BinaryOperator::CreateFDivFMF(YZ, X, &I);
     }
+  }
     // Z / (1.0 / Y) => (Y * Z)
     //
     // This is a special case of Z / (X / Y) => (Y * Z) / X, with X = 1.0. The
     // m_OneUse check is avoided because even in the case of the multiple uses
     // for 1.0/Y, the number of instructions remain the same and a division is
     // replaced by a multiplication.
-    if (match(Op1, m_FDiv(m_SpecificFP(1.0), m_Value(Y))))
+  if (I.hasAllowReciprocal()) {
+    Value *Y;
+    if (match(Op1, m_AllowReciprocal(m_FDiv(m_SpecificFP(1.0), m_Value(Y)))))
       return BinaryOperator::CreateFMulFMF(Y, Op0, &I);
   }
 
-  if (I.hasAllowReassoc() && Op0->hasOneUse() && Op1->hasOneUse()) {
+  if (I.hasAllowContract() && Op0->hasOneUse() && Op1->hasOneUse()) {
     // sin(X) / cos(X) -> tan(X)
     // cos(X) / sin(X) -> 1/tan(X) (cotangent)
     Value *X;
-    bool IsTan = match(Op0, m_Intrinsic<Intrinsic::sin>(m_Value(X))) &&
-                 match(Op1, m_Intrinsic<Intrinsic::cos>(m_Specific(X)));
+    bool IsTan =
+        match(Op0, m_AllowContract(m_Intrinsic<Intrinsic::sin>(m_Value(X)))) &&
+        match(Op1, m_AllowContract(m_Intrinsic<Intrinsic::cos>(m_Specific(X))));
     bool IsCot =
-        !IsTan && match(Op0, m_Intrinsic<Intrinsic::cos>(m_Value(X))) &&
-                  match(Op1, m_Intrinsic<Intrinsic::sin>(m_Specific(X)));
+        !IsTan &&
+        match(Op0, m_AllowContract(m_Intrinsic<Intrinsic::cos>(m_Value(X)))) &&
+        match(Op1, m_AllowContract(m_Intrinsic<Intrinsic::sin>(m_Specific(X))));
 
     if ((IsTan || IsCot) && hasFloatFn(M, &TLI, I.getType(), LibFunc_tan,
                                        LibFunc_tanf, LibFunc_tanl)) {
@@ -2215,7 +2244,7 @@ Instruction *InstCombinerImpl::visitFDiv(BinaryOperator &I) {
   // We can ignore the possibility that X is infinity because INF/INF is NaN.
   Value *X, *Y;
   if (I.hasNoNaNs() && I.hasAllowReassoc() &&
-      match(Op1, m_c_FMul(m_Specific(Op0), m_Value(Y)))) {
+      match(Op1, m_AllowReassoc(m_c_FMul(m_Specific(Op0), m_Value(Y))))) {
     replaceOperand(I, 0, ConstantFP::get(I.getType(), 1.0));
     replaceOperand(I, 1, Y);
     return &I;
@@ -2239,15 +2268,15 @@ Instruction *InstCombinerImpl::visitFDiv(BinaryOperator &I) {
 
   // pow(X, Y) / X --> pow(X, Y-1)
   if (I.hasAllowReassoc() &&
-      match(Op0, m_OneUse(m_Intrinsic<Intrinsic::pow>(m_Specific(Op1),
-                                                      m_Value(Y))))) {
+      match(Op0, m_AllowReassoc(m_OneUse(m_Intrinsic<Intrinsic::pow>(
+                     m_Specific(Op1), m_Value(Y)))))) {
     Value *Y1 =
         Builder.CreateFAddFMF(Y, ConstantFP::get(I.getType(), -1.0), &I);
     Value *Pow = Builder.CreateBinaryIntrinsic(Intrinsic::pow, Op1, Y1, &I);
     return replaceInstUsesWith(I, Pow);
   }
 
-  if (Instruction *FoldedPowi = foldPowiReassoc(I))
+  if (Instruction *FoldedPowi = foldPowi(I))
     return FoldedPowi;
 
   return nullptr;

--- a/llvm/test/Transforms/InstCombine/fdiv-cos-sin.ll
+++ b/llvm/test/Transforms/InstCombine/fdiv-cos-sin.ll
@@ -27,27 +27,27 @@ define double @fdiv_strict_cos_strict_sin_reassoc(double %a) {
   ret double %div
 }
 
-define double @fdiv_reassoc_cos_strict_sin_strict(double %a, ptr dereferenceable(2) %dummy) {
-; CHECK-LABEL: @fdiv_reassoc_cos_strict_sin_strict(
-; CHECK-NEXT:    [[TAN:%.*]] = call reassoc double @tan(double [[A:%.*]]) #[[ATTR1:[0-9]+]]
-; CHECK-NEXT:    [[DIV:%.*]] = fdiv reassoc double 1.000000e+00, [[TAN]]
+define double @fdiv_contract_cos_strict_sin_strict(double %a, ptr dereferenceable(2) %dummy) {
+; CHECK-LABEL: @fdiv_contract_cos_strict_sin_strict(
+; CHECK-NEXT:    [[TAN:%.*]] = call contract double @tan(double [[A:%.*]]) #[[ATTR1:[0-9]+]]
+; CHECK-NEXT:    [[DIV:%.*]] = fdiv contract double 1.000000e+00, [[TAN]]
 ; CHECK-NEXT:    ret double [[DIV]]
 ;
-  %1 = call double @llvm.cos.f64(double %a)
-  %2 = call double @llvm.sin.f64(double %a)
-  %div = fdiv reassoc double %1, %2
+  %1 = call contract double @llvm.cos.f64(double %a)
+  %2 = call contract double @llvm.sin.f64(double %a)
+  %div = fdiv contract double %1, %2
   ret double %div
 }
 
-define double @fdiv_reassoc_cos_reassoc_sin_strict(double %a) {
-; CHECK-LABEL: @fdiv_reassoc_cos_reassoc_sin_strict(
-; CHECK-NEXT:    [[TAN:%.*]] = call reassoc double @tan(double [[A:%.*]]) #[[ATTR1]]
-; CHECK-NEXT:    [[DIV:%.*]] = fdiv reassoc double 1.000000e+00, [[TAN]]
+define double @fdiv_contract_cos_contract_sin_strict(double %a) {
+; CHECK-LABEL: @fdiv_contract_cos_contract_sin_strict(
+; CHECK-NEXT:    [[TAN:%.*]] = call contract double @tan(double [[A:%.*]]) #[[ATTR1]]
+; CHECK-NEXT:    [[DIV:%.*]] = fdiv contract double 1.000000e+00, [[TAN]]
 ; CHECK-NEXT:    ret double [[DIV]]
 ;
-  %1 = call reassoc double @llvm.cos.f64(double %a)
-  %2 = call double @llvm.sin.f64(double %a)
-  %div = fdiv reassoc double %1, %2
+  %1 = call contract double @llvm.cos.f64(double %a)
+  %2 = call contract double @llvm.sin.f64(double %a)
+  %div = fdiv contract double %1, %2
   ret double %div
 }
 
@@ -66,15 +66,15 @@ define double @fdiv_cos_sin_reassoc_multiple_uses(double %a) {
   ret double %div
 }
 
-define double @fdiv_cos_sin_reassoc(double %a) {
-; CHECK-LABEL: @fdiv_cos_sin_reassoc(
-; CHECK-NEXT:    [[TAN:%.*]] = call reassoc double @tan(double [[A:%.*]]) #[[ATTR1]]
-; CHECK-NEXT:    [[DIV:%.*]] = fdiv reassoc double 1.000000e+00, [[TAN]]
+define double @fdiv_cos_sin_contract(double %a) {
+; CHECK-LABEL: @fdiv_cos_sin_contract(
+; CHECK-NEXT:    [[TAN:%.*]] = call contract double @tan(double [[A:%.*]]) #[[ATTR1]]
+; CHECK-NEXT:    [[DIV:%.*]] = fdiv contract double 1.000000e+00, [[TAN]]
 ; CHECK-NEXT:    ret double [[DIV]]
 ;
-  %1 = call reassoc double @llvm.cos.f64(double %a)
-  %2 = call reassoc double @llvm.sin.f64(double %a)
-  %div = fdiv reassoc double %1, %2
+  %1 = call contract double @llvm.cos.f64(double %a)
+  %2 = call contract double @llvm.sin.f64(double %a)
+  %div = fdiv contract double %1, %2
   ret double %div
 }
 
@@ -91,27 +91,27 @@ define half @fdiv_cosf16_sinf16_reassoc(half %a) {
   ret half %div
 }
 
-define float @fdiv_cosf_sinf_reassoc(float %a) {
-; CHECK-LABEL: @fdiv_cosf_sinf_reassoc(
-; CHECK-NEXT:    [[TANF:%.*]] = call reassoc float @tanf(float [[A:%.*]]) #[[ATTR1]]
-; CHECK-NEXT:    [[DIV:%.*]] = fdiv reassoc float 1.000000e+00, [[TANF]]
+define float @fdiv_cosf_sinf_contract(float %a) {
+; CHECK-LABEL: @fdiv_cosf_sinf_contract(
+; CHECK-NEXT:    [[TANF:%.*]] = call contract float @tanf(float [[A:%.*]]) #[[ATTR1]]
+; CHECK-NEXT:    [[DIV:%.*]] = fdiv contract float 1.000000e+00, [[TANF]]
 ; CHECK-NEXT:    ret float [[DIV]]
 ;
-  %1 = call reassoc float @llvm.cos.f32(float %a)
-  %2 = call reassoc float @llvm.sin.f32(float %a)
-  %div = fdiv reassoc float %1, %2
+  %1 = call contract float @llvm.cos.f32(float %a)
+  %2 = call contract float @llvm.sin.f32(float %a)
+  %div = fdiv contract float %1, %2
   ret float %div
 }
 
 define fp128 @fdiv_cosfp128_sinfp128_reassoc(fp128 %a) {
 ; CHECK-LABEL: @fdiv_cosfp128_sinfp128_reassoc(
-; CHECK-NEXT:    [[TANL:%.*]] = call reassoc fp128 @tanl(fp128 [[A:%.*]]) #[[ATTR1]]
-; CHECK-NEXT:    [[DIV:%.*]] = fdiv reassoc fp128 0xL00000000000000003FFF000000000000, [[TANL]]
+; CHECK-NEXT:    [[TANL:%.*]] = call contract fp128 @tanl(fp128 [[A:%.*]]) #[[ATTR1]]
+; CHECK-NEXT:    [[DIV:%.*]] = fdiv contract fp128 0xL00000000000000003FFF000000000000, [[TANL]]
 ; CHECK-NEXT:    ret fp128 [[DIV]]
 ;
-  %1 = call reassoc fp128 @llvm.cos.fp128(fp128 %a)
-  %2 = call reassoc fp128 @llvm.sin.fp128(fp128 %a)
-  %div = fdiv reassoc fp128 %1, %2
+  %1 = call contract fp128 @llvm.cos.fp128(fp128 %a)
+  %2 = call contract fp128 @llvm.sin.fp128(fp128 %a)
+  %div = fdiv contract fp128 %1, %2
   ret fp128 %div
 }
 

--- a/llvm/test/Transforms/InstCombine/fdiv-sin-cos.ll
+++ b/llvm/test/Transforms/InstCombine/fdiv-sin-cos.ll
@@ -27,25 +27,25 @@ define double @fdiv_strict_sin_strict_cos_reassoc(double %a) {
   ret double %div
 }
 
-define double @fdiv_reassoc_sin_strict_cos_strict(double %a, ptr dereferenceable(2) %dummy) {
-; CHECK-LABEL: @fdiv_reassoc_sin_strict_cos_strict(
-; CHECK-NEXT:    [[TAN:%.*]] = call reassoc double @tan(double [[A:%.*]]) #[[ATTR1:[0-9]+]]
+define double @fdiv_contract_sin_strict_cos_strict(double %a, ptr dereferenceable(2) %dummy) {
+; CHECK-LABEL: @fdiv_contract_sin_strict_cos_strict(
+; CHECK-NEXT:    [[TAN:%.*]] = call contract double @tan(double [[A:%.*]]) #[[ATTR1:[0-9]+]]
 ; CHECK-NEXT:    ret double [[TAN]]
 ;
-  %1 = call double @llvm.sin.f64(double %a)
-  %2 = call double @llvm.cos.f64(double %a)
-  %div = fdiv reassoc double %1, %2
+  %1 = call contract double @llvm.sin.f64(double %a)
+  %2 = call contract double @llvm.cos.f64(double %a)
+  %div = fdiv contract double %1, %2
   ret double %div
 }
 
-define double @fdiv_reassoc_sin_reassoc_cos_strict(double %a) {
-; CHECK-LABEL: @fdiv_reassoc_sin_reassoc_cos_strict(
-; CHECK-NEXT:    [[TAN:%.*]] = call reassoc double @tan(double [[A:%.*]]) #[[ATTR1]]
+define double @fdiv_contract_sin_contract_cos_strict(double %a) {
+; CHECK-LABEL: @fdiv_contract_sin_contract_cos_strict(
+; CHECK-NEXT:    [[TAN:%.*]] = call contract double @tan(double [[A:%.*]]) #[[ATTR1]]
 ; CHECK-NEXT:    ret double [[TAN]]
 ;
-  %1 = call reassoc double @llvm.sin.f64(double %a)
-  %2 = call double @llvm.cos.f64(double %a)
-  %div = fdiv reassoc double %1, %2
+  %1 = call contract double @llvm.sin.f64(double %a)
+  %2 = call contract double @llvm.cos.f64(double %a)
+  %div = fdiv contract double %1, %2
   ret double %div
 }
 
@@ -64,36 +64,36 @@ define double @fdiv_sin_cos_reassoc_multiple_uses(double %a) {
   ret double %div
 }
 
-define double @fdiv_sin_cos_reassoc(double %a) {
-; CHECK-LABEL: @fdiv_sin_cos_reassoc(
-; CHECK-NEXT:    [[TAN:%.*]] = call reassoc double @tan(double [[A:%.*]]) #[[ATTR1]]
+define double @fdiv_sin_cos_contract(double %a) {
+; CHECK-LABEL: @fdiv_sin_cos_contract(
+; CHECK-NEXT:    [[TAN:%.*]] = call contract double @tan(double [[A:%.*]]) #[[ATTR1]]
 ; CHECK-NEXT:    ret double [[TAN]]
 ;
-  %1 = call reassoc double @llvm.sin.f64(double %a)
-  %2 = call reassoc double @llvm.cos.f64(double %a)
-  %div = fdiv reassoc double %1, %2
+  %1 = call contract double @llvm.sin.f64(double %a)
+  %2 = call contract double @llvm.cos.f64(double %a)
+  %div = fdiv contract double %1, %2
   ret double %div
 }
 
-define float @fdiv_sinf_cosf_reassoc(float %a) {
-; CHECK-LABEL: @fdiv_sinf_cosf_reassoc(
-; CHECK-NEXT:    [[TANF:%.*]] = call reassoc float @tanf(float [[A:%.*]]) #[[ATTR1]]
+define float @fdiv_sinf_cosf_contract(float %a) {
+; CHECK-LABEL: @fdiv_sinf_cosf_contract(
+; CHECK-NEXT:    [[TANF:%.*]] = call contract float @tanf(float [[A:%.*]]) #[[ATTR1]]
 ; CHECK-NEXT:    ret float [[TANF]]
 ;
-  %1 = call reassoc float @llvm.sin.f32(float %a)
-  %2 = call reassoc float @llvm.cos.f32(float %a)
-  %div = fdiv reassoc float %1, %2
+  %1 = call contract float @llvm.sin.f32(float %a)
+  %2 = call contract float @llvm.cos.f32(float %a)
+  %div = fdiv contract float %1, %2
   ret float %div
 }
 
-define fp128 @fdiv_sinfp128_cosfp128_reassoc(fp128 %a) {
-; CHECK-LABEL: @fdiv_sinfp128_cosfp128_reassoc(
-; CHECK-NEXT:    [[TANL:%.*]] = call reassoc fp128 @tanl(fp128 [[A:%.*]]) #[[ATTR1]]
+define fp128 @fdiv_sinfp128_cosfp128_contract(fp128 %a) {
+; CHECK-LABEL: @fdiv_sinfp128_cosfp128_contract(
+; CHECK-NEXT:    [[TANL:%.*]] = call contract fp128 @tanl(fp128 [[A:%.*]]) #[[ATTR1]]
 ; CHECK-NEXT:    ret fp128 [[TANL]]
 ;
-  %1 = call reassoc fp128 @llvm.sin.fp128(fp128 %a)
-  %2 = call reassoc fp128 @llvm.cos.fp128(fp128 %a)
-  %div = fdiv reassoc fp128 %1, %2
+  %1 = call contract fp128 @llvm.sin.fp128(fp128 %a)
+  %2 = call contract fp128 @llvm.cos.fp128(fp128 %a)
+  %div = fdiv contract fp128 %1, %2
   ret fp128 %div
 }
 

--- a/llvm/test/Transforms/InstCombine/fdiv-sqrt.ll
+++ b/llvm/test/Transforms/InstCombine/fdiv-sqrt.ll
@@ -98,7 +98,7 @@ define double @sqrt_div_arcp_missing(double %x, double %y, double %z) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = fdiv reassoc double [[Z:%.*]], [[Y:%.*]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc arcp double @llvm.sqrt.f64(double [[TMP0]])
-; CHECK-NEXT:    [[DIV1:%.*]] = fmul reassoc arcp double [[X:%.*]], [[TMP1]]
+; CHECK-NEXT:    [[DIV1:%.*]] = fdiv reassoc arcp double [[X:%.*]], [[TMP1]]
 ; CHECK-NEXT:    ret double [[DIV1]]
 ;
 entry:
@@ -113,7 +113,7 @@ define double @sqrt_div_arcp_missing2(double %x, double %y, double %z) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv reassoc arcp double [[Y:%.*]], [[Z:%.*]]
 ; CHECK-NEXT:    [[SQRT:%.*]] = call reassoc double @llvm.sqrt.f64(double [[DIV]])
-; CHECK-NEXT:    [[DIV1:%.*]] = fdiv reassoc arcp double [[X:%.*]], [[SQRT]]
+; CHECK-NEXT:    [[DIV1:%.*]] = fmul reassoc arcp double [[X:%.*]], [[SQRT]]
 ; CHECK-NEXT:    ret double [[DIV1]]
 ;
 entry:

--- a/llvm/test/Transforms/InstCombine/fmul-exp.ll
+++ b/llvm/test/Transforms/InstCombine/fmul-exp.ll
@@ -21,14 +21,14 @@ define double @exp_a_exp_b(double %a, double %b) {
 ; exp(a) * exp(b) reassoc, multiple uses
 define double @exp_a_exp_b_multiple_uses(double %a, double %b) {
 ; CHECK-LABEL: @exp_a_exp_b_multiple_uses(
-; CHECK-NEXT:    [[T1:%.*]] = call double @llvm.exp.f64(double [[B:%.*]])
+; CHECK-NEXT:    [[T1:%.*]] = call reassoc double @llvm.exp.f64(double [[B:%.*]])
 ; CHECK-NEXT:    [[TMP1:%.*]] = fadd reassoc double [[A:%.*]], [[B]]
 ; CHECK-NEXT:    [[MUL:%.*]] = call reassoc double @llvm.exp.f64(double [[TMP1]])
 ; CHECK-NEXT:    call void @use(double [[T1]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %t = call double @llvm.exp.f64(double %a)
-  %t1 = call double @llvm.exp.f64(double %b)
+  %t = call reassoc double @llvm.exp.f64(double %a)
+  %t1 = call reassoc double @llvm.exp.f64(double %b)
   %mul = fmul reassoc double %t, %t1
   call void @use(double %t1)
   ret double %mul
@@ -59,8 +59,8 @@ define double @exp_a_exp_b_reassoc(double %a, double %b) {
 ; CHECK-NEXT:    [[MUL:%.*]] = call reassoc double @llvm.exp.f64(double [[TMP1]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %t = call double @llvm.exp.f64(double %a)
-  %t1 = call double @llvm.exp.f64(double %b)
+  %t = call reassoc double @llvm.exp.f64(double %a)
+  %t1 = call reassoc double @llvm.exp.f64(double %b)
   %mul = fmul reassoc double %t, %t1
   ret double %mul
 }
@@ -71,7 +71,7 @@ define double @exp_a_a(double %a) {
 ; CHECK-NEXT:    [[M:%.*]] = call reassoc double @llvm.exp.f64(double [[TMP1]])
 ; CHECK-NEXT:    ret double [[M]]
 ;
-  %t = call double @llvm.exp.f64(double %a)
+  %t = call reassoc double @llvm.exp.f64(double %a)
   %m = fmul reassoc double %t, %t
   ret double %m
 }
@@ -100,12 +100,12 @@ define double @exp_a_exp_b_exp_c_exp_d_fast(double %a, double %b, double %c, dou
 ; CHECK-NEXT:    [[MUL2:%.*]] = call reassoc double @llvm.exp.f64(double [[TMP3]])
 ; CHECK-NEXT:    ret double [[MUL2]]
 ;
-  %t = call double @llvm.exp.f64(double %a)
-  %t1 = call double @llvm.exp.f64(double %b)
+  %t = call reassoc double @llvm.exp.f64(double %a)
+  %t1 = call reassoc double @llvm.exp.f64(double %b)
   %mul = fmul reassoc double %t, %t1
-  %t2 = call double @llvm.exp.f64(double %c)
+  %t2 = call reassoc double @llvm.exp.f64(double %c)
   %mul1 = fmul reassoc double %mul, %t2
-  %t3 = call double @llvm.exp.f64(double %d)
+  %t3 = call reassoc double @llvm.exp.f64(double %d)
   %mul2 = fmul reassoc double %mul1, %t3
   ret double %mul2
 }

--- a/llvm/test/Transforms/InstCombine/fmul-exp2.ll
+++ b/llvm/test/Transforms/InstCombine/fmul-exp2.ll
@@ -21,14 +21,14 @@ define double @exp2_a_exp2_b(double %a, double %b) {
 ; exp2(a) * exp2(b) reassoc, multiple uses
 define double @exp2_a_exp2_b_multiple_uses(double %a, double %b) {
 ; CHECK-LABEL: @exp2_a_exp2_b_multiple_uses(
-; CHECK-NEXT:    [[T1:%.*]] = call double @llvm.exp2.f64(double [[B:%.*]])
+; CHECK-NEXT:    [[T1:%.*]] = call reassoc double @llvm.exp2.f64(double [[B:%.*]])
 ; CHECK-NEXT:    [[TMP1:%.*]] = fadd reassoc double [[A:%.*]], [[B]]
 ; CHECK-NEXT:    [[MUL:%.*]] = call reassoc double @llvm.exp2.f64(double [[TMP1]])
 ; CHECK-NEXT:    call void @use(double [[T1]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %t = call double @llvm.exp2.f64(double %a)
-  %t1 = call double @llvm.exp2.f64(double %b)
+  %t = call reassoc double @llvm.exp2.f64(double %a)
+  %t1 = call reassoc double @llvm.exp2.f64(double %b)
   %mul = fmul reassoc double %t, %t1
   call void @use(double %t1)
   ret double %mul
@@ -40,7 +40,7 @@ define double @exp2_a_a(double %a) {
 ; CHECK-NEXT:    [[M:%.*]] = call reassoc double @llvm.exp2.f64(double [[TMP1]])
 ; CHECK-NEXT:    ret double [[M]]
 ;
-  %t = call double @llvm.exp2.f64(double %a)
+  %t = call reassoc double @llvm.exp2.f64(double %a)
   %m = fmul reassoc double %t, %t
   ret double %m
 }
@@ -70,8 +70,8 @@ define double @exp2_a_exp2_b_reassoc(double %a, double %b) {
 ; CHECK-NEXT:    [[MUL:%.*]] = call reassoc double @llvm.exp2.f64(double [[TMP1]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %t = call double @llvm.exp2.f64(double %a)
-  %t1 = call double @llvm.exp2.f64(double %b)
+  %t = call reassoc double @llvm.exp2.f64(double %a)
+  %t1 = call reassoc double @llvm.exp2.f64(double %b)
   %mul = fmul reassoc double %t, %t1
   ret double %mul
 }
@@ -85,12 +85,12 @@ define double @exp2_a_exp2_b_exp2_c_exp2_d(double %a, double %b, double %c, doub
 ; CHECK-NEXT:    [[MUL2:%.*]] = call reassoc double @llvm.exp2.f64(double [[TMP3]])
 ; CHECK-NEXT:    ret double [[MUL2]]
 ;
-  %t = call double @llvm.exp2.f64(double %a)
-  %t1 = call double @llvm.exp2.f64(double %b)
+  %t = call reassoc double @llvm.exp2.f64(double %a)
+  %t1 = call reassoc double @llvm.exp2.f64(double %b)
   %mul = fmul reassoc double %t, %t1
-  %t2 = call double @llvm.exp2.f64(double %c)
+  %t2 = call reassoc double @llvm.exp2.f64(double %c)
   %mul1 = fmul reassoc double %mul, %t2
-  %t3 = call double @llvm.exp2.f64(double %d)
+  %t3 = call reassoc double @llvm.exp2.f64(double %d)
   %mul2 = fmul reassoc double %mul1, %t3
   ret double %mul2
 }

--- a/llvm/test/Transforms/InstCombine/fmul-pow.ll
+++ b/llvm/test/Transforms/InstCombine/fmul-pow.ll
@@ -26,7 +26,7 @@ define double @pow_ab_a_reassoc(double %a, double %b)  {
 ; CHECK-NEXT:    [[M:%.*]] = call reassoc double @llvm.pow.f64(double [[A:%.*]], double [[TMP1]])
 ; CHECK-NEXT:    ret double [[M]]
 ;
-  %p = call double @llvm.pow.f64(double %a, double %b)
+  %p = call reassoc double @llvm.pow.f64(double %a, double %b)
   %m = fmul reassoc double %p, %a
   ret double %m
 }
@@ -41,7 +41,7 @@ define double @pow_ab_a_reassoc_commute(double %pa, double %b)  {
 ; CHECK-NEXT:    ret double [[M]]
 ;
   %a = fadd double %pa, 42.0 ; thwart complexity-based canonicalization
-  %p = call double @llvm.pow.f64(double %a, double %b)
+  %p = call reassoc double @llvm.pow.f64(double %a, double %b)
   %m = fmul reassoc double %a, %p
   ret double %m
 }
@@ -181,8 +181,8 @@ define double @pow_ab_pow_cb_reassoc(double %a, double %b, double %c) {
 ; CHECK-NEXT:    [[MUL:%.*]] = call reassoc double @llvm.pow.f64(double [[TMP1]], double [[B:%.*]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %1 = call double @llvm.pow.f64(double %a, double %b)
-  %2 = call double @llvm.pow.f64(double %c, double %b)
+  %1 = call reassoc double @llvm.pow.f64(double %a, double %b)
+  %2 = call reassoc double @llvm.pow.f64(double %c, double %b)
   %mul = fmul reassoc double %2, %1
   ret double %mul
 }
@@ -191,14 +191,14 @@ define double @pow_ab_pow_cb_reassoc(double %a, double %b, double %c) {
 
 define double @pow_ab_pow_cb_reassoc_use1(double %a, double %b, double %c) {
 ; CHECK-LABEL: @pow_ab_pow_cb_reassoc_use1(
-; CHECK-NEXT:    [[AB:%.*]] = call double @llvm.pow.f64(double [[A:%.*]], double [[B:%.*]])
+; CHECK-NEXT:    [[AB:%.*]] = call reassoc double @llvm.pow.f64(double [[A:%.*]], double [[B:%.*]])
 ; CHECK-NEXT:    [[TMP1:%.*]] = fmul reassoc double [[A]], [[C:%.*]]
 ; CHECK-NEXT:    [[MUL:%.*]] = call reassoc double @llvm.pow.f64(double [[TMP1]], double [[B]])
 ; CHECK-NEXT:    call void @use(double [[AB]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %ab = call double @llvm.pow.f64(double %a, double %b)
-  %cb = call double @llvm.pow.f64(double %c, double %b)
+  %ab = call reassoc double @llvm.pow.f64(double %a, double %b)
+  %cb = call reassoc double @llvm.pow.f64(double %c, double %b)
   %mul = fmul reassoc double %ab, %cb
   call void @use(double %ab)
   ret double %mul
@@ -208,14 +208,14 @@ define double @pow_ab_pow_cb_reassoc_use1(double %a, double %b, double %c) {
 
 define double @pow_ab_pow_cb_reassoc_use2(double %a, double %b, double %c) {
 ; CHECK-LABEL: @pow_ab_pow_cb_reassoc_use2(
-; CHECK-NEXT:    [[CB:%.*]] = call double @llvm.pow.f64(double [[C:%.*]], double [[B:%.*]])
+; CHECK-NEXT:    [[CB:%.*]] = call reassoc double @llvm.pow.f64(double [[C:%.*]], double [[B:%.*]])
 ; CHECK-NEXT:    [[TMP1:%.*]] = fmul reassoc double [[A:%.*]], [[C]]
 ; CHECK-NEXT:    [[MUL:%.*]] = call reassoc double @llvm.pow.f64(double [[TMP1]], double [[B]])
 ; CHECK-NEXT:    call void @use(double [[CB]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %ab = call double @llvm.pow.f64(double %a, double %b)
-  %cb = call double @llvm.pow.f64(double %c, double %b)
+  %ab = call reassoc double @llvm.pow.f64(double %a, double %b)
+  %cb = call reassoc double @llvm.pow.f64(double %c, double %b)
   %mul = fmul reassoc double %ab, %cb
   call void @use(double %cb)
   ret double %mul
@@ -259,8 +259,8 @@ define double @pow_ab_x_pow_ac_reassoc(double %a, double %b, double %c) {
 ; CHECK-NEXT:    [[MUL:%.*]] = call reassoc double @llvm.pow.f64(double [[A:%.*]], double [[TMP1]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %1 = call double @llvm.pow.f64(double %a, double %b)
-  %2 = call double @llvm.pow.f64(double %a, double %c)
+  %1 = call reassoc double @llvm.pow.f64(double %a, double %b)
+  %2 = call reassoc double @llvm.pow.f64(double %a, double %c)
   %mul = fmul reassoc double %2, %1
   ret double %mul
 }
@@ -271,19 +271,19 @@ define double @pow_ab_reassoc(double %a, double %b) {
 ; CHECK-NEXT:    [[MUL:%.*]] = call reassoc double @llvm.pow.f64(double [[A:%.*]], double [[TMP1]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %1 = call double @llvm.pow.f64(double %a, double %b)
+  %1 = call reassoc double @llvm.pow.f64(double %a, double %b)
   %mul = fmul reassoc double %1, %1
   ret double %mul
 }
 
 define double @pow_ab_reassoc_extra_use(double %a, double %b) {
 ; CHECK-LABEL: @pow_ab_reassoc_extra_use(
-; CHECK-NEXT:    [[TMP1:%.*]] = call double @llvm.pow.f64(double [[A:%.*]], double [[B:%.*]])
+; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc double @llvm.pow.f64(double [[A:%.*]], double [[B:%.*]])
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc double [[TMP1]], [[TMP1]]
 ; CHECK-NEXT:    call void @use(double [[TMP1]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %1 = call double @llvm.pow.f64(double %a, double %b)
+  %1 = call reassoc double @llvm.pow.f64(double %a, double %b)
   %mul = fmul reassoc double %1, %1
   call void @use(double %1)
   ret double %mul
@@ -291,14 +291,14 @@ define double @pow_ab_reassoc_extra_use(double %a, double %b) {
 
 define double @pow_ab_x_pow_ac_reassoc_extra_use(double %a, double %b, double %c) {
 ; CHECK-LABEL: @pow_ab_x_pow_ac_reassoc_extra_use(
-; CHECK-NEXT:    [[TMP1:%.*]] = call double @llvm.pow.f64(double [[A:%.*]], double [[B:%.*]])
+; CHECK-NEXT:    [[TMP1:%.*]] = call reassoc double @llvm.pow.f64(double [[A:%.*]], double [[B:%.*]])
 ; CHECK-NEXT:    [[TMP2:%.*]] = fadd reassoc double [[B]], [[C:%.*]]
 ; CHECK-NEXT:    [[MUL:%.*]] = call reassoc double @llvm.pow.f64(double [[A]], double [[TMP2]])
 ; CHECK-NEXT:    call void @use(double [[TMP1]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %1 = call double @llvm.pow.f64(double %a, double %b)
-  %2 = call double @llvm.pow.f64(double %a, double %c)
+  %1 = call reassoc double @llvm.pow.f64(double %a, double %b)
+  %2 = call reassoc double @llvm.pow.f64(double %a, double %c)
   %mul = fmul reassoc double %1, %2
   call void @use(double %1)
   ret double %mul

--- a/llvm/test/Transforms/InstCombine/fmul-sqrt.ll
+++ b/llvm/test/Transforms/InstCombine/fmul-sqrt.ll
@@ -37,7 +37,7 @@ define double @sqrt_a_sqrt_b_multiple_uses(double %a, double %b) {
   ret double %mul
 }
 
-; sqrt(a) * sqrt(b) => sqrt(a*b) with fast-math
+; sqrt(a) * sqrt(b) => sqrt(a*b) with reassoc flag
 
 define double @sqrt_a_sqrt_b_reassoc_nnan(double %a, double %b) {
 ; CHECK-LABEL: @sqrt_a_sqrt_b_reassoc_nnan(
@@ -45,8 +45,8 @@ define double @sqrt_a_sqrt_b_reassoc_nnan(double %a, double %b) {
 ; CHECK-NEXT:    [[MUL:%.*]] = call reassoc nnan double @llvm.sqrt.f64(double [[TMP1]])
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
-  %1 = call double @llvm.sqrt.f64(double %a)
-  %2 = call double @llvm.sqrt.f64(double %b)
+  %1 = call reassoc double @llvm.sqrt.f64(double %a)
+  %2 = call reassoc double @llvm.sqrt.f64(double %b)
   %mul = fmul reassoc nnan double %1, %2
   ret double %mul
 }
@@ -67,8 +67,7 @@ define double @sqrt_a_sqrt_b_reassoc(double %a, double %b) {
   ret double %mul
 }
 
-; sqrt(a) * sqrt(b) * sqrt(c) * sqrt(d) => sqrt(a*b*c*d) with fast-math
-; 'reassoc nnan' on the fmuls is all that is required, but check propagation of other FMF.
+; sqrt(a) * sqrt(b) * sqrt(c) * sqrt(d) => sqrt(a*b*c*d)
 
 define double @sqrt_a_sqrt_b_sqrt_c_sqrt_d_reassoc(double %a, double %b, double %c, double %d) {
 ; CHECK-LABEL: @sqrt_a_sqrt_b_sqrt_c_sqrt_d_reassoc(
@@ -78,10 +77,10 @@ define double @sqrt_a_sqrt_b_sqrt_c_sqrt_d_reassoc(double %a, double %b, double 
 ; CHECK-NEXT:    [[MUL2:%.*]] = call reassoc nnan ninf double @llvm.sqrt.f64(double [[TMP3]])
 ; CHECK-NEXT:    ret double [[MUL2]]
 ;
-  %1 = call double @llvm.sqrt.f64(double %a)
-  %2 = call double @llvm.sqrt.f64(double %b)
-  %3 = call double @llvm.sqrt.f64(double %c)
-  %4 = call double @llvm.sqrt.f64(double %d)
+  %1 = call reassoc double @llvm.sqrt.f64(double %a)
+  %2 = call reassoc double @llvm.sqrt.f64(double %b)
+  %3 = call reassoc double @llvm.sqrt.f64(double %c)
+  %4 = call reassoc double @llvm.sqrt.f64(double %d)
   %mul = fmul reassoc nnan arcp double %1, %2
   %mul1 = fmul reassoc nnan double %mul, %3
   %mul2 = fmul reassoc nnan ninf double %mul1, %4
@@ -102,14 +101,14 @@ define double @rsqrt_squared(double %x) {
 define double @rsqrt_x_reassociate_extra_use(double %x, ptr %p) {
 ; CHECK-LABEL: @rsqrt_x_reassociate_extra_use(
 ; CHECK-NEXT:    [[SQRT:%.*]] = call double @llvm.sqrt.f64(double [[X:%.*]])
-; CHECK-NEXT:    [[RSQRT:%.*]] = fdiv double 1.000000e+00, [[SQRT]]
-; CHECK-NEXT:    [[RES:%.*]] = fdiv reassoc nsz double [[X]], [[SQRT]]
+; CHECK-NEXT:    [[RSQRT:%.*]] = fdiv arcp double 1.000000e+00, [[SQRT]]
+; CHECK-NEXT:    [[RES:%.*]] = fdiv nsz arcp double [[X]], [[SQRT]]
 ; CHECK-NEXT:    store double [[RSQRT]], ptr [[P:%.*]], align 8
 ; CHECK-NEXT:    ret double [[RES]]
 ;
   %sqrt = call double @llvm.sqrt.f64(double %x)
-  %rsqrt = fdiv double 1.0, %sqrt
-  %res = fmul reassoc nsz double %rsqrt, %x
+  %rsqrt = fdiv arcp double 1.0, %sqrt
+  %res = fmul arcp nsz double %rsqrt, %x
   store double %rsqrt, ptr %p
   ret double %res
 }
@@ -137,8 +136,8 @@ define double @sqrt_divisor_squared(double %x, double %y) {
 ; CHECK-NEXT:    [[SQUARED:%.*]] = fdiv reassoc nnan nsz double [[TMP1]], [[X:%.*]]
 ; CHECK-NEXT:    ret double [[SQUARED]]
 ;
-  %sqrt = call double @llvm.sqrt.f64(double %x)
-  %div = fdiv double %y, %sqrt
+  %sqrt = call reassoc double @llvm.sqrt.f64(double %x)
+  %div = fdiv reassoc double %y, %sqrt
   %squared = fmul reassoc nnan nsz double %div, %div
   ret double %squared
 }
@@ -149,7 +148,7 @@ define <2 x float> @sqrt_dividend_squared(<2 x float> %x, <2 x float> %y) {
 ; CHECK-NEXT:    [[SQUARED:%.*]] = fdiv fast <2 x float> [[X:%.*]], [[TMP1]]
 ; CHECK-NEXT:    ret <2 x float> [[SQUARED]]
 ;
-  %sqrt = call <2 x float> @llvm.sqrt.v2f32(<2 x float> %x)
+  %sqrt = call reassoc <2 x float> @llvm.sqrt.v2f32(<2 x float> %x)
   %div = fdiv fast <2 x float> %sqrt, %y
   %squared = fmul fast <2 x float> %div, %div
   ret <2 x float> %squared
@@ -175,13 +174,13 @@ define double @sqrt_divisor_squared_extra_use(double %x, double %y) {
 
 define double @sqrt_dividend_squared_extra_use(double %x, double %y) {
 ; CHECK-LABEL: @sqrt_dividend_squared_extra_use(
-; CHECK-NEXT:    [[SQRT:%.*]] = call double @llvm.sqrt.f64(double [[X:%.*]])
+; CHECK-NEXT:    [[SQRT:%.*]] = call reassoc double @llvm.sqrt.f64(double [[X:%.*]])
 ; CHECK-NEXT:    call void @use(double [[SQRT]])
 ; CHECK-NEXT:    [[TMP1:%.*]] = fmul fast double [[Y:%.*]], [[Y]]
 ; CHECK-NEXT:    [[SQUARED:%.*]] = fdiv fast double [[X]], [[TMP1]]
 ; CHECK-NEXT:    ret double [[SQUARED]]
 ;
-  %sqrt = call double @llvm.sqrt.f64(double %x)
+  %sqrt = call reassoc double @llvm.sqrt.f64(double %x)
   call void @use(double %sqrt)
   %div = fdiv fast double %sqrt, %y
   %squared = fmul fast double %div, %div

--- a/llvm/test/Transforms/InstCombine/fmul-tan-cos.ll
+++ b/llvm/test/Transforms/InstCombine/fmul-tan-cos.ll
@@ -35,8 +35,8 @@ define double @fmul_contract_tan_strict_cos_strict(double %a) {
 ; CHECK-NEXT:    [[RES:%.*]] = call contract double @llvm.sin.f64(double [[A]])
 ; CHECK-NEXT:    ret double [[RES]]
 ;
-  %tan = call double @llvm.tan.f64(double %a)
-  %cos = call double @llvm.cos.f64(double %a)
+  %tan = call contract double @llvm.tan.f64(double %a)
+  %cos = call contract double @llvm.cos.f64(double %a)
   %res = fmul contract double %tan, %cos
   ret double %res
 }
@@ -48,7 +48,7 @@ define double @fmul_contract_tan_contract_cos_strict(double %a) {
 ; CHECK-NEXT:    ret double [[RES]]
 ;
   %tan = call contract double @llvm.tan.f64(double %a)
-  %cos = call double @llvm.cos.f64(double %a)
+  %cos = call contract double @llvm.cos.f64(double %a)
   %res = fmul contract double %tan, %cos
   ret double %res
 }


### PR DESCRIPTION
As in title. Honoring of these semantics is realized via:
- adding missing checks for appropriate flags on nodes participating in rewrite (almost in every case only the innermost node was being checked);
- changing `reassoc` to more specific transformation in applicable cases (change `fast` check to `reassoc`, check for contract on `tan/ctan` rewrites)
- adding `arcp` checks on top of `reassoc` when reciprocal transformation is also being done as a step of a rewrite;
- expanding comments that detail rewrite steps so it's easier to see which transformations occur.