### PR TITLE
[MachinePipeliner] Remove isLoopCarriedDep calls in computeStart

### DIFF
--- a/llvm/include/llvm/CodeGen/MachinePipeliner.h
+++ b/llvm/include/llvm/CodeGen/MachinePipeliner.h
@@ -776,16 +776,6 @@ public:
   /// Return the last cycle in the finalized schedule.
   int getFinalCycle() const { return FirstCycle + InitiationInterval - 1; }
 
-  /// Return the cycle of the earliest scheduled instruction in the dependence
-  /// chain.
-  int earliestCycleInChain(const SwingSchedulerDDGEdge &Dep,
-                           const SwingSchedulerDDG *DDG);
-
-  /// Return the cycle of the latest scheduled instruction in the dependence
-  /// chain.
-  int latestCycleInChain(const SwingSchedulerDDGEdge &Dep,
-                         const SwingSchedulerDDG *DDG);
-
   void computeStart(SUnit *SU, int *MaxEarlyStart, int *MinLateStart, int II,
                     SwingSchedulerDAG *DAG);
   bool insert(SUnit *SU, int StartCycle, int EndCycle, int II);

--- a/llvm/test/CodeGen/AArch64/sms-instruction-scheduled-at-correct-cycle.mir
+++ b/llvm/test/CodeGen/AArch64/sms-instruction-scheduled-at-correct-cycle.mir
@@ -6,9 +6,9 @@
 # CHECK: {{^ *}}Try to schedule with 47
 # CHECK: {{^ *}}Inst (11)   %48:fpr128 = LDRQui %35:gpr64sp, 0 :: (load (s128) from %ir.lsr.iv63, align 4, !tbaa !0)
 # CHECK-EMPTY:
-# CHECK-NEXT: {{^ *}}es: ffffffe9 ls: ffffffe9
-# CHECK-NEXT: {{^ *}}Trying to insert node between -23 and -23 II: 47
-# CHECK-NEXT: {{^ *}}failed to insert at cycle -23   %48:fpr128 = LDRQui %35:gpr64sp, 0 :: (load (s128) from %ir.lsr.iv63, align 4, !tbaa !0)
+# CHECK-NEXT: {{^ *}}es: ffffffe8 ls: ffffffe9
+# CHECK-NEXT: {{^ *}}Trying to insert node between -24 and -23 II: 47
+# CHECK-NEXT: {{^ *}}insert at cycle -24   %48:fpr128 = LDRQui %35:gpr64sp, 0 :: (load (s128) from %ir.lsr.iv63, align 4, !tbaa !0)
 
 --- |
   target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"


### PR DESCRIPTION
When computing the viable cycles for scheduling an instruction, `computeStart` used to include special-case logic to handle loop-carried dependencies. This special handling was necessary because loop-carried dependencies were represented by reversed forward-direction edges in the DAG. Now that we have the DDG, which explicitly models loop-carried dependencies, this special handling is no longer required. As a first step towards completely removing `isLoopCarriedDep`, this patch eliminates the special-case logic from `computeStart` and some related functions.

Split off from https://github.com/llvm/llvm-project/pull/135148