### PR TITLE
[SystemZ] Change default backend to ASCII

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1675,11 +1675,11 @@ void SystemZAsmPrinter::emitPPA2(Module &M) {
       IsASCII = false;
     else if (CharMode != "ascii")
       OutContext.reportError(
-        {}, "Only ascii or ebcdic are allowed for zos_le_char_mode");
+          {}, "Only ascii or ebcdic are allowed for zos_le_char_mode");
   }
   if (IsASCII)
     Flgs |= static_cast<uint8_t>(
-      PPA2Flags::CompiledUnitASCII); // Setting bit for ASCII char. mode.
+        PPA2Flags::CompiledUnitASCII); // Setting bit for ASCII char. mode.
 
   OutStreamer->emitInt8(Flgs);
   OutStreamer->emitInt8(0x00);    // Reserved.

--- a/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZAsmPrinter.cpp
@@ -1668,17 +1668,18 @@ void SystemZAsmPrinter::emitPPA2(Module &M) {
   uint8_t Flgs = static_cast<uint8_t>(PPA2Flags::CompileForBinaryFloatingPoint);
   Flgs |= static_cast<uint8_t>(PPA2Flags::CompiledWithXPLink);
 
+  bool IsASCII = true;
   if (auto *MD = M.getModuleFlag("zos_le_char_mode")) {
     const StringRef &CharMode = cast<MDString>(MD)->getString();
-    if (CharMode == "ascii") {
-      Flgs |= static_cast<uint8_t>(
-          PPA2Flags::CompiledUnitASCII); // Setting bit for ASCII char. mode.
-    } else if (CharMode != "ebcdic") {
-      report_fatal_error(
-          "Only ascii or ebcdic are valid values for zos_le_char_mode "
-          "metadata");
-    }
+    if (CharMode == "ebcdic")
+      IsASCII = false;
+    else if (CharMode != "ascii")
+      OutContext.reportError(
+        {}, "Only ascii or ebcdic are allowed for zos_le_char_mode");
   }
+  if (IsASCII)
+    Flgs |= static_cast<uint8_t>(
+      PPA2Flags::CompiledUnitASCII); // Setting bit for ASCII char. mode.
 
   OutStreamer->emitInt8(Flgs);
   OutStreamer->emitInt8(0x00);    // Reserved.

--- a/llvm/test/CodeGen/SystemZ/zos-hlasm-out.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-hlasm-out.ll
@@ -58,3 +58,6 @@ entry:
 }
 
 declare void @outs(ptr noundef, ...)
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"zos_le_char_mode", !"ebcdic"}

--- a/llvm/test/CodeGen/SystemZ/zos-ppa2.ll
+++ b/llvm/test/CodeGen/SystemZ/zos-ppa2.ll
@@ -1,4 +1,10 @@
-; RUN: llc -mtriple s390x-ibm-zos -mcpu=z15 -asm-verbose=true < %s | FileCheck %s
+; RUN: sed -e 's/!"MODE"/!"ascii"/' -e 's/BYTE/133/' %s > %t.ascii.ll
+; RUN: llc -mtriple s390x-ibm-zos -mcpu=z15 -asm-verbose=true < %t.ascii.ll | \
+; RUN: FileCheck %t.ascii.ll
+
+; RUN: sed -e 's/!"MODE"/!"ebcdic"/' -e 's/BYTE/129/' %s > %t.ebcdic.ll
+; RUN: llc -mtriple s390x-ibm-zos -mcpu=z15 -asm-verbose=true < %t.ebcdic.ll | \
+; RUN: FileCheck %t.ebcdic.ll
 
 ; CHECK: C_CODE64 CATTR
 ; CHECK: L#PPA2:
@@ -10,7 +16,7 @@
 ; CHECK:    .long   0
 ; CHECK:    .long   L#DVS-L#PPA2
 ; CHECK:    .long   0
-; CHECK:    .byte   129
+; CHECK:    .byte   BYTE
 ; CHECK:    .byte   0
 ; CHECK:    .short  0
 ; CHECK: L#DVS:
@@ -24,6 +30,10 @@
 ; CHECK:    .byte   3
 ; CHECK:    .short  30
 ; CHECK:    .ascii  "\323\323\345\324@@@@@@{{((\\3[0-7]{2}){4})}}\361\371\367\360\360\361\360\361\360\360\360\360\360\360\360\360"
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"zos_le_char_mode", !"MODE"}
+
 define void @void_test() {
 entry:
   ret void


### PR DESCRIPTION
The current (and default) backend on z/OS is EBCDIC.

This patch updates the default backend to be ASCII, which is beneficial when porting new languages. With this change, ASCII is the default when no special metadata nodes (such as `zos_le_char_mode`) are present.