### PR TITLE
[analyzer][docs] CSA release notes for clang-22

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -845,8 +845,8 @@ Crash and bug fixes
   expression. (#GH147686)
 - `crosscheck-with-z3 <https://clang.llvm.org/docs/analyzer/user-docs/Options.html#crosscheck-with-z3>`__
   config option sometimes crashed. (#GH168034)
-- The ``alpha.core.StdVariant`` checker sometimes crashed when floating-point
-  values were involved. (#GH167341)
+- The ``alpha.core.StdVariant`` checker sometimes crashed when unknown
+  values or type aliases were involved. (#GH167341)
 - Hardened the engine for supporting platforms where different address-space
   pointers might have different sizes. (#GH151370)
 - The ``core.builtin.BuiltinFunctions`` checker crashed when passing

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -914,8 +914,9 @@ Improvements
 Moved checkers
 ^^^^^^^^^^^^^^
 
-- The ``valist.*`` checker package was moved to ``security.VAList.*``.
-  Also improved the diagnostic messages and other smaller improvements.
+- The functionality of the checkers in the package ``valist.*`` was
+  consolidated as a single new checker called ``security.VAList``.
+  Diagnostic messages were also improved.
   (#GH156682, #GH157846)
 
 Removed checkers

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -809,24 +809,129 @@ Code Completion
 
 Static Analyzer
 ---------------
-- The Clang Static Analyzer now handles parenthesized initialization.
-  (#GH148875)
-- ``__datasizeof`` (C++) and ``_Countof`` (C) no longer cause a failed assertion
-  when given an operand of VLA type. (#GH151711)
 
-New features
-^^^^^^^^^^^^
+New checkers or options
+^^^^^^^^^^^^^^^^^^^^^^^
+
+- Introduced the ``alpha.core.StoreToImmutable`` checker to catch writes to
+  immutable memory. See the `documentation
+  <https://clang.llvm.org/docs/analyzer/checkers.html#alpha-core-storetoimmutable-c-c>`__.
+  (#GH150417)
+- Introduced the ``core.NullPointerArithm`` checker to catch arithmetic on
+  null pointers. See the `documentation
+  <https://clang.llvm.org/docs/analyzer/checkers.html#core-nullpointerarithm-c-c>`__.
+  (#GH157129)
+- The ``core.CallAndMessage`` checker gained a new checker option called
+  ``ArgPointeeInitializednessComplete``, enabling suppression of diagnostics
+  of this checker in case at least some parts of the object was initialized.
+  By default it's disabled. (#GH164600)
 
 Crash and bug fixes
 ^^^^^^^^^^^^^^^^^^^
+
 - Fixed a crash in the static analyzer that when the expression in an
-  ``[[assume(expr)]]`` attribute was enclosed in parentheses.  (#GH151529)
+  ``[[assume(expr)]]`` attribute was enclosed in parentheses. (#GH151529)
+- Fixed an assertion failure of ``[[assume(expr)]]`` when the expression
+  couldn't be folded into a constant by the engine. (#GH151854)
+- ``__datasizeof`` (C++) and ``_Countof`` (C) no longer cause a failed assertion
+  when given an operand of VLA type. (#GH151711)
+- Sometimes the ``unix.Malloc`` checker asserted when constructing a report under
+  rare circumstances. (#GH149754)
+- The ``core.StackAddressEscape`` checker was crashing if a lambda or
+  Objective-C block expression captured itself. (#GH169208)
+- Fixed an assertion in the ``alpha.unix.cstring`` checker package when
+  non-default address-spaces were used in ``memcpy``. (#GH153498)
+- The engine sometimes crashed when modeling a parenthesis initializer-list
+  expression. (#GH147686)
+- `crosscheck-with-z3 <https://clang.llvm.org/docs/analyzer/user-docs/Options.html#crosscheck-with-z3>`__
+  config option sometimes crashed. (#GH168034)
+- The ``alpha.core.StdVariant`` checker sometimes crashed when floating-point
+  values were involved. (#GH167341)
+- Hardened the engine for supporting platforms where different address-space
+  pointers might have different sizes. (#GH151370)
+- The ``core.builtin.BuiltinFunctions`` checker crashed when passing
+  ``_BitInt(N)`` or ``__int128_t`` to ``__builtin_add_overflow`` or similar
+  checked arithmetic builtin functions. (#GH173795)
 
 Improvements
 ^^^^^^^^^^^^
 
+- The `expand-macros <https://clang.llvm.org/docs/analyzer/user-docs/Options.html#expand-macros>`__
+  analyzer config option now formats the macro expansions using LLVM-style
+  clang-format. (#GH154743)
+- ``[[clang::suppress]]`` now can suppress diagnostics within primary templates.
+  (#GH168954)
+- Improved the false-positive suppression for ``std::unique_ptr`` and
+  ``std::shared_ptr`` in the ``unix.Malloc`` checker. (#GH60896)
+- Improved the false-positive suppression for ``unix.Malloc`` on protobuf code.
+  (#GH162124)
+- Supporting parenthesized initialization. (#GH148875)
+- Fixed a false-positive of ``cplusplus.PlacementNew`` by assuming that
+  placement-new doesn't allocate. (#GH149240)
+- The ``unix.Malloc`` checker can now detect use-after-free even if the
+  address does not directly refer to the beginning of the object.
+  (For example, taking the address of a field.) (#GH152446)
+- Improved the modeling of cstring lengths in the ``alpha.unix.cstring``
+  checkers. (#GH159795)
+- The ``strxfrm`` is modeled in the ``alpha.unix.cstring`` checkers. (#GH156507)
+- Handling of placement-new expressions were improved in the
+  ``alpha.core.PointerArithm`` checker. (#GH155855)
+- The ``security.arraybound`` checker now mentions the element count in
+  underflow reports. (#GH158639)
+- The engine had a ``PrivateMethodCache`` that was not cleaned up - potentially
+  causing spuriously failing Objective-C unittest failures because that uses the
+  same process address-space but different clang instances inside - filling up
+  the static cache and cause spurious hits, thus crashes. It only affects
+  unittests. (#GH161327)
+- The internal ``-analyze-function`` option now also accepts Unified Symbol
+  Resolution (USR) names. See the `documentation
+  <https://clang.llvm.org/docs/analyzer/developer-docs/DebugChecks.html>`__.
+  (#GH161666)
+- The ``dump-entry-point-stats-to-csv`` analyzer config now includes the
+  Translation Unit path and the analysis entry point USR for each entry.
+  The CSV output got many more improvements. See the `documentation
+  <https://clang.llvm.org/docs/analyzer/developer-docs/Statistics.html>`__.
+  (#GH162839)
+- The engine became smarter in folding binary operations. (#GH161537)
+- The `model-path <https://clang.llvm.org/docs/analyzer/user-docs/Options.html#model-path>`__
+  analyzer config option now honors virtual file system
+  overlays (``-ivfsoverlay``). Similarly, the ``optin.taint.TaintPropagation``
+  checker-specific ``Config`` also accepts a virtual file path for the taint
+  configuration file. See the `documentation
+  <https://clang.llvm.org/docs/analyzer/user-docs/TaintAnalysisConfiguration.html>`__.
+  (#GH164323, #GH159164)
+- The dynamic memory modeling got more accurate by keeping extent information
+  for longer. (#GH163562)
+- The ``unix.BlockInCriticalSection`` checker started honoring ``defer_lock_t``.
+  (#GH166573)
+- Improved loop unrolling for compile-time upper-bounded loops. See the
+  documentation of `unroll-loops
+  <https://clang.llvm.org/docs/analyzer/user-docs/Options.html#unroll-loops>`__.
+  (#GH169400)
+- Improved the ``cplusplus.Move`` checker by relaxing how it handles opaque
+  function calls, making it more accurate. (#GH169626)
+
 Moved checkers
 ^^^^^^^^^^^^^^
+
+- The ``valist.*`` checker package was moved to ``security.VAList.*``.
+  Also improved the diagnostic messages and other smaller improvements.
+  (#GH156682, #GH157846)
+
+Removed checkers
+^^^^^^^^^^^^^^^^
+
+- The ``alpha.core.CastSize`` checker was removed. It had a poor
+  false-positives / true-positive ratio, thus rarely used in practice.
+  (#GH156350)
+
+Diagnostic changes
+^^^^^^^^^^^^^^^^^^
+
+- Harmonized the ``unix.Malloc`` checker diagnostics to use "release" instead
+  of "free". (#GH150935)
+- ``sarif-html`` outputs no longer report detected issues 3 times. (#GH158103)
+- ``sarif`` reports now also emit the ``IssueHash`` field. (#GH158159)
 
 .. _release-notes-sanitizers:
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -876,7 +876,7 @@ Improvements
 - The ``strxfrm`` is modeled in the ``alpha.unix.cstring`` checkers. (#GH156507)
 - Handling of placement-new expressions were improved in the
   ``alpha.core.PointerArithm`` checker. (#GH155855)
-- The ``security.arraybound`` checker now mentions the element count in
+- The ``security.ArrayBound`` checker now mentions the element count in
   underflow reports. (#GH158639)
 - The engine had a ``PrivateMethodCache`` that was not cleaned up - potentially
   causing spuriously failing Objective-C unittest failures because that uses the


### PR DESCRIPTION
The commits were gathered using:
```sh
git log --reverse --oneline llvmorg-22-init..llvm/main \
    clang/{lib/StaticAnalyzer,include/clang/StaticAnalyzer} | grep -v NFC | \
    grep -v OpenACC | grep -v -i revert | grep -v -i "webkit"
```

I used the `LLVM_ENABLE_SPHINX=ON` and `LLVM_ENABLE_DOXYGEN=ON` cmake options to enable the `docs-clang-html` build target, which generates the html into `build/tools/clang/docs/html/ReleaseNotes.html` of which I attach the screenshots to let you judge if it looks all good or not.