### PR TITLE
[lldb-dap] Add skipIfWindowsWithoutConPTY decorator for clearer test requirements

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -3,6 +3,7 @@
 # allow the use of the `list[str]` type hint in Python 3.8
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import wraps
 from packaging import version
 import ctypes
@@ -808,6 +809,13 @@ def skipIfWindows(func=None, windows_version=None):
     if func is not None:
         return decorator(func)
     return decorator
+
+
+def skipIfWindowsWithoutConPTY(func: Callable):
+    """Decorator to skip tests on Windows without ConPTY support.
+    see https://devblogs.microsoft.com/commandline/windows-command-line-introducing-the-windows-pseudo-console-conpty/
+    """
+    return skipIfWindows(func=func, windows_version=["<", "10.0.17763"])
 
 
 def skipIfWindowsAndNonEnglish(func):

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -16,7 +16,7 @@ import tempfile
 
 
 class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
-    @skipIfWindows(windows_version=["<", "10.0.17763"])
+    @skipIfWindowsWithoutConPTY
     def test_default(self):
         """
         Tests the default launch of a simple program. No arguments,
@@ -76,7 +76,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
             r"unexpected value, expected 'internalConsole\', 'integratedTerminal\' or 'externalTerminal\' at arguments.console",
         )
 
-    @skipIfWindows(windows_version=["<", "10.0.17763"])
+    @skipIfWindowsWithoutConPTY
     def test_termination(self):
         """
         Tests the correct termination of lldb-dap upon a 'disconnect'
@@ -210,7 +210,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(output, "", "expect no program output")
 
     @skipIfLinux  # shell argument expansion doesn't seem to work on Linux
-    @skipIfWindows(windows_version=["<", "10.0.17763"])
+    @skipIfWindowsWithoutConPTY
     @expectedFailureAll(oslist=["freebsd", "netbsd"], bugnumber="llvm.org/pr48349")
     def test_shellExpandArguments_enabled(self):
         """
@@ -233,7 +233,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
                     quote_path, line, 'verify "%s" expanded to "%s"' % (glob, program)
                 )
 
-    @skipIfWindows(windows_version=["<", "10.0.17763"])
+    @skipIfWindowsWithoutConPTY
     def test_shellExpandArguments_disabled(self):
         """
         Tests the default launch of a simple program with shell expansion
@@ -255,7 +255,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
                     quote_path, line, 'verify "%s" stayed to "%s"' % (glob, glob)
                 )
 
-    @skipIfWindows(windows_version=["<", "10.0.17763"])
+    @skipIfWindowsWithoutConPTY
     def test_args(self):
         """
         Tests launch of a simple program with arguments
@@ -280,7 +280,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
                 'arg[%i] "%s" not in "%s"' % (i + 1, quoted_arg, lines[i]),
             )
 
-    @skipIfWindows(windows_version=["<", "10.0.17763"])
+    @skipIfWindowsWithoutConPTY
     def test_environment_with_object(self):
         """
         Tests launch of a simple program with environment variables
@@ -558,7 +558,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         output = self.collect_console(pattern=terminateCommands[0])
         self.verify_commands("terminateCommands", output, terminateCommands)
 
-    @skipIfWindows(windows_version=["<", "10.0.17763"])
+    @skipIfWindowsWithoutConPTY
     def test_version(self):
         """
         Tests that "initialize" response contains the "version" string the same
@@ -642,7 +642,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
             )
 
     @skipIfAsan
-    @skipIfWindows(windows_version=["<", "10.0.17763"])
+    @skipIfWindowsWithoutConPTY
     @skipIf(oslist=["linux"], archs=no_match(["x86_64"]))
     @skipIfBuildType(["debug"])
     def test_stdio_redirection_and_console(self):


### PR DESCRIPTION
Replace version matching with the new decorator to prevent typos, and make to it clear why we skipped the test.