### PR TITLE
[SDAG] Use reference type in loop (NFC)

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -6302,7 +6302,7 @@ bool SelectionDAGBuilder::EmitFuncArgumentDbgValue(
     auto splitMultiRegDbgValue =
         [&](ArrayRef<std::pair<Register, TypeSize>> SplitRegs) -> bool {
       unsigned Offset = 0;
-      for (const auto [Reg, RegSizeInBits] : SplitRegs) {
+      for (const auto &[Reg, RegSizeInBits] : SplitRegs) {
         // FIXME: Scalable sizes are not supported in fragment expressions.
         if (RegSizeInBits.isScalable())
           return false;


### PR DESCRIPTION
Fixes a -Wrange-loop-construct warning.