### PR TITLE
[TableGen] Return unknown type for RegClassByHwMode when NotRegister is set in getImplicitType.

### DIFF
--- a/llvm/test/TableGen/RegClassByHwMode.td
+++ b/llvm/test/TableGen/RegClassByHwMode.td
@@ -192,6 +192,7 @@ include "Common/RegClassByHwModeCommon.td"
 // ISEL-SDAG-NEXT: OPC_RecordMemRef,
 // ISEL-SDAG-NEXT: OPC_RecordNode, // #0 = 'st' chained node
 // ISEL-SDAG-NEXT: OPC_RecordChild1, // #1 = $val
+// ISEL-SDAG-NEXT: OPC_CheckChild1TypeI64,
 // ISEL-SDAG-NEXT: OPC_RecordChild2, // #2 = $src
 // ISEL-SDAG-NEXT: OPC_Scope, {{[0-9]+}}, /*->{{[0-9]+}}*/ // 2 children in Scope
 // ISEL-SDAG-NEXT: OPC_CheckChild2TypeI32,

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -2367,6 +2367,8 @@ static TypeSetByHwMode getImplicitType(const Record *R, unsigned ResNo,
   }
 
   if (R->isSubClassOf("RegClassByHwMode")) {
+    if (NotRegisters)
+      return TypeSetByHwMode(); // Unknown.
     const CodeGenTarget &T = CDP.getTargetInfo();
     return getTypeForRegClassByHwMode(T, R, TP.getRecord()->getLoc());
   }


### PR DESCRIPTION
This matches what is done for regular RegisterClass. This flag is used by DAGISelMatcherGen when it is deciding which type checks are needed.