### PR TITLE
[RuntimeDyld][MIPS] Use AT for stub function instead of T9

### DIFF
--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
@@ -1003,45 +1003,45 @@ uint8_t *RuntimeDyldImpl::createStubFunction(uint8_t *Addr,
     writeBytesUnaligned(0x4c000180, Addr + 16, 4);
     return Addr;
   } else if (IsMipsO32ABI || IsMipsN32ABI) {
-    // 0:   3c190000        lui     t9,%hi(addr).
-    // 4:   27390000        addiu   t9,t9,%lo(addr).
-    // 8:   03200008        jr      t9.
+    // 0:   3c010000        lui     at,%hi(addr).
+    // 4:   24210000        addiu   at,at,%lo(addr).
+    // 8:   00200008        jr      at.
     // c:   00000000        nop.
-    const unsigned LuiT9Instr = 0x3c190000, AdduiT9Instr = 0x27390000;
+    const unsigned LuiATInstr = 0x3c010000, AdduiATInstr = 0x24210000;
     const unsigned NopInstr = 0x0;
-    unsigned JrT9Instr = 0x03200008;
+    unsigned JrATInstr = 0x00200008;
     if ((AbiVariant & ELF::EF_MIPS_ARCH) == ELF::EF_MIPS_ARCH_32R6 ||
         (AbiVariant & ELF::EF_MIPS_ARCH) == ELF::EF_MIPS_ARCH_64R6)
-      JrT9Instr = 0x03200009;
+      JrATInstr = 0x00200009;
 
-    writeBytesUnaligned(LuiT9Instr, Addr, 4);
-    writeBytesUnaligned(AdduiT9Instr, Addr + 4, 4);
-    writeBytesUnaligned(JrT9Instr, Addr + 8, 4);
+    writeBytesUnaligned(LuiATInstr, Addr, 4);
+    writeBytesUnaligned(AdduiATInstr, Addr + 4, 4);
+    writeBytesUnaligned(JrATInstr, Addr + 8, 4);
     writeBytesUnaligned(NopInstr, Addr + 12, 4);
     return Addr;
   } else if (IsMipsN64ABI) {
-    // 0:   3c190000        lui     t9,%highest(addr).
-    // 4:   67390000        daddiu  t9,t9,%higher(addr).
-    // 8:   0019CC38        dsll    t9,t9,16.
-    // c:   67390000        daddiu  t9,t9,%hi(addr).
-    // 10:  0019CC38        dsll    t9,t9,16.
-    // 14:  67390000        daddiu  t9,t9,%lo(addr).
-    // 18:  03200008        jr      t9.
+    // 0:   3c010000        lui     at,%highest(addr).
+    // 4:   64210000        daddiu  at,at,%higher(addr).
+    // 8:   00010C38        dsll    at,at,16.
+    // c:   64210000        daddiu  at,at,%hi(addr).
+    // 10:  00010C38        dsll    at,at,16.
+    // 14:  64210000        daddiu  at,at,%lo(addr).
+    // 18:  00200008        jr      at.
     // 1c:  00000000        nop.
-    const unsigned LuiT9Instr = 0x3c190000, DaddiuT9Instr = 0x67390000,
-                   DsllT9Instr = 0x19CC38;
+    const unsigned LuiATInstr = 0x3c010000, DaddiuATInstr = 0x64210000,
+                   DsllATInstr = 0x10c38;
     const unsigned NopInstr = 0x0;
-    unsigned JrT9Instr = 0x03200008;
+    unsigned JrATInstr = 0x00200008;
     if ((AbiVariant & ELF::EF_MIPS_ARCH) == ELF::EF_MIPS_ARCH_64R6)
-      JrT9Instr = 0x03200009;
+      JrATInstr = 0x00200009;
 
-    writeBytesUnaligned(LuiT9Instr, Addr, 4);
-    writeBytesUnaligned(DaddiuT9Instr, Addr + 4, 4);
-    writeBytesUnaligned(DsllT9Instr, Addr + 8, 4);
-    writeBytesUnaligned(DaddiuT9Instr, Addr + 12, 4);
-    writeBytesUnaligned(DsllT9Instr, Addr + 16, 4);
-    writeBytesUnaligned(DaddiuT9Instr, Addr + 20, 4);
-    writeBytesUnaligned(JrT9Instr, Addr + 24, 4);
+    writeBytesUnaligned(LuiATInstr, Addr, 4);
+    writeBytesUnaligned(DaddiuATInstr, Addr + 4, 4);
+    writeBytesUnaligned(DsllATInstr, Addr + 8, 4);
+    writeBytesUnaligned(DaddiuATInstr, Addr + 12, 4);
+    writeBytesUnaligned(DsllATInstr, Addr + 16, 4);
+    writeBytesUnaligned(DaddiuATInstr, Addr + 20, 4);
+    writeBytesUnaligned(JrATInstr, Addr + 24, 4);
     writeBytesUnaligned(NopInstr, Addr + 28, 4);
     return Addr;
   } else if (Arch == Triple::ppc64 || Arch == Triple::ppc64le) {


### PR DESCRIPTION
The stub function is generated for R_MIPS_26 relocation, which could be used for local jumping inside a function, and do not expect any temporary register to be clobbered.

Use AT instead of T9 for the stub function, otherwise functions using T9 will be messed up.