### PR TITLE
[flang] Ignore ambiguous use statement in use_stmt generation.

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -244,6 +244,9 @@ emitUseStatementsFromFunit(Fortran::lower::AbstractConverter &converter,
       if (ultimateSym.has<Fortran::semantics::DerivedTypeDetails>())
         return "";
 
+      if (ultimateSym.has<Fortran::semantics::UseErrorDetails>())
+        return "";
+
       if (const auto *generic =
               ultimateSym.detailsIf<Fortran::semantics::GenericDetails>()) {
         if (!generic->specific())

--- a/flang/test/Lower/debug-use-stmt-ambiguous.f90
+++ b/flang/test/Lower/debug-use-stmt-ambiguous.f90
@@ -1,0 +1,30 @@
+! RUN: %flang_fc1 -emit-hlfir -debug-info-kind=standalone %s -o -
+
+! The test checks that ambigious use statements don't cause a build failure
+! when generation of fir.use_stmt is enabled.
+module module_1st
+  integer :: mpi_integer = 1
+  integer :: mpi = 2, ssss = 3
+end module module_1st
+
+module module_2nd
+  integer :: dp, ssss
+end module module_2nd
+
+module module_3rd
+  use module_1st
+  use module_2nd
+  integer :: itmp
+end module module_3rd
+
+program test
+  use module_3rd, ONLY: ssss
+  use module_3rd, ONLY:
+  use module_1st
+  implicit none
+
+  ! Use non-ambiguous symbols
+  if (mpi_integer .ne. 1) print *, 'ng'
+  if (mpi .ne. 2) print *, 'ng'
+  print *, 'pass'
+end program test


### PR DESCRIPTION
The https://github.com/llvm/llvm-project/pull/168106 caused build failures in testcases which have ambiguous use statements. This PR fixes that by properly ignoring them in `emitUseStatementsFromFunit`.