### PR TITLE
Fix typo in clang/www/builtins.py

### DIFF
--- a/clang/www/builtins.py
+++ b/clang/www/builtins.py
@@ -33,7 +33,7 @@ repl_map = {
     "__builtin_ia32_divsd": "_mm_div_sd",
     "__builtin_ia32_divpd": "_mm_div_pd",
     "__builtin_ia32_divps": "_mm_div_ps",
-    "__builtin_ia32_subss": "_mm_div_ss",
+    "__builtin_ia32_divss": "_mm_div_ss",
     "__builtin_ia32_andpd": "_mm_and_pd",
     "__builtin_ia32_andps": "_mm_and_ps",
     "__builtin_ia32_pand128": "_mm_and_si128",


### PR DESCRIPTION
`__builtin_ia32_subss` appeared in the list twice; the 2nd one looks bugged