### PR TITLE
[BOLT] Enable merge branch profile with memory profile

### DIFF
--- a/bolt/test/merge-fdata-mixed-branch-memory.test
+++ b/bolt/test/merge-fdata-mixed-branch-memory.test
@@ -1,0 +1,15 @@
+## Check that merge-fdata correctly handles merging two fdata files with no_lbr/lbr sampling and memory sampling.
+
+# REQUIRES: system-linux
+
+# RUN: split-file %s %t
+# RUN: merge-fdata %t/a.fdata %t/b.fdata -o %t/merged.fdata
+# RUN: FileCheck %s --input-file %t/merged.fdata
+#
+# CHECK: 1 main 0 1 main 2 0 1
+# CHECK: 4 main 10 4 otherSym 123 1
+
+#--- a.fdata
+1 main 0 1 main 2 0 1
+#--- b.fdata
+4 main 10 4 otherSym 123 1


### PR DESCRIPTION
Allows merging the memory profiles with basic sampling profiles or LBR sampling profils.

Using std::map instead of StringMap to keep records in order: For profiles that mix branch and memory information, since llvm-bolt processes branch and memory information sequentially, it is essential to ensure that the data of these two types remains relatively independent.