### PR TITLE
[lldb-dap][NFC] Add missed references

### DIFF
--- a/lldb/tools/lldb-dap/ClientLauncher.cpp
+++ b/lldb/tools/lldb-dap/ClientLauncher.cpp
@@ -45,7 +45,7 @@ std::string VSCodeLauncher::URLEncode(llvm::StringRef str) {
 }
 
 std::string
-VSCodeLauncher::GetLaunchURL(const std::vector<llvm::StringRef> args) const {
+VSCodeLauncher::GetLaunchURL(const std::vector<llvm::StringRef> &args) const {
   assert(!args.empty() && "empty launch args");
 
   std::vector<std::string> encoded_launch_args;
@@ -59,7 +59,7 @@ VSCodeLauncher::GetLaunchURL(const std::vector<llvm::StringRef> args) const {
       .str();
 }
 
-llvm::Error VSCodeLauncher::Launch(const std::vector<llvm::StringRef> args) {
+llvm::Error VSCodeLauncher::Launch(const std::vector<llvm::StringRef> &args) {
   const std::string launch_url = GetLaunchURL(args);
   const std::string command =
       llvm::formatv("code --open-url {0}", launch_url).str();
@@ -68,7 +68,7 @@ llvm::Error VSCodeLauncher::Launch(const std::vector<llvm::StringRef> args) {
   return llvm::Error::success();
 }
 
-llvm::Error VSCodeURLPrinter::Launch(const std::vector<llvm::StringRef> args) {
+llvm::Error VSCodeURLPrinter::Launch(const std::vector<llvm::StringRef> &args) {
   llvm::outs() << GetLaunchURL(args) << '\n';
   return llvm::Error::success();
 }

--- a/lldb/tools/lldb-dap/ClientLauncher.h
+++ b/lldb/tools/lldb-dap/ClientLauncher.h
@@ -23,7 +23,7 @@ public:
   };
 
   virtual ~ClientLauncher() = default;
-  virtual llvm::Error Launch(const std::vector<llvm::StringRef> args) = 0;
+  virtual llvm::Error Launch(const std::vector<llvm::StringRef> &args) = 0;
 
   static std::optional<Client> GetClientFrom(llvm::StringRef str);
   static std::unique_ptr<ClientLauncher> GetLauncher(Client client);
@@ -33,16 +33,16 @@ class VSCodeLauncher : public ClientLauncher {
 public:
   using ClientLauncher::ClientLauncher;
 
-  llvm::Error Launch(const std::vector<llvm::StringRef> args) override;
+  llvm::Error Launch(const std::vector<llvm::StringRef> &args) override;
 
-  std::string GetLaunchURL(const std::vector<llvm::StringRef> args) const;
+  std::string GetLaunchURL(const std::vector<llvm::StringRef> &args) const;
   static std::string URLEncode(llvm::StringRef str);
 };
 
 class VSCodeURLPrinter : public VSCodeLauncher {
   using VSCodeLauncher::VSCodeLauncher;
 
-  llvm::Error Launch(const std::vector<llvm::StringRef> args) override;
+  llvm::Error Launch(const std::vector<llvm::StringRef> &args) override;
 };
 
 } // namespace lldb_dap


### PR DESCRIPTION
Pass `args` as const reference to methods.