### PR TITLE
[clang][bytecode] Fix typeid test under msan

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -4900,8 +4900,11 @@ Compiler<Emitter>::visitVarDecl(const VarDecl *VD, const Expr *Init,
 
     UnsignedOrNone GlobalIndex = P.getGlobal(VD);
     if (GlobalIndex) {
+      // The global was previously created but the initializer failed.
+      if (!P.getGlobal(*GlobalIndex)->isInitialized())
+        return false;
       // We've already seen and initialized this global.
-      if (P.getPtrGlobal(*GlobalIndex).isInitialized())
+      if (P.isGlobalInitialized(*GlobalIndex))
         return checkDecl();
       // The previous attempt at initialization might've been unsuccessful,
       // so let's try this one.

--- a/clang/test/AST/ByteCode/typeid.cpp
+++ b/clang/test/AST/ByteCode/typeid.cpp
@@ -72,3 +72,14 @@ namespace TypeidPtrRegression {
   }
 }
 
+namespace GH173950 {
+  struct A {
+    virtual void f();
+  };
+
+  static A &a = *new A;
+  extern A &a;
+
+  // This used to crash with: Assertion `IsInitialized' failed in invokeDtor()
+  const std::type_info &a_ti = typeid(a);
+}


### PR DESCRIPTION
The original problem description sounded sane but it was lacking a bit. What happens where is that the global block is ultimately not initialized simply because it was already created before and its initializer failed, causing us to call invokeDtor() in a previous evaluation.

Check for the initialion state earlier and abort there instead of accessing the (now uninitialized) data of the block, causing msan failures.

See the failed msan build at https://lab.llvm.org/buildbot/#/builders/164/builds/17206