### PR TITLE
[llvm] Bypass sandbox in `sys::fs::createTemporaryFile()`

### DIFF
--- a/llvm/lib/Support/Path.cpp
+++ b/llvm/lib/Support/Path.cpp
@@ -894,6 +894,10 @@ static std::error_code
 createTemporaryFile(const Twine &Model, int &ResultFD,
                     llvm::SmallVectorImpl<char> &ResultPath, FSEntity Type,
                     sys::fs::OpenFlags Flags = sys::fs::OF_None) {
+  // Any *temporary* file is assumed to be a compiler-internal output, not
+  // a formal one.
+  auto BypassSandbox = sys::sandbox::scopedDisable();
+
   SmallString<128> Storage;
   StringRef P = Model.toNullTerminatedStringRef(Storage);
   assert(P.find_first_of(separators(Style::native)) == StringRef::npos &&


### PR DESCRIPTION
Based on the name of the function, I think it's safe to assume `sys::fs::createTemporaryFile()` is not to be used for formal compiler outputs and should only be used for compiler-internal outputs (caches, debugging output, etc.). Thus, it should be fine to disable the IO sandbox and allow bypassing `vfs::OutputBackend` here.