### PR TITLE
[offload][lit] Use '%not' instead of 'not' in requires.c

### DIFF
--- a/offload/test/offloading/requires.c
+++ b/offload/test/offloading/requires.c
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: %libomptarget-compile-generic -DREQ=1 && %libomptarget-run-generic 2>&1 | %fcheck-generic -check-prefix=GOOD
-// RUN: %libomptarget-compile-generic -DREQ=2 && not --crash %libomptarget-run-generic 2>&1 | %fcheck-generic -check-prefix=BAD
+// RUN: %libomptarget-compile-generic -DREQ=2 && %not --crash %libomptarget-run-generic 2>&1 | %fcheck-generic -check-prefix=BAD
 // clang-format on
 
 /*


### PR DESCRIPTION
Typo exposed by recent `not` behavior change, we need to make sure we're using the LLVM one.