### PR TITLE
[MachinePipeliner] Add loop-carried dependences for FPExceptions

### DIFF
--- a/llvm/test/CodeGen/AArch64/sms-loop-carried-fp-exceptions1.mir
+++ b/llvm/test/CodeGen/AArch64/sms-loop-carried-fp-exceptions1.mir
@@ -10,17 +10,12 @@
 # SU(4): Store
 # SU(5): Barrier
 # SU(7): Barrier
-#
-# FIXME: Currently the following dependencies are missed.
-#
-# Loop carried edges from SU(7)
-#   Order
-#     SU(2)
-#     SU(3)
 
 # CHECK:      ===== Loop Carried Edges Begin =====
 # CHECK-NEXT: Loop carried edges from SU(7)
 # CHECK-NEXT:   Order
+# CHECK-NEXT:     SU(2)
+# CHECK-NEXT:     SU(3)
 # CHECK-NEXT:     SU(4)
 # CHECK-NEXT:     SU(5)
 # CHECK-NEXT: ===== Loop Carried Edges End =====


### PR DESCRIPTION
As with loads and stores, instructions that may trigger floating‑point exceptions must not be reordered across a barrier instruction. This patch adds the missing loop‑carried dependencies between such instructions and the barrier, preventing reordering that could previously occur. Same as #174391, the implementation is based on that of `ScheduleDAGInstrs::buildSchedGraph`.

Split off from #135148