### PR TITLE
[compiler-rt] fix crt target dependency.

### DIFF
--- a/compiler-rt/test/builtins/CMakeLists.txt
+++ b/compiler-rt/test/builtins/CMakeLists.txt
@@ -23,7 +23,7 @@ configure_lit_site_cfg(
 
 include(builtin-config-ix)
 
-if (COMPILER_RT_BUILD_CRT)
+if (COMPILER_RT_BUILD_CRT AND TARGET crt)
   list(APPEND BUILTINS_TEST_DEPS crt)
 endif()
 pythonize_bool(COMPILER_RT_BUILD_CRT)


### PR DESCRIPTION
This fixes cmake error from https://github.com/llvm/llvm-project/pull/171941 in chrome's llvm build where we have `COMPILER_RT_BUILD_BUILTINS=OFF` and have `COMPILER_RT_TEST_BUILTINS_DIR` set. That change makes it to depend on `crt` even if we don't have it in the prebuilt dir.

Log:
```
 CMake Error at CMakeLists.txt:349 (add_dependencies):
  The dependency target "crt" of target "runtimes-test-depends" does not
  exist.


CMake Error at /b/s/w/ir/cache/builder/src/third_party/llvm/llvm/cmake/modules/AddLLVM.cmake:2104 (add_dependencies):
  The dependency target "crt" of target "check-runtimes" does not exist.
Call Stack (most recent call first):
  /b/s/w/ir/cache/builder/src/third_party/llvm/llvm/cmake/modules/AddLLVM.cmake:2145 (add_lit_target)
  CMakeLists.txt:353 (umbrella_lit_testsuite_end)


CMake Error at /b/s/w/ir/cache/builder/src/third_party/llvm/compiler-rt/test/CMakeLists.txt:127 (add_dependencies):
  The dependency target "crt" of target "compiler-rt-test-depends" does not
  exist.


CMake Error at /b/s/w/ir/cache/builder/src/third_party/llvm/llvm/cmake/modules/AddLLVM.cmake:2104 (add_dependencies):
  The dependency target "crt" of target "check-compiler-rt" does not exist.
Call Stack (most recent call first):
  /b/s/w/ir/cache/builder/src/third_party/llvm/llvm/cmake/modules/AddLLVM.cmake:2145 (add_lit_target)
  /b/s/w/ir/cache/builder/src/third_party/llvm/compiler-rt/test/CMakeLists.txt:129 (umbrella_lit_testsuite_end)


CMake Error at /b/s/w/ir/cache/builder/src/third_party/llvm/llvm/cmake/modules/AddLLVM.cmake:2104 (add_dependencies):
  The dependency target "crt" of target "check-builtins" does not exist.
Call Stack (most recent call first):
  /b/s/w/ir/cache/builder/src/third_party/llvm/llvm/cmake/modules/AddLLVM.cmake:2171 (add_lit_target)
  /b/s/w/ir/cache/builder/src/third_party/llvm/compiler-rt/test/builtins/CMakeLists.txt:137 (add_lit_testsuite)
```