### PR TITLE
[MLIR] Use correct namespace for registering MLIR dialects

### DIFF
--- a/mlir/lib/Bindings/Python/DialectLLVM.cpp
+++ b/mlir/lib/Bindings/Python/DialectLLVM.cpp
@@ -212,5 +212,5 @@ static void populateDialectLLVMSubmodule(nanobind::module_ &m) {
 NB_MODULE(_mlirDialectsLLVM, m) {
   m.doc() = "MLIR LLVM Dialect";
 
-  python::mlir::llvm::populateDialectLLVMSubmodule(m);
+  mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::llvm::populateDialectLLVMSubmodule(m);
 }

--- a/mlir/lib/Bindings/Python/DialectLLVM.cpp
+++ b/mlir/lib/Bindings/Python/DialectLLVM.cpp
@@ -212,5 +212,6 @@ static void populateDialectLLVMSubmodule(nanobind::module_ &m) {
 NB_MODULE(_mlirDialectsLLVM, m) {
   m.doc() = "MLIR LLVM Dialect";
 
-  mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::llvm::populateDialectLLVMSubmodule(m);
+  mlir::python::MLIR_BINDINGS_PYTHON_DOMAIN::llvm::populateDialectLLVMSubmodule(
+      m);
 }


### PR DESCRIPTION
This seems to match how everything else was updated in the commit. This was failing in the bazel build, and possibly elsewhere.

Fixes https://github.com/llvm/llvm-project/commit/ee3338d135adc183fbd2fc7dc28af6a34bdaa60a.