### PR TITLE
[libclc] Update default triple support for AMD and deprecate 32-bit PTX

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -148,13 +148,11 @@ endif()
 # List of all targets. Note that some are added dynamically below.
 set( LIBCLC_TARGETS_ALL
   amdgcn--
-  amdgcn--amdhsa
+  amdgcn-amd-amdhsa
   clspv--
   clspv64--
   r600--
-  nvptx--
   nvptx64--
-  nvptx--nvidiacl
   nvptx64--nvidiacl
 )
 
@@ -205,12 +203,10 @@ add_subdirectory( utils )
 set( r600--_devices cedar cypress barts cayman )
 set( amdgcn--_devices tahiti )
 set( amdgcn-mesa-mesa3d_devices ${amdgcn--_devices} )
-set( amdgcn--amdhsa_devices none )
+set( amdgcn-amd-amdhsa_devices none )
 set( clspv--_devices none )
 set( clspv64--_devices none )
-set( nvptx--_devices none )
 set( nvptx64--_devices none )
-set( nvptx--nvidiacl_devices none )
 set( nvptx64--nvidiacl_devices none )
 set( spirv-mesa3d-_devices none )
 set( spirv64-mesa3d-_devices none )
@@ -303,7 +299,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
   endif()
 
   # Some targets' directories alias others
-  if( ${ARCH} STREQUAL nvptx OR ${ARCH} STREQUAL nvptx64 )
+  if( ${ARCH} STREQUAL nvptx64 )
     set( DARCH ptx )
   elseif( ${ARCH} STREQUAL clspv OR ${ARCH} STREQUAL clspv64 )
     set( DARCH clspv )

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -488,7 +488,7 @@ function(add_libclc_builtin_set)
   # Add a test for whether or not the libraries contain unresolved functions
   # which would usually indicate a build problem. Note that we don't perform
   # this test for all libclc targets:
-  # * nvptx-- targets don't include workitem builtins
+  # * nvptx64-- targets don't include workitem builtins
   # * clspv targets don't include all OpenCL builtins
   if( NOT ARG_ARCH MATCHES "^(nvptx|clspv)(64)?$" )
     add_test( NAME external-funcs-${obj_suffix}


### PR DESCRIPTION
Summary:
The standard `nvptx` target is not supported and has been completely
removed following the CUDA 12 release. It should be safe to drop support
for it in the default build. Additionally we add the `amd` vendor to the
amdgcn triple as this is the more canonical form and builds the same IR.
