### PR TITLE
[clang-tidy][NFC] use findNextTokenSkippingComments instead of Lexer::findNextToken

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/RedundantBranchConditionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/RedundantBranchConditionCheck.cpp
@@ -8,6 +8,7 @@
 
 #include "RedundantBranchConditionCheck.h"
 #include "../utils/Aliasing.h"
+#include "../utils/LexerUtils.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Analysis/Analyses/ExprMutationAnalyzer.h"
@@ -135,8 +136,8 @@ void RedundantBranchConditionCheck::check(
       const SourceLocation BeforeOtherSide =
           OtherSide->getBeginLoc().getLocWithOffset(-1);
       const SourceLocation AfterOtherSide =
-          Lexer::findNextToken(OtherSide->getEndLoc(), *Result.SourceManager,
-                               getLangOpts())
+          utils::lexer::findNextTokenSkippingComments(
+              OtherSide->getEndLoc(), *Result.SourceManager, getLangOpts())
               ->getLocation();
       Diag << FixItHint::CreateRemoval(
                   CharSourceRange::getTokenRange(IfBegin, BeforeOtherSide))
@@ -167,8 +168,9 @@ void RedundantBranchConditionCheck::check(
           CondOp->getLHS()->getBeginLoc(), BeforeRHS));
     } else {
       const SourceLocation AfterLHS =
-          Lexer::findNextToken(CondOp->getLHS()->getEndLoc(),
-                               *Result.SourceManager, getLangOpts())
+          utils::lexer::findNextTokenSkippingComments(
+              CondOp->getLHS()->getEndLoc(), *Result.SourceManager,
+              getLangOpts())
               ->getLocation();
       Diag << FixItHint::CreateRemoval(CharSourceRange::getTokenRange(
           AfterLHS, CondOp->getRHS()->getEndLoc()));

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "PreferMemberInitializerCheck.h"
+#include "../utils/LexerUtils.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
-#include "clang/Lex/Lexer.h"
 #include "llvm/ADT/DenseMap.h"
 
 using namespace clang::ast_matchers;
@@ -269,7 +269,7 @@ void PreferMemberInitializerCheck::check(
     }
 
     SourceLocation SemiColonEnd;
-    if (auto NextToken = Lexer::findNextToken(
+    if (auto NextToken = utils::lexer::findNextTokenSkippingComments(
             S->getEndLoc(), *Result.SourceManager, getLangOpts()))
       SemiColonEnd = NextToken->getEndLoc();
     else

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/VirtualClassDestructorCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/VirtualClassDestructorCheck.cpp
@@ -65,7 +65,7 @@ getVirtualKeywordRange(const CXXDestructorDecl &Destructor,
   /// Range ends with \c StartOfNextToken so that any whitespace after \c
   /// virtual is included.
   std::optional<Token> NextToken =
-      Lexer::findNextToken(VirtualEndLoc, SM, LangOpts);
+      utils::lexer::findNextTokenSkippingComments(VirtualEndLoc, SM, LangOpts);
   if (!NextToken)
     return std::nullopt;
   const SourceLocation StartOfNextToken = NextToken->getLocation();

--- a/clang-tools-extra/clang-tidy/llvm/UseNewMLIROpBuilderCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/UseNewMLIROpBuilderCheck.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "UseNewMLIROpBuilderCheck.h"
+#include "../utils/LexerUtils.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/Basic/LLVM.h"
-#include "clang/Lex/Lexer.h"
 #include "clang/Tooling/Transformer/RangeSelector.h"
 #include "clang/Tooling/Transformer/RewriteRule.h"
 #include "clang/Tooling/Transformer/Stencil.h"
@@ -52,11 +52,11 @@ static EditGenerator rewrite(RangeSelector Call, RangeSelector Builder) {
         return CurrentToken;
       if (CurrentToken->is(clang::tok::eof))
         return std::optional<Token>();
-      return clang::Lexer::findNextToken(CurrentToken->getLocation(), SM,
-                                         LangOpts);
+      return utils::lexer::findNextTokenSkippingComments(
+          CurrentToken->getLocation(), SM, LangOpts);
     };
     std::optional<Token> LessToken =
-        clang::Lexer::findNextToken(Begin, SM, LangOpts);
+        utils::lexer::findNextTokenSkippingComments(Begin, SM, LangOpts);
     while (LessToken && LessToken->getKind() != clang::tok::less)
       LessToken = NextToken(LessToken);
     if (!LessToken) {

--- a/clang-tools-extra/clang-tidy/modernize/ConcatNestedNamespacesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/ConcatNestedNamespacesCheck.cpp
@@ -34,9 +34,8 @@ std::optional<SourceRange>
 NS::getCleanedNamespaceFrontRange(const SourceManager &SM,
                                   const LangOptions &LangOpts) const {
   // Front from namespace tp '{'
-  std::optional<Token> Tok =
-      ::clang::tidy::utils::lexer::findNextTokenSkippingComments(
-          back()->getLocation(), SM, LangOpts);
+  std::optional<Token> Tok = utils::lexer::findNextTokenSkippingComments(
+      back()->getLocation(), SM, LangOpts);
   if (!Tok)
     return std::nullopt;
   while (Tok->getKind() != tok::TokenKind::l_brace) {

--- a/clang-tools-extra/clang-tidy/modernize/ReplaceDisallowCopyAndAssignMacroCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/ReplaceDisallowCopyAndAssignMacroCheck.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ReplaceDisallowCopyAndAssignMacroCheck.h"
+#include "../utils/LexerUtils.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/MacroArgs.h"
 #include "clang/Lex/PPCallbacks.h"
@@ -59,7 +60,7 @@ private:
   /// \returns \c true if the next token after the given \p MacroLoc is \b not a
   /// semicolon.
   bool shouldAppendSemi(SourceRange MacroLoc) {
-    std::optional<Token> Next = Lexer::findNextToken(
+    std::optional<Token> Next = utils::lexer::findNextTokenSkippingComments(
         MacroLoc.getEnd(), PP.getSourceManager(), PP.getLangOpts());
     return !(Next && Next->is(tok::semi));
   }

--- a/clang-tools-extra/clang-tidy/readability/AvoidUnconditionalPreprocessorIfCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/AvoidUnconditionalPreprocessorIfCheck.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AvoidUnconditionalPreprocessorIfCheck.h"
+#include "../utils/LexerUtils.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/Lex/PPCallbacks.h"
 #include "clang/Lex/Preprocessor.h"
@@ -45,7 +46,8 @@ struct AvoidUnconditionalPreprocessorIfPPCallbacks : public PPCallbacks {
 
     Token Tok;
     if (Lexer::getRawToken(Loc, Tok, SM, LangOpts, true)) {
-      std::optional<Token> TokOpt = Lexer::findNextToken(Loc, SM, LangOpts);
+      std::optional<Token> TokOpt =
+          utils::lexer::findNextTokenSkippingComments(Loc, SM, LangOpts);
       if (!TokOpt || TokOpt->getLocation().isMacroID())
         return false;
       Tok = *TokOpt;
@@ -55,8 +57,8 @@ struct AvoidUnconditionalPreprocessorIfPPCallbacks : public PPCallbacks {
       if (!isImmutableToken(Tok))
         return false;
 
-      std::optional<Token> TokOpt =
-          Lexer::findNextToken(Tok.getLocation(), SM, LangOpts);
+      std::optional<Token> TokOpt = utils::lexer::findNextTokenSkippingComments(
+          Tok.getLocation(), SM, LangOpts);
       if (!TokOpt || TokOpt->getLocation().isMacroID())
         return false;
       Tok = *TokOpt;

--- a/clang-tools-extra/clang-tidy/readability/RedundantInlineSpecifierCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantInlineSpecifierCheck.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "RedundantInlineSpecifierCheck.h"
+#include "../utils/LexerUtils.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
@@ -64,8 +65,8 @@ static SourceLocation getInlineTokenLocation(SourceRange RangeLocation,
         CurrentToken->getRawIdentifier() == "inline")
       return CurrentToken->getLocation();
 
-    CurrentToken =
-        Lexer::findNextToken(CurrentToken->getLocation(), Sources, LangOpts);
+    CurrentToken = utils::lexer::findNextTokenSkippingComments(
+        CurrentToken->getLocation(), Sources, LangOpts);
   }
   return {};
 }

--- a/clang-tools-extra/clang-tidy/utils/FormatStringConverter.cpp
+++ b/clang-tools-extra/clang-tidy/utils/FormatStringConverter.cpp
@@ -14,6 +14,7 @@
 
 #include "FormatStringConverter.h"
 #include "../utils/FixItHintUtils.h"
+#include "../utils/LexerUtils.h"
 #include "clang/AST/Expr.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Basic/LangOptions.h"
@@ -800,7 +801,8 @@ void FormatStringConverter::applyFixes(DiagnosticBuilder &Diag,
 
   for (const auto &[ArgIndex, Replacement] : ArgFixes) {
     const SourceLocation AfterOtherSide =
-        Lexer::findNextToken(Args[ArgIndex]->getEndLoc(), SM, LangOpts)
+        utils::lexer::findNextTokenSkippingComments(Args[ArgIndex]->getEndLoc(),
+                                                    SM, LangOpts)
             ->getLocation();
 
     Diag << FixItHint::CreateInsertion(Args[ArgIndex]->getBeginLoc(),

--- a/clang-tools-extra/clang-tidy/utils/LexerUtils.cpp
+++ b/clang-tools-extra/clang-tidy/utils/LexerUtils.cpp
@@ -100,7 +100,7 @@ bool rangeContainsExpansionsOrDirectives(SourceRange Range,
     if (Loc.isMacroID())
       return true;
 
-    std::optional<Token> Tok = Lexer::findNextToken(Loc, SM, LangOpts);
+    std::optional<Token> Tok = findNextTokenSkippingComments(Loc, SM, LangOpts);
 
     if (!Tok)
       return true;


### PR DESCRIPTION
Follow up to https://github.com/llvm/llvm-project/pull/174295.