### PR TITLE
[OpenMP] Add default stub for virtual methods

### DIFF
--- a/openmp/device/src/Misc.cpp
+++ b/openmp/device/src/Misc.cpp
@@ -136,4 +136,10 @@ unsigned long long __llvm_omp_host_call(void *fn, void *data, size_t size) {
 }
 }
 
+// C++ ABI helpers.
+extern "C" {
+[[gnu::weak]] void __cxa_pure_virtual(void) { __builtin_trap(); }
+[[gnu::weak]] void __cxa_deleted_virtual(void) { __builtin_trap(); }
+}
+
 ///}


### PR DESCRIPTION
Summary:
Recent OpenMP patches have added real support for virtual functions on
the device side. However, we don't provide some of the C++ ABI functions
that are emitted when using these. In practice these functions just call
`std::terminate` so we can just trap here. These are marked weak so they
will be overridden by a more correct implementation if not defined and
will also not extract on their own from a static library.
