### PR TITLE
[clang] Bypass sandbox in the rewriter

### DIFF
--- a/clang/lib/Rewrite/Rewriter.cpp
+++ b/clang/lib/Rewrite/Rewriter.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/IOSandbox.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <iterator>
@@ -320,6 +321,8 @@ bool Rewriter::overwriteChangedFiles() {
     OptionalFileEntryRef Entry = getSourceMgr().getFileEntryRefForID(I->first);
     llvm::SmallString<128> Path(Entry->getName());
     getSourceMgr().getFileManager().makeAbsolutePath(Path);
+    // FIXME(sandboxing): Remove this by adopting `llvm::vfs::OutputBackend`.
+    auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
     if (auto Error = llvm::writeToOutput(Path, [&](llvm::raw_ostream &OS) {
           I->second.write(OS);
           return llvm::Error::success();


### PR DESCRIPTION
Clang's rewriter currently violates the IO sandbox due to a call to `llvm::writeToOutput()`. Since the "blessed" `llvm::vfs::OutputBackend` isn't easily available in that particular spot, this PR instead disables the sandbox and leaves a FIXME behind.