### PR TITLE
[RISC-V][Mach-O] Print immediate operands in hexadecimal format.

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
@@ -362,7 +362,7 @@ void RISCVInstPrinter::printImmMachO(const MCInst *MI, unsigned OpNo,
 
   uint64_t Imm = Op.getImm();
   if (!STI.hasFeature(RISCV::Feature64Bit))
-    Imm = static_cast<uint32_t>(Imm);
+    Imm &= 0xffffffff;
   markup(O, Markup::Immediate) << formatHex(Imm);
 }
 

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.h
@@ -52,6 +52,8 @@ public:
                        const MCSubtargetInfo &STI, raw_ostream &O);
   void printVMaskReg(const MCInst *MI, unsigned OpNo,
                      const MCSubtargetInfo &STI, raw_ostream &O);
+  void printImmMachO(const MCInst *MI, unsigned OpNo,
+                     const MCSubtargetInfo &STI, raw_ostream &O);
   void printRegList(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,
                     raw_ostream &O);
   void printStackAdj(const MCInst *MI, unsigned OpNo,

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.h
@@ -52,8 +52,8 @@ public:
                        const MCSubtargetInfo &STI, raw_ostream &O);
   void printVMaskReg(const MCInst *MI, unsigned OpNo,
                      const MCSubtargetInfo &STI, raw_ostream &O);
-  void printImmMachO(const MCInst *MI, unsigned OpNo,
-                     const MCSubtargetInfo &STI, raw_ostream &O);
+  void printImm(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,
+                raw_ostream &O);
   void printRegList(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,
                     raw_ostream &O);
   void printStackAdj(const MCInst *MI, unsigned OpNo,

--- a/llvm/test/MC/RISCV/hex-imm-macho.s
+++ b/llvm/test/MC/RISCV/hex-imm-macho.s
@@ -1,0 +1,16 @@
+// RUN: llvm-mc -triple riscv32-apple-unknown-macho -mattr=+c --riscv-no-aliases %s | FileCheck %s
+
+// CHECK: andi a0, a0, 0x190
+// CHECK: ori a0, a0, 0x400
+// CHECK: xori a0, a0, 0xfffffff4
+andi a0, a0, 400
+ori a0, a0, 1024
+xori a0, a0, -12
+
+// CHECK: c.andi s0, 0x1f
+c.andi s0, 31
+
+// CHECK: auipc a0, 0x3e8
+// CHECK: lui a0, 0x2710
+auipc a0, 1000
+lui a0, 10000


### PR DESCRIPTION
This is done for logical operations and auipc/lui.

Patch based on code written by Tim Northover.