### PR TITLE
Honor alignment for HVX masked loads/stores (incl. loops)

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
@@ -15,9 +15,11 @@
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/AliasAnalysis.h"
+#include "llvm/Analysis/AssumeBundleQueries.h"
 #include "llvm/Analysis/AssumptionCache.h"
 #include "llvm/Analysis/InstSimplifyFolder.h"
 #include "llvm/Analysis/InstructionSimplify.h"
@@ -208,11 +210,11 @@ private:
 
   struct AddrInfo {
     AddrInfo(const AddrInfo &) = default;
+    AddrInfo &operator=(const AddrInfo &) = default;
     AddrInfo(const HexagonVectorCombine &HVC, Instruction *I, Value *A, Type *T,
              Align H)
         : Inst(I), Addr(A), ValTy(T), HaveAlign(H),
           NeedAlign(HVC.getTypeAlignment(ValTy)) {}
-    AddrInfo &operator=(const AddrInfo &) = default;
 
     // XXX: add Size member?
     Instruction *Inst;
@@ -350,19 +352,55 @@ private:
                         int ScLen, Value *AlignVal, Value *AlignAddr) const;
   void realignStoreGroup(IRBuilderBase &Builder, const ByteSpan &VSpan,
                          int ScLen, Value *AlignVal, Value *AlignAddr) const;
-  bool realignGroup(const MoveGroup &Move) const;
-
+  bool realignGroup(const MoveGroup &Move);
   Value *makeTestIfUnaligned(IRBuilderBase &Builder, Value *AlignVal,
                              int Alignment) const;
 
+  using AddrGroupMap = MapVector<Instruction *, AddrList>;
+  AddrGroupMap AddrGroups;
+
+  friend raw_ostream &operator<<(raw_ostream &OS, const AddrList &L);
   friend raw_ostream &operator<<(raw_ostream &OS, const AddrInfo &AI);
   friend raw_ostream &operator<<(raw_ostream &OS, const MoveGroup &MG);
+  friend raw_ostream &operator<<(raw_ostream &OS, const MoveList &L);
   friend raw_ostream &operator<<(raw_ostream &OS, const ByteSpan::Block &B);
   friend raw_ostream &operator<<(raw_ostream &OS, const ByteSpan &BS);
+  friend raw_ostream &operator<<(raw_ostream &OS, const AddrGroupMap &AG);
+  friend raw_ostream &operator<<(raw_ostream &OS, const AddrList &L);
+  friend raw_ostream &operator<<(raw_ostream &OS, const AddrInfo &AI);
+  friend raw_ostream &operator<<(raw_ostream &OS, const MoveGroup &MG);
+  friend raw_ostream &operator<<(raw_ostream &OS, const MoveList &L);
+  friend raw_ostream &operator<<(raw_ostream &OS, const ByteSpan::Block &B);
+  friend raw_ostream &operator<<(raw_ostream &OS, const ByteSpan &BS);
+  friend raw_ostream &operator<<(raw_ostream &OS, const AddrGroupMap &AG);
 
-  std::map<Instruction *, AddrList> AddrGroups;
   const HexagonVectorCombine &HVC;
 };
+
+[[maybe_unused]] raw_ostream &operator<<(raw_ostream &OS,
+                                         const AlignVectors::AddrGroupMap &AG) {
+  OS << "Printing AddrGroups:"
+     << "\n";
+  for (auto &It : AG) {
+    OS << "\n\tInstruction: ";
+    It.first->dump();
+    OS << "\n\tAddrInfo: ";
+    for (auto &AI : It.second)
+      OS << AI << "\n";
+  }
+  return OS;
+}
+
+[[maybe_unused]] raw_ostream &operator<<(raw_ostream &OS,
+                                         const AlignVectors::AddrList &AL) {
+  OS << "\n *** Addr List: ***\n";
+  for (auto &AG : AL) {
+    OS << "\n *** Addr Group: ***\n";
+    OS << AG;
+    OS << "\n";
+  }
+  return OS;
+}
 
 [[maybe_unused]] raw_ostream &operator<<(raw_ostream &OS,
                                          const AlignVectors::AddrInfo &AI) {
@@ -372,6 +410,17 @@ private:
   OS << "HaveAlign: " << AI.HaveAlign.value() << '\n';
   OS << "NeedAlign: " << AI.NeedAlign.value() << '\n';
   OS << "Offset: " << AI.Offset;
+  return OS;
+}
+
+[[maybe_unused]] raw_ostream &operator<<(raw_ostream &OS,
+                                         const AlignVectors::MoveList &ML) {
+  OS << "\n *** Move List: ***\n";
+  for (auto &MG : ML) {
+    OS << "\n *** Move Group: ***\n";
+    OS << MG;
+    OS << "\n";
+  }
   return OS;
 }
 
@@ -485,6 +534,18 @@ private:
   auto createMulLong(IRBuilderBase &Builder, ArrayRef<Value *> WordX,
                      Signedness SgnX, ArrayRef<Value *> WordY,
                      Signedness SgnY) const -> SmallVector<Value *>;
+
+  bool matchMLoad(Instruction &In) const;
+  bool matchMStore(Instruction &In) const;
+  Value *processMLoad(Instruction &In) const;
+  Value *processMStore(Instruction &In) const;
+  std::optional<uint64_t> getAlignment(Instruction &In, Value *ptr) const;
+  std::optional<uint64_t>
+  getAlignmentImpl(Instruction &In, Value *ptr,
+                   SmallPtrSet<Value *, 16> &Visited) const;
+  std::optional<uint64_t> getPHIBaseMinAlignment(Instruction &In,
+                                                 PHINode *PN) const;
+
   // Vector manipulations for Ripple
   bool matchScatter(Instruction &In) const;
   bool matchGather(Instruction &In) const;
@@ -529,25 +590,6 @@ template <> LoadInst *isCandidate<LoadInst>(Instruction *In) {
 }
 template <> StoreInst *isCandidate<StoreInst>(Instruction *In) {
   return getIfUnordered(dyn_cast<StoreInst>(In));
-}
-
-#if !defined(_MSC_VER) || _MSC_VER >= 1926
-// VS2017 and some versions of VS2019 have trouble compiling this:
-// error C2976: 'std::map': too few template arguments
-// VS 2019 16.x is known to work, except for 16.4/16.5 (MSC_VER 1924/1925)
-template <typename Pred, typename... Ts>
-void erase_if(std::map<Ts...> &map, Pred p)
-#else
-template <typename Pred, typename T, typename U>
-void erase_if(std::map<T, U> &map, Pred p)
-#endif
-{
-  for (auto i = map.begin(), e = map.end(); i != e;) {
-    if (p(*i))
-      i = map.erase(i);
-    else
-      i = std::next(i);
-  }
 }
 
 // Forward other erase_ifs to the LLVM implementations.
@@ -626,6 +668,16 @@ auto AlignVectors::ByteSpan::values() const -> SmallVector<Value *, 8> {
   for (int i = 0, e = Blocks.size(); i != e; ++i)
     Values[i] = Blocks[i].Seg.Val;
   return Values;
+}
+
+// Turn a requested integer alignment into the effective Align to use.
+// If Requested == 0 -> use ABI alignment of the value type (old semantics).
+// 0 means "ABI alignment" in old IR.
+static Align effectiveAlignForValueTy(const DataLayout &DL, Type *ValTy,
+                                      int Requested) {
+  if (Requested > 0)
+    return Align(static_cast<uint64_t>(Requested));
+  return Align(DL.getABITypeAlign(ValTy).value());
 }
 
 auto AlignVectors::getAddrInfo(Instruction &In) const
@@ -723,14 +775,13 @@ auto AlignVectors::createLoad(IRBuilderBase &Builder, Type *ValTy, Value *Ptr,
                               Value *Predicate, int Alignment, Value *Mask,
                               Value *PassThru,
                               ArrayRef<Value *> MDSources) const -> Value * {
-  bool HvxHasPredLoad = HVC.HST.useHVXV62Ops();
   // Predicate is nullptr if not creating predicated load
   if (Predicate) {
     assert(!Predicate->getType()->isVectorTy() &&
            "Expectning scalar predicate");
     if (HVC.isFalse(Predicate))
       return UndefValue::get(ValTy);
-    if (!HVC.isTrue(Predicate) && HvxHasPredLoad) {
+    if (!HVC.isTrue(Predicate)) {
       Value *Load = createPredicatedLoad(Builder, ValTy, Ptr, Predicate,
                                          Alignment, MDSources);
       return Builder.CreateSelect(Mask, Load, PassThru);
@@ -740,11 +791,14 @@ auto AlignVectors::createLoad(IRBuilderBase &Builder, Type *ValTy, Value *Ptr,
   assert(!HVC.isUndef(Mask)); // Should this be allowed?
   if (HVC.isZero(Mask))
     return PassThru;
-  if (HVC.isTrue(Mask))
-    return createSimpleLoad(Builder, ValTy, Ptr, Alignment, MDSources);
 
-  Instruction *Load = Builder.CreateMaskedLoad(ValTy, Ptr, Align(Alignment),
-                                               Mask, PassThru, "mld");
+  Align EffA = effectiveAlignForValueTy(HVC.DL, ValTy, Alignment);
+  if (HVC.isTrue(Mask))
+    return createSimpleLoad(Builder, ValTy, Ptr, EffA.value(), MDSources);
+
+  Instruction *Load =
+      Builder.CreateMaskedLoad(ValTy, Ptr, EffA, Mask, PassThru, "mld");
+  LLVM_DEBUG(dbgs() << "\t[Creating masked Load:] "; Load->dump());
   propagateMetadata(Load, MDSources);
   return Load;
 }
@@ -753,9 +807,10 @@ auto AlignVectors::createSimpleLoad(IRBuilderBase &Builder, Type *ValTy,
                                     Value *Ptr, int Alignment,
                                     ArrayRef<Value *> MDSources) const
     -> Value * {
-  Instruction *Load =
-      Builder.CreateAlignedLoad(ValTy, Ptr, Align(Alignment), "ald");
+  Align EffA = effectiveAlignForValueTy(HVC.DL, ValTy, Alignment);
+  Instruction *Load = Builder.CreateAlignedLoad(ValTy, Ptr, EffA, "ald");
   propagateMetadata(Load, MDSources);
+  LLVM_DEBUG(dbgs() << "\t[Creating Load:] "; Load->dump());
   return Load;
 }
 
@@ -768,11 +823,13 @@ auto AlignVectors::createPredicatedLoad(IRBuilderBase &Builder, Type *ValTy,
          "Predicates 'scalar' vector loads not yet supported");
   assert(Predicate);
   assert(!Predicate->getType()->isVectorTy() && "Expectning scalar predicate");
-  assert(HVC.getSizeOf(ValTy, HVC.Alloc) % Alignment == 0);
+  Align EffA = effectiveAlignForValueTy(HVC.DL, ValTy, Alignment);
+  assert(HVC.getSizeOf(ValTy, HVC.Alloc) % EffA.value() == 0);
+
   if (HVC.isFalse(Predicate))
     return UndefValue::get(ValTy);
   if (HVC.isTrue(Predicate))
-    return createSimpleLoad(Builder, ValTy, Ptr, Alignment, MDSources);
+    return createSimpleLoad(Builder, ValTy, Ptr, EffA.value(), MDSources);
 
   auto V6_vL32b_pred_ai = HVC.HST.getIntrinsicId(Hexagon::V6_vL32b_pred_ai);
   // FIXME: This may not put the offset from Ptr into the vmem offset.
@@ -826,7 +883,9 @@ auto AlignVectors::createSimpleStore(IRBuilderBase &Builder, Value *Val,
                                      Value *Ptr, int Alignment,
                                      ArrayRef<Value *> MDSources) const
     -> Value * {
-  Instruction *Store = Builder.CreateAlignedStore(Val, Ptr, Align(Alignment));
+  Align EffA = effectiveAlignForValueTy(HVC.DL, Val->getType(), Alignment);
+  Instruction *Store = Builder.CreateAlignedStore(Val, Ptr, EffA);
+  LLVM_DEBUG(dbgs() << "\t[Creating store:] "; Store->dump());
   propagateMetadata(Store, MDSources);
   return Store;
 }
@@ -836,15 +895,16 @@ auto AlignVectors::createPredicatedStore(IRBuilderBase &Builder, Value *Val,
                                          int Alignment,
                                          ArrayRef<Value *> MDSources) const
     -> Value * {
+  Align EffA = effectiveAlignForValueTy(HVC.DL, Val->getType(), Alignment);
   assert(HVC.HST.isTypeForHVX(Val->getType()) &&
          "Predicates 'scalar' vector stores not yet supported");
   assert(Predicate);
   if (HVC.isFalse(Predicate))
     return UndefValue::get(Val->getType());
   if (HVC.isTrue(Predicate))
-    return createSimpleStore(Builder, Val, Ptr, Alignment, MDSources);
+    return createSimpleStore(Builder, Val, Ptr, EffA.value(), MDSources);
 
-  assert(HVC.getSizeOf(Val, HVC.Alloc) % Alignment == 0);
+  assert(HVC.getSizeOf(Val, HVC.Alloc) % EffA.value() == 0);
   auto V6_vS32b_pred_ai = HVC.HST.getIntrinsicId(Hexagon::V6_vS32b_pred_ai);
   // FIXME: This may not put the offset from Ptr into the vmem offset.
   return HVC.createHvxIntrinsic(Builder, V6_vS32b_pred_ai, nullptr,
@@ -918,15 +978,15 @@ auto AlignVectors::createAddressGroups() -> bool {
   assert(WorkStack.empty());
 
   // AddrGroups are formed.
-
   // Remove groups of size 1.
-  erase_if(AddrGroups, [](auto &G) { return G.second.size() == 1; });
+  AddrGroups.remove_if([](auto &G) { return G.second.size() == 1; });
   // Remove groups that don't use HVX types.
-  erase_if(AddrGroups, [&](auto &G) {
+  AddrGroups.remove_if([&](auto &G) {
     return llvm::none_of(
         G.second, [&](auto &I) { return HVC.HST.isTypeForHVX(I.ValTy); });
   });
 
+  LLVM_DEBUG(dbgs() << AddrGroups);
   return !AddrGroups.empty();
 }
 
@@ -982,6 +1042,7 @@ auto AlignVectors::createLoadGroups(const AddrList &Group) const -> MoveList {
   if (!HVC.HST.useHVXV62Ops())
     erase_if(LoadGroups, [](const MoveGroup &G) { return G.IsHvx; });
 
+  LLVM_DEBUG(dbgs() << "LoadGroups list: " << LoadGroups);
   return LoadGroups;
 }
 
@@ -1412,7 +1473,7 @@ auto AlignVectors::realignStoreGroup(IRBuilderBase &Builder,
   }
 }
 
-auto AlignVectors::realignGroup(const MoveGroup &Move) const -> bool {
+auto AlignVectors::realignGroup(const MoveGroup &Move) -> bool {
   LLVM_DEBUG(dbgs() << "Realigning group:\n" << Move << '\n');
 
   // TODO: Needs support for masked loads/stores of "scalar" vectors.
@@ -1427,7 +1488,7 @@ auto AlignVectors::realignGroup(const MoveGroup &Move) const -> bool {
     });
   };
 
-  const AddrList &BaseInfos = AddrGroups.at(Move.Base);
+  AddrList &BaseInfos = AddrGroups[Move.Base];
 
   // Conceptually, there is a vector of N bytes covering the addresses
   // starting from the minimum offset (i.e. Base.Addr+Start). This vector
@@ -1439,11 +1500,12 @@ auto AlignVectors::realignGroup(const MoveGroup &Move) const -> bool {
   // of this conceptual vector.
   //
   // This vector will be loaded/stored starting at the nearest down-aligned
-  // address and the amount od the down-alignment will be AlignVal:
+  // address and the amount of the down-alignment will be AlignVal:
   //   valign(load_vector(align_down(Base+Start)), AlignVal)
 
   std::set<Instruction *> TestSet(Move.Main.begin(), Move.Main.end());
   AddrList MoveInfos;
+
   llvm::copy_if(
       BaseInfos, std::back_inserter(MoveInfos),
       [&TestSet](const AddrInfo &AI) { return TestSet.count(AI.Inst); });
@@ -1826,6 +1888,20 @@ inline bool HvxIdioms::matchGather(Instruction &In) const {
   if (!II)
     return false;
   return (II->getIntrinsicID() == Intrinsic::masked_gather);
+}
+
+inline bool HvxIdioms::matchMLoad(Instruction &In) const {
+  IntrinsicInst *II = dyn_cast<IntrinsicInst>(&In);
+  if (!II)
+    return false;
+  return (II->getIntrinsicID() == Intrinsic::masked_load);
+}
+
+inline bool HvxIdioms::matchMStore(Instruction &In) const {
+  IntrinsicInst *II = dyn_cast<IntrinsicInst>(&In);
+  if (!II)
+    return false;
+  return (II->getIntrinsicID() == Intrinsic::masked_store);
 }
 
 Instruction *locateDestination(Instruction *In, HvxIdioms::DstQualifier &Qual);
@@ -2654,6 +2730,188 @@ Value *HvxIdioms::processVGather(Instruction &In) const {
   return Gather;
 }
 
+// Go through all PHI incomming values and find minimal alignment for non GEP
+// members.
+std::optional<uint64_t> HvxIdioms::getPHIBaseMinAlignment(Instruction &In,
+                                                          PHINode *PN) const {
+  if (!PN)
+    return std::nullopt;
+
+  SmallVector<Value *, 16> Worklist;
+  SmallPtrSet<Value *, 16> Visited;
+  uint64_t minPHIAlignment = Value::MaximumAlignment;
+  Worklist.push_back(PN);
+
+  while (!Worklist.empty()) {
+    Value *V = Worklist.back();
+    Worklist.pop_back();
+    if (!Visited.insert(V).second)
+      continue;
+
+    if (PHINode *PN = dyn_cast<PHINode>(V)) {
+      for (unsigned i = 0; i < PN->getNumIncomingValues(); ++i) {
+        Worklist.push_back(PN->getIncomingValue(i));
+      }
+    } else if (isa<GetElementPtrInst>(V)) {
+      // Ignore geps for now.
+      continue;
+    } else {
+      Align KnownAlign = getKnownAlignment(V, HVC.DL, &In, &HVC.AC, &HVC.DT);
+      if (KnownAlign.value() < minPHIAlignment)
+        minPHIAlignment = KnownAlign.value();
+    }
+  }
+  if (minPHIAlignment != Value::MaximumAlignment)
+    return minPHIAlignment;
+  return std::nullopt;
+}
+
+// Helper function to discover alignment for a ptr.
+std::optional<uint64_t> HvxIdioms::getAlignment(Instruction &In,
+                                                Value *ptr) const {
+  SmallPtrSet<Value *, 16> Visited;
+  return getAlignmentImpl(In, ptr, Visited);
+}
+
+std::optional<uint64_t>
+HvxIdioms::getAlignmentImpl(Instruction &In, Value *ptr,
+                            SmallPtrSet<Value *, 16> &Visited) const {
+  LLVM_DEBUG(dbgs() << "[getAlignment] for : " << *ptr << "\n");
+  // Prevent infinite recursion
+  if (!Visited.insert(ptr).second)
+    return std::nullopt;
+  // Try AssumptionCache.
+  Align KnownAlign = getKnownAlignment(ptr, HVC.DL, &In, &HVC.AC, &HVC.DT);
+  // This is the most formal and reliable source of information.
+  if (KnownAlign.value() > 1) {
+    LLVM_DEBUG(dbgs() << "  VC align(" << KnownAlign.value() << ")\n");
+    return KnownAlign.value();
+  }
+
+  // If it is a PHI try to iterate through inputs
+  if (PHINode *PN = dyn_cast<PHINode>(ptr)) {
+    // See if we have a common base to which we know alignment.
+    auto baseAlignmentOpt = getPHIBaseMinAlignment(In, PN);
+    if (!baseAlignmentOpt)
+      return std::nullopt;
+
+    uint64_t minBaseAlignment = *baseAlignmentOpt;
+    // If it is 1, there is no point to keep on looking.
+    if (minBaseAlignment == 1)
+      return 1;
+    // No see if all other incomming phi nodes are just loop carried constants.
+    uint64_t minPHIAlignment = minBaseAlignment;
+    LLVM_DEBUG(dbgs() << "  It is a PHI with(" << PN->getNumIncomingValues()
+                      << ")nodes and min base aligned to (" << minBaseAlignment
+                      << ")\n");
+    for (unsigned i = 0; i < PN->getNumIncomingValues(); ++i) {
+      Value *IV = PN->getIncomingValue(i);
+      // We have already looked at all other values.
+      if (!isa<GetElementPtrInst>(IV))
+        continue;
+      uint64_t MemberAlignment = Value::MaximumAlignment;
+      if (auto res = getAlignment(*PN, IV))
+        MemberAlignment = *res;
+      else
+        return std::nullopt;
+      // Adjust total PHI alignment.
+      if (minPHIAlignment > MemberAlignment)
+        minPHIAlignment = MemberAlignment;
+    }
+    LLVM_DEBUG(dbgs() << "  total PHI alignment(" << minPHIAlignment << ")\n");
+    return minPHIAlignment;
+  }
+
+  if (auto *GEP = dyn_cast<GetElementPtrInst>(ptr)) {
+    auto *GEPPtr = GEP->getPointerOperand();
+    // Only if this is the induction variable with const offset
+    // Implicit assumption is that induction variable itself is a PHI
+    if (&In == GEPPtr) {
+      APInt Offset(HVC.DL.getPointerSizeInBits(
+                       GEPPtr->getType()->getPointerAddressSpace()),
+                   0);
+      if (GEP->accumulateConstantOffset(HVC.DL, Offset)) {
+        LLVM_DEBUG(dbgs() << "  Induction GEP with const step of ("
+                          << Offset.getZExtValue() << ")\n");
+        return Offset.getZExtValue();
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+
+Value *HvxIdioms::processMStore(Instruction &In) const {
+  auto *InpTy = dyn_cast<VectorType>(In.getOperand(0)->getType());
+  assert(InpTy && "Cannot handle no vector type for llvm.masked.store");
+
+  LLVM_DEBUG(dbgs() << "\n[Process mstore](" << In << ")\n"
+                    << *In.getParent() << "\n");
+  LLVM_DEBUG(dbgs() << "  Input type(" << *InpTy << ") elements("
+                    << HVC.length(InpTy) << ") VecLen(" << HVC.getSizeOf(InpTy)
+                    << ") type(" << *InpTy->getElementType() << ") of size("
+                    << InpTy->getScalarSizeInBits() << ")bits\n");
+  auto *CI = dyn_cast<CallBase>(&In);
+  assert(CI && "Expected llvm.masked.store to be a call");
+  Align HaveAlign = CI->getParamAlign(1).valueOrOne();
+
+  uint64_t KA = 1;
+  if (auto res = getAlignment(In, In.getOperand(1))) // ptr operand
+    KA = *res;
+  LLVM_DEBUG(dbgs() << "  HaveAlign(" << HaveAlign.value() << ") KnownAlign("
+                    << KA << ")\n");
+  // Normalize 0 -> ABI alignment of the stored value type (operand 0).
+  Type *ValTy = In.getOperand(0)->getType();
+  Align EffA =
+      (KA > 0) ? Align(KA) : Align(HVC.DL.getABITypeAlign(ValTy).value());
+
+  if (EffA < HaveAlign)
+    return nullptr;
+
+  // Attach/replace the param attribute on pointer param #1.
+  AttrBuilder AttrB(CI->getContext());
+  AttrB.addAlignmentAttr(EffA);
+  CI->setAttributes(
+      CI->getAttributes().addParamAttributes(CI->getContext(), 1, AttrB));
+  return CI;
+}
+
+Value *HvxIdioms::processMLoad(Instruction &In) const {
+  auto *InpTy = dyn_cast<VectorType>(In.getType());
+  assert(InpTy && "Cannot handle non vector type for llvm.masked.store");
+  LLVM_DEBUG(dbgs() << "\n[Process mload](" << In << ")\n"
+                    << *In.getParent() << "\n");
+  LLVM_DEBUG(dbgs() << "  Input type(" << *InpTy << ") elements("
+                    << HVC.length(InpTy) << ") VecLen(" << HVC.getSizeOf(InpTy)
+                    << ") type(" << *InpTy->getElementType() << ") of size("
+                    << InpTy->getScalarSizeInBits() << ")bits\n");
+  auto *CI = dyn_cast<CallBase>(&In);
+  assert(CI && "Expected to be a call to llvm.masked.load");
+  // The pointer is operand #0, and its param attribute index is also 0.
+  Align HaveAlign = CI->getParamAlign(0).valueOrOne();
+
+  // Compute best-known alignment KA from analysis.
+  uint64_t KA = 1;
+  if (auto res = getAlignment(In, In.getOperand(0))) // ptr operand
+    KA = *res;
+
+  // Normalize 0 → ABI alignment of the loaded value type.
+  Type *ValTy = In.getType();
+  Align EffA =
+      (KA > 0) ? Align(KA) : Align(HVC.DL.getABITypeAlign(ValTy).value());
+  if (EffA < HaveAlign)
+    return nullptr;
+  LLVM_DEBUG(dbgs() << "  HaveAlign(" << HaveAlign.value() << ") KnownAlign("
+                    << KA << ")\n");
+
+  // Attach/replace the param attribute on pointer param #0.
+  AttrBuilder AttrB(CI->getContext());
+  AttrB.addAlignmentAttr(EffA);
+  CI->setAttributes(
+      CI->getAttributes().addParamAttributes(CI->getContext(), 0, AttrB));
+  return CI;
+}
+
 auto HvxIdioms::processFxpMulChopped(IRBuilderBase &Builder, Instruction &In,
                                      const FxpOp &Op) const -> Value * {
   assert(Op.X.Val->getType() == Op.Y.Val->getType());
@@ -3015,6 +3273,18 @@ auto HvxIdioms::run() -> bool {
         It->eraseFromParent();
         It = cast<Instruction>(New)->getReverseIterator();
         RecursivelyDeleteTriviallyDeadInstructions(&*It, &HVC.TLI);
+        Changed = true;
+      } else if (matchMLoad(*It)) {
+        Value *New = processMLoad(*It);
+        if (!New)
+          continue;
+        LLVM_DEBUG(dbgs() << "  MLoad : " << *New << "\n");
+        Changed = true;
+      } else if (matchMStore(*It)) {
+        Value *New = processMStore(*It);
+        if (!New)
+          continue;
+        LLVM_DEBUG(dbgs() << "  MStore : " << *New << "\n");
         Changed = true;
       }
     }

--- a/llvm/test/CodeGen/Hexagon/hvx-align-mstore.ll
+++ b/llvm/test/CodeGen/Hexagon/hvx-align-mstore.ll
@@ -1,0 +1,35 @@
+; Test that we take alignment hint properly for mload/mstore
+; RUN: llc -mtriple=hexagon < %s | FileCheck %s
+
+; Test that we take alignment hint properly
+
+; CHECK-NOT: vmemu
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite)
+define dso_local void @_Z31puzzle_prefix_assign_ripple_badPDF16_PKDF16_j(ptr noalias noundef writeonly align 128 captures(none) %dest, ptr noalias noundef readonly align 128 captures(none) %in, i32 noundef %len) local_unnamed_addr #0 {
+entry:
+  %and.ripple.LS.instance = and i32 %len, 3
+  %and.ripple.LS.instance.ripple.bcast.splatinsert = insertelement <32 x i32> poison, i32 %and.ripple.LS.instance, i64 0
+  %and.ripple.LS.instance.ripple.bcast.splat = shufflevector <32 x i32> %and.ripple.LS.instance.ripple.bcast.splatinsert, <32 x i32> poison, <32 x i32> zeroinitializer
+  %cmp.ripple.LS.instance = icmp samesign ugt <32 x i32> %and.ripple.LS.instance.ripple.bcast.splat, <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  %.ripple.masked.load = tail call <32 x half> @llvm.masked.load.v32f16.p0(ptr %in, i32 2, <32 x i1> %cmp.ripple.LS.instance, <32 x half> poison)
+  tail call void @llvm.masked.store.v32f16.p0(<32 x half> %.ripple.masked.load, ptr %dest, i32 2, <32 x i1> %cmp.ripple.LS.instance)
+  ret void
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: read)
+declare <32 x half> @llvm.masked.load.v32f16.p0(ptr captures(none) %0, i32 immarg %1, <32 x i1> %2, <32 x half> %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: write)
+declare void @llvm.masked.store.v32f16.p0(<32 x half> %0, ptr captures(none) %1, i32 immarg %2, <32 x i1> %3) #2
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="hexagonv75" "target-features"="+hvx-length128b,+hvxv75,+v75,-long-calls" }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: read) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: write) }
+
+!llvm.module.flags = !{!0, !1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"frame-pointer", i32 2}
+!2 = !{!"Clang $LLVM_VERSION_MAJOR.$LLVM_VERSION_MINOR"}

--- a/llvm/test/CodeGen/Hexagon/hvx-align-mstore_1.ll
+++ b/llvm/test/CodeGen/Hexagon/hvx-align-mstore_1.ll
@@ -1,0 +1,55 @@
+; Test that we take alignment hint properly for mload/mstore
+; RUN: llc -mtriple=hexagon < %s | FileCheck %s
+
+; Test that we take alignment hint properly
+
+; CHECK-NOT: vmemu
+; CHECK-NOT: vlalign
+
+; Function Attrs: nofree norecurse nosync nounwind memory(argmem: readwrite, inaccessiblemem: readwrite)
+define dso_local void @foo(ptr noundef writeonly align 128 captures(none) %A, ptr noundef readonly align 128 captures(none) %B, ptr noundef readonly align 128 captures(none) %C, i32 noundef %key) local_unnamed_addr #0 {
+entry:
+  %key.ripple.bcast.splatinsert = insertelement <32 x i32> poison, i32 %key, i64 0
+  %key.ripple.bcast.splat = shufflevector <32 x i32> %key.ripple.bcast.splatinsert, <32 x i32> poison, <32 x i32> zeroinitializer
+  %cmp1.ripple.LS.instance = icmp ugt <32 x i32> %key.ripple.bcast.splat, <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  br label %if.then.ripple.branch.clone
+
+for.cond.cleanup:                                 ; preds = %if.then.ripple.branch.clone
+  ret void
+
+if.then.ripple.branch.clone:                      ; preds = %entry, %if.then.ripple.branch.clone
+  %lsr.iv25 = phi ptr [ %A, %entry ], [ %scevgep26, %if.then.ripple.branch.clone ]
+  %lsr.iv23 = phi ptr [ %C, %entry ], [ %scevgep24, %if.then.ripple.branch.clone ]
+  %lsr.iv = phi ptr [ %B, %entry ], [ %scevgep, %if.then.ripple.branch.clone ]
+  %i.08 = phi i32 [ 0, %entry ], [ %add7, %if.then.ripple.branch.clone ]
+  %.ripple.masked.load = tail call <32 x i32> @llvm.masked.load.v32i32.p0(ptr %lsr.iv, i32 4, <32 x i1> %cmp1.ripple.LS.instance, <32 x i32> poison)
+  %.ripple.masked.load21 = tail call <32 x i32> @llvm.masked.load.v32i32.p0(ptr %lsr.iv23, i32 4, <32 x i1> %cmp1.ripple.LS.instance, <32 x i32> poison)
+  %add4.ripple.LS.instance.ripple.branch.clone = add <32 x i32> %.ripple.masked.load21, %.ripple.masked.load
+  tail call void @llvm.masked.store.v32i32.p0(<32 x i32> %add4.ripple.LS.instance.ripple.branch.clone, ptr %lsr.iv25, i32 4, <32 x i1> %cmp1.ripple.LS.instance)
+  %add7 = add i32 %i.08, 32
+  %scevgep = getelementptr i8, ptr %lsr.iv, i32 128
+  %scevgep24 = getelementptr i8, ptr %lsr.iv23, i32 128
+  %scevgep26 = getelementptr i8, ptr %lsr.iv25, i32 128
+  %cmp = icmp ult i32 %add7, 128
+  br i1 %cmp, label %if.then.ripple.branch.clone, label %for.cond.cleanup, !llvm.loop !3
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: read)
+declare <32 x i32> @llvm.masked.load.v32i32.p0(ptr captures(none) %0, i32 immarg %1, <32 x i1> %2, <32 x i32> %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: write)
+declare void @llvm.masked.store.v32i32.p0(<32 x i32> %0, ptr captures(none) %1, i32 immarg %2, <32 x i1> %3) #2
+
+attributes #0 = { nofree norecurse nosync nounwind memory(argmem: readwrite, inaccessiblemem: readwrite) "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="hexagonv75" "target-features"="+hvx-length128b,+hvxv75,+v75,-long-calls" }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: read) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: write) }
+
+!llvm.module.flags = !{!0, !1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"frame-pointer", i32 2}
+!2 = !{!"Clang $LLVM_VERSION_MAJOR.$LLVM_VERSION_MINOR"}
+!3 = distinct !{!3, !4}
+!4 = !{!"llvm.loop.mustprogress"}
+


### PR DESCRIPTION
Teach VectorCombine to recognize HVX masked load/store patterns and recover base-pointer alignment, including through PHIs in loops. Compute effective alignment for vector types and attach it to masked intrinsics so the selector chooses aligned HVX memory operations when alignment is known. The patch also replace the AddrGroups map with MapVector to preserve insertion order and deterministic iteration, avoiding run-to-run codegen differences, and add concise debug logging to aid tracing.

Patch By: Fateme Hosseini