### PR TITLE
ValueTracking: Check if fmul operand could be undef

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -5599,7 +5599,8 @@ void computeKnownFPClass(const Value *V, const APInt &DemandedElts,
           : DenormalMode::getDynamic();
 
     // X * X is always non-negative or a NaN.
-    if (Op->getOperand(0) == Op->getOperand(1)) {
+    if (Op->getOperand(0) == Op->getOperand(1) &&
+        isGuaranteedNotToBeUndef(Op->getOperand(0), Q.AC, Q.CxtI, Q.DT)) {
       KnownFPClass KnownSrc;
       computeKnownFPClass(Op->getOperand(0), DemandedElts, fcAllFlags, KnownSrc,
                           Q, Depth + 1);

--- a/llvm/test/Transforms/AggressiveInstCombine/X86/sqrt.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/X86/sqrt.ll
@@ -54,7 +54,7 @@ define float @sqrt_call_nnan_f32_nobuiltin(float %x) {
   ret float %sqrt
 }
 
-define float @sqrt_call_f32_squared(float %x) {
+define float @sqrt_call_f32_squared(float noundef %x) {
 ; CHECK-LABEL: @sqrt_call_f32_squared(
 ; CHECK-NEXT:    [[X2:%.*]] = fmul float [[X:%.*]], [[X]]
 ; CHECK-NEXT:    [[SQRT1:%.*]] = call float @llvm.sqrt.f32(float [[X2]])

--- a/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-fmul.ll
@@ -14,8 +14,18 @@ define float @ret_fmul_f32(float %arg0, float %arg1) {
   ret float %fmul
 }
 
-define float @ret_fmul_square_f32(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) float @ret_fmul_square_f32(
+define float @ret_fmul_square_f32(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero nsub nnorm) float @ret_fmul_square_f32(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    [[FMUL:%.*]] = fmul float [[ARG]], [[ARG]]
+; CHECK-NEXT:    ret float [[FMUL]]
+;
+  %fmul = fmul float %arg, %arg
+  ret float %fmul
+}
+
+define float @ret_fmul_square_f32_maybe_undef(float %arg) {
+; CHECK-LABEL: define float @ret_fmul_square_f32_maybe_undef(
 ; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[FMUL:%.*]] = fmul float [[ARG]], [[ARG]]
 ; CHECK-NEXT:    ret float [[FMUL]]

--- a/llvm/test/Transforms/Attributor/nofpclass-nan-fmul.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-nan-fmul.ll
@@ -164,9 +164,9 @@ define float @ret_fmul_daz_nonan_nozero_nosub__nonan_nozero(float nofpclass(nan 
   ret float %fmul
 }
 
-define float @ret_fmul_square(float %arg) #0 {
-; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) float @ret_fmul_square
-; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR0]] {
+define float @ret_fmul_square(float noundef %arg) #0 {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero nsub nnorm) float @ret_fmul_square
+; CHECK-SAME: (float noundef [[ARG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[FMUL:%.*]] = fmul float [[ARG]], [[ARG]]
 ; CHECK-NEXT:    ret float [[FMUL]]
 ;
@@ -174,9 +174,9 @@ define float @ret_fmul_square(float %arg) #0 {
   ret float %fmul
 }
 
-define float @ret_fmul_square_nnan(float nofpclass(nan) %arg) #0 {
-; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) float @ret_fmul_square_nnan
-; CHECK-SAME: (float nofpclass(nan) [[ARG:%.*]]) #[[ATTR0]] {
+define float @ret_fmul_square_nnan(float noundef nofpclass(nan) %arg) #0 {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero nsub nnorm) float @ret_fmul_square_nnan
+; CHECK-SAME: (float noundef nofpclass(nan) [[ARG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[FMUL:%.*]] = fmul float [[ARG]], [[ARG]]
 ; CHECK-NEXT:    ret float [[FMUL]]
 ;
@@ -184,9 +184,9 @@ define float @ret_fmul_square_nnan(float nofpclass(nan) %arg) #0 {
   ret float %fmul
 }
 
-define float @ret_fmul_square_nnan_nzero(float nofpclass(nan zero) %arg) #0 {
-; CHECK-LABEL: define nofpclass(nan ninf nzero nsub nnorm) float @ret_fmul_square_nnan_nzero
-; CHECK-SAME: (float nofpclass(nan zero) [[ARG:%.*]]) #[[ATTR0]] {
+define float @ret_fmul_square_nnan_nzero(float noundef nofpclass(nan zero) %arg) #0 {
+; CHECK-LABEL: define noundef nofpclass(nan ninf nzero nsub nnorm) float @ret_fmul_square_nnan_nzero
+; CHECK-SAME: (float noundef nofpclass(nan zero) [[ARG:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[FMUL:%.*]] = fmul float [[ARG]], [[ARG]]
 ; CHECK-NEXT:    ret float [[FMUL]]
 ;

--- a/llvm/test/Transforms/Attributor/nofpclass.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass.ll
@@ -1854,10 +1854,10 @@ define i32 @fptosi(float nofpclass(inf nan) %arg) {
   ret i32 %add
 }
 
-define float @fptrunc(double nofpclass(inf nan) %arg) {
+define float @fptrunc(double noundef nofpclass(inf nan) %arg) {
 ; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) float @fptrunc
-; CHECK-SAME: (double nofpclass(nan inf) [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero nsub nnorm) float @fptrunc
+; CHECK-SAME: (double noundef nofpclass(nan inf) [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[CAST:%.*]] = fptrunc double [[ARG]] to float
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[CAST]], [[CAST]]
 ; CHECK-NEXT:    ret float [[MUL]]
@@ -1867,10 +1867,10 @@ define float @fptrunc(double nofpclass(inf nan) %arg) {
   ret float %mul
 }
 
-define double @fpext(float nofpclass(inf nan) %arg) {
+define double @fpext(float noundef nofpclass(inf nan) %arg) {
 ; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(none)
-; CHECK-LABEL: define nofpclass(nan ninf nzero nsub nnorm) double @fpext
-; CHECK-SAME: (float nofpclass(nan inf) [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-LABEL: define noundef nofpclass(nan ninf nzero nsub nnorm) double @fpext
+; CHECK-SAME: (float noundef nofpclass(nan inf) [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[CAST:%.*]] = fpext float [[ARG]] to double
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul double [[CAST]], [[CAST]]
 ; CHECK-NEXT:    ret double [[MUL]]
@@ -1891,32 +1891,32 @@ define float @atomicrmw_fadd(ptr %ptr, float nofpclass(inf nan) %val) {
   ret float %result
 }
 
-define float @load(ptr %ptr, float nofpclass(nan inf) %val) {
+define float @load(ptr %ptr, float noundef nofpclass(nan inf) %val) {
 ; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: readwrite)
-; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) float @load
-; CHECK-SAME: (ptr nofree noundef nonnull align 4 captures(none) dereferenceable(4) [[PTR:%.*]], float nofpclass(nan inf) [[VAL:%.*]]) #[[ATTR7:[0-9]+]] {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero nsub nnorm) float @load
+; CHECK-SAME: (ptr nofree noundef nonnull align 4 captures(none) dereferenceable(4) [[PTR:%.*]], float noundef nofpclass(nan inf) [[VAL:%.*]]) #[[ATTR7:[0-9]+]] {
 ; CHECK-NEXT:    store float [[VAL]], ptr [[PTR]], align 4
-; CHECK-NEXT:    [[LOAD:%.*]] = load float, ptr [[PTR]], align 4
+; CHECK-NEXT:    [[LOAD:%.*]] = load float, ptr [[PTR]], align 4, !noundef [[META0:![0-9]+]]
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[LOAD]], [[LOAD]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   store float %val, ptr %ptr
-  %load = load float, ptr %ptr
+  %load = load float, ptr %ptr, !noundef !0
   %mul = fmul float %load, %load
   ret float %mul
 }
 
-define float @load_atomic(ptr %ptr, float nofpclass(nan inf) %val) {
+define float @load_atomic(ptr %ptr, float noundef nofpclass(nan inf) %val) {
 ; CHECK: Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(argmem: readwrite)
-; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) float @load_atomic
-; CHECK-SAME: (ptr nofree noundef nonnull align 4 captures(none) dereferenceable(4) [[PTR:%.*]], float nofpclass(nan inf) [[VAL:%.*]]) #[[ATTR6]] {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero nsub nnorm) float @load_atomic
+; CHECK-SAME: (ptr nofree noundef nonnull align 4 captures(none) dereferenceable(4) [[PTR:%.*]], float noundef nofpclass(nan inf) [[VAL:%.*]]) #[[ATTR6]] {
 ; CHECK-NEXT:    store atomic float [[VAL]], ptr [[PTR]] seq_cst, align 4
-; CHECK-NEXT:    [[LOAD:%.*]] = load atomic float, ptr [[PTR]] seq_cst, align 4
+; CHECK-NEXT:    [[LOAD:%.*]] = load atomic float, ptr [[PTR]] seq_cst, align 4, !noundef [[META0]]
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[LOAD]], [[LOAD]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   store atomic float %val, ptr %ptr seq_cst, align 4
-  %load = load atomic float, ptr %ptr seq_cst, align 4
+  %load = load atomic float, ptr %ptr seq_cst, align 4, !noundef !0
   %mul = fmul float %load, %load
   ret float %mul
 }
@@ -2482,7 +2482,7 @@ define internal float @through_memory0(ptr %ptr.arg) {
 ; CGSCC-SAME: (float [[TMP0:%.*]]) #[[ATTR3]] {
 ; CGSCC-NEXT:    [[PTR_ARG_PRIV:%.*]] = alloca float, align 4
 ; CGSCC-NEXT:    store float [[TMP0]], ptr [[PTR_ARG_PRIV]], align 4
-; CGSCC-NEXT:    [[LOAD:%.*]] = load float, ptr [[PTR_ARG_PRIV]], align 4, !invariant.load [[META0:![0-9]+]]
+; CGSCC-NEXT:    [[LOAD:%.*]] = load float, ptr [[PTR_ARG_PRIV]], align 4, !invariant.load [[META0]]
 ; CGSCC-NEXT:    ret float [[LOAD]]
 ;
   %load = load float, ptr %ptr.arg
@@ -2521,7 +2521,7 @@ define internal float @through_memory2(ptr %ptr.arg) {
 ; CHECK-SAME: (float [[TMP0:%.*]]) #[[ATTR15:[0-9]+]] {
 ; CHECK-NEXT:    [[PTR_ARG_PRIV:%.*]] = alloca float, align 4
 ; CHECK-NEXT:    store float [[TMP0]], ptr [[PTR_ARG_PRIV]], align 4
-; CHECK-NEXT:    [[LOAD:%.*]] = load float, ptr [[PTR_ARG_PRIV]], align 4, !invariant.load [[META0:![0-9]+]]
+; CHECK-NEXT:    [[LOAD:%.*]] = load float, ptr [[PTR_ARG_PRIV]], align 4, !invariant.load [[META0]]
 ; CHECK-NEXT:    [[CALL:%.*]] = call float @extern.f32(float [[LOAD]])
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
@@ -3687,6 +3687,8 @@ attributes #6 = { "denormal-fp-math"="dynamic,dynamic" }
 attributes #7 = { "denormal-fp-math"="preserve-sign,ieee" }
 attributes #8 = { "denormal-fp-math"="dynamic,ieee" }
 attributes #9 = { "denormal-fp-math"="ieee,dynamic" }
+
+!0 = !{}
 
 ;; NOTE: These prefixes are unused and the list is autogenerated. Do not add tests below this line:
 ; CGSCC-CI: {{.*}}

--- a/llvm/test/Transforms/InstCombine/fabs.ll
+++ b/llvm/test/Transforms/InstCombine/fabs.ll
@@ -92,7 +92,7 @@ define fp128 @square_fabs_intrinsic_f128(fp128 %x) {
   ret fp128 %fabsl
 }
 
-define float @square_nnan_fabs_intrinsic_f32(float %x) {
+define float @square_nnan_fabs_intrinsic_f32(float noundef %x) {
 ; CHECK-LABEL: @square_nnan_fabs_intrinsic_f32(
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[X:%.*]], [[X]]
 ; CHECK-NEXT:    ret float [[MUL]]
@@ -191,7 +191,7 @@ define float @fabs_select_var_constant_negative(i32 %c, float %x) {
 
 ; The fabs cannot be eliminated because %x may be a NaN
 
-define float @square_fma_fabs_intrinsic_f32(float %x) {
+define float @square_fma_fabs_intrinsic_f32(float noundef %x) {
 ; CHECK-LABEL: @square_fma_fabs_intrinsic_f32(
 ; CHECK-NEXT:    [[FMA:%.*]] = call float @llvm.fma.f32(float [[X:%.*]], float [[X]], float 1.000000e+00)
 ; CHECK-NEXT:    [[FABSF:%.*]] = call float @llvm.fabs.f32(float [[FMA]])

--- a/llvm/test/Transforms/InstCombine/fast-math.ll
+++ b/llvm/test/Transforms/InstCombine/fast-math.ll
@@ -739,7 +739,7 @@ define double @sqrt_intrinsic_not_so_fast(double %x, double %y) {
   ret double %sqrt
 }
 
-define double @sqrt_intrinsic_arg_4th(double %x) {
+define double @sqrt_intrinsic_arg_4th(double noundef %x) {
 ; CHECK-LABEL: @sqrt_intrinsic_arg_4th(
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul fast double [[X:%.*]], [[X]]
 ; CHECK-NEXT:    ret double [[MUL]]
@@ -750,7 +750,7 @@ define double @sqrt_intrinsic_arg_4th(double %x) {
   ret double %sqrt
 }
 
-define double @sqrt_intrinsic_arg_5th(double %x) {
+define double @sqrt_intrinsic_arg_5th(double noundef %x) {
 ; CHECK-LABEL: @sqrt_intrinsic_arg_5th(
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul fast double [[X:%.*]], [[X]]
 ; CHECK-NEXT:    [[SQRT1:%.*]] = call fast double @llvm.sqrt.f64(double [[X]])

--- a/llvm/test/Transforms/InstSimplify/floating-point-compare.ll
+++ b/llvm/test/Transforms/InstSimplify/floating-point-compare.ll
@@ -205,7 +205,7 @@ define i1 @one_with_self(double %arg) {
 ; and between uge and olt, to give reasonble coverage
 ; without combinatorial explosion.
 
-define i1 @orderedLessZeroTree(float,float,float,float) {
+define i1 @orderedLessZeroTree(float noundef, float noundef, float noundef, float noundef) {
 ; CHECK-LABEL: @orderedLessZeroTree(
 ; CHECK-NEXT:    ret i1 true
 ;
@@ -260,7 +260,7 @@ define i1 @orderedLessZeroExp2Trunc(double) {
   ret i1 %olt
 }
 
-define i1 @orderedLessZeroPowi(double,double) {
+define i1 @orderedLessZeroPowi(double noundef, double noundef) {
 ; CHECK-LABEL: @orderedLessZeroPowi(
 ; CHECK-NEXT:    ret i1 false
 ;
@@ -1613,7 +1613,7 @@ entry:
 }
 
 ; Make sure we recognize fcmp < 0 is recognized as impossible here when simplifying the fcmp
-define float @fast_square_must_be_positive_ieee(float %arg, float %arg1) {
+define float @fast_square_must_be_positive_ieee(float noundef %arg, float noundef %arg1) {
 ; CHECK-LABEL: @fast_square_must_be_positive_ieee(
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I:%.*]] = fmul float [[ARG:%.*]], [[ARG]]
@@ -1631,7 +1631,7 @@ bb:
 }
 
 ; Make sure we recognize fcmp < 0 is recognized as impossible here when simplifying the fcmp
-define float @fast_square_must_be_positive_ieee_nnan(float %arg, float %arg1) {
+define float @fast_square_must_be_positive_ieee_nnan(float noundef %arg, float noundef %arg1) {
 ; CHECK-LABEL: @fast_square_must_be_positive_ieee_nnan(
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I:%.*]] = fmul float [[ARG:%.*]], [[ARG]]
@@ -1649,7 +1649,7 @@ bb:
 }
 
 ; Make sure we recognize fcmp < 0 is recognized as impossible here when simplifying the fcmp
-define float @fast_square_must_be_positive_daz(float %arg, float %arg1) #0 {
+define float @fast_square_must_be_positive_daz(float noundef %arg, float noundef %arg1) #0 {
 ; CHECK-LABEL: @fast_square_must_be_positive_daz(
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I:%.*]] = fmul float [[ARG:%.*]], [[ARG]]
@@ -1667,7 +1667,7 @@ bb:
 }
 
 ; Make sure we recognize fcmp < 0 is recognized as impossible here when simplifying the fcmp
-define float @fast_square_must_be_positive_daz_nnan(float %arg, float %arg1) #0 {
+define float @fast_square_must_be_positive_daz_nnan(float noundef %arg, float noundef %arg1) #0 {
 ; CHECK-LABEL: @fast_square_must_be_positive_daz_nnan(
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I:%.*]] = fmul float [[ARG:%.*]], [[ARG]]
@@ -1685,7 +1685,7 @@ bb:
 }
 
 ; Make the compare to negative constant is folded out
-define float @must_be_olt_negative_constant_daz(float %arg, float %arg1) #0 {
+define float @must_be_olt_negative_constant_daz(float noundef %arg, float noundef %arg1) #0 {
 ; CHECK-LABEL: @must_be_olt_negative_constant_daz(
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I:%.*]] = fmul float [[ARG:%.*]], [[ARG]]
@@ -1703,7 +1703,7 @@ bb:
 }
 
 ; Make the compare to negative constant is folded out
-define float @must_be_olt_negative_constant_daz_nnan(float %arg, float %arg1) #0 {
+define float @must_be_olt_negative_constant_daz_nnan(float noundef %arg, float noundef %arg1) #0 {
 ; CHECK-LABEL: @must_be_olt_negative_constant_daz_nnan(
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    [[I:%.*]] = fmul float [[ARG:%.*]], [[ARG]]

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -1655,7 +1655,7 @@ TEST_F(ComputeKnownFPClassTest, FSub) {
 
 TEST_F(ComputeKnownFPClassTest, FMul) {
   parseAssembly(
-      "define float @test(float nofpclass(nan inf) %nnan.ninf0, float nofpclass(nan inf) %nnan.ninf1, float nofpclass(nan) %nnan, float nofpclass(qnan) %no.qnan, float %unknown) {\n"
+      "define float @test(float noundef nofpclass(nan inf) %nnan.ninf0, float noundef nofpclass(nan inf) %nnan.ninf1, float noundef nofpclass(nan) %nnan, float noundef nofpclass(qnan) %no.qnan, float noundef %unknown) {\n"
       "  %A = fmul float %nnan.ninf0, %nnan.ninf1"
       "  %A2 = fmul float %nnan.ninf0, %nnan"
       "  %A3 = fmul float %nnan, %nnan.ninf0"
@@ -1672,7 +1672,7 @@ TEST_F(ComputeKnownFPClassTest, FMul) {
 
 TEST_F(ComputeKnownFPClassTest, FMulNoZero) {
   parseAssembly(
-      "define float @test(float nofpclass(zero) %no.zero, float nofpclass(zero nan) %no.zero.nan0, float nofpclass(zero nan) %no.zero.nan1, float nofpclass(nzero nan) %no.negzero.nan, float nofpclass(pzero nan) %no.poszero.nan, float nofpclass(inf nan) %no.inf.nan, float nofpclass(inf) %no.inf, float nofpclass(nan) %no.nan) {\n"
+      "define float @test(float noundef nofpclass(zero) %no.zero, float noundef nofpclass(zero nan) %no.zero.nan0, float noundef nofpclass(zero nan) %no.zero.nan1, float noundef nofpclass(nzero nan) %no.negzero.nan, float noundef nofpclass(pzero nan) %no.poszero.nan, float noundef nofpclass(inf nan) %no.inf.nan, float noundef nofpclass(inf) %no.inf, float noundef nofpclass(nan) %no.nan) {\n"
       "  %A = fmul float %no.zero.nan0, %no.zero.nan1"
       "  %A2 = fmul float %no.zero, %no.zero"
       "  %A3 = fmul float %no.poszero.nan, %no.zero.nan0"


### PR DESCRIPTION
In the special case for the same value for both operands,
ensure the value isn't undef.