### PR TITLE
ValueTracking: Check if fdiv operand could be undef

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -5667,7 +5667,8 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
   }
   case Instruction::FDiv:
   case Instruction::FRem: {
-    if (Op->getOperand(0) == Op->getOperand(1)) {
+    if (Op->getOperand(0) == Op->getOperand(1) &&
+        isGuaranteedNotToBeUndef(Op->getOperand(0), Q.AC, Q.CxtI, Q.DT)) {
       // TODO: Could filter out snan if we inspect the operand
       if (Op->getOpcode() == Instruction::FDiv) {
         // X / X is always exactly 1.0 or a NaN.

--- a/llvm/test/Transforms/Attributor/nofpclass-fdiv.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-fdiv.ll
@@ -355,8 +355,18 @@ define float @ret_fdiv_daz_noinf__nozero_nosub(float nofpclass(inf) %arg0, float
   ret float %fdiv
 }
 
-define float @ret_fdiv_same_operands(float %arg) #0 {
-; CHECK-LABEL: define nofpclass(inf zero sub nnorm) float @ret_fdiv_same_operands
+define float @ret_fdiv_same_operands(float noundef %arg) #0 {
+; CHECK-LABEL: define noundef nofpclass(inf zero sub nnorm) float @ret_fdiv_same_operands
+; CHECK-SAME: (float noundef [[ARG:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[FDIV:%.*]] = fdiv float [[ARG]], [[ARG]]
+; CHECK-NEXT:    ret float [[FDIV]]
+;
+  %fdiv = fdiv float %arg, %arg
+  ret float %fdiv
+}
+
+define float @ret_fdiv_same_operands_maybe_undef(float %arg) #0 {
+; CHECK-LABEL: define float @ret_fdiv_same_operands_maybe_undef
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[FDIV:%.*]] = fdiv float [[ARG]], [[ARG]]
 ; CHECK-NEXT:    ret float [[FDIV]]
@@ -365,9 +375,9 @@ define float @ret_fdiv_same_operands(float %arg) #0 {
   ret float %fdiv
 }
 
-define float @ret_fdiv_same_operands_nosnan(float nofpclass(snan) %arg) #0 {
-; CHECK-LABEL: define nofpclass(inf zero sub nnorm) float @ret_fdiv_same_operands_nosnan
-; CHECK-SAME: (float nofpclass(snan) [[ARG:%.*]]) #[[ATTR0]] {
+define float @ret_fdiv_same_operands_nosnan(float noundef nofpclass(snan) %arg) #0 {
+; CHECK-LABEL: define noundef nofpclass(inf zero sub nnorm) float @ret_fdiv_same_operands_nosnan
+; CHECK-SAME: (float noundef nofpclass(snan) [[ARG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[FDIV:%.*]] = fdiv float [[ARG]], [[ARG]]
 ; CHECK-NEXT:    ret float [[FDIV]]
 ;
@@ -375,9 +385,9 @@ define float @ret_fdiv_same_operands_nosnan(float nofpclass(snan) %arg) #0 {
   ret float %fdiv
 }
 
-define float @ret_fdiv_same_operands_noqnan(float nofpclass(qnan) %arg) #0 {
-; CHECK-LABEL: define nofpclass(inf zero sub nnorm) float @ret_fdiv_same_operands_noqnan
-; CHECK-SAME: (float nofpclass(qnan) [[ARG:%.*]]) #[[ATTR0]] {
+define float @ret_fdiv_same_operands_noqnan(float noundef nofpclass(qnan) %arg) #0 {
+; CHECK-LABEL: define noundef nofpclass(inf zero sub nnorm) float @ret_fdiv_same_operands_noqnan
+; CHECK-SAME: (float noundef nofpclass(qnan) [[ARG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[FDIV:%.*]] = fdiv float [[ARG]], [[ARG]]
 ; CHECK-NEXT:    ret float [[FDIV]]
 ;
@@ -385,9 +395,9 @@ define float @ret_fdiv_same_operands_noqnan(float nofpclass(qnan) %arg) #0 {
   ret float %fdiv
 }
 
-define float @ret_fdiv_same_operands_nonan(float nofpclass(nan) %arg) #0 {
-; CHECK-LABEL: define nofpclass(inf zero sub nnorm) float @ret_fdiv_same_operands_nonan
-; CHECK-SAME: (float nofpclass(nan) [[ARG:%.*]]) #[[ATTR0]] {
+define float @ret_fdiv_same_operands_nonan(float noundef nofpclass(nan) %arg) #0 {
+; CHECK-LABEL: define noundef nofpclass(inf zero sub nnorm) float @ret_fdiv_same_operands_nonan
+; CHECK-SAME: (float noundef nofpclass(nan) [[ARG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[FDIV:%.*]] = fdiv float [[ARG]], [[ARG]]
 ; CHECK-NEXT:    ret float [[FDIV]]
 ;

--- a/llvm/test/Transforms/Attributor/nofpclass-frem.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-frem.ll
@@ -355,8 +355,18 @@ define float @ret_frem_daz_noinf__nozero_nosub(float nofpclass(inf) %arg0, float
   ret float %frem
 }
 
-define float @ret_frem_same_operands(float %arg) #0 {
-; CHECK-LABEL: define nofpclass(inf sub norm) float @ret_frem_same_operands
+define float @ret_frem_same_operands(float noundef %arg) #0 {
+; CHECK-LABEL: define noundef nofpclass(inf sub norm) float @ret_frem_same_operands
+; CHECK-SAME: (float noundef [[ARG:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[FREM:%.*]] = frem float [[ARG]], [[ARG]]
+; CHECK-NEXT:    ret float [[FREM]]
+;
+  %frem = frem float %arg, %arg
+  ret float %frem
+}
+
+define float @ret_frem_same_operands_maybe_undef(float %arg) #0 {
+; CHECK-LABEL: define float @ret_frem_same_operands_maybe_undef
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[FREM:%.*]] = frem float [[ARG]], [[ARG]]
 ; CHECK-NEXT:    ret float [[FREM]]
@@ -365,9 +375,9 @@ define float @ret_frem_same_operands(float %arg) #0 {
   ret float %frem
 }
 
-define float @ret_frem_same_operands_nosnan(float nofpclass(snan) %arg) #0 {
-; CHECK-LABEL: define nofpclass(inf sub norm) float @ret_frem_same_operands_nosnan
-; CHECK-SAME: (float nofpclass(snan) [[ARG:%.*]]) #[[ATTR0]] {
+define float @ret_frem_same_operands_nosnan(float noundef nofpclass(snan) %arg) #0 {
+; CHECK-LABEL: define noundef nofpclass(inf sub norm) float @ret_frem_same_operands_nosnan
+; CHECK-SAME: (float noundef nofpclass(snan) [[ARG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[FREM:%.*]] = frem float [[ARG]], [[ARG]]
 ; CHECK-NEXT:    ret float [[FREM]]
 ;
@@ -375,9 +385,9 @@ define float @ret_frem_same_operands_nosnan(float nofpclass(snan) %arg) #0 {
   ret float %frem
 }
 
-define float @ret_frem_same_operands_noqnan(float nofpclass(qnan) %arg) #0 {
-; CHECK-LABEL: define nofpclass(inf sub norm) float @ret_frem_same_operands_noqnan
-; CHECK-SAME: (float nofpclass(qnan) [[ARG:%.*]]) #[[ATTR0]] {
+define float @ret_frem_same_operands_noqnan(float noundef nofpclass(qnan) %arg) #0 {
+; CHECK-LABEL: define noundef nofpclass(inf sub norm) float @ret_frem_same_operands_noqnan
+; CHECK-SAME: (float noundef nofpclass(qnan) [[ARG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[FREM:%.*]] = frem float [[ARG]], [[ARG]]
 ; CHECK-NEXT:    ret float [[FREM]]
 ;
@@ -385,9 +395,9 @@ define float @ret_frem_same_operands_noqnan(float nofpclass(qnan) %arg) #0 {
   ret float %frem
 }
 
-define float @ret_frem_same_operands_nonan(float nofpclass(nan) %arg) #0 {
-; CHECK-LABEL: define nofpclass(inf sub norm) float @ret_frem_same_operands_nonan
-; CHECK-SAME: (float nofpclass(nan) [[ARG:%.*]]) #[[ATTR0]] {
+define float @ret_frem_same_operands_nonan(float noundef nofpclass(nan) %arg) #0 {
+; CHECK-LABEL: define noundef nofpclass(inf sub norm) float @ret_frem_same_operands_nonan
+; CHECK-SAME: (float noundef nofpclass(nan) [[ARG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[FREM:%.*]] = frem float [[ARG]], [[ARG]]
 ; CHECK-NEXT:    ret float [[FREM]]
 ;

--- a/llvm/test/Transforms/InstSimplify/floating-point-compare.ll
+++ b/llvm/test/Transforms/InstSimplify/floating-point-compare.ll
@@ -220,7 +220,7 @@ define i1 @orderedLessZeroTree(float,float,float,float) {
   ret i1 %uge
 }
 
-define i1 @orderedLessZero_fdiv(float %x) {
+define i1 @orderedLessZero_fdiv(float noundef %x) {
 ; CHECK-LABEL: @orderedLessZero_fdiv(
 ; CHECK-NEXT:    ret i1 true
 ;


### PR DESCRIPTION
In the special case for fdiv/frem with the same operands, make
sure the input isn't undef.