### PR TITLE
[cmake] Make CMAKE_BUILD_TYPE=Release the default

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -79,15 +79,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(FATAL_ERROR "
-No build type selected. You need to pass -DCMAKE_BUILD_TYPE=<type> in order to configure LLVM.
-Available options are:
-  * -DCMAKE_BUILD_TYPE=Release - For an optimized build with no assertions or debug info.
-  * -DCMAKE_BUILD_TYPE=Debug - For an unoptimized build with assertions and debug info.
-  * -DCMAKE_BUILD_TYPE=RelWithDebInfo - For an optimized build with no assertions but with debug info.
-  * -DCMAKE_BUILD_TYPE=MinSizeRel - For a build optimized for size instead of speed.
-Learn more about these options in our documentation at https://llvm.org/docs/CMake.html#cmake-build-type
+  message(WARNING "No build type selected. Defaulted CMAKE_BUILD_TYPE=Release.
+Learn more about the options in our documentation at https://llvm.org/docs/CMake.html#cmake-build-type
 ")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel" FORCE)
 endif()
 
 # Set default build type for cmake's try_compile module.


### PR DESCRIPTION
Currently, we report a fatal error if the user leaves CMAKE_BUILD_TYPE blank. This was implemented in https://reviews.llvm.org/D124153 / 350bdf9227ceb , based on this RFC:
https://discourse.llvm.org/t/rfc-select-a-better-linker-by-default-or-warn-about-using-bfd/61899/1

Tom Stellard mentioned that he'd like to revisit this on Discord, and Aiden, myself, and apparently most people on the original RFC agree, so I'm proposing we do it. However, on the review, several folks objected and insisted that Debug was a better default. I want to reopen the question.

I think we've made the wrong tradeoff. I wish Debug builds worked out of the box on most systems, but they don't, and LLVM has only gotten bigger over the last four years, making the build scalability problems of Debug builds worse. I think we should optimize our build configuration for new developers, not experienced longtime contributors who are invested enough to tweak the build to their liking.

With this PR, we emit a warning, and set the build type to Release, which has a higher likelihood of success for first-time users. Making the build work out of the box is very important for making LLVM development more accessible to new contributors, so it seems worth smoothing over this rough edge.

A separate possible improvement would be to set
LLVM_ENABLE_ASSERTIONS=ON, but that is out of scope for this PR.