### PR TITLE
[MLIR][Python] Register `OpAttributeMap` as `Mapping` for `match` compatibility

### DIFF
--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -1782,6 +1782,9 @@ public:
 
   PyNamedAttribute dunderGetItemIndexed(intptr_t index);
 
+  nanobind::object getWithDefaultNamed(const std::string &key,
+                                       nanobind::object defaultValue);
+
   void dunderSetItem(const std::string &name, const PyAttribute &attr);
 
   void dunderDelItem(const std::string &name);

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -1783,7 +1783,7 @@ public:
   PyNamedAttribute dunderGetItemIndexed(intptr_t index);
 
   nanobind::typed<nanobind::object, std::optional<PyAttribute>>
-  getWithDefaultNamed(const std::string &key, nanobind::object defaultValue);
+  get(const std::string &key, nanobind::object defaultValue);
 
   void dunderSetItem(const std::string &name, const PyAttribute &attr);
 

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -1782,8 +1782,8 @@ public:
 
   PyNamedAttribute dunderGetItemIndexed(intptr_t index);
 
-  nanobind::object getWithDefaultNamed(const std::string &key,
-                                       nanobind::object defaultValue);
+  nanobind::typed<nanobind::object, std::optional<PyAttribute>>
+  getWithDefaultNamed(const std::string &key, nanobind::object defaultValue);
 
   void dunderSetItem(const std::string &name, const PyAttribute &attr);
 

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2388,6 +2388,16 @@ PyOpAttributeMap::dunderGetItemNamed(const std::string &name) {
   return PyAttribute(operation->getContext(), attr).maybeDownCast();
 }
 
+nb::object PyOpAttributeMap::getWithDefaultNamed(const std::string &key,
+                                                 nb::object defaultValue) {
+  MlirAttribute attr =
+      mlirOperationGetAttributeByName(operation->get(), toMlirStringRef(key));
+  if (mlirAttributeIsNull(attr)) {
+    return defaultValue;
+  }
+  return PyAttribute(operation->getContext(), attr).maybeDownCast();
+}
+
 PyNamedAttribute PyOpAttributeMap::dunderGetItemIndexed(intptr_t index) {
   if (index < 0) {
     index += dunderLen();
@@ -2450,6 +2460,10 @@ void PyOpAttributeMap::bind(nb::module_ &m) {
            "Sets an attribute with the given name.")
       .def("__delitem__", &PyOpAttributeMap::dunderDelItem, "name"_a,
            "Deletes an attribute with the given name.")
+      .def("get", &PyOpAttributeMap::getWithDefaultNamed, nb::arg("key"),
+           nb::arg("default") = nb::none(),
+           "Gets an attribute by name or the default value, if it does not "
+           "exist.")
       .def(
           "__iter__",
           [](PyOpAttributeMap &self) {

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2389,7 +2389,7 @@ PyOpAttributeMap::dunderGetItemNamed(const std::string &name) {
 }
 
 nb::typed<nb::object, std::optional<PyAttribute>>
-PyOpAttributeMap::getWithDefaultNamed(const std::string &key, nb::object defaultValue) {
+PyOpAttributeMap::get(const std::string &key, nb::object defaultValue) {
   MlirAttribute attr =
       mlirOperationGetAttributeByName(operation->get(), toMlirStringRef(key));
   if (mlirAttributeIsNull(attr))
@@ -2459,7 +2459,7 @@ void PyOpAttributeMap::bind(nb::module_ &m) {
            "Sets an attribute with the given name.")
       .def("__delitem__", &PyOpAttributeMap::dunderDelItem, "name"_a,
            "Deletes an attribute with the given name.")
-      .def("get", &PyOpAttributeMap::getWithDefaultNamed, nb::arg("key"),
+      .def("get", &PyOpAttributeMap::get, nb::arg("key"),
            nb::arg("default") = nb::none(),
            "Gets an attribute by name or the default value, if it does not "
            "exist.")

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2392,9 +2392,8 @@ nb::object PyOpAttributeMap::getWithDefaultNamed(const std::string &key,
                                                  nb::object defaultValue) {
   MlirAttribute attr =
       mlirOperationGetAttributeByName(operation->get(), toMlirStringRef(key));
-  if (mlirAttributeIsNull(attr)) {
+  if (mlirAttributeIsNull(attr))
     return defaultValue;
-  }
   return PyAttribute(operation->getContext(), attr).maybeDownCast();
 }
 

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2388,8 +2388,8 @@ PyOpAttributeMap::dunderGetItemNamed(const std::string &name) {
   return PyAttribute(operation->getContext(), attr).maybeDownCast();
 }
 
-nb::object PyOpAttributeMap::getWithDefaultNamed(const std::string &key,
-                                                 nb::object defaultValue) {
+nb::typed<nb::object, std::optional<PyAttribute>>
+PyOpAttributeMap::getWithDefaultNamed(const std::string &key, nb::object defaultValue) {
   MlirAttribute attr =
       mlirOperationGetAttributeByName(operation->get(), toMlirStringRef(key));
   if (mlirAttributeIsNull(attr))

--- a/mlir/python/mlir/_mlir_libs/__init__.py
+++ b/mlir/python/mlir/_mlir_libs/__init__.py
@@ -2,7 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
 import os
 
@@ -245,6 +245,7 @@ def _site_initialize():
     Sequence.register(ir.OpResultList)
     Sequence.register(ir.OpSuccessors)
     Sequence.register(ir.RegionSequence)
+    Mapping.register(ir.OpAttributeMap)
 
 
 _site_initialize()


### PR DESCRIPTION
This is a continuation of the idea from #174091 to add `match` support for MLIR containers. In this PR the `OpAttributeMap` container is registered as a `Mapping`, so be mapped as a "dictionary" in `match` statements.

For this to work the `get(key, default=None)` method had to be implemented. Those are pretty much copys of `dunderGetItemNamed` and `dunderGetItemIndexed` with an added argument and `nb::object` as return type, because they can now return other types than just `PyAttribute`. Was unsure if I should refactor this to make `dunderGetItem...` use the new `getWithDefault...` or if a separate method is preferred. Kept it as a copy for simplicitys sake for now.

Even though the `OpAttributeMap` supports indexing by `int` and `str`, Python does not allow to register it as a `Sequence` and a `Mapping` at the same time. If it is registered as a Sequence it only returns the attribute names as string, not as `NamedAttribute`. It is technically possible to also use integer keys for the `dict`-like match, but it doesn't provide any constraints on the number of attributes, etc., so probably not recommended.

<details><summary>Example</summary>

```python
from mlir.ir import Context, Module, OpAttributeMap
from collections.abc import Sequence

ctx = Context()
ctx.allow_unregistered_dialects = True
module = Module.parse(
    r"""
"some.op"() { some.attribute = 1 : i8,
                other.attribute = 3.0,
                dependent = "text" } : () -> ()
""",
    ctx,
)
op = module.body.operations[0]

def test(attr):
    match attr:
        case [*args]:
            print("matched a Sequence", args)
        case _:
            print("Didn't match as Sequence")
    match attr:
        case {"some.attribute": a, "other.attribute": b, "dependent": c}:
            print("Matched as Mapping individually", a, b, c)
        case _:
            print("Didn't match a Mapping")
    match attr:
        case {0: a, 1: b}:
            print("Matched as Mapping with 2 int keys", a, b)
        case _:
            print("Didn't match as Mapping with 2 int keys")
print("Registered as Mapping only:")
test(op.attributes)
print("\nAfter additonally registering as Sequence:")
Sequence.register(OpAttributeMap)
test(op.attributes)
```
Output:
```
Registered as Mapping only:
Didn't match as Sequence
Matched as Mapping individually 1 : i8 3.000000e+00 : f64 "text"
Matched as Mapping with 2 int keys NamedAttribute(dependent="text") NamedAttribute(other.attribute=3.000000e+00 : f64)

After additonally registering as Sequence:
matched a Sequence ['dependent', 'other.attribute', 'some.attribute']
Didn't match a Mapping
Didn't match as Mapping with 2 int keys
```
</details>

makslevental Would be great if you could take a look again ❤️ 