### PR TITLE
[Flang-RT] Add test dependency

### DIFF
--- a/flang-rt/test/CMakeLists.txt
+++ b/flang-rt/test/CMakeLists.txt
@@ -43,6 +43,11 @@ set_target_properties(flang-rt-test-depends PROPERTIES FOLDER "Flang-RT/Meta")
 add_dependencies(flang-rt-test-depends
     flang_rt.runtime
   )
+if (TARGET flang_rt.quadmath)
+  add_dependencies(flang-rt-test-depends
+      flang_rt.quadmath
+    )
+endif ()
 
 add_lit_testsuite(check-flang-rt "Running the Flang-RT regression tests"
     ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
When building with `FLANG_RUNTIME_F128_MATH_LIB=libquadmath`, the tests
```
  flang-rt :: Driver/ctofortran.f90
  flang-rt :: Driver/exec.f90
```
also depend on `libflang_rt.quadmath.a`. Add a dependency to ensure it is built with `ninja check-flang-rt`.