### PR TITLE
[NFC][AMDGPU] Use getMixedSize in FatRawBufferCastOp dim reification

### DIFF
--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUDialect.cpp
@@ -151,12 +151,7 @@ FailureOr<OpFoldResult> FatRawBufferCastOp::reifyDimOfResult(OpBuilder &builder,
                                                              int resultIndex,
                                                              int dim) {
   assert(resultIndex == 0 && "FatRawBufferCastOp has a single result");
-  Value source = getSource();
-  auto sourceType = cast<MemRefType>(source.getType());
-  if (sourceType.isDynamicDim(dim))
-    return OpFoldResult(
-        builder.createOrFold<memref::DimOp>(getLoc(), source, dim));
-  return OpFoldResult(builder.getIndexAttr(sourceType.getDimSize(dim)));
+  return memref::getMixedSize(builder, getLoc(), getSource(), dim);
 }
 
 LogicalResult FatRawBufferCastOp::verify() {


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/174477, I found similar logic that can be replaced by `memref::getMixedSize` in the FatRawBufferCastOp dimension reification function.