### PR TITLE
[PowerPC] Optimize vector compares not equal to non-zero elements

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -17164,6 +17164,51 @@ static SDValue DAGCombineAddc(SDNode *N,
   return SDValue();
 }
 
+// The following transformation is meant to optimize vector compares not equal
+// to non-zeros Ex: vec[i] != 7, where vec is a vector and the comparison is
+// element non-zero number. (and (anyext (setcc A, B, SETNE)), splat32(1))
+//  -> (zext (add (setcc A, B, SETEQ), splat16(1)))
+static SDValue combineVectorZExtCompare(SDNode *N, SelectionDAG &DAG,
+                                        const PPCSubtarget &Subtarget) {
+  if (!Subtarget.hasVSX() || N->getOpcode() != ISD::AND)
+    return SDValue();
+
+  SDLoc DL(N);
+  EVT VT = N->getValueType(0);
+  SDValue Op0 = N->getOperand(0);
+  SDValue Op1 = N->getOperand(1);
+
+  APInt SplatVal;
+  if (!ISD::isConstantSplatVector(Op1.getNode(), SplatVal) || SplatVal != 1)
+    std::swap(Op0, Op1);
+  if (!ISD::isConstantSplatVector(Op1.getNode(), SplatVal) || SplatVal != 1)
+    return SDValue();
+
+  if (Op0.getOpcode() != ISD::ANY_EXTEND_VECTOR_INREG &&
+      Op0.getOpcode() != ISD::ZERO_EXTEND_VECTOR_INREG)
+    return SDValue();
+
+  SDValue SetCC = Op0.getOperand(0);
+  if (SetCC.getOpcode() != ISD::SETCC)
+    return SDValue();
+
+  ISD::CondCode CC = cast<CondCodeSDNode>(SetCC.getOperand(2))->get();
+  if (CC != ISD::SETNE)
+    return SDValue();
+
+  EVT SrcVT = SetCC.getValueType();
+  EVT EltVT = SrcVT.getVectorElementType();
+
+  //(zext (add (setcc X, Y, SETEQ), splat(1)))
+  SDValue EqCmp = DAG.getSetCC(DL, SrcVT, SetCC.getOperand(0),
+                               SetCC.getOperand(1), ISD::SETEQ);
+  SDValue OneSplat =
+      DAG.getSplatBuildVector(SrcVT, DL, DAG.getConstant(1, DL, EltVT));
+  SDValue Add = DAG.getNode(ISD::ADD, DL, SrcVT, EqCmp, OneSplat);
+
+  return DAG.getNode(ISD::ZERO_EXTEND_VECTOR_INREG, DL, VT, Add);
+}
+
 SDValue PPCTargetLowering::PerformDAGCombine(SDNode *N,
                                              DAGCombinerInfo &DCI) const {
   SelectionDAG &DAG = DCI.DAG;
@@ -17173,6 +17218,10 @@ SDValue PPCTargetLowering::PerformDAGCombine(SDNode *N,
   case ISD::ADD:
     return combineADD(N, DCI);
   case ISD::AND: {
+    // Convert (and (anyext (setcc A, B, SETNE)), splat32(1))
+    //  -> (zext (add (setcc A, B, SETEQ), splat16(1)))
+    if (SDValue V = combineVectorZExtCompare(N, DAG, Subtarget))
+      return V;
     // We don't want (and (zext (shift...)), C) if C fits in the width of the
     // original input as that will prevent us from selecting optimal rotates.
     // This only matters if the input to the extend is i32 widened to i64.

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.h
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.h
@@ -873,6 +873,7 @@ namespace llvm {
     SDValue combineADD(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineFMALike(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineTRUNCATE(SDNode *N, DAGCombinerInfo &DCI) const;
+    SDValue combineVectorZExtCompare(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineSetCC(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineVectorShuffle(ShuffleVectorSDNode *SVN,
                                  SelectionDAG &DAG) const;

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.h
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.h
@@ -872,8 +872,8 @@ namespace llvm {
     SDValue combineMUL(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineADD(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineFMALike(SDNode *N, DAGCombinerInfo &DCI) const;
-    SDValue combineTRUNCATE(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineVectorZExtCompare(SDNode *N, DAGCombinerInfo &DCI) const;
+    SDValue combineTRUNCATE(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineSetCC(SDNode *N, DAGCombinerInfo &DCI) const;
     SDValue combineVectorShuffle(ShuffleVectorSDNode *SVN,
                                  SelectionDAG &DAG) const;

--- a/llvm/test/CodeGen/PowerPC/optimize-vector-not-equal.ll
+++ b/llvm/test/CodeGen/PowerPC/optimize-vector-not-equal.ll
@@ -16,13 +16,12 @@
 define i32 @cols_needed(<4 x i16> %wide.load) {
 ; POWERPC_64LE-LABEL: cols_needed:
 ; POWERPC_64LE:       # %bb.0: # %entry
-; POWERPC_64LE-NEXT:    vspltish v3, 7
+; POWERPC_64LE-NEXT:    xxlxor v3, v3, v3
+; POWERPC_64LE-NEXT:    xxleqv v4, v4, v4
 ; POWERPC_64LE-NEXT:    li r3, 0
 ; POWERPC_64LE-NEXT:    vcmpequh v2, v2, v3
-; POWERPC_64LE-NEXT:    vspltisw v3, 1
-; POWERPC_64LE-NEXT:    xxlnor v2, v2, v2
-; POWERPC_64LE-NEXT:    vmrglh v2, v2, v2
-; POWERPC_64LE-NEXT:    xxland v2, v2, v3
+; POWERPC_64LE-NEXT:    vsubuhm v2, v2, v4
+; POWERPC_64LE-NEXT:    vmrglh v2, v3, v2
 ; POWERPC_64LE-NEXT:    xxswapd v3, v2
 ; POWERPC_64LE-NEXT:    vadduwm v2, v2, v3
 ; POWERPC_64LE-NEXT:    xxspltw v3, v2, 2
@@ -32,13 +31,12 @@ define i32 @cols_needed(<4 x i16> %wide.load) {
 ;
 ; POWERPC_64-LABEL: cols_needed:
 ; POWERPC_64:       # %bb.0: # %entry
-; POWERPC_64-NEXT:    vspltish v3, 7
+; POWERPC_64-NEXT:    xxlxor v3, v3, v3
+; POWERPC_64-NEXT:    xxleqv v4, v4, v4
 ; POWERPC_64-NEXT:    li r3, 0
 ; POWERPC_64-NEXT:    vcmpequh v2, v2, v3
-; POWERPC_64-NEXT:    vspltisw v3, 1
-; POWERPC_64-NEXT:    xxlnor v2, v2, v2
-; POWERPC_64-NEXT:    vmrghh v2, v2, v2
-; POWERPC_64-NEXT:    xxland v2, v2, v3
+; POWERPC_64-NEXT:    vsubuhm v2, v2, v4
+; POWERPC_64-NEXT:    vmrghh v2, v3, v2
 ; POWERPC_64-NEXT:    xxswapd v3, v2
 ; POWERPC_64-NEXT:    vadduwm v2, v2, v3
 ; POWERPC_64-NEXT:    xxspltw v3, v2, 1
@@ -48,12 +46,11 @@ define i32 @cols_needed(<4 x i16> %wide.load) {
 ;
 ; POWERPC_32-LABEL: cols_needed:
 ; POWERPC_32:       # %bb.0: # %entry
-; POWERPC_32-NEXT:    vspltish v3, 7
+; POWERPC_32-NEXT:    xxlxor v3, v3, v3
+; POWERPC_32-NEXT:    xxleqv v4, v4, v4
 ; POWERPC_32-NEXT:    vcmpequh v2, v2, v3
-; POWERPC_32-NEXT:    vspltisw v3, 1
-; POWERPC_32-NEXT:    xxlnor v2, v2, v2
-; POWERPC_32-NEXT:    vmrghh v2, v2, v2
-; POWERPC_32-NEXT:    xxland v2, v2, v3
+; POWERPC_32-NEXT:    vsubuhm v2, v2, v4
+; POWERPC_32-NEXT:    vmrghh v2, v3, v2
 ; POWERPC_32-NEXT:    xxswapd v3, v2
 ; POWERPC_32-NEXT:    vadduwm v2, v2, v3
 ; POWERPC_32-NEXT:    xxspltw v3, v2, 1

--- a/llvm/test/CodeGen/PowerPC/optimize-vector-not-equal.ll
+++ b/llvm/test/CodeGen/PowerPC/optimize-vector-not-equal.ll
@@ -16,11 +16,12 @@
 define i32 @cols_needed(<4 x i16> %wide.load) {
 ; POWERPC_64LE-LABEL: cols_needed:
 ; POWERPC_64LE:       # %bb.0: # %entry
-; POWERPC_64LE-NEXT:    xxlxor v3, v3, v3
-; POWERPC_64LE-NEXT:    xxleqv v4, v4, v4
+; POWERPC_64LE-NEXT:    vspltish v3, 7
 ; POWERPC_64LE-NEXT:    li r3, 0
 ; POWERPC_64LE-NEXT:    vcmpequh v2, v2, v3
-; POWERPC_64LE-NEXT:    vsubuhm v2, v2, v4
+; POWERPC_64LE-NEXT:    xxleqv v3, v3, v3
+; POWERPC_64LE-NEXT:    vsubuhm v2, v2, v3
+; POWERPC_64LE-NEXT:    xxlxor v3, v3, v3
 ; POWERPC_64LE-NEXT:    vmrglh v2, v3, v2
 ; POWERPC_64LE-NEXT:    xxswapd v3, v2
 ; POWERPC_64LE-NEXT:    vadduwm v2, v2, v3
@@ -31,11 +32,12 @@ define i32 @cols_needed(<4 x i16> %wide.load) {
 ;
 ; POWERPC_64-LABEL: cols_needed:
 ; POWERPC_64:       # %bb.0: # %entry
-; POWERPC_64-NEXT:    xxlxor v3, v3, v3
-; POWERPC_64-NEXT:    xxleqv v4, v4, v4
+; POWERPC_64-NEXT:    vspltish v3, 7
 ; POWERPC_64-NEXT:    li r3, 0
 ; POWERPC_64-NEXT:    vcmpequh v2, v2, v3
-; POWERPC_64-NEXT:    vsubuhm v2, v2, v4
+; POWERPC_64-NEXT:    xxleqv v3, v3, v3
+; POWERPC_64-NEXT:    vsubuhm v2, v2, v3
+; POWERPC_64-NEXT:    xxlxor v3, v3, v3
 ; POWERPC_64-NEXT:    vmrghh v2, v3, v2
 ; POWERPC_64-NEXT:    xxswapd v3, v2
 ; POWERPC_64-NEXT:    vadduwm v2, v2, v3
@@ -46,10 +48,11 @@ define i32 @cols_needed(<4 x i16> %wide.load) {
 ;
 ; POWERPC_32-LABEL: cols_needed:
 ; POWERPC_32:       # %bb.0: # %entry
-; POWERPC_32-NEXT:    xxlxor v3, v3, v3
-; POWERPC_32-NEXT:    xxleqv v4, v4, v4
+; POWERPC_32-NEXT:    vspltish v3, 7
 ; POWERPC_32-NEXT:    vcmpequh v2, v2, v3
-; POWERPC_32-NEXT:    vsubuhm v2, v2, v4
+; POWERPC_32-NEXT:    xxleqv v3, v3, v3
+; POWERPC_32-NEXT:    vsubuhm v2, v2, v3
+; POWERPC_32-NEXT:    xxlxor v3, v3, v3
 ; POWERPC_32-NEXT:    vmrghh v2, v3, v2
 ; POWERPC_32-NEXT:    xxswapd v3, v2
 ; POWERPC_32-NEXT:    vadduwm v2, v2, v3


### PR DESCRIPTION
Patch to make the comparisons of vector elements with non-zeros (Eg: vec[i] != 7) to be faster by removing `xxland` instructions and performing the negation with the addition of 1 to the result of `vcmp` and extending the results into words by making use of `zero_extend`. Here is a brief overview of the transformation:

- The current implementation: `(and (anyext (setcc A, B, SETNE)), splat32(1))`
- Optimized version: `zext (add (setcc A, B, SETEQ), splat16(1)))`