### PR TITLE
[lldb-dap] Add language model tool

### DIFF
--- a/lldb/tools/lldb-dap/package-lock.json
+++ b/lldb/tools/lldb-dap/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lldb-dap",
-  "version": "0.2.16",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lldb-dap",
-      "version": "0.2.16",
+      "version": "0.4.1",
       "license": "Apache 2.0 License with LLVM exceptions",
       "dependencies": {
         "chokidar": "^4.0.3"
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@types/node": "^18.19.41",
         "@types/tabulator-tables": "^6.2.10",
-        "@types/vscode": "1.75.0",
+        "@types/vscode": "1.95.0",
         "@types/vscode-webview": "^1.57.5",
         "@vscode/debugprotocol": "^1.68.0",
         "@vscode/vsce": "^3.2.2",
@@ -25,7 +25,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "vscode": "^1.75.0"
+        "vscode": "^1.95.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -856,9 +856,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
-      "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+      "version": "1.95.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.95.0.tgz",
+      "integrity": "sha512-0LBD8TEiNbet3NvWsmn59zLzOFu/txSlGxnv5yAFHCrhG9WvAnR3IvfHzMOs2aeWqgvNjq9pO99IUw8d3n+unw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2656,6 +2656,7 @@
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -22,7 +22,7 @@
     "LLDB"
   ],
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.95.0"
   },
   "categories": [
     "Debuggers"
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/node": "^18.19.41",
     "@types/tabulator-tables": "^6.2.10",
-    "@types/vscode": "1.75.0",
+    "@types/vscode": "1.95.0",
     "@types/vscode-webview": "^1.57.5",
     "@vscode/debugprotocol": "^1.68.0",
     "@vscode/vsce": "^3.2.2",
@@ -946,6 +946,26 @@
           "icon": "$(symbol-module)"
         }
       ]
-    }
+    },
+    "languageModelTools": [
+			{
+				"name": "lldb_dap_command",
+				"displayName": "Run an lldb command.",
+				"modelDescription": "Run an lldb command.",
+				"canBeReferencedInPrompt": true,
+				"toolReferenceName": "lldb_dap_command",
+				"inputSchema": {
+					"type": "object",
+					"properties": {
+						"command": {
+							"type": "string",
+							"description": "The command and its arguments as a string."
+						}
+					},
+					"required": [ "command" ]
+				},
+				"when": "debugType == 'lldb-dap'"
+			}
+		]
   }
 }

--- a/lldb/tools/lldb-dap/src-ts/command-tool.ts
+++ b/lldb/tools/lldb-dap/src-ts/command-tool.ts
@@ -1,0 +1,26 @@
+import * as vscode from "vscode";
+
+export interface CommandArgs {
+  command: string;
+}
+
+export class CommandTool implements vscode.LanguageModelTool<CommandArgs> {
+  async invoke(
+    options: vscode.LanguageModelToolInvocationOptions<CommandArgs>,
+    token: vscode.CancellationToken,
+  ): Promise<vscode.LanguageModelToolResult> {
+    const session = vscode.debug.activeDebugSession;
+    if (session === undefined) {
+      return new vscode.LanguageModelToolResult([
+        new vscode.LanguageModelTextPart("Error: no debug session is active"),
+      ]);
+    }
+    const response = await session.customRequest("evaluate", {
+      expression: options.input.command,
+      context: "repl",
+    });
+    return new vscode.LanguageModelToolResult([
+      new vscode.LanguageModelTextPart(response.result),
+    ]);
+  }
+}

--- a/lldb/tools/lldb-dap/src-ts/extension.ts
+++ b/lldb/tools/lldb-dap/src-ts/extension.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 
+import { CommandTool } from "./command-tool";
 import { LLDBDapDescriptorFactory } from "./debug-adapter-factory";
 import { DisposableContext } from "./disposable-context";
 import { LaunchUriHandler } from "./uri-launch-handler";
@@ -52,6 +53,7 @@ export class LLDBDapExtension extends DisposableContext {
         new ModulesDataProvider(sessionTracker),
       ),
       vscode.window.registerUriHandler(new LaunchUriHandler()),
+      vscode.lm.registerTool("lldb_dap_command", new CommandTool()),
     );
 
     this.pushSubscription(vscode.commands.registerCommand(


### PR DESCRIPTION
VS Code 1.95 added [support](https://code.visualstudio.com/updates/v1_95#_tools-for-language-models) for language model tools. It is a simple analogue of MCP server. LLDB already has MCP server implementation, but it needs some manual actions to start, so I prefer to add a simpler way.

There are some discussion topics:
1) We should bump the minimal VS Code version that might affect some users.
2) I just copied the tool (execute lldb command) from the original MCP server, but we can provide more DAP-like API (e.g. get all threads, get all variables, ...).

WDYT?