### PR TITLE
[RISCV] Don't generate QC.SWMI pair if the start reg is X0

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVLoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVLoadStoreOptimizer.cpp
@@ -247,7 +247,7 @@ bool RISCVLoadStoreOpt::tryConvertToXqcilsmLdStPair(
       XqciOpc = RISCV::QC_SETWMI;
       StartRegState = getKillRegState(FirstOp0.isKill() || SecondOp0.isKill());
       AddNextReg = false;
-    } else if (NextReg == StartReg + 1) {
+    } else if (NextReg == StartReg + 1 && StartReg != RISCV::X0) {
       XqciOpc = RISCV::QC_SWMI;
       StartRegState = getKillRegState(FirstOp0.isKill());
       NextRegState = RegState::Implicit | getKillRegState(SecondOp0.isKill());

--- a/llvm/test/CodeGen/RISCV/xqcilsm-lwmi-swmi.mir
+++ b/llvm/test/CodeGen/RISCV/xqcilsm-lwmi-swmi.mir
@@ -252,7 +252,8 @@ body: |
     ; CHECK-LABEL: name: no_pair_if_rd_is_x0_swmi
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: QC_SWMI $x0, $x10, 2, 0, implicit $x1 :: (store (s32))
+    ; CHECK-NEXT: SW $x0, $x10, 0 :: (store (s32))
+    ; CHECK-NEXT: SW $x1, $x10, 4 :: (store (s32))
     ; CHECK-NEXT: PseudoRET
     SW $x0, $x10, 0 :: (store (s32), align 4)
     SW $x1, $x10, 4 :: (store (s32), align 4)

--- a/llvm/test/CodeGen/RISCV/xqcilsm-lwmi-swmi.mir
+++ b/llvm/test/CodeGen/RISCV/xqcilsm-lwmi-swmi.mir
@@ -15,7 +15,9 @@
   define void @no_pair_if_offset_out_of_range_lw() nounwind { ret void }
   define void @no_pair_if_offset_out_of_range_sw() nounwind { ret void }
   define void @no_pair_if_non_consecutive_regs() nounwind { ret void }
-  define void @no_pair_if_rd_is_x0() nounwind { ret void }
+  define void @no_pair_if_rd_is_x0_lwmi() nounwind { ret void }
+  define void @no_pair_if_rd_is_x0_swmi() nounwind { ret void }
+  define void @pair_if_rd_is_x0_setwmi() nounwind { ret void }
   define void @no_pair_if_lw_rd_equals_base() nounwind { ret void }
   define void @pair_if_not_adjacent() nounwind { ret void }
   define void @pair_if_not_adjacent_use() nounwind { ret void }
@@ -225,12 +227,12 @@ body: |
 
 ...
 ---
-name: no_pair_if_rd_is_x0
+name: no_pair_if_rd_is_x0_lwmi
 tracksRegLiveness: false
 body: |
   bb.0:
     liveins: $x10
-    ; CHECK-LABEL: name: no_pair_if_rd_is_x0
+    ; CHECK-LABEL: name: no_pair_if_rd_is_x0_lwmi
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: $x0 = LW $x10, 0 :: (load (s32))
@@ -238,6 +240,38 @@ body: |
     ; CHECK-NEXT: PseudoRET
     $x0 = LW $x10, 0 :: (load (s32), align 4)
     $x1 = LW $x10, 4 :: (load (s32), align 4)
+    PseudoRET
+
+...
+---
+name: no_pair_if_rd_is_x0_swmi
+tracksRegLiveness: false
+body: |
+  bb.0:
+    liveins: $x10
+    ; CHECK-LABEL: name: no_pair_if_rd_is_x0_swmi
+    ; CHECK: liveins: $x10
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: QC_SWMI $x0, $x10, 2, 0, implicit $x1 :: (store (s32))
+    ; CHECK-NEXT: PseudoRET
+    SW $x0, $x10, 0 :: (store (s32), align 4)
+    SW $x1, $x10, 4 :: (store (s32), align 4)
+    PseudoRET
+
+...
+---
+name: pair_if_rd_is_x0_setwmi
+tracksRegLiveness: false
+body: |
+  bb.0:
+    liveins: $x10
+    ; CHECK-LABEL: name: pair_if_rd_is_x0_setwmi
+    ; CHECK: liveins: $x10
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: QC_SETWMI $x0, $x10, 2, 0 :: (store (s32))
+    ; CHECK-NEXT: PseudoRET
+    SW $x0, $x10, 0 :: (store (s32), align 4)
+    SW $x0, $x10, 4 :: (store (s32), align 4)
     PseudoRET
 
 ...


### PR DESCRIPTION
The register containing the values stored by `QC.SWMI` need to be `GPRNoX0`.