### PR TITLE
[clang][unittest] BasicTests fail to link

### DIFF
--- a/clang/unittests/Basic/CMakeLists.txt
+++ b/clang/unittests/Basic/CMakeLists.txt
@@ -16,6 +16,7 @@ add_distinct_clang_unittest(BasicTests
   clangBasic
   clangLex
   LINK_LIBS
+  LLVMTargetParser
   LLVMTestingSupport
   LLVM_COMPONENTS
   Support


### PR DESCRIPTION
DarwinSDKInfo.PlatformPrefix adds use of Triple but failed to add a link to LLVMTargetParser, add that.