### PR TITLE
Revert "Add merge-calling-conv.ll to profcheck-xfail.txt"

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -505,7 +505,6 @@ Transforms/MergeFunc/merge-fp-intrinsics.ll
 Transforms/MergeFunc/mergefunc-preserve-nonnull.ll
 Transforms/MergeFunc/mergefunc-preserve-vfe-intrinsics.ll
 Transforms/MergeFunc/mergefunc-struct-return.ll
-Transforms/MergeFunc/merge-calling-conv.ll
 Transforms/MergeFunc/merge-linkonce-odr-used.ll
 Transforms/MergeFunc/merge-linkonce-odr-weak-odr-mixed-used.ll
 Transforms/MergeFunc/merge-ptr-and-int.ll


### PR DESCRIPTION
Reverts llvm/llvm-project#174418

Already excluded in dbc9feb35fc4cf090fedb72f649bc90ebcdbd2e8 (with the correct sorting).