### PR TITLE
[lldb-dap] add timeout to spawn_and_wait test utility

### DIFF
--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -2,6 +2,7 @@
 Test lldb-dap attach request
 """
 
+from datetime import datetime, timedelta
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
@@ -25,10 +26,15 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         )
 
     def spawn_and_wait(self, program, delay):
+        SPAWN_AND_WAIT_TIMEOUT = 900
         time.sleep(delay)
         proc = self.spawn(program=program)
-        # Wait for either the process to exit or the event to be set
+        start_time = datetime.now()
+        # Wait for either the process to exit or the event to be set.
         while proc.poll() is None and not self.spawn_event.is_set():
+            elapsed = datetime.now() - start_time
+            if elapsed >= timedelta(seconds=SPAWN_AND_WAIT_TIMEOUT):
+                break
             time.sleep(0.1)
         proc.kill()
         proc.wait()

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -2,7 +2,6 @@
 Test lldb-dap attach request
 """
 
-from datetime import datetime, timedelta
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
@@ -26,14 +25,14 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         )
 
     def spawn_and_wait(self, program, delay):
-        SPAWN_AND_WAIT_TIMEOUT = 900
+        SPAWN_AND_WAIT_TIMEOUT_SECONDS = 900.0
         time.sleep(delay)
         proc = self.spawn(program=program)
-        start_time = datetime.now()
+        start_time = time.time()
         # Wait for either the process to exit or the event to be set.
         while proc.poll() is None and not self.spawn_event.is_set():
-            elapsed = datetime.now() - start_time
-            if elapsed >= timedelta(seconds=SPAWN_AND_WAIT_TIMEOUT):
+            elapsed = time.time() - start_time
+            if elapsed >= SPAWN_AND_WAIT_TIMEOUT_SECONDS:
                 break
             time.sleep(0.1)
         proc.kill()

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -25,14 +25,13 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         )
 
     def spawn_and_wait(self, program, delay):
-        SPAWN_AND_WAIT_TIMEOUT_SECONDS = 900.0
         time.sleep(delay)
         proc = self.spawn(program=program)
         start_time = time.time()
         # Wait for either the process to exit or the event to be set.
         while proc.poll() is None and not self.spawn_event.is_set():
             elapsed = time.time() - start_time
-            if elapsed >= SPAWN_AND_WAIT_TIMEOUT_SECONDS:
+            if elapsed >= self.DEFAULT_TIMEOUT:
                 break
             time.sleep(0.1)
         proc.kill()


### PR DESCRIPTION
This is a follow up to https://github.com/llvm/llvm-project/pull/172879.

This patch adds a timeout to the `TestDAP_attach.spawn_and_wait` method. The helper method was previously relying on the per test lit timeout, which does not work if `psutil` is not installed. The timeout is now enforced whether or not `psutil` is installed.

