### PR TITLE
[lldb] Step over non-lldb breakpoints

### DIFF
--- a/lldb/include/lldb/Core/Architecture.h
+++ b/lldb/include/lldb/Core/Architecture.h
@@ -139,12 +139,11 @@ public:
     return lldb::UnwindPlanSP();
   }
 
-  /// Returns whether a given byte sequence is a valid breakpoint for the
-  /// architecture. Some architectures have breakpoint instructions that
-  /// have immediates that can take on any value, resulting in a family
-  /// of valid byte sequences. If the observed byte sequence is shorter
-  /// than the reference then they are considered not to match, even if
-  /// the initial bytes would match.
+  /// Returns whether a given byte sequence is a valid trap instruction for the
+  /// architecture. Some architectures feature instructions that have immediates
+  /// that can take on any value, resulting in a family of valid byte sequences.
+  /// If the observed byte sequence is shorter than the reference then they are
+  /// considered not to match, even if the initial bytes would match.
   virtual bool IsValidTrapInstruction(llvm::ArrayRef<uint8_t> reference,
                                       llvm::ArrayRef<uint8_t> observed) const {
     if (reference.size() > observed.size())

--- a/lldb/include/lldb/Core/Architecture.h
+++ b/lldb/include/lldb/Core/Architecture.h
@@ -145,9 +145,8 @@ public:
   /// of valid byte sequences. If the observed byte sequence is shorter
   /// than the reference then they are considered not to match, even if
   /// the initial bytes would match.
-  virtual bool
-  IsValidBreakpointInstruction(llvm::ArrayRef<uint8_t> reference,
-                               llvm::ArrayRef<uint8_t> observed) const {
+  virtual bool IsValidTrapInstruction(llvm::ArrayRef<uint8_t> reference,
+                                      llvm::ArrayRef<uint8_t> observed) const {
     if (reference.size() > observed.size())
       return false;
     return !std::memcmp(reference.data(), observed.data(), reference.size());

--- a/lldb/include/lldb/Core/Architecture.h
+++ b/lldb/include/lldb/Core/Architecture.h
@@ -138,6 +138,18 @@ public:
       std::shared_ptr<const UnwindPlan> current_unwindplan) {
     return lldb::UnwindPlanSP();
   }
+
+  /// Returns whether a given byte sequence is a valid breakpoint for the
+  /// architecture. Some architectures have breakpoint instructions that
+  /// have immediates that can take on any value, resulting in a family
+  /// of valid byte sequences. Bases the size comparison on the reference.
+  virtual bool
+  IsValidBreakpointInstruction(llvm::ArrayRef<uint8_t> reference,
+                               llvm::ArrayRef<uint8_t> observed) const {
+    if (reference.size() > observed.size())
+      return false;
+    return !std::memcmp(reference.data(), observed.data(), reference.size());
+  }
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Core/Architecture.h
+++ b/lldb/include/lldb/Core/Architecture.h
@@ -142,7 +142,9 @@ public:
   /// Returns whether a given byte sequence is a valid breakpoint for the
   /// architecture. Some architectures have breakpoint instructions that
   /// have immediates that can take on any value, resulting in a family
-  /// of valid byte sequences. Bases the size comparison on the reference.
+  /// of valid byte sequences. If the observed byte sequence is shorter
+  /// than the reference then they are considered not to match, even if
+  /// the initial bytes would match.
   virtual bool
   IsValidBreakpointInstruction(llvm::ArrayRef<uint8_t> reference,
                                llvm::ArrayRef<uint8_t> observed) const {

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -336,11 +336,15 @@ public:
   /// those bits set as 0.
   ///
   /// \param[in] arch
-  ///     The architecture of the inferior
+  ///     The architecture of the inferior.
   /// \param size_hint
   ///     A hint to disambiguate which instruction is used on platforms where
   ///     there are multiple interrupts with different sizes in the ISA (e.g
-  ///     ARM Thumb, RISC-V)
+  ///     ARM Thumb, RISC-V).
+  ///
+  /// \return
+  ///     The bytes of the interrupt instruction, with any immediate value
+  ///     bits set to 0.
   llvm::ArrayRef<uint8_t> SoftwareTrapOpcodeBytes(const ArchSpec &arch,
                                                   size_t size_hint = 0);
 
@@ -352,11 +356,14 @@ public:
   /// and zero meaning no applicable hint.
   ///
   /// \param[in] target
-  ///     The target of the inferior
+  ///     The target of the inferior.
   /// \param addr
-  ///     The address of the instruction
+  ///     The address of the instruction.
   /// \param bytes
-  ///     The raw bytes of the instruction
+  ///     The raw bytes of the instruction.
+  /// \return
+  ///     The estimated size in bytes of the instruction for this target at
+  ///     the given address, or 0 if no estimate is available.
   size_t GetTrapOpcodeSizeHint(Target &target, Address addr,
                                llvm::ArrayRef<uint8_t> bytes);
 

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -353,17 +353,9 @@ public:
   /// instead of the "normal" encoding. This function attempts to determine
   /// a size hint for the size of the instruction at address \a addr, and
   /// return 0, 2 or 4, with 2 and 4 corresponding to the estimated size
-  /// and zero meaning no applicable hint.
-  ///
-  /// \param[in] target
-  ///     The target of the inferior.
-  /// \param addr
-  ///     The address of the instruction.
-  /// \param bytes
-  ///     The raw bytes of the instruction.
-  /// \return
-  ///     The estimated size in bytes of the instruction for this target at
-  ///     the given address, or 0 if no estimate is available.
+  /// and zero meaning no applicable hint. Returns the estimated size in bytes 
+  /// of the instruction for this target at the given address, or 0 if no 
+  /// estimate is available.
   size_t GetTrapOpcodeSizeHint(Target &target, Address addr,
                                llvm::ArrayRef<uint8_t> bytes);
 

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -330,7 +330,10 @@ public:
   virtual std::vector<ArchSpec>
   GetSupportedArchitectures(const ArchSpec &process_host_arch) = 0;
 
-  /// Get the bytes of the platform's software interrupt instruction.
+  /// Get the bytes of the platform's software interrupt instruction. If there
+  /// are multiple possible encodings, for example where there are immediate
+  /// values encoded in the instruction, this will return the instruction with
+  /// those bits set as 0.
   ///
   /// \param[in] arch
   ///     The architecture of the inferior
@@ -342,6 +345,11 @@ public:
                                                   size_t size_hint = 0);
 
   /// Get the suggested size hint for a trap instruction on the given target.
+  /// Some platforms have a compressed instruction set which can be used
+  /// instead of the "normal" encoding. This function attempts to determine
+  /// a size hint for the size of the instruction at address \a addr, and
+  /// return 0, 2 or 4, with 2 and 4 corresponding to the estimated size
+  /// and zero meaning no applicable hint.
   ///
   /// \param[in] target
   ///     The target of the inferior

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -330,6 +330,17 @@ public:
   virtual std::vector<ArchSpec>
   GetSupportedArchitectures(const ArchSpec &process_host_arch) = 0;
 
+  /// Get the bytes of the platform's software interrupt instruction.
+  ///
+  /// \param[in] arch
+  ///     The architecture of the inferior
+  /// \param size_hint
+  ///     A hint to disambiguate which instruction is used on platforms where
+  ///     there are multiple interrupts with different sizes in the ISA (e.g
+  ///     ARM Thumb, RISC-V)
+  llvm::ArrayRef<uint8_t> SoftwareTrapOpcodeTable(const ArchSpec &arch,
+                                                  size_t size_hint = 0);
+
   virtual size_t GetSoftwareBreakpointTrapOpcode(Target &target,
                                                  BreakpointSite *bp_site);
 

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -353,8 +353,8 @@ public:
   /// instead of the "normal" encoding. This function attempts to determine
   /// a size hint for the size of the instruction at address \a addr, and
   /// return 0, 2 or 4, with 2 and 4 corresponding to the estimated size
-  /// and zero meaning no applicable hint. Returns the estimated size in bytes 
-  /// of the instruction for this target at the given address, or 0 if no 
+  /// and zero meaning no applicable hint. Returns the estimated size in bytes
+  /// of the instruction for this target at the given address, or 0 if no
   /// estimate is available.
   size_t GetTrapOpcodeSizeHint(Target &target, Address addr,
                                llvm::ArrayRef<uint8_t> bytes);

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -341,6 +341,17 @@ public:
   llvm::ArrayRef<uint8_t> SoftwareTrapOpcodeBytes(const ArchSpec &arch,
                                                   size_t size_hint = 0);
 
+  /// Get the suggested size hint for a trap instruction on the given target.
+  ///
+  /// \param[in] target
+  ///     The target of the inferior
+  /// \param addr
+  ///     The address of the instruction
+  /// \param bytes
+  ///     The raw bytes of the instruction
+  size_t GetTrapOpcodeSizeHint(Target &target, Address addr,
+                               llvm::ArrayRef<uint8_t> bytes);
+
   virtual size_t GetSoftwareBreakpointTrapOpcode(Target &target,
                                                  BreakpointSite *bp_site);
 

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -338,7 +338,7 @@ public:
   ///     A hint to disambiguate which instruction is used on platforms where
   ///     there are multiple interrupts with different sizes in the ISA (e.g
   ///     ARM Thumb, RISC-V)
-  llvm::ArrayRef<uint8_t> SoftwareTrapOpcodeTable(const ArchSpec &arch,
+  llvm::ArrayRef<uint8_t> SoftwareTrapOpcodeBytes(const ArchSpec &arch,
                                                   size_t size_hint = 0);
 
   virtual size_t GetSoftwareBreakpointTrapOpcode(Target &target,

--- a/lldb/include/lldb/Target/StopInfo.h
+++ b/lldb/include/lldb/Target/StopInfo.h
@@ -218,6 +218,10 @@ protected:
   // to consult this later on.
   virtual bool ShouldStop(Event *event_ptr) { return true; }
 
+  // Shared implementation for when a trap instruction leaves the CPU PC at
+  // the trap instruction instead of just after it.
+  void SkipOverTrapInstruction();
+
   // Classes that inherit from StackID can see and modify these
   lldb::ThreadWP m_thread_wp; // The thread corresponding to the stop reason.
   uint32_t m_stop_id;   // The process stop ID for which this stop info is valid

--- a/lldb/include/lldb/Target/StopInfo.h
+++ b/lldb/include/lldb/Target/StopInfo.h
@@ -219,7 +219,9 @@ protected:
   virtual bool ShouldStop(Event *event_ptr) { return true; }
 
   // Shared implementation for when a trap instruction leaves the CPU PC at
-  // the trap instruction instead of just after it.
+  // the trap instruction, instead of just after it. Currently the subclasses
+  // StopInfoMachException and StopInfoUnixSignal use this to skip over the
+  // instruction at the PC if it is a matching trap instruction.
   void SkipOverTrapInstruction();
 
   // Classes that inherit from StackID can see and modify these

--- a/lldb/source/Plugins/Architecture/AArch64/ArchitectureAArch64.cpp
+++ b/lldb/source/Plugins/Architecture/AArch64/ArchitectureAArch64.cpp
@@ -144,7 +144,7 @@ bool ArchitectureAArch64::ReconfigureRegisterInfo(DynamicRegisterInfo &reg_info,
   return true;
 }
 
-bool ArchitectureAArch64::IsValidBreakpointInstruction(
+bool ArchitectureAArch64::IsValidTrapInstruction(
     llvm::ArrayRef<uint8_t> reference, llvm::ArrayRef<uint8_t> observed) const {
   if (reference.size() < 4 || observed.size() < 4)
     return false;

--- a/lldb/source/Plugins/Architecture/AArch64/ArchitectureAArch64.cpp
+++ b/lldb/source/Plugins/Architecture/AArch64/ArchitectureAArch64.cpp
@@ -150,8 +150,8 @@ bool ArchitectureAArch64::IsValidBreakpointInstruction(
     return false;
   auto ref_bytes = llvm::support::endian::read32le(reference.data());
   auto bytes = llvm::support::endian::read32le(observed.data());
-  // Only the 11 highest bits define the breakpoint, the others include an
-  // immediate which is stored to a CPU register.
+  // Only the 11 highest bits define the breakpoint instruction, the others
+  // include an immediate value that we will explicitly check against.
   uint32_t mask = 0xFFE00000;
   // Check that the masked bytes match the reference, but also check that the
   // immediate in the instruction is the default output by llvm.debugtrap

--- a/lldb/source/Plugins/Architecture/AArch64/ArchitectureAArch64.cpp
+++ b/lldb/source/Plugins/Architecture/AArch64/ArchitectureAArch64.cpp
@@ -154,7 +154,7 @@ bool ArchitectureAArch64::IsValidTrapInstruction(
   // include an immediate value that we will explicitly check against.
   uint32_t mask = 0xFFE00000;
   // Check that the masked bytes match the reference, but also check that the
-  // immediate in the instruction is the default output by llvm.debugtrap
-  // The reference has the immediate set as all-zero, so mask and check here
+  // immediate in the instruction is the default output by llvm.debugtrap.
+  // The reference has the immediate set as all-zero, so mask and check here.
   return (ref_bytes == (bytes & mask)) && ((bytes & ~mask) >> 5 == 0xF000);
 }

--- a/lldb/source/Plugins/Architecture/AArch64/ArchitectureAArch64.h
+++ b/lldb/source/Plugins/Architecture/AArch64/ArchitectureAArch64.h
@@ -39,9 +39,8 @@ public:
                                DataExtractor &reg_data,
                                RegisterContext &reg_context) const override;
 
-  bool
-  IsValidBreakpointInstruction(llvm::ArrayRef<uint8_t> reference,
-                               llvm::ArrayRef<uint8_t> observed) const override;
+  bool IsValidTrapInstruction(llvm::ArrayRef<uint8_t> reference,
+                              llvm::ArrayRef<uint8_t> observed) const override;
 
 private:
   static std::unique_ptr<Architecture> Create(const ArchSpec &arch);

--- a/lldb/source/Plugins/Architecture/AArch64/ArchitectureAArch64.h
+++ b/lldb/source/Plugins/Architecture/AArch64/ArchitectureAArch64.h
@@ -39,6 +39,10 @@ public:
                                DataExtractor &reg_data,
                                RegisterContext &reg_context) const override;
 
+  bool
+  IsValidBreakpointInstruction(llvm::ArrayRef<uint8_t> reference,
+                               llvm::ArrayRef<uint8_t> observed) const override;
+
 private:
   static std::unique_ptr<Architecture> Create(const ArchSpec &arch);
   ArchitectureAArch64() = default;

--- a/lldb/source/Plugins/Architecture/Arm/ArchitectureArm.cpp
+++ b/lldb/source/Plugins/Architecture/Arm/ArchitectureArm.cpp
@@ -339,7 +339,7 @@ UnwindPlanSP ArchitectureArm::GetArchitectureUnwindPlan(
   return new_plan;
 }
 
-bool ArchitectureArm::IsValidBreakpointInstruction(
+bool ArchitectureArm::IsValidTrapInstruction(
     llvm::ArrayRef<uint8_t> reference, llvm::ArrayRef<uint8_t> observed) const {
   if (reference.size() > observed.size())
     return false;

--- a/lldb/source/Plugins/Architecture/Arm/ArchitectureArm.cpp
+++ b/lldb/source/Plugins/Architecture/Arm/ArchitectureArm.cpp
@@ -22,6 +22,8 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegisterValue.h"
 
+#include "llvm/Support/Endian.h"
+
 using namespace lldb_private;
 using namespace lldb;
 
@@ -335,4 +337,32 @@ UnwindPlanSP ArchitectureArm::GetArchitectureUnwindPlan(
     new_plan->AppendRow(row);
   }
   return new_plan;
+}
+
+bool ArchitectureArm::IsValidBreakpointInstruction(
+    llvm::ArrayRef<uint8_t> reference, llvm::ArrayRef<uint8_t> observed) const {
+  auto is_bkpt = false;
+  if (observed.size() < reference.size())
+    return false;
+  if (reference.size() == 2) {
+    auto ref_bytes = llvm::support::endian::read16le(reference.data());
+    auto obs_bytes = llvm::support::endian::read16le(observed.data());
+    is_bkpt = ref_bytes == obs_bytes;
+    // LLDB uses an undef instruction encoding for breakpoints
+    // perhaps we have an actual BKPT in the inferior
+    if (!is_bkpt) {
+      uint16_t mask = 0xF0;
+      is_bkpt = (obs_bytes & mask) == 0xBE00;
+    }
+  } else if (reference.size() == 4) {
+    auto ref_bytes = llvm::support::endian::read32le(reference.data());
+    auto obs_bytes = llvm::support::endian::read32le(observed.data());
+    is_bkpt = ref_bytes == obs_bytes;
+    if (!is_bkpt) {
+      uint32_t mask = 0x0FF000F0;
+      uint32_t bkpt_pattern = 0xE1200070;
+      is_bkpt = (obs_bytes & mask) == bkpt_pattern;
+    }
+  }
+  return is_bkpt;
 }

--- a/lldb/source/Plugins/Architecture/Arm/ArchitectureArm.cpp
+++ b/lldb/source/Plugins/Architecture/Arm/ArchitectureArm.cpp
@@ -341,9 +341,10 @@ UnwindPlanSP ArchitectureArm::GetArchitectureUnwindPlan(
 
 bool ArchitectureArm::IsValidBreakpointInstruction(
     llvm::ArrayRef<uint8_t> reference, llvm::ArrayRef<uint8_t> observed) const {
-  auto is_bkpt = false;
-  if (observed.size() < reference.size())
+  if (reference.size() > observed.size())
     return false;
+
+  auto is_bkpt = false;
   if (reference.size() == 2) {
     auto ref_bytes = llvm::support::endian::read16le(reference.data());
     auto obs_bytes = llvm::support::endian::read16le(observed.data());

--- a/lldb/source/Plugins/Architecture/Arm/ArchitectureArm.h
+++ b/lldb/source/Plugins/Architecture/Arm/ArchitectureArm.h
@@ -34,6 +34,10 @@ public:
       lldb_private::Thread &thread, lldb_private::RegisterContextUnwind *regctx,
       std::shared_ptr<const UnwindPlan> current_unwindplan) override;
 
+  bool
+  IsValidBreakpointInstruction(llvm::ArrayRef<uint8_t> reference,
+                               llvm::ArrayRef<uint8_t> observed) const override;
+
 private:
   static std::unique_ptr<Architecture> Create(const ArchSpec &arch);
   ArchitectureArm() = default;

--- a/lldb/source/Plugins/Architecture/Arm/ArchitectureArm.h
+++ b/lldb/source/Plugins/Architecture/Arm/ArchitectureArm.h
@@ -34,9 +34,8 @@ public:
       lldb_private::Thread &thread, lldb_private::RegisterContextUnwind *regctx,
       std::shared_ptr<const UnwindPlan> current_unwindplan) override;
 
-  bool
-  IsValidBreakpointInstruction(llvm::ArrayRef<uint8_t> reference,
-                               llvm::ArrayRef<uint8_t> observed) const override;
+  bool IsValidTrapInstruction(llvm::ArrayRef<uint8_t> reference,
+                              llvm::ArrayRef<uint8_t> observed) const override;
 
 private:
   static std::unique_ptr<Architecture> Create(const ArchSpec &arch);

--- a/lldb/source/Plugins/Architecture/Mips/ArchitectureMips.cpp
+++ b/lldb/source/Plugins/Architecture/Mips/ArchitectureMips.cpp
@@ -19,6 +19,8 @@
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 
+#include "llvm/Support/Endian.h"
+
 using namespace lldb_private;
 using namespace lldb;
 
@@ -228,4 +230,13 @@ Instruction *ArchitectureMips::GetInstructionAtAddress(
   }
 
   return nullptr;
+}
+
+bool ArchitectureMips::IsValidBreakpointInstruction(
+    llvm::ArrayRef<uint8_t> reference, llvm::ArrayRef<uint8_t> observed) const {
+  // The middle twenty bits of BREAK can be anything, so zero them
+  uint32_t mask = 0xFC00003F;
+  auto ref_bytes = llvm::support::endian::read32le(reference.data());
+  auto bytes = llvm::support::endian::read32le(observed.data());
+  return (ref_bytes & mask) == (bytes & mask);
 }

--- a/lldb/source/Plugins/Architecture/Mips/ArchitectureMips.cpp
+++ b/lldb/source/Plugins/Architecture/Mips/ArchitectureMips.cpp
@@ -232,7 +232,7 @@ Instruction *ArchitectureMips::GetInstructionAtAddress(
   return nullptr;
 }
 
-bool ArchitectureMips::IsValidBreakpointInstruction(
+bool ArchitectureMips::IsValidTrapInstruction(
     llvm::ArrayRef<uint8_t> reference, llvm::ArrayRef<uint8_t> observed) const {
   // The middle twenty bits of BREAK can be anything, so zero them
   uint32_t mask = 0xFC00003F;

--- a/lldb/source/Plugins/Architecture/Mips/ArchitectureMips.h
+++ b/lldb/source/Plugins/Architecture/Mips/ArchitectureMips.h
@@ -33,9 +33,8 @@ public:
   lldb::addr_t GetOpcodeLoadAddress(lldb::addr_t load_addr,
                                     AddressClass addr_class) const override;
 
-  bool
-  IsValidBreakpointInstruction(llvm::ArrayRef<uint8_t> reference,
-                               llvm::ArrayRef<uint8_t> observed) const override;
+  bool IsValidTrapInstruction(llvm::ArrayRef<uint8_t> reference,
+                              llvm::ArrayRef<uint8_t> observed) const override;
 
 private:
   Instruction *GetInstructionAtAddress(Target &target,

--- a/lldb/source/Plugins/Architecture/Mips/ArchitectureMips.h
+++ b/lldb/source/Plugins/Architecture/Mips/ArchitectureMips.h
@@ -33,6 +33,10 @@ public:
   lldb::addr_t GetOpcodeLoadAddress(lldb::addr_t load_addr,
                                     AddressClass addr_class) const override;
 
+  bool
+  IsValidBreakpointInstruction(llvm::ArrayRef<uint8_t> reference,
+                               llvm::ArrayRef<uint8_t> observed) const override;
+
 private:
   Instruction *GetInstructionAtAddress(Target &target,
                                        const Address &resolved_addr,

--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
@@ -827,6 +827,13 @@ StopInfoSP StopInfoMachException::CreateStopReasonWithMachException(
       not_stepping_but_got_singlestep_exception);
 }
 
+void StopInfoMachException::PerformAction([[maybe_unused]] Event *event_ptr) {
+  if (!(m_value == 6 /*EXC_BREAKPOINT*/ &&
+        m_exc_code == 1 /*EXC_ARM_BREAKPOINT*/))
+    return;
+  SkipOverTrapInstruction();
+}
+
 // Detect an unusual situation on Darwin where:
 //
 //   0. We did an instruction-step before this.

--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.h
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.h
@@ -86,6 +86,10 @@ public:
   };
 #endif
 
+  /// Allow this plugin to respond to stop events to enable skip-over-trap
+  /// behaviour on AArch64.
+  void PerformAction(Event *event_ptr) override;
+
   // Since some mach exceptions will be reported as breakpoints, signals,
   // or trace, we use this static accessor which will translate the mach
   // exception into the correct StopInfo.

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -2103,7 +2103,7 @@ size_t Platform::GetSoftwareBreakpointTrapOpcode(Target &target,
   }
 
   size_t size_hint = 0;
-  // Check for either ARM or RISC-V short instruction conditions
+  // Check for either ARM or RISC-V short instruction conditions.
   if ((addr_class == AddressClass::eCodeAlternateISA) ||
       (arch.GetFlags() & ArchSpec::eRISCV_rvc))
     size_hint = 2;

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -2056,7 +2056,7 @@ llvm::ArrayRef<uint8_t> Platform::SoftwareTrapOpcodeBytes(const ArchSpec &arch,
     static const uint8_t g_wasm_opcode[] = {0x00};
     trap_opcode = llvm::ArrayRef<uint8_t>(g_wasm_opcode, sizeof(g_wasm_opcode));
   } break;
-  // The default case should not match against anything, so return empty Array
+  // The default case should not match against anything, so return empty Array.
   default: {
     trap_opcode = llvm::ArrayRef<uint8_t>{};
   };
@@ -2071,7 +2071,7 @@ size_t Platform::GetTrapOpcodeSizeHint(Target &target, Address addr,
   const auto &triple = arch.GetTriple();
 
   if (bytes.size() && triple.isRISCV()) {
-    // RISC-V instructions have the two LSB as 0b11 if they are four-byte
+    // RISC-V instructions have the two LSB as 0b11 if they are four-byte.
     return (bytes[0] & 0b11) == 0b11 ? 4 : 2;
   }
 
@@ -2079,6 +2079,8 @@ size_t Platform::GetTrapOpcodeSizeHint(Target &target, Address addr,
     if (auto addr_class = addr.GetAddressClass();
         addr_class == AddressClass::eCodeAlternateISA) {
       return 2;
+    } else {
+      return 4;
     }
   }
   return 0;

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -2056,11 +2056,9 @@ llvm::ArrayRef<uint8_t> Platform::SoftwareTrapOpcodeBytes(const ArchSpec &arch,
     static const uint8_t g_wasm_opcode[] = {0x00};
     trap_opcode = llvm::ArrayRef<uint8_t>(g_wasm_opcode, sizeof(g_wasm_opcode));
   } break;
-  // The default case should not match against anything, so return a zero
-  // size array.
+  // The default case should not match against anything, so return a nullptr
   default: {
-    static const uint8_t g_no_opcode[] = {};
-    trap_opcode = llvm::ArrayRef<uint8_t>(g_no_opcode, 0);
+    trap_opcode = llvm::ArrayRef<uint8_t>(nullptr, 0);
   };
   }
   return trap_opcode;

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -2058,7 +2058,7 @@ llvm::ArrayRef<uint8_t> Platform::SoftwareTrapOpcodeBytes(const ArchSpec &arch,
   } break;
   // The default case should not match against anything, so return a nullptr
   default: {
-    trap_opcode = llvm::ArrayRef<uint8_t>(nullptr, 0);
+    trap_opcode = llvm::ArrayRef<uint8_t>{}};
   };
   }
   return trap_opcode;

--- a/lldb/source/Target/StopInfo.cpp
+++ b/lldb/source/Target/StopInfo.cpp
@@ -107,9 +107,6 @@ void StopInfo::SkipOverTrapInstruction() {
   auto platform_opcode =
       platform_sp->SoftwareTrapOpcodeBytes(target.GetArchitecture(), size_hint);
 
-  auto is_valid_trap = arch_plugin->IsValidTrapInstruction(platform_opcode,
-      llvm::ArrayRef<uint8_t>(bytes_at_pc.data(), bytes_at_pc.size()
-
   if (auto *arch_plugin = target.GetArchitecturePlugin();
       arch_plugin &&
       arch_plugin->IsValidTrapInstruction(

--- a/lldb/source/Target/StopInfo.cpp
+++ b/lldb/source/Target/StopInfo.cpp
@@ -1186,7 +1186,7 @@ public:
 
     if (auto *arch_plugin = target.GetArchitecturePlugin();
         arch_plugin &&
-        arch_plugin->IsValidBreakpointInstruction(
+        arch_plugin->IsValidTrapInstruction(
             platform_opcode,
             llvm::ArrayRef<uint8_t>(bytes_at_pc.data(), bytes_at_pc.size()))) {
       LLDB_LOG(log, "stepping over breakpoint in debuggee to new pc: {}",

--- a/lldb/source/Target/StopInfo.cpp
+++ b/lldb/source/Target/StopInfo.cpp
@@ -1197,9 +1197,8 @@ public:
 
   void PerformAction([[maybe_unused]] Event *event_ptr) override {
     // A signal of SIGTRAP indicates that a trap instruction has been hit.
-    if (m_value != SIGTRAP)
-      return;
-    SkipOverTrapInstruction();
+    if (m_value == SIGTRAP)
+      SkipOverTrapInstruction();
   }
 
   bool ShouldStop(Event *event_ptr) override { return IsShouldStopSignal(); }

--- a/lldb/test/API/functionalities/builtin-debugtrap/Makefile
+++ b/lldb/test/API/functionalities/builtin-debugtrap/Makefile
@@ -1,3 +1,3 @@
-CXX_SOURCES := main.cpp
+C_SOURCES := main.c
 
 include Makefile.rules

--- a/lldb/test/API/functionalities/builtin-debugtrap/TestBuiltinDebugTrap.py
+++ b/lldb/test/API/functionalities/builtin-debugtrap/TestBuiltinDebugTrap.py
@@ -55,7 +55,8 @@ class BuiltinDebugTrapTestCase(TestBase):
         self.assertEqual(global_value.GetValueAsUnsigned(), 10)
 
         # Change the handling of SIGILL on x86-64 Linux - do not pass it
-        # to the inferior, but stop and notify lldb.
+        # to the inferior, but stop and notify lldb. If we don't do this,
+        # the inferior will receive the SIGILL and be terminated.
         if self.getArchitecture() == "x86_64" and platform == "linux":
             self.runCmd("process handle -p false SIGILL")
 

--- a/lldb/test/API/functionalities/builtin-debugtrap/TestBuiltinDebugTrap.py
+++ b/lldb/test/API/functionalities/builtin-debugtrap/TestBuiltinDebugTrap.py
@@ -54,6 +54,11 @@ class BuiltinDebugTrapTestCase(TestBase):
         # "global" is now 10.
         self.assertEqual(global_value.GetValueAsUnsigned(), 10)
 
+        # Change the handling of SIGILL on x86-64 Linux - do not pass it
+        # to the inferior, but stop and notify lldb.
+        if self.getArchitecture() == "x86_64" and platform == "linux":
+            self.runCmd("process handle -p false SIGILL")
+
         # We should be at the same point as before -- cannot advance
         # past a __builtin_trap().
         process.Continue()
@@ -61,10 +66,6 @@ class BuiltinDebugTrapTestCase(TestBase):
             self.runCmd("f")
             self.runCmd("bt")
             self.runCmd("ta v global")
-
-        # Some platforms might exit when seeing the trap instruction
-        if process.GetState() == lldb.eStateExited:
-            return
 
         self.assertEqual(
             process.GetSelectedThread().GetStopReason(), platform_stop_reason

--- a/lldb/test/API/functionalities/builtin-debugtrap/main.c
+++ b/lldb/test/API/functionalities/builtin-debugtrap/main.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 int global = 0;
-int main()
-{
+int main() {
   global = 5; // Set a breakpoint here
   puts("");
   __builtin_debugtrap();

--- a/lldb/tools/debugserver/source/MacOSX/arm64/DNBArchImplARM64.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/arm64/DNBArchImplARM64.cpp
@@ -842,28 +842,6 @@ bool DNBArchMachARM64::NotifyException(MachException::Data &exc) {
 
       return true;
     }
-    // detect a __builtin_debugtrap instruction pattern ("brk #0xf000")
-    // and advance the $pc past it, so that the user can continue execution.
-    // Generally speaking, this knowledge should be centralized in lldb,
-    // recognizing the builtin_trap instruction and knowing how to advance
-    // the pc past it, so that continue etc work.
-    if (exc.exc_data.size() == 2 && exc.exc_data[0] == EXC_ARM_BREAKPOINT) {
-      nub_addr_t pc = GetPC(INVALID_NUB_ADDRESS);
-      if (pc != INVALID_NUB_ADDRESS && pc > 0) {
-        DNBBreakpoint *bp =
-            m_thread->Process()->Breakpoints().FindByAddress(pc);
-        if (bp == nullptr) {
-          uint8_t insnbuf[4];
-          if (m_thread->Process()->ReadMemory(pc, 4, insnbuf) == 4) {
-            uint8_t builtin_debugtrap_insn[4] = {0x00, 0x00, 0x3e,
-                                                 0xd4}; // brk #0xf000
-            if (memcmp(insnbuf, builtin_debugtrap_insn, 4) == 0) {
-              SetPC(pc + 4);
-            }
-          }
-        }
-      }
-    }
     break;
   }
   return false;

--- a/lldb/tools/debugserver/source/MacOSX/arm64/DNBArchImplARM64.cpp
+++ b/lldb/tools/debugserver/source/MacOSX/arm64/DNBArchImplARM64.cpp
@@ -842,6 +842,28 @@ bool DNBArchMachARM64::NotifyException(MachException::Data &exc) {
 
       return true;
     }
+    // detect a __builtin_debugtrap instruction pattern ("brk #0xf000")
+    // and advance the $pc past it, so that the user can continue execution.
+    // Generally speaking, this knowledge should be centralized in lldb,
+    // recognizing the builtin_trap instruction and knowing how to advance
+    // the pc past it, so that continue etc work.
+    if (exc.exc_data.size() == 2 && exc.exc_data[0] == EXC_ARM_BREAKPOINT) {
+      nub_addr_t pc = GetPC(INVALID_NUB_ADDRESS);
+      if (pc != INVALID_NUB_ADDRESS && pc > 0) {
+        DNBBreakpoint *bp =
+            m_thread->Process()->Breakpoints().FindByAddress(pc);
+        if (bp == nullptr) {
+          uint8_t insnbuf[4];
+          if (m_thread->Process()->ReadMemory(pc, 4, insnbuf) == 4) {
+            uint8_t builtin_debugtrap_insn[4] = {0x00, 0x00, 0x3e,
+                                                 0xd4}; // brk #0xf000
+            if (memcmp(insnbuf, builtin_debugtrap_insn, 4) == 0) {
+              SetPC(pc + 4);
+            }
+          }
+        }
+      }
+    }
     break;
   }
   return false;


### PR DESCRIPTION
Several languages support some sort of "breakpoint" function, which adds ISA-specific instructions to generate an interrupt at runtime. However, on some platforms, these instructions don't increment the program counter. When LLDB sets these instructions it isn't a problem, as we remove them before continuing, then re-add them after stepping over the location. However, for breakpoint sequences that are part of the inferior process, this doesn't happen - and so users might be left unable to continue past the breakpoint without manually interfering with the program counter.

This patch adds logic to LLDB to intercept SIGTRAPs, inspect the bytes of the inferior at the program counter, and if the instruction looks like a BRK or BKPT or similar, increment the pc by the size of the instruction we found. This unifies platform behaviour (e.g. on x86_64, LLDB debug sessions already look like this) and improves UX (in my opinion, but I think it beats messing with stuff every break).

Some ISAs (like AArch64) require slightly different handling, as while there are multiple possible instructions, we should be careful only to find the ones likely to have been emitted by a compiler backend, and not those inserted from (for example) the UB sanitizer, or any others.

There is an existing builtin-debugtrap test which was under the macos folder before. I've now moved that to "functionalities", made it pure C only, and updated it a little bit so that it works regardless of platform.

What I've not done is change the existing code in debugserver which was added by Jason Molenda about five years ago (https://reviews.llvm.org/D91238, 92b036d). It might not be required any more after this change. Reading the history there, it seems like it was agreed that this behaviour (skipping over unknown bps) was the desired end goal.

Fixes #56268