### PR TITLE
InstCombine: Reorder exp's known-nan source handling

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2182,6 +2182,11 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Value *V,
       if (KnownSrc.isKnownAlways(fcZero))
         return ConstantFP::get(VTy, 1.0);
 
+      // Only perform nan propagation.
+      // Note: Dropping canonicalize / quiet of signaling nan.
+      if (KnownSrc.isKnownAlways(fcNan))
+        return CI->getArgOperand(0);
+
       // exp(0 | nan) => x == 0.0 ? 1.0 : x
       if (KnownSrc.isKnownAlways(fcZero | fcNan)) {
         IRBuilderBase::InsertPointGuard Guard(Builder);
@@ -2209,11 +2214,6 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Value *V,
             IsPosInfOrNan, X, ConstantFP::getZero(VTy), FMF, DEBUG_TYPE);
         return ZeroOrInf;
       }
-
-      // Only perform nan propagation.
-      // Note: Dropping canonicalize / quiet of signaling nan.
-      if (KnownSrc.isKnownAlways(fcNan))
-        return CI->getArgOperand(0);
 
       Known = KnownFPClass::exp(KnownSrc);
       break;

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-exp.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-exp.ll
@@ -410,8 +410,7 @@ define nofpclass(nzero) float @source_is_known_ninf(float nofpclass(pinf nan nor
 define nofpclass(nzero) float @source_is_known_nan(float nofpclass(inf norm sub zero) %must.be.nan) {
 ; CHECK-LABEL: define nofpclass(nzero) float @source_is_known_nan(
 ; CHECK-SAME: float nofpclass(inf zero sub norm) [[MUST_BE_NAN:%.*]]) {
-; CHECK-NEXT:    [[TMP1:%.*]] = fadd float [[MUST_BE_NAN]], 1.000000e+00
-; CHECK-NEXT:    ret float [[TMP1]]
+; CHECK-NEXT:    ret float [[MUST_BE_NAN]]
 ;
   %exp = call float @llvm.exp2.f32(float %must.be.nan)
   ret float %exp
@@ -420,8 +419,7 @@ define nofpclass(nzero) float @source_is_known_nan(float nofpclass(inf norm sub 
 define nofpclass(nzero) float @source_is_known_nan_preserve_flags(float nofpclass(inf norm sub zero) %must.be.nan) {
 ; CHECK-LABEL: define nofpclass(nzero) float @source_is_known_nan_preserve_flags(
 ; CHECK-SAME: float nofpclass(inf zero sub norm) [[MUST_BE_NAN:%.*]]) {
-; CHECK-NEXT:    [[TMP1:%.*]] = fadd nsz contract float [[MUST_BE_NAN]], 1.000000e+00
-; CHECK-NEXT:    ret float [[TMP1]]
+; CHECK-NEXT:    ret float [[MUST_BE_NAN]]
 ;
   %exp = call contract nsz float @llvm.exp2.f32(float %must.be.nan)
   ret float %exp
@@ -483,8 +481,7 @@ define nofpclass(pzero) <2 x float> @source_is_known_zero_or_nan_vec(<2 x float>
 define nofpclass(nzero) float @source_is_known_snan(float nofpclass(inf norm sub zero qnan) %must.be.snan) {
 ; CHECK-LABEL: define nofpclass(nzero) float @source_is_known_snan(
 ; CHECK-SAME: float nofpclass(qnan inf zero sub norm) [[MUST_BE_SNAN:%.*]]) {
-; CHECK-NEXT:    [[TMP1:%.*]] = fadd float [[MUST_BE_SNAN]], 1.000000e+00
-; CHECK-NEXT:    ret float [[TMP1]]
+; CHECK-NEXT:    ret float [[MUST_BE_SNAN]]
 ;
   %exp = call float @llvm.exp2.f32(float %must.be.snan)
   ret float %exp
@@ -493,8 +490,7 @@ define nofpclass(nzero) float @source_is_known_snan(float nofpclass(inf norm sub
 define nofpclass(nzero) float @source_is_known_qnan(float nofpclass(inf norm sub zero snan) %must.be.qnan) {
 ; CHECK-LABEL: define nofpclass(nzero) float @source_is_known_qnan(
 ; CHECK-SAME: float nofpclass(snan inf zero sub norm) [[MUST_BE_QNAN:%.*]]) {
-; CHECK-NEXT:    [[TMP1:%.*]] = fadd float [[MUST_BE_QNAN]], 1.000000e+00
-; CHECK-NEXT:    ret float [[TMP1]]
+; CHECK-NEXT:    ret float [[MUST_BE_QNAN]]
 ;
   %exp = call float @llvm.exp2.f32(float %must.be.qnan)
   ret float %exp


### PR DESCRIPTION
In SimplifyDemandedFPClass, reorder the known-nan source
handling above The known-zero-or-nan handling. The more
specific cases need to be handled first. Avoids spurious
diff in an upcoming patch for fadd support; this would introduce
a simplifiable fadd when we can just go directly to the end
result.