### PR TITLE
[TSan] Fix TSan instrumenting pointers from non-default address spaces

### DIFF
--- a/llvm/test/Instrumentation/ThreadSanitizer/tsan_address_space_attr_cast.ll
+++ b/llvm/test/Instrumentation/ThreadSanitizer/tsan_address_space_attr_cast.ll
@@ -1,0 +1,12 @@
+; RUN: opt < %s -passes='tsan' -S | FileCheck %s
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @read_4_bytes(ptr %a) sanitize_thread {
+entry:
+  %b = addrspacecast ptr %a to ptr addrspace(1)
+  %tmp1 = load volatile i32, ptr addrspace(1) %b, align 4
+  ret i32 %tmp1
+}
+
+; CHECK-NOT: call void @__tsan_read


### PR DESCRIPTION
Casting a pointer to a different address space is a nice trick to prevent an access from being instrumented by sanitizers such as ASan. However, this trick is currently broken, as the test demonstrates.

A minimal C PoC of the issue is:

```
void access(void *p) {
  auto tmp = (unsigned long __attribute__((address_space(1))) volatile *)p;
  *tmp = 0;
}
```

Under fsanitize=address, the access does not get instrumented, but under fsanitize=thread, it does.

(Note: Before this patch, this test will actually hit a CallInst assertion if you have them turned on, because the TSan runtime functions are defined to take pointer arguments, and non-default address space pointers are not compatible).

rdar://166743781