### PR TITLE
[clang][SME] Rework streaming mode always_inline errors/warnings

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1370,6 +1370,11 @@ public:
   /// are stored here.
   llvm::DenseMap<const CXXMethodDecl *, CXXCastPath> LambdaCastPaths;
 
+  /// Keep track of functions that contain expressions that are not valid in
+  /// streaming mode on AArch64. This is used to check inlining validity.
+  llvm::DenseSet<const FunctionDecl *>
+      AArch64ContansExprNotSafeForStreamingFunctions;
+
   ASTContext(LangOptions &LOpts, SourceManager &SM, IdentifierTable &idents,
              SelectorTable &sels, Builtin::Context &builtins,
              TranslationUnitKind TUKind);

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1373,7 +1373,7 @@ public:
   /// Keep track of functions that contain expressions that are not valid in
   /// streaming mode on AArch64. This is used to check inlining validity.
   llvm::DenseSet<const FunctionDecl *>
-      AArch64ContansExprNotSafeForStreamingFunctions;
+      AArch64ContainsExprNotSafeForStreamingFunctions;
 
   ASTContext(LangOptions &LOpts, SourceManager &SM, IdentifierTable &idents,
              SelectorTable &sels, Builtin::Context &builtins,

--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -296,7 +296,9 @@ def err_function_always_inline_attribute_mismatch : Error<
   "always_inline function %1 and its caller %0 have mismatching %2 attributes">;
 def warn_function_always_inline_attribute_mismatch : Warning<
   "always_inline function %1 and its caller %0 have mismatching %2 attributes, "
-  "inlining may change runtime behaviour">, InGroup<AArch64SMEAttributes>;
+  "inlining may change runtime behaviour">, InGroup<AArch64SMEAttributes>, DefaultIgnore;
+def err_function_always_inline_non_streaming_builtins : Error<
+  "always_inline function %0 cannot be inlined into streaming caller as it contains calls to non-streaming builtins">;
 def err_function_always_inline_new_za : Error<
   "always_inline function %0 has new za state">;
 def err_function_always_inline_new_zt0

--- a/clang/include/clang/Sema/SemaARM.h
+++ b/clang/include/clang/Sema/SemaARM.h
@@ -83,6 +83,10 @@ public:
 
   void CheckSMEFunctionDefAttributes(const FunctionDecl *FD);
 
+  void setFunctionContainsExprNotSafeForStreamingMode(const FunctionDecl *FD) {
+    getASTContext().AArch64ContansExprNotSafeForStreamingFunctions.insert(FD);
+  }
+
   /// Return true if the given types are an SVE builtin and a VectorType that
   /// is a fixed-length representation of the SVE builtin for a specific
   /// vector-length.

--- a/clang/include/clang/Sema/SemaARM.h
+++ b/clang/include/clang/Sema/SemaARM.h
@@ -84,7 +84,7 @@ public:
   void CheckSMEFunctionDefAttributes(const FunctionDecl *FD);
 
   void setFunctionContainsExprNotSafeForStreamingMode(const FunctionDecl *FD) {
-    getASTContext().AArch64ContansExprNotSafeForStreamingFunctions.insert(FD);
+    getASTContext().AArch64ContainsExprNotSafeForStreamingFunctions.insert(FD);
   }
 
   /// Return true if the given types are an SVE builtin and a VectorType that

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -5284,7 +5284,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
   // attribute-target/features. Give them a chance to diagnose.
   const FunctionDecl *CallerDecl = dyn_cast_or_null<FunctionDecl>(CurCodeDecl);
   const FunctionDecl *CalleeDecl = dyn_cast_or_null<FunctionDecl>(TargetDecl);
-  CGM.getTargetCodeGenInfo().checkFunctionCallABI(CGM, Loc, CallerDecl,
+  CGM.getTargetCodeGenInfo().checkFunctionCallABI(*this, Loc, CallerDecl,
                                                   CalleeDecl, CallArgs, RetTy);
 
   // 1. Set up the arguments.
@@ -5860,7 +5860,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
   // Note: This corresponds to the [[clang::always_inline]] statement attribute.
   if (InAlwaysInlineAttributedStmt &&
       !CGM.getTargetCodeGenInfo().wouldInliningViolateFunctionCallABI(
-          CallerDecl, CalleeDecl))
+          *this, CallerDecl, CalleeDecl))
     Attrs =
         Attrs.addFnAttribute(getLLVMContext(), llvm::Attribute::AlwaysInline);
 
@@ -5878,7 +5878,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
       !InNoInlineAttributedStmt &&
       !(TargetDecl && TargetDecl->hasAttr<NoInlineAttr>()) &&
       !CGM.getTargetCodeGenInfo().wouldInliningViolateFunctionCallABI(
-          CallerDecl, CalleeDecl)) {
+          *this, CallerDecl, CalleeDecl)) {
     Attrs =
         Attrs.addFnAttribute(getLLVMContext(), llvm::Attribute::AlwaysInline);
   }

--- a/clang/lib/CodeGen/TargetInfo.h
+++ b/clang/lib/CodeGen/TargetInfo.h
@@ -98,11 +98,10 @@ public:
 
   /// Any further codegen related checks that need to be done on a function call
   /// in a target specific manner.
-  virtual void checkFunctionCallABI(CodeGenModule &CGM, SourceLocation CallLoc,
-                                    const FunctionDecl *Caller,
-                                    const FunctionDecl *Callee,
-                                    const CallArgList &Args,
-                                    QualType ReturnType) const {}
+  virtual void
+  checkFunctionCallABI(CodeGenFunction &CGF, SourceLocation CallLoc,
+                       const FunctionDecl *Caller, const FunctionDecl *Callee,
+                       const CallArgList &Args, QualType ReturnType) const {}
 
   /// Returns true if inlining the function call would produce incorrect code
   /// for the current target and should be ignored (even with the always_inline
@@ -117,7 +116,8 @@ public:
   /// See previous discussion here:
   /// https://discourse.llvm.org/t/rfc-avoid-inlining-alwaysinline-functions-when-they-cannot-be-inlined/79528
   virtual bool
-  wouldInliningViolateFunctionCallABI(const FunctionDecl *Caller,
+  wouldInliningViolateFunctionCallABI(CodeGenFunction &CGF,
+                                      const FunctionDecl *Caller,
                                       const FunctionDecl *Callee) const {
     return false;
   }

--- a/clang/lib/CodeGen/Targets/AArch64.cpp
+++ b/clang/lib/CodeGen/Targets/AArch64.cpp
@@ -1245,13 +1245,13 @@ static bool
 functionContainsExprNotSafeForStreamingMode(CodeGenModule &CGM,
                                             const FunctionDecl *FD) {
   return CGM.getContext()
-      .AArch64ContansExprNotSafeForStreamingFunctions.contains(FD);
+      .AArch64ContainsExprNotSafeForStreamingFunctions.contains(FD);
 }
 
 static void
 setFunctionContainsExprNotSafeForStreamingMode(CodeGenModule &CGM,
                                                const FunctionDecl *FD) {
-  CGM.getContext().AArch64ContansExprNotSafeForStreamingFunctions.insert(FD);
+  CGM.getContext().AArch64ContainsExprNotSafeForStreamingFunctions.insert(FD);
 }
 
 /// Determines if there are any Arm SME ABI issues with inlining \p Callee into

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -1504,7 +1504,7 @@ public:
     }
   }
 
-  void checkFunctionCallABI(CodeGenModule &CGM, SourceLocation CallLoc,
+  void checkFunctionCallABI(CodeGenFunction &CGF, SourceLocation CallLoc,
                             const FunctionDecl *Caller,
                             const FunctionDecl *Callee, const CallArgList &Args,
                             QualType ReturnType) const override;
@@ -1570,7 +1570,7 @@ static bool checkAVXParam(DiagnosticsEngine &Diag, ASTContext &Ctx,
   return false;
 }
 
-void X86_64TargetCodeGenInfo::checkFunctionCallABI(CodeGenModule &CGM,
+void X86_64TargetCodeGenInfo::checkFunctionCallABI(CodeGenFunction &CGF,
                                                    SourceLocation CallLoc,
                                                    const FunctionDecl *Caller,
                                                    const FunctionDecl *Callee,
@@ -1579,6 +1579,7 @@ void X86_64TargetCodeGenInfo::checkFunctionCallABI(CodeGenModule &CGM,
   if (!Callee)
     return;
 
+  CodeGenModule &CGM = CGF.CGM;
   llvm::StringMap<bool> CallerMap;
   llvm::StringMap<bool> CalleeMap;
   unsigned ArgIndex = 0;

--- a/clang/lib/Sema/SemaARM.cpp
+++ b/clang/lib/Sema/SemaARM.cpp
@@ -623,9 +623,11 @@ static bool checkArmStreamingBuiltin(Sema &S, CallExpr *TheCall,
            BuiltinType == SemaARM::ArmStreaming)
     S.Diag(TheCall->getBeginLoc(), diag::err_attribute_arm_sm_incompat_builtin)
         << TheCall->getSourceRange() << "streaming";
-  else
+  else {
+    if (BuiltinType == SemaARM::ArmNonStreaming)
+      S.ARM().setFunctionContainsExprNotSafeForStreamingMode(FD);
     return false;
-
+  }
   return true;
 }
 

--- a/clang/test/CodeGen/AArch64/sme-always-inline.cpp
+++ b/clang/test/CodeGen/AArch64/sme-always-inline.cpp
@@ -1,0 +1,56 @@
+// RUN: %clang_cc1 -Waarch64-sme-attributes -triple aarch64-none-linux-gnu -S -o /dev/null -target-feature +sme -target-feature +neon -verify=expected-attr %s -DTEST_STREAMING
+// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -S -o /dev/null -target-feature +sme -target-feature +neon -verify %s -DTEST_STREAMING
+// RUN: %clang_cc1 -Waarch64-sme-attributes -triple aarch64-none-linux-gnu -S -o /dev/null -target-feature +sme -target-feature +neon -verify=expected-attr %s -DTEST_COMPATIBLE
+// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -S -o /dev/null -target-feature +sme -target-feature +neon -verify %s -DTEST_COMPATIBLE
+
+#if defined(TEST_STREAMING)
+#define SM_ATTR __arm_streaming
+#elif defined(TEST_COMPATIBLE)
+#define SM_ATTR __arm_streaming_compatible
+#else
+#error "Expected TEST_STREAMING or TEST_COMPATIBLE"
+#endif
+
+__attribute__((always_inline)) void incompatible_neon() {
+  __attribute((vector_size(16))) char vec = { 0 };
+  vec = __builtin_neon_vqaddq_v(vec, vec, 33);
+}
+
+__attribute__((always_inline)) void compatible_missing_attrs() {
+    // <Empty>
+}
+
+void foo() {
+    incompatible_neon();
+}
+
+// expected-note@+2 {{conflicting attribute is here}}
+// expected-attr-note@+1 {{conflicting attribute is here}}
+__attribute__((always_inline)) void bar() {
+    incompatible_neon();
+}
+
+__attribute__((always_inline)) void baz() {
+    compatible_missing_attrs();
+}
+
+void streaming_error() SM_ATTR {
+    // expected-error@+3 {{always_inline function 'bar' cannot be inlined into streaming caller as it contains calls to non-streaming builtins}}
+    // expected-attr-warning@+2 {{always_inline function 'bar' and its caller 'streaming_error' have mismatching streaming attributes, inlining may change runtime behaviour}}
+    // expected-attr-error@+1 {{always_inline function 'bar' cannot be inlined into streaming caller as it contains calls to non-streaming builtins}}
+    bar(); // -> incompatible_neon -> __builtin_neon_vqaddq_v (error)
+}
+
+void streaming_warning() SM_ATTR {
+    // expected-attr-warning@+1 {{always_inline function 'baz' and its caller 'streaming_warning' have mismatching streaming attributes, inlining may change runtime behaviour}}
+    baz(); // -> compatible_missing_attrs (no error)
+
+    /// `noinline` has higher precedence than always_inline (so this is not an error)
+    // expected-warning@+2 {{statement attribute 'clang::noinline' has higher precedence than function attribute 'always_inline'}}
+    // expected-attr-warning@+1 {{statement attribute 'clang::noinline' has higher precedence than function attribute 'always_inline'}}
+    [[clang::noinline]] bar();
+}
+
+void streaming_no_warning() SM_ATTR {
+    foo(); // `foo` is not always_inline (no error/warning)
+}

--- a/clang/test/CodeGen/AArch64/sme-inline-streaming-attrs.c
+++ b/clang/test/CodeGen/AArch64/sme-inline-streaming-attrs.c
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -S -o /dev/null -target-feature +sme -target-feature +sme2 -verify -DTEST_NONE %s
-// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -S -o /dev/null -target-feature +sme -target-feature +sme2 -verify -DTEST_COMPATIBLE %s
-// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -S -o /dev/null -target-feature +sme -target-feature +sme2 -verify -DTEST_STREAMING %s
-// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -S -o /dev/null -target-feature +sme -target-feature +sme2 -verify -DTEST_LOCALLY %s
+// RUN: %clang_cc1 -Waarch64-sme-attributes -triple aarch64-none-linux-gnu -S -o /dev/null -target-feature +sme -target-feature +sme2 -verify -DTEST_NONE %s
+// RUN: %clang_cc1 -Waarch64-sme-attributes -triple aarch64-none-linux-gnu -S -o /dev/null -target-feature +sme -target-feature +sme2 -verify -DTEST_COMPATIBLE %s
+// RUN: %clang_cc1 -Waarch64-sme-attributes -triple aarch64-none-linux-gnu -S -o /dev/null -target-feature +sme -target-feature +sme2 -verify -DTEST_STREAMING %s
+// RUN: %clang_cc1 -Waarch64-sme-attributes -triple aarch64-none-linux-gnu -S -o /dev/null -target-feature +sme -target-feature +sme2 -verify -DTEST_LOCALLY %s
 
 // REQUIRES: aarch64-registered-target
 


### PR DESCRIPTION
Previously, we would emit a warning when if we encountered a `always_inline` function with incompatible streaming attributes within a `streaming[_compatible]` function.

This has two major issues.

1. It's prone to false-positives/non-issue warnings
   * Existing library code may be marked `always_inline` without the appropriate `__arm_streaming_compatible` attribute, but the body  the function could still be safe to inline
   * In these cases, the warning can be an annoyance as the issue may not be in the user's code
2. It does not catch transitive errors with non-streaming safe builtins
   * If a non-streaming safe builtin is wrapped in an `always_inline` function, calling that function from a streaming function is simply a warning in the frontend, but can result in a backend crash

This patch improves this by adding a set to `ASTContext` to track if a function contains an expression that is not safe in streaming mode. A function is inserted into this set when a non-streaming builtin is found, or an `always_inline` call to a function in the set is found.

With this, we can emit an error if a non-streaming safe builtin occurs within a function directly or transitively via `always_inline` callees.

This allows us to downgrade the existing warning to only occur with `-Waarch64-sme-attributes`, as it is unlikely to be an issue if the error was not emitted.