### PR TITLE
[mlir][Python] use maybeDowncast for PyType/PyAttribute returns after #174156

### DIFF
--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -888,7 +888,7 @@ public:
   /// is taken by calling this function.
   static PyType createFromCapsule(nanobind::object capsule);
 
-  nanobind::object maybeDownCast();
+  nanobind::typed<nanobind::object, PyType> maybeDownCast();
 
 private:
   MlirType type;
@@ -1014,7 +1014,7 @@ public:
   /// is taken by calling this function.
   static PyAttribute createFromCapsule(const nanobind::object &capsule);
 
-  nanobind::object maybeDownCast();
+  nanobind::typed<nanobind::object, PyAttribute> maybeDownCast();
 
 private:
   MlirAttribute attr;
@@ -1171,7 +1171,7 @@ public:
   /// Gets a capsule wrapping the void* within the MlirValue.
   nanobind::object getCapsule();
 
-  nanobind::object maybeDownCast();
+  nanobind::typed<nanobind::object, PyValue> maybeDownCast();
 
   /// Creates a PyValue from the MlirValue wrapped by a capsule. Ownership of
   /// the underlying MlirValue is still tied to the owning operation.

--- a/mlir/lib/Bindings/Python/DialectGPU.cpp
+++ b/mlir/lib/Bindings/Python/DialectGPU.cpp
@@ -76,7 +76,8 @@ struct ObjectAttr : PyConcreteAttribute<ObjectAttr> {
         "Gets a gpu.object from parameters.");
 
     c.def_prop_ro("target", [](ObjectAttr &self) {
-      return PyAttribute(self.getContext(), mlirGPUObjectAttrGetTarget(self));
+      return PyAttribute(self.getContext(), mlirGPUObjectAttrGetTarget(self))
+          .maybeDownCast();
     });
     c.def_prop_ro("format", [](const ObjectAttr &self) {
       return mlirGPUObjectAttrGetFormat(self);
@@ -93,10 +94,12 @@ struct ObjectAttr : PyConcreteAttribute<ObjectAttr> {
           return std::nullopt;
         });
     c.def_prop_ro("kernels",
-                  [](ObjectAttr &self) -> std::optional<PyAttribute> {
+                  [](ObjectAttr &self)
+                      -> std::optional<nb::typed<nb::object, PyAttribute>> {
                     if (mlirGPUObjectAttrHasKernels(self))
                       return PyAttribute(self.getContext(),
-                                         mlirGPUObjectAttrGetKernels(self));
+                                         mlirGPUObjectAttrGetKernels(self))
+                          .maybeDownCast();
                     return std::nullopt;
                   });
   }

--- a/mlir/lib/Bindings/Python/DialectPDL.cpp
+++ b/mlir/lib/Bindings/Python/DialectPDL.cpp
@@ -102,8 +102,8 @@ struct RangeType : PyConcreteType<RangeType> {
     c.def_prop_ro(
         "element_type",
         [](RangeType &type) {
-          return PyType(type.getContext(),
-                        mlirPDLRangeTypeGetElementType(type));
+          return PyType(type.getContext(), mlirPDLRangeTypeGetElementType(type))
+              .maybeDownCast();
         },
         "Get the element type.");
   }

--- a/mlir/lib/Bindings/Python/DialectQuant.cpp
+++ b/mlir/lib/Bindings/Python/DialectQuant.cpp
@@ -58,7 +58,8 @@ struct QuantizedType : PyConcreteType<QuantizedType> {
         "expressed_type",
         [](QuantizedType &type) {
           return PyType(type.getContext(),
-                        mlirQuantizedTypeGetExpressedType(type));
+                        mlirQuantizedTypeGetExpressedType(type))
+              .maybeDownCast();
         },
         "Type expressed by this quantized type.");
     c.def_prop_ro(
@@ -78,7 +79,8 @@ struct QuantizedType : PyConcreteType<QuantizedType> {
         "storage_type",
         [](QuantizedType &type) {
           return PyType(type.getContext(),
-                        mlirQuantizedTypeGetStorageType(type));
+                        mlirQuantizedTypeGetStorageType(type))
+              .maybeDownCast();
         },
         "Storage type backing this quantized type.");
     c.def_prop_ro(
@@ -111,7 +113,8 @@ struct QuantizedType : PyConcreteType<QuantizedType> {
         "quantized_element_type",
         [](QuantizedType &type) {
           return PyType(type.getContext(),
-                        mlirQuantizedTypeGetQuantizedElementType(type));
+                        mlirQuantizedTypeGetQuantizedElementType(type))
+              .maybeDownCast();
         },
         "Element type of this quantized type expressed as quantized type.");
     c.def(
@@ -131,10 +134,10 @@ struct QuantizedType : PyConcreteType<QuantizedType> {
         nb::arg("candidate"));
     c.def_static(
         "cast_to_storage_type",
-        [](QuantizedType &type) {
+        [](PyType &type) {
           MlirType castResult = mlirQuantizedTypeCastToStorageType(type);
           if (!mlirTypeIsNull(castResult))
-            return PyType(type.getContext(), castResult);
+            return PyType(type.getContext(), castResult).maybeDownCast();
           throw nb::type_error("Invalid cast.");
         },
         "Casts from a type based on a quantized type to a corresponding type "
@@ -147,7 +150,7 @@ struct QuantizedType : PyConcreteType<QuantizedType> {
           MlirType castResult =
               mlirQuantizedTypeCastFromExpressedType(type, candidate);
           if (!mlirTypeIsNull(castResult))
-            return PyType(type.getContext(), castResult);
+            return PyType(type.getContext(), castResult).maybeDownCast();
           throw nb::type_error("Invalid cast.");
         },
         "Casts from a type based on the expressed type of this quantized type "
@@ -157,10 +160,10 @@ struct QuantizedType : PyConcreteType<QuantizedType> {
         nb::arg("candidate"));
     c.def_static(
         "cast_to_expressed_type",
-        [](QuantizedType &type) {
+        [](PyType &type) {
           MlirType castResult = mlirQuantizedTypeCastToExpressedType(type);
           if (!mlirTypeIsNull(castResult))
-            return PyType(type.getContext(), castResult);
+            return PyType(type.getContext(), castResult).maybeDownCast();
           throw nb::type_error("Invalid cast.");
         },
         "Casts from a type based on a quantized type to a corresponding type "
@@ -174,7 +177,7 @@ struct QuantizedType : PyConcreteType<QuantizedType> {
           MlirType castResult =
               mlirQuantizedTypeCastExpressedToStorageType(type, candidate);
           if (!mlirTypeIsNull(castResult))
-            return PyType(type.getContext(), castResult);
+            return PyType(type.getContext(), castResult).maybeDownCast();
           throw nb::type_error("Invalid cast.");
         },
         "Casts from a type based on the expressed type of this quantized type "

--- a/mlir/lib/Bindings/Python/DialectSparseTensor.cpp
+++ b/mlir/lib/Bindings/Python/DialectSparseTensor.cpp
@@ -121,21 +121,25 @@ struct EncodingAttr : PyConcreteAttribute<EncodingAttr> {
     c.def_prop_ro("pos_width", mlirSparseTensorEncodingAttrGetPosWidth);
     c.def_prop_ro("crd_width", mlirSparseTensorEncodingAttrGetCrdWidth);
 
-    c.def_prop_ro(
-        "explicit_val", [](EncodingAttr &self) -> std::optional<PyAttribute> {
-          MlirAttribute ret = mlirSparseTensorEncodingAttrGetExplicitVal(self);
-          if (mlirAttributeIsNull(ret))
-            return {};
-          return PyAttribute(self.getContext(), ret);
-        });
+    c.def_prop_ro("explicit_val",
+                  [](EncodingAttr &self)
+                      -> std::optional<nb::typed<nb::object, PyAttribute>> {
+                    MlirAttribute ret =
+                        mlirSparseTensorEncodingAttrGetExplicitVal(self);
+                    if (mlirAttributeIsNull(ret))
+                      return {};
+                    return PyAttribute(self.getContext(), ret).maybeDownCast();
+                  });
 
-    c.def_prop_ro(
-        "implicit_val", [](EncodingAttr &self) -> std::optional<PyAttribute> {
-          MlirAttribute ret = mlirSparseTensorEncodingAttrGetImplicitVal(self);
-          if (mlirAttributeIsNull(ret))
-            return {};
-          return PyAttribute(self.getContext(), ret);
-        });
+    c.def_prop_ro("implicit_val",
+                  [](EncodingAttr &self)
+                      -> std::optional<nb::typed<nb::object, PyAttribute>> {
+                    MlirAttribute ret =
+                        mlirSparseTensorEncodingAttrGetImplicitVal(self);
+                    if (mlirAttributeIsNull(ret))
+                      return {};
+                    return PyAttribute(self.getContext(), ret).maybeDownCast();
+                  });
 
     c.def_prop_ro("structured_n", [](const EncodingAttr &self) -> unsigned {
       const int lvlRank = mlirSparseTensorEncodingGetLvlRank(self);

--- a/mlir/lib/Bindings/Python/DialectTransform.cpp
+++ b/mlir/lib/Bindings/Python/DialectTransform.cpp
@@ -150,7 +150,8 @@ struct ParamType : PyConcreteType<ParamType> {
     c.def_prop_ro(
         "type",
         [](ParamType type) {
-          return PyType(type.getContext(), mlirTransformParamTypeGetType(type));
+          return PyType(type.getContext(), mlirTransformParamTypeGetType(type))
+              .maybeDownCast();
         },
         "Get the type this ParamType is associated with.");
   }

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -1917,7 +1917,7 @@ PyAttribute PyAttribute::createFromCapsule(const nb::object &capsule) {
       PyMlirContext::forContext(mlirAttributeGetContext(rawAttr)), rawAttr);
 }
 
-nb::object PyAttribute::maybeDownCast() {
+nb::typed<nb::object, PyAttribute> PyAttribute::maybeDownCast() {
   MlirTypeID mlirTypeID = mlirAttributeGetTypeID(this->get());
   assert(!mlirTypeIDIsNull(mlirTypeID) &&
          "mlirTypeID was expected to be non-null.");
@@ -1963,7 +1963,7 @@ PyType PyType::createFromCapsule(nb::object capsule) {
                 rawType);
 }
 
-nb::object PyType::maybeDownCast() {
+nb::typed<nb::object, PyType> PyType::maybeDownCast() {
   MlirTypeID mlirTypeID = mlirTypeGetTypeID(this->get());
   assert(!mlirTypeIDIsNull(mlirTypeID) &&
          "mlirTypeID was expected to be non-null.");
@@ -2003,7 +2003,7 @@ nb::object PyValue::getCapsule() {
   return nb::steal<nb::object>(mlirPythonValueToCapsule(get()));
 }
 
-nb::object PyValue::maybeDownCast() {
+nb::typed<nb::object, PyValue> PyValue::maybeDownCast() {
   MlirType type = mlirValueGetType(get());
   MlirTypeID mlirTypeID = mlirTypeGetTypeID(type);
   assert(!mlirTypeIDIsNull(mlirTypeID) &&

--- a/mlir/test/python/dialects/quant.py
+++ b/mlir/test/python/dialects/quant.py
@@ -42,6 +42,11 @@ def test_type_hierarchy():
         assert not isinstance(sub_channel, quant.UniformQuantizedType)
         assert not isinstance(sub_channel, quant.UniformQuantizedPerAxisType)
 
+        generic_t = Type(uniform)
+        assert type(generic_t) is Type
+        r = quant.QuantizedType.cast_to_storage_type(generic_t)
+        assert isinstance(r, IntegerType)
+
 
 # CHECK-LABEL: TEST: test_any_quantized_type
 @run


### PR DESCRIPTION
#174156 made all gettors return `Py*` but skipped downcasting where possible. So restore it by calling `.maybeDowncast`.