### PR TITLE
[M68k] Fix MOVEM collapse pass for 2 instances of same register

### DIFF
--- a/llvm/lib/Target/M68k/M68kCollapseMOVEMPass.cpp
+++ b/llvm/lib/Target/M68k/M68kCollapseMOVEMPass.cpp
@@ -104,6 +104,11 @@ public:
   }
 
   bool update(int O, int M) {
+    if (Mask & M)
+      // We've already seen this register and are planning on collapsing it
+      // into a MOVEM. This cannot be done twice for the same register in the
+      // same MOVEM, so bail out now.
+      return false;
     UpdateType Type = classifyUpdateByMask(M);
     if (Type == Intermixed)
       return false;

--- a/llvm/test/CodeGen/M68k/CollapseMOVEM.mir
+++ b/llvm/test/CodeGen/M68k/CollapseMOVEM.mir
@@ -161,3 +161,16 @@ body: |
     MOVM32pm -8, $sp, 16
 
 ...
+--- # CollapseMOVEM_Overlapping_Regs
+#
+# CHECK-LABEL: CollapseMOVEM_Overlapping_Regs
+# CHECK:       movem.l %d1-%d2, (0,%sp)
+# CHECK-NEXT:  movem.l %d2, (-4,%sp)
+name: CollapseMOVEM_Overlapping_Regs
+body: |
+  bb.0:
+    MOVM32pm 0, $sp, 2
+    MOVM32pm 4, $sp, 4
+    MOVM32pm -4, $sp, 4
+
+...


### PR DESCRIPTION
Add test case for MOVEM collapse opt pass failure and fix pass handling of 2 appearances of the same register in a MOVEM block.