### PR TITLE
[mlir][dataflow] Use successor.isParent to replace successor.getSuccessor (NFC)

### DIFF
--- a/mlir/lib/Analysis/AliasAnalysis/LocalAliasAnalysis.cpp
+++ b/mlir/lib/Analysis/AliasAnalysis/LocalAliasAnalysis.cpp
@@ -173,7 +173,7 @@ static void collectUnderlyingAddressValues(BlockArgument arg, unsigned maxDepth,
     RegionSuccessor regionSuccessor(region);
     bool found = false;
     for (RegionSuccessor &successor : successors) {
-      if (!successor.isParent()) {
+      if (successor.getSuccessor() == region) {
         LDBG() << "  Found matching region successor: " << successor;
         found = true;
         regionSuccessor = successor;

--- a/mlir/lib/Analysis/AliasAnalysis/LocalAliasAnalysis.cpp
+++ b/mlir/lib/Analysis/AliasAnalysis/LocalAliasAnalysis.cpp
@@ -173,7 +173,7 @@ static void collectUnderlyingAddressValues(BlockArgument arg, unsigned maxDepth,
     RegionSuccessor regionSuccessor(region);
     bool found = false;
     for (RegionSuccessor &successor : successors) {
-      if (successor.getSuccessor() == region) {
+      if (!successor.isParent()) {
         LDBG() << "  Found matching region successor: " << successor;
         found = true;
         regionSuccessor = successor;

--- a/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/DeadCodeAnalysis.cpp
@@ -514,9 +514,9 @@ void DeadCodeAnalysis::visitRegionBranchEdges(
   for (const RegionSuccessor &successor : successors) {
     // The successor can be either an entry block or the parent operation.
     ProgramPoint *point =
-        successor.getSuccessor()
-            ? getProgramPointBefore(&successor.getSuccessor()->front())
-            : getProgramPointAfter(regionBranchOp);
+        successor.isParent()
+            ? getProgramPointAfter(regionBranchOp)
+            : getProgramPointBefore(&successor.getSuccessor()->front());
 
     // Mark the entry block as executable.
     auto *state = getOrCreate<Executable>(point);

--- a/mlir/test/lib/Analysis/DataFlow/TestDenseBackwardDataFlowAnalysis.cpp
+++ b/mlir/test/lib/Analysis/DataFlow/TestDenseBackwardDataFlowAnalysis.cpp
@@ -373,7 +373,7 @@ struct TestNextAccessPass
       SmallVector<RegionSuccessor> regionSuccessors;
       iface.getSuccessorRegions(RegionBranchPoint::parent(), regionSuccessors);
       for (const RegionSuccessor &successor : regionSuccessors) {
-        if (!successor.getSuccessor() || successor.getSuccessor()->empty())
+        if (successor.isParent() || successor.getSuccessor()->empty())
           continue;
         Block &successorBlock = successor.getSuccessor()->front();
         ProgramPoint *successorPoint =


### PR DESCRIPTION
When we check the condition. To make the code logic clearer, use successor.isParent to replace successor.getSuccessor.