### PR TITLE
[X86] combineOr - attempt to concat `OR(X,KSHIFTL(Y,Elts/2))` sub-16-element masks

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -52976,8 +52976,8 @@ static SDValue combineOr(SDNode *N, SelectionDAG &DAG,
       // If we can locate the original half subvectors, then see if we can
       // concat the operands directly.
       MVT HalfVT = VT.getSimpleVT().getHalfNumVectorElementsVT();
-      if (sd_match(X, m_InsertSubvector(m_Zero(), m_SpecificVT(HalfVT),
-                                        m_Zero())) &&
+      if (sd_match(
+              X, m_InsertSubvector(m_Zero(), m_SpecificVT(HalfVT), m_Zero())) &&
           sd_match(Y, m_InsertSubvector(m_Undef(), m_SpecificVT(HalfVT),
                                         m_Zero()))) {
         if (SDValue Concat = combineConcatVectorOps(

--- a/llvm/test/CodeGen/X86/avx512-skx-insert-subvec.ll
+++ b/llvm/test/CodeGen/X86/avx512-skx-insert-subvec.ll
@@ -98,12 +98,10 @@ define <16 x i1> @test6(<2 x i1> %a, <2 x i1>%b) {
 define <32 x i1> @test7(<4 x i1> %a, <4 x i1>%b) {
 ; CHECK-LABEL: test7:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vpslld $31, %xmm1, %xmm1
-; CHECK-NEXT:    vpmovd2m %xmm1, %k0
-; CHECK-NEXT:    vpslld $31, %xmm0, %xmm0
-; CHECK-NEXT:    vpmovd2m %xmm0, %k1
-; CHECK-NEXT:    kshiftlb $4, %k0, %k0
-; CHECK-NEXT:    korb %k0, %k1, %k0
+; CHECK-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
+; CHECK-NEXT:    vinserti128 $1, %xmm1, %ymm0, %ymm0
+; CHECK-NEXT:    vpslld $31, %ymm0, %ymm0
+; CHECK-NEXT:    vpmovd2m %ymm0, %k0
 ; CHECK-NEXT:    vpmovm2b %k0, %ymm0
 ; CHECK-NEXT:    retq
 

--- a/llvm/test/CodeGen/X86/combine-rndscale.ll
+++ b/llvm/test/CodeGen/X86/combine-rndscale.ll
@@ -177,14 +177,15 @@ define i8 @concat_roundps_cmp_v8f32_v4f32(<4 x float> %x0, <4 x float> %x1, <4 x
 ;
 ; AVX512-LABEL: concat_roundps_cmp_v8f32_v4f32:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vroundps $4, %xmm0, %xmm0
-; AVX512-NEXT:    vroundps $4, %xmm1, %xmm1
-; AVX512-NEXT:    vcmpltps %xmm2, %xmm0, %k0
-; AVX512-NEXT:    vcmpltps %xmm3, %xmm1, %k1
-; AVX512-NEXT:    kshiftlb $4, %k1, %k1
-; AVX512-NEXT:    korb %k1, %k0, %k0
+; AVX512-NEXT:    # kill: def $xmm2 killed $xmm2 def $ymm2
+; AVX512-NEXT:    # kill: def $xmm0 killed $xmm0 def $ymm0
+; AVX512-NEXT:    vinsertf128 $1, %xmm3, %ymm2, %ymm2
+; AVX512-NEXT:    vinsertf128 $1, %xmm1, %ymm0, %ymm0
+; AVX512-NEXT:    vroundps $4, %ymm0, %ymm0
+; AVX512-NEXT:    vcmpltps %ymm2, %ymm0, %k0
 ; AVX512-NEXT:    kmovd %k0, %eax
 ; AVX512-NEXT:    # kill: def $al killed $al killed $eax
+; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
   %rnd0 = call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %x0, i32 4)
   %rnd1 = call <4 x float> @llvm.x86.sse41.round.ps(<4 x float> %x1, i32 4)


### PR DESCRIPTION
We can't convert these to CONCAT_VECTORS/KUNPCK, but we might be able to concat the operands directly.