### PR TITLE
[MLIR][Python] Add a method to get full name of MLIR types

### DIFF
--- a/mlir/examples/standalone/python/StandaloneExtensionNanobind.cpp
+++ b/mlir/examples/standalone/python/StandaloneExtensionNanobind.cpp
@@ -24,6 +24,7 @@ struct PyCustomType
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirStandaloneCustomTypeGetTypeID;
   static constexpr const char *pyClassName = "CustomType";
+  static constexpr const char *name = "standalone.custom";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -979,6 +979,10 @@ public:
       printAccum.parts.append(")");
       return printAccum.join();
     });
+    cls.def_prop_ro_static("type_name", [](nanobind::object & /*cls*/) {
+      return DerivedTy::name ? nanobind::str(DerivedTy::name)
+                             : nanobind::none();
+    });
 
     if (DerivedTy::getTypeIdFunction) {
       PyGlobals::get().registerTypeCaster(

--- a/mlir/include/mlir/Bindings/Python/IRTypes.h
+++ b/mlir/include/mlir/Bindings/Python/IRTypes.h
@@ -10,6 +10,7 @@
 #define MLIR_BINDINGS_PYTHON_IRTYPES_H
 
 #include "mlir-c/BuiltinTypes.h"
+#include "mlir/Bindings/Python/IRCore.h"
 
 namespace mlir {
 namespace python {
@@ -24,6 +25,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirIntegerTypeGetTypeID;
   static constexpr const char *pyClassName = "IntegerType";
+  static constexpr const char *name = "builtin.integer";
   using PyConcreteType::PyConcreteType;
 
   enum Signedness { Signless, Signed, Unsigned };
@@ -39,6 +41,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirIndexTypeGetTypeID;
   static constexpr const char *pyClassName = "IndexType";
+  static constexpr const char *name = "builtin.index";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -49,6 +52,7 @@ class MLIR_PYTHON_API_EXPORTED PyFloatType
 public:
   static constexpr IsAFunctionTy isaFunction = mlirTypeIsAFloat;
   static constexpr const char *pyClassName = "FloatType";
+  static constexpr const char *name = nullptr;
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -62,6 +66,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat4E2M1FNTypeGetTypeID;
   static constexpr const char *pyClassName = "Float4E2M1FNType";
+  static constexpr const char *name = "builtin.f4E2M1FN";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -75,6 +80,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat6E2M3FNTypeGetTypeID;
   static constexpr const char *pyClassName = "Float6E2M3FNType";
+  static constexpr const char *name = "builtin.f6E2M3FN";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -88,6 +94,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat6E3M2FNTypeGetTypeID;
   static constexpr const char *pyClassName = "Float6E3M2FNType";
+  static constexpr const char *name = "builtin.f6E3M2FN";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -101,6 +108,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E4M3FNTypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E4M3FNType";
+  static constexpr const char *name = "builtin.f8E4M3FN";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -114,6 +122,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E5M2TypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E5M2Type";
+  static constexpr const char *name = "builtin.f8E5M2";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -127,6 +136,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E4M3TypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E4M3Type";
+  static constexpr const char *name = "builtin.f8E4M3";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -140,6 +150,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E4M3FNUZTypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E4M3FNUZType";
+  static constexpr const char *name = "builtin.f8E4M3FNUZ";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -153,6 +164,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E4M3B11FNUZTypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E4M3B11FNUZType";
+  static constexpr const char *name = "builtin.f8E4M3B11FNUZ";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -166,6 +178,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E5M2FNUZTypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E5M2FNUZType";
+  static constexpr const char *name = "builtin.f8E5M2FNUZ";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -179,6 +192,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E3M4TypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E3M4Type";
+  static constexpr const char *name = "builtin.f8E3M4";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -192,6 +206,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E8M0FNUTypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E8M0FNUType";
+  static constexpr const char *name = "builtin.f8E8M0FNU";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -205,6 +220,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirBFloat16TypeGetTypeID;
   static constexpr const char *pyClassName = "BF16Type";
+  static constexpr const char *name = "builtin.bf16";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -218,6 +234,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat16TypeGetTypeID;
   static constexpr const char *pyClassName = "F16Type";
+  static constexpr const char *name = "builtin.f16";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -231,6 +248,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloatTF32TypeGetTypeID;
   static constexpr const char *pyClassName = "FloatTF32Type";
+  static constexpr const char *name = "builtin.tf32";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -244,6 +262,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat32TypeGetTypeID;
   static constexpr const char *pyClassName = "F32Type";
+  static constexpr const char *name = "builtin.f32";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -257,6 +276,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat64TypeGetTypeID;
   static constexpr const char *pyClassName = "F64Type";
+  static constexpr const char *name = "builtin.f64";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -269,6 +289,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirNoneTypeGetTypeID;
   static constexpr const char *pyClassName = "NoneType";
+  static constexpr const char *name = "builtin.none";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -282,6 +303,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirComplexTypeGetTypeID;
   static constexpr const char *pyClassName = "ComplexType";
+  static constexpr const char *name = "builtin.complex";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -293,6 +315,7 @@ class MLIR_PYTHON_API_EXPORTED MLIR_PYTHON_API_EXPORTED PyShapedType
 public:
   static const IsAFunctionTy isaFunction;
   static constexpr const char *pyClassName = "ShapedType";
+  static constexpr const char *name = nullptr;
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -309,6 +332,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirVectorTypeGetTypeID;
   static constexpr const char *pyClassName = "VectorType";
+  static constexpr const char *name = "builtin.vector";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -334,6 +358,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirRankedTensorTypeGetTypeID;
   static constexpr const char *pyClassName = "RankedTensorType";
+  static constexpr const char *name = "builtin.tensor";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -347,6 +372,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirUnrankedTensorTypeGetTypeID;
   static constexpr const char *pyClassName = "UnrankedTensorType";
+  static constexpr const char *name = "builtin.unranked_tensor";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -360,6 +386,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirMemRefTypeGetTypeID;
   static constexpr const char *pyClassName = "MemRefType";
+  static constexpr const char *name = "builtin.memref";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -373,6 +400,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirUnrankedMemRefTypeGetTypeID;
   static constexpr const char *pyClassName = "UnrankedMemRefType";
+  static constexpr const char *name = "builtin.unranked_memref";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -386,6 +414,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirTupleTypeGetTypeID;
   static constexpr const char *pyClassName = "TupleType";
+  static constexpr const char *name = "builtin.tuple";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -399,6 +428,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFunctionTypeGetTypeID;
   static constexpr const char *pyClassName = "FunctionType";
+  static constexpr const char *name = "builtin.function";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -412,6 +442,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirOpaqueTypeGetTypeID;
   static constexpr const char *pyClassName = "OpaqueType";
+  static constexpr const char *name = "builtin.opaque";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);

--- a/mlir/lib/Bindings/Python/DialectAMDGPU.cpp
+++ b/mlir/lib/Bindings/Python/DialectAMDGPU.cpp
@@ -26,6 +26,7 @@ struct TDMBaseType : PyConcreteType<TDMBaseType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirAMDGPUTDMBaseTypeGetTypeID;
   static constexpr const char *pyClassName = "TDMBaseType";
+  static constexpr const char *name = "amdgpu.tdm_base";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -47,6 +48,7 @@ struct TDMDescriptorType : PyConcreteType<TDMDescriptorType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirAMDGPUTDMDescriptorTypeGetTypeID;
   static constexpr const char *pyClassName = "TDMDescriptorType";
+  static constexpr const char *name = "amdgpu.tdm_descriptor";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -68,6 +70,7 @@ struct TDMGatherBaseType : PyConcreteType<TDMGatherBaseType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirAMDGPUTDMGatherBaseTypeGetTypeID;
   static constexpr const char *pyClassName = "TDMGatherBaseType";
+  static constexpr const char *name = "amdgpu.tdm_gather_base";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectGPU.cpp
+++ b/mlir/lib/Bindings/Python/DialectGPU.cpp
@@ -29,6 +29,7 @@ namespace gpu {
 struct AsyncTokenType : PyConcreteType<AsyncTokenType> {
   static constexpr IsAFunctionTy isaFunction = mlirTypeIsAGPUAsyncTokenType;
   static constexpr const char *pyClassName = "AsyncTokenType";
+  static constexpr const char *name = "gpu.async_token";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectLLVM.cpp
+++ b/mlir/lib/Bindings/Python/DialectLLVM.cpp
@@ -37,6 +37,7 @@ struct StructType : PyConcreteType<StructType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirLLVMStructTypeGetTypeID;
   static constexpr const char *pyClassName = "StructType";
+  static constexpr const char *name = "llvm.struct";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -169,6 +170,7 @@ struct PointerType : PyConcreteType<PointerType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirLLVMPointerTypeGetTypeID;
   static constexpr const char *pyClassName = "PointerType";
+  static constexpr const char *name = "llvm.ptr";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectNVGPU.cpp
+++ b/mlir/lib/Bindings/Python/DialectNVGPU.cpp
@@ -24,6 +24,7 @@ struct TensorMapDescriptorType : PyConcreteType<TensorMapDescriptorType> {
   static constexpr IsAFunctionTy isaFunction =
       mlirTypeIsANVGPUTensorMapDescriptorType;
   static constexpr const char *pyClassName = "TensorMapDescriptorType";
+  static constexpr const char *name = "nvgpu.tensormap.descriptor";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectPDL.cpp
+++ b/mlir/lib/Bindings/Python/DialectPDL.cpp
@@ -28,6 +28,7 @@ namespace pdl {
 struct PDLType : PyConcreteType<PDLType> {
   static constexpr IsAFunctionTy isaFunction = mlirTypeIsAPDLType;
   static constexpr const char *pyClassName = "PDLType";
+  static constexpr const char *name = "pdl.type";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {}
@@ -42,6 +43,7 @@ struct AttributeType : PyConcreteType<AttributeType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirPDLAttributeTypeGetTypeID;
   static constexpr const char *pyClassName = "AttributeType";
+  static constexpr const char *name = "pdl.attribute";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -65,6 +67,7 @@ struct OperationType : PyConcreteType<OperationType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirPDLOperationTypeGetTypeID;
   static constexpr const char *pyClassName = "OperationType";
+  static constexpr const char *name = "pdl.operation";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -88,6 +91,7 @@ struct RangeType : PyConcreteType<RangeType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirPDLRangeTypeGetTypeID;
   static constexpr const char *pyClassName = "RangeType";
+  static constexpr const char *name = "pdl.range";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -118,6 +122,7 @@ struct TypeType : PyConcreteType<TypeType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirPDLTypeTypeGetTypeID;
   static constexpr const char *pyClassName = "TypeType";
+  static constexpr const char *name = "pdl.type";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -141,6 +146,7 @@ struct ValueType : PyConcreteType<ValueType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirPDLValueTypeGetTypeID;
   static constexpr const char *pyClassName = "ValueType";
+  static constexpr const char *name = "pdl.value";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectQuant.cpp
+++ b/mlir/lib/Bindings/Python/DialectQuant.cpp
@@ -31,6 +31,7 @@ namespace quant {
 struct QuantizedType : PyConcreteType<QuantizedType> {
   static constexpr IsAFunctionTy isaFunction = mlirTypeIsAQuantizedType;
   static constexpr const char *pyClassName = "QuantizedType";
+  static constexpr const char *name = nullptr;
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -198,6 +199,7 @@ struct AnyQuantizedType : PyConcreteType<AnyQuantizedType, QuantizedType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirAnyQuantizedTypeGetTypeID;
   static constexpr const char *pyClassName = "AnyQuantizedType";
+  static constexpr const char *name = "quant.any";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -229,6 +231,7 @@ struct UniformQuantizedType
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirUniformQuantizedTypeGetTypeID;
   static constexpr const char *pyClassName = "UniformQuantizedType";
+  static constexpr const char *name = "quant.uniform";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectSMT.cpp
+++ b/mlir/lib/Bindings/Python/DialectSMT.cpp
@@ -30,6 +30,7 @@ namespace smt {
 struct BoolType : PyConcreteType<BoolType> {
   static constexpr IsAFunctionTy isaFunction = mlirSMTTypeIsABool;
   static constexpr const char *pyClassName = "BoolType";
+  static constexpr const char *name = "smt.bool";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -46,6 +47,7 @@ struct BoolType : PyConcreteType<BoolType> {
 struct BitVectorType : PyConcreteType<BitVectorType> {
   static constexpr IsAFunctionTy isaFunction = mlirSMTTypeIsABitVector;
   static constexpr const char *pyClassName = "BitVectorType";
+  static constexpr const char *name = "smt.bv";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -63,6 +65,7 @@ struct BitVectorType : PyConcreteType<BitVectorType> {
 struct IntType : PyConcreteType<IntType> {
   static constexpr IsAFunctionTy isaFunction = mlirSMTTypeIsAInt;
   static constexpr const char *pyClassName = "IntType";
+  static constexpr const char *name = "smt.int";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectTransform.cpp
+++ b/mlir/lib/Bindings/Python/DialectTransform.cpp
@@ -31,6 +31,7 @@ struct AnyOpType : PyConcreteType<AnyOpType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirTransformAnyOpTypeGetTypeID;
   static constexpr const char *pyClassName = "AnyOpType";
+  static constexpr const char *name = "transform.any_op";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -54,6 +55,7 @@ struct AnyParamType : PyConcreteType<AnyParamType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirTransformAnyParamTypeGetTypeID;
   static constexpr const char *pyClassName = "AnyParamType";
+  static constexpr const char *name = "transform.any_param";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -77,6 +79,7 @@ struct AnyValueType : PyConcreteType<AnyValueType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirTransformAnyValueTypeGetTypeID;
   static constexpr const char *pyClassName = "AnyValueType";
+  static constexpr const char *name = "transform.any_value";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -101,6 +104,7 @@ struct OperationType : PyConcreteType<OperationType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirTransformOperationTypeGetTypeID;
   static constexpr const char *pyClassName = "OperationType";
+  static constexpr const char *name = "transform.op";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -136,6 +140,7 @@ struct ParamType : PyConcreteType<ParamType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirTransformParamTypeGetTypeID;
   static constexpr const char *pyClassName = "ParamType";
+  static constexpr const char *name = "transform.param";
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/test/python/ir/builtin_types.py
+++ b/mlir/test/python/ir/builtin_types.py
@@ -191,6 +191,30 @@ def testStandardTypeCasts():
         print("Exception not produced")
 
 
+# CHECK-LABEL: TEST: testTypeName
+@run
+def testTypeName():
+    with Context() as ctx:
+        # CHECK: builtin.integer
+        print(IntegerType.type_name)
+        # CHECK: builtin.f32
+        print(F32Type.type_name)
+        # CHECK: builtin.f6E2M3FN
+        print(Float6E2M3FNType.type_name)
+        # CHECK: builtin.vector
+        print(VectorType.type_name)
+        # CHECK: builtin.tensor
+        print(RankedTensorType.type_name)
+        # CHECK: builtin.unranked_tensor
+        print(UnrankedTensorType.type_name)
+        # CHECK: builtin.memref
+        print(MemRefType.type_name)
+        # CHECK: builtin.unranked_memref
+        print(UnrankedMemRefType.type_name)
+        # CHECK: builtin.none
+        print(NoneType.type_name)
+
+
 # CHECK-LABEL: TEST: testIntegerType
 @run
 def testIntegerType():

--- a/mlir/test/python/lib/PythonTestModuleNanobind.cpp
+++ b/mlir/test/python/lib/PythonTestModuleNanobind.cpp
@@ -34,6 +34,7 @@ struct PyTestType
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirPythonTestTestTypeGetTypeID;
   static constexpr const char *pyClassName = "TestType";
+  static constexpr const char *name = "python_test.test_type";
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c) {


### PR DESCRIPTION
This PR adds a `type_name` property to the Python classes for MLIR types, e.g. `IntegerType.type_name -> "builtin.integer"`. This makes it easy to obtain the full name of an MLIR type directly from the Python class—for example, in IRDL we no longer need to manually provide a string like `irdl.base("!builtin.integer")`.

To support this, each `PyConcreteType` must define a `static constexpr const char *name` class member (for parent classes that don’t have direct instances, such as `FloatType`, this can be set to `nullptr`). I intentionally made this class member non-optional because I want it to cause a compile-time error if it’s accidentally left out.

