### PR TITLE
[Polly] Add null pointer check before size retrieval

### DIFF
--- a/polly/lib/Analysis/ScopBuilder.cpp
+++ b/polly/lib/Analysis/ScopBuilder.cpp
@@ -3250,7 +3250,11 @@ static bool buildMinMaxAccess(isl::set Set,
   Set = Set.remove_divs();
   polly::simplify(Set);
 
-  if (unsignedFromIslSize(Set.n_basic_set()) > RunTimeChecksMaxAccessDisjuncts)
+  unsigned SetSize = 0;
+  if (!Set.is_null())
+    SetSize = unsignedFromIslSize(Set.n_basic_set());
+
+  if (SetSize > RunTimeChecksMaxAccessDisjuncts)
     Set = Set.simple_hull();
 
   // Restrict the number of parameters involved in the access as the lexmin/

--- a/polly/lib/Analysis/ScopBuilder.cpp
+++ b/polly/lib/Analysis/ScopBuilder.cpp
@@ -3250,11 +3250,10 @@ static bool buildMinMaxAccess(isl::set Set,
   Set = Set.remove_divs();
   polly::simplify(Set);
 
-  unsigned SetSize = 0;
-  if (!Set.is_null())
-    SetSize = unsignedFromIslSize(Set.n_basic_set());
+  if (Set.is_null())
+    return false;
 
-  if (SetSize > RunTimeChecksMaxAccessDisjuncts)
+  if (unsignedFromIslSize(Set.n_basic_set()) > RunTimeChecksMaxAccessDisjuncts)
     Set = Set.simple_hull();
 
   // Restrict the number of parameters involved in the access as the lexmin/


### PR DESCRIPTION
This patch avoids assertion failures by ensuring a null pointer check is performed before accessing the object's size.
Note: The corresponding test case remains too large even after reduction, so it has not been included in this patch.

Fixes #174147