### PR TITLE
[X86] combineConcatVectorOps - concat fma chains which share concatenated operands

### DIFF
--- a/llvm/test/CodeGen/X86/combine-fma-concat.ll
+++ b/llvm/test/CodeGen/X86/combine-fma-concat.ll
@@ -204,26 +204,35 @@ define <16 x float> @concat_fmsub_v16f32_v8f32_constant_split(<8 x float> %a0, <
 define <8 x float> @concat_fma_v8f32_v4f32_constant_repeatedop(<4 x float> %a0, <4 x float> %a1, <4 x float> %a2, <4 x float> %a3) {
 ; FMA4-LABEL: concat_fma_v8f32_v4f32_constant_repeatedop:
 ; FMA4:       # %bb.0:
-; FMA4-NEXT:    vmovaps {{.*#+}} xmm4 = [1.0E+0,1.0E+0,1.0E+0,1.0E+0]
-; FMA4-NEXT:    vmovaps {{.*#+}} xmm5 = [2.0E+0,2.0E+0,2.0E+0,2.0E+0]
-; FMA4-NEXT:    vfmaddps {{.*#+}} xmm2 = (xmm0 * xmm2) + xmm4
-; FMA4-NEXT:    vfmaddps {{.*#+}} xmm3 = (xmm1 * xmm3) + xmm4
-; FMA4-NEXT:    vfmaddps {{.*#+}} xmm0 = (xmm0 * xmm2) + xmm5
-; FMA4-NEXT:    vfmaddps {{.*#+}} xmm1 = (xmm1 * xmm3) + xmm5
+; FMA4-NEXT:    # kill: def $xmm2 killed $xmm2 def $ymm2
+; FMA4-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
+; FMA4-NEXT:    vinsertf128 $1, %xmm3, %ymm2, %ymm2
 ; FMA4-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
+; FMA4-NEXT:    vfmaddps {{.*#+}} ymm1 = (ymm0 * ymm2) + mem
+; FMA4-NEXT:    vfmaddps {{.*#+}} ymm0 = (ymm0 * ymm1) + mem
 ; FMA4-NEXT:    retq
 ;
-; FMA3-LABEL: concat_fma_v8f32_v4f32_constant_repeatedop:
-; FMA3:       # %bb.0:
-; FMA3-NEXT:    # kill: def $xmm2 killed $xmm2 def $ymm2
-; FMA3-NEXT:    vbroadcastss {{.*#+}} xmm4 = [1.0E+0,1.0E+0,1.0E+0,1.0E+0]
-; FMA3-NEXT:    vfmadd213ps {{.*#+}} xmm2 = (xmm0 * xmm2) + xmm4
-; FMA3-NEXT:    vfmadd213ps {{.*#+}} xmm3 = (xmm1 * xmm3) + xmm4
-; FMA3-NEXT:    vbroadcastss {{.*#+}} xmm4 = [2.0E+0,2.0E+0,2.0E+0,2.0E+0]
-; FMA3-NEXT:    vfmadd213ps {{.*#+}} xmm2 = (xmm0 * xmm2) + xmm4
-; FMA3-NEXT:    vfmadd213ps {{.*#+}} xmm3 = (xmm1 * xmm3) + xmm4
-; FMA3-NEXT:    vinsertf128 $1, %xmm3, %ymm2, %ymm0
-; FMA3-NEXT:    retq
+; AVX2-LABEL: concat_fma_v8f32_v4f32_constant_repeatedop:
+; AVX2:       # %bb.0:
+; AVX2-NEXT:    # kill: def $xmm2 killed $xmm2 def $ymm2
+; AVX2-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
+; AVX2-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm1
+; AVX2-NEXT:    vinsertf128 $1, %xmm3, %ymm2, %ymm0
+; AVX2-NEXT:    vbroadcastss {{.*#+}} ymm2 = [1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0,1.0E+0]
+; AVX2-NEXT:    vfmadd231ps {{.*#+}} ymm2 = (ymm1 * ymm0) + ymm2
+; AVX2-NEXT:    vbroadcastss {{.*#+}} ymm0 = [2.0E+0,2.0E+0,2.0E+0,2.0E+0,2.0E+0,2.0E+0,2.0E+0,2.0E+0]
+; AVX2-NEXT:    vfmadd231ps {{.*#+}} ymm0 = (ymm1 * ymm2) + ymm0
+; AVX2-NEXT:    retq
+;
+; AVX512-LABEL: concat_fma_v8f32_v4f32_constant_repeatedop:
+; AVX512:       # %bb.0:
+; AVX512-NEXT:    # kill: def $xmm2 killed $xmm2 def $ymm2
+; AVX512-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
+; AVX512-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm1
+; AVX512-NEXT:    vinsertf128 $1, %xmm3, %ymm2, %ymm0
+; AVX512-NEXT:    vfmadd213ps {{.*#+}} ymm0 = (ymm1 * ymm0) + mem
+; AVX512-NEXT:    vfmadd213ps {{.*#+}} ymm0 = (ymm1 * ymm0) + mem
+; AVX512-NEXT:    retq
   %l0 = call <4 x float> @llvm.fma.v4f32(<4 x float> %a0, <4 x float> %a2, <4 x float> splat (float 1.000000e+00))
   %h0 = call <4 x float> @llvm.fma.v4f32(<4 x float> %a1, <4 x float> %a3, <4 x float> splat (float 1.000000e+00))
   %l1 = call <4 x float> @llvm.fma.v4f32(<4 x float> %a0, <4 x float> %l0, <4 x float> splat (float 2.000000e+00))
@@ -253,13 +262,14 @@ define <8 x double> @concat_fma_fmsub_v8f64_v4f64_constant_repeatedop_commute(<4
 ;
 ; AVX512-LABEL: concat_fma_fmsub_v8f64_v4f64_constant_repeatedop_commute:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vbroadcastsd {{.*#+}} ymm4 = [-2.0E+0,-2.0E+0,-2.0E+0,-2.0E+0]
 ; AVX512-NEXT:    # kill: def $ymm2 killed $ymm2 def $zmm2
-; AVX512-NEXT:    vfmadd213pd {{.*#+}} ymm2 = (ymm0 * ymm2) + ymm4
-; AVX512-NEXT:    vfmadd213pd {{.*#+}} ymm3 = (ymm1 * ymm3) + ymm4
-; AVX512-NEXT:    vfmsub213pd {{.*#+}} ymm2 = (ymm0 * ymm2) - ymm4
-; AVX512-NEXT:    vfmsub213pd {{.*#+}} ymm3 = (ymm1 * ymm3) - ymm4
-; AVX512-NEXT:    vinsertf64x4 $1, %ymm3, %zmm2, %zmm0
+; AVX512-NEXT:    # kill: def $ymm0 killed $ymm0 def $zmm0
+; AVX512-NEXT:    vinsertf64x4 $1, %ymm3, %zmm2, %zmm2
+; AVX512-NEXT:    vinsertf64x4 $1, %ymm1, %zmm0, %zmm0
+; AVX512-NEXT:    vbroadcastsd {{.*#+}} zmm1 = [-2.0E+0,-2.0E+0,-2.0E+0,-2.0E+0,-2.0E+0,-2.0E+0,-2.0E+0,-2.0E+0]
+; AVX512-NEXT:    vfmadd213pd {{.*#+}} zmm2 = (zmm0 * zmm2) + zmm1
+; AVX512-NEXT:    vfmsub213pd {{.*#+}} zmm2 = (zmm0 * zmm2) - zmm1
+; AVX512-NEXT:    vmovapd %zmm2, %zmm0
 ; AVX512-NEXT:    retq
   %l0 = call <4 x double> @llvm.fma.v4f32(<4 x double> %a2, <4 x double> %a0, <4 x double> splat (double -2.000000e+00))
   %h0 = call <4 x double> @llvm.fma.v4f32(<4 x double> %a3, <4 x double> %a1, <4 x double> splat (double -2.000000e+00))


### PR DESCRIPTION
We often have fma chains that reuse operands down the chain (e.g mathlib taylor series expansion) - FMA(FMA(X,Y,Z),X,W) etc.

This patch attempts to at least see if there is an inner FMA node with repeated operands that could share the cost of concatenation (but not if they are free already)