### PR TITLE
Resolve undefined prefetch targets to zero to effectively prefetch the next instruction.

### DIFF
--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -772,6 +772,8 @@ static int64_t getTlsTpOffset(Ctx &ctx, const Symbol &s) {
 
 uint64_t InputSectionBase::getRelocTargetVA(Ctx &ctx, const Relocation &r,
                                             uint64_t p) const {
+  // Resolve undefined prefetch targets to zero, to effectively prefetch the
+  // next instruction.
   if (r.sym->isUndefined() &&
       r.sym->getName().starts_with(prefetchSymbolPrefix)) {
     return 0;

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -772,6 +772,9 @@ static int64_t getTlsTpOffset(Ctx &ctx, const Symbol &s) {
 
 uint64_t InputSectionBase::getRelocTargetVA(Ctx &ctx, const Relocation &r,
                                             uint64_t p) const {
+  if (r.sym->isUndefined() && r.sym->getName().starts_with(prefetchSymbolPrefix)) {
+    return 0;
+  }
   int64_t a = r.addend;
   switch (r.expr) {
   case R_ABS:

--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -772,7 +772,8 @@ static int64_t getTlsTpOffset(Ctx &ctx, const Symbol &s) {
 
 uint64_t InputSectionBase::getRelocTargetVA(Ctx &ctx, const Relocation &r,
                                             uint64_t p) const {
-  if (r.sym->isUndefined() && r.sym->getName().starts_with(prefetchSymbolPrefix)) {
+  if (r.sym->isUndefined() &&
+      r.sym->getName().starts_with(prefetchSymbolPrefix)) {
     return 0;
   }
   int64_t a = r.addend;

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -959,14 +959,13 @@ void RelocScan::process(RelExpr expr, RelType type, uint64_t offset,
 
   if (sym.getName().starts_with(prefetchSymbolPrefix)) {
     sec->addReloc({expr, type, offset, addend, &sym});
-    dbgs() << "MY Sym: " << sym.getName() << " " << offset  << " " << addend << "\n";
+    dbgs() << "MY Sym: " << sym.getName() << " " << offset << " " << addend
+           << "\n";
     // Prefetch target symbols may be undefined due to inaccurate profiles.
     // The unresolved relocation will result in 0x0, effectively prefetching the
     // next instruction.
     return;
   }
-
-
 
   if (needsGot(expr)) {
     if (ctx.arg.emachine == EM_MIPS) {

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -959,8 +959,6 @@ void RelocScan::process(RelExpr expr, RelType type, uint64_t offset,
 
   if (sym.getName().starts_with(prefetchSymbolPrefix)) {
     sec->addReloc({expr, type, offset, addend, &sym});
-    dbgs() << "MY Sym: " << sym.getName() << " " << offset << " " << addend
-           << "\n";
     // Prefetch target symbols may be undefined due to inaccurate profiles.
     // The unresolved relocation will result in 0x0, effectively prefetching the
     // next instruction.

--- a/lld/ELF/Relocations.h
+++ b/lld/ELF/Relocations.h
@@ -16,6 +16,9 @@
 #include <vector>
 
 namespace lld::elf {
+
+constexpr const char prefetchSymbolPrefix[] = "__llvm_prefetch_target_";
+
 struct Ctx;
 struct ELFSyncStream;
 class Defined;

--- a/lld/test/ELF/prefetch-undefined-symbol.s
+++ b/lld/test/ELF/prefetch-undefined-symbol.s
@@ -1,0 +1,19 @@
+# REQUIRES: x86
+# RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t
+# RUN: ld.lld %t -o %tout
+# RUN: llvm-nm -D %tout
+
+	.global foo
+	.local bar
+	.global __llvm_prefetch_target_bar
+
+	.section .text.foo,"ax",%progbits
+foo:
+	prefetchit1 __llvm_prefetch_target_bar(%rip)
+	prefetchit1 __llvm_prefetch_target_baz(%rip)
+
+	.section .text.bar,"ax",%progbits
+bar:
+__llvm_prefetch_target_bar:
+        nop
+

--- a/lld/test/ELF/prefetch-undefined-symbol.s
+++ b/lld/test/ELF/prefetch-undefined-symbol.s
@@ -1,7 +1,7 @@
 # REQUIRES: x86
 # RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t
 # RUN: ld.lld %t -o %tout
-# RUN: llvm-nm -D %tout
+# RUN: llvm-objdump -d %tout | FileCheck %s
 
 	.global foo
 	.local bar
@@ -9,7 +9,9 @@
 
 	.section .text.foo,"ax",%progbits
 foo:
+# CHECK:      prefetchit1 0x7(%rip)
 	prefetchit1 __llvm_prefetch_target_bar(%rip)
+# CHECK-NEXT: prefetchit1 (%rip)
 	prefetchit1 __llvm_prefetch_target_baz(%rip)
 
 	.section .text.bar,"ax",%progbits


### PR DESCRIPTION
This PR handles the undefined symbol resolution described in **https://discourse.llvm.org/t/rfc-code-prefetch-insertion/88668**.

Prefetch directives are specified via a post-link profile based on the symbol names and SHT_LLVM_BB_ADDR_MAP from a previous build. Prefetch targets are defined as global to allow prefetching across different modules (https://github.com/llvm/llvm-project/pull/168439). So we must guard against undefined symbols. This PR handles it by resolving undefined prefetch targets as zero. The prefetch instruction will then prefetch the next instruction which is less intrusive than prefetching a random address.