### PR TITLE
[C++20] [Modules] Fix incorrect read of TULocalOffset for delayed namespace

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -4223,7 +4223,7 @@ llvm::Error ASTReader::ReadASTBlock(ModuleFile &F,
             TULocalLocalOffset ? BaseOffset + TULocalLocalOffset : 0;
 
         DelayedNamespaceOffsetMap[ID] = {
-            {VisibleOffset, TULocalOffset, ModuleLocalOffset}, LexicalOffset};
+            {VisibleOffset, ModuleLocalOffset, TULocalOffset}, LexicalOffset};
 
         assert(!GetExistingDecl(ID) &&
                "We shouldn't load the namespace in the front of delayed "

--- a/clang/test/Modules/pr158321.cppm
+++ b/clang/test/Modules/pr158321.cppm
@@ -1,0 +1,27 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -std=c++20 %t/m.cppm -emit-reduced-module-interface -o %t/m.pcm
+// RUN: %clang_cc1 -std=c++20 %t/consumer.cpp -fprebuilt-module-path=%t -fsyntax-only -verify
+
+//--- repro_header.h
+namespace n
+{
+}
+
+//--- m.cppm
+module;
+#include "repro_header.h"
+export module m;
+namespace n
+{
+    int x;
+}
+
+//--- consumer.cpp
+// expected-no-diagnostics
+import m;
+namespace n
+{
+}


### PR DESCRIPTION

Close https://github.com/llvm/llvm-project/issues/158321

The root cause of the problem is a mismatch in an initializer.