### PR TITLE
[compiler-rt] Fix check-builtins buildbot failures

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -287,7 +287,7 @@ macro(darwin_add_builtin_library name suffix)
   
   # Write out the sources that were used to compile the builtins so that tests can be run in
   # an independent compiler-rt build (see: compiler-rt/test/builtins/CMakeLists.txt)
-  file(WRITE "${CMAKE_BINARY_DIR}/${libname}.sources.txt" "${LIB_SOURCES}")
+  file(WRITE "${COMPILER_RT_OUTPUT_LIBRARY_DIR}/${libname}.sources.txt" "${LIB_SOURCES}")
 
   if(DARWIN_${LIB_OS}_SYSROOT)
     set(sysroot_flag -isysroot ${DARWIN_${LIB_OS}_SYSROOT})

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -1032,8 +1032,9 @@ else ()
 
       # Write out the sources that were used to compile the builtins so that tests can be run in
       # an independent compiler-rt build (see: compiler-rt/test/builtins/CMakeLists.txt)
+      get_compiler_rt_output_dir(${arch} BUILTIN_LIB_OUTPUT_DIR)
       set_output_name(BUILTIN_LIB_OUTPUT_NAME clang_rt.builtins ${arch})
-      file(WRITE "${CMAKE_BINARY_DIR}/${BUILTIN_LIB_OUTPUT_NAME}.sources.txt" "${${arch}_SOURCES}")
+      file(WRITE "${BUILTIN_LIB_OUTPUT_DIR}/${BUILTIN_LIB_OUTPUT_NAME}.sources.txt" "${${arch}_SOURCES}")
       cmake_pop_check_state()
     endif ()
   endforeach ()

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -1032,8 +1032,8 @@ else ()
 
       # Write out the sources that were used to compile the builtins so that tests can be run in
       # an independent compiler-rt build (see: compiler-rt/test/builtins/CMakeLists.txt)
-      set_output_name(BUILTIN_LIB_TARGET_NAME clang_rt.builtins ${arch})
-      file(WRITE "${CMAKE_BINARY_DIR}/${BUILTIN_LIB_TARGET_NAME}.sources.txt" "${${arch}_SOURCES}")
+      set_output_name(BUILTIN_LIB_OUTPUT_NAME clang_rt.builtins ${arch})
+      file(WRITE "${CMAKE_BINARY_DIR}/${BUILTIN_LIB_OUTPUT_NAME}.sources.txt" "${${arch}_SOURCES}")
       cmake_pop_check_state()
     endif ()
   endforeach ()

--- a/compiler-rt/test/CMakeLists.txt
+++ b/compiler-rt/test/CMakeLists.txt
@@ -73,10 +73,10 @@ endfunction()
 # Run sanitizer tests only if we're sure that clang would produce
 # working binaries.
 if(COMPILER_RT_CAN_EXECUTE_TESTS)
-  # COMPILER_RT_TEST_BUILTINS_DIR allows running tests against builtins built
+  # COMPILER_RT_TEST_EXTERNAL_BUILTINS allows running tests against builtins built
   # in an independent build. This option is only indended to be used by
   # LLVM_ENABLE_RUNTIMES-based builds.
-  if(COMPILER_RT_BUILD_BUILTINS OR COMPILER_RT_TEST_BUILTINS_DIR)
+  if(COMPILER_RT_BUILD_BUILTINS OR COMPILER_RT_TEST_EXTERNAL_BUILTINS)
     add_subdirectory(builtins)
   endif()
   if(COMPILER_RT_BUILD_SANITIZERS)

--- a/compiler-rt/test/builtins/CMakeLists.txt
+++ b/compiler-rt/test/builtins/CMakeLists.txt
@@ -91,13 +91,15 @@ foreach(arch ${BUILTIN_TEST_ARCH})
   if(APPLE)
     # TODO: Support other Apple platforms.
     set(BUILTIN_LIB_TARGET_NAME "clang_rt.builtins_${arch}_osx")
+    set(BUILTIN_LIB_OUTPUT_NAME "clang_rt.builtins_${arch}_osx")
   else()
-    set_output_name(BUILTIN_LIB_TARGET_NAME clang_rt.builtins ${arch})
+    set(BUILTIN_LIB_TARGET_NAME "clang_rt.builtins-${arch}")
+    set_output_name(BUILTIN_LIB_OUTPUT_NAME clang_rt.builtins ${arch})
   endif()
   # Normally, we can just inspect the target directly to get the sources, but if
   # we are testing an externally-built builtins library, we expect
   # COMPILER_RT_TEST_BUILTINS_DIR to be set and contain a file named
-  # ${BUILTIN_LIB_TARGET_NAME}.sources.txt from the builtins build. This file
+  # ${BUILTIN_LIB_OUTPUT_NAME}.sources.txt from the builtins build. This file
   # is created by compiler-rt/lib/builtins/CMakeLists.txt
   if(NOT COMPILER_RT_TEST_BUILTINS_DIR)
     if (NOT TARGET "${BUILTIN_LIB_TARGET_NAME}")
@@ -105,7 +107,7 @@ foreach(arch ${BUILTIN_TEST_ARCH})
     endif()
     get_target_property(BUILTIN_LIB_SOURCES "${BUILTIN_LIB_TARGET_NAME}" SOURCES)
   else()
-    file(READ "${COMPILER_RT_TEST_BUILTINS_DIR}/${BUILTIN_LIB_TARGET_NAME}.sources.txt" BUILTIN_LIB_SOURCES)
+    file(READ "${COMPILER_RT_TEST_BUILTINS_DIR}/${BUILTIN_LIB_OUTPUT_NAME}.sources.txt" BUILTIN_LIB_SOURCES)
   endif()
   list(LENGTH BUILTIN_LIB_SOURCES BUILTIN_LIB_SOURCES_LENGTH)
   if (BUILTIN_LIB_SOURCES_LENGTH EQUAL 0)

--- a/compiler-rt/test/builtins/CMakeLists.txt
+++ b/compiler-rt/test/builtins/CMakeLists.txt
@@ -1,11 +1,11 @@
 set(BUILTINS_LIT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-# If COMPILER_RT_TEST_BUILTINS_DIR is set, the builtins
+# If COMPILER_RT_TEST_EXTERNAL_BUILTINS is set, the builtins
 # were already built and we are just going to test them.
 # NOTE: This is currently an LLVM-internal option which should
 # only be used by the LLVM_ENABLE_RUNTIMES build configured
 # in llvm/runtimes/CMakeLists.txt
-if(COMPILER_RT_TEST_BUILTINS_DIR)
+if(COMPILER_RT_TEST_EXTERNAL_BUILTINS)
   set(BUILTINS_TEST_DEPS ${SANITIZER_COMMON_LIT_TEST_DEPS})
 else()
   set(BUILTINS_TEST_DEPS ${SANITIZER_COMMON_LIT_TEST_DEPS} builtins)
@@ -97,17 +97,17 @@ foreach(arch ${BUILTIN_TEST_ARCH})
     set_output_name(BUILTIN_LIB_OUTPUT_NAME clang_rt.builtins ${arch})
   endif()
   # Normally, we can just inspect the target directly to get the sources, but if
-  # we are testing an externally-built builtins library, we expect
-  # COMPILER_RT_TEST_BUILTINS_DIR to be set and contain a file named
-  # ${BUILTIN_LIB_OUTPUT_NAME}.sources.txt from the builtins build. This file
-  # is created by compiler-rt/lib/builtins/CMakeLists.txt
-  if(NOT COMPILER_RT_TEST_BUILTINS_DIR)
+  # we are testing an externally-built builtins library, we expect a file named
+  # ${BUILTIN_LIB_OUTPUT_NAME}.sources.txt in the compiler-rt output directory.
+  # This file is created by compiler-rt/lib/builtins/CMakeLists.txt
+  if(NOT COMPILER_RT_TEST_EXTERNAL_BUILTINS)
     if (NOT TARGET "${BUILTIN_LIB_TARGET_NAME}")
       message(FATAL_ERROR "Target ${BUILTIN_LIB_TARGET_NAME} does not exist")
     endif()
     get_target_property(BUILTIN_LIB_SOURCES "${BUILTIN_LIB_TARGET_NAME}" SOURCES)
   else()
-    file(READ "${COMPILER_RT_TEST_BUILTINS_DIR}/${BUILTIN_LIB_OUTPUT_NAME}.sources.txt" BUILTIN_LIB_SOURCES)
+    get_compiler_rt_output_dir(${arch} BUILTIN_LIB_OUTPUT_DIR)
+    file(READ "${BUILTIN_LIB_OUTPUT_DIR}/${BUILTIN_LIB_OUTPUT_NAME}.sources.txt" BUILTIN_LIB_SOURCES)
   endif()
   list(LENGTH BUILTIN_LIB_SOURCES BUILTIN_LIB_SOURCES_LENGTH)
   if (BUILTIN_LIB_SOURCES_LENGTH EQUAL 0)

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -263,9 +263,7 @@ function(runtime_default_target)
   if(LLVM_INCLUDE_TESTS)
     set_property(GLOBAL APPEND PROPERTY LLVM_ALL_LIT_TESTSUITES "@${LLVM_BINARY_DIR}/runtimes/runtimes-bins/lit.tests")
     list(APPEND test_targets runtimes-test-depends check-runtimes check-builtins)
-
-    # The default runtimes target can run tests the default builtins target
-    list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_TEST_BUILTINS_DIR=${LLVM_BINARY_DIR}/runtimes/builtins-bins/")
+    list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_TEST_EXTERNAL_BUILTINS=ON")
   endif()
 
   set_enable_per_target_runtime_dir()
@@ -376,7 +374,7 @@ function(runtime_register_target name)
     # If a builtins-${name} target exists, we'll test those builtins
     # with this runtimes build
     if(TARGET builtins-${name})
-      list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_TEST_BUILTINS_DIR=${LLVM_BINARY_DIR}/runtimes/builtins-${name}-bins/")
+      list(APPEND ARG_CMAKE_ARGS "-DCOMPILER_RT_TEST_EXTERNAL_BUILTINS=ON")
       set(check-builtins-${name} check-builtins)
       list(APPEND ${name}_test_targets check-builtins-${name})
       list(APPEND test_targets check-builtins-${name})


### PR DESCRIPTION
After #171941, there are two issues:

First, some buildbots that use the old-style build are failing at:

```
Target ${BUILTIN_LIB_TARGET_NAME} does not exist"
```

Example failure: https://lab.llvm.org/buildbot/#/builders/139/builds/25097

...during CMake configure. This appears to be caused by mismatch between the builtin library's _target_ name and the output name from set_output_name. This reverts the change to BUILTIN_LIB_TARGET_NAME made by #171941, but still use the output name for naming the .sources.txt file used for configuring builtins tests.

Second, this speculatively fixes an issue caused by two builtins libraries that are produced with the same name in different directories because of `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR` (e.g. `lib/clang/22/lib/i386-unknown-linux-gnu/libclang_rt.builtins.a` and `lib/clang/22/lib/x86_64-unknown-linux-gnu/libclang_rt.builtins.a`), and thus the `.sources.txt` paths alias. This causes us to run the wrong tests against one of the builtins libraries. The chosen fix is to store the .sources.txt files in `get_compiler_rt_output_dir` (which takes `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR` into account) rather than `CMAKE_BINARY_DIR`.

As a side-effect, this allows for the replacement of `COMPILER_RT_TEST_BUILTINS_DIR` with a simpler boolean option `COMPILER_RT_TEST_EXTERNAL_BUILTINS`.

Example failure: https://lab.llvm.org/buildbot/#/builders/66/builds/24433