### PR TITLE
[Sema] Fix crash in TypeLoc::initializeFullCopy with mismatched types

### DIFF
--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -6138,7 +6138,11 @@ namespace {
         TypeSourceInfo *TInfo = nullptr;
         Sema::GetTypeFromParser(DS.getRepAsType(), &TInfo);
         assert(TInfo);
-        TL.getValueLoc().initializeFullCopy(TInfo->getTypeLoc());
+        if (TL.getValueLoc().getType() == TInfo->getTypeLoc().getType())
+          TL.getValueLoc().initializeFullCopy(TInfo->getTypeLoc());
+        else
+          TL.getValueLoc().initialize(Context,
+                                      TInfo->getTypeLoc().getBeginLoc());
       } else {
         TL.setKWLoc(DS.getAtomicSpecLoc());
         // No parens, to indicate this was spelled as an _Atomic qualifier.
@@ -6152,7 +6156,12 @@ namespace {
 
       TypeSourceInfo *TInfo = nullptr;
       Sema::GetTypeFromParser(DS.getRepAsType(), &TInfo);
-      TL.getValueLoc().initializeFullCopy(TInfo->getTypeLoc());
+      if (TInfo && TL.getValueLoc().getType() == TInfo->getTypeLoc().getType())
+        TL.getValueLoc().initializeFullCopy(TInfo->getTypeLoc());
+      else
+        TL.getValueLoc().initialize(Context,
+                                    TInfo ? TInfo->getTypeLoc().getBeginLoc()
+                                          : DS.getTypeSpecTypeLoc());
     }
 
     void VisitExtIntTypeLoc(BitIntTypeLoc TL) {

--- a/clang/test/Sema/atomic-type-mismatch-crash.c
+++ b/clang/test/Sema/atomic-type-mismatch-crash.c
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// This test checks that we don't crash when parsing malformed _Atomic types
+// with nested sizeof/alignof expressions. See GitHub issue #173886.
+
+int a[100];
+int main() {
+  a[__alignof__(_Atomic(void) _Atomic double unsigned)]; // expected-error {{cannot combine with previous '_Atomic' declaration specifier}} \
+                                                         // expected-error {{'_Atomic' cannot be signed or unsigned}} \
+                                                         // expected-error {{_Atomic cannot be applied to incomplete type 'void'}}
+}


### PR DESCRIPTION
Fix assertion failure 'getType() == Other.getType()' in TypeLoc::initializeFullCopy when parsing malformed _Atomic types with nested sizeof/alignof expressions.

When error recovery produces a type that differs from the original TypeSourceInfo, we now fall back to initialize() instead of initializeFullCopy() to avoid the assertion failure.

Fixes #173886