### PR TITLE
[mlir][NVVM] Set SpecialRangeableRegisterOp default int range to max

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -4544,6 +4544,8 @@ static void nvvmInferResultRanges(Operation *op, Value result,
   if (auto rangeAttr = op->getAttrOfType<LLVM::ConstantRangeAttr>("range")) {
     setResultRanges(result, {rangeAttr.getLower(), rangeAttr.getUpper(),
                              rangeAttr.getLower(), rangeAttr.getUpper()});
+  } else {
+    setResultRanges(result, IntegerValueRange::getMaxRange(result).getValue());
   }
 }
 

--- a/mlir/test/Dialect/LLVMIR/nvvm-test-range.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm-test-range.mlir
@@ -4,7 +4,7 @@ gpu.module @module{
         %tidx = nvvm.read.ptx.sreg.tid.x range <i32, 0, 32> : i32
         %tidy = nvvm.read.ptx.sreg.tid.y range <i32, 0, 128> : i32
         %tidz = nvvm.read.ptx.sreg.tid.z range <i32, 0, 4> : i32
-        %ctaid = nvvm.read.ptx.sreg.cluster.ctaid.x : i32 // unspecified range
+        %cidx = nvvm.read.ptx.sreg.cluster.ctaid.x : i32 // unspecified range
         %cond = ub.poison : i1
         %c64 = arith.constant 64 : i32
         
@@ -20,8 +20,8 @@ gpu.module @module{
         scf.if %3 {
             gpu.printf "threadidz"
         }
-        %4 = arith.select %cond, %ctaid, %c64 : i32
-        gpu.printf "ctaid", %4 : i32
+        %4 = arith.select %cond, %cidx, %c64 : i32
+        gpu.printf "ctaidx", %4 : i32
 
         gpu.return
     }

--- a/mlir/test/Dialect/LLVMIR/nvvm-test-range.mlir
+++ b/mlir/test/Dialect/LLVMIR/nvvm-test-range.mlir
@@ -4,6 +4,8 @@ gpu.module @module{
         %tidx = nvvm.read.ptx.sreg.tid.x range <i32, 0, 32> : i32
         %tidy = nvvm.read.ptx.sreg.tid.y range <i32, 0, 128> : i32
         %tidz = nvvm.read.ptx.sreg.tid.z range <i32, 0, 4> : i32
+        %ctaid = nvvm.read.ptx.sreg.cluster.ctaid.x : i32 // unspecified range
+        %cond = ub.poison : i1
         %c64 = arith.constant 64 : i32
         
         %1 = arith.cmpi sgt, %tidx, %c64 : i32
@@ -18,6 +20,9 @@ gpu.module @module{
         scf.if %3 {
             gpu.printf "threadidz"
         }
+        %4 = arith.select %cond, %ctaid, %c64 : i32
+        gpu.printf "ctaid", %4 : i32
+
         gpu.return
     }
 }
@@ -33,3 +38,4 @@ gpu.module @module{
 // CHECK: gpu.printf "threadidy"
 // CHECK: scf.if %[[false]] {
 // CHECK: gpu.printf "threadidz"
+// CHECK: arith.select


### PR DESCRIPTION
This PR added fix to ensure NVVM SpecialRangeableRegisterOp values default int range have correct semantic (max range i.e. unknown), rather than uninitialized. 