### PR TITLE
[bazel] Add comment about DEFAULT_TARGETS

### DIFF
--- a/utils/bazel/configure.bzl
+++ b/utils/bazel/configure.bzl
@@ -4,6 +4,7 @@
 
 """Helper macros to configure the LLVM overlay project."""
 
+# Should be kept in sync with LLVM_ALL_TARGETS in llvm/CMakeLists.txt
 DEFAULT_TARGETS = [
     "AArch64",
     "AMDGPU",


### PR DESCRIPTION
This should not include targets that aren't enabled in cmake.

6ccf97674b2deaa03e271725306b18a712a56113
