### PR TITLE
[SPIRV] Handle poison values in lifetime intrinsics

### DIFF
--- a/llvm/test/CodeGen/SPIRV/lifetime-poison.ll
+++ b/llvm/test/CodeGen/SPIRV/lifetime-poison.ll
@@ -1,0 +1,18 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown < %s | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown -filetype=obj < %s  | spirv-val %}
+
+target triple = "spirv64-amd-amdhsa"
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(ptr captures(none)) addrspace(4) #0
+
+define spir_kernel void @foo() addrspace(4) {
+; CHECK: %4 = OpFunction %2 None %3              ; -- Begin function foo
+; CHECK: %5 = OpLabel
+; CHECK: OpReturn
+  call addrspace(4) void @llvm.lifetime.start.p0(ptr poison)
+  call addrspace(4) void @llvm.lifetime.end.p0(ptr poison)
+  ret void
+}
+
+attributes #0 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }


### PR DESCRIPTION
The toSpvLifetimeIntrinsic function crashed when attempting to cast a poison value to AllocaInst. This patch adds a check to detect poison values in the first argument of lifetime intrinsics and erases the intrinsic early, as lifetime intrinsics with poison arguments have no effect per LLVM semantics.

This LLVM defect was identified via the AMD Fuzzing project