### PR TITLE
[clang][Sema] Handle zero initialization of atomic pointers

### DIFF
--- a/clang/test/CodeGen/atomic_zero_initialize.c
+++ b/clang/test/CodeGen/atomic_zero_initialize.c
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK-C
+// RUN: %clang_cc1 -emit-llvm -o - %s -x c++ | FileCheck %s --check-prefixes=CHECK-CXX
+
+// CHECK-LABEL: @initlist_atomic_pointer_zero
+struct range_tree_node_s {
+  long base;
+  long left;
+  struct range_tree_node_s *_Atomic right;
+};
+
+void initlist_atomic_pointer_zero() {
+  (struct range_tree_node_s){.right = 0};
+}
+
+// CHECK-LABEL: @scalar_atomic_init
+void scalar_atomic_init() {
+  // CHECK-C: store ptr null
+  // CHECK-CXX: store ptr null
+  _Atomic(int*) p = 0;
+}


### PR DESCRIPTION
Currently, atomic pointer initializers can reach CodeGen without the expected null-to-pointer cast, triggering an assert. This change ensures that atomic pointer initializers are correctly handled for scalar initializations and init-list elements.