### PR TITLE
[BOLT][AArch64] Prefer non reloc layout for short branches beyond fragment.

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -2432,6 +2432,8 @@ public:
   /// addresses of basic blocks.
   bool requiresAddressMap() const;
 
+  bool hasShortRangeBranchBeyondFragment() const;
+
   /// Adjust branch instructions to match the CFG.
   ///
   /// As it comes to internal branches, the CFG represents "the ultimate source

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -1748,6 +1748,13 @@ public:
     return false;
   }
 
+  /// Some targets with short range branches use this to choose code
+  /// layout which does not require relocations.
+  virtual bool isShortRangeBranch(MCInst &Inst) const {
+    assert(isBranch(Inst) && "Branch expected.");
+    return false;
+  }
+
   /// Receives a list of MCInst of the basic block to analyze and interpret the
   /// terminators of this basic block. TBB must be initialized with the original
   /// fall-through for this BB.

--- a/bolt/lib/Passes/LongJmp.cpp
+++ b/bolt/lib/Passes/LongJmp.cpp
@@ -402,8 +402,11 @@ LongJmpPass::tentativeLayoutRelocMode(const BinaryContext &BC,
 void LongJmpPass::tentativeLayout(const BinaryContext &BC,
                                   BinaryFunctionListType &SortedFunctions) {
   uint64_t DotAddress = BC.LayoutStartAddress;
+  bool PreferNonRelocLayout = any_of(SortedFunctions, [](BinaryFunction *F) {
+    return F->hasShortRangeBranchBeyondFragment();
+  });
 
-  if (!BC.HasRelocations) {
+  if (!BC.HasRelocations || PreferNonRelocLayout) {
     for (BinaryFunction *Func : SortedFunctions) {
       HotAddresses[Func] = Func->getAddress();
       DotAddress = alignTo(DotAddress, ColdFragAlign);

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -2114,6 +2114,11 @@ public:
       convertJmpToTailCall(Inst);
   }
 
+  bool isShortRangeBranch(MCInst &Inst) const override {
+    assert(isBranch(Inst) && "Branch expected.");
+    return isConditionalBranch(Inst);
+  }
+
   bool analyzeBranch(InstructionIterator Begin, InstructionIterator End,
                      const MCSymbol *&TBB, const MCSymbol *&FBB,
                      MCInst *&CondBranch,

--- a/bolt/test/AArch64/short-range-cond-branch-layout.s
+++ b/bolt/test/AArch64/short-range-cond-branch-layout.s
@@ -1,0 +1,62 @@
+# This test checks that when spliting functions which contain short range
+# conditional branches, we choose such a code layout that relocations are
+# not needed.
+
+# REQUIRES: system-linux, asserts
+
+# RUN: %clang %cflags -Wl,-q %s -o %t
+# RUN: link_fdata --no-lbr %s %t %t.fdata
+# RUN: llvm-bolt %t -o %t.bolt --data %t.fdata -split-functions
+# RUN: llvm-objdump -d %t.bolt | FileCheck %s
+
+  .text
+
+  .globl  foo
+  .type foo, %function
+foo:
+.entry_foo:
+# FDATA: 1 foo #.entry_foo# 10
+    cbz x0, .Lcold_foo
+    ret
+.Lcold_foo:
+    mov x0, #1
+    ret
+
+  .globl  bar
+  .type bar, %function
+bar:
+.entry_bar:
+# FDATA: 1 bar  #.entry_bar# 10
+    tbz x0, #1, .Lcold_bar
+    ret
+.Lcold_bar:
+    mov x0, #2
+    ret
+
+## Force relocation mode.
+.reloc 0, R_AARCH64_NONE
+
+
+# CHECK: Disassembly of section .text:
+
+# CHECK: <foo>:
+# CHECK-NEXT:            {{.*}} cbnz x0, 0x[[ADDR0:[0-9a-f]+]] <{{.*}}>
+# CHECK-NEXT:            {{.*}} b        0x[[ADDR1:[0-9a-f]+]] <{{.*}}>
+# CHECK-NEXT: [[ADDR0]]: {{.*}} b        0x[[ADDR2:[0-9a-f]+]] <{{.*}}>
+
+# CHECK: <bar>:
+# CHECK-NEXT:            {{.*}} tbnz w0, #0x1, 0x[[ADDR3:[0-9a-f]+]] <{{.*}}>
+# CHECK-NEXT:            {{.*}} b              0x[[ADDR4:[0-9a-f]+]] <{{.*}}>
+# CHECK-NEXT: [[ADDR3]]: {{.*}} b              0x[[ADDR5:[0-9a-f]+]] <{{.*}}>
+
+# CHECK: Disassembly of section .text.cold:
+
+# CHECK: <foo.cold.0>:
+# CHECK-NEXT: [[ADDR2]]: {{.*}} ret
+# CHECK-NEXT: [[ADDR1]]: {{.*}} mov x0, #0x1 // =1
+# CHECK-NEXT:            {{.*}} ret
+
+# CHECK: <bar.cold.0>:
+# CHECK-NEXT: [[ADDR5]]: {{.*}} ret
+# CHECK-NEXT: [[ADDR4]]: {{.*}} mov x0, #0x2 // =2
+# CHECK-NEXT:            {{.*}} ret


### PR DESCRIPTION
When splitting functions which contain short range conditional branches, we should prefer a layout which doesn't require relocations. We should do this even when in relocation mode. That is because the cold code may reside in a fragment far away making the branches go out of range.

The Arm ELF64 ABI supports two kinds of control flow relocations for short range conditional branches:
 * R_<CLS>_TSTBR14   (for TBZ)
 * R_<CLS>_CONDBR19  (for CBZ, B.\<cond\>)

https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst#relocation

The prefered layout looks as follows:
```
tbz x0, #3, cold_target   ~>   tbnz x0, #3, skip
                               b   cold_target
                               skip:
```
I have added a target specific hook `isShortRangeBranch` even though for AArch64 all conditional branches are considered short, to avoid affecting layout decisions on other targets.