### PR TITLE
[LLVM] Make crashing tests with not use --crash

### DIFF
--- a/llvm/test/CodeGen/SPIRV/ga-interp-func-interp.ll
+++ b/llvm/test/CodeGen/SPIRV/ga-interp-func-interp.ll
@@ -1,4 +1,3 @@
-; REQUIRES: asserts
 ; RUN: not --crash llc -O0 -mtriple=spirv64-unknown-unknown < %s 2>&1 | FileCheck %s
 ; CHECK: unable to translate instruction: call (in function: kernel)
 

--- a/llvm/test/CodeGen/SPIRV/ga-interp-func-noninterp.ll
+++ b/llvm/test/CodeGen/SPIRV/ga-interp-func-noninterp.ll
@@ -1,4 +1,3 @@
-; REQUIRES: asserts
 ; RUN: not --crash llc -O0 -mtriple=spirv64-unknown-unknown < %s 2>&1 | FileCheck %s
 ; CHECK: unable to translate instruction: call (in function: kernel)
 

--- a/llvm/test/CodeGen/SPIRV/ga-noninterp-func-interp.ll
+++ b/llvm/test/CodeGen/SPIRV/ga-noninterp-func-interp.ll
@@ -1,4 +1,3 @@
-; REQUIRES: asserts
 ; RUN: not --crash llc -O0 -mtriple=spirv64-unknown-unknown < %s 2>&1 | FileCheck %s
 ; CHECK: unable to translate instruction: call (in function: kernel)
 

--- a/llvm/test/CodeGen/SPIRV/hlsl-resources/UniqueImplicitBindingNumber.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-resources/UniqueImplicitBindingNumber.ll
@@ -1,4 +1,3 @@
-; REQUIRES: asserts
 ; RUN: not --crash llc -O0 -mtriple=spirv32-unknown-unknown %s -o %t.spvt 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ; CHECK-ERROR: LLVM ERROR: Implicit binding calls with the same order ID must have the same descriptor set
 

--- a/llvm/test/Verifier/token1.ll
+++ b/llvm/test/Verifier/token1.ll
@@ -1,4 +1,5 @@
-; RUN: not llvm-as -disable-output %s 2>&1 | FileCheck %s
+; RUN: %if !asserts %{ not llvm-as -disable-output %s 2>&1 | FileCheck %s %}
+; RUN: %if asserts %{ not --crash llvm-as -disable-output %s 2>&1 | FileCheck %s %}
 
 define void @f(token %A, token %B) {
 entry:

--- a/llvm/test/Verifier/token1.ll
+++ b/llvm/test/Verifier/token1.ll
@@ -1,5 +1,4 @@
-; RUN: %if !asserts %{ not llvm-as -disable-output %s 2>&1 | FileCheck %s %}
-; RUN: %if asserts %{ not --crash llvm-as -disable-output %s 2>&1 | FileCheck %s %}
+; RUN: not llvm-as -disable-output %s 2>&1 | FileCheck %s
 
 define void @f(token %A, token %B) {
 entry:


### PR DESCRIPTION
This makes them compliant with the behavior from prior to the internal
shell. A future PR will fix the behavior with the internal shell so that
it behaves properly.
