### PR TITLE
[clang-tidy][NFC] Simplify 'utils::lexer::findNextTokenSkippingComments'

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/LexerUtils.cpp
+++ b/clang-tools-extra/clang-tidy/utils/LexerUtils.cpp
@@ -75,21 +75,6 @@ SourceLocation findNextTerminator(SourceLocation Start, const SourceManager &SM,
   return findNextAnyTokenKind(Start, SM, LangOpts, tok::comma, tok::semi);
 }
 
-std::optional<Token>
-findNextTokenSkippingComments(SourceLocation Start, const SourceManager &SM,
-                              const LangOptions &LangOpts) {
-  while (Start.isValid()) {
-    std::optional<Token> CurrentToken =
-        Lexer::findNextToken(Start, SM, LangOpts);
-    if (!CurrentToken || !CurrentToken->is(tok::comment))
-      return CurrentToken;
-
-    Start = CurrentToken->getLocation();
-  }
-
-  return std::nullopt;
-}
-
 bool rangeContainsExpansionsOrDirectives(SourceRange Range,
                                          const SourceManager &SM,
                                          const LangOptions &LangOpts) {

--- a/clang-tools-extra/clang-tidy/utils/LexerUtils.h
+++ b/clang-tools-extra/clang-tidy/utils/LexerUtils.h
@@ -89,6 +89,7 @@ SourceLocation findNextAnyTokenKind(SourceLocation Start,
   }
 }
 
+// Finds next token that's including a comment.
 inline std::optional<Token>
 findNextTokenIncludingComments(SourceLocation Start, const SourceManager &SM,
                                const LangOptions &LangOpts) {
@@ -96,9 +97,11 @@ findNextTokenIncludingComments(SourceLocation Start, const SourceManager &SM,
 }
 
 // Finds next token that's not a comment.
-std::optional<Token> findNextTokenSkippingComments(SourceLocation Start,
-                                                   const SourceManager &SM,
-                                                   const LangOptions &LangOpts);
+inline std::optional<Token>
+findNextTokenSkippingComments(SourceLocation Start, const SourceManager &SM,
+                              const LangOptions &LangOpts) {
+  return Lexer::findNextToken(Start, SM, LangOpts, false);
+}
 
 /// Re-lex the provide \p Range and return \c false if either a macro spans
 /// multiple tokens, a pre-processor directive or failure to retrieve the

--- a/clang-tools-extra/clang-tidy/utils/LexerUtils.h
+++ b/clang-tools-extra/clang-tidy/utils/LexerUtils.h
@@ -89,7 +89,7 @@ SourceLocation findNextAnyTokenKind(SourceLocation Start,
   }
 }
 
-// Finds next token that's including a comment.
+// Finds next token, possibly a comment.
 inline std::optional<Token>
 findNextTokenIncludingComments(SourceLocation Start, const SourceManager &SM,
                                const LangOptions &LangOpts) {


### PR DESCRIPTION
Will later refactor checks to use `findNextTokenSkippingComments`/`findNextTokenIncludingComments` because the 4th argument of `Lexer::findNextToken` is pain to remember every time (moreover it has default value of skipping comments that is also hard to remember).

The cool part is that in the 22nd release (which will happen in a few weeks) we will be able to use `CustomQueryChecks` and I think we can prohibit usage of `Lexer::findNextToken` in favor of "safer api" alternatives
