### PR TITLE
[UEFI] Codeview do not crash when no llvm.dbg.cu

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -591,10 +591,10 @@ bool AsmPrinter::doInitialization(Module &M) {
 
   if (MAI->doesSupportDebugInformation()) {
     bool EmitCodeView = M.getCodeViewFlag();
-    // On Windows targets, emit minimal CodeView compiler info even when debug
-    // info is disabled.
-    if ((Target.isOSWindows() && M.getNamedMetadata("llvm.dbg.cu")) ||
-        (Target.isUEFI() && EmitCodeView))
+    // On Windows and UEFI targets, emit minimal CodeView compiler info even
+    // when debug info is disabled.
+    if (EmitCodeView || ((Target.isOSWindows() || Target.isUEFI()) &&
+                         M.getNamedMetadata("llvm.dbg.cu")))
       Handlers.push_back(std::make_unique<CodeViewDebug>(this));
     if (!EmitCodeView || M.getDwarfVersion()) {
       if (hasDebugInfo()) {

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -591,10 +591,10 @@ bool AsmPrinter::doInitialization(Module &M) {
 
   if (MAI->doesSupportDebugInformation()) {
     bool EmitCodeView = M.getCodeViewFlag();
-    // On Windows and UEFI targets, emit minimal CodeView compiler info even
-    // when debug info is disabled.
-    if (EmitCodeView || ((Target.isOSWindows() || Target.isUEFI()) &&
-                         M.getNamedMetadata("llvm.dbg.cu")))
+    // On Windows targets, emit minimal CodeView compiler info even when debug
+    // info is disabled.
+    if ((Target.isOSWindows() && M.getNamedMetadata("llvm.dbg.cu")) ||
+        (Target.isUEFI() && EmitCodeView && M.getNamedMetadata("llvm.dbg.cu")))
       Handlers.push_back(std::make_unique<CodeViewDebug>(this));
     if (!EmitCodeView || M.getDwarfVersion()) {
       if (hasDebugInfo()) {

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -593,8 +593,8 @@ bool AsmPrinter::doInitialization(Module &M) {
     bool EmitCodeView = M.getCodeViewFlag();
     // On Windows targets, emit minimal CodeView compiler info even when debug
     // info is disabled.
-    if ((Target.isOSWindows() && M.getNamedMetadata("llvm.dbg.cu")) ||
-        (Target.isUEFI() && EmitCodeView && M.getNamedMetadata("llvm.dbg.cu")))
+    if ((Target.isOSWindows() || (Target.isUEFI() && EmitCodeView)) &&
+        M.getNamedMetadata("llvm.dbg.cu"))
       Handlers.push_back(std::make_unique<CodeViewDebug>(this));
     if (!EmitCodeView || M.getDwarfVersion()) {
       if (hasDebugInfo()) {

--- a/llvm/test/DebugInfo/X86/codeview-empty-dbg-cu-crash.ll
+++ b/llvm/test/DebugInfo/X86/codeview-empty-dbg-cu-crash.ll
@@ -1,5 +1,4 @@
 ; RUN: llc -mtriple=x86_64-pc-windows-msvc < %s | FileCheck %s
-; RUN: llc -mtriple=x86_64-unknown-uefi < %s | FileCheck %s
 
 ; CHECK: .file	"<stdin>"
 ; CHECK-NEXT: .section	.debug$S,"dr"

--- a/llvm/test/DebugInfo/X86/codeview-empty-dbg-cu-crash.ll
+++ b/llvm/test/DebugInfo/X86/codeview-empty-dbg-cu-crash.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -mtriple=x86_64-pc-windows-msvc < %s | FileCheck %s
+; RUN: llc -mtriple=x86_64-unknown-uefi < %s | FileCheck %s
 
 ; CHECK: .file	"<stdin>"
 ; CHECK-NEXT: .section	.debug$S,"dr"

--- a/llvm/test/DebugInfo/X86/uefi-no-codeview-crash.ll
+++ b/llvm/test/DebugInfo/X86/uefi-no-codeview-crash.ll
@@ -1,0 +1,15 @@
+;; This test ensures that the backend does not crash when CodeView is enabled
+;; through module flags but llvm.dbg.cu is missing.
+
+; RUN: llc < %s -mtriple=x86_64-unknown-uefi | FileCheck %s
+
+define void @foo() {
+entry:
+  ret void
+}
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 2, !"CodeView", i32 1}
+
+; CHECK-LABEL: foo:
+; CHECK: retq


### PR DESCRIPTION
PR #142970 Added for Windows targets to emit minimal codeview metadata even when debug info is disabled. This crashes the backend for UEFI x86_64-uefi triple as llvm.dbg.cu is expected unconditionally there. Handling it correctly in AsmPrinter and adding a regression test.
