### PR TITLE
[ELF] Add VersionNode lexer state for better version script parsing

### DIFF
--- a/lld/ELF/ScriptLexer.h
+++ b/lld/ELF/ScriptLexer.h
@@ -44,6 +44,8 @@ protected:
   enum class State {
     Script,
     Expr,
+    // Used by version node and dynamic list parsing.
+    VersionNode,
   };
 
   struct Token {

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -179,6 +179,7 @@ static ExprValue bitOr(LinkerScript &s, ExprValue a, ExprValue b) {
 }
 
 void ScriptParser::readDynamicList() {
+  SaveAndRestore saved(lexState, State::VersionNode);
   expect("{");
   SmallVector<SymbolVersion, 0> locals;
   SmallVector<SymbolVersion, 0> globals;
@@ -207,6 +208,7 @@ void ScriptParser::readVersionScript() {
 }
 
 void ScriptParser::readVersionScriptCommand() {
+  SaveAndRestore saved(lexState, State::VersionNode);
   if (consume("{")) {
     readAnonymousDeclaration();
     return;
@@ -1779,11 +1781,11 @@ ScriptParser::readSymbols() {
       SmallVector<SymbolVersion, 0> ext = readVersionExtern();
       v->insert(v->end(), ext.begin(), ext.end());
     } else {
-      if (tok == "local:" || (tok == "local" && consume(":"))) {
+      if (tok == "local" && consume(":")) {
         v = &locals;
         continue;
       }
-      if (tok == "global:" || (tok == "global" && consume(":"))) {
+      if (tok == "global" && consume(":")) {
         v = &globals;
         continue;
       }

--- a/lld/test/ELF/dynamic-list-extern.s
+++ b/lld/test/ELF/dynamic-list-extern.s
@@ -2,6 +2,7 @@
 
 # Test that we can parse multiple externs.
 
+# RUN: rm -rf %t && mkdir %t && cd %t
 # RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %s -o %t.o
 
 # RUN: echo '{ extern "C" { foo; }; extern "C++" { bar; }; };' > %t.list
@@ -9,3 +10,12 @@
 
 # RUN: echo '{ extern "C" { foo }; extern "C++" { bar }; };' > %t.list
 # RUN: ld.lld --dynamic-list %t.list %t.o -shared -o %t.so
+
+# RUN: echo '{ extern "C++" { std::foo; }; };' > %t.list
+# RUN: ld.lld --dynamic-list %t.list %t.o -shared -o %t.so
+
+# RUN: echo '{ extern "C++" { std:foo; }; };' > a.list
+# RUN: not ld.lld --dynamic-list a.list %t.o -shared 2>&1 | FileCheck %s --check-prefix=ERR-COLON
+# RUN: echo '{ extern "C++" { std:::foo; }; };' > a.list
+# RUN: not ld.lld --dynamic-list a.list %t.o -shared 2>&1 | FileCheck %s --check-prefix=ERR-COLON
+# ERR-COLON: error: a.list:1: ; expected, but got :

--- a/lld/test/ELF/linkerscript/version-script.s
+++ b/lld/test/ELF/linkerscript/version-script.s
@@ -6,7 +6,8 @@
 # RUN: llvm-readobj -V %t.so | FileCheck %s
 
 # RUN: echo "SECTIONS { .text : { bar = foo; *(.text) } }" > %t.script
-# RUN: echo "VERSION { V { global: foo; bar; local: *; }; }" >> %t.script
+## `:` in `local:*` is lexed as a separate token.
+# RUN: echo "VERSION { V { global: foo; bar; local:*; }; }" >> %t.script
 # RUN: ld.lld -T %t.script -shared --no-undefined-version %t.o -o %t.so
 # RUN: llvm-readobj -V %t.so | FileCheck %s
 

--- a/lld/test/ELF/version-script.s
+++ b/lld/test/ELF/version-script.s
@@ -8,8 +8,9 @@
 # RUN: ld.lld --version-script %t.script -shared %t.o %t2.so -o %t.so --fatal-warnings
 # RUN: llvm-readelf --dyn-syms %t.so | FileCheck --check-prefix=DSO %s
 
+## `:` in `local:*` is lexed as a separate token.
 # RUN: echo "# comment" > %t3.script
-# RUN: echo "{ local: *; # comment" >> %t3.script
+# RUN: echo "{ local:*; # comment" >> %t3.script
 # RUN: echo -n "}; # comment" >> %t3.script
 # RUN: ld.lld --version-script %t3.script -shared %t.o %t2.so -o %t3.so
 # RUN: llvm-readelf --dyn-syms %t3.so | FileCheck --check-prefix=DSO2 %s


### PR DESCRIPTION
... so that `local:*;` will be lexed as three tokens instead of a single
one in a version node. This is used by both version scripts and dynamic
lists. Fix #174363

In addition, clean up special code for space-separated `local :` and `global :`.

This patch brings our lexer behavior closer to GNU ld. While GNU ld
additionally rejects more characters like `~/+,=`, we don't implement
this additional validation.
