### PR TITLE
[clang-tidy] Rename clang::tidy::matchers::matchesAnyListedName() to matchesAnyListedRegexName

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/AssertSideEffectCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/AssertSideEffectCheck.cpp
@@ -104,7 +104,7 @@ void AssertSideEffectCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 
 void AssertSideEffectCheck::registerMatchers(MatchFinder *Finder) {
   auto IgnoredFunctionsMatcher =
-      matchers::matchesAnyListedName(IgnoredFunctions);
+      matchers::matchesAnyListedRegexName(IgnoredFunctions);
 
   auto DescendantWithSideEffect =
       traverse(TK_AsIs, hasDescendant(expr(hasSideEffect(

--- a/clang-tools-extra/clang-tidy/bugprone/CapturingThisInMemberVariableCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/CapturingThisInMemberVariableCheck.cpp
@@ -85,7 +85,7 @@ void CapturingThisInMemberVariableCheck::storeOptions(
 void CapturingThisInMemberVariableCheck::registerMatchers(MatchFinder *Finder) {
   auto IsStdFunctionField =
       fieldDecl(hasType(cxxRecordDecl(
-                    matchers::matchesAnyListedName(FunctionWrapperTypes))))
+                    matchers::matchesAnyListedRegexName(FunctionWrapperTypes))))
           .bind("field");
   auto CaptureThis = lambdaCapture(anyOf(
       // [this]
@@ -96,10 +96,10 @@ void CapturingThisInMemberVariableCheck::registerMatchers(MatchFinder *Finder) {
       lambdaExpr(hasAnyCapture(CaptureThis)).bind("lambda");
 
   auto IsBindCapturingThis =
-      callExpr(
-          callee(functionDecl(matchers::matchesAnyListedName(BindFunctions))
-                     .bind("callee")),
-          hasAnyArgument(cxxThisExpr()))
+      callExpr(callee(functionDecl(
+                          matchers::matchesAnyListedRegexName(BindFunctions))
+                          .bind("callee")),
+               hasAnyArgument(cxxThisExpr()))
           .bind("bind");
 
   auto IsInitWithLambdaOrBind =

--- a/clang-tools-extra/clang-tidy/bugprone/EmptyCatchCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/EmptyCatchCheck.cpp
@@ -77,8 +77,8 @@ std::optional<TraversalKind> EmptyCatchCheck::getCheckTraversalKind() const {
 }
 
 void EmptyCatchCheck::registerMatchers(MatchFinder *Finder) {
-  auto AllowedNamedExceptionDecl =
-      namedDecl(matchers::matchesAnyListedName(AllowEmptyCatchForExceptions));
+  auto AllowedNamedExceptionDecl = namedDecl(
+      matchers::matchesAnyListedRegexName(AllowEmptyCatchForExceptions));
   auto AllowedNamedExceptionTypes =
       qualType(anyOf(hasDeclaration(AllowedNamedExceptionDecl),
                      references(AllowedNamedExceptionDecl),

--- a/clang-tools-extra/clang-tidy/bugprone/InvalidEnumDefaultInitializationCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/InvalidEnumDefaultInitializationCheck.cpp
@@ -108,7 +108,7 @@ void InvalidEnumDefaultInitializationCheck::registerMatchers(
     MatchFinder *Finder) {
   auto EnumWithoutZeroValue = enumType(hasDeclaration(
       enumDecl(isCompleteAndHasNoZeroValue(),
-               unless(matchers::matchesAnyListedName(IgnoredEnums)))
+               unless(matchers::matchesAnyListedRegexName(IgnoredEnums)))
           .bind("enum")));
   auto EnumOrArrayOfEnum = qualType(hasUnqualifiedDesugaredType(
       anyOf(EnumWithoutZeroValue,

--- a/clang-tools-extra/clang-tidy/bugprone/NonZeroEnumToBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NonZeroEnumToBoolConversionCheck.cpp
@@ -58,7 +58,7 @@ void NonZeroEnumToBoolConversionCheck::registerMatchers(MatchFinder *Finder) {
                hasSourceExpression(
                    expr(hasType(qualType(hasCanonicalType(hasDeclaration(
                             enumDecl(isCompleteAndHasNoZeroValue(),
-                                     unless(matchers::matchesAnyListedName(
+                                     unless(matchers::matchesAnyListedRegexName(
                                          EnumIgnoreList)))
                                 .bind("enum"))))),
                         unless(declRefExpr(to(enumConstantDecl()))),

--- a/clang-tools-extra/clang-tidy/bugprone/SuspiciousStringviewDataUsageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SuspiciousStringviewDataUsageCheck.cpp
@@ -48,9 +48,9 @@ void SuspiciousStringviewDataUsageCheck::registerMatchers(MatchFinder *Finder) {
       initListExpr(
           hasType(qualType(hasCanonicalType(hasDeclaration(recordDecl()))))));
 
-  auto DataMethod =
-      cxxMethodDecl(hasName("data"),
-                    ofClass(matchers::matchesAnyListedName(StringViewTypes)));
+  auto DataMethod = cxxMethodDecl(
+      hasName("data"),
+      ofClass(matchers::matchesAnyListedRegexName(StringViewTypes)));
 
   auto SizeCall = cxxMemberCallExpr(
       callee(cxxMethodDecl(hasAnyName("size", "length"))),
@@ -73,13 +73,14 @@ void SuspiciousStringviewDataUsageCheck::registerMatchers(MatchFinder *Finder) {
                       ignoringParenImpCasts(equalsBoundNode("data-call"))),
                   unless(hasAnyArgument(ignoringParenImpCasts(SizeCall))),
                   unless(hasAnyArgument(DescendantSizeCall)),
-                  hasDeclaration(namedDecl(
-                      unless(matchers::matchesAnyListedName(AllowedCallees))))),
-              initListExpr(expr().bind("parent"),
-                           hasType(qualType(hasCanonicalType(hasDeclaration(
-                               recordDecl(unless(matchers::matchesAnyListedName(
-                                   AllowedCallees))))))),
-                           unless(DescendantSizeCall)))))),
+                  hasDeclaration(namedDecl(unless(
+                      matchers::matchesAnyListedRegexName(AllowedCallees))))),
+              initListExpr(
+                  expr().bind("parent"),
+                  hasType(qualType(hasCanonicalType(hasDeclaration(
+                      recordDecl(unless(matchers::matchesAnyListedRegexName(
+                          AllowedCallees))))))),
+                  unless(DescendantSizeCall)))))),
       this);
 }
 

--- a/clang-tools-extra/clang-tidy/bugprone/UnsafeFunctionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnsafeFunctionsCheck.cpp
@@ -155,7 +155,7 @@ parseCheckedFunctions(StringRef Option, ClangTidyContext *Context) {
 
     Result.push_back(
         {Name.trim().str(),
-         matchers::MatchesAnyListedNameMatcher::NameMatcher(Name.trim()),
+         matchers::MatchesAnyListedRegexNameMatcher::NameMatcher(Name.trim()),
          Replacement.trim().str(), Reason.trim().str()});
   }
 
@@ -247,7 +247,8 @@ void UnsafeFunctionsCheck::registerMatchers(MatchFinder *Finder) {
     for (const auto &Entry : CustomFunctions)
       FunctionNames.emplace_back(Entry.Name);
 
-    auto CustomFunctionsMatcher = matchers::matchesAnyListedName(FunctionNames);
+    auto CustomFunctionsMatcher =
+        matchers::matchesAnyListedRegexName(FunctionNames);
 
     Finder->addMatcher(declRefExpr(to(functionDecl(CustomFunctionsMatcher)
                                           .bind(CustomFunctionNamesId)))

--- a/clang-tools-extra/clang-tidy/bugprone/UnsafeFunctionsCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/UnsafeFunctionsCheck.h
@@ -35,7 +35,7 @@ public:
 
   struct CheckedFunction {
     std::string Name;
-    matchers::MatchesAnyListedNameMatcher::NameMatcher Pattern;
+    matchers::MatchesAnyListedRegexNameMatcher::NameMatcher Pattern;
     std::string Replacement;
     std::string Reason;
   };

--- a/clang-tools-extra/clang-tidy/bugprone/UnusedLocalNonTrivialVariableCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedLocalNonTrivialVariableCheck.cpp
@@ -69,13 +69,13 @@ void UnusedLocalNonTrivialVariableCheck::registerMatchers(MatchFinder *Finder) {
               unless(isExceptionVariable()), hasLocalStorage(), isDefinition(),
               unless(hasType(isReferenceType())), unless(hasType(isTrivial())),
               unless(explicitMarkUnused()),
-              hasType(hasUnqualifiedDesugaredType(
-                  anyOf(recordType(hasDeclaration(namedDecl(
-                            matchesAnyListedName(IncludeTypes),
-                            unless(matchesAnyListedName(ExcludeTypes))))),
-                        templateSpecializationType(hasDeclaration(namedDecl(
-                            matchesAnyListedName(IncludeTypes),
-                            unless(matchesAnyListedName(ExcludeTypes)))))))))
+              hasType(hasUnqualifiedDesugaredType(anyOf(
+                  recordType(hasDeclaration(namedDecl(
+                      matchesAnyListedRegexName(IncludeTypes),
+                      unless(matchesAnyListedRegexName(ExcludeTypes))))),
+                  templateSpecializationType(hasDeclaration(namedDecl(
+                      matchesAnyListedRegexName(IncludeTypes),
+                      unless(matchesAnyListedRegexName(ExcludeTypes)))))))))
           .bind("var"),
       this);
 }

--- a/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedReturnValueCheck.cpp
@@ -171,18 +171,18 @@ void UnusedReturnValueCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 }
 
 void UnusedReturnValueCheck::registerMatchers(MatchFinder *Finder) {
-  auto MatchedDirectCallExpr =
-      expr(callExpr(callee(functionDecl(
-                        // Don't match copy or move assignment operator.
-                        unless(isAssignmentOverloadedOperator()),
-                        // Don't match void overloads of checked functions.
-                        unless(returns(voidType())),
-                        anyOf(isInstantiatedFrom(matchers::matchesAnyListedName(
-                                  CheckedFunctions)),
-                              returns(hasCanonicalType(hasDeclaration(
-                                  namedDecl(matchers::matchesAnyListedName(
-                                      CheckedReturnTypes)))))))))
-               .bind("match"));
+  auto MatchedDirectCallExpr = expr(
+      callExpr(callee(functionDecl(
+                   // Don't match copy or move assignment operator.
+                   unless(isAssignmentOverloadedOperator()),
+                   // Don't match void overloads of checked functions.
+                   unless(returns(voidType())),
+                   anyOf(isInstantiatedFrom(matchers::matchesAnyListedRegexName(
+                             CheckedFunctions)),
+                         returns(hasCanonicalType(hasDeclaration(
+                             namedDecl(matchers::matchesAnyListedRegexName(
+                                 CheckedReturnTypes)))))))))
+          .bind("match"));
 
   auto CheckCastToVoid =
       AllowCastToVoid ? castExpr(unless(hasCastKind(CK_ToVoid))) : castExpr();

--- a/clang-tools-extra/clang-tidy/bugprone/UseAfterMoveCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UseAfterMoveCheck.cpp
@@ -85,7 +85,7 @@ private:
 
 static auto getNameMatcher(llvm::ArrayRef<StringRef> InvalidationFunctions) {
   return anyOf(hasAnyName("::std::move", "::std::forward"),
-               matchers::matchesAnyListedName(InvalidationFunctions));
+               matchers::matchesAnyListedRegexName(InvalidationFunctions));
 }
 
 static StatementMatcher
@@ -138,11 +138,12 @@ makeReinitMatcher(const ValueDecl *MovedVariable,
                                        hasAttr(clang::attr::Reinitializes)))),
                  // Functions that are specified in ReinitializationFunctions
                  // option.
-                 callExpr(callee(functionDecl(matchers::matchesAnyListedName(
-                              ReinitializationFunctions))),
-                          anyOf(cxxMemberCallExpr(on(DeclRefMatcher)),
-                                callExpr(unless(cxxMemberCallExpr()),
-                                         hasArgument(0, DeclRefMatcher)))),
+                 callExpr(
+                     callee(functionDecl(matchers::matchesAnyListedRegexName(
+                         ReinitializationFunctions))),
+                     anyOf(cxxMemberCallExpr(on(DeclRefMatcher)),
+                           callExpr(unless(cxxMemberCallExpr()),
+                                    hasArgument(0, DeclRefMatcher)))),
                  // Passing variable to a function as a non-const pointer.
                  callExpr(forEachArgumentWithParam(
                      unaryOperator(hasOperatorName("&"),

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/NoSuspendWithLockCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/NoSuspendWithLockCheck.cpp
@@ -24,7 +24,7 @@ void NoSuspendWithLockCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 
 void NoSuspendWithLockCheck::registerMatchers(MatchFinder *Finder) {
   auto LockType = templateSpecializationType(
-      hasDeclaration(namedDecl(matchers::matchesAnyListedName(
+      hasDeclaration(namedDecl(matchers::matchesAnyListedRegexName(
           utils::options::parseStringList(LockGuards)))));
 
   const StatementMatcher Lock =

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsAvoidUncheckedContainerAccessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/ProBoundsAvoidUncheckedContainerAccessCheck.cpp
@@ -95,7 +95,7 @@ void ProBoundsAvoidUncheckedContainerAccessCheck::registerMatchers(
               cxxMethodDecl(
                   hasOverloadedOperatorName("[]"),
                   anyOf(parameterCountIs(0), parameterCountIs(1)),
-                  unless(matchers::matchesAnyListedName(ExcludedClasses)))
+                  unless(matchers::matchesAnyListedRegexName(ExcludedClasses)))
                   .bind("operator")))
           .bind("caller"),
       this);

--- a/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
@@ -98,8 +98,8 @@ void ConstCorrectnessCheck::registerMatchers(MatchFinder *Finder) {
       hasType(referenceType(pointee(hasCanonicalType(templateTypeParmType())))),
       hasType(referenceType(pointee(substTemplateTypeParmType()))));
 
-  auto AllowedTypeDecl = namedDecl(
-      anyOf(matchers::matchesAnyListedName(AllowedTypes), usingShadowDecl()));
+  auto AllowedTypeDecl = namedDecl(anyOf(
+      matchers::matchesAnyListedRegexName(AllowedTypes), usingShadowDecl()));
 
   const auto AllowedType = hasType(qualType(
       anyOf(hasDeclaration(AllowedTypeDecl), references(AllowedTypeDecl),

--- a/clang-tools-extra/clang-tidy/misc/OverrideWithDifferentVisibilityCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/OverrideWithDifferentVisibilityCheck.cpp
@@ -71,7 +71,7 @@ void OverrideWithDifferentVisibilityCheck::storeOptions(
 void OverrideWithDifferentVisibilityCheck::registerMatchers(
     MatchFinder *Finder) {
   const auto IgnoredDecl =
-      namedDecl(matchers::matchesAnyListedName(IgnoredFunctions));
+      namedDecl(matchers::matchesAnyListedRegexName(IgnoredFunctions));
   const auto FilterDestructors =
       CheckDestructors ? decl() : decl(unless(cxxDestructorDecl()));
   const auto FilterOperators =

--- a/clang-tools-extra/clang-tidy/modernize/UseStdFormatCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdFormatCheck.cpp
@@ -50,7 +50,7 @@ void UseStdFormatCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       callExpr(argumentCountAtLeast(1),
                hasArgument(0, stringLiteral(isOrdinary())),
-               callee(functionDecl(matchers::matchesAnyListedName(
+               callee(functionDecl(matchers::matchesAnyListedRegexName(
                                        StrFormatLikeFunctions))
                           .bind("func_decl")))
           .bind("strformat"),

--- a/clang-tools-extra/clang-tidy/modernize/UseStdPrintCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdPrintCheck.cpp
@@ -99,7 +99,7 @@ void UseStdPrintCheck::registerMatchers(MatchFinder *Finder) {
         unusedReturnValue(
             callExpr(argumentCountAtLeast(1),
                      hasArgument(0, stringLiteral(isOrdinary())),
-                     callee(functionDecl(matchers::matchesAnyListedName(
+                     callee(functionDecl(matchers::matchesAnyListedRegexName(
                                              PrintfLikeFunctions))
                                 .bind("func_decl")))
                 .bind("printf")),
@@ -110,7 +110,7 @@ void UseStdPrintCheck::registerMatchers(MatchFinder *Finder) {
         unusedReturnValue(
             callExpr(argumentCountAtLeast(2),
                      hasArgument(1, stringLiteral(isOrdinary())),
-                     callee(functionDecl(matchers::matchesAnyListedName(
+                     callee(functionDecl(matchers::matchesAnyListedRegexName(
                                              FprintfLikeFunctions))
                                 .bind("func_decl")))
                 .bind("fprintf")),

--- a/clang-tools-extra/clang-tidy/performance/EnumSizeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/EnumSizeCheck.cpp
@@ -91,7 +91,7 @@ void EnumSizeCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
       enumDecl(unless(isExpansionInSystemHeader()), isDefinition(),
                hasEnumerators(),
-               unless(matchers::matchesAnyListedName(EnumIgnoreList)))
+               unless(matchers::matchesAnyListedRegexName(EnumIgnoreList)))
           .bind("e"),
       this);
 }

--- a/clang-tools-extra/clang-tidy/performance/ForRangeCopyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/ForRangeCopyCheck.cpp
@@ -38,7 +38,7 @@ void ForRangeCopyCheck::registerMatchers(MatchFinder *Finder) {
   auto HasReferenceOrPointerTypeOrIsAllowed = hasType(qualType(
       unless(anyOf(hasCanonicalType(anyOf(referenceType(), pointerType())),
                    hasDeclaration(namedDecl(
-                       matchers::matchesAnyListedName(AllowedTypes)))))));
+                       matchers::matchesAnyListedRegexName(AllowedTypes)))))));
   auto IteratorReturnsValueType = cxxOperatorCallExpr(
       hasOverloadedOperatorName("*"),
       callee(

--- a/clang-tools-extra/clang-tidy/performance/NoAutomaticMoveCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/NoAutomaticMoveCheck.cpp
@@ -36,7 +36,7 @@ void NoAutomaticMoveCheck::registerMatchers(MatchFinder *Finder) {
                   isConstQualified(),
                   hasCanonicalType(matchers::isExpensiveToCopy()),
                   unless(hasDeclaration(namedDecl(
-                      matchers::matchesAnyListedName(AllowedTypes)))))))
+                      matchers::matchesAnyListedRegexName(AllowedTypes)))))))
           .bind("vardecl");
 
   // A matcher for a `DstT::DstT(const Src&)` where DstT also has a

--- a/clang-tools-extra/clang-tidy/performance/UnnecessaryCopyInitializationCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/UnnecessaryCopyInitializationCheck.cpp
@@ -93,8 +93,8 @@ AST_MATCHER_FUNCTION_P(StatementMatcher,
       // Access through dereference, typically used for `operator[]`: `(*a)[3]`.
       unaryOperator(hasOperatorName("*"), hasUnaryOperand(ReceiverExpr)));
   const auto ReceiverType =
-      hasCanonicalType(recordType(hasDeclaration(namedDecl(
-          unless(matchers::matchesAnyListedName(ExcludedContainerTypes))))));
+      hasCanonicalType(recordType(hasDeclaration(namedDecl(unless(
+          matchers::matchesAnyListedRegexName(ExcludedContainerTypes))))));
 
   return expr(
       anyOf(cxxMemberCallExpr(callee(MethodDecl), on(OnExpr),
@@ -246,7 +246,7 @@ void UnnecessaryCopyInitializationCheck::registerMatchers(MatchFinder *Finder) {
                                            unless(hasDeclaration(namedDecl(
                                                hasName("::std::function")))))),
                                        unless(hasDeclaration(namedDecl(
-                                           matchers::matchesAnyListedName(
+                                           matchers::matchesAnyListedRegexName(
                                                AllowedTypes)))))),
                                    unless(isImplicit()),
                                    hasInitializer(traverse(

--- a/clang-tools-extra/clang-tidy/performance/UnnecessaryValueParamCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/UnnecessaryValueParamCheck.cpp
@@ -51,11 +51,11 @@ UnnecessaryValueParamCheck::UnnecessaryValueParamCheck(
 
 void UnnecessaryValueParamCheck::registerMatchers(MatchFinder *Finder) {
   const auto ExpensiveValueParamDecl = parmVarDecl(
-      hasType(qualType(
-          hasCanonicalType(matchers::isExpensiveToCopy()),
-          unless(anyOf(hasCanonicalType(referenceType()),
-                       hasDeclaration(namedDecl(
-                           matchers::matchesAnyListedName(AllowedTypes))))))),
+      hasType(qualType(hasCanonicalType(matchers::isExpensiveToCopy()),
+                       unless(anyOf(hasCanonicalType(referenceType()),
+                                    hasDeclaration(namedDecl(
+                                        matchers::matchesAnyListedRegexName(
+                                            AllowedTypes))))))),
       decl().bind("param"));
   Finder->addMatcher(
       traverse(TK_AsIs,

--- a/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerDataPointerCheck.cpp
@@ -37,7 +37,7 @@ ContainerDataPointerCheck::ContainerDataPointerCheck(StringRef Name,
 void ContainerDataPointerCheck::registerMatchers(MatchFinder *Finder) {
   const auto Record =
       cxxRecordDecl(
-          unless(matchers::matchesAnyListedName(IgnoredContainers)),
+          unless(matchers::matchesAnyListedRegexName(IgnoredContainers)),
           isSameOrDerivedFrom(
               namedDecl(
                   has(cxxMethodDecl(isPublic(), hasName("data")).bind("data")))

--- a/clang-tools-extra/clang-tidy/readability/ContainerSizeEmptyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerSizeEmptyCheck.cpp
@@ -217,13 +217,14 @@ void ContainerSizeEmptyCheck::registerMatchers(MatchFinder *Finder) {
                     expr(hasType(pointsTo(ValidContainer))).bind("Pointee"))),
             expr(hasType(ValidContainer)).bind("STLObject"));
 
-  const auto ExcludedComparisonTypesMatcher = qualType(anyOf(
-      hasDeclaration(
-          cxxRecordDecl(matchers::matchesAnyListedName(ExcludedComparisonTypes))
-              .bind("excluded")),
-      hasCanonicalType(hasDeclaration(
-          cxxRecordDecl(matchers::matchesAnyListedName(ExcludedComparisonTypes))
-              .bind("excluded")))));
+  const auto ExcludedComparisonTypesMatcher = qualType(
+      anyOf(hasDeclaration(cxxRecordDecl(matchers::matchesAnyListedRegexName(
+                                             ExcludedComparisonTypes))
+                               .bind("excluded")),
+            hasCanonicalType(hasDeclaration(
+                cxxRecordDecl(matchers::matchesAnyListedRegexName(
+                                  ExcludedComparisonTypes))
+                    .bind("excluded")))));
   const auto SameExcludedComparisonTypesMatcher =
       qualType(anyOf(hasDeclaration(cxxRecordDecl(equalsBoundNode("excluded"))),
                      hasCanonicalType(hasDeclaration(

--- a/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantParenthesesCheck.cpp
@@ -51,13 +51,13 @@ void RedundantParenthesesCheck::registerMatchers(MatchFinder *Finder) {
       expr(anyOf(integerLiteral(), floatLiteral(), characterLiteral(),
                  cxxBoolLiteral(), stringLiteral(), cxxNullPtrLiteralExpr()));
   Finder->addMatcher(
-      parenExpr(
-          subExpr(anyOf(parenExpr(), ConstantExpr,
-                        declRefExpr(to(namedDecl(unless(
-                            matchers::matchesAnyListedName(AllowedDecls))))))),
-          unless(anyOf(isInMacro(),
-                       // sizeof(...) is common used.
-                       hasParent(unaryExprOrTypeTraitExpr()))))
+      parenExpr(subExpr(anyOf(
+                    parenExpr(), ConstantExpr,
+                    declRefExpr(to(namedDecl(unless(
+                        matchers::matchesAnyListedRegexName(AllowedDecls))))))),
+                unless(anyOf(isInMacro(),
+                             // sizeof(...) is common used.
+                             hasParent(unaryExprOrTypeTraitExpr()))))
           .bind("dup"),
       this);
 }

--- a/clang-tools-extra/clang-tidy/readability/RedundantStringCStrCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantStringCStrCheck.cpp
@@ -154,11 +154,11 @@ void RedundantStringCStrCheck::registerMatchers(
     // Detect redundant 'c_str()' calls in parameters passed to std::format in
     // C++20 onwards and std::print in C++23 onwards.
     Finder->addMatcher(
-        traverse(TK_AsIs,
-                 callExpr(callee(functionDecl(matchers::matchesAnyListedName(
-                              StringParameterFunctions))),
-                          forEachArgumentWithParam(StringCStrCallExpr,
-                                                   parmVarDecl()))),
+        traverse(TK_AsIs, callExpr(callee(functionDecl(
+                                       matchers::matchesAnyListedRegexName(
+                                           StringParameterFunctions))),
+                                   forEachArgumentWithParam(StringCStrCallExpr,
+                                                            parmVarDecl()))),
         this);
   }
 }

--- a/clang-tools-extra/clang-tidy/utils/Matchers.h
+++ b/clang-tools-extra/clang-tidy/utils/Matchers.h
@@ -77,10 +77,11 @@ AST_MATCHER(Expr, hasUnevaluatedContext) {
 // A matcher implementation that matches a list of type name regular expressions
 // against a NamedDecl. If a regular expression contains the substring "::"
 // matching will occur against the qualified name, otherwise only the typename.
-class MatchesAnyListedNameMatcher
+class MatchesAnyListedRegexNameMatcher
     : public ast_matchers::internal::MatcherInterface<NamedDecl> {
 public:
-  explicit MatchesAnyListedNameMatcher(llvm::ArrayRef<StringRef> NameList) {
+  explicit MatchesAnyListedRegexNameMatcher(
+      llvm::ArrayRef<StringRef> NameList) {
     std::transform(
         NameList.begin(), NameList.end(), std::back_inserter(NameMatchers),
         [](const llvm::StringRef Name) { return NameMatcher(Name); });
@@ -143,9 +144,9 @@ private:
 // expressions. If a regular expression contains starts ':' the NamedDecl's
 // qualified name will be used for matching, otherwise its name will be used.
 inline ::clang::ast_matchers::internal::Matcher<NamedDecl>
-matchesAnyListedName(llvm::ArrayRef<StringRef> NameList) {
+matchesAnyListedRegexName(llvm::ArrayRef<StringRef> NameList) {
   return ::clang::ast_matchers::internal::Matcher(
-      new MatchesAnyListedNameMatcher(NameList));
+      new MatchesAnyListedRegexNameMatcher(NameList));
 }
 
 // Predicate that verify if statement is not identical to one bound to ID node.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format-custom.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format-custom.cpp
@@ -44,7 +44,7 @@ std::string StrFormat_strict_conversion() {
   // CHECK-FIXES-STRICT: return fmt::format("Integer {} from unsigned char\n", static_cast<signed char>(uc));
 }
 
-// Ensure that MatchesAnyListedNameMatcher::NameMatcher::match() can cope with a
+// Ensure that MatchesAnyListedRegexNameMatcher::NameMatcher::match() can cope with a
 // NamedDecl that has no name when we're trying to match unqualified_strprintf.
 std::string A(const std::string &in)
 {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-print-custom.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-print-custom.cpp
@@ -80,7 +80,7 @@ int fprintf_uses_return_value(int i) {
   // CHECK-FIXES-NOT: std::println(stderr, "return value {}", i);
 }
 
-// Ensure that MatchesAnyListedNameMatcher::NameMatcher::match() can cope with a
+// Ensure that MatchesAnyListedRegexNameMatcher::NameMatcher::match() can cope with a
 // NamedDecl that has no name when we're trying to match unqualified_printf.
 void no_name(const std::string &in)
 {


### PR DESCRIPTION
This clarifies that patterns are regular expressions.

Closes: #174229