### PR TITLE
[flang] Do not error on constant nonzero UB in substring of ZLA

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -1215,13 +1215,14 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::Substring &ss) {
               if (!ubValue) {
                 ubValue = len;
               }
-              if (lbValue && ubValue && *lbValue > *ubValue) {
+              if ((len && *len == 0) ||
+                  (lbValue && ubValue && *lbValue > *ubValue)) {
                 // valid, substring is empty
               } else if (lbValue && *lbValue < 1 && (ubValue || !last)) {
                 Say("Substring must begin at 1 or later, not %jd"_err_en_US,
                     static_cast<std::intmax_t>(*lbValue));
                 return std::nullopt;
-              } else if (ubValue && len && *len > 0 && *ubValue > *len &&
+              } else if (ubValue && len && *ubValue > *len &&
                   (lbValue || !first)) {
                 Say("Substring must end at %jd or earlier, not %jd"_err_en_US,
                     static_cast<std::intmax_t>(*len),

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -1221,9 +1221,9 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::Substring &ss) {
                 Say("Substring must begin at 1 or later, not %jd"_err_en_US,
                     static_cast<std::intmax_t>(*lbValue));
                 return std::nullopt;
-              } else if (ubValue && len && *ubValue > *len &&
+              } else if (ubValue && len && *len > 0 && *ubValue > *len &&
                   (lbValue || !first)) {
-                Say("Substring must end at %zd or earlier, not %jd"_err_en_US,
+                Say("Substring must end at %jd or earlier, not %jd"_err_en_US,
                     static_cast<std::intmax_t>(*len),
                     static_cast<std::intmax_t>(*ubValue));
                 return std::nullopt;

--- a/flang/test/Semantics/zero_len_char_array.f90
+++ b/flang/test/Semantics/zero_len_char_array.f90
@@ -1,0 +1,30 @@
+! RUN: %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck --allow-empty %s
+! CHECK-NOT: error:
+! Test that zero-length character substrings with lbound>ubounds indices
+! do not produce spurious errors when the character array is zero length.
+
+integer function init(i)
+  integer i
+  init=i
+end
+
+program flang_t7052
+  character*(*), parameter :: param_char = ""
+  character*(0)            :: zero_len_char
+
+  if ( param_char(init(5):init(3)) > zero_len_char(1:-2) ) then
+    print *,"Test failed"
+  endif
+
+  if ( param_char(init(5):init(3)) > zero_len_char(10:2) ) then
+    print *,"Test failed"
+  endif
+
+  if ( param_char(init(5):init(3)) > zero_len_char(init(10):2) ) then
+    print *,"Test failed"
+  endif
+
+  if ( param_char(init(5):init(3)) > zero_len_char(init(10):-2) ) then
+    print *,"Test failed"
+  endif
+end program

--- a/flang/test/Semantics/zero_len_char_array.f90
+++ b/flang/test/Semantics/zero_len_char_array.f90
@@ -2,13 +2,8 @@
 ! CHECK-NOT: error:
 ! Test that zero-length character substrings with lbound>ubounds indices
 ! do not produce spurious errors when the character array is zero length.
-
-integer function init(i)
-  integer i
-  init=i
-end
-
 program flang_t7052
+  implicit none
   character*(*), parameter :: param_char = ""
   character*(0)            :: zero_len_char
 
@@ -27,4 +22,16 @@ program flang_t7052
   if ( param_char(init(5):init(3)) > zero_len_char(init(10):-2) ) then
     print *,"Test failed"
   endif
+
+  if ( param_char(init(5):init(3)) > zero_len_char(2:init(10)) ) then
+    print *,"Test failed"
+  endif
+
+contains
+
+  integer function init(i)
+    integer, intent(in) :: i
+    init=i
+  end
+
 end program


### PR DESCRIPTION
A substring reference where the lower bound is higher than the upper bound is defined in 9.4.1 to be zero-length.

Thus, a reference to a substring of a CHARACTER*(0) string such as

    string(foo():2)

cannot be a compile-time error since we do not know the return value of foo().

We also should not error if the lbound > ubound at compile time.