### PR TITLE
[MC][CodeGen] Add --large-eh-encoding flag for x86_64 & Aarch64 ELF

### DIFF
--- a/llvm/include/llvm/MC/MCTargetOptions.h
+++ b/llvm/include/llvm/MC/MCTargetOptions.h
@@ -120,6 +120,12 @@ public:
   // Whether or not to use full register names on PowerPC.
   bool PPCUseFullRegisterNames : 1;
 
+  // Force 8-byte (sdata8) pointer encodings for ELF exception-handling.
+  // On x86_64 this affects the .eh_frame FDE CFI plus the personality, LSDA,
+  // and TType encodings; on AArch64/PPC64 only the FDE CFI encoding changes
+  // (personality/LSDA/TType already default to sdata8).
+  bool LargeEHEncoding = false;
+
   LLVM_ABI MCTargetOptions();
 
   /// getABIName - If this returns a non-empty string this represents the

--- a/llvm/include/llvm/MC/MCTargetOptions.h
+++ b/llvm/include/llvm/MC/MCTargetOptions.h
@@ -119,6 +119,11 @@ public:
   // Whether or not to use full register names on PowerPC.
   bool PPCUseFullRegisterNames : 1;
 
+  // Use 8-byte (sdata8) pointer encodings for all ELF EH sections
+  // (.eh_frame FDE, personality, LSDA, TType) to avoid relocation overflows
+  // in large binaries.
+  bool LargeEHEncoding = false;
+
   LLVM_ABI MCTargetOptions();
 
   /// getABIName - If this returns a non-empty string this represents the

--- a/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
+++ b/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
@@ -66,6 +66,8 @@ LLVM_ABI bool getX86Sse2Avx();
 
 LLVM_ABI RelocSectionSymType getRelocSectionSym();
 
+LLVM_ABI bool getLargeEHEncoding();
+
 LLVM_ABI StringRef getABIName();
 
 LLVM_ABI StringRef getAsSecureLogFile();

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -151,6 +151,8 @@ void TargetLoweringObjectFileELF::Initialize(MCContext &Ctx,
                         : dwarf::DW_EH_PE_absptr;
     break;
   case Triple::x86_64:
+    if (TgtM.Options.MCOptions.LargeEHEncoding)
+      CM = CodeModel::Large;
     if (isPositionIndependent()) {
       PersonalityEncoding = dwarf::DW_EH_PE_indirect | dwarf::DW_EH_PE_pcrel |
         ((CM == CodeModel::Small || CM == CodeModel::Medium)

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -369,7 +369,9 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T, bool Large) {
   case Triple::aarch64_be:
   case Triple::x86_64:
     FDECFIEncoding = dwarf::DW_EH_PE_pcrel |
-                     (Large ? dwarf::DW_EH_PE_sdata8 : dwarf::DW_EH_PE_sdata4);
+                     ((Large || Ctx->getTargetOptions().LargeEHEncoding)
+                          ? dwarf::DW_EH_PE_sdata8
+                          : dwarf::DW_EH_PE_sdata4);
     break;
   case Triple::bpfel:
   case Triple::bpfeb:

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -357,8 +357,12 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T, bool Large) {
   case Triple::aarch64:
   case Triple::aarch64_be:
   case Triple::x86_64:
+    // TODO: refactor after #180464 to avoid nullable MCTargetOptions
     FDECFIEncoding = dwarf::DW_EH_PE_pcrel |
-                     (Large ? dwarf::DW_EH_PE_sdata8 : dwarf::DW_EH_PE_sdata4);
+                     ((Large || (Ctx->getTargetOptions() &&
+                                Ctx->getTargetOptions()->LargeEHEncoding))
+                          ? dwarf::DW_EH_PE_sdata8
+                          : dwarf::DW_EH_PE_sdata4);
     break;
   case Triple::bpfel:
   case Triple::bpfeb:

--- a/llvm/lib/MC/MCTargetOptions.cpp
+++ b/llvm/lib/MC/MCTargetOptions.cpp
@@ -20,7 +20,7 @@ MCTargetOptions::MCTargetOptions()
       EmitDwarfUnwind(EmitDwarfUnwindType::Default),
       MCUseDwarfDirectory(DefaultDwarfDirectory),
       EmitCompactUnwindNonCanonical(false), EmitSFrameUnwind(false),
-      PPCUseFullRegisterNames(false) {}
+      PPCUseFullRegisterNames(false), LargeEHEncoding(false) {}
 
 StringRef MCTargetOptions::getABIName() const {
   return ABIName;

--- a/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
+++ b/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
@@ -60,6 +60,7 @@ MCOPT(bool, ImplicitMapSyms)
 MCOPT(bool, X86RelaxRelocations)
 MCOPT(bool, X86Sse2Avx)
 MCOPT(RelocSectionSymType, RelocSectionSym)
+MCOPT(bool, LargeEHEncoding)
 MCSTROPT(ABIName)
 MCSTROPT(AsSecureLogFile)
 
@@ -182,6 +183,13 @@ llvm::mc::RegisterMCTargetOptionsFlags::RegisterMCTargetOptionsFlags() {
                      "Never use section symbols")));
   MCBINDOPT(RelocSectionSym);
 
+  static cl::opt<bool> LargeEHEncoding(
+      "large-eh-encoding",
+      cl::desc("Use 8-byte pointer size for all x86_64 ELF EH encodings "
+               "(FDE, personality, LSDA, TType) to avoid relocation "
+               "overflows in large binaries"));
+  MCBINDOPT(LargeEHEncoding);
+
   static cl::opt<std::string> ABIName(
       "target-abi",
       cl::desc("The name of the ABI to be targeted from the backend."),
@@ -214,6 +222,7 @@ MCTargetOptions llvm::mc::InitMCTargetOptionsFromFlags() {
   Options.X86RelaxRelocations = getX86RelaxRelocations();
   Options.X86Sse2Avx = getX86Sse2Avx();
   Options.RelocSectionSym = getRelocSectionSym();
+  Options.LargeEHEncoding = getLargeEHEncoding();
   Options.EmitDwarfUnwind = getEmitDwarfUnwind();
   Options.EmitCompactUnwindNonCanonical = getEmitCompactUnwindNonCanonical();
   Options.EmitSFrameUnwind = getEmitSFrameUnwind();

--- a/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
+++ b/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
@@ -60,6 +60,7 @@ MCOPT(bool, ImplicitMapSyms)
 MCOPT(bool, X86RelaxRelocations)
 MCOPT(bool, X86Sse2Avx)
 MCOPT(RelocSectionSymType, RelocSectionSym)
+MCOPT(bool, LargeEHEncoding)
 MCSTROPT(ABIName)
 MCSTROPT(AsSecureLogFile)
 
@@ -184,6 +185,14 @@ llvm::mc::RegisterMCTargetOptionsFlags::RegisterMCTargetOptionsFlags() {
                      "Never use section symbols")));
   MCBINDOPT(RelocSectionSym);
 
+  static cl::opt<bool> LargeEHEncoding(
+      "large-eh-encoding",
+      cl::desc("Force 8-byte (sdata8) pointer encodings for ELF "
+               "exception-handling sections to avoid relocation overflows in "
+               "large binaries (x86_64: FDE/personality/LSDA/TType; "
+               "AArch64/PPC64: FDE only, the rest are already sdata8)"));
+  MCBINDOPT(LargeEHEncoding);
+
   static cl::opt<std::string> ABIName(
       "target-abi",
       cl::desc("The name of the ABI to be targeted from the backend."),
@@ -216,6 +225,7 @@ MCTargetOptions llvm::mc::InitMCTargetOptionsFromFlags() {
   Options.X86RelaxRelocations = getX86RelaxRelocations();
   Options.X86Sse2Avx = getX86Sse2Avx();
   Options.RelocSectionSym = getRelocSectionSym();
+  Options.LargeEHEncoding = getLargeEHEncoding();
   Options.EmitDwarfUnwind = getEmitDwarfUnwind();
   Options.EmitCompactUnwindNonCanonical = getEmitCompactUnwindNonCanonical();
   Options.EmitSFrameUnwind = getEmitSFrameUnwind();

--- a/llvm/test/CodeGen/AArch64/large-eh-encoding.ll
+++ b/llvm/test/CodeGen/AArch64/large-eh-encoding.ll
@@ -1,0 +1,35 @@
+; Test that on AArch64 the personality, LSDA, and TType EH encodings already
+; default to 8-byte (sdata8), so --large-eh-encoding leaves them unchanged.
+; The flag's only effect on AArch64 is the FDE CFI encoding, which is checked
+; in llvm/test/MC/AArch64/large-eh-encoding.s.
+
+; Without the flag, with the flag, and with the flag under PIC all produce the
+; same sdata8 encodings (the AArch64 case does not depend on the reloc model).
+; RUN: llc -mtriple aarch64-linux-gnu < %s | FileCheck %s
+; RUN: llc -mtriple aarch64-linux-gnu --large-eh-encoding < %s | FileCheck %s
+; RUN: llc -mtriple aarch64-linux-gnu -relocation-model=pic --large-eh-encoding < %s | FileCheck %s
+
+@_ZTIi = external constant ptr
+
+define i32 @main() uwtable personality ptr @__gxx_personality_v0 {
+entry:
+  invoke void @foo()
+          to label %try.cont unwind label %lpad
+
+lpad:
+  %0 = landingpad { ptr, i32 }
+          catch ptr @_ZTIi
+  br label %try.cont
+
+try.cont:
+  ret i32 0
+}
+
+declare void @foo()
+declare i32 @__gxx_personality_v0(...)
+
+;; AArch64 always uses these regardless of --large-eh-encoding / reloc model:
+;; PersonalityEncoding = DW_EH_PE_indirect|DW_EH_PE_pcrel|DW_EH_PE_sdata8 = 156
+;; LSDAEncoding        = DW_EH_PE_pcrel|DW_EH_PE_sdata8 = 28
+; CHECK: .cfi_personality 156, DW.ref.__gxx_personality_v0
+; CHECK: .cfi_lsda 28,

--- a/llvm/test/CodeGen/X86/large-eh-encoding.ll
+++ b/llvm/test/CodeGen/X86/large-eh-encoding.ll
@@ -1,0 +1,49 @@
+; Test that --large-eh-encoding uses 8-byte encodings for personality, LSDA,
+; and TType in x86_64 ELF targets.
+
+; Default (small code model, no flag): sdata4 encodings
+; RUN: llc -mtriple x86_64-pc-linux-gnu -code-model=small < %s | FileCheck %s --check-prefix=DEFAULT
+; RUN: llc -mtriple x86_64-pc-linux-gnu -code-model=small -relocation-model=pic < %s | FileCheck %s --check-prefix=DEFAULT-PIC
+
+; With --large-eh-encoding: sdata8 encodings
+; RUN: llc -mtriple x86_64-pc-linux-gnu -code-model=small --large-eh-encoding < %s | FileCheck %s --check-prefix=LARGE
+; RUN: llc -mtriple x86_64-pc-linux-gnu -code-model=small -relocation-model=pic --large-eh-encoding < %s | FileCheck %s --check-prefix=LARGE-PIC
+
+@_ZTIi = external constant ptr
+
+define i32 @main() uwtable personality ptr @__gxx_personality_v0 {
+entry:
+  invoke void @foo()
+          to label %try.cont unwind label %lpad
+
+lpad:
+  %0 = landingpad { ptr, i32 }
+          catch ptr @_ZTIi
+  br label %try.cont
+
+try.cont:
+  ret i32 0
+}
+
+declare void @foo()
+declare i32 @__gxx_personality_v0(...)
+
+;; Non-PIC, default: PersonalityEncoding = DW_EH_PE_udata4 = 3
+;; Non-PIC, default: LSDAEncoding = DW_EH_PE_udata4 = 3
+; DEFAULT:      .cfi_personality 3, __gxx_personality_v0
+; DEFAULT-NEXT: .cfi_lsda 3,
+
+;; PIC, default (small): PersonalityEncoding = DW_EH_PE_indirect|DW_EH_PE_pcrel|DW_EH_PE_sdata4 = 155
+;; PIC, default (small): LSDAEncoding = DW_EH_PE_pcrel|DW_EH_PE_sdata4 = 27
+; DEFAULT-PIC:      .cfi_personality 155, DW.ref.__gxx_personality_v0
+; DEFAULT-PIC-NEXT: .cfi_lsda 27,
+
+;; Non-PIC, large-eh-encoding: PersonalityEncoding = DW_EH_PE_absptr = 0
+;; Non-PIC, large-eh-encoding: LSDAEncoding = DW_EH_PE_absptr = 0
+; LARGE:      .cfi_personality 0, __gxx_personality_v0
+; LARGE-NEXT: .cfi_lsda 0,
+
+;; PIC, large-eh-encoding: PersonalityEncoding = DW_EH_PE_indirect|DW_EH_PE_pcrel|DW_EH_PE_sdata8 = 156
+;; PIC, large-eh-encoding: LSDAEncoding = DW_EH_PE_pcrel|DW_EH_PE_sdata8 = 28
+; LARGE-PIC:      .cfi_personality 156, DW.ref.__gxx_personality_v0
+; LARGE-PIC-NEXT: .cfi_lsda 28,

--- a/llvm/test/MC/AArch64/large-eh-encoding.s
+++ b/llvm/test/MC/AArch64/large-eh-encoding.s
@@ -1,0 +1,35 @@
+## Test that --large-eh-encoding uses 8-byte pointers in the FDE CIE encoding
+## for AArch64 ELF targets. The FDE CFI encoding is the only EH encoding that
+## changes on AArch64: personality/LSDA/TType already default to sdata8 (see
+## llvm/test/CodeGen/AArch64/large-eh-encoding.ll), so the FDE was the last
+## sdata4 encoding that could overflow in large binaries.
+
+## Default encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata4 = 0x1B
+# RUN: llvm-mc -filetype=obj %s -o %t.o -triple aarch64
+# RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefix=SDATA4 %s
+
+## With --large-eh-encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata8 = 0x1C
+# RUN: llvm-mc -filetype=obj %s -o %t.o -triple aarch64 --large-eh-encoding
+# RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefix=SDATA8 %s
+
+## --large-code-model should also use sdata8
+# RUN: llvm-mc -filetype=obj %s -o %t.o -triple aarch64 --large-code-model
+# RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefix=SDATA8 %s
+
+func:
+	.cfi_startproc
+	.cfi_endproc
+
+# SDATA4: {{[0-9a-f]+}} {{[0-9a-f]+}} 00000000 CIE
+# SDATA4-NEXT:   Format: DWARF32
+# SDATA4-NEXT:   Version: 1
+# SDATA4-NEXT:   Augmentation: "zR"
+# SDATA4: Augmentation data: 1B
+## ^^ fde pointer encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata4
+
+# SDATA8: {{[0-9a-f]+}} {{[0-9a-f]+}} 00000000 CIE
+# SDATA8-NEXT:   Format: DWARF32
+# SDATA8-NEXT:   Version: 1
+# SDATA8-NEXT:   Augmentation: "zR"
+# SDATA8: Augmentation data: 1C
+## ^^ fde pointer encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata8

--- a/llvm/test/MC/X86/large-eh-encoding.s
+++ b/llvm/test/MC/X86/large-eh-encoding.s
@@ -1,0 +1,32 @@
+## Test that --large-eh-encoding uses 8-byte pointers in FDE CIE encoding
+## for x86_64 ELF targets.
+
+## Default encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata4 = 0x1B
+# RUN: llvm-mc -filetype=obj %s -o %t.o -triple x86_64
+# RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefix=SDATA4 %s
+
+## With --large-eh-encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata8 = 0x1C
+# RUN: llvm-mc -filetype=obj %s -o %t.o -triple x86_64 --large-eh-encoding
+# RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefix=SDATA8 %s
+
+## Also test with --large-code-model which should also use sdata8
+# RUN: llvm-mc -filetype=obj %s -o %t.o -triple x86_64 --large-code-model
+# RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefix=SDATA8 %s
+
+func:
+	.cfi_startproc
+	.cfi_endproc
+
+# SDATA4: {{[0-9a-f]+}} {{[0-9a-f]+}} 00000000 CIE
+# SDATA4-NEXT:   Format: DWARF32
+# SDATA4-NEXT:   Version: 1
+# SDATA4-NEXT:   Augmentation: "zR"
+# SDATA4: Augmentation data: 1B
+## ^^ fde pointer encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata4
+
+# SDATA8: {{[0-9a-f]+}} {{[0-9a-f]+}} 00000000 CIE
+# SDATA8-NEXT:   Format: DWARF32
+# SDATA8-NEXT:   Version: 1
+# SDATA8-NEXT:   Augmentation: "zR"
+# SDATA8: Augmentation data: 1C
+## ^^ fde pointer encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata8

--- a/llvm/test/MC/X86/large-eh-encoding.s
+++ b/llvm/test/MC/X86/large-eh-encoding.s
@@ -1,0 +1,32 @@
+// Test that --large-eh-encoding uses 8-byte pointers in FDE CIE encoding
+// for x86_64 ELF targets.
+
+// Default encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata4 = 0x1B
+// RUN: llvm-mc -filetype=obj %s -o %t.o -triple x86_64
+// RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefix=SDATA4 %s
+
+// With --large-eh-encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata8 = 0x1C
+// RUN: llvm-mc -filetype=obj %s -o %t.o -triple x86_64 --large-eh-encoding
+// RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefix=SDATA8 %s
+
+// Also test with --large-code-model which should also use sdata8
+// RUN: llvm-mc -filetype=obj %s -o %t.o -triple x86_64 --large-code-model
+// RUN: llvm-dwarfdump -eh-frame %t.o | FileCheck --check-prefix=SDATA8 %s
+
+func:
+	.cfi_startproc
+	.cfi_endproc
+
+// SDATA4: {{[0-9a-f]+}} {{[0-9a-f]+}} 00000000 CIE
+// SDATA4-NEXT:   Format: DWARF32
+// SDATA4-NEXT:   Version: 1
+// SDATA4-NEXT:   Augmentation: "zR"
+// SDATA4: Augmentation data: 1B
+// ^^ fde pointer encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata4
+
+// SDATA8: {{[0-9a-f]+}} {{[0-9a-f]+}} 00000000 CIE
+// SDATA8-NEXT:   Format: DWARF32
+// SDATA8-NEXT:   Version: 1
+// SDATA8-NEXT:   Augmentation: "zR"
+// SDATA8: Augmentation data: 1C
+// ^^ fde pointer encoding: DW_EH_PE_pcrel | DW_EH_PE_sdata8


### PR DESCRIPTION
Add a --large-eh-encoding option that forces 8-byte (DW_EH_PE_sdata8) pointer encodings for all x86_64 & aarch64 ELF EH sections: FDE CFI encoding, personality, LSDA, and TType encodings.

This is useful for large binaries where .text may exceed 2GB, causing relocation overflows in .eh_frame and .gcc_except_table even under the small or medium code model. The cost is purely in section size (a few extra bytes per FDE/LSDA entry) with no runtime performance impact.