### PR TITLE
[CIR] Upstream CIR method attribute handling

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -179,6 +179,11 @@ public:
     return getPointerTo(cir::VoidType::get(getContext()), as);
   }
 
+  cir::MethodAttr getMethodAttr(cir::MethodType ty, cir::FuncOp methodFuncOp) {
+    auto methodFuncSymbolRef = mlir::FlatSymbolRefAttr::get(methodFuncOp);
+    return cir::MethodAttr::get(ty, methodFuncSymbolRef);
+  }
+
   cir::BoolAttr getCIRBoolAttr(bool state) {
     return cir::BoolAttr::get(getContext(), state);
   }

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -515,6 +515,20 @@ def CIR_MethodAttr : CIR_Attr<"Method", "method", [TypedAttrInterface]> {
 
     If `symbol` is not present, the attribute represents a null pointer
     constant.
+
+    Examples:
+    ```
+    // Non-virtual method
+    %0 = cir.const #cir.method<@_ZN1S2m1Ei> :
+             !cir.method<!cir.func<(!s32i)> in !rec_S>
+
+    // Virtual method (not yet implemented)
+    %1 = cir.const #cir.method<vtable_offset = 8> :
+             !cir.method<!cir.func<(!s32i)> in !rec_S>
+
+    // Null method pointer
+    %0 = cir.const #cir.method<null> :
+             !cir.method<!cir.func<(!s32i)> in !rec_S>
   }];
 
   let parameters = (ins AttributeSelfTypeParameter<

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -499,6 +499,49 @@ def CIR_DataMemberAttr : CIR_Attr<"DataMember", "data_member", [
 }
 
 //===----------------------------------------------------------------------===//
+// MethodAttr
+//===----------------------------------------------------------------------===//
+
+def CIR_MethodAttr : CIR_Attr<"Method", "method", [TypedAttrInterface]> {
+  let summary = "Holds a constant pointer-to-member-function value";
+  let description = [{
+    A method attribute is a literal attribute that represents a constant
+    pointer-to-member-function value.
+
+    If the member function is a non-virtual function, the `symbol` parameter
+    gives the global symbol for the non-virtual member function.
+
+    Virtual function handling is not yet implemented.
+
+    If `symbol` is not present, the attribute represents a null pointer
+    constant.
+  }];
+
+  let parameters = (ins AttributeSelfTypeParameter<
+                            "", "cir::MethodType">:$type,
+                        OptionalParameter<
+                            "std::optional<mlir::FlatSymbolRefAttr>">:$symbol);
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "cir::MethodType":$type), [{
+      return $_get(type.getContext(), type, std::nullopt);
+    }]>,
+    AttrBuilderWithInferredContext<(ins "cir::MethodType":$type,
+                                        "mlir::FlatSymbolRefAttr":$symbol), [{
+      return $_get(type.getContext(), type, symbol);
+    }]>,
+  ];
+
+  let hasCustomAssemblyFormat = 1;
+
+  let extraClassDeclaration = [{
+    bool isNull() const {
+      return !getSymbol().has_value();
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // GlobalViewAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -347,6 +347,7 @@ struct MissingFeatures {
   static bool useEHCleanupForArray() { return false; }
   static bool vaArgABILowering() { return false; }
   static bool vectorConstants() { return false; }
+  static bool virtualMethodAttr() { return false; }
   static bool vlas() { return false; }
   static bool vtableInitialization() { return false; }
   static bool vtableEmitMetadata() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1527,9 +1527,18 @@ mlir::Value CIRGenModule::emitMemberPointerConstant(const UnaryOperator *e) {
   const auto *decl = cast<DeclRefExpr>(e->getSubExpr())->getDecl();
 
   // A member function pointer.
-  if (isa<CXXMethodDecl>(decl)) {
-    errorNYI(e->getSourceRange(), "emitMemberPointerConstant: method pointer");
-    return {};
+  if (const auto *methodDecl = dyn_cast<CXXMethodDecl>(decl)) {
+    auto ty = mlir::cast<cir::MethodType>(convertType(e->getType()));
+    if (methodDecl->isVirtual()) {
+      assert(!cir::MissingFeatures::virtualMethodAttr());
+      errorNYI(e->getSourceRange(),
+               "emitMemberPointerConstant: virtual method pointer");
+      return {};
+    }
+
+    auto methodFuncOp = getAddrOfFunction(methodDecl);
+    return cir::ConstantOp::create(builder, loc,
+                                   builder.getMethodAttr(ty, methodFuncOp));
   }
 
   // Otherwise, a member data pointer.

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1536,7 +1536,7 @@ mlir::Value CIRGenModule::emitMemberPointerConstant(const UnaryOperator *e) {
       return {};
     }
 
-    auto methodFuncOp = getAddrOfFunction(methodDecl);
+    cir::FuncOp methodFuncOp = getAddrOfFunction(methodDecl);
     return cir::ConstantOp::create(builder, loc,
                                    builder.getMethodAttr(ty, methodFuncOp));
   }

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -313,7 +313,7 @@ Attribute MethodAttr::parse(AsmParser &parser, Type odsType) {
 
   // Try to parse the null pointer constant.
   if (parser.parseOptionalKeyword("null").succeeded()) {
-    if (parser.parseGreater())
+    if (parser.parseGreater().failed())
       return {};
     return get(ty);
   }
@@ -321,11 +321,12 @@ Attribute MethodAttr::parse(AsmParser &parser, Type odsType) {
   // Try to parse a flat symbol ref for a pointer to non-virtual member
   // function.
   FlatSymbolRefAttr symbol;
-  auto parseSymbolRefResult = parser.parseOptionalAttribute(symbol);
+  mlir::OptionalParseResult parseSymbolRefResult =
+      parser.parseOptionalAttribute(symbol);
   if (parseSymbolRefResult.has_value()) {
     if (parseSymbolRefResult.value().failed())
       return {};
-    if (parser.parseGreater())
+    if (parser.parseGreater().failed())
       return {};
     return get(ty, symbol);
   }

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -302,6 +302,50 @@ DataMemberAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 }
 
 //===----------------------------------------------------------------------===//
+// MethodAttr definitions
+//===----------------------------------------------------------------------===//
+
+Attribute MethodAttr::parse(AsmParser &parser, Type odsType) {
+  auto ty = mlir::cast<cir::MethodType>(odsType);
+
+  if (parser.parseLess().failed())
+    return {};
+
+  // Try to parse the null pointer constant.
+  if (parser.parseOptionalKeyword("null").succeeded()) {
+    if (parser.parseGreater())
+      return {};
+    return get(ty);
+  }
+
+  // Try to parse a flat symbol ref for a pointer to non-virtual member
+  // function.
+  FlatSymbolRefAttr symbol;
+  auto parseSymbolRefResult = parser.parseOptionalAttribute(symbol);
+  if (parseSymbolRefResult.has_value()) {
+    if (parseSymbolRefResult.value().failed())
+      return {};
+    if (parser.parseGreater())
+      return {};
+    return get(ty, symbol);
+  }
+
+  return {};
+}
+
+void MethodAttr::print(AsmPrinter &printer) const {
+  auto symbol = getSymbol();
+
+  printer << '<';
+  if (symbol.has_value()) {
+    printer << *symbol;
+  } else {
+    printer << "null";
+  }
+  printer << '>';
+}
+
+//===----------------------------------------------------------------------===//
 // CIR ConstArrayAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -358,9 +358,9 @@ static LogicalResult checkConstantTypes(mlir::Operation *op, mlir::Type opType,
     return success();
   }
 
-  if (isa<cir::DataMemberAttr>(attrType)) {
+  if (isa<cir::DataMemberAttr, cir::MethodAttr>(attrType)) {
     // More detailed type verifications are already done in
-    // DataMemberAttr::verify. Don't need to repeat here.
+    // DataMemberAttr::verify or MethodAttr::verify. Don't need to repeat here.
     return success();
   }
 

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -143,6 +143,15 @@ mlir::LogicalResult CIRConstantOpABILowering::matchAndRewrite(
     return mlir::success();
   }
 
+  if (mlir::isa<cir::MethodType>(op.getType())) {
+    auto method = mlir::cast<cir::MethodAttr>(op.getValue());
+    mlir::DataLayout layout(op->getParentOfType<mlir::ModuleOp>());
+    mlir::TypedAttr abiValue = lowerModule->getCXXABI().lowerMethodConstant(
+        method, layout, *getTypeConverter());
+    rewriter.replaceOpWithNewOp<ConstantOp>(op, abiValue);
+    return mlir::success();
+  }
+
   llvm_unreachable("constant operand is not an CXXABI-dependent type");
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -53,6 +53,12 @@ public:
                           const mlir::DataLayout &layout,
                           const mlir::TypeConverter &typeConverter) const = 0;
 
+  /// Lower the given member function pointer constant to a constant of the ABI
+  /// type. The returned constant is represented as an attribute as well.
+  virtual mlir::TypedAttr
+  lowerMethodConstant(cir::MethodAttr attr, const mlir::DataLayout &layout,
+                      const mlir::TypeConverter &typeConverter) const = 0;
+
   /// Lower the given cir.get_runtime_member op to a sequence of more
   /// "primitive" CIR operations that act on the ABI types.
   virtual mlir::Operation *

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -47,6 +47,10 @@ public:
       cir::DataMemberAttr attr, const mlir::DataLayout &layout,
       const mlir::TypeConverter &typeConverter) const override;
 
+  mlir::TypedAttr
+  lowerMethodConstant(cir::MethodAttr attr, const mlir::DataLayout &layout,
+                      const mlir::TypeConverter &typeConverter) const override;
+
   mlir::Operation *
   lowerGetRuntimeMember(cir::GetRuntimeMemberOp op, mlir::Type loweredResultTy,
                         mlir::Value loweredAddr, mlir::Value loweredMember,
@@ -127,6 +131,50 @@ mlir::TypedAttr LowerItaniumCXXABI::lowerDataMemberConstant(
 
   mlir::Type abiTy = lowerDataMemberType(attr.getType(), typeConverter);
   return cir::IntAttr::get(abiTy, memberOffset);
+}
+
+mlir::TypedAttr LowerItaniumCXXABI::lowerMethodConstant(
+    cir::MethodAttr attr, const mlir::DataLayout &layout,
+    const mlir::TypeConverter &typeConverter) const {
+  cir::IntType ptrdiffCIRTy = getPtrDiffCIRTy(lm);
+  auto loweredMethodTy = mlir::cast<cir::RecordType>(
+      lowerMethodType(attr.getType(), typeConverter));
+
+  auto zero = cir::IntAttr::get(ptrdiffCIRTy, 0);
+
+  // Itanium C++ ABI 2.3.2:
+  //   In all representations, the basic ABI properties of member function
+  //   pointer types are those of the following class, where fnptr_t is the
+  //   appropriate function-pointer type for a member function of this type:
+  //
+  //   struct {
+  //     fnptr_t ptr;
+  //     ptrdiff_t adj;
+  //   };
+
+  if (attr.isNull()) {
+    // Itanium C++ ABI 2.3.2:
+    //
+    //   In the standard representation, a null member function pointer is
+    //   represented with ptr set to a null pointer. The value of adj is
+    //   unspecified for null member function pointers.
+    //
+    // clang CodeGen emits struct{null, null} for null member function pointers.
+    // Let's do the same here.
+    return cir::ConstRecordAttr::get(
+        loweredMethodTy, mlir::ArrayAttr::get(attr.getContext(), {zero, zero}));
+  }
+
+  assert(!cir::MissingFeatures::virtualMethodAttr());
+
+  // Itanium C++ ABI 2.3.2:
+  //
+  //   A member function pointer for a non-virtual member function is
+  //   represented with ptr set to a pointer to the function, using the base
+  //   ABI's representation of function pointers.
+  auto ptr = cir::GlobalViewAttr::get(ptrdiffCIRTy, attr.getSymbol().value());
+  return cir::ConstRecordAttr::get(
+      loweredMethodTy, mlir::ArrayAttr::get(attr.getContext(), {ptr, zero}));
 }
 
 mlir::Operation *LowerItaniumCXXABI::lowerGetRuntimeMember(

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -137,6 +137,10 @@ mlir::TypedAttr LowerItaniumCXXABI::lowerMethodConstant(
     cir::MethodAttr attr, const mlir::DataLayout &layout,
     const mlir::TypeConverter &typeConverter) const {
   cir::IntType ptrdiffCIRTy = getPtrDiffCIRTy(lm);
+
+  // lowerMethodType returns the CIR type used to represent the method pointer
+  // in an ABI-specific way. That's why lowerMethodType returns cir::RecordType
+  // here.
   auto loweredMethodTy = mlir::cast<cir::RecordType>(
       lowerMethodType(attr.getType(), typeConverter));
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -578,6 +578,10 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::GlobalViewAttr globalAttr) {
                                   mlir::LLVM::GEPNoWrapFlags::none);
   }
 
+  // We can have a global view with an integer type in the case of method
+  // pointers. With the Itanium ABI, the #cir.method attribute is lowered to a
+  // #cir.global_view with a pointer-sized integer representing the address of
+  // the method.
   if (auto intTy = mlir::dyn_cast<cir::IntType>(globalAttr.getType())) {
     mlir::Type llvmDstTy = converter->convertType(globalAttr.getType());
     return mlir::LLVM::PtrToIntOp::create(rewriter, parentOp->getLoc(),

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -579,7 +579,7 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::GlobalViewAttr globalAttr) {
   }
 
   if (auto intTy = mlir::dyn_cast<cir::IntType>(globalAttr.getType())) {
-    auto llvmDstTy = converter->convertType(globalAttr.getType());
+    mlir::Type llvmDstTy = converter->convertType(globalAttr.getType());
     return mlir::LLVM::PtrToIntOp::create(rewriter, parentOp->getLoc(),
                                           llvmDstTy, addrOp);
   }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -578,11 +578,11 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::GlobalViewAttr globalAttr) {
                                   mlir::LLVM::GEPNoWrapFlags::none);
   }
 
-  // The incubator has handling here for the attribute having integer type, but
-  // the only test case I could find that reaches it is a direct CIR-to-LLVM IR
-  // lowering with no clear indication of how the CIR might have been generated.
-  // We'll hit the unreachable below if this happens.
-  assert(!cir::MissingFeatures::globalViewIntLowering());
+  if (auto intTy = mlir::dyn_cast<cir::IntType>(globalAttr.getType())) {
+    auto llvmDstTy = converter->convertType(globalAttr.getType());
+    return mlir::LLVM::PtrToIntOp::create(rewriter, parentOp->getLoc(),
+                                          llvmDstTy, addrOp);
+  }
 
   if (auto ptrTy = mlir::dyn_cast<cir::PointerType>(globalAttr.getType())) {
     mlir::Type llvmEltTy =
@@ -1802,7 +1802,10 @@ mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
   } else if (mlir::isa<cir::IntType>(op.getType())) {
     // Lower GlobalViewAttr to llvm.mlir.addressof + llvm.mlir.ptrtoint
     if (auto ga = mlir::dyn_cast<cir::GlobalViewAttr>(op.getValue())) {
-      // See the comment in visitCirAttr for why this isn't implemented.
+      // We can have a global view with an integer type in the case of method
+      // pointers, but the lowering of those doesn't go through this path.
+      // They are handled in the visitCirAttr. This is left as an error until
+      // we have a test case that reaches it.
       assert(!cir::MissingFeatures::globalViewIntLowering());
       op.emitError() << "global view with integer type";
       return mlir::failure();

--- a/clang/test/CIR/IR/method-attr.cir
+++ b/clang/test/CIR/IR/method-attr.cir
@@ -1,0 +1,41 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+!void = !cir.void
+
+!rec_Foo = !cir.record<struct "Foo" {!cir.vptr}>
+!s32i = !cir.int<s, 32>
+module {
+  cir.func private @_ZN3Foo2m1Ei(!s32i)
+  cir.func no_inline dso_local @_Z16make_non_virtualv() -> !cir.method<!cir.func<(!s32i)> in !rec_Foo> {
+    %0 = cir.alloca !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, ["__retval"] {alignment = 8 : i64}
+    %1 = cir.const #cir.method<@_ZN3Foo2m1Ei> : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+    cir.store %1, %0 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>
+    %2 = cir.load %0 : !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+    cir.return %2 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+  }
+
+// CHECK:  cir.func no_inline dso_local @_Z16make_non_virtualv() -> !cir.method<!cir.func<(!s32i)> in !rec_Foo> {
+// CHECK:    %0 = cir.alloca !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, ["__retval"] {alignment = 8 : i64}
+// CHECK:    %1 = cir.const #cir.method<@_ZN3Foo2m1Ei> : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CHECK:    cir.store %1, %0 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>
+// CHECK:    %2 = cir.load %0 : !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CHECK:    cir.return %2 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CHECK:  }
+
+  cir.func no_inline dso_local @_Z9make_nullv() -> !cir.method<!cir.func<(!s32i)> in !rec_Foo> {
+    %0 = cir.alloca !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, ["__retval"] {alignment = 8 : i64}
+    %1 = cir.const #cir.method<null> : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+    cir.store %1, %0 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>
+    %2 = cir.load %0 : !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+    cir.return %2 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+  }
+
+// CHECK:  cir.func no_inline dso_local @_Z9make_nullv() -> !cir.method<!cir.func<(!s32i)> in !rec_Foo> {
+// CHECK:    %0 = cir.alloca !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, ["__retval"] {alignment = 8 : i64}
+// CHECK:    %1 = cir.const #cir.method<null> : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CHECK:    cir.store %1, %0 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>
+// CHECK:    %2 = cir.load %0 : !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CHECK:    cir.return %2 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CHECK:  }
+
+}


### PR DESCRIPTION
This adds code for generating cir.method attributes and lowering them to LLVM IR to implement support the C++ method pointer variables.