### PR TITLE
[libc] Provide empty weak definition for __cxa_thread_finalize

### DIFF
--- a/libc/src/stdlib/exit.cpp
+++ b/libc/src/stdlib/exit.cpp
@@ -15,21 +15,25 @@ namespace LIBC_NAMESPACE_DECL {
 
 extern "C" void __cxa_finalize(void *);
 
-// exit needs to clean up TLS and call associated destructors.
+// exit() needs to clean up TLS and call associated destructors.
+//
+// The weak no-op implementation is in the same TU with its caller for the case
+// where the real definition is not linked in. This is preferable over weak
+// undefined symbol with a check since that requires a GOT slot.
+//
+// The strong implementation is in libc/src/__support/threads/thread.cpp
+// but not every platform supports threads (e.g. baremetal) in which case the
+// the no-op implementation is sufficient.
+//
 // TODO: Strictly speaking, it is not valid to call exit in overlay mode
 //       as we have no way to ensure system libc will call the TLS destructors.
 //       We should run exit related tests in hermetic mode but this is currently
 //       blocked by https://github.com/llvm/llvm-project/issues/133925.
-extern "C" [[gnu::weak]] void __cxa_thread_finalize();
+extern "C" [[gnu::weak]] void __cxa_thread_finalize() {}
 
 // TODO: use recursive mutex to protect this routine.
 [[noreturn]] LLVM_LIBC_FUNCTION(void, exit, (int status)) {
-// FIXME: The NVPTX target does not support external weak symbols correctly
-//        despite being an ELF platform. Disable pending a future split.
-#if !defined(LIBC_TARGET_ARCH_IS_NVPTX)
-  if (__cxa_thread_finalize)
-    __cxa_thread_finalize();
-#endif
+  __cxa_thread_finalize();
   __cxa_finalize(nullptr);
   internal::exit(status);
 }


### PR DESCRIPTION
This avoids the GOT slot being generated which is undesirable when using static linking. A better solution would be to reorganize the code to avoid the use of weak symbols altogether.

Fixes #173409