### PR TITLE
[Clang][Modules] Emit C++20 BMIs to working directory with -fmodule-output

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3783,11 +3783,10 @@ clang::driver::tools::getCXX20NamedModuleOutputPath(const ArgList &Args,
   if (Arg *FinalOutput = Args.getLastArg(options::OPT_o);
       FinalOutput && Args.hasArg(options::OPT_c))
     OutputPath = FinalOutput->getValue();
-  else{
+  else {
     llvm::sys::fs::current_path(OutputPath);
-    llvm::sys::path::append(OutputPath,llvm::sys::path::filename(BaseInput));
+    llvm::sys::path::append(OutputPath, llvm::sys::path::filename(BaseInput));
   }
-
 
   const char *Extension = types::getTypeTempSuffix(types::TY_ModuleFile);
   llvm::sys::path::replace_extension(OutputPath, Extension);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3783,8 +3783,11 @@ clang::driver::tools::getCXX20NamedModuleOutputPath(const ArgList &Args,
   if (Arg *FinalOutput = Args.getLastArg(options::OPT_o);
       FinalOutput && Args.hasArg(options::OPT_c))
     OutputPath = FinalOutput->getValue();
-  else
-    OutputPath = BaseInput;
+  else{
+    llvm::sys::fs::current_path(OutputPath);
+    llvm::sys::path::append(OutputPath,llvm::sys::path::filename(BaseInput));
+  }
+
 
   const char *Extension = types::getTypeTempSuffix(types::TY_ModuleFile);
   llvm::sys::path::replace_extension(OutputPath, Extension);

--- a/clang/test/Driver/module-fgen-reduced-bmi.cppm
+++ b/clang/test/Driver/module-fgen-reduced-bmi.cppm
@@ -51,7 +51,7 @@
 
 // RUN: %clang -std=c++20 Hello.cppm --precompile -fmodules-reduced-bmi \
 // RUN:     -### 2>&1 | FileCheck Hello.cppm \
-// RUN:     --check-prefix=CHECK-OVERRIDE-WARN
+// RUN:     --check-prefix=CHECK-OVERRIDE-WARN-NOT
 
 // RUN: %clang -std=c++20 Hello.cppm --precompile -fmodules-reduced-bmi \
 // RUN:     -o Hello.pcm -### 2>&1 | FileCheck Hello.cppm \
@@ -74,7 +74,7 @@ export module Hello;
 // CHECK-NOT: -emit-module-interface
 // CHECK: "-fmodules-reduced-bmi"
 
-// CHECK-UNSPECIFIED: -fmodule-output=Hello.pcm
+// CHECK-UNSPECIFIED: -fmodule-output={{.*}}Hello.pcm
 
 // CHECK-NO-O: -fmodule-output=Hello.pcm
 // CHECK-ANOTHER-NAME: -fmodule-output=AnotherName.pcm
@@ -83,7 +83,7 @@ export module Hello;
 // flag.
 // CHECK-EMIT-MODULE-INTERFACE: -emit-module-interface
 
-// CHECK-OVERRIDE-WARN: warning: the implicit output of reduced BMI may be overrided by the output file specified by '--precompile'. {{.*}}-Wreduced-bmi-output-overrided
+// CHECK-OVERRIDE-WARN-NOT: warning:
 
 // NO_WARN-NOT: warning
 

--- a/clang/test/Driver/module-fgen-reduced-bmi.cppm
+++ b/clang/test/Driver/module-fgen-reduced-bmi.cppm
@@ -48,14 +48,10 @@
 // RUN: %clang -std=c++20 Hello.cppm --precompile -fmodules-reduced-bmi \
 // RUN:     -o Hello.full.pcm -### 2>&1 | FileCheck Hello.cppm \
 // RUN:     --check-prefix=CHECK-EMIT-MODULE-INTERFACE
-
-// RUN: %clang -std=c++20 Hello.cppm --precompile -fmodules-reduced-bmi \
-// RUN:     -### 2>&1 | FileCheck Hello.cppm \
-// RUN:     --check-prefix=CHECK-OVERRIDE-WARN-NOT
-
-// RUN: %clang -std=c++20 Hello.cppm --precompile -fmodules-reduced-bmi \
-// RUN:     -o Hello.pcm -### 2>&1 | FileCheck Hello.cppm \
-// RUN:    --check-prefix=CHECK-OVERRIDE-WARN
+//
+// RUN: %clang -std=c++20 %t/Hello.cppm --precompile -fmodules-reduced-bmi \
+// RUN:     -o %t/Hello.pcm -### 2>&1 | FileCheck %t/Hello.cppm \
+// RUN:     --check-prefix=CHECK-OVERRIDE-WARN
 //
 // RUN: %clang -std=c++20 Hello.cc -fmodules-reduced-bmi -Wall -Werror \
 // RUN:     -c -o Hello.o -### 2>&1 | FileCheck Hello.cc
@@ -75,15 +71,13 @@ export module Hello;
 // CHECK: "-fmodules-reduced-bmi"
 
 // CHECK-UNSPECIFIED: -fmodule-output={{.*}}Hello.pcm
-
-// CHECK-NO-O: -fmodule-output=Hello.pcm
-// CHECK-ANOTHER-NAME: -fmodule-output=AnotherName.pcm
+// CHECK-NO-O: -fmodule-output={{.*}}Hello.pcm
+// CHECK-ANOTHER-NAME: -fmodule-output={{.*}}AnotherName.pcm
 
 // With `-emit-module-interface` specified, we should still see the `-emit-module-interface`
 // flag.
 // CHECK-EMIT-MODULE-INTERFACE: -emit-module-interface
-
-// CHECK-OVERRIDE-WARN-NOT: warning:
+// CHECK-OVERRIDE-WARN: implicit output of reduced BMI{{.*}}-Wreduced-bmi-output-overrided
 
 // NO_WARN-NOT: warning
 

--- a/clang/test/Driver/module-output.cppm
+++ b/clang/test/Driver/module-output.cppm
@@ -42,7 +42,7 @@ export module Hello;
 
 // CHECK: "-emit-module-interface" {{.*}}"-main-file-name" "Hello.cppm" {{.*}}"-o" "{{.*}}/output/Hello.pcm" "-x" "c++" "{{.*}}/Hello.cppm"
 // CHECK: "-emit-obj" {{.*}}"-main-file-name" "Hello.cppm" {{.*}}"-o" "{{.*}}/output/Hello.o" "-x" "pcm" "{{.*}}/output/Hello.pcm"
-
+// CHECK-CWD: -fmodule-output={{.*}}/build/Hello.pcm
 // MULTIPLE-ARCH: option '-fmodule-output' cannot be used with multiple arch options
 
 // CHECK-SPECIFIED: "-emit-module-interface" {{.*}}"-main-file-name" "Hello.cppm" {{.*}}"-o" "{{.*}}/pcm/Hello.pcm" "-x" "c++" "{{.*}}/Hello.cppm"


### PR DESCRIPTION
Close #173689.

When -fmodule-output is specified without an explicit path, Clang currently emits the generated .pcm next to the source file. This contradicts the documentation and breaks out-of-tree builds.

This patch updates the fallback behavior to emit the BMI in the working directory, instead of the source file directory.

Driver tests are updated accordingly. Explicit -fmodule-output=PATH behavior is unchanged.