### PR TITLE
[X86][llvm][CodeGen] Use 64-bit EH encodings for medium code model

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -151,22 +151,24 @@ void TargetLoweringObjectFileELF::Initialize(MCContext &Ctx,
                         : dwarf::DW_EH_PE_absptr;
     break;
   case Triple::x86_64:
+    // For huge binaries (>2GiB), medium code model may need 64-bit encodings
+    // to avoid relocation overflow in sections such as .gcc_except_table
+    // (LSDA).
     if (isPositionIndependent()) {
       PersonalityEncoding = dwarf::DW_EH_PE_indirect | dwarf::DW_EH_PE_pcrel |
-        ((CM == CodeModel::Small || CM == CodeModel::Medium)
-         ? dwarf::DW_EH_PE_sdata4 : dwarf::DW_EH_PE_sdata8);
+                            (CM == CodeModel::Small ? dwarf::DW_EH_PE_sdata4
+                                                    : dwarf::DW_EH_PE_sdata8);
       LSDAEncoding = dwarf::DW_EH_PE_pcrel |
-        (CM == CodeModel::Small
-         ? dwarf::DW_EH_PE_sdata4 : dwarf::DW_EH_PE_sdata8);
+                     (CM == CodeModel::Small ? dwarf::DW_EH_PE_sdata4
+                                             : dwarf::DW_EH_PE_sdata8);
       TTypeEncoding = dwarf::DW_EH_PE_indirect | dwarf::DW_EH_PE_pcrel |
-        ((CM == CodeModel::Small || CM == CodeModel::Medium)
-         ? dwarf::DW_EH_PE_sdata4 : dwarf::DW_EH_PE_sdata8);
+                      (CM == CodeModel::Small ? dwarf::DW_EH_PE_sdata4
+                                              : dwarf::DW_EH_PE_sdata8);
     } else {
-      PersonalityEncoding =
-        (CM == CodeModel::Small || CM == CodeModel::Medium)
-        ? dwarf::DW_EH_PE_udata4 : dwarf::DW_EH_PE_absptr;
-      LSDAEncoding = (CM == CodeModel::Small)
-        ? dwarf::DW_EH_PE_udata4 : dwarf::DW_EH_PE_absptr;
+      PersonalityEncoding = (CM == CodeModel::Small) ? dwarf::DW_EH_PE_udata4
+                                                     : dwarf::DW_EH_PE_absptr;
+      LSDAEncoding = (CM == CodeModel::Small) ? dwarf::DW_EH_PE_udata4
+                                              : dwarf::DW_EH_PE_absptr;
       TTypeEncoding = (CM == CodeModel::Small)
         ? dwarf::DW_EH_PE_udata4 : dwarf::DW_EH_PE_absptr;
     }

--- a/llvm/test/CodeGen/X86/gcc_except_table_bb_sections.ll
+++ b/llvm/test/CodeGen/X86/gcc_except_table_bb_sections.ll
@@ -19,7 +19,7 @@ define i32 @main() uwtable optsize ssp personality ptr @__gxx_personality_v0 {
 ; PersonalityEncoding = dwarf::DW_EH_PE_udata4 (small/medium)
 ; PersonalityEncoding = dwarf::DW_EH_PE_absptr (large)
 ; CHECK-NON-PIC-SMALL-NEXT:  .cfi_personality 3, __gxx_personality_v0
-; CHECK-NON-PIC-MEDIUM-NEXT: .cfi_personality 3, __gxx_personality_v0
+; CHECK-NON-PIC-MEDIUM-NEXT: .cfi_personality 0, __gxx_personality_v0
 ; CHECK-NON-PIC-LARGE-NEXT:  .cfi_personality 0, __gxx_personality_v0
 ; LSDAEncoding = dwarf::DW_EH_PE_udata4 (small)
 ; LSDAEncoding = dwarf::DW_EH_PE_absptr (medium/large)
@@ -31,7 +31,7 @@ define i32 @main() uwtable optsize ssp personality ptr @__gxx_personality_v0 {
 ; PersonalityEncoding = DW_EH_PE_indirect | DW_EH_PE_pcrel | DW_EH_PE_sdata4 (small/medium)
 ; PersonalityEncoding = DW_EH_PE_indirect | DW_EH_PE_pcrel | DW_EH_PE_sdata8 (large)
 ; CHECK-PIC-SMALL-NEXT:  .cfi_personality 155, DW.ref.__gxx_personality_v0
-; CHECK-PIC-MEDIUM-NEXT: .cfi_personality 155, DW.ref.__gxx_personality_v0
+; CHECK-PIC-MEDIUM-NEXT: .cfi_personality 156, DW.ref.__gxx_personality_v0
 ; CHECK-PIC-LARGE-NEXT:  .cfi_personality 156, DW.ref.__gxx_personality_v0
 ; LSDAEncoding = DW_EH_PE_pcrel | DW_EH_PE_sdata4 (small)
 ; LSDAEncoding = DW_EH_PE_pcrel | DW_EH_PE_sdata8 (medium/large)
@@ -54,14 +54,14 @@ define i32 @main() uwtable optsize ssp personality ptr @__gxx_personality_v0 {
 ; CHECK-NEXT:           .cfi_startproc
 
 ; CHECK-NON-PIC-SMALL-NEXT:  .cfi_personality 3, __gxx_personality_v0
-; CHECK-NON-PIC-MEDIUM-NEXT: .cfi_personality 3, __gxx_personality_v0
+; CHECK-NON-PIC-MEDIUM-NEXT: .cfi_personality 0, __gxx_personality_v0
 ; CHECK-NON-PIC-LARGE-NEXT:  .cfi_personality 0, __gxx_personality_v0
 ; CHECK-NON-PIC-SMALL-NEXT:  .cfi_lsda 3, .Lexception1
 ; CHECK-NON-PIC-MEDIUM-NEXT: .cfi_lsda 0, .Lexception1
 ; CHECK-NON-PIC-LARGE-NEXT:  .cfi_lsda 0, .Lexception1
 
 ; CHECK-PIC-SMALL-NEXT:  .cfi_personality 155, DW.ref.__gxx_personality_v0
-; CHECK-PIC-MEDIUM-NEXT: .cfi_personality 155, DW.ref.__gxx_personality_v0
+; CHECK-PIC-MEDIUM-NEXT: .cfi_personality 156, DW.ref.__gxx_personality_v0
 ; CHECK-PIC-LARGE-NEXT:  .cfi_personality 156, DW.ref.__gxx_personality_v0
 ; CHECK-PIC-SMALL-NEXT:  .cfi_lsda 27, .Lexception1
 ; CHECK-PIC-MEDIUM-NEXT: .cfi_lsda 28, .Lexception1
@@ -73,14 +73,14 @@ define i32 @main() uwtable optsize ssp personality ptr @__gxx_personality_v0 {
 ; CHECK-NEXT:           .cfi_startproc
 
 ; CHECK-NON-PIC-SMALL-NEXT:  .cfi_personality 3, __gxx_personality_v0
-; CHECK-NON-PIC-MEDIUM-NEXT: .cfi_personality 3, __gxx_personality_v0
+; CHECK-NON-PIC-MEDIUM-NEXT: .cfi_personality 0, __gxx_personality_v0
 ; CHECK-NON-PIC-LARGE-NEXT:  .cfi_personality 0, __gxx_personality_v0
 ; CHECK-NON-PIC-SMALL-NEXT:  .cfi_lsda 3, .Lexception2
 ; CHECK-NON-PIC-MEDIUM-NEXT: .cfi_lsda 0, .Lexception2
 ; CHECK-NON-PIC-LARGE-NEXT:  .cfi_lsda 0, .Lexception2
 
 ; CHECK-PIC-SMALL-NEXT:  .cfi_personality 155, DW.ref.__gxx_personality_v0
-; CHECK-PIC-MEDIUM-NEXT: .cfi_personality 155, DW.ref.__gxx_personality_v0
+; CHECK-PIC-MEDIUM-NEXT: .cfi_personality 156, DW.ref.__gxx_personality_v0
 ; CHECK-PIC-LARGE-NEXT:  .cfi_personality 156, DW.ref.__gxx_personality_v0
 ; CHECK-PIC-SMALL-NEXT:  .cfi_lsda 27, .Lexception2
 ; CHECK-PIC-MEDIUM-NEXT: .cfi_lsda 28, .Lexception2
@@ -137,7 +137,7 @@ declare i32 @__gxx_personality_v0(...)
 
 ;; Verify @TType encoding for PIC mode.
 ; CHECK-PIC-SMALL-NEXT: .byte 155                       # @TType Encoding = indirect pcrel sdata4
-; CHECK-PIC-MEDIUM-NEXT:.byte 155                       # @TType Encoding = indirect pcrel sdata4
+; CHECK-PIC-MEDIUM-NEXT:.byte 156                       # @TType Encoding = indirect pcrel sdata8
 ; CHECK-PIC-LARGE-NEXT: .byte 156                       # @TType Encoding = indirect pcrel sdata8
 
 ; CHECK-NEXT:           .uleb128 .Lttbase0-.Lttbaseref0
@@ -166,7 +166,7 @@ declare i32 @__gxx_personality_v0(...)
 ; CHECK-NON-PIC-LARGE-NEXT:  .byte	0               # @TType Encoding = absptr
 
 ; CHECK-PIC-SMALL-NEXT: .byte 155                       # @TType Encoding = indirect pcrel sdata4
-; CHECK-PIC-MEDIUM-NEXT:.byte 155                       # @TType Encoding = indirect pcrel sdata4
+; CHECK-PIC-MEDIUM-NEXT:.byte 156                       # @TType Encoding = indirect pcrel sdata8
 ; CHECK-PIC-LARGE-NEXT: .byte 156                       # @TType Encoding = indirect pcrel sdata8
 
 ; CHECK-NEXT:           .uleb128 .Lttbase0-.Lttbaseref1
@@ -191,7 +191,7 @@ declare i32 @__gxx_personality_v0(...)
 ; CHECK-NON-PIC-LARGE-NEXT:  .byte	0               # @TType Encoding = absptr
 
 ; CHECK-PIC-SMALL-NEXT:  .byte 155                      # @TType Encoding = indirect pcrel sdata4
-; CHECK-PIC-MEDIUM-NEXT: .byte 155                      # @TType Encoding = indirect pcrel sdata4
+; CHECK-PIC-MEDIUM-NEXT: .byte 156                      # @TType Encoding = indirect pcrel sdata8
 ; CHECK-PIC-LARGE-NEXT:  .byte 156                      # @TType Encoding = indirect pcrel sdata8
 
 ; CHECK-NEXT:           .uleb128 .Lttbase0-.Lttbaseref2
@@ -219,7 +219,7 @@ declare i32 @__gxx_personality_v0(...)
 
 ; CHECK-PIC-NEXT:     [[DOT:\.Ltmp[0-9]+]]:
 ; CHECK-PIC-SMALL-NEXT:  .long .L_ZTIi.DW.stub-[[DOT]]
-; CHECK-PIC-MEDIUM-NEXT: .long .L_ZTIi.DW.stub-[[DOT]]
+; CHECK-PIC-MEDIUM-NEXT: .quad .L_ZTIi.DW.stub-[[DOT]]
 ; CHECK-PIC-LARGE-NEXT:  .quad .L_ZTIi.DW.stub-[[DOT]]
 
 ; CHECK-NEXT:         .Lttbase0:


### PR DESCRIPTION
Motivation:
This is related to #174486  & #174508 and part of a larger effort to support larger binaries (>2GiB .text) while still retaining the medium code-model.

Summary:
For huge binaries (>2GiB), the medium code model may need 64-bit encodings to avoid relocation overflow in exception handling sections such as .gcc_except_table (LSDA).

Previously, both Small and Medium code models used 4-byte (sdata4/udata4) encodings for PersonalityEncoding and TTypeEncoding. However, when binaries exceed 2GiB, PC-relative offsets may overflow with 32-bit encodings, leading to linker errors; this can occur with sections in between the two causing huge bloat.

This change modifies x86_64 to only use 4-byte encodings for the Small code model, allowing Medium and Large code models to use 8-byte encodings (sdata8/absptr) which can address the full 64-bit address space.

Design consideration:
I chose to make this the default for the medium code-model however I can also introduce another configuration variable similar to #174508 (or leverage the same one).