### PR TITLE
[CIR] [Fix] W64 Compiler error for std::max

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
@@ -97,7 +97,7 @@ EHScopeStack::getInnermostActiveNormalCleanup() const {
 char *EHScopeStack::allocate(size_t size) {
   size = llvm::alignTo(size, ScopeStackAlignment);
   if (!startOfBuffer) {
-    unsigned capacity = llvm::PowerOf2Ceil(std::max(size, 1024ul));
+    unsigned capacity = llvm::PowerOf2Ceil(std::max<size_t>(size, 1024ul));
     startOfBuffer = std::make_unique<char[]>(capacity);
     startOfData = endOfBuffer = startOfBuffer.get() + capacity;
   } else if (static_cast<size_t>(startOfData - startOfBuffer.get()) < size) {


### PR DESCRIPTION
In W64, size_t and ul are different sizes. So, std::max cannot correctly deduce the operator type, resulting an error at compile time. 

The fix was originally added in https://github.com/llvm/llvm-project/pull/173802, but as suggested it's best to keep unrelated changes separate. 