### PR TITLE
[flang][acc] Introduce interface for rematerializable ops

### DIFF
--- a/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.h
+++ b/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.h
@@ -18,7 +18,11 @@
 namespace fir {
 class AddrOfOp;
 class DeclareOp;
+class FieldIndexOp;
 class GlobalOp;
+class ShapeOp;
+class ShapeShiftOp;
+class ShiftOp;
 } // namespace fir
 
 namespace hlfir {
@@ -76,6 +80,15 @@ struct IndirectGlobalAccessModel
                             llvm::SmallVectorImpl<mlir::SymbolRefAttr> &symbols,
                             mlir::SymbolTable *symbolTable) const;
 };
+
+/// External model for OutlineRematerializationOpInterface.
+/// This interface marks operations that are candidates for rematerialization
+/// during outlining. These operations produce synthetic types or values
+/// that cannot be passed as arguments to outlined regions.
+template <typename Op>
+struct OutlineRematerializationModel
+    : public mlir::acc::OutlineRematerializationOpInterface::ExternalModel<
+          OutlineRematerializationModel<Op>, Op> {};
 
 } // namespace fir::acc
 

--- a/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.h
+++ b/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCOpsInterfaces.h
@@ -18,11 +18,7 @@
 namespace fir {
 class AddrOfOp;
 class DeclareOp;
-class FieldIndexOp;
 class GlobalOp;
-class ShapeOp;
-class ShapeShiftOp;
-class ShiftOp;
 } // namespace fir
 
 namespace hlfir {

--- a/flang/lib/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.cpp
@@ -65,12 +65,12 @@ void registerOpenACCExtensions(mlir::DialectRegistry &registry) {
     // Attach OutlineRematerializationOpInterface to FIR operations that
     // produce synthetic types (shapes, field indices) which cannot be passed
     // as arguments to outlined regions and must be rematerialized inside.
-    fir::ShapeOp::attachInterface<
-        OutlineRematerializationModel<fir::ShapeOp>>(*ctx);
+    fir::ShapeOp::attachInterface<OutlineRematerializationModel<fir::ShapeOp>>(
+        *ctx);
     fir::ShapeShiftOp::attachInterface<
         OutlineRematerializationModel<fir::ShapeShiftOp>>(*ctx);
-    fir::ShiftOp::attachInterface<
-        OutlineRematerializationModel<fir::ShiftOp>>(*ctx);
+    fir::ShiftOp::attachInterface<OutlineRematerializationModel<fir::ShiftOp>>(
+        *ctx);
     fir::FieldIndexOp::attachInterface<
         OutlineRematerializationModel<fir::FieldIndexOp>>(*ctx);
   });

--- a/flang/lib/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/RegisterOpenACCExtensions.cpp
@@ -61,6 +61,18 @@ void registerOpenACCExtensions(mlir::DialectRegistry &registry) {
         *ctx);
     fir::TypeDescOp::attachInterface<
         IndirectGlobalAccessModel<fir::TypeDescOp>>(*ctx);
+
+    // Attach OutlineRematerializationOpInterface to FIR operations that
+    // produce synthetic types (shapes, field indices) which cannot be passed
+    // as arguments to outlined regions and must be rematerialized inside.
+    fir::ShapeOp::attachInterface<
+        OutlineRematerializationModel<fir::ShapeOp>>(*ctx);
+    fir::ShapeShiftOp::attachInterface<
+        OutlineRematerializationModel<fir::ShapeShiftOp>>(*ctx);
+    fir::ShiftOp::attachInterface<
+        OutlineRematerializationModel<fir::ShiftOp>>(*ctx);
+    fir::FieldIndexOp::attachInterface<
+        OutlineRematerializationModel<fir::FieldIndexOp>>(*ctx);
   });
 
   // Register HLFIR operation interfaces

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCOps.td
@@ -471,7 +471,8 @@ def OpenACC_VarNameAttr : OpenACC_Attr<"VarName", "var_name"> {
 // Used for data specification in data clauses (2.7.1).
 // Either (or both) extent and upperbound must be specified.
 def OpenACC_DataBoundsOp : OpenACC_Op<"bounds",
-    [AttrSizedOperandSegments, NoMemoryEffect]> {
+    [AttrSizedOperandSegments, NoMemoryEffect,
+     OutlineRematerializationOpInterface]> {
   let summary = "Represents normalized bounds information for acc data clause.";
 
   let description = [{

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCOpsInterfaces.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCOpsInterfaces.td
@@ -10,6 +10,7 @@
 #define OPENACC_OPS_INTERFACES
 
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 def ComputeRegionOpInterface : OpInterface<"ComputeRegionOpInterface"> {
   let cppNamespace = "::mlir::acc";
@@ -112,6 +113,12 @@ def OutlineRematerializationOpInterface : OpInterface<"OutlineRematerializationO
     Operations implementing this interface are expected to be memory effect
     free. Their results are typically used for type construction or providing
     metadata (such as shape information for arrays).
+  }];
+
+  let verify = [{
+    if (!::mlir::isMemoryEffectFree($_op))
+      return $_op->emitOpError("must be memory effect free");
+    return ::mlir::success();
   }];
 }
 

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCOpsInterfaces.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCOpsInterfaces.td
@@ -100,4 +100,19 @@ def IndirectGlobalAccessOpInterface : OpInterface<"IndirectGlobalAccessOpInterfa
   ];
 }
 
+def OutlineRematerializationOpInterface : OpInterface<"OutlineRematerializationOpInterface"> {
+  let cppNamespace = "::mlir::acc";
+
+  let description = [{
+    An interface for operations that are candidates for rematerialization
+    during outlining. These operations produce synthetic types or values
+    that cannot be passed as arguments to outlined regions and must be
+    rematerialized inside the region instead.
+
+    Operations implementing this interface are expected to be memory effect
+    free. Their results are typically used for type construction or providing
+    metadata (such as shape information for arrays).
+  }];
+}
+
 #endif // OPENACC_OPS_INTERFACES


### PR DESCRIPTION
During the outlining process when offloading acc regions, the body of the compute kernel is separated from its original location and live-in values are handled in various ways including becoming function arguments.

However, some operations are purely synthetic and only make sense when included with another operation (usually such operations exist to simplify IR design). Bounds and shapes are examples where during outlining they should be recreated inside to capture the full information.

Therefore, introduce a new operation interface named OutlineRematerializationOpInterface meant to be attached to such operations. It is currently expected that all such operations are memory effect free to ensure there are no considerations needed when moving or cloning them into outlined regions.

The interface is attached to the following operations:
- acc.bounds (directly in TableGen)
- fir.shape (via external model)
- fir.shape_shift (via external model)
- fir.shift (via external model)
- fir.field_index (via external model)

The pass that will use this interface and associated testing will follow in another pull request.