### PR TITLE
[C-API] Allow SectionMemoryManager's ReserveAlloc flag to be enabled

### DIFF
--- a/llvm/include/llvm-c/OrcEE.h
+++ b/llvm/include/llvm-c/OrcEE.h
@@ -60,6 +60,15 @@ LLVMOrcCreateRTDyldObjectLinkingLayerWithSectionMemoryManager(
     LLVMOrcExecutionSessionRef ES);
 
 /**
+ * Create a RTDyldObjectLinkingLayer instance using the standard
+ * SectionMemoryManager for memory management. If ReserveAlloc is true then
+ * a contiguous range of memory will be reserved for each object file.
+ */
+LLVM_C_ABI LLVMOrcObjectLayerRef
+LLVMOrcCreateRTDyldObjectLinkingLayerWithSectionMemoryManagerReserveAlloc(
+    LLVMOrcExecutionSessionRef ES, bool ReserveAlloc);
+
+/**
  * Create a RTDyldObjectLinkingLayer instance using MCJIT-memory-manager-like
  * callbacks.
  *

--- a/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
@@ -1041,6 +1041,16 @@ LLVMOrcCreateRTDyldObjectLinkingLayerWithSectionMemoryManager(
 }
 
 LLVMOrcObjectLayerRef
+LLVMOrcCreateRTDyldObjectLinkingLayerWithSectionMemoryManagerReserveAlloc(
+    LLVMOrcExecutionSessionRef ES, bool ReserveAlloc) {
+  assert(ES && "ES must not be null");
+  return wrap(new RTDyldObjectLinkingLayer(
+      *unwrap(ES), [ReserveAlloc](const MemoryBuffer &) {
+        return std::make_unique<SectionMemoryManager>(nullptr, ReserveAlloc);
+      }));
+}
+
+LLVMOrcObjectLayerRef
 LLVMOrcCreateRTDyldObjectLinkingLayerWithMCJITMemoryManagerLikeCallbacks(
     LLVMOrcExecutionSessionRef ES, void *CreateContextCtx,
     LLVMMemoryManagerCreateContextCallback CreateContext,


### PR DESCRIPTION
Allow C programs to pass a ReserveAlloc flag to the constructor of
llvm::SessionMemoryManager, using a new variant of
LLVMOrcCreateRTDyldObjectLinkingLayerWithSectionMemoryManager that has
...ReserveAlloc() appended to its name.