### PR TITLE
[clang][bytecode] Fix a crash in `CheckExtern()`

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -390,8 +390,9 @@ bool CheckExtern(InterpState &S, CodePtr OpPC, const Pointer &Ptr) {
   if (!Ptr.isExtern())
     return true;
 
-  if (Ptr.isInitialized() ||
-      (Ptr.getDeclDesc()->asVarDecl() == S.EvaluatingDecl))
+  if (!Ptr.isPastEnd() &&
+      (Ptr.isInitialized() ||
+       (Ptr.getDeclDesc()->asVarDecl() == S.EvaluatingDecl)))
     return true;
 
   if (S.checkingPotentialConstantExpression() && S.getLangOpts().CPlusPlus &&

--- a/clang/test/AST/ByteCode/typeid.cpp
+++ b/clang/test/AST/ByteCode/typeid.cpp
@@ -83,3 +83,13 @@ namespace GH173950 {
   // This used to crash with: Assertion `IsInitialized' failed in invokeDtor()
   const std::type_info &a_ti = typeid(a);
 }
+
+namespace MissingInitalizer {
+  struct Item {
+    const std::type_info &ti;
+  };
+  extern constexpr Item items[] = ; // both-error {{expected expression}} \
+                                    // both-note {{declared here}}
+  constexpr auto &x = items[0].ti; // both-error {{must be initialized by a constant expression}} \
+                                   // both-note {{initializer of 'items' is unknown}}
+}


### PR DESCRIPTION
Check if the pointer field descriptor can be accessed at all before calling `isInitialized()`, which relies on that.

Fixes https://github.com/llvm/llvm-project/issues/174382