### PR TITLE
[clang][bytecode] Mark volatile composite locals as such

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -4673,7 +4673,8 @@ UnsignedOrNone Compiler<Emitter>::allocateLocal(DeclTy &&Src, QualType Ty,
 
   Descriptor *D = P.createDescriptor(
       Src, Ty.getTypePtr(), Descriptor::InlineDescMD, Ty.isConstQualified(),
-      IsTemporary, /*IsMutable=*/false, /*IsVolatile=*/false, Init);
+      IsTemporary, /*IsMutable=*/false, /*IsVolatile=*/Ty.isVolatileQualified(),
+      Init);
   if (!D)
     return std::nullopt;
   D->IsConstexprUnknown = IsConstexprUnknown;

--- a/clang/test/AST/ByteCode/cxx23.cpp
+++ b/clang/test/AST/ByteCode/cxx23.cpp
@@ -450,6 +450,20 @@ namespace VolatileWrites {
                             // all-note {{in call to}}
 }
 
+namespace VolatileReads {
+  constexpr int test1(bool b) {
+    if (!b)
+      return -1;
+    struct C {
+      int a;
+    };
+    volatile C c{12}; // all-note {{volatile object declared here}}
+    return ((C&)(c)).a; // all-note {{read of volatile object}}
+  }
+  static_assert(test1(true) == 0); // all-error {{not an integral constant expression}} \
+                                   // all-note {{in call to}}
+}
+
 namespace AIEWithIndex0Narrows {
   template <class _Tp> struct greater {
     constexpr void operator()(_Tp, _Tp) {}


### PR DESCRIPTION
We were forgetting to pass the volatile-ness along.