### PR TITLE
[RISCV] Add SimplifyDemandedBits and hasAllNBitUsers support for CLSW.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -4085,6 +4085,7 @@ bool RISCVDAGToDAGISel::hasAllNBitUsers(SDNode *Node, unsigned Bits,
     case RISCV::ROLW:
     case RISCV::RORW:
     case RISCV::RORIW:
+    case RISCV::CLSW:
     case RISCV::CLZW:
     case RISCV::CTZW:
     case RISCV::CPOPW:

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -20909,6 +20909,7 @@ SDValue RISCVTargetLowering::PerformDAGCombine(SDNode *N,
     break;
   }
   case RISCVISD::ABSW:
+  case RISCVISD::CLSW:
   case RISCVISD::CLZW:
   case RISCVISD::CTZW: {
     // Only the lower 32 bits of the first operand are read

--- a/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
+++ b/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
@@ -168,6 +168,7 @@ static bool hasAllNBitUsers(const MachineInstr &OrigMI,
       case RISCV::ROLW:
       case RISCV::RORW:
       case RISCV::RORIW:
+      case RISCV::CLSW:
       case RISCV::CLZW:
       case RISCV::CTZW:
       case RISCV::CPOPW:


### PR DESCRIPTION
This matches what we do for CLZW and other W instructions.