### PR TITLE
[mlir][python] Fix recursion error for __str__

### DIFF
--- a/mlir/test/mlir-tblgen/enums-python-bindings.td
+++ b/mlir/test/mlir-tblgen/enums-python-bindings.td
@@ -90,8 +90,6 @@ def TestBitEnum_Attr : EnumAttr<Test_Dialect, TestBitEnum, "testbitenum">;
 // CHECK:         return bin(self).count("1")
 
 // CHECK:     def __str__(self):
-// CHECK:         if len(self) > 1:
-// CHECK:             return " | ".join(map(str, self))
 // CHECK:         if self is TestBitEnum.User:
 // CHECK:             return "user"
 // CHECK:         if self is TestBitEnum.Group:
@@ -100,6 +98,8 @@ def TestBitEnum_Attr : EnumAttr<Test_Dialect, TestBitEnum, "testbitenum">;
 // CHECK:             return "other"
 // CHECK:         if self is TestBitEnum.Any:
 // CHECK:             return "any"
+// CHECK:         if len(self) > 1:
+// CHECK:             return " | ".join(map(str, self))
 // CHECK:         raise ValueError("Unknown TestBitEnum enum entry.")
 
 // CHECK: @register_attribute_builder("TestBitEnum")

--- a/mlir/test/python/dialects/arith_dialect.py
+++ b/mlir/test/python/dialects/arith_dialect.py
@@ -37,6 +37,18 @@ def testFastMathFlags():
             print(r)
 
 
+# CHECK-LABEL: TEST: testFastMathFlagsFast
+@run
+def testFastMathFlagsFast():
+    with Context() as ctx, Location.unknown():
+        module = Module.create()
+        with InsertionPoint(module.body):
+            a = arith.ConstantOp(value=42.42, result=F32Type.get())
+            r = arith.AddFOp(a, a, fastmath=arith.FastMathFlags.fast)
+            # CHECK: %0 = arith.addf %cst, %cst fastmath<fast> : f32
+            print(r)
+
+
 # CHECK-LABEL: TEST: testArithValue
 @run
 def testArithValue():

--- a/mlir/tools/mlir-tblgen/EnumPythonBindingGen.cpp
+++ b/mlir/tools/mlir-tblgen/EnumPythonBindingGen.cpp
@@ -71,15 +71,15 @@ static void emitEnumClass(EnumInfo enumInfo, raw_ostream &os) {
   }
 
   os << formatv("    def __str__(self):\n");
-  if (enumInfo.isBitEnum())
-    os << formatv("        if len(self) > 1:\n"
-                  "            return \"{0}\".join(map(str, self))\n",
-                  enumInfo.getDef().getValueAsString("separator"));
   for (const EnumCase &enumCase : enumInfo.getAllCases()) {
     os << formatv("        if self is {0}.{1}:\n", enumInfo.getEnumClassName(),
                   makePythonEnumCaseName(enumCase.getSymbol()));
     os << formatv("            return \"{0}\"\n", enumCase.getStr());
   }
+  if (enumInfo.isBitEnum())
+  os << formatv("        if len(self) > 1:\n"
+                "            return \"{0}\".join(map(str, self))\n",
+                enumInfo.getDef().getValueAsString("separator"));
   os << formatv("        raise ValueError(\"Unknown {0} enum entry.\")\n\n\n",
                 enumInfo.getEnumClassName());
   os << "\n";

--- a/mlir/tools/mlir-tblgen/EnumPythonBindingGen.cpp
+++ b/mlir/tools/mlir-tblgen/EnumPythonBindingGen.cpp
@@ -77,9 +77,9 @@ static void emitEnumClass(EnumInfo enumInfo, raw_ostream &os) {
     os << formatv("            return \"{0}\"\n", enumCase.getStr());
   }
   if (enumInfo.isBitEnum())
-  os << formatv("        if len(self) > 1:\n"
-                "            return \"{0}\".join(map(str, self))\n",
-                enumInfo.getDef().getValueAsString("separator"));
+    os << formatv("        if len(self) > 1:\n"
+                  "            return \"{0}\".join(map(str, self))\n",
+                  enumInfo.getDef().getValueAsString("separator"));
   os << formatv("        raise ValueError(\"Unknown {0} enum entry.\")\n\n\n",
                 enumInfo.getEnumClassName());
   os << "\n";


### PR DESCRIPTION
The implementation of "__str__" may cause recursion error: maximum recursion depth exceeded in __instancecheck__. Fix this issue by changing the sequence of judgment.