### PR TITLE
[IR] Do not assert and verify that phi nodes do not have a token type

### DIFF
--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -2650,7 +2650,6 @@ class PHINode : public Instruction {
                    InsertPosition InsertBefore = nullptr)
       : Instruction(Ty, Instruction::PHI, AllocMarker, InsertBefore),
         ReservedSpace(NumReservedValues) {
-    assert(!Ty->isTokenTy() && "PHI nodes cannot have token type!");
     setName(NameStr);
     allocHungoffUses(ReservedSpace);
   }


### PR DESCRIPTION
We were asserting and checking in the IR verifier ( https://github.com/llvm/llvm-project/blob/984c57794f9e8253ababfebe84303bda33e8f388/llvm/lib/IR/Verifier.cpp#L3793, https://github.com/llvm/llvm-project/blob/984c57794f9e8253ababfebe84303bda33e8f388/llvm/include/llvm/IR/Instructions.h#L2653) that phi nodes do not have a token type. This caused behavior differences between asserts and non-asserts builds (assert if we feed incorrect IR in an assertions enabled build while just erroring normally in a release build).