### PR TITLE
[lldb][test] Rewrite TestStringPrinter.py in a non-inline API test style

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/stringprinter/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/stringprinter/Makefile
@@ -1,0 +1,4 @@
+CXX_SOURCES := main.cpp
+CXXFLAGS_EXTRAS := -std=c++20
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/stringprinter/TestStringPrinter.py
+++ b/lldb/test/API/functionalities/data-formatter/stringprinter/TestStringPrinter.py
@@ -1,7 +1,52 @@
-from lldbsuite.test import lldbinline
-from lldbsuite.test import decorators
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
 
-lldbinline.MakeInlineTest(
-    __file__,
-    globals(),
-)
+
+class TestStringPrinter(TestBase):
+    def test(self):
+        self.build()
+
+        self.addTearDownHook(
+            lambda x: x.runCmd("setting set escape-non-printables true")
+        )
+
+        lldbutil.run_to_source_breakpoint(
+            self, "Break here", lldb.SBFileSpec("main.cpp", False)
+        )
+
+        self.expect_var_path(
+            "charwithtabs",
+            summary='"Hello\\t\\tWorld\\nI am here\\t\\tto say hello\\n"',
+        )
+        self.expect_var_path("a.data", summary='"FOOB"')
+        self.expect_var_path("b.data", summary=r'"FO\0B"')
+        self.expect_var_path("c.data", summary=r'"F\0O"')
+        self.expect_var_path("manytrailingnuls", summary=r'"F\0OO\0BA\0R"')
+
+        for c in ["", "const"]:
+            for v in ["", "volatile"]:
+                for s in ["", "unsigned"]:
+                    summary = '"' + c + v + s + 'char"'
+                    self.expect_var_path(c + v + s + "chararray", summary=summary)
+                    # These should be printed normally
+                    self.expect_var_path(c + v + s + "charstar", summary=summary)
+
+        Schar5 = self.expect_var_path(
+            "Schar5", children=[ValueCheck(name="x", value="0")]
+        )
+        self.assertIsNone(Schar5.GetSummary())
+        Scharstar = self.expect_var_path(
+            "Scharstar", children=[ValueCheck(name="x", value="0")]
+        )
+        self.assertIsNone(Scharstar.GetSummary())
+
+        self.runCmd("setting set escape-non-printables false")
+        self.expect_var_path(
+            "charwithtabs", summary='"Hello\t\tWorld\nI am here\t\tto say hello\n"'
+        )
+        self.assertTrue(
+            self.frame().FindVariable("longconstcharstar").GetSummary().endswith('"...')
+        )
+
+        # FIXME: make "b.data" and "c.data" work sanely

--- a/lldb/test/API/functionalities/data-formatter/stringprinter/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/stringprinter/main.cpp
@@ -1,4 +1,4 @@
-#include <string>
+#include <cstdio>
 #include <cstring>
 
 struct A {
@@ -20,67 +20,63 @@ struct A {
 MAKE_VARS();
 MAKE_VARS(const);
 
-template<typename T>
-struct S {
+template <typename T> struct S {
   int x = 0;
 };
 S<char[5]> Schar5;
 S<char *> Scharstar;
 
-int main (int argc, char const *argv[])
-{
-    const char manytrailingnuls[] = "F\0OO\0BA\0R\0\0\0\0";
-    A a, b, c;
-    // Deliberately write past the end of data to test that the formatter stops
-    // at the end of array.
-    memcpy(a.data, "FOOBAR", 7);
-    memcpy(b.data, "FO\0BAR", 7);
-    memcpy(c.data, "F\0O\0AR", 7);
-    std::string stdstring("Hello\t\tWorld\nI am here\t\tto say hello\n"); //%self.addTearDownHook(lambda x: x.runCmd("setting set escape-non-printables true"))
-    const char *charwithtabs = stdstring.c_str();
-    std::string longstring(
-"I am a very long string; in fact I am longer than any reasonable length that a string should be; quite long indeed; oh my, so many words; so many letters; this is kind of like writing a poem; except in real life all that is happening"
-" is just me producing a very very long set of words; there is text here, text there, text everywhere; it fills me with glee to see so much text; all around me it's just letters, and symbols, and other pleasant drawings that cause me"
-" a large amount of joy upon visually seeing them with my eyes; well, this is now a lot of letters, but it is still not enough for the purpose of the test I want to test, so maybe I should copy and paste this a few times, you know.."
-" for science, or something"
-      "I am a very long string; in fact I am longer than any reasonable length that a string should be; quite long indeed; oh my, so many words; so many letters; this is kind of like writing a poem; except in real life all that is happening"
-      " is just me producing a very very long set of words; there is text here, text there, text everywhere; it fills me with glee to see so much text; all around me it's just letters, and symbols, and other pleasant drawings that cause me"
-      " a large amount of joy upon visually seeing them with my eyes; well, this is now a lot of letters, but it is still not enough for the purpose of the test I want to test, so maybe I should copy and paste this a few times, you know.."
+int main(int argc, char const *argv[]) {
+  const char manytrailingnuls[] = "F\0OO\0BA\0R\0\0\0\0";
+  A a, b, c;
+  // Deliberately write past the end of data to test that the formatter stops
+  // at the end of array.
+  memcpy(a.data, "FOOBAR", 7);
+  memcpy(b.data, "FO\0BAR", 7);
+  memcpy(c.data, "F\0O\0AR", 7);
+  const char *charwithtabs = "Hello\t\tWorld\nI am here\t\tto say hello\n";
+  const char *longconstcharstar =
+      "I am a very long string; in fact I am longer than any reasonable length "
+      "that a string should be; quite long indeed; oh my, so many words; so "
+      "many letters; this is kind of like writing a poem; except in real life "
+      "all that is happening"
+      " is just me producing a very very long set of words; there is text "
+      "here, text there, text everywhere; it fills me with glee to see so much "
+      "text; all around me it's just letters, and symbols, and other pleasant "
+      "drawings that cause me"
+      " a large amount of joy upon visually seeing them with my eyes; well, "
+      "this is now a lot of letters, but it is still not enough for the "
+      "purpose of the test I want to test, so maybe I should copy and paste "
+      "this a few times, you know.."
       " for science, or something"
-            "I am a very long string; in fact I am longer than any reasonable length that a string should be; quite long indeed; oh my, so many words; so many letters; this is kind of like writing a poem; except in real life all that is happening"
-            " is just me producing a very very long set of words; there is text here, text there, text everywhere; it fills me with glee to see so much text; all around me it's just letters, and symbols, and other pleasant drawings that cause me"
-            " a large amount of joy upon visually seeing them with my eyes; well, this is now a lot of letters, but it is still not enough for the purpose of the test I want to test, so maybe I should copy and paste this a few times, you know.."
-            " for science, or something"
-      );
-    const char* longconstcharstar = longstring.c_str();
-    return 0;     //% if self.TraceOn(): self.runCmd('frame variable')
-    //%
-    //% self.expect_var_path('stdstring', summary='"Hello\\t\\tWorld\\nI am here\\t\\tto say hello\\n"')
-    //% self.expect_var_path('charwithtabs', summary='"Hello\\t\\tWorld\\nI am here\\t\\tto say hello\\n"')
-    //% self.expect_var_path("a.data", summary='"FOOB"')
-    //% self.expect_var_path("b.data", summary=r'"FO\0B"')
-    //% self.expect_var_path("c.data", summary=r'"F\0O"')
-    //% self.expect_var_path("manytrailingnuls", summary=r'"F\0OO\0BA\0R"')
-    //%
-    //% for c in ["", "const"]:
-    //%   for v in ["", "volatile"]:
-    //%     for s in ["", "unsigned"]:
-    //%       summary = '"'+c+v+s+'char"'
-    //%       self.expect_var_path(c+v+s+"chararray", summary=summary)
-    //% # These should be printed normally
-    //%       self.expect_var_path(c+v+s+"charstar", summary=summary)
-    //% Schar5 = self.expect_var_path("Schar5",
-    //%     children=[ValueCheck(name="x", value="0")])
-    //% self.assertIsNone(Schar5.GetSummary())
-    //% Scharstar = self.expect_var_path("Scharstar",
-    //%     children=[ValueCheck(name="x", value="0")])
-    //% self.assertIsNone(Scharstar.GetSummary())
-    //%
-    //% self.runCmd("setting set escape-non-printables false")
-    //% self.expect_var_path('stdstring', summary='"Hello\t\tWorld\nI am here\t\tto say hello\n"')
-    //% self.expect_var_path('charwithtabs', summary='"Hello\t\tWorld\nI am here\t\tto say hello\n"')
-    //% self.assertTrue(self.frame().FindVariable('longstring').GetSummary().endswith('"...'))
-    //% self.assertTrue(self.frame().FindVariable('longconstcharstar').GetSummary().endswith('"...'))
-    // FIXME: make "b.data" and "c.data" work sanely
-}
+      "I am a very long string; in fact I am longer than any reasonable length "
+      "that a string should be; quite long indeed; oh my, so many words; so "
+      "many letters; this is kind of like writing a poem; except in real life "
+      "all that is happening"
+      " is just me producing a very very long set of words; there is text "
+      "here, text there, text everywhere; it fills me with glee to see so much "
+      "text; all around me it's just letters, and symbols, and other pleasant "
+      "drawings that cause me"
+      " a large amount of joy upon visually seeing them with my eyes; well, "
+      "this is now a lot of letters, but it is still not enough for the "
+      "purpose of the test I want to test, so maybe I should copy and paste "
+      "this a few times, you know.."
+      " for science, or something"
+      "I am a very long string; in fact I am longer than any reasonable length "
+      "that a string should be; quite long indeed; oh my, so many words; so "
+      "many letters; this is kind of like writing a poem; except in real life "
+      "all that is happening"
+      " is just me producing a very very long set of words; there is text "
+      "here, text there, text everywhere; it fills me with glee to see so much "
+      "text; all around me it's just letters, and symbols, and other pleasant "
+      "drawings that cause me"
+      " a large amount of joy upon visually seeing them with my eyes; well, "
+      "this is now a lot of letters, but it is still not enough for the "
+      "purpose of the test I want to test, so maybe I should copy and paste "
+      "this a few times, you know.."
+      " for science, or something";
 
+  puts("Break here");
+
+  return 0;
+}


### PR DESCRIPTION
Motivation here is that I'm planning to add more test cases to this and it's easier to read/maintain as an API test.

Drive-by:
* I also removed the `std::string` checks since those belong in the STL formatter tests.