### PR TITLE
[SCEV] Sink SCEVPtrToAddr to leaf SCEVUnknowns.

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -1129,34 +1129,27 @@ const SCEV *ScalarEvolution::getPtrToAddrExpr(const SCEV *Op) {
   assert(Op->getType()->isPointerTy() && "Op must be a pointer");
   Type *Ty = DL.getAddressType(Op->getType());
 
-  FoldingSetNodeID ID;
-  ID.AddInteger(scPtrToAddr);
-  ID.AddPointer(Op);
-
-  void *IP = nullptr;
-
-  // Is there already an expression for such a cast?
-  if (const SCEV *S = UniqueSCEVs.FindNodeOrInsertPos(ID, IP))
-    return S;
-
-  // If not, is this expression something we can't reduce any further?
-  if (auto *U = dyn_cast<SCEVUnknown>(Op)) {
-    // Perform some basic constant folding. If the operand of the ptr2addr cast
-    // is a null pointer, don't create a ptr2addr SCEV expression (that will be
-    // left as-is), but produce a zero constant.
-    // NOTE: We could handle a more general case, but lack motivational cases.
-    if (isa<ConstantPointerNull>(U->getValue()))
-      return getZero(Ty);
-  }
-
-  // Create an explicit cast node.
-  // We can reuse the existing insert position since if we get here,
-  // we won't have made any changes which would invalidate it.
-  SCEV *S =
-      new (SCEVAllocator) SCEVPtrToAddrExpr(ID.Intern(SCEVAllocator), Op, Ty);
-  UniqueSCEVs.InsertNode(S, IP);
-  registerUser(S, Op);
-  return S;
+  // Use the rewriter to sink the cast down to SCEVUnknown leaves.
+  // The rewriter handles null pointer constant folding.
+  const SCEV *IntOp = SCEVCastSinkingRewriter::rewrite(
+      Op, *this, Ty, [this, Ty](const SCEVUnknown *U) {
+        FoldingSetNodeID ID;
+        ID.AddInteger(scPtrToAddr);
+        ID.AddPointer(U);
+        ID.AddPointer(Ty);
+        void *IP = nullptr;
+        if (const SCEV *S = UniqueSCEVs.FindNodeOrInsertPos(ID, IP))
+          return S;
+        SCEV *S = new (SCEVAllocator)
+            SCEVPtrToAddrExpr(ID.Intern(SCEVAllocator), U, Ty);
+        UniqueSCEVs.InsertNode(S, IP);
+        registerUser(S, U);
+        return static_cast<const SCEV *>(S);
+      });
+  assert(IntOp->getType()->isIntegerTy() &&
+         "We must have succeeded in sinking the cast, "
+         "and ending up with an integer-typed expression!");
+  return IntOp;
 }
 
 const SCEV *ScalarEvolution::getPtrToIntExpr(const SCEV *Op, Type *Ty) {

--- a/llvm/test/Analysis/ScalarEvolution/ptrtoaddr-i32-index-width.ll
+++ b/llvm/test/Analysis/ScalarEvolution/ptrtoaddr-i32-index-width.ll
@@ -60,7 +60,7 @@ define void @ptrtoaddr_of_gep(ptr %in, ptr %out0) {
 ; CHECK-NEXT:    %in_adj = getelementptr inbounds i8, ptr %in, i64 42
 ; CHECK-NEXT:    --> (42 + %in) U: full-set S: full-set
 ; CHECK-NEXT:    %p0 = ptrtoaddr ptr %in_adj to i32
-; CHECK-NEXT:    --> (ptrtoaddr ptr (42 + %in) to i32) U: full-set S: full-set
+; CHECK-NEXT:    --> (42 + (ptrtoaddr ptr %in to i32)) U: full-set S: full-set
 ; CHECK-NEXT:  Determining loop execution counts for: @ptrtoaddr_of_gep
 ;
   %in_adj = getelementptr inbounds i8, ptr %in, i64 42

--- a/llvm/test/Analysis/ScalarEvolution/ptrtoaddr.ll
+++ b/llvm/test/Analysis/ScalarEvolution/ptrtoaddr.ll
@@ -60,10 +60,28 @@ define void @ptrtoaddr_of_gep(ptr %in, ptr %out0) {
 ; CHECK-NEXT:    %in_adj = getelementptr inbounds i8, ptr %in, i64 42
 ; CHECK-NEXT:    --> (42 + %in) U: full-set S: full-set
 ; CHECK-NEXT:    %p0 = ptrtoaddr ptr %in_adj to i64
-; CHECK-NEXT:    --> (ptrtoaddr ptr (42 + %in) to i64) U: full-set S: full-set
+; CHECK-NEXT:    --> (42 + (ptrtoaddr ptr %in to i64)) U: full-set S: full-set
 ; CHECK-NEXT:  Determining loop execution counts for: @ptrtoaddr_of_gep
 ;
   %in_adj = getelementptr inbounds i8, ptr %in, i64 42
+  %p0 = ptrtoaddr ptr %in_adj to i64
+  store i64  %p0, ptr  %out0
+  ret void
+}
+
+define void @ptrtoaddr_of_gep_with_unknown_int(ptr %in, ptr %out0, ptr %offset) {
+; CHECK-LABEL: 'ptrtoaddr_of_gep_with_unknown_int'
+; CHECK-NEXT:  Classifying expressions for: @ptrtoaddr_of_gep_with_unknown_int
+; CHECK-NEXT:    %l = load i64, ptr %offset, align 4
+; CHECK-NEXT:    --> %l U: full-set S: full-set
+; CHECK-NEXT:    %in_adj = getelementptr inbounds i8, ptr %in, i64 %l
+; CHECK-NEXT:    --> (%l + %in) U: full-set S: full-set
+; CHECK-NEXT:    %p0 = ptrtoaddr ptr %in_adj to i64
+; CHECK-NEXT:    --> ((ptrtoaddr ptr %in to i64) + %l) U: full-set S: full-set
+; CHECK-NEXT:  Determining loop execution counts for: @ptrtoaddr_of_gep_with_unknown_int
+;
+  %l = load i64, ptr %offset
+  %in_adj = getelementptr inbounds i8, ptr %in, i64 %l
   %p0 = ptrtoaddr ptr %in_adj to i64
   store i64  %p0, ptr  %out0
   ret void


### PR DESCRIPTION
Use CastSinkingRewriter for SCEVPtrToAddr expressions as well, sinking
them the same as SCEVPtrToInt expressions.

Depends on https://github.com/llvm/llvm-project/pull/174435 (included in PR)
and https://github.com/llvm/llvm-project/pull/158032 (included in PR)