### PR TITLE
llvm: Convert some assorted lit tests to opaque pointers

### DIFF
--- a/llvm/test/Analysis/DependenceAnalysis/FlipFlopBaseAddress.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/FlipFlopBaseAddress.ll
@@ -20,10 +20,10 @@ entry:
   br label %for.body
 
 for.body:
-  %p = phi float* [ %g, %entry ], [ %q, %for.body ]
-  %q = phi float* [ %h, %entry ], [ %p, %for.body ]
-  %0 = load float, float* %p, align 4
-  store float %f, float* %q, align 4
+  %p = phi ptr [ %g, %entry ], [ %q, %for.body ]
+  %q = phi ptr [ %h, %entry ], [ %p, %for.body ]
+  %0 = load float, ptr %p, align 4
+  store float %f, ptr %q, align 4
   %branch_cond = fcmp ugt float %0, 0.0
   br i1 %branch_cond, label %for.cond.cleanup, label %for.body
 
@@ -47,10 +47,10 @@ entry:
 
 for.body:
   %i = phi i32 [0, %entry ], [ %inc, %for.body ]
-  %p = phi float* [ %g, %entry ], [ %q, %for.body ]
-  %q = phi float* [ %h, %entry ], [ %p, %for.body ]
-  %0 = load float, float* %p, align 4
-  store float 0.0, float* %q, align 4
+  %p = phi ptr [ %g, %entry ], [ %q, %for.body ]
+  %q = phi ptr [ %h, %entry ], [ %p, %for.body ]
+  %0 = load float, ptr %p, align 4
+  store float 0.0, ptr %q, align 4
   %inc = add nuw i32 %i, 1
   %branch_cond = icmp ult i32 %i, %n
   br i1 %branch_cond, label %for.body, label %for.cond.cleanup

--- a/llvm/test/CodeGen/AArch64/aggressive-interleaving.ll
+++ b/llvm/test/CodeGen/AArch64/aggressive-interleaving.ll
@@ -7,7 +7,7 @@
 ; multiple loads / multiplies / adds in the vector body.
 
 
-define void @test_interleave_reduction(i32*** %arg, double** %arg1) {
+define void @test_interleave_reduction(ptr %arg, ptr %arg1) {
 ; A320-LABEL: define void @test_interleave_reduction(
 ; A320-SAME: ptr [[ARG:%.*]], ptr [[ARG1:%.*]]) #[[ATTR0:[0-9]+]] {
 ; A320-NEXT:  [[ENTRY:.*:]]
@@ -99,16 +99,16 @@ define void @test_interleave_reduction(i32*** %arg, double** %arg1) {
 ; A320-NEXT:    br label %[[OUTER]]
 ;
 entry:
-  %tpm15 = load i32**, i32*** %arg, align 8
-  %tpm19 = load double*, double** %arg1, align 8
+  %tpm15 = load ptr, ptr %arg, align 8
+  %tpm19 = load ptr, ptr %arg1, align 8
   br label %outer
 
 outer:                                            ; preds = %inner, %entry
   %tpm26 = add i64 0, 1
   %tpm10 = alloca i32, align 8
   %tpm27 = getelementptr inbounds i32, ptr %tpm10, i64 %tpm26
-  %tpm28 = getelementptr inbounds i32*, ptr %tpm15, i64 0
-  %tpm29 = load i32*, ptr %tpm28, align 8
+  %tpm28 = getelementptr inbounds ptr, ptr %tpm15, i64 0
+  %tpm29 = load ptr, ptr %tpm28, align 8
   %tpm17 = alloca double, align 8
   %tpm32 = getelementptr inbounds double, ptr %tpm17, i64 %tpm26
   br label %inner
@@ -144,7 +144,7 @@ exit.inner:                                       ; preds = %inner
 ;    duplicated loads and adds.
 ;===---------------------------------------------------------------------===;
 
-define double @sum_reduction(double* nocapture readonly %a, i64 %n) {
+define double @sum_reduction(ptr nocapture readonly %a, i64 %n) {
 ; A320-LABEL: define double @sum_reduction(
 ; A320-SAME: ptr readonly captures(none) [[A:%.*]], i64 [[N:%.*]]) #[[ATTR0]] {
 ; A320-NEXT:  [[ENTRY:.*]]:
@@ -225,7 +225,7 @@ exit:
 ;    have multiple pairs of loads and fmuls/fadds.
 ;===---------------------------------------------------------------------===;
 
-define double @dot_product(double* nocapture readonly %a, double* nocapture readonly %b, i64 %n) {
+define double @dot_product(ptr nocapture readonly %a, ptr nocapture readonly %b, i64 %n) {
 ; A320-LABEL: define double @dot_product(
 ; A320-SAME: ptr readonly captures(none) [[A:%.*]], ptr readonly captures(none) [[B:%.*]], i64 [[N:%.*]]) #[[ATTR0]] {
 ; A320-NEXT:  [[ENTRY:.*]]:

--- a/llvm/test/CodeGen/AArch64/apply-terminal-rule.mir
+++ b/llvm/test/CodeGen/AArch64/apply-terminal-rule.mir
@@ -11,7 +11,7 @@
     br i1 %cmp63, label %for.body.preheader, label %for.cond.cleanup
 
   for.body.preheader:                               ; preds = %entry
-    %0 = load i32, i32* getelementptr inbounds ([100 x i32], [100 x i32]* @A, i64 0, i64 0), align 4
+    %0 = load i32, ptr @A, align 4
     br label %for.body
 
   for.cond.cleanup:                                 ; preds = %for.body, %entry
@@ -96,7 +96,7 @@ body:             |
     successors: %bb.3(0x80000000)
 
     %1:gpr64common = ADRP target-flags(aarch64-page) @A
-    %2:gpr32 = LDRWui %1:gpr64common, target-flags(aarch64-pageoff, aarch64-nc) @A :: (dereferenceable load (s32) from `i32* getelementptr inbounds ([100 x i32], [100 x i32]* @A, i64 0, i64 0)`)
+    %2:gpr32 = LDRWui %1:gpr64common, target-flags(aarch64-pageoff, aarch64-nc) @A :: (dereferenceable load (s32) from `i32* getelementptr inbounds ([100 x i32], ptr @A, i64 0, i64 0)`)
     %3:gpr32all = COPY %2:gpr32
     %4:gpr32sp = COPY %0:gpr32common
     %5:gpr32 = COPY %0:gpr32common

--- a/llvm/test/CodeGen/AArch64/speculation-hardening-sls-blr.mir
+++ b/llvm/test/CodeGen/AArch64/speculation-hardening-sls-blr.mir
@@ -12,14 +12,14 @@
 # Check that the BLR SLS hardening transforms a BLR into a BL with operands as
 # expected.
 --- |
-  @a = dso_local local_unnamed_addr global i32 (...)* null, align 8
+  @a = dso_local local_unnamed_addr global ptr null, align 8
   @b = dso_local local_unnamed_addr global i32 0, align 4
 
   define dso_local void @fn1() local_unnamed_addr "target-features"="+harden-sls-blr" {
   entry:
-    %0 = load i32 ()*, i32 ()** bitcast (i32 (...)** @a to i32 ()**), align 8
+    %0 = load ptr, ptr @a, align 8
     %call = tail call i32 %0() nounwind
-    store i32 %call, i32* @b, align 4
+    store i32 %call, ptr @b, align 4
     ret void
   }
 ...
@@ -35,7 +35,7 @@ body:             |
     frame-setup CFI_INSTRUCTION def_cfa_offset 16
     frame-setup CFI_INSTRUCTION offset $w30, -16
     renamable $x8 = ADRP target-flags(aarch64-page) @a
-    renamable $x8 = LDRXui killed renamable $x8, target-flags(aarch64-pageoff, aarch64-nc) @a :: (dereferenceable load (s64) from `i32 ()** bitcast (i32 (...)** @a to i32 ()**)`)
+    renamable $x8 = LDRXui killed renamable $x8, target-flags(aarch64-pageoff, aarch64-nc) @a :: (dereferenceable load (s64) from `ptr bitcast (ptr @a to ptr)`)
     BLRNoIP killed renamable $x8, csr_aarch64_aapcs, implicit-def dead $lr, implicit $sp, implicit-def $sp, implicit-def $w0
   ; CHECK:  BL <mcsymbol __llvm_slsblr_thunk_x8>, csr_aarch64_aapcs, implicit-def dead $lr, implicit $sp, implicit-def $sp, implicit-def $w0, implicit killed $x8
     renamable $x8 = ADRP target-flags(aarch64-page) @b

--- a/llvm/test/CodeGen/AArch64/tail-dup-redundant-phi.mir
+++ b/llvm/test/CodeGen/AArch64/tail-dup-redundant-phi.mir
@@ -4,7 +4,7 @@
   target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
   target triple = "aarch64-none-linux-gnu"
 
-  define void @ham() gc "statepoint-example" personality i32* ()* @baz {
+  define void @ham() gc "statepoint-example" personality ptr @baz {
   bb:
     switch i32 undef, label %bb4 [
       i32 2050, label %bb1
@@ -12,16 +12,16 @@
     ]
 
   bb1:                                              ; preds = %bb
-    %tmp = call token (i64, i32, void (i32)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_isVoidi32f(i64 2882400000, i32 0, void (i32)* nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 10, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
+    %tmp = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 10, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
     unreachable
 
   bb2:                                              ; preds = %bb
-    %tmp3 = call token (i64, i32, void (i32)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_isVoidi32f(i64 2882400000, i32 0, void (i32)* nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 10, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
+    %tmp3 = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 10, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
     unreachable
 
   bb4:                                              ; preds = %bb
-    %tmp5 = call token (i64, i32, i8 addrspace(1)* (i8 addrspace(1)*)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_p1i8p1i8f(i64 2882400000, i32 0, i8 addrspace(1)* (i8 addrspace(1)*)* elementtype(i8 addrspace(1)* (i8 addrspace(1)*)) undef, i32 1, i32 0, i8 addrspace(1)* nonnull undef, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
-    %tmp10 = call token (i64, i32, i8 addrspace(1)* (i8 addrspace(1)*)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_p1i8p1i8f(i64 2, i32 4, i8 addrspace(1)* (i8 addrspace(1)*)* nonnull elementtype(i8 addrspace(1)* (i8 addrspace(1)*)) @barney, i32 1, i32 0, i8 addrspace(1)* nonnull undef, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
+    %tmp5 = call token (i64, i32, ptr addrspace(1) (ptr addrspace(1))*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr addrspace(1) (ptr addrspace(1))* elementtype(ptr addrspace(1) (ptr addrspace(1))) undef, i32 1, i32 0, ptr addrspace(1) nonnull undef, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
+    %tmp10 = call token (i64, i32, ptr addrspace(1) (ptr addrspace(1))*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2, i32 4, ptr addrspace(1) (ptr addrspace(1))* nonnull elementtype(ptr addrspace(1) (ptr addrspace(1))) @barney, i32 1, i32 0, ptr addrspace(1) nonnull undef, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
     br i1 undef, label %bb40, label %bb24
 
   bb24:                                             ; preds = %bb4
@@ -32,30 +32,30 @@
     ]
 
   bb25:                                             ; preds = %bb24
-    %tmp26 = call token (i64, i32, i8 addrspace(1)* (i8 addrspace(1)*)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_p1i8p1i8f(i64 2, i32 4, i8 addrspace(1)* (i8 addrspace(1)*)* nonnull elementtype(i8 addrspace(1)* (i8 addrspace(1)*)) @wobble, i32 1, i32 0, i8 addrspace(1)* nonnull undef, i32 0, i32 0) [ "deopt"(), "gc-live"(i8 addrspace(1)* null) ]
-    %tmp27 = call align 8 i8 addrspace(1)* @llvm.experimental.gc.result.p1i8(token %tmp26)
-    %tmp28 = call coldcc i8 addrspace(1)* @llvm.experimental.gc.relocate.p1i8(token %tmp26, i32 0, i32 0) ; (null, null)
+    %tmp26 = call token (i64, i32, ptr addrspace(1) (ptr addrspace(1))*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2, i32 4, ptr addrspace(1) (ptr addrspace(1))* nonnull elementtype(ptr addrspace(1) (ptr addrspace(1))) @wobble, i32 1, i32 0, ptr addrspace(1) nonnull undef, i32 0, i32 0) [ "deopt"(), "gc-live"(ptr addrspace(1) null) ]
+    %tmp27 = call align 8 ptr addrspace(1) @llvm.experimental.gc.result.p1(token %tmp26)
+    %tmp28 = call coldcc ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token %tmp26, i32 0, i32 0) ; (null, null)
     br label %bb36
 
   bb29:                                             ; preds = %bb24
-    %tmp30 = call token (i64, i32, i8 addrspace(1)* (i8 addrspace(1)*)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_p1i8p1i8f(i64 2, i32 4, i8 addrspace(1)* (i8 addrspace(1)*)* nonnull elementtype(i8 addrspace(1)* (i8 addrspace(1)*)) @bar, i32 1, i32 0, i8 addrspace(1)* nonnull undef, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
+    %tmp30 = call token (i64, i32, ptr addrspace(1) (ptr addrspace(1))*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2, i32 4, ptr addrspace(1) (ptr addrspace(1))* nonnull elementtype(ptr addrspace(1) (ptr addrspace(1))) @bar, i32 1, i32 0, ptr addrspace(1) nonnull undef, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
     br label %bb36
 
   bb31:                                             ; preds = %bb24
-    %tmp32 = call token (i64, i32, void (i32)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_isVoidi32f(i64 2882400000, i32 0, void (i32)* nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 10, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
+    %tmp32 = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 10, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
     unreachable
 
   bb35:                                             ; preds = %bb24
     unreachable
 
   bb36:                                             ; preds = %bb29, %bb25
-    %tmp37 = phi i8 addrspace(1)* [ undef, %bb29 ], [ %tmp28, %bb25 ]
-    %tmp38 = phi i8 addrspace(1)* [ undef, %bb29 ], [ %tmp27, %bb25 ]
-    %tmp39 = icmp eq i8 addrspace(1)* %tmp38, null
+    %tmp37 = phi ptr addrspace(1) [ undef, %bb29 ], [ %tmp28, %bb25 ]
+    %tmp38 = phi ptr addrspace(1) [ undef, %bb29 ], [ %tmp27, %bb25 ]
+    %tmp39 = icmp eq ptr addrspace(1) %tmp38, null
     br i1 %tmp39, label %bb51, label %bb42
 
   bb40:                                             ; preds = %bb4
-    %tmp41 = call token (i64, i32, void (i32)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_isVoidi32f(i64 2882400000, i32 0, void (i32)* nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 10, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
+    %tmp41 = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 10, i32 0, i32 0) [ "deopt"(), "gc-live"() ]
     unreachable
 
   bb42:                                             ; preds = %bb36
@@ -64,35 +64,33 @@
     br i1 %or.cond, label %bb49, label %bb47
 
   bb47:                                             ; preds = %bb42
-    %tmp48 = call token (i64, i32, void (i32)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_isVoidi32f(i64 2882400000, i32 0, void (i32)* nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 14, i32 0, i32 0) [ "deopt"(i8 addrspace(1)* %tmp37, i8 addrspace(1)* %tmp38), "gc-live"() ]
+    %tmp48 = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 14, i32 0, i32 0) [ "deopt"(ptr addrspace(1) %tmp37, ptr addrspace(1) %tmp38), "gc-live"() ]
     unreachable
 
   bb49:                                             ; preds = %bb42
-    %tmp50 = call token (i64, i32, void (i32)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_isVoidi32f(i64 2882400000, i32 0, void (i32)* nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 10, i32 0, i32 0) [ "deopt"(i8 addrspace(1)* %tmp37, i8 addrspace(1)* %tmp38, i8 addrspace(1)* %tmp38), "gc-live"() ]
+    %tmp50 = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 10, i32 0, i32 0) [ "deopt"(ptr addrspace(1) %tmp37, ptr addrspace(1) %tmp38, ptr addrspace(1) %tmp38), "gc-live"() ]
     unreachable
 
   bb51:                                             ; preds = %bb36
-    %tmp52 = call token (i64, i32, void (i32)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_isVoidi32f(i64 2882400000, i32 0, void (i32)* nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 24, i32 0, i32 0) [ "deopt"(i8 addrspace(1)* %tmp37), "gc-live"() ]
+    %tmp52 = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr nonnull elementtype(void (i32)) @wombat, i32 1, i32 0, i32 24, i32 0, i32 0) [ "deopt"(ptr addrspace(1) %tmp37), "gc-live"() ]
     unreachable
   }
 
-  declare i32* @baz()
+  declare ptr @baz()
 
-  declare i8 addrspace(1)* @barney(i8 addrspace(1)*)
+  declare ptr addrspace(1) @barney(ptr addrspace(1))
 
-  declare i8 addrspace(1)* @wobble(i8 addrspace(1)*)
+  declare ptr addrspace(1) @wobble(ptr addrspace(1))
 
-  declare i8 addrspace(1)* @bar(i8 addrspace(1)*)
+  declare ptr addrspace(1) @bar(ptr addrspace(1))
 
-  declare i8 addrspace(1)* @llvm.experimental.gc.relocate.p1i8(token, i32 immarg, i32 immarg) #0
+  declare ptr addrspace(1) @llvm.experimental.gc.relocate.p1(token, i32 immarg, i32 immarg) #0
 
-  declare i8 addrspace(1)* @llvm.experimental.gc.result.p1i8(token) #0
+  declare ptr addrspace(1) @llvm.experimental.gc.result.p1(token) #0
 
   declare void @wombat(i32)
 
-  declare token @llvm.experimental.gc.statepoint.p0f_isVoidi32f(i64 immarg, i32 immarg, void (i32)*, i32 immarg, i32 immarg, ...)
-
-  declare token @llvm.experimental.gc.statepoint.p0f_p1i8p1i8f(i64 immarg, i32 immarg, i8 addrspace(1)* (i8 addrspace(1)*)*, i32 immarg, i32 immarg, ...)
+  declare token @llvm.experimental.gc.statepoint.p0(i64 immarg, i32 immarg, ptr, i32 immarg, i32 immarg, ...)
 
   attributes #0 = { nounwind readnone }
 

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-miscellaneous-uniform-intrinsic.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-miscellaneous-uniform-intrinsic.ll
@@ -91,7 +91,7 @@ define amdgpu_kernel void @permlane64_uniform(ptr addrspace(1) %out, i32 %src) {
   ret void
 }
 
-define amdgpu_kernel void @permlane64_nonuniform(i32 addrspace(1)* %out) {
+define amdgpu_kernel void @permlane64_nonuniform(ptr addrspace(1) %out) {
 ; CHECK-LABEL: permlane64_nonuniform:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
@@ -104,12 +104,12 @@ define amdgpu_kernel void @permlane64_nonuniform(i32 addrspace(1)* %out) {
 ; CHECK-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %v = call i32 @llvm.amdgcn.permlane64(i32 %tid)
-  %out_ptr = getelementptr i32, i32 addrspace(1)* %out, i32 %tid
-  store i32 %v, i32 addrspace(1)* %out_ptr
+  %out_ptr = getelementptr i32, ptr addrspace(1) %out, i32 %tid
+  store i32 %v, ptr addrspace(1) %out_ptr
   ret void
 }
 
-define amdgpu_kernel void @permlane64_nonuniform_expression(i32 addrspace(1)* %out) {
+define amdgpu_kernel void @permlane64_nonuniform_expression(ptr addrspace(1) %out) {
 ; CHECK-LABEL: permlane64_nonuniform_expression:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
@@ -124,8 +124,8 @@ define amdgpu_kernel void @permlane64_nonuniform_expression(i32 addrspace(1)* %o
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid2 = add i32 %tid, 1
   %v = call i32 @llvm.amdgcn.permlane64(i32 %tid2)
-  %out_ptr = getelementptr i32, i32 addrspace(1)* %out, i32 %tid
-  store i32 %v, i32 addrspace(1)* %out_ptr
+  %out_ptr = getelementptr i32, ptr addrspace(1) %out, i32 %tid
+  store i32 %v, ptr addrspace(1) %out_ptr
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-uniform-intrinsic-combine.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-uniform-intrinsic-combine.ll
@@ -46,7 +46,7 @@ define amdgpu_kernel void @permlane64_uniform(ptr addrspace(1) %out, i32 %src) {
   ret void
 }
 
-define amdgpu_kernel void @permlane64_nonuniform(i32 addrspace(1)* %out) {
+define amdgpu_kernel void @permlane64_nonuniform(ptr addrspace(1) %out) {
 ; CURRENT-CHECK-LABEL: define amdgpu_kernel void @permlane64_nonuniform(
 ; CURRENT-CHECK-SAME: ptr addrspace(1) writeonly captures(none) [[OUT:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {
 ; CURRENT-CHECK-NEXT:    [[TID:%.*]] = tail call i32 @llvm.amdgcn.workitem.id.x()
@@ -74,12 +74,12 @@ define amdgpu_kernel void @permlane64_nonuniform(i32 addrspace(1)* %out) {
 ;
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %v = call i32 @llvm.amdgcn.permlane64(i32 %tid)
-  %out_ptr = getelementptr i32, i32 addrspace(1)* %out, i32 %tid
-  store i32 %v, i32 addrspace(1)* %out_ptr
+  %out_ptr = getelementptr i32, ptr addrspace(1) %out, i32 %tid
+  store i32 %v, ptr addrspace(1) %out_ptr
   ret void
 }
 
-define amdgpu_kernel void @permlane64_nonuniform_expression(i32 addrspace(1)* %out) {
+define amdgpu_kernel void @permlane64_nonuniform_expression(ptr addrspace(1) %out) {
 ; CURRENT-CHECK-LABEL: define amdgpu_kernel void @permlane64_nonuniform_expression(
 ; CURRENT-CHECK-SAME: ptr addrspace(1) writeonly captures(none) [[OUT:%.*]]) local_unnamed_addr #[[ATTR1]] {
 ; CURRENT-CHECK-NEXT:    [[TID:%.*]] = tail call i32 @llvm.amdgcn.workitem.id.x()
@@ -111,8 +111,8 @@ define amdgpu_kernel void @permlane64_nonuniform_expression(i32 addrspace(1)* %o
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid2 = add i32 %tid, 1
   %v = call i32 @llvm.amdgcn.permlane64(i32 %tid2)
-  %out_ptr = getelementptr i32, i32 addrspace(1)* %out, i32 %tid
-  store i32 %v, i32 addrspace(1)* %out_ptr
+  %out_ptr = getelementptr i32, ptr addrspace(1) %out, i32 %tid
+  store i32 %v, ptr addrspace(1) %out_ptr
   ret void
 }
 
@@ -158,7 +158,7 @@ define amdgpu_kernel void @readlane_nonuniform_indices(ptr addrspace(1) %out, i3
   ret void
 }
 
-define amdgpu_kernel void @readlane_nonuniform_workitem(i32 addrspace(1)* %out) {
+define amdgpu_kernel void @readlane_nonuniform_workitem(ptr addrspace(1) %out) {
 ; CURRENT-CHECK-LABEL: define amdgpu_kernel void @readlane_nonuniform_workitem(
 ; CURRENT-CHECK-SAME: ptr addrspace(1) writeonly captures(none) [[OUT:%.*]]) local_unnamed_addr #[[ATTR2:[0-9]+]] {
 ; CURRENT-CHECK-NEXT:    [[TIDX:%.*]] = tail call i32 @llvm.amdgcn.workitem.id.x()
@@ -190,12 +190,12 @@ define amdgpu_kernel void @readlane_nonuniform_workitem(i32 addrspace(1)* %out) 
   %tidx = call i32 @llvm.amdgcn.workitem.id.x()
   %tidy = call i32 @llvm.amdgcn.workitem.id.y()
   %v = call i32 @llvm.amdgcn.readlane(i32 %tidx, i32 %tidy)
-  %out_ptr = getelementptr i32, i32 addrspace(1)* %out, i32 %tidx
-  store i32 %v, i32 addrspace(1)* %out_ptr
+  %out_ptr = getelementptr i32, ptr addrspace(1) %out, i32 %tidx
+  store i32 %v, ptr addrspace(1) %out_ptr
   ret void
 }
 
-define amdgpu_kernel void @readlane_nonuniform_expression(i32 addrspace(1)* %out) {
+define amdgpu_kernel void @readlane_nonuniform_expression(ptr addrspace(1) %out) {
 ; CURRENT-CHECK-LABEL: define amdgpu_kernel void @readlane_nonuniform_expression(
 ; CURRENT-CHECK-SAME: ptr addrspace(1) writeonly captures(none) [[OUT:%.*]]) local_unnamed_addr #[[ATTR2]] {
 ; CURRENT-CHECK-NEXT:    [[TIDX:%.*]] = tail call i32 @llvm.amdgcn.workitem.id.x()
@@ -235,8 +235,8 @@ define amdgpu_kernel void @readlane_nonuniform_expression(i32 addrspace(1)* %out
   %tidx2 = add i32 %tidx, 1
   %tidy2 = add i32 %tidy, 2
   %v = call i32 @llvm.amdgcn.readlane(i32 %tidx2, i32 %tidy2)
-  %out_ptr = getelementptr i32, i32 addrspace(1)* %out, i32 %tidx
-  store i32 %v, i32 addrspace(1)* %out_ptr
+  %out_ptr = getelementptr i32, ptr addrspace(1) %out, i32 %tidx
+  store i32 %v, ptr addrspace(1) %out_ptr
   ret void
 }
 
@@ -286,7 +286,7 @@ define amdgpu_kernel void @readfirstlane_with_argument(ptr addrspace(1) %out, i3
   ret void
 }
 
-define amdgpu_kernel void @readfirstlane_with_workitem_id(i32 addrspace(1)* %out) {
+define amdgpu_kernel void @readfirstlane_with_workitem_id(ptr addrspace(1) %out) {
 ; CURRENT-CHECK-LABEL: define amdgpu_kernel void @readfirstlane_with_workitem_id(
 ; CURRENT-CHECK-SAME: ptr addrspace(1) writeonly captures(none) [[OUT:%.*]]) local_unnamed_addr #[[ATTR1]] {
 ; CURRENT-CHECK-NEXT:    [[TID:%.*]] = tail call i32 @llvm.amdgcn.workitem.id.x()
@@ -314,12 +314,12 @@ define amdgpu_kernel void @readfirstlane_with_workitem_id(i32 addrspace(1)* %out
 ;
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %v = call i32 @llvm.amdgcn.readfirstlane(i32 %tid)
-  %out_ptr = getelementptr i32, i32 addrspace(1)* %out, i32 %tid
-  store i32 %v, i32 addrspace(1)* %out_ptr
+  %out_ptr = getelementptr i32, ptr addrspace(1) %out, i32 %tid
+  store i32 %v, ptr addrspace(1) %out_ptr
   ret void
 }
 
-define amdgpu_kernel void @readfirstlane_expression(i32 addrspace(1)* %out) {
+define amdgpu_kernel void @readfirstlane_expression(ptr addrspace(1) %out) {
 ; CURRENT-CHECK-LABEL: define amdgpu_kernel void @readfirstlane_expression(
 ; CURRENT-CHECK-SAME: ptr addrspace(1) writeonly captures(none) [[OUT:%.*]]) local_unnamed_addr #[[ATTR1]] {
 ; CURRENT-CHECK-NEXT:    [[TID:%.*]] = tail call i32 @llvm.amdgcn.workitem.id.x()
@@ -351,8 +351,8 @@ define amdgpu_kernel void @readfirstlane_expression(i32 addrspace(1)* %out) {
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %tid2 = add i32 %tid, 1
   %v = call i32 @llvm.amdgcn.readfirstlane(i32 %tid2)
-  %out_ptr = getelementptr i32, i32 addrspace(1)* %out, i32 %tid2
-  store i32 %v, i32 addrspace(1)* %out_ptr
+  %out_ptr = getelementptr i32, ptr addrspace(1) %out, i32 %tid2
+  store i32 %v, ptr addrspace(1) %out_ptr
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/merge-load-store.mir
+++ b/llvm/test/CodeGen/AMDGPU/merge-load-store.mir
@@ -13,15 +13,15 @@
 # CHECK: DS_WRITE_B32 killed %0, %5, 0
 
 --- |
-  define amdgpu_kernel void @mem_dependency(i32 addrspace(3)* %ptr.0) nounwind {
-    %ptr.4 = getelementptr i32, i32 addrspace(3)* %ptr.0, i32 1
-    %ptr.64 = getelementptr i32, i32 addrspace(3)* %ptr.0, i32 16
-    %1 = load i32, i32 addrspace(3)* %ptr.0
-    store i32 %1, i32 addrspace(3)* %ptr.64
-    %2 = load i32, i32 addrspace(3)* %ptr.64
-    %3 = load i32, i32 addrspace(3)* %ptr.4
+  define amdgpu_kernel void @mem_dependency(ptr addrspace(3) %ptr.0) nounwind {
+    %ptr.4 = getelementptr i32, ptr addrspace(3) %ptr.0, i32 1
+    %ptr.64 = getelementptr i32, ptr addrspace(3) %ptr.0, i32 16
+    %1 = load i32, ptr addrspace(3) %ptr.0
+    store i32 %1, ptr addrspace(3) %ptr.64
+    %2 = load i32, ptr addrspace(3) %ptr.64
+    %3 = load i32, ptr addrspace(3) %ptr.4
     %4 = add i32 %2, %3
-    store i32 %4, i32 addrspace(3)* %ptr.0
+    store i32 %4, ptr addrspace(3) %ptr.0
     ret void
   }
 
@@ -32,27 +32,27 @@
 
   define void @asm_defines_address() #0 {
   bb:
-    %tmp1 = load i32, i32 addrspace(3)* getelementptr inbounds ([256 x i32], [256 x i32] addrspace(3)* @lds0, i32 0, i32 0), align 4
+    %tmp1 = load i32, ptr addrspace(3) @lds0, align 4
     %0 = and i32 %tmp1, 255
-    %tmp3 = load i32, i32 addrspace(3)* getelementptr ([256 x i32], [256 x i32] addrspace(3)* @lds1, i32 0, i32 poison), align 4
-    %tmp6 = load i32, i32 addrspace(3)* getelementptr ([256 x i32], [256 x i32] addrspace(3)* @lds3, i32 0, i32 poison), align 4
+    %tmp3 = load i32, ptr addrspace(3) getelementptr ([256 x i32], ptr addrspace(3) @lds1, i32 0, i32 poison), align 4
+    %tmp6 = load i32, ptr addrspace(3) getelementptr ([256 x i32], ptr addrspace(3) @lds3, i32 0, i32 poison), align 4
     %tmp7 = tail call i32 asm "v_or_b32 $0, 0, $1", "=v,v"(i32 %tmp6) #1
     %tmp10 = lshr i32 %tmp7, 16
     %tmp11 = and i32 %tmp10, 255
-    %tmp12 = getelementptr inbounds [256 x i32], [256 x i32] addrspace(3)* @lds1, i32 0, i32 %tmp11
-    %tmp13 = load i32, i32 addrspace(3)* %tmp12, align 4
+    %tmp12 = getelementptr inbounds [256 x i32], ptr addrspace(3) @lds1, i32 0, i32 %tmp11
+    %tmp13 = load i32, ptr addrspace(3) %tmp12, align 4
     %tmp14 = xor i32 %tmp3, %tmp13
     %tmp15 = lshr i32 %tmp14, 8
     %tmp16 = and i32 %tmp15, 16711680
     %tmp19 = lshr i32 %tmp16, 16
     %tmp20 = and i32 %tmp19, 255
-    %tmp21 = getelementptr inbounds [256 x i32], [256 x i32] addrspace(3)* @lds1, i32 0, i32 %tmp20
-    %tmp22 = load i32, i32 addrspace(3)* %tmp21, align 4
-    %tmp24 = load i32, i32 addrspace(3)* getelementptr ([256 x i32], [256 x i32] addrspace(3)* @lds2, i32 0, i32 poison), align 4
+    %tmp21 = getelementptr inbounds [256 x i32], ptr addrspace(3) @lds1, i32 0, i32 %tmp20
+    %tmp22 = load i32, ptr addrspace(3) %tmp21, align 4
+    %tmp24 = load i32, ptr addrspace(3) getelementptr ([256 x i32], ptr addrspace(3) @lds2, i32 0, i32 poison), align 4
     %tmp25 = xor i32 %tmp22, %tmp24
     %tmp26 = and i32 %tmp25, -16777216
     %tmp28 = or i32 %0, %tmp26
-    store volatile i32 %tmp28, i32 addrspace(1)* undef
+    store volatile i32 %tmp28, ptr addrspace(1) undef
     ret void
   }
 
@@ -65,8 +65,8 @@
 
   attributes #0 = { convergent nounwind }
 
-  define amdgpu_kernel void @merge_mmos(i32 addrspace(1)* %ptr_addr1) { ret void }
-  define amdgpu_kernel void @reorder_offsets(i32 addrspace(1)* %reorder_addr1) { ret void }
+  define amdgpu_kernel void @merge_mmos(ptr addrspace(1) %ptr_addr1) { ret void }
+  define amdgpu_kernel void @reorder_offsets(ptr addrspace(1) %reorder_addr1) { ret void }
 
 ...
 ---
@@ -128,13 +128,13 @@ registers:
 body:             |
   bb.0:
     %1:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    %2:vgpr_32 = DS_READ_B32 %1, 3072, 0, implicit $m0, implicit $exec :: (dereferenceable load (s32) from `i32 addrspace(3)* getelementptr inbounds ([256 x i32], [256 x i32] addrspace(3)* @lds0, i32 0, i32 0)`, addrspace 3)
-    %3:vgpr_32 = DS_READ_B32 %1, 2048, 0, implicit $m0, implicit $exec :: (load (s32) from `i32 addrspace(3)* getelementptr ([256 x i32], [256 x i32] addrspace(3)* @lds1, i32 0, i32 poison)`, addrspace 3)
-    %4:vgpr_32 = DS_READ_B32 %1, 1024, 0, implicit $m0, implicit $exec :: (load (s32) from `i32 addrspace(3)* getelementptr ([256 x i32], [256 x i32] addrspace(3)* @lds3, i32 0, i32 poison)`, addrspace 3)
+    %2:vgpr_32 = DS_READ_B32 %1, 3072, 0, implicit $m0, implicit $exec :: (dereferenceable load (s32) from `ptr addrspace(3) bitcast (ptr addrspace(3) @lds0 to ptr addrspace(3))`, addrspace 3)
+    %3:vgpr_32 = DS_READ_B32 %1, 2048, 0, implicit $m0, implicit $exec :: (load (s32) from `ptr addrspace(3) getelementptr ([256 x i32], ptr addrspace(3) @lds1, i32 0, i32 poison)`, addrspace 3)
+    %4:vgpr_32 = DS_READ_B32 %1, 1024, 0, implicit $m0, implicit $exec :: (load (s32) from `ptr addrspace(3) getelementptr ([256 x i32], ptr addrspace(3) @lds3, i32 0, i32 poison)`, addrspace 3)
     INLINEASM &"v_or_b32 $0, 0, $1", 32, 327690, def %0, 327689, %4
     %5:vgpr_32 = DS_READ_B32 %0, 2048, 0, implicit $m0, implicit $exec :: (load (s32) from %ir.tmp12, addrspace 3)
     %6:vgpr_32 = DS_READ_B32 %5, 2048, 0, implicit $m0, implicit $exec :: (load (s32) from %ir.tmp21, addrspace 3)
-    %7:vgpr_32 = DS_READ_B32 %1, 0, 0, implicit $m0, implicit $exec :: (load (s32) from `i32 addrspace(3)* getelementptr ([256 x i32], [256 x i32] addrspace(3)* @lds2, i32 0, i32 poison)`, addrspace 3)
+    %7:vgpr_32 = DS_READ_B32 %1, 0, 0, implicit $m0, implicit $exec :: (load (s32) from `ptr addrspace(3) getelementptr ([256 x i32], ptr addrspace(3) @lds2, i32 0, i32 poison)`, addrspace 3)
     S_SETPC_B64_return undef $sgpr30_sgpr31, implicit %6, implicit %7
 
 ...

--- a/llvm/test/CodeGen/AMDGPU/wait-xcnt.mir
+++ b/llvm/test/CodeGen/AMDGPU/wait-xcnt.mir
@@ -105,7 +105,7 @@ body: |
     ; GCN-NEXT: $vgpr3 = V_LSHLREV_B32_e64 16, $vgpr2, implicit $exec
     ; GCN-NEXT: $vgpr4 = V_MOV_B32_e32 1, implicit $exec
     ; GCN-NEXT: $vgpr0 = nofpexcept V_ADD_F32_e32 killed $vgpr3, killed $vgpr4, implicit $mode, implicit $exec
-    $vgpr2 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec:: (load (s32) from `float addrspace(1)* undef`, align 4, addrspace 1)
+    $vgpr2 = GLOBAL_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec:: (load (s32) from `ptr addrspace(1) undef`, align 4, addrspace 1)
     $vgpr3 = V_LSHLREV_B32_e64 16, $vgpr2, implicit $exec
     $vgpr4 = V_MOV_B32_e32 1, implicit $exec
     $vgpr0 = nofpexcept V_ADD_F32_e32 killed $vgpr3, killed $vgpr4, implicit $mode, implicit $exec
@@ -770,9 +770,9 @@ body: |
     ; GCN-NEXT: DS_WRITE_B32_gfx9 killed $vgpr0, killed $vgpr1, 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(3) undef`, addrspace 3)
     ; GCN-NEXT: $vgpr0 = V_MOV_B32_e32 20, implicit $exec
      $vgpr1 = V_MOV_B32_e32 1, implicit $exec
-     $vgpr0 = DS_READ_B32_gfx9 killed $vgpr1, 0, 0, implicit $exec :: (load (s32) from `i32 addrspace(3)* undef`)
+     $vgpr0 = DS_READ_B32_gfx9 killed $vgpr1, 0, 0, implicit $exec :: (load (s32) from `ptr addrspace(3) undef`)
      $vgpr1 = V_MOV_B32_e32 2, implicit $exec
-     DS_WRITE_B32_gfx9 killed $vgpr0, killed $vgpr1, 0, 0, implicit $exec :: (store (s32) into `i32 addrspace(3)* undef`)
+     DS_WRITE_B32_gfx9 killed $vgpr0, killed $vgpr1, 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(3) undef`)
      $vgpr0 = V_MOV_B32_e32 20, implicit $exec
 ...
 

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-looptest.ll
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-looptest.ll
@@ -17,8 +17,8 @@
 
 define amdgpu_kernel void @testKernel(ptr addrspace(1) nocapture %arg) local_unnamed_addr #0 {
 bb:
-  store <2 x float> <float 1.000000e+00, float 1.000000e+00>, ptr bitcast (ptr getelementptr ([100 x float], ptr addrspacecast ([100 x float] addrspace(1)* @data_generic to ptr), i64 0, i64 4) to ptr), align 4
-  store <2 x float> <float 1.000000e+00, float 1.000000e+00>, ptr bitcast (ptr getelementptr ([100 x float], ptr addrspacecast ([100 x float] addrspace(1)* @data_reference to ptr), i64 0, i64 4) to ptr), align 4
+  store <2 x float> <float 1.000000e+00, float 1.000000e+00>, ptr bitcast (ptr getelementptr ([100 x float], ptr addrspacecast (ptr addrspace(1) @data_generic to ptr), i64 0, i64 4) to ptr), align 4
+  store <2 x float> <float 1.000000e+00, float 1.000000e+00>, ptr bitcast (ptr getelementptr ([100 x float], ptr addrspacecast (ptr addrspace(1) @data_reference to ptr), i64 0, i64 4) to ptr), align 4
   br label %bb18
 
 bb1:                                              ; preds = %bb18

--- a/llvm/test/CodeGen/AMDGPU/wqm.ll
+++ b/llvm/test/CodeGen/AMDGPU/wqm.ll
@@ -3435,7 +3435,7 @@ bb:
   call void @llvm.amdgcn.init.exec(i64 -1)
   call void @llvm.amdgcn.raw.buffer.store.v4f32(<4 x float> zeroinitializer, <4 x i32> zeroinitializer, i32 0, i32 0, i32 0)
   %i = call i32 @llvm.amdgcn.wqm.i32(i32 0)
-  store i32 %i, i32 addrspace(3)* null, align 4
+  store i32 %i, ptr addrspace(3) null, align 4
   ret void
 }
 

--- a/llvm/test/CodeGen/BPF/BTF/ptr-named-2.ll
+++ b/llvm/test/CodeGen/BPF/BTF/ptr-named-2.ll
@@ -12,7 +12,7 @@ source_filename = "ptr-named-2.ll"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpfel-unknown-none"
 
-%struct.TypeExamples = type { i32*, i32, i32, i32* }
+%struct.TypeExamples = type { ptr, i32, i32, ptr }
 
 @type_examples = internal global %struct.TypeExamples zeroinitializer, align 8, !dbg !0
 

--- a/llvm/test/CodeGen/BPF/unaligned_load_store.ll
+++ b/llvm/test/CodeGen/BPF/unaligned_load_store.ll
@@ -17,31 +17,31 @@
 ; ---------------------------------------------------------------------
 ; i8 load
 ; ---------------------------------------------------------------------
-define i8 @test_load_i8(i8* %p) {
+define i8 @test_load_i8(ptr %p) {
 ; ALL-LABEL: test_load_i8:
 ; ALL:       # %bb.0:
 ; ALL-NEXT:    w{{[0-9]+}} = *(u8 *)(r1 + 0)
 ; ALL-NEXT:    exit
-  %v = load i8, i8* %p, align 1
+  %v = load i8, ptr %p, align 1
   ret i8 %v
 }
 
 ; ---------------------------------------------------------------------
 ; i8 store
 ; ---------------------------------------------------------------------
-define void @test_store_i8(i8* %p, i8 %v) {
+define void @test_store_i8(ptr %p, i8 %v) {
 ; ALL-LABEL: test_store_i8:
 ; ALL:       # %bb.0:
 ; ALL-NEXT:    *(u8 *)(r1 + 0) = w{{[0-9]+}}
 ; ALL-NEXT:    exit
-  store i8 %v, i8* %p, align 1
+  store i8 %v, ptr %p, align 1
   ret void
 }
 
 ; ---------------------------------------------------------------------
 ; i16 load
 ; ---------------------------------------------------------------------
-define i16 @test_load_i16(i16* %p) {
+define i16 @test_load_i16(ptr %p) {
 ; MISALIGN-LABEL: test_load_i16:
 ; MISALIGN:       # %bb.0:
 ; MISALIGN:    w{{[0-9]+}} = *(u16 *)(r1 + 0)
@@ -54,14 +54,14 @@ define i16 @test_load_i16(i16* %p) {
 ; ALIGN-DAG:    w{{[0-9]+}} <<= 8
 ; ALIGN-DAG:    w{{[0-9]+}} |= w{{[0-9]+}}
 ; ALIGN:        exit
-  %v = load i16, i16* %p, align 1
+  %v = load i16, ptr %p, align 1
   ret i16 %v
 }
 
 ; ---------------------------------------------------------------------
 ; i16 store
 ; ---------------------------------------------------------------------
-define void @test_store_i16(i16* %p, i16 %v) {
+define void @test_store_i16(ptr %p, i16 %v) {
 ; MISALIGN-LABEL: test_store_i16:
 ; MISALIGN:       # %bb.0:
 ; MISALIGN:    *(u16 *)(r1 + 0) = w{{[0-9]+}}
@@ -73,7 +73,7 @@ define void @test_store_i16(i16* %p, i16 %v) {
 ; ALIGN-DAG:    w{{[0-9]+}} >>= 8
 ; ALIGN-DAG:    *(u8 *)(r1 + 1) = w{{[0-9]+}}
 ; ALIGN:        exit
-  store i16 %v, i16* %p, align 1
+  store i16 %v, ptr %p, align 1
   ret void
 }
 
@@ -81,7 +81,7 @@ define void @test_store_i16(i16* %p, i16 %v) {
 ; i32 load
 ; ---------------------------------------------------------------------
 
-define i32 @test_load_i32(i32* %p) {
+define i32 @test_load_i32(ptr %p) {
 ; MISALIGN-LABEL: test_load_i32:
 ; MISALIGN:       # %bb.0:
 ; MISALIGN:    w{{[0-9]+}} = *(u32 *)(r1 + 0)
@@ -98,7 +98,7 @@ define i32 @test_load_i32(i32* %p) {
 ; ALIGN-DAG:    w{{[0-9]+}} = *(u8 *)(r1 + 3)
 ; ALIGN-DAG:    w{{[0-9]+}} <<= 24
 ; ALIGN:        exit
-  %v = load i32, i32* %p, align 1
+  %v = load i32, ptr %p, align 1
   ret i32 %v
 }
 
@@ -106,7 +106,7 @@ define i32 @test_load_i32(i32* %p) {
 ; i32 store
 ; ---------------------------------------------------------------------
 
-define void @test_store_i32(i32* %p, i32 %v) {
+define void @test_store_i32(ptr %p, i32 %v) {
 ; MISALIGN-LABEL: test_store_i32:
 ; MISALIGN:       # %bb.0:
 ; MISALIGN:    *(u32 *)(r1 + 0) = w{{[0-9]+}}
@@ -124,7 +124,7 @@ define void @test_store_i32(i32* %p, i32 %v) {
 ; ALIGN-DAG:    w{{[0-9]+}} >>= 8
 ; ALIGN-DAG:    *(u8 *)(r1 + 3) = w{{[0-9]+}}
 ; ALIGN:        exit
-  store i32 %v, i32* %p, align 1
+  store i32 %v, ptr %p, align 1
   ret void
 }
 
@@ -132,7 +132,7 @@ define void @test_store_i32(i32* %p, i32 %v) {
 ; i64 load
 ; ---------------------------------------------------------------------
 
-define i64 @test_load_i64(i64* %p) {
+define i64 @test_load_i64(ptr %p) {
 ; MISALIGN-LABEL: test_load_i64:
 ; MISALIGN:       # %bb.0:
 ; MISALIGN:    r0 = *(u64 *)(r1 + 0)
@@ -158,7 +158,7 @@ define i64 @test_load_i64(i64* %p) {
 ; ALIGN-DAG:    w{{[0-9]+}} <<= 24
 ; ALIGN-DAG:    r{{[0-9]+}} <<= 32
 ; ALIGN:        exit
-  %v = load i64, i64* %p, align 1
+  %v = load i64, ptr %p, align 1
   ret i64 %v
 }
 
@@ -166,7 +166,7 @@ define i64 @test_load_i64(i64* %p) {
 ; i64 store
 ; ---------------------------------------------------------------------
 
-define void @test_store_i64(i64* %p, i64 %v) {
+define void @test_store_i64(ptr %p, i64 %v) {
 ; MISALIGN-LABEL: test_store_i64:
 ; MISALIGN:       # %bb.0:
 ; MISALIGN:    *(u64 *)(r1 + 0) = r2
@@ -191,6 +191,6 @@ define void @test_store_i64(i64* %p, i64 %v) {
 ; ALIGN-DAG:    r{{[0-9]+}} >>= 8
 ; ALIGN-DAG:    *(u8 *)(r1 + 7) = w{{[0-9]+}}
 ; ALIGN:        exit
-  store i64 %v, i64* %p, align 1
+  store i64 %v, ptr %p, align 1
   ret void
 }

--- a/llvm/test/CodeGen/Hexagon/and_mask_cmp0_sink.ll
+++ b/llvm/test/CodeGen/Hexagon/and_mask_cmp0_sink.ll
@@ -28,7 +28,7 @@ define i32 @and_sink1(i32 %a) {
   br label %bb0
 bb0:
   %cmp = icmp eq i32 %and, 0
-  store i32 0, i32* @A
+  store i32 0, ptr @A
   br i1 %cmp, label %bb0, label %bb2
 bb2:
   ret i32 0
@@ -61,7 +61,7 @@ define i32 @and_sink2(i32 %a) {
   br label %bb0
 bb0:
   %cmp = icmp eq i32 %and, 0
-  store i32 0, i32* @A
+  store i32 0, ptr @A
   br i1 %cmp, label %bb0, label %bb2
 bb2:
   ret i32 0

--- a/llvm/test/CodeGen/Hexagon/autohvx/addi-offset-opt-addr-mode.ll
+++ b/llvm/test/CodeGen/Hexagon/autohvx/addi-offset-opt-addr-mode.ll
@@ -14,21 +14,21 @@ target triple = "hexagon"
 
 define dllexport void @foo() local_unnamed_addr #0 {
 entry:
-  %0 = load i8*, i8** undef, align 4
-  %1 = bitcast i8* %0 to half*
+  %0 = load ptr, ptr undef, align 4
+  %1 = bitcast ptr %0 to ptr
   %2 = or i32 undef, 128
-  %3 = getelementptr half, half* %1, i32 %2
-  %4 = bitcast half* %3 to <64 x half>*
-  %5 = load i8*, i8** undef, align 4
-  %6 = getelementptr i8, i8* %5, i32 1024
-  %7 = bitcast i8* %6 to <64 x half>*
-  %8 = load <64 x half>, <64 x half>* %7
-  %9 = getelementptr i8, i8* %5, i32 1152
-  %10 = bitcast i8* %9 to <64 x half>*
-  %11 = load <64 x half>, <64 x half>* %10
+  %3 = getelementptr half, ptr %1, i32 %2
+  %4 = bitcast ptr %3 to ptr
+  %5 = load ptr, ptr undef, align 4
+  %6 = getelementptr i8, ptr %5, i32 1024
+  %7 = bitcast ptr %6 to ptr
+  %8 = load <64 x half>, ptr %7
+  %9 = getelementptr i8, ptr %5, i32 1152
+  %10 = bitcast ptr %9 to ptr
+  %11 = load <64 x half>, ptr %10
   %12 = fadd <64 x half> %8, %11
-  store <64 x half> %12, <64 x half>* %4, align 128
-  call void @llvm.assume(i1 true) [ "align"(i8* undef, i32 128) ]
+  store <64 x half> %12, ptr %4, align 128
+  call void @llvm.assume(i1 true) [ "align"(ptr undef, i32 128) ]
   ret void
 }
 
@@ -36,6 +36,6 @@ entry:
 declare void @llvm.assume(i1 noundef) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind readonly willreturn
-declare <64 x half> @llvm.masked.load.v64f16.p0v64f16(<64 x half>*, i32 immarg, <64 x i1>, <64 x half>) #2
+declare <64 x half> @llvm.masked.load.v64f16.p0(ptr, i32 immarg, <64 x i1>, <64 x half>) #2
 
 attributes #0 = { "target-features"="+hvxv68,+hvx-length128b,+hvx-qfloat" }

--- a/llvm/test/CodeGen/Hexagon/bittracker-regclass.ll
+++ b/llvm/test/CodeGen/Hexagon/bittracker-regclass.ll
@@ -19,7 +19,7 @@ for.body.i198:
   br i1 %cond, label %for.body34.preheader, label %for.body.i198
 
 for.body34.preheader:
-  %wide.load269.5 = load <16 x i32>, <16 x i32>* bitcast (i32* getelementptr inbounds ([100 x i32], [100 x i32]* @out, i32 0, i32 80) to <16 x i32>*), align 64
+  %wide.load269.5 = load <16 x i32>, ptr getelementptr inbounds ([100 x i32], ptr @out, i32 0, i32 80), align 64
   %0 = add nsw <16 x i32> %wide.load269.5, zeroinitializer
   %rdx.shuf270 = shufflevector <16 x i32> %0, <16 x i32> undef, <16 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
   %bin.rdx271 = add <16 x i32> %0, %rdx.shuf270
@@ -31,10 +31,10 @@ for.body34.preheader:
   %add45.1 = add nsw i32 0, %add45
   %add45.2 = add nsw i32 0, %add45.1
   %add45.3 = add nsw i32 0, %add45.2
-  call void (i8*, ...) @printf(i8* getelementptr inbounds ([29 x i8], [29 x i8]* @.str.3, i32 0, i32 0), i32 %add45.3) #2
-  store i32 32, i32* getelementptr inbounds ([55 x i32], [55 x i32]* @in55, i32 0, i32 32), align 128
-  store i32 33, i32* getelementptr inbounds ([55 x i32], [55 x i32]* @in55, i32 0, i32 33), align 4
+  call void (ptr, ...) @printf(ptr getelementptr inbounds ([29 x i8], ptr @.str.3, i32 0, i32 0), i32 %add45.3) #2
+  store i32 32, ptr getelementptr inbounds ([55 x i32], ptr @in55, i32 0, i32 32), align 128
+  store i32 33, ptr getelementptr inbounds ([55 x i32], ptr @in55, i32 0, i32 33), align 4
   ret void
 }
 
-declare dso_local void @printf(i8*, ...) local_unnamed_addr #1
+declare dso_local void @printf(ptr, ...) local_unnamed_addr #1

--- a/llvm/test/CodeGen/Hexagon/isel-fold-shl-zext.ll
+++ b/llvm/test/CodeGen/Hexagon/isel-fold-shl-zext.ll
@@ -10,7 +10,7 @@ target datalayout = "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i
 target triple = "hexagon"
 
 ; Function Attrs: nofree nosync nounwind memory(readwrite, inaccessiblemem: none)
-define dso_local void @foo(i64* nocapture noundef %buf, i32 %a, i32 %b) local_unnamed_addr {
+define dso_local void @foo(ptr nocapture noundef %buf, i32 %a, i32 %b) local_unnamed_addr {
 ; CHECK-LABEL: foo:
 ; CHECK:         .cfi_startproc
 ; CHECK-NEXT:  // %bb.0: // %entry
@@ -26,7 +26,7 @@ define dso_local void @foo(i64* nocapture noundef %buf, i32 %a, i32 %b) local_un
 ; CHECK-NEXT:     memd(r0+#8) = r3:2
 ; CHECK-NEXT:    }
 entry:
-  %arrayidx = getelementptr inbounds i64, i64* %buf, i32 1
+  %arrayidx = getelementptr inbounds i64, ptr %buf, i32 1
   %add0 = shl nsw i32 %a, 1
   %add1 = add nsw i32 %add0, %b
   %add2 = add nsw i32 %add1, %add0
@@ -34,6 +34,6 @@ entry:
   %shift0 = shl nuw i64 %ext0, 32
   %ext1 = zext i32 %add2 to i64
   %or0 = or i64 %shift0, %ext1
-  store i64 %or0, i64* %arrayidx, align 8
+  store i64 %or0, ptr %arrayidx, align 8
   ret void
 }

--- a/llvm/test/CodeGen/Hexagon/mpy-operand-hoist.ll
+++ b/llvm/test/CodeGen/Hexagon/mpy-operand-hoist.ll
@@ -10,7 +10,7 @@ source_filename = "39544.c"
 target datalayout = "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048"
 target triple = "hexagon"
 
-define dso_local void @mul_n(i64* nocapture %p, i32* nocapture readonly %a, i32 %k, i32 %n) local_unnamed_addr {
+define dso_local void @mul_n(ptr nocapture %p, ptr nocapture readonly %a, i32 %k, i32 %n) local_unnamed_addr {
 entry:
   %cmp7 = icmp sgt i32 %n, 0
   br i1 %cmp7, label %for.body.lr.ph, label %for.cond.cleanup
@@ -23,16 +23,16 @@ for.cond.cleanup:                                 ; preds = %for.body, %entry
   ret void
 
 for.body:                                         ; preds = %for.body, %for.body.lr.ph
-  %arrayidx.phi = phi i32* [ %a, %for.body.lr.ph ], [ %arrayidx.inc, %for.body ]
-  %arrayidx2.phi = phi i64* [ %p, %for.body.lr.ph ], [ %arrayidx2.inc, %for.body ]
+  %arrayidx.phi = phi ptr [ %a, %for.body.lr.ph ], [ %arrayidx.inc, %for.body ]
+  %arrayidx2.phi = phi ptr [ %p, %for.body.lr.ph ], [ %arrayidx2.inc, %for.body ]
   %i.08 = phi i32 [ 0, %for.body.lr.ph ], [ %inc, %for.body ]
-  %0 = load i32, i32* %arrayidx.phi, align 4
+  %0 = load i32, ptr %arrayidx.phi, align 4
   %conv = sext i32 %0 to i64
   %mul = mul nsw i64 %conv, %conv1
-  store i64 %mul, i64* %arrayidx2.phi, align 8
+  store i64 %mul, ptr %arrayidx2.phi, align 8
   %inc = add nuw nsw i32 %i.08, 1
   %exitcond = icmp eq i32 %inc, %n
-  %arrayidx.inc = getelementptr i32, i32* %arrayidx.phi, i32 1
-  %arrayidx2.inc = getelementptr i64, i64* %arrayidx2.phi, i32 1
+  %arrayidx.inc = getelementptr i32, ptr %arrayidx.phi, i32 1
+  %arrayidx2.inc = getelementptr i64, ptr %arrayidx2.phi, i32 1
   br i1 %exitcond, label %for.cond.cleanup, label %for.body
 }

--- a/llvm/test/CodeGen/Hexagon/swp-pragma-disable.ii
+++ b/llvm/test/CodeGen/Hexagon/swp-pragma-disable.ii
@@ -2,33 +2,33 @@
 ; RUN:     -debug-only=pipeliner < %s 2>&1 > /dev/null -pipeliner-experimental-cg=true | FileCheck %s
 ; REQUIRES: asserts
 ;
-; Test that checks if pipeliner disabled by pragma 
+; Test that checks if pipeliner disabled by pragma
 
-; CHECK: Can not pipeline loop 
+; CHECK: Can not pipeline loop
 
 ; Function Attrs: nounwind
-define void @f0(i32* nocapture %a0, i32 %a1) #0 {
+define void @f0(ptr nocapture %a0, i32 %a1) #0 {
 b0:
   %v0 = icmp sgt i32 %a1, 1
   br i1 %v0, label %b1, label %b4
 
 b1:                                               ; preds = %b0
-  %v1 = load i32, i32* %a0, align 4
+  %v1 = load i32, ptr %a0, align 4
   %v2 = add i32 %v1, 10
-  %v3 = getelementptr i32, i32* %a0, i32 1
+  %v3 = getelementptr i32, ptr %a0, i32 1
   %v4 = add i32 %a1, -1
   br label %b2
 
 b2:                                               ; preds = %b2, %b1
   %v5 = phi i32 [ %v12, %b2 ], [ %v4, %b1 ]
-  %v6 = phi i32* [ %v11, %b2 ], [ %v3, %b1 ]
+  %v6 = phi ptr [ %v11, %b2 ], [ %v3, %b1 ]
   %v7 = phi i32 [ %v10, %b2 ], [ %v2, %b1 ]
-  store i32 %v7, i32* %v6, align 4
+  store i32 %v7, ptr %v6, align 4
   %v8 = add i32 %v7, 10
-  %v9 = getelementptr i32, i32* %v6, i32 -1
-  store i32 %v8, i32* %v9, align 4
+  %v9 = getelementptr i32, ptr %v6, i32 -1
+  store i32 %v8, ptr %v9, align 4
   %v10 = add i32 %v7, 10
-  %v11 = getelementptr i32, i32* %v6, i32 1
+  %v11 = getelementptr i32, ptr %v6, i32 1
   %v12 = add i32 %v5, -1
   %v13 = icmp eq i32 %v12, 0
   br i1 %v13, label %b3, label %b2

--- a/llvm/test/CodeGen/Hexagon/swp-pragma-initiation-interval.ii
+++ b/llvm/test/CodeGen/Hexagon/swp-pragma-initiation-interval.ii
@@ -4,31 +4,31 @@
 ;
 ; Test that checks if the II set by pragma was taken by pipeliner.
 
-; CHECK: MII = 2 MAX_II = 2 
+; CHECK: MII = 2 MAX_II = 2
 
 ; Function Attrs: nounwind
-define void @f0(i32* nocapture %a0, i32 %a1) #0 {
+define void @f0(ptr nocapture %a0, i32 %a1) #0 {
 b0:
   %v0 = icmp sgt i32 %a1, 1
   br i1 %v0, label %b1, label %b4
 
 b1:                                               ; preds = %b0
-  %v1 = load i32, i32* %a0, align 4
+  %v1 = load i32, ptr %a0, align 4
   %v2 = add i32 %v1, 10
-  %v3 = getelementptr i32, i32* %a0, i32 1
+  %v3 = getelementptr i32, ptr %a0, i32 1
   %v4 = add i32 %a1, -1
   br label %b2
 
 b2:                                               ; preds = %b2, %b1
   %v5 = phi i32 [ %v12, %b2 ], [ %v4, %b1 ]
-  %v6 = phi i32* [ %v11, %b2 ], [ %v3, %b1 ]
+  %v6 = phi ptr [ %v11, %b2 ], [ %v3, %b1 ]
   %v7 = phi i32 [ %v10, %b2 ], [ %v2, %b1 ]
-  store i32 %v7, i32* %v6, align 4
+  store i32 %v7, ptr %v6, align 4
   %v8 = add i32 %v7, 10
-  %v9 = getelementptr i32, i32* %v6, i32 -1
-  store i32 %v8, i32* %v9, align 4
+  %v9 = getelementptr i32, ptr %v6, i32 -1
+  store i32 %v8, ptr %v9, align 4
   %v10 = add i32 %v7, 10
-  %v11 = getelementptr i32, i32* %v6, i32 1
+  %v11 = getelementptr i32, ptr %v6, i32 1
   %v12 = add i32 %v5, -1
   %v13 = icmp eq i32 %v12, 0
   br i1 %v13, label %b3, label %b2

--- a/llvm/test/CodeGen/MLRegAlloc/Inputs/input.ll
+++ b/llvm/test/CodeGen/MLRegAlloc/Inputs/input.ll
@@ -3,21 +3,21 @@
 ; and the test ML policy: different eviction choices, and different reward.
 ;
 ;
-%struct.TMP.1 = type { %struct.TMP.2*, %struct.TMP.2*, [1024 x i8] }
-%struct.TMP.2 = type { i8*, i32, i32, i16, i16, %struct.TMP.3, i32, i8*, i32 (i8*)*, i32 (i8*, i8*, i32)*, i64 (i8*, i64, i32)*, i32 (i8*, i8*, i32)*, %struct.TMP.3, %struct.TMP.4*, i32, [3 x i8], [1 x i8], %struct.TMP.3, i32, i64 }
+%struct.TMP.1 = type { ptr, ptr, [1024 x i8] }
+%struct.TMP.2 = type { ptr, i32, i32, i16, i16, %struct.TMP.3, i32, ptr, ptr, ptr, ptr, ptr, %struct.TMP.3, ptr, i32, [3 x i8], [1 x i8], %struct.TMP.3, i32, i64 }
 %struct.TMP.4 = type opaque
-%struct.TMP.3 = type { i8*, i32 }
+%struct.TMP.3 = type { ptr, i32 }
 
 @syBuf = external global [16 x %struct.TMP.1], align 16
 @syHistory = external global [8192 x i8], align 16
 @SyFgets.yank = external global [512 x i8], align 16
 @syCTRO = external global i32, align 4
 
-define i8* @SyFgets(i8* %line, i64 %length, i64 %fid) {
+define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 entry:
-  %sub.ptr.rhs.cast646 = ptrtoint i8* %line to i64
+  %sub.ptr.rhs.cast646 = ptrtoint ptr %line to i64
   %old = alloca [512 x i8], align 16
-  %0 = getelementptr inbounds [512 x i8], [512 x i8]* %old, i64 0, i64 0
+  %0 = getelementptr inbounds [512 x i8], ptr %old, i64 0, i64 0
   switch i64 %fid, label %if.then [
     i64 2, label %if.end
     i64 0, label %if.end
@@ -57,24 +57,24 @@ if.then.i2712:
   unreachable
 
 SyTime.exit2720:
-  %add.ptr = getelementptr [512 x i8], [512 x i8]* %old, i64 0, i64 512
-  %cmp293427 = icmp ult i8* %0, %add.ptr
+  %add.ptr = getelementptr [512 x i8], ptr %old, i64 0, i64 512
+  %cmp293427 = icmp ult ptr %0, %add.ptr
   br i1 %cmp293427, label %for.body.lr.ph, label %while.body.preheader
 
 for.body.lr.ph:
-  call void @llvm.memset.p0i8.i64(i8* align 16 undef, i8 32, i64 512, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 16 undef, i8 32, i64 512, i1 false)
   br label %while.body.preheader
 
 while.body.preheader:
-  %add.ptr1603 = getelementptr [512 x i8], [512 x i8]* null, i64 0, i64 512
-  %echo.i3101 = getelementptr [16 x %struct.TMP.1], [16 x %struct.TMP.1]* @syBuf, i64 0, i64 %fid, i32 1
+  %add.ptr1603 = getelementptr [512 x i8], ptr null, i64 0, i64 512
+  %echo.i3101 = getelementptr [16 x %struct.TMP.1], ptr @syBuf, i64 0, i64 %fid, i32 1
   %1 = xor i64 %sub.ptr.rhs.cast646, -1
   br label %do.body
 
 do.body:
   %ch2.0 = phi i32 [ 0, %while.body.preheader ], [ %ch.12.ch2.12, %do.body ]
   %rep.0 = phi i32 [ 1, %while.body.preheader ], [ %rep.6, %do.body ]
-  store i32 0, i32* @syCTRO, align 4, !tbaa !1
+  store i32 0, ptr @syCTRO, align 4, !tbaa !1
   %ch.0.ch2.0 = select i1 undef, i32 14, i32 %ch2.0
   %ch2.2 = select i1 undef, i32 0, i32 %ch.0.ch2.0
   %ch.2.ch2.2 = select i1 undef, i32 0, i32 %ch2.2
@@ -154,7 +154,7 @@ for.body643.us:
 while.cond201.preheader:
   %umax = select i1 false, i64 undef, i64 %1
   %2 = xor i64 %umax, -1
-  %3 = inttoptr i64 %2 to i8*
+  %3 = inttoptr i64 %2 to ptr
   br label %while.cond197.backedge
 
 sw.bb206:
@@ -185,7 +185,7 @@ do.body479.preheader:
   br i1 %cmp4833314, label %if.end517, label %land.rhs485
 
 land.rhs485:
-  %incdec.ptr4803316 = phi i8* [ %incdec.ptr480, %do.body479.backedge.land.rhs485_crit_edge ], [ undef, %do.body479.preheader ]
+  %incdec.ptr4803316 = phi ptr [ %incdec.ptr480, %do.body479.backedge.land.rhs485_crit_edge ], [ undef, %do.body479.preheader ]
   %isascii.i.i27763151 = icmp sgt i8 undef, -1
   br i1 %isascii.i.i27763151, label %cond.true.i.i2780, label %cond.false.i.i2782
 
@@ -207,7 +207,7 @@ land.lhs.true504:
   br i1 undef, label %do.body479.backedge, label %if.end517
 
 do.body479.backedge:
-  %incdec.ptr480 = getelementptr i8, i8* %incdec.ptr4803316, i64 1
+  %incdec.ptr480 = getelementptr i8, ptr %incdec.ptr4803316, i64 1
   %cmp483 = icmp eq i8 undef, 0
   br i1 %cmp483, label %if.end517, label %do.body479.backedge.land.rhs485_crit_edge
 
@@ -215,7 +215,7 @@ do.body479.backedge.land.rhs485_crit_edge:
   br label %land.rhs485
 
 if.end517:
-  %q.4 = phi i8* [ undef, %sw.bb474 ], [ undef, %do.body479.preheader ], [ %incdec.ptr480, %do.body479.backedge ], [ %incdec.ptr4803316, %land.lhs.true504 ]
+  %q.4 = phi ptr [ undef, %sw.bb474 ], [ undef, %do.body479.preheader ], [ %incdec.ptr480, %do.body479.backedge ], [ %incdec.ptr4803316, %land.lhs.true504 ]
   switch i32 %last.13371, label %if.then532 [
     i32 383, label %for.cond534
     i32 356, label %for.cond534
@@ -225,7 +225,7 @@ if.end517:
   ]
 
 if.then532:
-  store i8 0, i8* getelementptr inbounds ([512 x i8], [512 x i8]* @SyFgets.yank, i64 0, i64 0), align 16, !tbaa !5
+  store i8 0, ptr @SyFgets.yank, align 16, !tbaa !5
   br label %for.cond534
 
 for.cond534:
@@ -239,11 +239,11 @@ for.body545:
   br i1 undef, label %for.end552, label %for.body545
 
 for.end552:
-  %s.2.lcssa = phi i8* [ undef, %for.cond542.preheader ], [ %q.4, %for.body545 ]
-  %sub.ptr.lhs.cast553 = ptrtoint i8* %s.2.lcssa to i64
+  %s.2.lcssa = phi ptr [ undef, %for.cond542.preheader ], [ %q.4, %for.body545 ]
+  %sub.ptr.lhs.cast553 = ptrtoint ptr %s.2.lcssa to i64
   %sub.ptr.sub555 = sub i64 %sub.ptr.lhs.cast553, 0
-  %arrayidx556 = getelementptr i8, i8* null, i64 %sub.ptr.sub555
-  store i8 0, i8* %arrayidx556, align 1, !tbaa !5
+  %arrayidx556 = getelementptr i8, ptr null, i64 %sub.ptr.sub555
+  store i8 0, ptr %arrayidx556, align 1, !tbaa !5
   br label %while.cond197.backedge
 
 sw.bb566:
@@ -305,9 +305,9 @@ for.cond1480.preheader:
   br i1 undef, label %for.body1606.lr.ph, label %for.end1609
 
 if.then1477:
-  %p.1.lcssa3539 = phi i8* [ null, %while.end1465 ], [ null, %while.end1465 ], [ null, %while.end1465 ], [ null, %while.end1465 ], [ %line, %while.body200 ]
-  %call1.i3057 = call i64 @"\01_write"(i32 undef, i8* undef, i64 1)
-  %sub.ptr.lhs.cast1717 = ptrtoint i8* %p.1.lcssa3539 to i64
+  %p.1.lcssa3539 = phi ptr [ null, %while.end1465 ], [ null, %while.end1465 ], [ null, %while.end1465 ], [ null, %while.end1465 ], [ %line, %while.body200 ]
+  %call1.i3057 = call i64 @"\01_write"(i32 undef, ptr undef, i64 1)
+  %sub.ptr.lhs.cast1717 = ptrtoint ptr %p.1.lcssa3539 to i64
   %sub.ptr.sub1719 = sub i64 %sub.ptr.lhs.cast1717, %sub.ptr.rhs.cast646
   %idx.neg1727 = sub i64 0, %sub.ptr.sub1719
   br label %for.body1723
@@ -322,7 +322,7 @@ land.lhs.true1614:
   br label %for.cond1659.preheader
 
 for.cond1659.preheader:
-  %cmp16623414 = icmp ult i8* undef, %add.ptr1603
+  %cmp16623414 = icmp ult ptr undef, %add.ptr1603
   br i1 %cmp16623414, label %for.body1664.lr.ph, label %while.body1703.lr.ph
 
 for.body1664.lr.ph:
@@ -337,8 +337,8 @@ while.cond1683.preheader:
 
 while.body1679:
   %oldc.43406 = phi i32 [ %inc, %syEchoch.exit3070 ], [ %oldc.1.lcssa, %for.body1664.lr.ph ]
-  %4 = load %struct.TMP.2*, %struct.TMP.2** %echo.i3101, align 8, !tbaa !6
-  %call.i3062 = call i32 @fileno(%struct.TMP.2* %4)
+  %4 = load ptr, ptr %echo.i3101, align 8, !tbaa !6
+  %call.i3062 = call i32 @fileno(ptr %4)
   br i1 undef, label %if.then.i3069, label %syEchoch.exit3070
 
 if.then.i3069:
@@ -357,20 +357,20 @@ while.end1693:
   unreachable
 
 for.body1723:
-  %q.303203 = phi i8* [ getelementptr inbounds ([8192 x i8], [8192 x i8]* @syHistory, i64 0, i64 8189), %if.then1477 ], [ %incdec.ptr1730, %for.body1723 ]
-  %add.ptr1728 = getelementptr i8, i8* %q.303203, i64 %idx.neg1727
-  %5 = load i8, i8* %add.ptr1728, align 1, !tbaa !5
-  %incdec.ptr1730 = getelementptr i8, i8* %q.303203, i64 -1
+  %q.303203 = phi ptr [ getelementptr inbounds ([8192 x i8], ptr @syHistory, i64 0, i64 8189), %if.then1477 ], [ %incdec.ptr1730, %for.body1723 ]
+  %add.ptr1728 = getelementptr i8, ptr %q.303203, i64 %idx.neg1727
+  %5 = load i8, ptr %add.ptr1728, align 1, !tbaa !5
+  %incdec.ptr1730 = getelementptr i8, ptr %q.303203, i64 -1
   br label %for.body1723
 
 cleanup:
-  ret i8* undef
+  ret ptr undef
 }
 
-declare i32 @fileno(%struct.TMP.2* nocapture)
-declare i64 @"\01_write"(i32, i8*, i64)
+declare i32 @fileno(ptr nocapture)
+declare i64 @"\01_write"(i32, ptr, i64)
 declare i32 @__maskrune(i32, i64)
-declare void @llvm.memset.p0i8.i64(i8* nocapture, i8, i64, i1)
+declare void @llvm.memset.p0.i64(ptr nocapture, i8, i64, i1)
 
 !llvm.ident = !{!0}
 

--- a/llvm/test/CodeGen/MLRegAlloc/Inputs/two-large-fcts.ll
+++ b/llvm/test/CodeGen/MLRegAlloc/Inputs/two-large-fcts.ll
@@ -3,21 +3,21 @@
 ; and the test ML policy: different eviction choices, and different reward.
 ;
 ;
-%struct.TMP.1 = type { %struct.TMP.2*, %struct.TMP.2*, [1024 x i8] }
-%struct.TMP.2 = type { i8*, i32, i32, i16, i16, %struct.TMP.3, i32, i8*, i32 (i8*)*, i32 (i8*, i8*, i32)*, i64 (i8*, i64, i32)*, i32 (i8*, i8*, i32)*, %struct.TMP.3, %struct.TMP.4*, i32, [3 x i8], [1 x i8], %struct.TMP.3, i32, i64 }
+%struct.TMP.1 = type { ptr, ptr, [1024 x i8] }
+%struct.TMP.2 = type { ptr, i32, i32, i16, i16, %struct.TMP.3, i32, ptr, ptr, ptr, ptr, ptr, %struct.TMP.3, ptr, i32, [3 x i8], [1 x i8], %struct.TMP.3, i32, i64 }
 %struct.TMP.4 = type opaque
-%struct.TMP.3 = type { i8*, i32 }
+%struct.TMP.3 = type { ptr, i32 }
 
 @syBuf = external global [16 x %struct.TMP.1], align 16
 @syHistory = external global [8192 x i8], align 16
 @SyFgets.yank = external global [512 x i8], align 16
 @syCTRO = external global i32, align 4
 
-define i8* @SyFgets(i8* %line, i64 %length, i64 %fid) {
+define ptr @SyFgets(ptr %line, i64 %length, i64 %fid) {
 entry:
-  %sub.ptr.rhs.cast646 = ptrtoint i8* %line to i64
+  %sub.ptr.rhs.cast646 = ptrtoint ptr %line to i64
   %old = alloca [512 x i8], align 16
-  %0 = getelementptr inbounds [512 x i8], [512 x i8]* %old, i64 0, i64 0
+  %0 = getelementptr inbounds [512 x i8], ptr %old, i64 0, i64 0
   switch i64 %fid, label %if.then [
     i64 2, label %if.end
     i64 0, label %if.end
@@ -57,24 +57,24 @@ if.then.i2712:
   unreachable
 
 SyTime.exit2720:
-  %add.ptr = getelementptr [512 x i8], [512 x i8]* %old, i64 0, i64 512
-  %cmp293427 = icmp ult i8* %0, %add.ptr
+  %add.ptr = getelementptr [512 x i8], ptr %old, i64 0, i64 512
+  %cmp293427 = icmp ult ptr %0, %add.ptr
   br i1 %cmp293427, label %for.body.lr.ph, label %while.body.preheader
 
 for.body.lr.ph:
-  call void @llvm.memset.p0i8.i64(i8* align 16 undef, i8 32, i64 512, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 16 undef, i8 32, i64 512, i1 false)
   br label %while.body.preheader
 
 while.body.preheader:
-  %add.ptr1603 = getelementptr [512 x i8], [512 x i8]* null, i64 0, i64 512
-  %echo.i3101 = getelementptr [16 x %struct.TMP.1], [16 x %struct.TMP.1]* @syBuf, i64 0, i64 %fid, i32 1
+  %add.ptr1603 = getelementptr [512 x i8], ptr null, i64 0, i64 512
+  %echo.i3101 = getelementptr [16 x %struct.TMP.1], ptr @syBuf, i64 0, i64 %fid, i32 1
   %1 = xor i64 %sub.ptr.rhs.cast646, -1
   br label %do.body
 
 do.body:
   %ch2.0 = phi i32 [ 0, %while.body.preheader ], [ %ch.12.ch2.12, %do.body ]
   %rep.0 = phi i32 [ 1, %while.body.preheader ], [ %rep.6, %do.body ]
-  store i32 0, i32* @syCTRO, align 4, !tbaa !1
+  store i32 0, ptr @syCTRO, align 4, !tbaa !1
   %ch.0.ch2.0 = select i1 undef, i32 14, i32 %ch2.0
   %ch2.2 = select i1 undef, i32 0, i32 %ch.0.ch2.0
   %ch.2.ch2.2 = select i1 undef, i32 0, i32 %ch2.2
@@ -154,7 +154,7 @@ for.body643.us:
 while.cond201.preheader:
   %umax = select i1 false, i64 undef, i64 %1
   %2 = xor i64 %umax, -1
-  %3 = inttoptr i64 %2 to i8*
+  %3 = inttoptr i64 %2 to ptr
   br label %while.cond197.backedge
 
 sw.bb206:
@@ -185,7 +185,7 @@ do.body479.preheader:
   br i1 %cmp4833314, label %if.end517, label %land.rhs485
 
 land.rhs485:
-  %incdec.ptr4803316 = phi i8* [ %incdec.ptr480, %do.body479.backedge.land.rhs485_crit_edge ], [ undef, %do.body479.preheader ]
+  %incdec.ptr4803316 = phi ptr [ %incdec.ptr480, %do.body479.backedge.land.rhs485_crit_edge ], [ undef, %do.body479.preheader ]
   %isascii.i.i27763151 = icmp sgt i8 undef, -1
   br i1 %isascii.i.i27763151, label %cond.true.i.i2780, label %cond.false.i.i2782
 
@@ -207,7 +207,7 @@ land.lhs.true504:
   br i1 undef, label %do.body479.backedge, label %if.end517
 
 do.body479.backedge:
-  %incdec.ptr480 = getelementptr i8, i8* %incdec.ptr4803316, i64 1
+  %incdec.ptr480 = getelementptr i8, ptr %incdec.ptr4803316, i64 1
   %cmp483 = icmp eq i8 undef, 0
   br i1 %cmp483, label %if.end517, label %do.body479.backedge.land.rhs485_crit_edge
 
@@ -215,7 +215,7 @@ do.body479.backedge.land.rhs485_crit_edge:
   br label %land.rhs485
 
 if.end517:
-  %q.4 = phi i8* [ undef, %sw.bb474 ], [ undef, %do.body479.preheader ], [ %incdec.ptr480, %do.body479.backedge ], [ %incdec.ptr4803316, %land.lhs.true504 ]
+  %q.4 = phi ptr [ undef, %sw.bb474 ], [ undef, %do.body479.preheader ], [ %incdec.ptr480, %do.body479.backedge ], [ %incdec.ptr4803316, %land.lhs.true504 ]
   switch i32 %last.13371, label %if.then532 [
     i32 383, label %for.cond534
     i32 356, label %for.cond534
@@ -225,7 +225,7 @@ if.end517:
   ]
 
 if.then532:
-  store i8 0, i8* getelementptr inbounds ([512 x i8], [512 x i8]* @SyFgets.yank, i64 0, i64 0), align 16, !tbaa !5
+  store i8 0, ptr @SyFgets.yank, align 16, !tbaa !5
   br label %for.cond534
 
 for.cond534:
@@ -239,11 +239,11 @@ for.body545:
   br i1 undef, label %for.end552, label %for.body545
 
 for.end552:
-  %s.2.lcssa = phi i8* [ undef, %for.cond542.preheader ], [ %q.4, %for.body545 ]
-  %sub.ptr.lhs.cast553 = ptrtoint i8* %s.2.lcssa to i64
+  %s.2.lcssa = phi ptr [ undef, %for.cond542.preheader ], [ %q.4, %for.body545 ]
+  %sub.ptr.lhs.cast553 = ptrtoint ptr %s.2.lcssa to i64
   %sub.ptr.sub555 = sub i64 %sub.ptr.lhs.cast553, 0
-  %arrayidx556 = getelementptr i8, i8* null, i64 %sub.ptr.sub555
-  store i8 0, i8* %arrayidx556, align 1, !tbaa !5
+  %arrayidx556 = getelementptr i8, ptr null, i64 %sub.ptr.sub555
+  store i8 0, ptr %arrayidx556, align 1, !tbaa !5
   br label %while.cond197.backedge
 
 sw.bb566:
@@ -305,9 +305,9 @@ for.cond1480.preheader:
   br i1 undef, label %for.body1606.lr.ph, label %for.end1609
 
 if.then1477:
-  %p.1.lcssa3539 = phi i8* [ null, %while.end1465 ], [ null, %while.end1465 ], [ null, %while.end1465 ], [ null, %while.end1465 ], [ %line, %while.body200 ]
-  %call1.i3057 = call i64 @"\01_write"(i32 undef, i8* undef, i64 1)
-  %sub.ptr.lhs.cast1717 = ptrtoint i8* %p.1.lcssa3539 to i64
+  %p.1.lcssa3539 = phi ptr [ null, %while.end1465 ], [ null, %while.end1465 ], [ null, %while.end1465 ], [ null, %while.end1465 ], [ %line, %while.body200 ]
+  %call1.i3057 = call i64 @"\01_write"(i32 undef, ptr undef, i64 1)
+  %sub.ptr.lhs.cast1717 = ptrtoint ptr %p.1.lcssa3539 to i64
   %sub.ptr.sub1719 = sub i64 %sub.ptr.lhs.cast1717, %sub.ptr.rhs.cast646
   %idx.neg1727 = sub i64 0, %sub.ptr.sub1719
   br label %for.body1723
@@ -322,7 +322,7 @@ land.lhs.true1614:
   br label %for.cond1659.preheader
 
 for.cond1659.preheader:
-  %cmp16623414 = icmp ult i8* undef, %add.ptr1603
+  %cmp16623414 = icmp ult ptr undef, %add.ptr1603
   br i1 %cmp16623414, label %for.body1664.lr.ph, label %while.body1703.lr.ph
 
 for.body1664.lr.ph:
@@ -337,8 +337,8 @@ while.cond1683.preheader:
 
 while.body1679:
   %oldc.43406 = phi i32 [ %inc, %syEchoch.exit3070 ], [ %oldc.1.lcssa, %for.body1664.lr.ph ]
-  %4 = load %struct.TMP.2*, %struct.TMP.2** %echo.i3101, align 8, !tbaa !6
-  %call.i3062 = call i32 @fileno(%struct.TMP.2* %4)
+  %4 = load ptr, ptr %echo.i3101, align 8, !tbaa !6
+  %call.i3062 = call i32 @fileno(ptr %4)
   br i1 undef, label %if.then.i3069, label %syEchoch.exit3070
 
 if.then.i3069:
@@ -357,22 +357,22 @@ while.end1693:
   unreachable
 
 for.body1723:
-  %q.303203 = phi i8* [ getelementptr inbounds ([8192 x i8], [8192 x i8]* @syHistory, i64 0, i64 8189), %if.then1477 ], [ %incdec.ptr1730, %for.body1723 ]
-  %add.ptr1728 = getelementptr i8, i8* %q.303203, i64 %idx.neg1727
-  %5 = load i8, i8* %add.ptr1728, align 1, !tbaa !5
-  %incdec.ptr1730 = getelementptr i8, i8* %q.303203, i64 -1
+  %q.303203 = phi ptr [ getelementptr inbounds ([8192 x i8], ptr @syHistory, i64 0, i64 8189), %if.then1477 ], [ %incdec.ptr1730, %for.body1723 ]
+  %add.ptr1728 = getelementptr i8, ptr %q.303203, i64 %idx.neg1727
+  %5 = load i8, ptr %add.ptr1728, align 1, !tbaa !5
+  %incdec.ptr1730 = getelementptr i8, ptr %q.303203, i64 -1
   br label %for.body1723
 
 cleanup:
-  ret i8* undef
+  ret ptr undef
 }
 
 
-define i8* @SyFgetsCopy(i8* %line, i64 %length, i64 %fid) {
+define ptr @SyFgetsCopy(ptr %line, i64 %length, i64 %fid) {
 entry:
-  %sub.ptr.rhs.cast646 = ptrtoint i8* %line to i64
+  %sub.ptr.rhs.cast646 = ptrtoint ptr %line to i64
   %old = alloca [512 x i8], align 16
-  %0 = getelementptr inbounds [512 x i8], [512 x i8]* %old, i64 0, i64 0
+  %0 = getelementptr inbounds [512 x i8], ptr %old, i64 0, i64 0
   switch i64 %fid, label %if.then [
     i64 2, label %if.end
     i64 0, label %if.end
@@ -412,24 +412,24 @@ if.then.i2712:
   unreachable
 
 SyTime.exit2720:
-  %add.ptr = getelementptr [512 x i8], [512 x i8]* %old, i64 0, i64 512
-  %cmp293427 = icmp ult i8* %0, %add.ptr
+  %add.ptr = getelementptr [512 x i8], ptr %old, i64 0, i64 512
+  %cmp293427 = icmp ult ptr %0, %add.ptr
   br i1 %cmp293427, label %for.body.lr.ph, label %while.body.preheader
 
 for.body.lr.ph:
-  call void @llvm.memset.p0i8.i64(i8* align 16 undef, i8 32, i64 512, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 16 undef, i8 32, i64 512, i1 false)
   br label %while.body.preheader
 
 while.body.preheader:
-  %add.ptr1603 = getelementptr [512 x i8], [512 x i8]* null, i64 0, i64 512
-  %echo.i3101 = getelementptr [16 x %struct.TMP.1], [16 x %struct.TMP.1]* @syBuf, i64 0, i64 %fid, i32 1
+  %add.ptr1603 = getelementptr [512 x i8], ptr null, i64 0, i64 512
+  %echo.i3101 = getelementptr [16 x %struct.TMP.1], ptr @syBuf, i64 0, i64 %fid, i32 1
   %1 = xor i64 %sub.ptr.rhs.cast646, -1
   br label %do.body
 
 do.body:
   %ch2.0 = phi i32 [ 0, %while.body.preheader ], [ %ch.12.ch2.12, %do.body ]
   %rep.0 = phi i32 [ 1, %while.body.preheader ], [ %rep.6, %do.body ]
-  store i32 0, i32* @syCTRO, align 4, !tbaa !1
+  store i32 0, ptr @syCTRO, align 4, !tbaa !1
   %ch.0.ch2.0 = select i1 undef, i32 14, i32 %ch2.0
   %ch2.2 = select i1 undef, i32 0, i32 %ch.0.ch2.0
   %ch.2.ch2.2 = select i1 undef, i32 0, i32 %ch2.2
@@ -509,7 +509,7 @@ for.body643.us:
 while.cond201.preheader:
   %umax = select i1 false, i64 undef, i64 %1
   %2 = xor i64 %umax, -1
-  %3 = inttoptr i64 %2 to i8*
+  %3 = inttoptr i64 %2 to ptr
   br label %while.cond197.backedge
 
 sw.bb206:
@@ -540,7 +540,7 @@ do.body479.preheader:
   br i1 %cmp4833314, label %if.end517, label %land.rhs485
 
 land.rhs485:
-  %incdec.ptr4803316 = phi i8* [ %incdec.ptr480, %do.body479.backedge.land.rhs485_crit_edge ], [ undef, %do.body479.preheader ]
+  %incdec.ptr4803316 = phi ptr [ %incdec.ptr480, %do.body479.backedge.land.rhs485_crit_edge ], [ undef, %do.body479.preheader ]
   %isascii.i.i27763151 = icmp sgt i8 undef, -1
   br i1 %isascii.i.i27763151, label %cond.true.i.i2780, label %cond.false.i.i2782
 
@@ -562,7 +562,7 @@ land.lhs.true504:
   br i1 undef, label %do.body479.backedge, label %if.end517
 
 do.body479.backedge:
-  %incdec.ptr480 = getelementptr i8, i8* %incdec.ptr4803316, i64 1
+  %incdec.ptr480 = getelementptr i8, ptr %incdec.ptr4803316, i64 1
   %cmp483 = icmp eq i8 undef, 0
   br i1 %cmp483, label %if.end517, label %do.body479.backedge.land.rhs485_crit_edge
 
@@ -570,7 +570,7 @@ do.body479.backedge.land.rhs485_crit_edge:
   br label %land.rhs485
 
 if.end517:
-  %q.4 = phi i8* [ undef, %sw.bb474 ], [ undef, %do.body479.preheader ], [ %incdec.ptr480, %do.body479.backedge ], [ %incdec.ptr4803316, %land.lhs.true504 ]
+  %q.4 = phi ptr [ undef, %sw.bb474 ], [ undef, %do.body479.preheader ], [ %incdec.ptr480, %do.body479.backedge ], [ %incdec.ptr4803316, %land.lhs.true504 ]
   switch i32 %last.13371, label %if.then532 [
     i32 383, label %for.cond534
     i32 356, label %for.cond534
@@ -580,7 +580,7 @@ if.end517:
   ]
 
 if.then532:
-  store i8 0, i8* getelementptr inbounds ([512 x i8], [512 x i8]* @SyFgets.yank, i64 0, i64 0), align 16, !tbaa !5
+  store i8 0, ptr @SyFgets.yank, align 16, !tbaa !5
   br label %for.cond534
 
 for.cond534:
@@ -594,11 +594,11 @@ for.body545:
   br i1 undef, label %for.end552, label %for.body545
 
 for.end552:
-  %s.2.lcssa = phi i8* [ undef, %for.cond542.preheader ], [ %q.4, %for.body545 ]
-  %sub.ptr.lhs.cast553 = ptrtoint i8* %s.2.lcssa to i64
+  %s.2.lcssa = phi ptr [ undef, %for.cond542.preheader ], [ %q.4, %for.body545 ]
+  %sub.ptr.lhs.cast553 = ptrtoint ptr %s.2.lcssa to i64
   %sub.ptr.sub555 = sub i64 %sub.ptr.lhs.cast553, 0
-  %arrayidx556 = getelementptr i8, i8* null, i64 %sub.ptr.sub555
-  store i8 0, i8* %arrayidx556, align 1, !tbaa !5
+  %arrayidx556 = getelementptr i8, ptr null, i64 %sub.ptr.sub555
+  store i8 0, ptr %arrayidx556, align 1, !tbaa !5
   br label %while.cond197.backedge
 
 sw.bb566:
@@ -660,9 +660,9 @@ for.cond1480.preheader:
   br i1 undef, label %for.body1606.lr.ph, label %for.end1609
 
 if.then1477:
-  %p.1.lcssa3539 = phi i8* [ null, %while.end1465 ], [ null, %while.end1465 ], [ null, %while.end1465 ], [ null, %while.end1465 ], [ %line, %while.body200 ]
-  %call1.i3057 = call i64 @"\01_write"(i32 undef, i8* undef, i64 1)
-  %sub.ptr.lhs.cast1717 = ptrtoint i8* %p.1.lcssa3539 to i64
+  %p.1.lcssa3539 = phi ptr [ null, %while.end1465 ], [ null, %while.end1465 ], [ null, %while.end1465 ], [ null, %while.end1465 ], [ %line, %while.body200 ]
+  %call1.i3057 = call i64 @"\01_write"(i32 undef, ptr undef, i64 1)
+  %sub.ptr.lhs.cast1717 = ptrtoint ptr %p.1.lcssa3539 to i64
   %sub.ptr.sub1719 = sub i64 %sub.ptr.lhs.cast1717, %sub.ptr.rhs.cast646
   %idx.neg1727 = sub i64 0, %sub.ptr.sub1719
   br label %for.body1723
@@ -677,7 +677,7 @@ land.lhs.true1614:
   br label %for.cond1659.preheader
 
 for.cond1659.preheader:
-  %cmp16623414 = icmp ult i8* undef, %add.ptr1603
+  %cmp16623414 = icmp ult ptr undef, %add.ptr1603
   br i1 %cmp16623414, label %for.body1664.lr.ph, label %while.body1703.lr.ph
 
 for.body1664.lr.ph:
@@ -692,8 +692,8 @@ while.cond1683.preheader:
 
 while.body1679:
   %oldc.43406 = phi i32 [ %inc, %syEchoch.exit3070 ], [ %oldc.1.lcssa, %for.body1664.lr.ph ]
-  %4 = load %struct.TMP.2*, %struct.TMP.2** %echo.i3101, align 8, !tbaa !6
-  %call.i3062 = call i32 @fileno(%struct.TMP.2* %4)
+  %4 = load ptr, ptr %echo.i3101, align 8, !tbaa !6
+  %call.i3062 = call i32 @fileno(ptr %4)
   br i1 undef, label %if.then.i3069, label %syEchoch.exit3070
 
 if.then.i3069:
@@ -712,20 +712,20 @@ while.end1693:
   unreachable
 
 for.body1723:
-  %q.303203 = phi i8* [ getelementptr inbounds ([8192 x i8], [8192 x i8]* @syHistory, i64 0, i64 8189), %if.then1477 ], [ %incdec.ptr1730, %for.body1723 ]
-  %add.ptr1728 = getelementptr i8, i8* %q.303203, i64 %idx.neg1727
-  %5 = load i8, i8* %add.ptr1728, align 1, !tbaa !5
-  %incdec.ptr1730 = getelementptr i8, i8* %q.303203, i64 -1
+  %q.303203 = phi ptr [ getelementptr inbounds ([8192 x i8], ptr @syHistory, i64 0, i64 8189), %if.then1477 ], [ %incdec.ptr1730, %for.body1723 ]
+  %add.ptr1728 = getelementptr i8, ptr %q.303203, i64 %idx.neg1727
+  %5 = load i8, ptr %add.ptr1728, align 1, !tbaa !5
+  %incdec.ptr1730 = getelementptr i8, ptr %q.303203, i64 -1
   br label %for.body1723
 
 cleanup:
-  ret i8* undef
+  ret ptr undef
 }
 
-declare i32 @fileno(%struct.TMP.2* nocapture)
-declare i64 @"\01_write"(i32, i8*, i64)
+declare i32 @fileno(ptr nocapture)
+declare i64 @"\01_write"(i32, ptr, i64)
 declare i32 @__maskrune(i32, i64)
-declare void @llvm.memset.p0i8.i64(i8* nocapture, i8, i64, i1)
+declare void @llvm.memset.p0.i64(ptr nocapture, i8, i64, i1)
 
 !llvm.ident = !{!0}
 

--- a/llvm/test/CodeGen/MLRegAlloc/default-eviction-advisor.ll
+++ b/llvm/test/CodeGen/MLRegAlloc/default-eviction-advisor.ll
@@ -10,9 +10,9 @@
 ; regalloc-enable-advisor is not enabled for NVPTX
 ; UNSUPPORTED: target=nvptx{{.*}}
 
-define void @f2(i64 %lhs, i64 %rhs, i64* %addr) {
+define void @f2(i64 %lhs, i64 %rhs, ptr %addr) {
   %sum = add i64 %lhs, %rhs
-  store i64 %sum, i64* %addr
+  store i64 %sum, ptr %addr
   ret void
 }
 

--- a/llvm/test/CodeGen/MLRegAlloc/default-priority-advisor.ll
+++ b/llvm/test/CodeGen/MLRegAlloc/default-priority-advisor.ll
@@ -10,9 +10,9 @@
 ; regalloc-enable-priority-advisor is not enabled for NVPTX
 ; UNSUPPORTED: target=nvptx{{.*}}
 
-define void @f2(i64 %lhs, i64 %rhs, i64* %addr) {
+define void @f2(i64 %lhs, i64 %rhs, ptr %addr) {
   %sum = add i64 %lhs, %rhs
-  store i64 %sum, i64* %addr
+  store i64 %sum, ptr %addr
   ret void
 }
 

--- a/llvm/test/CodeGen/MLRegAlloc/dev-mode-log-2-fcts.ll
+++ b/llvm/test/CodeGen/MLRegAlloc/dev-mode-log-2-fcts.ll
@@ -16,16 +16,16 @@
 
 declare void @f();
 
-define void @f1(i64 %lhs, i64 %rhs, i64* %addr) !prof !15 {
+define void @f1(i64 %lhs, i64 %rhs, ptr %addr) !prof !15 {
   %sum = add i64 %lhs, %rhs
   call void @f();
-  store i64 %sum, i64* %addr
+  store i64 %sum, ptr %addr
   ret void
 }
 
-define void @f2(i64 %lhs, i64 %rhs, i64* %addr) !prof !16 {
+define void @f2(i64 %lhs, i64 %rhs, ptr %addr) !prof !16 {
   %sum = add i64 %lhs, %rhs
-  store i64 %sum, i64* %addr
+  store i64 %sum, ptr %addr
   ret void
 }
 

--- a/llvm/test/CodeGen/MLRegAlloc/empty-log.ll
+++ b/llvm/test/CodeGen/MLRegAlloc/empty-log.ll
@@ -13,18 +13,18 @@
 
 declare void @f();
 
-define void @f1(i64 %lhs, i64 %rhs, i64* %addr) {
+define void @f1(i64 %lhs, i64 %rhs, ptr %addr) {
   ret void
 }
 
-define void @f2(i64 %lhs, i64 %rhs, i64* %addr) {
+define void @f2(i64 %lhs, i64 %rhs, ptr %addr) {
   %sum = add i64 %lhs, %rhs
   call void @f();
-  store i64 %sum, i64* %addr
+  store i64 %sum, ptr %addr
   ret void
 }
 
-define void @f3(i64 %lhs, i64 %rhs, i64* %addr) {
+define void @f3(i64 %lhs, i64 %rhs, ptr %addr) {
   ret void
 }
 

--- a/llvm/test/CodeGen/Mips/GlobalISel/legalizer/load_split_because_of_memsize_or_align
+++ b/llvm/test/CodeGen/Mips/GlobalISel/legalizer/load_split_because_of_memsize_or_align
@@ -29,179 +29,179 @@
   @i64_align4 = common global i64 0, align 4
   @i64_align8 = common global i64 0, align 8
 
-  define i32 @load3align1(%struct.MemSize3_Align1* %S) {
+  define i32 @load3align1(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize3_Align1* %S to i24*
-    %bf.load = load i24, i24* %0, align 1
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i24, ptr %0, align 1
     %bf.cast = zext i24 %bf.load to i32
     ret i32 %bf.cast
   }
 
-  define i32 @load3align2(%struct.MemSize3_Align2* %S) {
+  define i32 @load3align2(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize3_Align2* %S to i24*
-    %bf.load = load i24, i24* %0, align 2
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i24, ptr %0, align 2
     %bf.cast = zext i24 %bf.load to i32
     ret i32 %bf.cast
   }
 
-  define i32 @load3align4(%struct.MemSize3_Align4* %S, i32 signext %a) {
+  define i32 @load3align4(ptr %S, i32 signext %a) {
   entry:
-    %0 = bitcast %struct.MemSize3_Align4* %S to i24*
-    %bf.load = load i24, i24* %0, align 4
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i24, ptr %0, align 4
     %bf.cast = zext i24 %bf.load to i32
     ret i32 %bf.cast
   }
 
-  define i32 @load3align8(%struct.MemSize3_Align8* %S, i32 signext %a) {
+  define i32 @load3align8(ptr %S, i32 signext %a) {
   entry:
-    %0 = bitcast %struct.MemSize3_Align8* %S to i24*
-    %bf.load = load i24, i24* %0, align 8
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i24, ptr %0, align 8
     %bf.cast = zext i24 %bf.load to i32
     ret i32 %bf.cast
   }
 
-  define i64 @load5align1(%struct.MemSize5_Align1* %S) {
+  define i64 @load5align1(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize5_Align1* %S to i40*
-    %bf.load = load i40, i40* %0, align 1
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i40, ptr %0, align 1
     %bf.cast = zext i40 %bf.load to i64
     ret i64 %bf.cast
   }
 
-  define i64 @load5align2(%struct.MemSize5_Align2* %S) {
+  define i64 @load5align2(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize5_Align2* %S to i40*
-    %bf.load = load i40, i40* %0, align 2
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i40, ptr %0, align 2
     %bf.cast = zext i40 %bf.load to i64
     ret i64 %bf.cast
   }
 
-  define i64 @load5align4(%struct.MemSize5_Align4* %S) {
+  define i64 @load5align4(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize5_Align4* %S to i40*
-    %bf.load = load i40, i40* %0, align 4
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i40, ptr %0, align 4
     %bf.cast = zext i40 %bf.load to i64
     ret i64 %bf.cast
   }
 
-  define i64 @load5align8(%struct.MemSize5_Align8* %S) {
+  define i64 @load5align8(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize5_Align8* %S to i40*
-    %bf.load = load i40, i40* %0, align 8
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i40, ptr %0, align 8
     %bf.cast = zext i40 %bf.load to i64
     ret i64 %bf.cast
   }
 
-  define i64 @load6align1(%struct.MemSize6_Align1* %S) {
+  define i64 @load6align1(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize6_Align1* %S to i48*
-    %bf.load = load i48, i48* %0, align 1
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i48, ptr %0, align 1
     %bf.cast = zext i48 %bf.load to i64
     ret i64 %bf.cast
   }
 
-  define i64 @load6align2(%struct.MemSize6_Align2* %S) {
+  define i64 @load6align2(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize6_Align2* %S to i48*
-    %bf.load = load i48, i48* %0, align 2
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i48, ptr %0, align 2
     %bf.cast = zext i48 %bf.load to i64
     ret i64 %bf.cast
   }
 
-  define i64 @load6align4(%struct.MemSize6_Align4* %S) {
+  define i64 @load6align4(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize6_Align4* %S to i48*
-    %bf.load = load i48, i48* %0, align 4
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i48, ptr %0, align 4
     %bf.cast = zext i48 %bf.load to i64
     ret i64 %bf.cast
   }
 
-  define i64 @load6align8(%struct.MemSize6_Align8* %S) {
+  define i64 @load6align8(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize6_Align8* %S to i48*
-    %bf.load = load i48, i48* %0, align 8
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i48, ptr %0, align 8
     %bf.cast = zext i48 %bf.load to i64
     ret i64 %bf.cast
   }
 
-  define i64 @load7align1(%struct.MemSize7_Align1* %S) {
+  define i64 @load7align1(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize7_Align1* %S to i56*
-    %bf.load = load i56, i56* %0, align 1
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i56, ptr %0, align 1
     %bf.cast = zext i56 %bf.load to i64
     ret i64 %bf.cast
   }
 
-  define i64 @load7align2(%struct.MemSize7_Align2* %S) {
+  define i64 @load7align2(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize7_Align2* %S to i56*
-    %bf.load = load i56, i56* %0, align 2
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i56, ptr %0, align 2
     %bf.cast = zext i56 %bf.load to i64
     ret i64 %bf.cast
   }
 
-  define i64 @load7align4(%struct.MemSize7_Align4* %S) {
+  define i64 @load7align4(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize7_Align4* %S to i56*
-    %bf.load = load i56, i56* %0, align 4
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i56, ptr %0, align 4
     %bf.cast = zext i56 %bf.load to i64
     ret i64 %bf.cast
   }
 
-  define i64 @load7align8(%struct.MemSize7_Align8* %S) {
+  define i64 @load7align8(ptr %S) {
   entry:
-    %0 = bitcast %struct.MemSize7_Align8* %S to i56*
-    %bf.load = load i56, i56* %0, align 8
+    %0 = bitcast ptr %S to ptr
+    %bf.load = load i56, ptr %0, align 8
     %bf.cast = zext i56 %bf.load to i64
     ret i64 %bf.cast
   }
 
   define double @load_double_align1() {
   entry:
-    %0 = load double, double* @double_align1, align 1
+    %0 = load double, ptr @double_align1, align 1
     ret double %0
   }
 
   define double @load_double_align2() {
   entry:
-    %0 = load double, double* @double_align2, align 2
+    %0 = load double, ptr @double_align2, align 2
     ret double %0
   }
 
   define double @load_double_align4() {
   entry:
-    %0 = load double, double* @double_align4, align 4
+    %0 = load double, ptr @double_align4, align 4
     ret double %0
   }
 
   define double @load_double_align8() {
   entry:
-    %0 = load double, double* @double_align8, align 8
+    %0 = load double, ptr @double_align8, align 8
     ret double %0
   }
 
   define i64 @load_i64_align1() {
   entry:
-    %0 = load i64, i64* @i64_align1, align 1
+    %0 = load i64, ptr @i64_align1, align 1
     ret i64 %0
   }
 
   define i64 @load_i64_align2() {
   entry:
-    %0 = load i64, i64* @i64_align2, align 2
+    %0 = load i64, ptr @i64_align2, align 2
     ret i64 %0
   }
 
   define i64 @load_i64_align4() {
   entry:
-    %0 = load i64, i64* @i64_align4, align 4
+    %0 = load i64, ptr @i64_align4, align 4
     ret i64 %0
   }
 
   define i64 @load_i64_align8() {
   entry:
-    %0 = load i64, i64* @i64_align8, align 8
+    %0 = load i64, ptr @i64_align8, align 8
     ret i64 %0
   }
 

--- a/llvm/test/CodeGen/RISCV/xandesbfhcvt.ll
+++ b/llvm/test/CodeGen/RISCV/xandesbfhcvt.ll
@@ -52,13 +52,13 @@ define void @loadstorebf16(ptr %bf, ptr %sf) nounwind {
 ; ZFH-NEXT:    fsh fa5, 0(a0)
 ; ZFH-NEXT:    ret
 entry:
-  %0 = load bfloat, bfloat* %bf, align 2
+  %0 = load bfloat, ptr %bf, align 2
   %1 = fpext bfloat %0 to float
-  store volatile float %1, float* %sf, align 4
+  store volatile float %1, ptr %sf, align 4
 
-  %2 = load float, float* %sf, align 4
+  %2 = load float, ptr %sf, align 4
   %3 = fptrunc float %2 to bfloat
-  store volatile bfloat %3, bfloat* %bf, align 2
+  store volatile bfloat %3, ptr %bf, align 2
 
   ret void
 }

--- a/llvm/test/CodeGen/RISCV/xqcilo.ll
+++ b/llvm/test/CodeGen/RISCV/xqcilo.ll
@@ -4,7 +4,7 @@
 ; RUN: llc -mtriple=riscv32 -mattr=+xqcilo -verify-machineinstrs < %s \
 ; RUN:   | FileCheck %s -check-prefixes=RV32IXQCILO
 
-define i32 @lb_ri(i8* %a) {
+define i32 @lb_ri(ptr %a) {
 ; RV32I-LABEL: lb_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    lui a1, 2
@@ -16,13 +16,13 @@ define i32 @lb_ri(i8* %a) {
 ; RV32IXQCILO:       # %bb.0:
 ; RV32IXQCILO-NEXT:    qc.e.lb a0, 10000(a0)
 ; RV32IXQCILO-NEXT:    ret
-  %1 = getelementptr i8, i8* %a, i32 10000
-  %2 = load i8, i8* %1
+  %1 = getelementptr i8, ptr %a, i32 10000
+  %2 = load i8, ptr %1
   %3 = sext i8 %2 to i32
   ret i32 %3
 }
 
-define i32 @lbu_ri(i8* %a) {
+define i32 @lbu_ri(ptr %a) {
 ; RV32I-LABEL: lbu_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    lui a1, 1048574
@@ -34,13 +34,13 @@ define i32 @lbu_ri(i8* %a) {
 ; RV32IXQCILO:       # %bb.0:
 ; RV32IXQCILO-NEXT:    qc.e.lbu a0, -8000(a0)
 ; RV32IXQCILO-NEXT:    ret
-  %1 = getelementptr i8, i8* %a, i32 -8000
-  %2 = load i8, i8* %1
+  %1 = getelementptr i8, ptr %a, i32 -8000
+  %2 = load i8, ptr %1
   %3 = zext i8 %2 to i32
   ret i32 %3
 }
 
-define i32 @lh_ri(i16* %a) {
+define i32 @lh_ri(ptr %a) {
 ; RV32I-LABEL: lh_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    lui a1, 11
@@ -52,13 +52,13 @@ define i32 @lh_ri(i16* %a) {
 ; RV32IXQCILO:       # %bb.0:
 ; RV32IXQCILO-NEXT:    qc.e.lhu a0, 44444(a0)
 ; RV32IXQCILO-NEXT:    ret
-  %1 = getelementptr i16, i16* %a, i32 22222
-  %2 = load i16, i16* %1
+  %1 = getelementptr i16, ptr %a, i32 22222
+  %2 = load i16, ptr %1
   %3 = zext i16 %2 to i32
   ret i32 %3
 }
 
-define i32 @lhu_ri(i16* %a) {
+define i32 @lhu_ri(ptr %a) {
 ; RV32I-LABEL: lhu_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    lui a1, 1048570
@@ -70,13 +70,13 @@ define i32 @lhu_ri(i16* %a) {
 ; RV32IXQCILO:       # %bb.0:
 ; RV32IXQCILO-NEXT:    qc.e.lhu a0, -24456(a0)
 ; RV32IXQCILO-NEXT:    ret
-  %1 = getelementptr i16, i16* %a, i32 -12228
-  %2 = load i16, i16* %1
+  %1 = getelementptr i16, ptr %a, i32 -12228
+  %2 = load i16, ptr %1
   %3 = zext i16 %2 to i32
   ret i32 %3
 }
 
-define i32 @lw_ri(i32* %a) {
+define i32 @lw_ri(ptr %a) {
 ; RV32I-LABEL: lw_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    addi a0, a0, 2047
@@ -87,12 +87,12 @@ define i32 @lw_ri(i32* %a) {
 ; RV32IXQCILO:       # %bb.0:
 ; RV32IXQCILO-NEXT:    qc.e.lw a0, 4000(a0)
 ; RV32IXQCILO-NEXT:    ret
-  %1 = getelementptr i32, i32* %a, i32 1000
-  %2 = load i32, i32* %1
+  %1 = getelementptr i32, ptr %a, i32 1000
+  %2 = load i32, ptr %1
   ret i32 %2
 }
 
-define void @sb_ri(i8* %a, i8 %b) {
+define void @sb_ri(ptr %a, i8 %b) {
 ; RV32I-LABEL: sb_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    lui a2, 2
@@ -104,12 +104,12 @@ define void @sb_ri(i8* %a, i8 %b) {
 ; RV32IXQCILO:       # %bb.0:
 ; RV32IXQCILO-NEXT:    qc.e.sb a1, 10000(a0)
 ; RV32IXQCILO-NEXT:    ret
-  %1 = getelementptr i8, i8* %a, i32 10000
-  store i8 %b, i8* %1
+  %1 = getelementptr i8, ptr %a, i32 10000
+  store i8 %b, ptr %1
   ret void
 }
 
-define void @sh_ri(i16* %a, i16 %b) {
+define void @sh_ri(ptr %a, i16 %b) {
 ; RV32I-LABEL: sh_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    lui a2, 11
@@ -121,12 +121,12 @@ define void @sh_ri(i16* %a, i16 %b) {
 ; RV32IXQCILO:       # %bb.0:
 ; RV32IXQCILO-NEXT:    qc.e.sh a1, 44444(a0)
 ; RV32IXQCILO-NEXT:    ret
-  %1 = getelementptr i16, i16* %a, i32 22222
-  store i16 %b, i16* %1
+  %1 = getelementptr i16, ptr %a, i32 22222
+  store i16 %b, ptr %1
   ret void
 }
 
-define void @sw_ri(i32* %a, i32 %b) {
+define void @sw_ri(ptr %a, i32 %b) {
 ; RV32I-LABEL: sw_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    addi a0, a0, 2047
@@ -137,7 +137,7 @@ define void @sw_ri(i32* %a, i32 %b) {
 ; RV32IXQCILO:       # %bb.0:
 ; RV32IXQCILO-NEXT:    qc.e.sw a1, 4000(a0)
 ; RV32IXQCILO-NEXT:    ret
-  %1 = getelementptr i32, i32* %a, i32 1000
-  store i32 %b, i32* %1
+  %1 = getelementptr i32, ptr %a, i32 1000
+  store i32 %b, ptr %1
   ret void
 }

--- a/llvm/test/CodeGen/RISCV/xqcisls.ll
+++ b/llvm/test/CodeGen/RISCV/xqcisls.ll
@@ -6,7 +6,7 @@
 ; RUN: llc -mtriple=riscv32 -mattr=+zba,+xqcisls -verify-machineinstrs < %s \
 ; RUN:   | FileCheck %s -check-prefixes=RV32IZBAXQCISLS
 
-define i32 @lb_ri(i8* %a, i32 %b) {
+define i32 @lb_ri(ptr %a, i32 %b) {
 ; RV32I-LABEL: lb_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    slli a1, a1, 3
@@ -25,13 +25,13 @@ define i32 @lb_ri(i8* %a, i32 %b) {
 ; RV32IZBAXQCISLS-NEXT:    qc.lrb a0, a0, a1, 3
 ; RV32IZBAXQCISLS-NEXT:    ret
   %shl = shl i32 %b, 3
-  %1 = getelementptr i8, i8* %a, i32 %shl
-  %2 = load i8, i8* %1
+  %1 = getelementptr i8, ptr %a, i32 %shl
+  %2 = load i8, ptr %1
   %3 = sext i8 %2 to i32
   ret i32 %3
 }
 
-define i32 @lbu_ri(i8* %a, i32 %b) {
+define i32 @lbu_ri(ptr %a, i32 %b) {
 ; RV32I-LABEL: lbu_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    slli a1, a1, 2
@@ -50,13 +50,13 @@ define i32 @lbu_ri(i8* %a, i32 %b) {
 ; RV32IZBAXQCISLS-NEXT:    qc.lrbu a0, a0, a1, 2
 ; RV32IZBAXQCISLS-NEXT:    ret
   %shl = shl i32 %b, 2
-  %1 = getelementptr i8, i8* %a, i32 %shl
-  %2 = load i8, i8* %1
+  %1 = getelementptr i8, ptr %a, i32 %shl
+  %2 = load i8, ptr %1
   %3 = zext i8 %2 to i32
   ret i32 %3
 }
 
-define i32 @lh_ri(i16* %a, i32 %b) {
+define i32 @lh_ri(ptr %a, i32 %b) {
 ; RV32I-LABEL: lh_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    slli a1, a1, 5
@@ -76,13 +76,13 @@ define i32 @lh_ri(i16* %a, i32 %b) {
 ; RV32IZBAXQCISLS-NEXT:    qc.lrh a0, a0, a1, 5
 ; RV32IZBAXQCISLS-NEXT:    ret
   %shl = shl i32 %b, 4
-  %1 = getelementptr i16, i16* %a, i32 %shl
-  %2 = load i16, i16* %1
+  %1 = getelementptr i16, ptr %a, i32 %shl
+  %2 = load i16, ptr %1
   %3 = sext i16 %2 to i32
   ret i32 %3
 }
 
-define i32 @lhu_ri(i16* %a, i32 %b) {
+define i32 @lhu_ri(ptr %a, i32 %b) {
 ; RV32I-LABEL: lhu_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    slli a1, a1, 6
@@ -102,13 +102,13 @@ define i32 @lhu_ri(i16* %a, i32 %b) {
 ; RV32IZBAXQCISLS-NEXT:    qc.lrhu a0, a0, a1, 6
 ; RV32IZBAXQCISLS-NEXT:    ret
   %shl = shl i32 %b, 5
-  %1 = getelementptr i16, i16* %a, i32 %shl
-  %2 = load i16, i16* %1
+  %1 = getelementptr i16, ptr %a, i32 %shl
+  %2 = load i16, ptr %1
   %3 = zext i16 %2 to i32
   ret i32 %3
 }
 
-define i32 @lw_ri(i32* %a, i32 %b) {
+define i32 @lw_ri(ptr %a, i32 %b) {
 ; RV32I-LABEL: lw_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    slli a1, a1, 6
@@ -128,12 +128,12 @@ define i32 @lw_ri(i32* %a, i32 %b) {
 ; RV32IZBAXQCISLS-NEXT:    qc.lrw a0, a0, a1, 6
 ; RV32IZBAXQCISLS-NEXT:    ret
   %shl = shl i32 %b, 4
-  %1 = getelementptr i32, i32* %a, i32 %shl
-  %2 = load i32, i32* %1
+  %1 = getelementptr i32, ptr %a, i32 %shl
+  %2 = load i32, ptr %1
   ret i32 %2
 }
 
-define void @sb_ri(i8* %a, i8 %b, i32 %c) {
+define void @sb_ri(ptr %a, i8 %b, i32 %c) {
 ; RV32I-LABEL: sb_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    slli a2, a2, 7
@@ -153,12 +153,12 @@ define void @sb_ri(i8* %a, i8 %b, i32 %c) {
 ; RV32IZBAXQCISLS-NEXT:    qc.srb a1, a0, a2, 7
 ; RV32IZBAXQCISLS-NEXT:    ret
   %shl = shl i32 %c, 7
-  %1 = getelementptr i8, i8* %a, i32 %shl
-  store i8 %b, i8* %1
+  %1 = getelementptr i8, ptr %a, i32 %shl
+  store i8 %b, ptr %1
   ret void
 }
 
-define void @sh_ri(i16* %a, i16 %b, i32 %c) {
+define void @sh_ri(ptr %a, i16 %b, i32 %c) {
 ; RV32I-LABEL: sh_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    slli a2, a2, 3
@@ -177,12 +177,12 @@ define void @sh_ri(i16* %a, i16 %b, i32 %c) {
 ; RV32IZBAXQCISLS-NEXT:    qc.srh a1, a0, a2, 3
 ; RV32IZBAXQCISLS-NEXT:    ret
   %shl = shl i32 %c, 2
-  %1 = getelementptr i16, i16* %a, i32 %shl
-  store i16 %b, i16* %1
+  %1 = getelementptr i16, ptr %a, i32 %shl
+  store i16 %b, ptr %1
   ret void
 }
 
-define void @sw_ri(i32* %a, i32 %b, i32 %c) {
+define void @sw_ri(ptr %a, i32 %b, i32 %c) {
 ; RV32I-LABEL: sw_ri:
 ; RV32I:       # %bb.0:
 ; RV32I-NEXT:    slli a2, a2, 3
@@ -201,8 +201,8 @@ define void @sw_ri(i32* %a, i32 %b, i32 %c) {
 ; RV32IZBAXQCISLS-NEXT:    qc.srw a1, a0, a2, 3
 ; RV32IZBAXQCISLS-NEXT:    ret
   %shl = shl i32 %c, 1
-  %1 = getelementptr i32, i32* %a, i32 %shl
-  store i32 %b, i32* %1
+  %1 = getelementptr i32, ptr %a, i32 %shl
+  store i32 %b, ptr %1
   ret void
 }
 

--- a/llvm/test/CodeGen/SystemZ/debuginstr-cgp.mir
+++ b/llvm/test/CodeGen/SystemZ/debuginstr-cgp.mir
@@ -14,19 +14,19 @@
 #
 # bin/llc -mtriple=s390x-linux-gnu -mcpu=z13 -stop-before codegenprepare -simplify-mir
 #
-# %0 = type { i32 (...)**, i16, %1* }
-# %1 = type { i32 (...)** }
-# %2 = type { i32 (...)**, %1*, i8, i32, i32, i32, i16, i32, i16, i32, i16*, %3*, %6*, %9 }
+# %0 = type { ptr, i16, ptr }
+# %1 = type { ptr }
+# %2 = type { ptr, ptr, i8, i32, i32, i32, i16, i32, i16, i32, ptr, ptr, ptr, %9 }
 # %3 = type { %4 }
-# %4 = type { i32 (...)**, i8, i32, i32, %5**, %1* }
+# %4 = type { ptr, i8, i32, i32, ptr, ptr }
 # %5 = type { i32, i32 }
-# %6 = type { %7*, %0*, %0*, %0*, %0*, %0*, %0*, %0*, %0*, %0*, %0*, %0*, %0*, %0*, %0*, %1* }
+# %6 = type { ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }
 # %7 = type { %8 }
-# %8 = type { i32 (...)**, i8, i32, i32, %0**, %1* }
-# %9 = type { i8* }
-# %10 = type { %0, i32, i32, %0* }
+# %8 = type { ptr, i8, i32, i32, ptr, ptr }
+# %9 = type { ptr }
+# %10 = type { %0, i32, i32, ptr }
 #
-# define %0* @Fun(%2* %arg) !dbg !7 {
+# define ptr @Fun(ptr %arg) !dbg !7 {
 # bb:
 #   switch i32 undef, label %bb3 [
 #     i32 58, label %bb1
@@ -37,22 +37,22 @@
 #   br label %bb4, !dbg !15
 #
 # bb2:                                              ; preds = %bb
-#   %tmp = tail call %10* @hoge(%6* undef, %0* undef, i32 signext 0, i32 signext 0), !dbg !16
-#   call void @llvm.dbg.value(metadata %10* %tmp, metadata !10, metadata !DIExpression()), !dbg !16
+#   %tmp = tail call ptr @hoge(ptr undef, ptr undef, i32 signext 0, i32 signext 0), !dbg !16
+#   call void @llvm.dbg.value(metadata ptr %tmp, metadata !10, metadata !DIExpression()), !dbg !16
 #   br label %bb4, !dbg !17
 #
 # bb3:                                              ; preds = %bb
 #   unreachable, !dbg !18
 #
 # bb4:                                              ; preds = %bb2, %bb1
-#   %tmp5 = phi %10* [ undef, %bb1 ], [ %tmp, %bb2 ], !dbg !19
-#   call void @llvm.dbg.value(metadata %10* %tmp5, metadata !12, metadata !DIExpression()), !dbg !19
-#   %tmp6 = bitcast %10* %tmp5 to %0*, !dbg !20
-#   call void @llvm.dbg.value(metadata %0* %tmp6, metadata !13, metadata !DIExpression()), !dbg !20
-#   ret %0* %tmp6, !dbg !21
+#   %tmp5 = phi ptr [ undef, %bb1 ], [ %tmp, %bb2 ], !dbg !19
+#   call void @llvm.dbg.value(metadata ptr %tmp5, metadata !12, metadata !DIExpression()), !dbg !19
+#   %tmp6 = bitcast ptr %tmp5 to ptr, !dbg !20
+#   call void @llvm.dbg.value(metadata ptr %tmp6, metadata !13, metadata !DIExpression()), !dbg !20
+#   ret ptr %tmp6, !dbg !21
 # }
 #
-# declare %10* @hoge(%6*, %0*, i32, i32)
+# declare ptr @hoge(ptr, ptr, i32, i32)
 #
 # ; Function Attrs: nounwind readnone speculatable
 # declare void @llvm.dbg.value(metadata, metadata, metadata) #1

--- a/llvm/test/CodeGen/X86/conditional-tailcall-samedest.mir
+++ b/llvm/test/CodeGen/X86/conditional-tailcall-samedest.mir
@@ -35,12 +35,12 @@
     ]
 
   sw.bb:                                            ; preds = %entry, %entry
-    %tmp = load atomic i8, i8* bitcast (i64* @static_local_guard to i8*) acquire, align 8
+    %tmp = load atomic i8, ptr @static_local_guard acquire, align 8
     %guard.uninitialized.i = icmp eq i8 %tmp, 0
     br i1 %guard.uninitialized.i, label %init.check.i, label %return, !prof !0
 
   init.check.i:                                     ; preds = %sw.bb
-    tail call void @initialize_static_local(i64* nonnull @static_local_guard)
+    tail call void @initialize_static_local(ptr nonnull @static_local_guard)
     ret void
 
   sw.bb2:                                           ; preds = %entry
@@ -57,10 +57,10 @@
 
   declare void @mergeable_conditional_tailcall()
 
-  declare void @initialize_static_local(i64*)
+  declare void @initialize_static_local(ptr)
 
   ; Function Attrs: nounwind
-  declare void @llvm.stackprotector(i8*, i8**) #1
+  declare void @llvm.stackprotector(ptr, ptr) #1
 
   attributes #0 = { optsize }
   attributes #1 = { nounwind }
@@ -118,7 +118,7 @@ body:             |
   bb.2.sw.bb:
     successors: %bb.3(0x00000800), %bb.6(0x7ffff800)
 
-    $al = MOV8rm $rip, 1, $noreg, @static_local_guard, $noreg :: (volatile load acquire (s8) from `i8* bitcast (i64* @static_local_guard to i8*)`, align 8)
+    $al = MOV8rm $rip, 1, $noreg, @static_local_guard, $noreg :: (volatile load acquire (s8) from `ptr bitcast (ptr @static_local_guard to ptr)`, align 8)
     TEST8rr killed $al, $al, implicit-def $eflags
     JCC_1 %bb.6, 5, implicit killed $eflags
     JMP_1 %bb.3

--- a/llvm/test/CodeGen/X86/isel-fabs-x87.ll
+++ b/llvm/test/CodeGen/X86/isel-fabs-x87.ll
@@ -39,7 +39,7 @@ define void @test_float_abs(ptr %argptr)   {
 ; GISEL-X86-ISEL-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; GISEL-X86-ISEL-NEXT:    andl $2147483647, (%eax) # imm = 0x7FFFFFFF
 ; GISEL-X86-ISEL-NEXT:    retl
-     %arg = load  float, float* %argptr
+     %arg = load  float, ptr %argptr
      %abs = tail call float @llvm.fabs.f32(float %arg)
      store float %abs, ptr %argptr
      ret void
@@ -69,9 +69,9 @@ define void @test_double_abs(ptr %argptr)  {
 ; X86-NEXT:    fabs
 ; X86-NEXT:    fstpl (%eax)
 ; X86-NEXT:    retl
-    %arg = load double, double* %argptr
+    %arg = load double, ptr %argptr
     %abs = tail call double @llvm.fabs.f64(double %arg)
-    store double %abs, double* %argptr
+    store double %abs, ptr %argptr
     ret void
 }
 

--- a/llvm/test/CodeGen/X86/non-value-mem-operand.mir
+++ b/llvm/test/CodeGen/X86/non-value-mem-operand.mir
@@ -6,27 +6,27 @@
   target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
   target triple = "x86_64-unknown-linux-gnu"
 
-  @global = external global i8*
-  @global.1 = external global i8*
+  @global = external global ptr
+  @global.1 = external global ptr
 
-  declare i8* @ham(i8*, i8**)
+  declare ptr @ham(ptr, ptr)
 
-  define void @eggs(i8* %arg) gc "statepoint-example" {
+  define void @eggs(ptr %arg) gc "statepoint-example" {
   bb:
-    %tmp = call i8* undef(i8* undef, i8** undef)
-    %tmp1 = icmp eq i8* %tmp, null
+    %tmp = call ptr undef(ptr undef, ptr undef)
+    %tmp1 = icmp eq ptr %tmp, null
     br i1 %tmp1, label %bb2, label %bb3, !make.implicit !0
 
   bb2:                                              ; preds = %bb
     br i1 undef, label %bb51, label %bb59
 
   bb3:                                              ; preds = %bb
-    %tmp4 = getelementptr inbounds i8, i8* %tmp, i64 16
-    %tmp5 = bitcast i8* %tmp4 to i64*
+    %tmp4 = getelementptr inbounds i8, ptr %tmp, i64 16
+    %tmp5 = bitcast ptr %tmp4 to ptr
     br label %bb7
 
   bb7:                                              ; preds = %bb37, %bb3
-    %tmp8 = phi i64* [ %tmp5, %bb3 ], [ %tmp18, %bb37 ]
+    %tmp8 = phi ptr [ %tmp5, %bb3 ], [ %tmp18, %bb37 ]
     %tmp10 = phi i32 [ undef, %bb3 ], [ %tmp48, %bb37 ]
     %tmp12 = phi i32 [ 0, %bb3 ], [ 6, %bb37 ]
     %tmp13 = phi double [ 0.000000e+00, %bb3 ], [ 2.000000e+00, %bb37 ]
@@ -34,53 +34,53 @@
     br i1 undef, label %bb26, label %bb15
 
   bb15:                                             ; preds = %bb7
-    %tmp16 = call token (i64, i32, void ()*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_isVoidf(i64 2882400000, i32 0, void ()* nonnull elementtype(void ()) @wibble, i32 0, i32 0, i32 0, i32 0) ["deopt" (i32 1, i32 0, i32 99, i32 0, i32 12, i32 0, i32 10, i32 %tmp10, i32 10, i32 0, i32 10, i32 %tmp12, i32 10, i32 undef, i32 6, float undef, i32 7, double %tmp13, i32 99, i8* null, i32 7, double undef, i32 99, i8* null, i32 13, i8* %tmp, i32 7, double undef, i32 99, i8* null, i8* undef)]
+    %tmp16 = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr nonnull elementtype(void ()) @wibble, i32 0, i32 0, i32 0, i32 0) ["deopt" (i32 1, i32 0, i32 99, i32 0, i32 12, i32 0, i32 10, i32 %tmp10, i32 10, i32 0, i32 10, i32 %tmp12, i32 10, i32 undef, i32 6, float undef, i32 7, double %tmp13, i32 99, ptr null, i32 7, double undef, i32 99, ptr null, i32 13, ptr %tmp, i32 7, double undef, i32 99, ptr null, ptr undef)]
     br label %bb26
 
   bb26:                                             ; preds = %bb15, %bb7
-    %tmp18 = phi i64* [ %tmp8, %bb7 ], [ undef, %bb15 ]
+    %tmp18 = phi ptr [ %tmp8, %bb7 ], [ undef, %bb15 ]
     %tmp20 = sub i32 0, 0
     %tmp21 = select i1 undef, i32 0, i32 %tmp20
     %tmp22 = sext i32 %tmp21 to i64
-    %tmp23 = load i8*, i8** @global.1, align 8
-    %tmp24 = icmp eq i8* %tmp23, null
-    %tmp25 = select i1 %tmp24, i8* null, i8* undef
-    %tmp27 = load i32, i32* undef, align 4
+    %tmp23 = load ptr, ptr @global.1, align 8
+    %tmp24 = icmp eq ptr %tmp23, null
+    %tmp25 = select i1 %tmp24, ptr null, ptr undef
+    %tmp27 = load i32, ptr undef, align 4
     %sunkaddr = mul i64 %tmp14, 8
-    %tmp2 = bitcast i64* %tmp18 to i8*
-    %sunkaddr1 = getelementptr i8, i8* %tmp2, i64 %sunkaddr
-    %tmp3 = bitcast i8* %sunkaddr1 to i64*
-    %tmp28 = load i64, i64* %tmp3, align 8
+    %tmp2 = bitcast ptr %tmp18 to ptr
+    %sunkaddr1 = getelementptr i8, ptr %tmp2, i64 %sunkaddr
+    %tmp3 = bitcast ptr %sunkaddr1 to ptr
+    %tmp28 = load i64, ptr %tmp3, align 8
     %tmp29 = add i64 %tmp28, 1
-    store i64 %tmp29, i64* %tmp3, align 8
+    store i64 %tmp29, ptr %tmp3, align 8
     %tmp30 = trunc i64 %tmp28 to i32
     %tmp31 = sub i32 %tmp27, %tmp30
-    store i32 %tmp31, i32* undef, align 4
-    %tmp32 = getelementptr inbounds i8, i8* %tmp25, i64 768
-    %tmp33 = bitcast i8* %tmp32 to i64*
-    %tmp34 = load i64, i64* %tmp33, align 8
+    store i32 %tmp31, ptr undef, align 4
+    %tmp32 = getelementptr inbounds i8, ptr %tmp25, i64 768
+    %tmp33 = bitcast ptr %tmp32 to ptr
+    %tmp34 = load i64, ptr %tmp33, align 8
     br i1 undef, label %bb37, label %bb35
 
   bb35:                                             ; preds = %bb26
-    %tmp36 = call i8* @ham(i8* undef, i8** nonnull @global)
+    %tmp36 = call ptr @ham(ptr undef, ptr nonnull @global)
     br label %bb37
 
   bb37:                                             ; preds = %bb35, %bb26
-    %tmp38 = phi i8* [ %tmp36, %bb35 ], [ undef, %bb26 ]
-    %tmp39 = getelementptr inbounds i8, i8* %tmp38, i64 760
-    %tmp40 = bitcast i8* %tmp39 to i64*
-    %tmp41 = load i64, i64* %tmp40, align 8
+    %tmp38 = phi ptr [ %tmp36, %bb35 ], [ undef, %bb26 ]
+    %tmp39 = getelementptr inbounds i8, ptr %tmp38, i64 760
+    %tmp40 = bitcast ptr %tmp39 to ptr
+    %tmp41 = load i64, ptr %tmp40, align 8
     %tmp42 = icmp slt i64 %tmp34, %tmp41
     %tmp43 = select i1 %tmp42, i64 %tmp41, i64 %tmp34
     %tmp44 = and i64 %tmp43, 63
     %tmp45 = ashr i64 %tmp29, %tmp44
     %sunkaddr2 = mul i64 %tmp14, 8
-    %tmp6 = bitcast i64* %tmp18 to i8*
-    %sunkaddr3 = getelementptr i8, i8* %tmp6, i64 %sunkaddr2
-    %tmp7 = bitcast i8* %sunkaddr3 to i64*
-    store i64 %tmp45, i64* %tmp7, align 8
+    %tmp6 = bitcast ptr %tmp18 to ptr
+    %sunkaddr3 = getelementptr i8, ptr %tmp6, i64 %sunkaddr2
+    %tmp7 = bitcast ptr %sunkaddr3 to ptr
+    store i64 %tmp45, ptr %tmp7, align 8
     %tmp46 = sub i64 0, %tmp22
-    store i64 %tmp46, i64* undef, align 8
+    store i64 %tmp46, ptr undef, align 8
     %tmp47 = add nsw i32 %tmp12, 1
     %tmp48 = add i32 %tmp10, 1
     %tmp49 = icmp sgt i32 %tmp48, 15140
@@ -95,11 +95,11 @@
     %tmp53 = phi double [ 2.000000e+00, %bb51.loopexit ], [ 0.000000e+00, %bb2 ]
     %tmp54 = phi i32 [ %tmp9, %bb51.loopexit ], [ undef, %bb2 ]
     %tmp56 = add i32 %tmp54, 0
-    %tmp57 = call token (i64, i32, void (i32)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_isVoidi32f(i64 2882400000, i32 0, void (i32)* nonnull elementtype(void (i32)) @wobble, i32 1, i32 0, i32 -121, i32 0, i32 0) ["deopt" (i32 1, i32 0, i32 270, i32 4, i32 12, i32 0, i32 11, i64 undef, i32 99, i8* null, i32 10, i32 %tmp56, i32 6, float undef, i32 99, i8* null, i32 99, i8* null, i32 10, i32 %tmp52, i32 10, i32 undef, i32 99, i8* null, i32 7, double %tmp53, i32 99, i8* null, i32 7, double undef, i32 99, i8* null, i32 13, i8* undef, i32 99, i8* null, i32 99, i8* null, i8* undef)]
+    %tmp57 = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr nonnull elementtype(void (i32)) @wobble, i32 1, i32 0, i32 -121, i32 0, i32 0) ["deopt" (i32 1, i32 0, i32 270, i32 4, i32 12, i32 0, i32 11, i64 undef, i32 99, ptr null, i32 10, i32 %tmp56, i32 6, float undef, i32 99, ptr null, i32 99, ptr null, i32 10, i32 %tmp52, i32 10, i32 undef, i32 99, ptr null, i32 7, double %tmp53, i32 99, ptr null, i32 7, double undef, i32 99, ptr null, i32 13, ptr undef, i32 99, ptr null, i32 99, ptr null, ptr undef)]
     unreachable
 
   bb59:                                             ; preds = %bb2
-    %tmp61 = call token (i64, i32, void (i32)*, i32, i32, ...) @llvm.experimental.gc.statepoint.p0f_isVoidi32f(i64 2882400000, i32 0, void (i32)* nonnull elementtype(void (i32)) @wobble, i32 1, i32 0, i32 8, i32 0, i32 0) ["deopt" (i32 1, i32 0, i32 123, i32 4, i32 12, i32 0, i32 13, i8* null, i32 99, i32 undef, i32 13, i8* null, i32 10, i32 undef, i32 99, i32 undef, i32 99, i32 undef, i32 99, i32 undef, i32 99, i8* null, i32 99, float undef, i32 99, double undef, i32 99, i8* null, i32 99, double undef, i32 99, i8* null, i32 13, i8* null, i32 99, double undef, i32 99, i8* null)]
+    %tmp61 = call token (i64, i32, ptr, i32, i32, ...) @llvm.experimental.gc.statepoint.p0(i64 2882400000, i32 0, ptr nonnull elementtype(void (i32)) @wobble, i32 1, i32 0, i32 8, i32 0, i32 0) ["deopt" (i32 1, i32 0, i32 123, i32 4, i32 12, i32 0, i32 13, ptr null, i32 99, i32 undef, i32 13, ptr null, i32 10, i32 undef, i32 99, i32 undef, i32 99, i32 undef, i32 99, i32 undef, i32 99, ptr null, i32 99, float undef, i32 99, double undef, i32 99, ptr null, i32 99, double undef, i32 99, ptr null, i32 13, ptr null, i32 99, double undef, i32 99, ptr null)]
     unreachable
   }
 
@@ -107,12 +107,9 @@
 
   declare void @wobble(i32)
 
-  declare token @llvm.experimental.gc.statepoint.p0f_isVoidi32f(i64, i32, void (i32)*, i32, i32, ...)
+  declare token @llvm.experimental.gc.statepoint.p0(i64, i32, ptr, i32, i32, ...)
 
-  declare token @llvm.experimental.gc.statepoint.p0f_isVoidf(i64, i32, void ()*, i32, i32, ...)
-
-  ; Function Attrs: nounwind
-  declare void @llvm.stackprotector(i8*, i8**) #0
+  declare void @llvm.stackprotector(ptr, ptr) #0
 
   attributes #0 = { nounwind }
 
@@ -218,12 +215,12 @@ body:             |
     $rax = MOV64rm killed $rax, 1, $noreg, 0, $noreg :: (dereferenceable load (s64) from @global.1)
     TEST64rr $rax, $rax, implicit-def $eflags
     $rax = CMOV64rr undef $rax, killed $rax, 4, implicit killed $eflags
-    $ecx = MOV32rm undef $rax, 1, $noreg, 0, $noreg :: (load (s32) from `i32* undef`)
+    $ecx = MOV32rm undef $rax, 1, $noreg, 0, $noreg :: (load (s32) from `ptr undef`)
     $rdx = MOV64rm $r12, 8, $r14, 0, $noreg :: (load (s64) from %ir.tmp3)
     $r15 = LEA64r $rdx, 1, $noreg, 1, _
     MOV64mr $r12, 8, $r14, 0, $noreg, $r15 :: (store (s64) into %ir.tmp3)
     $ecx = SUB32rr killed $ecx, $edx, implicit-def dead $eflags, implicit killed $rdx
-    MOV32mr undef $rax, 1, $noreg, 0, $noreg, killed $ecx :: (store (s32) into `i32* undef`)
+    MOV32mr undef $rax, 1, $noreg, 0, $noreg, killed $ecx :: (store (s32) into `ptr undef`)
     $r13 = MOV64rm killed $rax, 1, $noreg, 768, $noreg :: (load (s64) from %ir.tmp33)
     TEST8rr $sil, $sil, implicit-def $eflags
     $rax = IMPLICIT_DEF
@@ -259,7 +256,7 @@ body:             |
     $cl = KILL $cl, implicit killed $rcx
     $r15 = SAR64rCL killed $r15, implicit-def dead $eflags, implicit $cl
     MOV64mr $r12, 8, killed $r14, 0, $noreg, killed $r15 :: (store (s64) into %ir.tmp7)
-    MOV64mi32 undef $rax, 1, $noreg, 0, $noreg, 0 :: (store (s64) into `i64* undef`)
+    MOV64mi32 undef $rax, 1, $noreg, 0, $noreg, 0 :: (store (s64) into `ptr undef`)
     $eax = LEA64_32r $rbx, 1, $noreg, 1, _
     $ecx = MOV32ri 6
     CMP32ri $eax, 15141, implicit-def $eflags

--- a/llvm/test/Feature/testalloca.ll
+++ b/llvm/test/Feature/testalloca.ll
@@ -8,15 +8,15 @@
 define i32 @testfunction(i32 %i0, i32 %j0) {
         alloca i8, i32 5                ; <i8*>:1 [#uses=0]
         %ptr = alloca i32               ; <i32*> [#uses=2]
-        store i32 3, i32* %ptr
-        %val = load i32, i32* %ptr           ; <i32> [#uses=0]
+        store i32 3, ptr %ptr
+        %val = load i32, ptr %ptr           ; <i32> [#uses=0]
         %sptr = alloca %struct          ; <%struct*> [#uses=2]
-        %nsptr = getelementptr %struct, %struct* %sptr, i64 0, i32 1             ; <%inners*> [#uses=1]
-        %ubsptr = getelementptr %inners, %inners* %nsptr, i64 0, i32 1           ; <{ i8 }*> [#uses=1]
-        %idx = getelementptr { i8 }, { i8 }* %ubsptr, i64 0, i32 0              ; <i8*> [#uses=1]
+        %nsptr = getelementptr %struct, ptr %sptr, i64 0, i32 1             ; <%inners*> [#uses=1]
+        %ubsptr = getelementptr %inners, ptr %nsptr, i64 0, i32 1           ; <{ i8 }*> [#uses=1]
+        %idx = getelementptr { i8 }, ptr %ubsptr, i64 0, i32 0              ; <i8*> [#uses=1]
         store i8 4, i8* %idx
-        %fptr = getelementptr %struct, %struct* %sptr, i64 0, i32 1, i32 0               ; <float*> [#uses=1]
-        store float 4.000000e+00, float* %fptr
+        %fptr = getelementptr %struct, ptr %sptr, i64 0, i32 1, i32 0               ; <float*> [#uses=1]
+        store float 4.000000e+00, ptr %fptr
         ret i32 3
 }
 

--- a/llvm/test/Instrumentation/NumericalStabilitySanitizer/cfg.ll
+++ b/llvm/test/Instrumentation/NumericalStabilitySanitizer/cfg.ll
@@ -34,7 +34,7 @@ block1:
   br label %loop
 }
 
-define float @forward_use_with_load(float* %p) sanitize_numerical_stability {
+define float @forward_use_with_load(ptr %p) sanitize_numerical_stability {
 ; CHECK-LABEL: @forward_use_with_load(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[BLOCK1:%.*]]
@@ -71,7 +71,7 @@ loop:
 
 block1:
   %a = phi float [ %d, %loop], [ 1.0, %entry ]
-  %l = load float, float* %p ; the load creates a new block
+  %l = load float, ptr %p ; the load creates a new block
   %b = fadd float %l, 1.0 ; this requires shadow(%l).
   br label %loop
 }

--- a/llvm/test/Instrumentation/NumericalStabilitySanitizer/memory.ll
+++ b/llvm/test/Instrumentation/NumericalStabilitySanitizer/memory.ll
@@ -5,9 +5,9 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ; Tests with memory manipulation (memcpy, llvm.memcpy, ...).
 
 
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)
+declare void @llvm.memcpy.p0i8.p0i8.i64(ptr, ptr, i64, i1)
 
-define void @call_memcpy_intrinsics(i8* nonnull align 8 dereferenceable(16) %a, i8* nonnull align 8 dereferenceable(16) %b) sanitize_numerical_stability {
+define void @call_memcpy_intrinsics(ptr nonnull align 8 dereferenceable(16) %a, ptr nonnull align 8 dereferenceable(16) %b) sanitize_numerical_stability {
 ; CHECK-LABEL: @call_memcpy_intrinsics(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    call void @__nsan_copy_4(ptr [[A:%.*]], ptr [[B:%.*]])
@@ -28,20 +28,20 @@ entry:
   ret void
 }
 
-declare dso_local i8* @memcpy(i8*, i8*, i64) local_unnamed_addr
+declare dso_local ptr @memcpy(ptr, ptr, i64) local_unnamed_addr
 
-define void @call_memcpy(i8* nonnull align 8 dereferenceable(16) %a, i8* nonnull align 8 dereferenceable(16) %b) sanitize_numerical_stability {
+define void @call_memcpy(ptr nonnull align 8 dereferenceable(16) %a, ptr nonnull align 8 dereferenceable(16) %b) sanitize_numerical_stability {
 ; CHECK-LABEL: @call_memcpy(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = tail call ptr @memcpy(ptr nonnull align 8 dereferenceable(16) [[A:%.*]], ptr nonnull align 8 dereferenceable(16) [[B:%.*]], i64 16) #[[ATTR3:[0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
-  tail call i8* @memcpy(ptr nonnull align 8 dereferenceable(16) %a, ptr nonnull align 8 dereferenceable(16) %b, i64 16)
+  tail call ptr @memcpy(ptr nonnull align 8 dereferenceable(16) %a, ptr nonnull align 8 dereferenceable(16) %b, i64 16)
   ret void
 }
 
-define void @call_memset_intrinsics(i8* nonnull align 8 dereferenceable(16) %a) sanitize_numerical_stability {
+define void @call_memset_intrinsics(ptr nonnull align 8 dereferenceable(16) %a) sanitize_numerical_stability {
 ; CHECK-LABEL: @call_memset_intrinsics(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    call void @__nsan_set_value_unknown_4(ptr [[A:%.*]])
@@ -62,7 +62,7 @@ entry:
   ret void
 }
 
-define void @transfer_float(float* %dst, float* %src) sanitize_numerical_stability {
+define void @transfer_float(ptr %dst, ptr %src) sanitize_numerical_stability {
 ; CHECK-LABEL: @transfer_float(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[T:%.*]] = load float, ptr [[SRC:%.*]], align 4
@@ -198,7 +198,7 @@ define void @swap_untyped2(i64* nonnull align 8 %p, i64* nonnull align 8 %q) san
   ret void
 }
 
-define void @swap_ft1(float* nonnull align 8 %p, float* nonnull align 8 %q) sanitize_numerical_stability {
+define void @swap_ft1(ptr nonnull align 8 %p, ptr nonnull align 8 %q) sanitize_numerical_stability {
 ; CHECK-LABEL: @swap_ft1(
 ; CHECK-NEXT:    [[QV:%.*]] = load float, ptr [[Q:%.*]], align 4
 ; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @__nsan_get_shadow_ptr_for_float_load(ptr [[Q]], i64 1)
@@ -250,7 +250,7 @@ define void @swap_ft1(float* nonnull align 8 %p, float* nonnull align 8 %q) sani
 }
 
 ; Same as swap_ft1, but the load/stores are in the opposite order.
-define void @swap_ft2(float* nonnull align 8 %p, float* nonnull align 8 %q) sanitize_numerical_stability {
+define void @swap_ft2(ptr nonnull align 8 %p, ptr nonnull align 8 %q) sanitize_numerical_stability {
 ; CHECK-LABEL: @swap_ft2(
 ; CHECK-NEXT:    [[PV:%.*]] = load float, ptr [[P:%.*]], align 4
 ; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @__nsan_get_shadow_ptr_for_float_load(ptr [[P]], i64 1)

--- a/llvm/test/LTO/Resolution/X86/comdat.ll
+++ b/llvm/test/LTO/Resolution/X86/comdat.ll
@@ -28,22 +28,22 @@ target triple = "x86_64-unknown-linux-gnu"
 $c1 = comdat any
 
 @v1 = weak_odr global i32 42, comdat($c1)
-define weak_odr i32 @f1(i8*) comdat($c1) {
+define weak_odr i32 @f1(ptr) comdat($c1) {
 bb10:
   br label %bb11
 bb11:
   ret i32 42
 }
 
-@r11 = global i32* @v1
-@r12 = global i32 (i8*)* @f1
+@r11 = global ptr @v1
+@r12 = global ptr @f1
 
-@a11 = alias i32, i32* @v1
-@a12 = alias i16, bitcast (i32* @v1 to i16*)
+@a11 = alias i32, ptr @v1
+@a12 = alias i16, ptr @v1
 
-@a13 = alias i32 (i8*), i32 (i8*)* @f1
-@a14 = alias i16, bitcast (i32 (i8*)* @f1 to i16*)
-@a15 = alias i16, i16* @a14
+@a13 = alias i32 (ptr), ptr @f1
+@a14 = alias i16, ptr @f1
+@a15 = alias i16, ptr @a14
 
 ; CHECK: $c1 = comdat any
 ; CHECK: $c2 = comdat any

--- a/llvm/test/Linker/2003-08-23-GlobalVarLinking.ll
+++ b/llvm/test/Linker/2003-08-23-GlobalVarLinking.ll
@@ -6,6 +6,6 @@
 
 ; After linking this testcase, there should be no opaque types left.  The two
 ; S's should cause the opaque type to be resolved to 'int'.
-@S = global { i32, i32* } { i32 5, i32* null }		; <{ i32, i32* }*> [#uses=0]
+@S = global { i32, ptr } { i32 5, ptr null }		; <{ i32, i32* }*> [#uses=0]
 
-declare void @F(i32*)
+declare void @F(ptr)

--- a/llvm/test/Transforms/LoopVersioning/add-phi-update-users.ll
+++ b/llvm/test/Transforms/LoopVersioning/add-phi-update-users.ll
@@ -4,7 +4,7 @@
 ; This test case used to end like this:
 ;
 ;    Instruction does not dominate all uses!
-;      %t2 = load i16, i16* @b, align 1, !tbaa !2, !alias.scope !6
+;      %t2 = load i16, ptr @b, align 1, !tbaa !2, !alias.scope !6
 ;      %tobool = icmp eq i16 %t2, 0
 ;    LLVM ERROR: Broken function found, compilation aborted!
 ;

--- a/llvm/test/Transforms/PGOProfile/Inputs/cspgo_bar_sample.ll
+++ b/llvm/test/Transforms/PGOProfile/Inputs/cspgo_bar_sample.ll
@@ -10,7 +10,7 @@ $__llvm_profile_sampling = comdat any
 @__llvm_profile_filename = local_unnamed_addr constant [25 x i8] c"pass2/default_%m.profraw\00", comdat
 @__llvm_profile_raw_version = local_unnamed_addr constant i64 216172782113783812, comdat
 @__llvm_profile_sampling = thread_local global i16 0, comdat
-@llvm.used = appending global [1 x i8*] [i8* bitcast (i64* @__llvm_profile_sampling to i8*)], section "llvm.metadata"
+@llvm.used = appending global [1 x ptr] [ptr @__llvm_profile_sampling], section "llvm.metadata"
 
 define dso_local void @bar(i32 %n) !prof !30 {
 entry:
@@ -19,15 +19,15 @@ entry:
   br i1 %tobool, label %if.else, label %if.then, !prof !31
 
 if.then:
-  %0 = load i32, i32* @odd, align 4, !tbaa !32
+  %0 = load i32, ptr @odd, align 4, !tbaa !32
   %inc = add i32 %0, 1
-  store i32 %inc, i32* @odd, align 4, !tbaa !32
+  store i32 %inc, ptr @odd, align 4, !tbaa !32
   br label %if.end
 
 if.else:
-  %1 = load i32, i32* @even, align 4, !tbaa !32
+  %1 = load i32, ptr @even, align 4, !tbaa !32
   %inc1 = add i32 %1, 1
-  store i32 %inc1, i32* @even, align 4, !tbaa !32
+  store i32 %inc1, ptr @even, align 4, !tbaa !32
   br label %if.end
 
 if.end:


### PR DESCRIPTION
Some of the MIR test hit a bug where it errors if there is a
raw global reference as the referenced value. Worked around some
of those by just keeping a no-op bitcast constant expression.