### PR TITLE
[clang-doc] Add a border box to comments in HTML

### DIFF
--- a/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
+++ b/clang-tools-extra/clang-doc/assets/clang-doc-mustache.css
@@ -384,6 +384,14 @@ body, html {
     margin-bottom:1rem; 
 }
 
+.nested-delimiter-container {
+    margin-bottom: 1rem;
+}
+
+.nested-delimiter-container:last-of-type {
+    margin-bottom: 0rem;
+}
+
 .resizer {
     width: 5px;
     cursor: col-resize;
@@ -442,7 +450,7 @@ body, html {
     left: 250px;
     position: relative;
     width: calc(100% - 250px);
-    height: 100vh;
+    min-height: 100vh;
 }
 
 .sidebar-item {
@@ -470,4 +478,13 @@ a, a:visited, a:hover, a:active {
 
 .code-block {
   white-space: pre-line;
+}
+
+.doc-card {
+  border: 3px solid rgba(0, 0, 0, 0.12);
+  border-radius: 10px;
+  background: var(--surface1);
+  margin: 14px 0;
+  overflow: hidden;
+  padding: 10px;
 }

--- a/clang-tools-extra/clang-doc/assets/class-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/class-template.mustache
@@ -155,7 +155,7 @@
                         <h1 class="hero__title-large">{{TagType}} {{Name}}</h1>
                         <p>Defined at line {{Location.LineNumber}} of file {{Location.Filename}}</p>
                         {{#Description}}
-                        <div class="hero__subtitle">
+                        <div class="doc-card">
                             {{>Comments}}
                         </div>
                         {{/Description}}
@@ -198,11 +198,9 @@
                 {{#HasPublicFunctions}}
                 <section id="PublicMethods" class="section-container">
                     <h2>Public Methods</h2>
-                    <div>
-                        {{#PublicFunctions}}
-                        {{>FunctionPartial}}
-                        {{/PublicFunctions}}
-                    </div>
+                    {{#PublicFunctions}}
+                    {{>FunctionPartial}}
+                    {{/PublicFunctions}}
                 </section>
                 {{/PublicFunctions}}
                 {{#ProtectedFunction}}

--- a/clang-tools-extra/clang-doc/assets/comment-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/comment-template.mustache
@@ -6,17 +6,17 @@
     This file defines templates for generating comments
 }}
 {{#BriefComments}}
-<div>
-{{#.}}
+<div class="nested-delimiter-container">
+    {{#.}}
     <p>{{TextComment}}</p>
-{{/.}}
+    {{/.}}
 </div>
 {{/BriefComments}}
 {{#ParagraphComments}}
-<div>
-{{#.}}
+<div class="nested-delimiter-container">
+    {{#.}}
     <p>{{TextComment}}</p>
-{{/.}}
+    {{/.}}
 </div>
 {{/ParagraphComments}}
 {{#ParagraphComment}}
@@ -25,28 +25,34 @@
 {{/Children}}
 {{/ParagraphComment}}
 {{#HasParamComments}}
-<h3>Parameters</h3>
-{{#ParamComments}}
-<div>
-    <b>{{ParamName}}</b> {{#Explicit}}{{Direction}}{{/Explicit}} {{#Children}}{{TextComment}}{{/Children}}
-</div> 
-{{/ParamComments}}
+<div class="nested-delimiter-container">
+    <h3>Parameters</h3>
+    {{#ParamComments}}
+    <div>
+        <b>{{ParamName}}</b> {{#Explicit}}{{Direction}}{{/Explicit}} {{#Children}}{{TextComment}}{{/Children}}
+    </div> 
+    {{/ParamComments}}
+</div>
 {{/HasParamComments}}
 {{#HasTParamComments}}
 <h3>Template Parameters</h3>
 {{#TParamComments}}
-<div>
-    <b>{{ParamName}}</b> {{#Explicit}}{{Direction}}{{/Explicit}} {{#Children}}{{TextComment}}{{/Children}}
-</div> 
+<div class="nested-delimiter-container">
+    <div>
+        <b>{{ParamName}}</b> {{#Explicit}}{{Direction}}{{/Explicit}} {{#Children}}{{TextComment}}{{/Children}}
+    </div>
+</div>
 {{/#TParamComments}}
 {{/HasTParamComments}}
 {{#HasReturnComments}}
-<h3>Returns</h3>
-{{#ReturnComments}}
-{{#.}}
-<p>{{TextComment}}</p>
-{{/.}}
-{{/ReturnComments}}
+<div class="nested-delimiter-container">
+    <h3>Returns</h3>
+    {{#ReturnComments}}
+        {{#.}}
+        <p>{{TextComment}}</p>
+        {{/.}}
+    {{/ReturnComments}}
+</div>
 {{/HasReturnComments}}
 {{#HasCodeComments}}
 <h3>Code</h3> 
@@ -63,12 +69,14 @@
 {{/CodeComments}}
 {{/HasCodeComments}}
 {{#HasThrowsComments}}
-<h3>Throws</h3>
-{{#ThrowsComments}}
-<div>
-    <b>{{Exception}}</b> {{#Children}}{{TextComment}}{{/Children}}
+<div class="nested-delimiter-container">
+    <h3>Throws</h3>
+    {{#ThrowsComments}}
+    <div>
+      <b>{{Exception}}</b> {{#Children}}{{TextComment}}{{/Children}}
+    </div>
+    {{/ThrowsComments}}
 </div>
-{{/ThrowsComments}}
 {{/HasThrowsComments}}
 {{#BlockCommandComment}}
     <div class="block-command-comment__command">

--- a/clang-tools-extra/clang-doc/assets/function-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/function-template.mustache
@@ -5,8 +5,7 @@
 
     This file defines the template for functions/methods
 }}
-<div class="delimiter-container">
-    <div id="{{USR}}">
+<div id="{{USR}}" class="delimiter-container">
         {{#Template}}
         <pre><code class="language-cpp code-clang-doc">template &lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;</code></pre>
         {{/Template}}
@@ -14,10 +13,9 @@
         <pre><code class="language-cpp code-clang-doc">{{ReturnType.QualName}} {{Name}}{{#Template}}{{#Specialization}}&lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;{{/Specialization}}{{/Template}} ({{#Params}}{{Type.QualName}} {{Name}}{{^End}}, {{/End}}{{/Params}})</code></pre>
         {{! Function Comments }}
         {{#Description}}
-        <div>
+        <div class="doc-card">
             {{>Comments}}
         </div>
         {{/Description}}
         <p>Defined at line {{Location.LineNumber}} of file {{Location.Filename}}</p>
-    </div>
 </div>

--- a/clang-tools-extra/test/clang-doc/basic-project.mustache.test
+++ b/clang-tools-extra/test/clang-doc/basic-project.mustache.test
@@ -61,11 +61,11 @@ HTML-SHAPE:         <div class="content">
 HTML-SHAPE:             <section class="hero section-container">
 HTML-SHAPE:                 <div class="hero__title">
 HTML-SHAPE:                     <h1 class="hero__title-large">class Shape</h1>
-HTML-SHAPE:                     <div class="hero__subtitle">
-HTML-SHAPE:                         <div>
+HTML-SHAPE:                     <div class="doc-card">
+HTML-SHAPE:                         <div class="nested-delimiter-container">
 HTML-SHAPE:                             <p> Abstract base class for shapes.</p>
 HTML-SHAPE:                         </div>
-HTML-SHAPE:                         <div>
+HTML-SHAPE:                         <div class="nested-delimiter-container">
 HTML-SHAPE:                             <p> Provides a common interface for different types of shapes.</p>
 HTML-SHAPE:                         </div>
 HTML-SHAPE:                     </div>
@@ -73,42 +73,38 @@ HTML-SHAPE:                 </div>
 HTML-SHAPE:             </section>
 HTML-SHAPE:             <section id="PublicMethods" class="section-container">
 HTML-SHAPE:                 <h2>Public Methods</h2>
-HTML-SHAPE:                 <div>
-HTML-SHAPE:                     <div class="delimiter-container">
-HTML-SHAPE:                         <div id="{{([0-9A-F]{40})}}">
+HTML-SHAPE:                         <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 HTML-SHAPE:                             <pre><code class="language-cpp code-clang-doc">double area ()</code></pre>
-HTML-SHAPE:                             <div>
-HTML-SHAPE:                                 <div>
+HTML-SHAPE:                             <div class="doc-card">
+HTML-SHAPE:                                 <div class="nested-delimiter-container">
 HTML-SHAPE:                                     <p> Calculates the area of the shape.</p>
 HTML-SHAPE:                                 </div>
-HTML-SHAPE:                                 <h3>Returns</h3>
-HTML-SHAPE:                                 <p> double The area of the shape.</p>
+HTML-SHAPE:                                 <div class="nested-delimiter-container">
+HTML-SHAPE:                                     <h3>Returns</h3>
+HTML-SHAPE:                                     <p> double The area of the shape.</p>
+HTML-SHAPE:                                 </div>
 HTML-SHAPE:                             </div>
 HTML-SHAPE:                         </div>
-HTML-SHAPE:                     </div>
-HTML-SHAPE:                     <div class="delimiter-container">
-HTML-SHAPE:                         <div id="{{([0-9A-F]{40})}}">
+HTML-SHAPE:                         <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 HTML-SHAPE:                             <pre><code class="language-cpp code-clang-doc">double perimeter ()</code></pre>
-HTML-SHAPE:                             <div>
-HTML-SHAPE:                                 <div>
+HTML-SHAPE:                             <div class="doc-card">
+HTML-SHAPE:                                 <div class="nested-delimiter-container">
 HTML-SHAPE:                                     <p> Calculates the perimeter of the shape.</p>
 HTML-SHAPE:                                 </div>
-HTML-SHAPE:                                 <h3>Returns</h3>
-HTML-SHAPE:                                 <p> double The perimeter of the shape.</p>
+HTML-SHAPE:                                 <div class="nested-delimiter-container">
+HTML-SHAPE:                                     <h3>Returns</h3>
+HTML-SHAPE:                                     <p> double The perimeter of the shape.</p>
+HTML-SHAPE:                                 </div>
 HTML-SHAPE:                             </div>
 HTML-SHAPE:                         </div>
-HTML-SHAPE:                     </div>
-HTML-SHAPE:                     <div class="delimiter-container">
-HTML-SHAPE:                         <div id="{{([0-9A-F]{40})}}">
+HTML-SHAPE:                         <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 HTML-SHAPE:                             <pre><code class="language-cpp code-clang-doc">void ~Shape ()</code></pre>
-HTML-SHAPE:                             <div>
-HTML-SHAPE:                                 <div>
+HTML-SHAPE:                             <div class="doc-card">
+HTML-SHAPE:                                 <div class="nested-delimiter-container">
 HTML-SHAPE:                                     <p> Virtual destructor.</p>
 HTML-SHAPE:                                 </div>
 HTML-SHAPE:                             </div>
 HTML-SHAPE:                         </div>
-HTML-SHAPE:                     </div>
-HTML-SHAPE:                 </div>
 HTML-SHAPE:             </section>
 HTML-SHAPE:         </div>
 HTML-SHAPE:     </div>
@@ -193,11 +189,11 @@ HTML-CALC:         <div class="content">
 HTML-CALC:             <section class="hero section-container">
 HTML-CALC:                 <div class="hero__title">
 HTML-CALC:                     <h1 class="hero__title-large">class Calculator</h1>
-HTML-CALC:                     <div class="hero__subtitle">
-HTML-CALC:                         <div>
+HTML-CALC:                     <div class="doc-card">
+HTML-CALC:                         <div class="nested-delimiter-container">
 HTML-CALC:                             <p> A simple calculator class.</p>
 HTML-CALC:                         </div>
-HTML-CALC:                         <div>
+HTML-CALC:                         <div class="nested-delimiter-container">
 HTML-CALC:                             <p> Provides basic arithmetic operations.</p>
 HTML-CALC:                         </div>
 HTML-CALC:                     </div>
@@ -216,115 +212,117 @@ HTML-CALC:                 </div>
 HTML-CALC:             </section>
 HTML-CALC:             <section id="PublicMethods" class="section-container">
 HTML-CALC:                 <h2>Public Methods</h2>
-HTML-CALC:                 <div>
-HTML-CALC:                     <div class="delimiter-container">
-HTML-CALC:                         <div id="{{([0-9A-F]{40})}}">
-HTML-CALC:                             <pre><code class="language-cpp code-clang-doc">int add (int a, int b)</code></pre>
+HTML-CALC:                 <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
+HTML-CALC:                     <pre><code class="language-cpp code-clang-doc">int add (int a, int b)</code></pre>
+HTML-CALC:                     <div class="doc-card">
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <p> Adds two integers.</p>
+HTML-CALC:                         </div>
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <h3>Parameters</h3>
 HTML-CALC:                             <div>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <p> Adds two integers.</p>
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <h3>Parameters</h3>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <b>a</b>   First integer.
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <b>b</b>   Second integer.
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <h3>Returns</h3>
-HTML-CALC:                                 <p> int The sum of a and b.</p>
+HTML-CALC:                                 <b>a</b>   First integer.
+HTML-CALC:                             </div>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <b>b</b>   Second integer.
 HTML-CALC:                             </div>
 HTML-CALC:                         </div>
-HTML-CALC:                     </div>
-HTML-CALC:                     <div class="delimiter-container">
-HTML-CALC:                         <div id="{{([0-9A-F]{40})}}">
-HTML-CALC:                             <pre><code class="language-cpp code-clang-doc">int subtract (int a, int b)</code></pre>
-HTML-CALC:                             <div>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <p> Subtracts the second integer from the first.</p>
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <h3>Parameters</h3>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <b>a</b>   First integer.
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <b>b</b>   Second integer.
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <h3>Returns</h3>
-HTML-CALC:                                 <p> int The result of a - b.</p>
-HTML-CALC:                             </div>
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <h3>Returns</h3>
+HTML-CALC:                             <p> int The sum of a and b.</p>
 HTML-CALC:                         </div>
 HTML-CALC:                     </div>
-HTML-CALC:                     <div class="delimiter-container">
-HTML-CALC:                         <div id="{{([0-9A-F]{40})}}">
-HTML-CALC:                             <pre><code class="language-cpp code-clang-doc">int multiply (int a, int b)</code></pre>
+HTML-CALC:                 </div>
+HTML-CALC:                 <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
+HTML-CALC:                     <pre><code class="language-cpp code-clang-doc">int subtract (int a, int b)</code></pre>
+HTML-CALC:                     <div class="doc-card">
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <p> Subtracts the second integer from the first.</p>
+HTML-CALC:                         </div>
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <h3>Parameters</h3>
 HTML-CALC:                             <div>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <p> Multiplies two integers.</p>
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <h3>Parameters</h3>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <b>a</b>   First integer.
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <b>b</b>   Second integer.
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <h3>Returns</h3>
-HTML-CALC:                                 <p> int The product of a and b.</p>
+HTML-CALC:                                 <b>a</b>   First integer.
+HTML-CALC:                             </div>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <b>b</b>   Second integer.
 HTML-CALC:                             </div>
 HTML-CALC:                         </div>
-HTML-CALC:                     </div>
-HTML-CALC:                     <div class="delimiter-container">
-HTML-CALC:                         <div id="{{([0-9A-F]{40})}}">
-HTML-CALC:                             <pre><code class="language-cpp code-clang-doc">double divide (int a, int b)</code></pre>
-HTML-CALC:                             <div>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <p> Divides the first integer by the second.</p>
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <h3>Parameters</h3>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <b>a</b>   First integer.
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <b>b</b>   Second integer.
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <h3>Returns</h3>
-HTML-CALC:                                 <p> double The result of a / b.</p>
-HTML-CALC:                                 <h3>Throws</h3>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <b>std::invalid_argument</b> if b is zero.
-HTML-CALC:                                 </div>
-HTML-CALC:                             </div>
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <h3>Returns</h3>
+HTML-CALC:                             <p> int The result of a - b.</p>
 HTML-CALC:                         </div>
 HTML-CALC:                     </div>
-HTML-CALC:                     <div class="delimiter-container">
-HTML-CALC:                         <div id="{{([0-9A-F]{40})}}">
-HTML-CALC:                             <pre><code class="language-cpp code-clang-doc">int mod (int a, int b)</code></pre>
+HTML-CALC:                 </div>
+HTML-CALC:                 <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
+HTML-CALC:                     <pre><code class="language-cpp code-clang-doc">int multiply (int a, int b)</code></pre>
+HTML-CALC:                     <div class="doc-card">
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <p> Multiplies two integers.</p>
+HTML-CALC:                         </div>
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <h3>Parameters</h3>
 HTML-CALC:                             <div>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <p> Performs the mod operation on integers.</p>
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <h3>Parameters</h3>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <b>a</b>   First integer.
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <div>
-HTML-CALC:                                     <b>b</b>   Second integer.
-HTML-CALC:                                 </div>
-HTML-CALC:                                 <h3>Returns</h3>
-HTML-CALC:                                 <p> The result of a % b.</p>
+HTML-CALC:                                 <b>a</b>   First integer.
+HTML-CALC:                             </div>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <b>b</b>   Second integer.
+HTML-CALC:                             </div>
+HTML-CALC:                         </div>
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <h3>Returns</h3>
+HTML-CALC:                             <p> int The product of a and b.</p>
+HTML-CALC:                         </div>
+HTML-CALC:                     </div>
+HTML-CALC:                 </div>
+HTML-CALC:                 <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
+HTML-CALC:                     <pre><code class="language-cpp code-clang-doc">double divide (int a, int b)</code></pre>
+HTML-CALC:                     <div class="doc-card">
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <p> Divides the first integer by the second.</p>
+HTML-CALC:                         </div>
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <h3>Parameters</h3>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <b>a</b>   First integer.
+HTML-CALC:                             </div>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <b>b</b>   Second integer.
+HTML-CALC:                             </div>
+HTML-CALC:                         </div>
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <h3>Returns</h3>
+HTML-CALC:                             <p> double The result of a / b.</p>
+HTML-CALC:                         </div>
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <h3>Throws</h3>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <b>std::invalid_argument</b> if b is zero.
 HTML-CALC:                             </div>
 HTML-CALC:                         </div>
 HTML-CALC:                     </div>
 HTML-CALC:                 </div>
-HTML-CALC:             </section>
-HTML-CALC:         </div>
-HTML-CALC:     </div>
-HTML-CALC: </main>
-HTML-CALC: </body>
-HTML-CALC: </html>
-
-
+HTML-CALC:                 <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
+HTML-CALC:                     <pre><code class="language-cpp code-clang-doc">int mod (int a, int b)</code></pre>
+HTML-CALC:                     <div class="doc-card">
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <p> Performs the mod operation on integers.</p>
+HTML-CALC:                         </div>
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <h3>Parameters</h3>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <b>a</b>   First integer.
+HTML-CALC:                             </div>
+HTML-CALC:                             <div>
+HTML-CALC:                                 <b>b</b>   Second integer.
+HTML-CALC:                             </div>
+HTML-CALC:                         </div>
+HTML-CALC:                         <div class="nested-delimiter-container">
+HTML-CALC:                             <h3>Returns</h3>
+HTML-CALC:                             <p> The result of a % b.</p>
+HTML-CALC:                         </div>
+HTML-CALC:                     </div>
+HTML-CALC:                 </div>
 
 HTML-RECTANGLE: <!DOCTYPE html>
 HTML-RECTANGLE: <html lang="en-US">
@@ -381,11 +379,11 @@ HTML-RECTANGLE:         <div class="content">
 HTML-RECTANGLE:             <section class="hero section-container">
 HTML-RECTANGLE:                 <div class="hero__title">
 HTML-RECTANGLE:                     <h1 class="hero__title-large">class Rectangle</h1>
-HTML-RECTANGLE:                     <div class="hero__subtitle">
-HTML-RECTANGLE:                         <div>
+HTML-RECTANGLE:                     <div class="doc-card">
+HTML-RECTANGLE:                         <div class="nested-delimiter-container">
 HTML-RECTANGLE:                             <p> Rectangle class derived from Shape.</p>
 HTML-RECTANGLE:                         </div>
-HTML-RECTANGLE:                         <div>
+HTML-RECTANGLE:                         <div class="nested-delimiter-container">
 HTML-RECTANGLE:                             <p> Represents a rectangle with a given width and height.</p>
 HTML-RECTANGLE:                         </div>
 HTML-RECTANGLE:                     </div>
@@ -393,55 +391,47 @@ HTML-RECTANGLE:                 </div>
 HTML-RECTANGLE:             </section>
 HTML-RECTANGLE:             <section id="PublicMethods" class="section-container">
 HTML-RECTANGLE:                 <h2>Public Methods</h2>
-HTML-RECTANGLE:                 <div>
-HTML-RECTANGLE:                     <div class="delimiter-container">
-HTML-RECTANGLE:                         <div id="{{([0-9A-F]{40})}}">
-HTML-RECTANGLE:                             <pre><code class="language-cpp code-clang-doc">void Rectangle (double width, double height)</code></pre>
-HTML-RECTANGLE:                             <div>
-HTML-RECTANGLE:                                 <div>
-HTML-RECTANGLE:                                     <p> Constructs a new Rectangle object.</p>
-HTML-RECTANGLE:                                 </div>
-HTML-RECTANGLE:                                 <h3>Parameters</h3>
-HTML-RECTANGLE:                                 <div>
-HTML-RECTANGLE:                                     <b>width</b>   Width of the rectangle.
-HTML-RECTANGLE:                                 </div>
-HTML-RECTANGLE:                                 <div>
-HTML-RECTANGLE:                                     <b>height</b>   Height of the rectangle.
-HTML-RECTANGLE:                                 </div>
-HTML-RECTANGLE:                             </div>
+HTML-RECTANGLE:                 <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
+HTML-RECTANGLE:                     <pre><code class="language-cpp code-clang-doc">void Rectangle (double width, double height)</code></pre>
+HTML-RECTANGLE:                     <div class="doc-card">
+HTML-RECTANGLE:                         <div class="nested-delimiter-container">
+HTML-RECTANGLE:                             <p> Constructs a new Rectangle object.</p>
 HTML-RECTANGLE:                         </div>
-HTML-RECTANGLE:                     </div>
-HTML-RECTANGLE:                     <div class="delimiter-container">
-HTML-RECTANGLE:                         <div id="{{([0-9A-F]{40})}}">
-HTML-RECTANGLE:                             <pre><code class="language-cpp code-clang-doc">double area ()</code></pre>
+HTML-RECTANGLE:                         <div class="nested-delimiter-container">
+HTML-RECTANGLE:                             <h3>Parameters</h3>
 HTML-RECTANGLE:                             <div>
-HTML-RECTANGLE:                                 <div>
-HTML-RECTANGLE:                                     <p> Calculates the area of the rectangle.</p>
-HTML-RECTANGLE:                                 </div>
-HTML-RECTANGLE:                                 <h3>Returns</h3>
-HTML-RECTANGLE:                                 <p> double The area of the rectangle.</p>
+HTML-RECTANGLE:                                 <b>width</b>   Width of the rectangle.
 HTML-RECTANGLE:                             </div>
-HTML-RECTANGLE:                         </div>
-HTML-RECTANGLE:                     </div>
-HTML-RECTANGLE:                     <div class="delimiter-container">
-HTML-RECTANGLE:                         <div id="{{([0-9A-F]{40})}}">
-HTML-RECTANGLE:                             <pre><code class="language-cpp code-clang-doc">double perimeter ()</code></pre>
 HTML-RECTANGLE:                             <div>
-HTML-RECTANGLE:                                 <div>
-HTML-RECTANGLE:                                     <p> Calculates the perimeter of the rectangle.</p>
-HTML-RECTANGLE:                                 </div>
-HTML-RECTANGLE:                                 <h3>Returns</h3>
-HTML-RECTANGLE:                                 <p> double The perimeter of the rectangle.</p>
+HTML-RECTANGLE:                                 <b>height</b>   Height of the rectangle.
 HTML-RECTANGLE:                             </div>
 HTML-RECTANGLE:                         </div>
 HTML-RECTANGLE:                     </div>
 HTML-RECTANGLE:                 </div>
-HTML-RECTANGLE:             </section>
-HTML-RECTANGLE:         </div>
-HTML-RECTANGLE:     </div>
-HTML-RECTANGLE: </main>
-HTML-RECTANGLE: </body>
-HTML-RECTANGLE: </html>
+HTML-RECTANGLE:                 <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
+HTML-RECTANGLE:                     <pre><code class="language-cpp code-clang-doc">double area ()</code></pre>
+HTML-RECTANGLE:                     <div class="doc-card">
+HTML-RECTANGLE:                         <div class="nested-delimiter-container">
+HTML-RECTANGLE:                             <p> Calculates the area of the rectangle.</p>
+HTML-RECTANGLE:                         </div>
+HTML-RECTANGLE:                         <div class="nested-delimiter-container">
+HTML-RECTANGLE:                             <h3>Returns</h3>
+HTML-RECTANGLE:                             <p> double The area of the rectangle.</p>
+HTML-RECTANGLE:                         </div>
+HTML-RECTANGLE:                     </div>
+HTML-RECTANGLE:                 </div>
+HTML-RECTANGLE:                 <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
+HTML-RECTANGLE:                     <pre><code class="language-cpp code-clang-doc">double perimeter ()</code></pre>
+HTML-RECTANGLE:                     <div class="doc-card">
+HTML-RECTANGLE:                         <div class="nested-delimiter-container">
+HTML-RECTANGLE:                             <p> Calculates the perimeter of the rectangle.</p>
+HTML-RECTANGLE:                         </div>
+HTML-RECTANGLE:                         <div class="nested-delimiter-container">
+HTML-RECTANGLE:                             <h3>Returns</h3>
+HTML-RECTANGLE:                             <p> double The perimeter of the rectangle.</p>
+HTML-RECTANGLE:                         </div>
+HTML-RECTANGLE:                     </div>
+HTML-RECTANGLE:                 </div>
 
 
 
@@ -500,11 +490,11 @@ HTML-CIRCLE:         <div class="content">
 HTML-CIRCLE:             <section class="hero section-container">
 HTML-CIRCLE:                 <div class="hero__title">
 HTML-CIRCLE:                     <h1 class="hero__title-large">class Circle</h1>
-HTML-CIRCLE:                     <div class="hero__subtitle">
-HTML-CIRCLE:                         <div>
+HTML-CIRCLE:                     <div class="doc-card">
+HTML-CIRCLE:                         <div class="nested-delimiter-container">
 HTML-CIRCLE:                             <p> Circle class derived from Shape.</p>
 HTML-CIRCLE:                         </div>
-HTML-CIRCLE:                         <div>
+HTML-CIRCLE:                         <div class="nested-delimiter-container">
 HTML-CIRCLE:                             <p> Represents a circle with a given radius.</p>
 HTML-CIRCLE:                         </div>
 HTML-CIRCLE:                     </div>
@@ -512,59 +502,51 @@ HTML-CIRCLE:                 </div>
 HTML-CIRCLE:             </section>
 HTML-CIRCLE:             <section id="PublicMethods" class="section-container">
 HTML-CIRCLE:                 <h2>Public Methods</h2>
-HTML-CIRCLE:                 <div>
-HTML-CIRCLE:                     <div class="delimiter-container">
-HTML-CIRCLE:                         <div id="{{([0-9A-F]{40})}}">
-HTML-CIRCLE:                             <pre><code class="language-cpp code-clang-doc">void Circle (double radius)</code></pre>
-HTML-CIRCLE:                             <div>
-HTML-CIRCLE:                                 <div>
-HTML-CIRCLE:                                     <p> Constructs a new Circle object.</p>
-HTML-CIRCLE:                                 </div>
-HTML-CIRCLE:                                 <h3>Parameters</h3>
-HTML-CIRCLE:                                 <div>
-HTML-CIRCLE:                                     <b>radius</b>   Radius of the circle.
-HTML-CIRCLE:                                 </div>
-HTML-CIRCLE:                             </div>
+HTML-CIRCLE:                 <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
+HTML-CIRCLE:                     <pre><code class="language-cpp code-clang-doc">void Circle (double radius)</code></pre>
+HTML-CIRCLE:                     <div class="doc-card">
+HTML-CIRCLE:                         <div class="nested-delimiter-container">
+HTML-CIRCLE:                             <p> Constructs a new Circle object.</p>
 HTML-CIRCLE:                         </div>
-HTML-CIRCLE:                     </div>
-HTML-CIRCLE:                     <div class="delimiter-container">
-HTML-CIRCLE:                         <div id="{{([0-9A-F]{40})}}">
-HTML-CIRCLE:                             <pre><code class="language-cpp code-clang-doc">double area ()</code></pre>
+HTML-CIRCLE:                         <div class="nested-delimiter-container">
+HTML-CIRCLE:                             <h3>Parameters</h3>
 HTML-CIRCLE:                             <div>
-HTML-CIRCLE:                                 <div>
-HTML-CIRCLE:                                     <p> Calculates the area of the circle.</p>
-HTML-CIRCLE:                                 </div>
-HTML-CIRCLE:                                 <h3>Returns</h3>
-HTML-CIRCLE:                                 <p> double The area of the circle.</p>
-HTML-CIRCLE:                             </div>
-HTML-CIRCLE:                         </div>
-HTML-CIRCLE:                     </div>
-HTML-CIRCLE:                     <div class="delimiter-container">
-HTML-CIRCLE:                         <div id="{{([0-9A-F]{40})}}">
-HTML-CIRCLE:                             <pre><code class="language-cpp code-clang-doc">double perimeter ()</code></pre>
-HTML-CIRCLE:                             <div>
-HTML-CIRCLE:                                 <div>
-HTML-CIRCLE:                                     <p> Calculates the perimeter of the circle.</p>
-HTML-CIRCLE:                                 </div>
-HTML-CIRCLE:                                 <h3>Returns</h3>
-HTML-CIRCLE:                                 <p> double The perimeter of the circle.</p>
-HTML-CIRCLE:                                 <h3>Code</h3>
-HTML-CIRCLE:                                 <div>
-HTML-CIRCLE:                                     <pre class="code-block">
-HTML-CIRCLE:                                         <code>
-HTML-CIRCLE:                                              Circle circle(5.0);
-HTML-CIRCLE:                                              double perimeter = circle.perimeter();
-HTML-CIRCLE:                                         </code>
-HTML-CIRCLE:                                     </pre>
-HTML-CIRCLE:                                 </div>
+HTML-CIRCLE:                                 <b>radius</b>   Radius of the circle.
 HTML-CIRCLE:                             </div>
 HTML-CIRCLE:                         </div>
 HTML-CIRCLE:                     </div>
 HTML-CIRCLE:                 </div>
+HTML-CIRCLE:                 <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
+HTML-CIRCLE:                     <pre><code class="language-cpp code-clang-doc">double area ()</code></pre>
+HTML-CIRCLE:                     <div class="doc-card">
+HTML-CIRCLE:                         <div class="nested-delimiter-container">
+HTML-CIRCLE:                             <p> Calculates the area of the circle.</p>
+HTML-CIRCLE:                         </div>
+HTML-CIRCLE:                         <div class="nested-delimiter-container">
+HTML-CIRCLE:                             <h3>Returns</h3>
+HTML-CIRCLE:                             <p> double The area of the circle.</p>
+HTML-CIRCLE:                         </div>
+HTML-CIRCLE:                     </div>
+HTML-CIRCLE:                 </div>
+HTML-CIRCLE:                 <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
+HTML-CIRCLE:                     <pre><code class="language-cpp code-clang-doc">double perimeter ()</code></pre>
+HTML-CIRCLE:                     <div class="doc-card">
+HTML-CIRCLE:                         <div class="nested-delimiter-container">
+HTML-CIRCLE:                             <p> Calculates the perimeter of the circle.</p>
+HTML-CIRCLE:                         </div>
+HTML-CIRCLE:                         <div class="nested-delimiter-container">
+HTML-CIRCLE:                             <h3>Returns</h3>
+HTML-CIRCLE:                             <p> double The perimeter of the circle.</p>
+HTML-CIRCLE:                         </div>
+HTML-CIRCLE:                             <h3>Code</h3>
+HTML-CIRCLE:                             <div>
+HTML-CIRCLE:                                 <pre class="code-block">
+HTML-CIRCLE:                                     <code>
+HTML-CIRCLE:                                          Circle circle(5.0);
+HTML-CIRCLE:                                          double perimeter = circle.perimeter();
+HTML-CIRCLE:                                     </code>
+HTML-CIRCLE:                                 </pre>
+HTML-CIRCLE:                             </div>
+HTML-CIRCLE:                     </div>
+HTML-CIRCLE:                 </div>
 HTML-CIRCLE:             </section>
-HTML-CIRCLE:         </div>
-HTML-CIRCLE:     </div>
-HTML-CIRCLE: </main>
-HTML-CIRCLE: </body>
-HTML-CIRCLE: </html>
-

--- a/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
+++ b/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
@@ -23,8 +23,8 @@
 
 
 // HTML-MYCLASS: <pre><code class="language-cpp code-clang-doc">int Add (int a, int b)</code></pre>
-// HTML-MYCLASS: <div>
-// HTML-MYCLASS:     <div>
+// HTML-MYCLASS: <div class="doc-card">
+// HTML-MYCLASS:     <div class="nested-delimiter-container">
 // HTML-MYCLASS:         <p> Declare a method to calculate the sum of two numbers</p>
 // HTML-MYCLASS:     </div>
 

--- a/clang-tools-extra/test/clang-doc/conversion_function.cpp
+++ b/clang-tools-extra/test/clang-doc/conversion_function.cpp
@@ -14,6 +14,6 @@ struct MyStruct {
 // Output correct conversion names.
 // CHECK-YAML:         Name:            'operator T'
 
-// CHECK-HTML: <div id="{{([0-9A-F]{40})}}">
+// CHECK-HTML: <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // CHECK-HTML:     <pre><code class="language-cpp code-clang-doc">T operator T ()</code></pre>
 // CHECK-HTML: </div>

--- a/clang-tools-extra/test/clang-doc/json/class.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class.cpp
@@ -324,15 +324,14 @@ private:
 // HTML-NEXT:     <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // HTML-NEXT:         <pre><code class="language-cpp code-clang-doc">template &lt;typename T&gt;</code></pre>
 // HTML-NEXT:         <pre><code class="language-cpp code-clang-doc">void MyClass (int )</code></pre>
-// HTML-NEXT:         <div>
+// HTML-NEXT:         <div class="nested-delimiter-container">
 // HTML-NEXT:             <p> This is a function template friend.</p>
 // HTML-NEXT:         </div>
 // HTML-NEXT:     </div>
 // HTML-NEXT:     <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // HTML-NEXT:         <pre><code class="language-cpp code-clang-doc">class Foo</code></pre>
-// HTML-NEXT:         <div>
+// HTML-NEXT:         <div class="nested-delimiter-container">
 // HTML-NEXT:             <p> This is a struct friend.</p>
 // HTML-NEXT:         </div>
 // HTML-NEXT:     </div>
 // HTML-NEXT: </section>
-

--- a/clang-tools-extra/test/clang-doc/json/compound-constraints.cpp
+++ b/clang-tools-extra/test/clang-doc/json/compound-constraints.cpp
@@ -148,52 +148,60 @@ template<typename T> requires (Incrementable<T> && Decrementable<T>) || PreIncre
 // CHECK-HTML-NEXT:         <div>
 // CHECK-HTML-NEXT:             <pre><code class="language-cpp code-clang-doc">template &lt;typename T&gt; Incrementable requires (T a) { a++; }</code></pre> 
 // CHECK-HTML-NEXT:         </div>
-// CHECK-HTML-NEXT:         <div>
+// CHECK-HTML-NEXT:         <div class="nested-delimiter-container">
 // CHECK-HTML-NEXT:             <p> Concept for an incrementable value</p>
 // CHECK-HTML-NEXT:         </div>
 // CHECK-HTML-NEXT:         <h3>Template Parameters</h3>
-// CHECK-HTML-NEXT:         <div>
-// CHECK-HTML-NEXT:             <b>T</b>   A value that can be incremented.
+// CHECK-HTML-NEXT:         <div class="nested-delimiter-container">
+// CHECK-HTML-NEXT:             <div>
+// CHECK-HTML-NEXT:                 <b>T</b>   A value that can be incremented.
+// CHECK-HTML-NEXT:             </div>
 // CHECK-HTML-NEXT:         </div> 
-// CHECK-HTML-NEXT:         <p>Defined at line [[@LINE-149]] of file {{.*}}compound-constraints.cpp</p>
+// CHECK-HTML-NEXT:         <p>Defined at line [[@LINE-151]] of file {{.*}}compound-constraints.cpp</p>
 // CHECK-HTML-NEXT:     </div>
 // CHECK-HTML-NEXT:     <div id="" class="delimiter-container">
 // CHECK-HTML-NEXT:         <div>
 // CHECK-HTML-NEXT:             <pre><code class="language-cpp code-clang-doc">template &lt;typename T&gt; Decrementable requires (T a) { a--; }</code></pre> 
 // CHECK-HTML-NEXT:         </div>
-// CHECK-HTML-NEXT:         <div>
+// CHECK-HTML-NEXT:         <div class="nested-delimiter-container">
 // CHECK-HTML-NEXT:             <p> Concept for a decrementable value</p>
 // CHECK-HTML-NEXT:         </div>
 // CHECK-HTML-NEXT:         <h3>Template Parameters</h3>
-// CHECK-HTML-NEXT:         <div>
-// CHECK-HTML-NEXT:             <b>T</b>   A value that can be decremented
+// CHECK-HTML-NEXT:         <div class="nested-delimiter-container">
+// CHECK-HTML-NEXT:             <div>
+// CHECK-HTML-NEXT:                 <b>T</b>   A value that can be decremented
+// CHECK-HTML-NEXT:             </div>
 // CHECK-HTML-NEXT:         </div> 
-// CHECK-HTML-NEXT:         <p>Defined at line [[@LINE-155]] of file {{.*}}compound-constraints.cpp</p>
+// CHECK-HTML-NEXT:         <p>Defined at line [[@LINE-159]] of file {{.*}}compound-constraints.cpp</p>
 // CHECK-HTML-NEXT:     </div>
 // CHECK-HTML-NEXT:     <div id="" class="delimiter-container">
 // CHECK-HTML-NEXT:         <div>
 // CHECK-HTML-NEXT:             <pre><code class="language-cpp code-clang-doc">template &lt;typename T&gt; PreIncrementable requires (T a) { ++a; }</code></pre> 
 // CHECK-HTML-NEXT:         </div>
-// CHECK-HTML-NEXT:         <div>
+// CHECK-HTML-NEXT:         <div class="nested-delimiter-container">
 // CHECK-HTML-NEXT:             <p> Concept for a pre-incrementable value</p>
 // CHECK-HTML-NEXT:         </div>
 // CHECK-HTML-NEXT:         <h3>Template Parameters</h3>
-// CHECK-HTML-NEXT:         <div>
-// CHECK-HTML-NEXT:             <b>T</b>   A value that can be pre-incremented
+// CHECK-HTML-NEXT:         <div class="nested-delimiter-container">
+// CHECK-HTML-NEXT:             <div>
+// CHECK-HTML-NEXT:                 <b>T</b>   A value that can be pre-incremented
+// CHECK-HTML-NEXT:             </div>
 // CHECK-HTML-NEXT:         </div> 
-// CHECK-HTML-NEXT:         <p>Defined at line [[@LINE-161]] of file {{.*}}compound-constraints.cpp</p>
+// CHECK-HTML-NEXT:         <p>Defined at line [[@LINE-167]] of file {{.*}}compound-constraints.cpp</p>
 // CHECK-HTML-NEXT:     </div>
 // CHECK-HTML-NEXT:     <div id="" class="delimiter-container">
 // CHECK-HTML-NEXT:         <div>
 // CHECK-HTML-NEXT:             <pre><code class="language-cpp code-clang-doc">template &lt;typename T&gt; PreDecrementable requires (T a) { --a; }</code></pre> 
 // CHECK-HTML-NEXT:         </div>
-// CHECK-HTML-NEXT:         <div>
+// CHECK-HTML-NEXT:         <div class="nested-delimiter-container">
 // CHECK-HTML-NEXT:             <p> Concept for a -pre-decrementable value</p>
 // CHECK-HTML-NEXT:         </div>
 // CHECK-HTML-NEXT:         <h3>Template Parameters</h3>
-// CHECK-HTML-NEXT:         <div>
-// CHECK-HTML-NEXT:             <b>T</b>   A value that can be pre-decremented
+// CHECK-HTML-NEXT:         <div class="nested-delimiter-container">
+// CHECK-HTML-NEXT:             <div>
+// CHECK-HTML-NEXT:                 <b>T</b>   A value that can be pre-decremented
+// CHECK-HTML-NEXT:             </div>
 // CHECK-HTML-NEXT:         </div> 
-// CHECK-HTML-NEXT:         <p>Defined at line [[@LINE-167]] of file {{.*}}compound-constraints.cpp</p>
+// CHECK-HTML-NEXT:         <p>Defined at line [[@LINE-175]] of file {{.*}}compound-constraints.cpp</p>
 // CHECK-HTML-NEXT:     </div>
 // CHECK-HTML-NEXT: </section>

--- a/clang-tools-extra/test/clang-doc/namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/namespace.cpp
@@ -128,16 +128,13 @@ class ClassInNestedNamespace {};
 // HTML-NESTED-INDEX:             </a>
 // HTML-NESTED-INDEX:         </li>
 // HTML-NESTED-INDEX:     </ul>
-// HTML-NESTED-INDEX:     <div class="delimiter-container">
-// HTML-NESTED-INDEX:         <div id="{{([0-9A-F]{40})}}">
-// HTML-NESTED-INDEX:             <pre><code class="language-cpp code-clang-doc">void functionInNestedNamespace ()</code></pre>
-// HTML-NESTED-INDEX:             <div>
-// HTML-NESTED-INDEX:                 <div>
-// HTML-NESTED-INDEX:                     <p> Function in NestedNamespace</p>
-// HTML-NESTED-INDEX:                 </div>
+// HTML-NESTED-INDEX:         <pre><code class="language-cpp code-clang-doc">void functionInNestedNamespace ()</code></pre>
+// HTML-NESTED-INDEX:         <div class="doc-card">
+// HTML-NESTED-INDEX:             <div class="nested-delimiter-container">
+// HTML-NESTED-INDEX:                 <p> Function in NestedNamespace</p>
 // HTML-NESTED-INDEX:             </div>
-// HTML-NESTED-INDEX:             <p>Defined at line 98 of file {{.*}}namespace.cpp</p>
 // HTML-NESTED-INDEX:         </div>
+// HTML-NESTED-INDEX:         <p>Defined at line 98 of file {{.*}}namespace.cpp</p>
 // HTML-NESTED-INDEX:     </div>
 } // namespace PrimaryNamespace
 
@@ -163,16 +160,13 @@ class ClassInNestedNamespace {};
 // HTML-PRIMARY-INDEX:                 </a>
 // HTML-PRIMARY-INDEX:              </li>
 // HTML-PRIMARY-INDEX:          </ul>
-// HTML-PRIMARY-INDEX:      <div class="delimiter-container">
-// HTML-PRIMARY-INDEX:          <div id="{{([0-9A-F]{40})}}">
-// HTML-PRIMARY-INDEX:              <pre><code class="language-cpp code-clang-doc">void functionInPrimaryNamespace ()</code></pre>
-// HTML-PRIMARY-INDEX:              <div>
-// HTML-PRIMARY-INDEX:                  <div>
-// HTML-PRIMARY-INDEX:                      <p> Function in PrimaryNamespace</p>
-// HTML-PRIMARY-INDEX:                  </div>
+// HTML-PRIMARY-INDEX:          <pre><code class="language-cpp code-clang-doc">void functionInPrimaryNamespace ()</code></pre>
+// HTML-PRIMARY-INDEX:          <div class="doc-card">
+// HTML-PRIMARY-INDEX:              <div class="nested-delimiter-container">
+// HTML-PRIMARY-INDEX:                  <p> Function in PrimaryNamespace</p>
 // HTML-PRIMARY-INDEX:              </div>
-// HTML-PRIMARY-INDEX:              <p>Defined at line 81 of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp</p>
 // HTML-PRIMARY-INDEX:          </div>
+// HTML-PRIMARY-INDEX:          <p>Defined at line 81 of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp</p>
 // HTML-PRIMARY-INDEX:      </div>
 // AnotherNamespace
 namespace AnotherNamespace {
@@ -211,17 +205,15 @@ class ClassInAnotherNamespace {};
 // HTML-ANOTHER-INDEX:             </a>
 // HTML-ANOTHER-INDEX:         </li>
 // HTML-ANOTHER-INDEX:     </ul>
-// HTML-ANOTHER-INDEX:     <div class="delimiter-container">
-// HTML-ANOTHER-INDEX:         <div id="{{([0-9A-F]{40})}}">
-// HTML-ANOTHER-INDEX:             <pre><code class="language-cpp code-clang-doc">void functionInAnotherNamespace ()</code></pre>
-// HTML-ANOTHER-INDEX:             <div>
-// HTML-ANOTHER-INDEX:                 <div>
-// HTML-ANOTHER-INDEX:                     <p> Function in AnotherNamespace</p>
-// HTML-ANOTHER-INDEX:                 </div>
+// HTML-ANOTHER-INDEX:         <pre><code class="language-cpp code-clang-doc">void functionInAnotherNamespace ()</code></pre>
+// HTML-ANOTHER-INDEX:         <div class="doc-card">
+// HTML-ANOTHER-INDEX:             <div class="nested-delimiter-container">
+// HTML-ANOTHER-INDEX:                 <p> Function in AnotherNamespace</p>
 // HTML-ANOTHER-INDEX:             </div>
-// HTML-ANOTHER-INDEX:             <p>Defined at line 180 of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp</p>
 // HTML-ANOTHER-INDEX:         </div>
+// HTML-ANOTHER-INDEX:         <p>Defined at line 174 of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp</p>
 // HTML-ANOTHER-INDEX:     </div>
+// HTML-ANOTHER-INDEX: </div>
 
 // COM: FIXME: Add namespaces to namespace template
 // HTML-GLOBAL-INDEX-NOT: <div id="main-content" class="col-xs-12 col-sm-9 col-md-8 main-content">

--- a/clang-tools-extra/test/clang-doc/templates.cpp
+++ b/clang-tools-extra/test/clang-doc/templates.cpp
@@ -77,13 +77,10 @@ void ParamPackFunction(T... args);
 // JSON-NEXT:        ]
 // JSON-NEXT:      },
 
-// HTML:       <div class="delimiter-container">
-// HTML-NEXT:      <div id="{{([0-9A-F]{40})}}">
-// HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">template &lt;class... T&gt;</code></pre>
-// HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">void ParamPackFunction (T... args)</code></pre>
-// COM:                FIXME: Omit defined line if not defined, or emit declaration line.
-// HTML-NEXT:          <p>Defined at line of file </p>
-// HTML-NEXT:      </div>
+// HTML:        <pre><code class="language-cpp code-clang-doc">template &lt;class... T&gt;</code></pre>
+// HTML-NEXT:      <pre><code class="language-cpp code-clang-doc">void ParamPackFunction (T... args)</code></pre>
+// COM:            FIXME: Omit defined line if not defined, or emit declaration line.
+// HTML-NEXT:      <p>Defined at line of file </p>
 // HTML-NEXT:  </div>
 
 template <typename T, int U = 1>
@@ -143,12 +140,9 @@ void function(T x) {}
 // JSON-NEXT:        ]
 // JSON-NEXT:      }
 
-// HTML:       <div class="delimiter-container">
-// HTML-NEXT:      <div id="{{([0-9A-F]{40})}}">
-// HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">template &lt;typename T, int U = 1&gt;</code></pre>
-// HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">void function (T x)</code></pre>
-// HTML-NEXT:          <p>Defined at line [[# @LINE - 60]] of file {{.*}}templates.cpp</p>
-// HTML-NEXT:      </div>
+// HTML:           <pre><code class="language-cpp code-clang-doc">template &lt;typename T, int U = 1&gt;</code></pre>
+// HTML-NEXT:      <pre><code class="language-cpp code-clang-doc">void function (T x)</code></pre>
+// HTML-NEXT:      <p>Defined at line [[# @LINE - 58]] of file {{.*}}templates.cpp</p>
 // HTML-NEXT:  </div>
 
 
@@ -214,12 +208,9 @@ void function<bool, 0>(bool x) {}
 // JSON-NEXT:        }
 // JSON-NEXT:      },
 
-// HTML:       <div class="delimiter-container">
-// HTML-NEXT:      <div id="{{([0-9A-F]{40})}}">
-// HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">template &lt;&gt;</code></pre>
-// HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">void function&lt;bool, 0&gt; (bool x)</code></pre>
-// HTML-NEXT:          <p>Defined at line [[# @LINE - 66]] of file {{.*}}templates.cpp</p>
-// HTML-NEXT:      </div>
+// HTML:           <pre><code class="language-cpp code-clang-doc">template &lt;&gt;</code></pre>
+// HTML-NEXT:      <pre><code class="language-cpp code-clang-doc">void function&lt;bool, 0&gt; (bool x)</code></pre>
+// HTML-NEXT:      <p>Defined at line [[# @LINE - 64]] of file {{.*}}templates.cpp</p>
 // HTML-NEXT:  </div>
 
 /// A Tuple type
@@ -233,11 +224,11 @@ struct tuple {};
 // HTML-STRUCT-NEXT:       <div class="hero__title">
 // HTML-STRUCT-NEXT:           <h1 class="hero__title-large">struct tuple</h1>
 // HTML-STRUCT-NEXT:           <p>Defined at line [[# @LINE - 6]] of file {{.*}}templates.cpp</p>
-// HTML-STRUCT-NEXT:           <div class="hero__subtitle">
-// HTML-STRUCT-NEXT:               <div>
+// HTML-STRUCT-NEXT:           <div class="doc-card">
+// HTML-STRUCT-NEXT:               <div class="nested-delimiter-container">
 // HTML-STRUCT-NEXT:                   <p> A Tuple type</p>
 // HTML-STRUCT-NEXT:               </div>
-// HTML-STRUCT-NEXT:               <div>
+// HTML-STRUCT-NEXT:               <div class="nested-delimiter-container">
 // HTML-STRUCT-NEXT:                   <p> Does Tuple things.</p>
 // HTML-STRUCT-NEXT:               </div>
 // HTML-STRUCT-NEXT:           </div>
@@ -316,18 +307,16 @@ tuple<int, int, bool> func_with_tuple_param(tuple<int, int, bool> t) { return t;
 // JSON-NEXT:        "USR": "{{([0-9A-F]{40})}}"
 // JSON-NEXT:      },
 
-// HTML:       <div class="delimiter-container">
-// HTML-NEXT:      <div id="{{([0-9A-F]{40})}}">
-// HTML-NEXT:          <pre><code class="language-cpp code-clang-doc">tuple&lt;int, int, bool&gt; func_with_tuple_param (tuple&lt;int, int, bool&gt; t)</code></pre>
-// HTML-NEXT:          <div>
-// HTML-NEXT:              <div>
-// HTML-NEXT:                  <p> A function with a tuple parameter</p>
-// HTML-NEXT:              </div>
+// HTML:           <pre><code class="language-cpp code-clang-doc">tuple&lt;int, int, bool&gt; func_with_tuple_param (tuple&lt;int, int, bool&gt; t)</code></pre>
+// HTML-NEXT:      <div class="doc-card">
+// HTML-NEXT:          <div class="nested-delimiter-container">
+// HTML-NEXT:              <p> A function with a tuple parameter</p>
+// HTML-NEXT:          </div>
+// HTML-NEXT:          <div class="nested-delimiter-container">
 // HTML-NEXT:              <h3>Parameters</h3>
 // HTML-NEXT:              <div>
 // HTML-NEXT:                  <b>t</b>   The input to func_with_tuple_param
 // HTML-NEXT:              </div> 
 // HTML-NEXT:          </div>
-// HTML-NEXT:          <p>Defined at line [[# @LINE - 81]] of file {{.*}}templates.cpp</p>
 // HTML-NEXT:      </div>
-// HTML-NEXT:  </div>
+// HTML-NEXT:      <p>Defined at line [[# @LINE - 81]] of file {{.*}}templates.cpp</p>

--- a/clang-tools-extra/test/clang-doc/typedef-alias.cpp
+++ b/clang-tools-extra/test/clang-doc/typedef-alias.cpp
@@ -40,14 +40,14 @@ using IntVec = Vector<int>;
 // HTML-GLOBAL-NEXT:     <h2>Typedefs</h2>
 // HTML-GLOBAL-NEXT:     <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // HTML-GLOBAL-NEXT:         <pre><code class="language-cpp code-clang-doc">using u_long = unsigned long</code></pre>
-// HTML-GLOBAL-NEXT:         <div>
+// HTML-GLOBAL-NEXT:         <div class="nested-delimiter-container">
 // HTML-GLOBAL-NEXT:             <p> This is u_long</p>
 // HTML-GLOBAL-NEXT:         </div>
 // HTML-GLOBAL-NEXT:         <p>Defined at line 8 of file {{.*}}typedef-alias.cpp</p>
 // HTML-GLOBAL-NEXT:     </div>
 // HTML-GLOBAL-NEXT:     <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // HTML-GLOBAL-NEXT:         <pre><code class="language-cpp code-clang-doc">typedef IntPtr int *</code></pre>
-// HTML-GLOBAL-NEXT:         <div>
+// HTML-GLOBAL-NEXT:         <div class="nested-delimiter-container">
 // HTML-GLOBAL-NEXT:             <p> This is IntPtr</p>
 // HTML-GLOBAL-NEXT:         </div>
 // HTML-GLOBAL-NEXT:         <p>Defined at line 11 of file {{.*}}typedef-alias.cpp</p>
@@ -74,7 +74,7 @@ using IntVec = Vector<int>;
 // HTML-VECTOR-NEXT:     <h2>Typedefs</h2>
 // HTML-VECTOR-NEXT:     <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // HTML-VECTOR-NEXT:         <pre><code class="language-cpp code-clang-doc">using Ptr = IntPtr</code></pre>
-// HTML-VECTOR-NEXT:         <div>
+// HTML-VECTOR-NEXT:         <div class="nested-delimiter-container">
 // HTML-VECTOR-NEXT:             <p> This is a Ptr</p>
 // HTML-VECTOR-NEXT:         </div>
 // HTML-VECTOR-NEXT:         <p>Defined at line 16 of file {{.*}}typedef-alias.cpp</p>


### PR DESCRIPTION
Comments weren't very visually distinctive in HTML. They immediately
proceeded the declaration header and didn't have spacing between them.
To visually organize them, they now have a thin border around them.
Different comment types are also now separated by a small gap. This also
allows them to be easily changed in the future. Some extraneous `<div>`
tags are also removed or merged.