### PR TITLE
[ItaniumCXXABI] Use getSigned() for offset hint

### DIFF
--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -1656,7 +1656,7 @@ llvm::Value *ItaniumCXXABI::emitDynamicCastCall(
   // Compute the offset hint.
   const CXXRecordDecl *SrcDecl = SrcRecordTy->getAsCXXRecordDecl();
   const CXXRecordDecl *DestDecl = DestRecordTy->getAsCXXRecordDecl();
-  llvm::Value *OffsetHint = llvm::ConstantInt::get(
+  llvm::Value *OffsetHint = llvm::ConstantInt::getSigned(
       PtrDiffLTy,
       computeOffsetHint(CGF.getContext(), SrcDecl, DestDecl).getQuantity());
 

--- a/clang/test/CodeGenCXX/dynamic-cast-hint.cpp
+++ b/clang/test/CodeGenCXX/dynamic-cast-hint.cpp
@@ -1,6 +1,7 @@
-// RUN: %clang_cc1 -triple x86_64-apple-darwin12 -emit-llvm -o - %s | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-apple-darwin12 -emit-llvm -std=c++98 -o - %s | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-apple-darwin12 -emit-llvm -std=c++11 -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-apple-darwin12 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,64BIT
+// RUN: %clang_cc1 -triple x86_64-apple-darwin12 -emit-llvm -std=c++98 -o - %s | FileCheck %s --check-prefixes=CHECK,64BIT
+// RUN: %clang_cc1 -triple x86_64-apple-darwin12 -emit-llvm -std=c++11 -o - %s | FileCheck %s --check-prefixes=CHECK,64BIT
+// RUN: %clang_cc1 -triple i686-apple-darwin12 -emit-llvm -o - %s | FileCheck %s --check-prefixes=CHECK,32BIT
 
 class A { protected: virtual ~A() {} };
 class B { protected: virtual ~B() {} };
@@ -24,32 +25,35 @@ class X : public XA, public XB, public XC { };
 
 void test(A *a, B *b) {
   volatile C *ac = dynamic_cast<C *>(a);
-// CHECK: ptr @_ZTI1A, ptr @_ZTI1C, i64 -2)
+// CHECK: ptr @_ZTI1A, ptr @_ZTI1C, [[INT:i64|i32]] -2)
   volatile D *ad = dynamic_cast<D *>(a);
-// CHECK: ptr @_ZTI1A, ptr @_ZTI1D, i64 0)
+// CHECK: ptr @_ZTI1A, ptr @_ZTI1D, [[INT]] 0)
   volatile E *ae = dynamic_cast<E *>(a);
-// CHECK: ptr @_ZTI1A, ptr @_ZTI1E, i64 0)
+// CHECK: ptr @_ZTI1A, ptr @_ZTI1E, [[INT]] 0)
   volatile F *af = dynamic_cast<F *>(a);
-// CHECK: ptr @_ZTI1A, ptr @_ZTI1F, i64 -1)
+// CHECK: ptr @_ZTI1A, ptr @_ZTI1F, [[INT]] -1)
   volatile G *ag = dynamic_cast<G *>(a);
-// CHECK: ptr @_ZTI1A, ptr @_ZTI1G, i64 -2)
+// CHECK: ptr @_ZTI1A, ptr @_ZTI1G, [[INT]] -2)
   volatile H *ah = dynamic_cast<H *>(a);
-// CHECK: ptr @_ZTI1A, ptr @_ZTI1H, i64 0)
+// CHECK: ptr @_ZTI1A, ptr @_ZTI1H, [[INT]] 0)
   volatile I *ai = dynamic_cast<I *>(a);
-// CHECK: ptr @_ZTI1A, ptr @_ZTI1I, i64 -1)
+// CHECK: ptr @_ZTI1A, ptr @_ZTI1I, [[INT]] -1)
   volatile J *aj = dynamic_cast<J *>(a);
-// CHECK: ptr @_ZTI1A, ptr @_ZTI1J, i64 0)
+// CHECK: ptr @_ZTI1A, ptr @_ZTI1J, [[INT]] 0)
   volatile K *ak = dynamic_cast<K *>(a);
-// CHECK: ptr @_ZTI1A, ptr @_ZTI1K, i64 -2)
+// CHECK: ptr @_ZTI1A, ptr @_ZTI1K, [[INT]] -2)
   volatile X *ax = dynamic_cast<X *>(a);
-// CHECK: ptr @_ZTI1A, ptr @_ZTI1X, i64 -1)
+// CHECK: ptr @_ZTI1A, ptr @_ZTI1X, [[INT]] -1)
 
   volatile E *be = dynamic_cast<E *>(b);
-// CHECK: ptr @_ZTI1B, ptr @_ZTI1E, i64 8)
+// 64BIT: ptr @_ZTI1B, ptr @_ZTI1E, [[INT]] 8)
+// 32BIT: ptr @_ZTI1B, ptr @_ZTI1E, [[INT]] 4)
   volatile G *bg = dynamic_cast<G *>(b);
-// CHECK: ptr @_ZTI1B, ptr @_ZTI1G, i64 -2)
+// CHECK: ptr @_ZTI1B, ptr @_ZTI1G, [[INT]] -2)
   volatile J *bj = dynamic_cast<J *>(b);
-// CHECK: ptr @_ZTI1B, ptr @_ZTI1J, i64 8)
+// 64BIT: ptr @_ZTI1B, ptr @_ZTI1J, [[INT]] 8)
+// 32BIT: ptr @_ZTI1B, ptr @_ZTI1J, [[INT]] 4)
   volatile K *bk = dynamic_cast<K *>(b);
-// CHECK: ptr @_ZTI1B, ptr @_ZTI1K, i64 16)
+// 64BIT: ptr @_ZTI1B, ptr @_ZTI1K, [[INT]] 16)
+// 32BIT: ptr @_ZTI1B, ptr @_ZTI1K, [[INT]] 8)
 }


### PR DESCRIPTION
The offset hint can be negative, so we should use getSigned() here. This avoids an assertion failure with https://github.com/llvm/llvm-project/pull/171456.

Extend the dynamic_cast tests to include a 32-bit target to cover this case.