### PR TITLE
Update test for C++20 defaulting compilers after #173236 changed the expected diagnostic message.

### DIFF
--- a/clang/test/SemaCXX/typeid.cpp
+++ b/clang/test/SemaCXX/typeid.cpp
@@ -2,7 +2,12 @@
 
 void f()
 {
-  (void)typeid(int); // expected-error {{you need to include <typeinfo> before using the 'typeid' operator}}
+  (void)typeid(int);
+#if __cplusplus >= 202002L
+   // expected-error@-2 {{you need to include <typeinfo> or import std before using the 'typeid' operator}}
+#else
+   // expected-error@-4 {{you need to include <typeinfo> before using the 'typeid' operator}}
+#endif
 }
 
 namespace std {


### PR DESCRIPTION
Change #173236 changed the emitted error message which caused the test `clang/test/SemaCXX/typeid.cpp` to fail if tested with a compiler that defaults to C++20 because the error message has changed. This change updates the test to expect the correct error message depending on whether the compiler defaults to C++20 or earlier.