### PR TITLE
[clang][test] Rebuild lld if the clang driver tests will use it

### DIFF
--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -185,6 +185,10 @@ if( NOT CLANG_BUILT_STANDALONE )
     yaml2obj
     )
 
+  if(TARGET lld)
+    list(APPEND CLANG_TEST_DEPS lld)
+  endif()
+
   if(TARGET llvm-lto)
     list(APPEND CLANG_TEST_DEPS llvm-lto)
   endif()


### PR DESCRIPTION
Cyndy suggested that the reason I was seeing lld-repro.c fail wasn't because `lld` doesn't support Darwin, but rather I had a swiftlang branch checked out when I built `lld` (which has Darwin support explicitly disabled), and `lld` didn't rebuild when I switched to an llvm branch. That appears to be the case, so set `lld` as a dependency of the clang tests.