### PR TITLE
[libclc] Add support for `nvptx64-nvidia-cuda` triple

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -310,7 +310,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     set( DARCH ${ARCH} )
   endif()
   if ( "${OS}" STREQUAL cuda )
-    set( DOS nvidiacl )
+    set( OS nvidiacl )
   endif()
 
   # Append a variety of target- and triple-based directories to search,

--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -154,6 +154,7 @@ set( LIBCLC_TARGETS_ALL
   r600--
   nvptx64--
   nvptx64--nvidiacl
+  nvptx64-nvidia-cuda
 )
 
 # The mesa3d environment is only available since LLVM 4.0
@@ -205,6 +206,7 @@ set( clspv--_devices none )
 set( clspv64--_devices none )
 set( nvptx64--_devices none )
 set( nvptx64--nvidiacl_devices none )
+set( nvptx64-nvidia-cuda_devices none )
 set( spirv-mesa3d-_devices none )
 set( spirv64-mesa3d-_devices none )
 
@@ -306,6 +308,9 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     set( DARCH amdgcn-amdhsa )
   else()
     set( DARCH ${ARCH} )
+  endif()
+  if ( "${OS}" STREQUAL cuda )
+    set( DOS nvidiacl )
   endif()
 
   # Append a variety of target- and triple-based directories to search,


### PR DESCRIPTION
Summary:
The OS here is the standard CUDA support target, which is the ABI used
for all of the same intrinsics the `nvidiacl` target uses. These can be
aliases asn `cuda` in the triple is the canonical form for most all GPU
compute.
