### PR TITLE
[DependencyScanning] Do not use maybe null OverlayFS

### DIFF
--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -96,7 +96,7 @@ bool DependencyScanningWorker::computeDependencies(
     }
 
     auto DiagEngineWithDiagOpts =
-        DiagnosticsEngineWithDiagOpts(Cmd, OverlayFS, DiagConsumer);
+        DiagnosticsEngineWithDiagOpts(Cmd, FS, DiagConsumer);
     auto &Diags = *DiagEngineWithDiagOpts.DiagEngine;
 
     // Create an invocation that uses the underlying file system to ensure that


### PR DESCRIPTION
computeDependencies takes in a pointer to an OverlayFileSystem, checks if it is null, and creates a FileSystem object if it is. But then the code later unconditionally uses OverlayFS, which may be null. Use the pointer that is created/moved by the nullptr check.

We saw this come up in some downstream builds where we were seeing SIGILL.