### PR TITLE
[InstCombine] Shrink added constant using LHS known zeros

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -605,9 +605,9 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
         SimplifyDemandedBits(I, 0, DemandedFromLHS, LHSKnown, Q, Depth + 1))
       return disableWrapFlagsBasedOnUnusedHighBits(I, NLZ);
 
-    unsigned LHSTrailingOnes = (~DemandedMask & LHSKnown.Zero).countr_one();
+    unsigned NtzLHS = (~DemandedMask & LHSKnown.Zero).countr_one();
     APInt DemandedFromRHS = DemandedFromOps;
-    DemandedFromRHS.clearLowBits(LHSTrailingOnes);
+    DemandedFromRHS.clearLowBits(NtzLHS);
     if (ShrinkDemandedConstant(I, 1, DemandedFromRHS))
       return disableWrapFlagsBasedOnUnusedHighBits(I, NLZ);
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -605,6 +605,12 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
         SimplifyDemandedBits(I, 0, DemandedFromLHS, LHSKnown, Q, Depth + 1))
       return disableWrapFlagsBasedOnUnusedHighBits(I, NLZ);
 
+    unsigned NTZ_LHS = (~DemandedMask & LHSKnown.Zero).countr_one();
+    APInt DemandedFromRHS = DemandedFromOps;
+    DemandedFromRHS.clearLowBits(NTZ_LHS);
+    if (ShrinkDemandedConstant(I, 1, DemandedFromRHS))
+      return disableWrapFlagsBasedOnUnusedHighBits(I, NTZ_LHS);
+
     // If we are known to be adding zeros to every bit below
     // the highest demanded bit, we just return the other side.
     if (DemandedFromOps.isSubsetOf(RHSKnown.Zero))

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -605,11 +605,11 @@ Value *InstCombinerImpl::SimplifyDemandedUseBits(Instruction *I,
         SimplifyDemandedBits(I, 0, DemandedFromLHS, LHSKnown, Q, Depth + 1))
       return disableWrapFlagsBasedOnUnusedHighBits(I, NLZ);
 
-    unsigned NTZ_LHS = (~DemandedMask & LHSKnown.Zero).countr_one();
+    unsigned LHSTrailingOnes = (~DemandedMask & LHSKnown.Zero).countr_one();
     APInt DemandedFromRHS = DemandedFromOps;
-    DemandedFromRHS.clearLowBits(NTZ_LHS);
+    DemandedFromRHS.clearLowBits(LHSTrailingOnes);
     if (ShrinkDemandedConstant(I, 1, DemandedFromRHS))
-      return disableWrapFlagsBasedOnUnusedHighBits(I, NTZ_LHS);
+      return disableWrapFlagsBasedOnUnusedHighBits(I, NLZ);
 
     // If we are known to be adding zeros to every bit below
     // the highest demanded bit, we just return the other side.

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -1609,7 +1609,7 @@ define i8 @fold_add_constant_preserve_nuw(i8 %x) {
 define i32 @sdiv_to_udiv(i32 %arg0, i32 %arg1) {
 ; CHECK-LABEL: @sdiv_to_udiv(
 ; CHECK-NEXT:    [[T0:%.*]] = shl nuw nsw i32 [[ARG0:%.*]], 8
-; CHECK-NEXT:    [[T2:%.*]] = add nuw nsw i32 [[T0]], 6242049
+; CHECK-NEXT:    [[T2:%.*]] = add nuw i32 [[T0]], 6242048
 ; CHECK-NEXT:    [[T3:%.*]] = udiv i32 [[T2]], 192
 ; CHECK-NEXT:    ret i32 [[T3]]
 ;
@@ -4455,7 +4455,7 @@ define i32 @ceil_div_multi_use(i32 range(i32 0, 100) %x) {
   ret i32 %r
 }
 
-; Commuted test: add operands are swapped  
+; Commuted test: add operands are swapped
 define i32 @ceil_div_commuted(i32 range(i32 0, 100) %x) {
 ; CHECK-LABEL: @ceil_div_commuted(
 ; CHECK-NEXT:    [[TMP1:%.*]] = add nuw nsw i32 [[X:%.*]], 7

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -1609,7 +1609,7 @@ define i8 @fold_add_constant_preserve_nuw(i8 %x) {
 define i32 @sdiv_to_udiv(i32 %arg0, i32 %arg1) {
 ; CHECK-LABEL: @sdiv_to_udiv(
 ; CHECK-NEXT:    [[T0:%.*]] = shl nuw nsw i32 [[ARG0:%.*]], 8
-; CHECK-NEXT:    [[T2:%.*]] = add nuw i32 [[T0]], 6242048
+; CHECK-NEXT:    [[T2:%.*]] = add nuw nsw i32 [[T0]], 6242048
 ; CHECK-NEXT:    [[T3:%.*]] = udiv i32 [[T2]], 192
 ; CHECK-NEXT:    ret i32 [[T3]]
 ;

--- a/llvm/test/Transforms/InstCombine/add2.ll
+++ b/llvm/test/Transforms/InstCombine/add2.ll
@@ -510,3 +510,81 @@ define i32 @sub_undemanded_low_bits(i32 %x) {
   %shr = lshr i32 %sub, 4
   ret i32 %shr
 }
+
+define i32 @rhs_undemanded_low_bits_exact_boundary(i32 %x) {
+; CHECK-LABEL: @rhs_undemanded_low_bits_exact_boundary(
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X:%.*]], 4
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[SHL]], 47
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], -16
+; CHECK-NEXT:    ret i32 [[AND]]
+;
+  %shl = shl i32 %x, 4
+  %add = add i32 %shl, 47  ; 47 = 32 + 15
+  %and = and i32 %add, -16 ; 0xFFFFFFF0 (Low 4bits masked out)
+  ret i32 %and
+}
+
+define i32 @rhs_undemanded_low_bits_overshift_collision(i32 %x) {
+; CHECK-LABEL: @rhs_undemanded_low_bits_overshift_collision(
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X:%.*]], 8
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[SHL]], 288
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], -16
+; CHECK-NEXT:    ret i32 [[AND]]
+;
+  %shl = shl i32 %x, 8
+  %add = add i32 %shl, 303  ; 303 = 256 + 32 + 15
+  %and = and i32 %add, -16  ; 0xFFFFFFF0
+  ret i32 %and
+}
+
+define i32 @rhs_undemanded_low_bits_undershift(i32 %x) {
+; CHECK-LABEL: @rhs_undemanded_low_bits_undershift(
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X:%.*]], 2
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[SHL]], 47
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], -16
+; CHECK-NEXT:    ret i32 [[AND]]
+;
+  %shl = shl i32 %x, 2
+  %add = add i32 %shl, 47
+  %and = and i32 %add, -16 ; 0xFFFFFFF0
+  ret i32 %and
+}
+
+define <2 x i32> @rhs_undemanded_low_bits_vector(<2 x i32> %x) {
+; CHECK-LABEL: @rhs_undemanded_low_bits_vector(
+; CHECK-NEXT:    [[SHL:%.*]] = shl <2 x i32> [[X:%.*]], splat (i32 4)
+; CHECK-NEXT:    [[ADD:%.*]] = add <2 x i32> [[SHL]], splat (i32 47)
+; CHECK-NEXT:    [[AND:%.*]] = and <2 x i32> [[ADD]], splat (i32 -16)
+; CHECK-NEXT:    ret <2 x i32> [[AND]]
+;
+  %shl = shl <2 x i32> %x, <i32 4, i32 4>
+  %add = add <2 x i32> %shl, <i32 47, i32 47>
+  %and = and <2 x i32> %add, <i32 -16, i32 -16>
+  ret <2 x i32> %and
+}
+
+; Negative tests
+define i32 @rhs_undemanded_low_bits_negative_lsb_demanded(i32 %x) {
+; CHECK-LABEL: @rhs_undemanded_low_bits_negative_lsb_demanded(
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X:%.*]], 4
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[SHL]], 47
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], -15
+; CHECK-NEXT:    ret i32 [[AND]]
+;
+  %shl = shl i32 %x, 4
+  %add = add i32 %shl, 47  ; 47 = 0010 1111
+  %and = and i32 %add, -15 ; Mask = ...1111 0001 (Bit 0 is kept!)
+  ret i32 %and
+}
+
+define i32 @rhs_undemanded_low_bits_negative_unknown_lhs(i32 %x) {
+; CHECK-LABEL: @rhs_undemanded_low_bits_negative_unknown_lhs(
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[X:%.*]], 47
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], -16
+; CHECK-NEXT:    ret i32 [[AND]]
+;
+  ; No shift here
+  %add = add i32 %x, 47
+  %and = and i32 %add, -16
+  ret i32 %and
+}

--- a/llvm/test/Transforms/InstCombine/add2.ll
+++ b/llvm/test/Transforms/InstCombine/add2.ll
@@ -514,8 +514,7 @@ define i32 @sub_undemanded_low_bits(i32 %x) {
 define i32 @rhs_undemanded_low_bits_exact_boundary(i32 %x) {
 ; CHECK-LABEL: @rhs_undemanded_low_bits_exact_boundary(
 ; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X:%.*]], 4
-; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[SHL]], 47
-; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], -16
+; CHECK-NEXT:    [[AND:%.*]] = add i32 [[SHL]], 32
 ; CHECK-NEXT:    ret i32 [[AND]]
 ;
   %shl = shl i32 %x, 4
@@ -528,8 +527,7 @@ define i32 @rhs_undemanded_low_bits_overshift_collision(i32 %x) {
 ; CHECK-LABEL: @rhs_undemanded_low_bits_overshift_collision(
 ; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X:%.*]], 8
 ; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[SHL]], 288
-; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], -16
-; CHECK-NEXT:    ret i32 [[AND]]
+; CHECK-NEXT:    ret i32 [[ADD]]
 ;
   %shl = shl i32 %x, 8
   %add = add i32 %shl, 303  ; 303 = 256 + 32 + 15
@@ -540,7 +538,7 @@ define i32 @rhs_undemanded_low_bits_overshift_collision(i32 %x) {
 define i32 @rhs_undemanded_low_bits_undershift(i32 %x) {
 ; CHECK-LABEL: @rhs_undemanded_low_bits_undershift(
 ; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X:%.*]], 2
-; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[SHL]], 47
+; CHECK-NEXT:    [[ADD:%.*]] = add i32 [[SHL]], 44
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[ADD]], -16
 ; CHECK-NEXT:    ret i32 [[AND]]
 ;
@@ -553,8 +551,7 @@ define i32 @rhs_undemanded_low_bits_undershift(i32 %x) {
 define <2 x i32> @rhs_undemanded_low_bits_vector(<2 x i32> %x) {
 ; CHECK-LABEL: @rhs_undemanded_low_bits_vector(
 ; CHECK-NEXT:    [[SHL:%.*]] = shl <2 x i32> [[X:%.*]], splat (i32 4)
-; CHECK-NEXT:    [[ADD:%.*]] = add <2 x i32> [[SHL]], splat (i32 47)
-; CHECK-NEXT:    [[AND:%.*]] = and <2 x i32> [[ADD]], splat (i32 -16)
+; CHECK-NEXT:    [[AND:%.*]] = add <2 x i32> [[SHL]], splat (i32 32)
 ; CHECK-NEXT:    ret <2 x i32> [[AND]]
 ;
   %shl = shl <2 x i32> %x, <i32 4, i32 4>

--- a/llvm/test/Transforms/InstCombine/rem-mul-shl.ll
+++ b/llvm/test/Transforms/InstCombine/rem-mul-shl.ll
@@ -903,8 +903,8 @@ define i64 @urem_shl_vscale_overlap() vscale_range(1,16) {
 ; CHECK-LABEL: @urem_shl_vscale_overlap(
 ; CHECK-NEXT:    [[VSCALE:%.*]] = call i64 @llvm.vscale.i64()
 ; CHECK-NEXT:    [[SHIFT:%.*]] = shl nuw nsw i64 [[VSCALE]], 10
-; CHECK-NEXT:    [[TMP1:%.*]] = add nuw nsw i64 [[SHIFT]], 2047
-; CHECK-NEXT:    [[REM:%.*]] = and i64 [[TMP1]], 1024
+; CHECK-NEXT:    [[TMP1:%.*]] = and i64 [[SHIFT]], 1024
+; CHECK-NEXT:    [[REM:%.*]] = xor i64 [[TMP1]], 1024
 ; CHECK-NEXT:    ret i64 [[REM]]
 ;
   %vscale = call i64 @llvm.vscale.i64()
@@ -930,7 +930,7 @@ define i64 @and_add_shl_vscale_not_power2() vscale_range(1,16) {
 ; CHECK-LABEL: @and_add_shl_vscale_not_power2(
 ; CHECK-NEXT:    [[VSCALE:%.*]] = call i64 @llvm.vscale.i64()
 ; CHECK-NEXT:    [[SHIFT:%.*]] = shl nuw nsw i64 [[VSCALE]], 6
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i64 [[SHIFT]], 4095
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i64 [[SHIFT]], 4032
 ; CHECK-NEXT:    [[REM:%.*]] = and i64 [[ADD]], 3072
 ; CHECK-NEXT:    ret i64 [[REM]]
 ;


### PR DESCRIPTION
Previously, `SimplifyDemandedUseBits` for `add` instructions only
used known zeros from the RHS to simplify the LHS. It failed to
handle the symmetric case where the LHS has known zeros and the
result does not demand the low bits.

This patch implements this missing optimization, allowing the RHS
constant to be shrunk when the LHS low bits are known zero and unused.

Proof: https://alive2.llvm.org/ce/z/6v9iFY
Fixed: https://github.com/llvm/llvm-project/issues/135411