### PR TITLE
[lldb][Format] Unwrap references to C-strings when printing C-string summaries

### DIFF
--- a/lldb/source/DataFormatters/FormatManager.cpp
+++ b/lldb/source/DataFormatters/FormatManager.cpp
@@ -720,7 +720,7 @@ void FormatManager::LoadSystemFormatters() {
   TypeSummaryImpl::Flags string_flags;
   string_flags.SetCascades(true)
       .SetSkipPointers(true)
-      .SetSkipReferences(false)
+      .SetSkipReferences(true)
       .SetDontShowChildren(true)
       .SetDontShowValue(false)
       .SetShowMembersOneLiner(false)

--- a/lldb/test/API/functionalities/data-formatter/stringprinter/TestStringPrinter.py
+++ b/lldb/test/API/functionalities/data-formatter/stringprinter/TestStringPrinter.py
@@ -53,13 +53,13 @@ class TestStringPrinter(TestBase):
 
         self.expect_var_path(
             "ref",
-            summary="<no value available>",
+            summary=None,
             children=[ValueCheck(name="&ref", summary='"Hello"')],
         )
 
         # FIXME: should LLDB use "&&refref" for the name here?
         self.expect_var_path(
             "refref",
-            summary="<no value available>",
+            summary=None,
             children=[ValueCheck(name="&refref", summary='"Hi"')],
         )

--- a/lldb/test/API/functionalities/data-formatter/stringprinter/TestStringPrinter.py
+++ b/lldb/test/API/functionalities/data-formatter/stringprinter/TestStringPrinter.py
@@ -51,6 +51,7 @@ class TestStringPrinter(TestBase):
 
         # FIXME: make "b.data" and "c.data" work sanely
 
+        self.expect("frame variable ref", substrs=['(&ref = "Hello")'])
         self.expect_var_path(
             "ref",
             summary=None,
@@ -58,6 +59,7 @@ class TestStringPrinter(TestBase):
         )
 
         # FIXME: should LLDB use "&&refref" for the name here?
+        self.expect("frame variable refref", substrs=['(&refref = "Hi")'])
         self.expect_var_path(
             "refref",
             summary=None,


### PR DESCRIPTION
Depends on:
* https://github.com/llvm/llvm-project/pull/174385

(only last commit is relevant for this review)

The `${var%s}` format isn't capable of formatting references to C-strings. So the summary for those becomes `<no value available>`. This patch prevents the system C-string formatter from applying to references, which means the summary for such types will be empty. This prompts LLDB to instead print the child, which is the referenced C-string.

Before:
```
(lldb) v ref
(const char *&) ref = 0x000000016fdfe960 <no value available>
```

After:
```
(lldb) v ref
(const char *&) ref = 0x000000016fdfec40 (&ref = "hi")
```

An alternative would be to support references in the `ValueObject` dump methods. We assume C-string are pointers/arrays in a lot of places, so such a fix would be a more intrusive undertaking, and I'm not sure we would want to support references there in the first place. So for now I went with the fallback logic in this PR.