### PR TITLE
Revert "[clang][test][darwin] disable lld-repro for macOS (#173425)"

### DIFF
--- a/clang/test/Driver/lld-repro.c
+++ b/clang/test/Driver/lld-repro.c
@@ -1,5 +1,5 @@
 // REQUIRES: lld
-// UNSUPPORTED: target={{.*-(ps4|ps5)}}, target={{.*}}-zos{{.*}}, target={{.*}}-macosx{{.*}}, target={{.*}}-darwin{{.*}}
+// UNSUPPORTED: target={{.*-(ps4|ps5)}}, target={{.*}}-zos{{.*}}
 
 // RUN: echo "-nostartfiles -nostdlib -fuse-ld=lld -gen-reproducer=error -fcrash-diagnostics-dir=%t" \
 // RUN:   | sed -e 's/\\/\\\\/g' > %t.rsp


### PR DESCRIPTION
Oddly this test has started working even though it was failing for me for months...

This reverts commit ec719db95b1c8e2a6d4ce68a220c86b69159bbd8.