### PR TITLE
[NFC][Hexagon] Fix unused variable warning

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
@@ -2842,7 +2842,8 @@ HvxIdioms::getAlignmentImpl(Instruction &In, Value *ptr,
 }
 
 Value *HvxIdioms::processMStore(Instruction &In) const {
-  auto *InpTy = dyn_cast<VectorType>(In.getOperand(0)->getType());
+  [[maybe_unused]] auto *InpTy =
+      dyn_cast<VectorType>(In.getOperand(0)->getType());
   assert(InpTy && "Cannot handle no vector type for llvm.masked.store");
 
   LLVM_DEBUG(dbgs() << "\n[Process mstore](" << In << ")\n"
@@ -2877,7 +2878,7 @@ Value *HvxIdioms::processMStore(Instruction &In) const {
 }
 
 Value *HvxIdioms::processMLoad(Instruction &In) const {
-  auto *InpTy = dyn_cast<VectorType>(In.getType());
+  [[maybe_unused]] auto *InpTy = dyn_cast<VectorType>(In.getType());
   assert(InpTy && "Cannot handle non vector type for llvm.masked.store");
   LLVM_DEBUG(dbgs() << "\n[Process mload](" << In << ")\n"
                     << *In.getParent() << "\n");


### PR DESCRIPTION
8f5b067dc321b977353b2342aa8fcfbbbd09d04b introduced this. The variable is not used in non-asserts configurations, which throws a compiler warning.