### PR TITLE
[flang][cuda] Skip sizeof intrinsic in check

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -342,7 +342,7 @@ static bool DefersSameTypeParameters(
 // arguments.
 static const llvm::StringSet<> cudaSkippedIntrinsics = {"__builtin_c_devloc",
     "__builtin_c_f_pointer", "__builtin_c_loc", "allocated", "associated",
-    "kind", "lbound", "loc", "present", "shape", "size", "ubound"};
+    "kind", "lbound", "loc", "present", "shape", "size", "sizeof", "ubound"};
 
 static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
     const std::string &dummyName, evaluate::Expr<evaluate::SomeType> &actual,

--- a/flang/test/Semantics/cuf23.cuf
+++ b/flang/test/Semantics/cuf23.cuf
@@ -75,4 +75,5 @@ subroutine intrinsic_error_size(n)
   integer :: n, x
   real(8), device :: d(n,n)
   x = size(d,dim=1) ! ok
+  x = sizeof(d) ! ok
 end subroutine


### PR DESCRIPTION
#174025 introduced a new semantic check for host intrinsic with device variable.`sizeof` intrinsic extension should be skipped for this check. 