### PR TITLE
[lldb][crashlog] Account for alternate format of 'Triggered by Thread:' string

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -1118,7 +1118,16 @@ class TextCrashLogParser(CrashLogParser):
             self.crashlog.crashed_thread_idx = int(line[15:].strip().split()[0])
             return
         elif line.startswith("Triggered by Thread:"):  # iOS
-            self.crashlog.crashed_thread_idx = int(line[20:].strip().split()[0])
+            # Possible formats:
+            # Triggered by Thread: 0, Dispatch Queue: com.apple.main-thread
+            # Triggered by Thread: 1
+
+            triggered = line[20:].strip().split()[0]
+
+            # Strip the possibly trailing comma.
+            triggered = triggered.replace(",", "")
+
+            self.crashlog.crashed_thread_idx = int(triggered)
             return
         elif line.startswith("Report Version:"):
             self.crashlog.version = int(line[15:].strip())


### PR DESCRIPTION
When the crashing thread was submitted to a libdispatch queue, the `Triggered by Thread:` string looks like:
```
Triggered by Thread: 0, Dispatch Queue: com.apple.main-thread
```

Trying to run the `crashlog` command on such crashlog file fails with:
```
(lldb) crashlog -i '/tmp/lldb.crash'
Traceback (most recent call last):
  File "Git/llvm-worktrees/main/builds/release/lib/python3.13/site-packages/lldb/macosx/crashlog.py", line 1444, in __call__
    SymbolicateCrashLogs(debugger, shlex.split(command), result, True)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Git/llvm-worktrees/main/builds/release/lib/python3.13/site-packages/lldb/macosx/crashlog.py", line 1888, in SymbolicateCrashLogs
    load_crashlog_in_scripted_process(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        debugger, crashlog_path, options, result
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "Git/llvm-worktrees/main/builds/release/lib/python3.13/site-packages/lldb/macosx/crashlog.py", line 1495, in load_crashlog_in_scripted_process
    crashlog = CrashLogParser.create(debugger, crashlog_path, options).parse()
  File "Git/llvm-worktrees/main/builds/release/lib/python3.13/site-packages/lldb/macosx/crashlog.py", line 1043, in parse
    self.parsers[self.parse_mode](line)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "Git/llvm-worktrees/main/builds/release/lib/python3.13/site-packages/lldb/macosx/crashlog.py", line 1121, in parse_normal
    self.crashlog.crashed_thread_idx = int(line[20:].strip().split()[0])
                                       ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '0,'
```

This patch strips the possibly trailing comma in when parsing this string.

Tested locally that this fixes the issue. LLDB test suggestions welcome