### PR TITLE
[compiler-rt] Support default-True lit config options (follow up to #174522)

### DIFF
--- a/compiler-rt/test/lit.common.configured.in
+++ b/compiler-rt/test/lit.common.configured.in
@@ -2,7 +2,7 @@
 
 # Set attribute value if it is unset.
 def set_default(attr, value):
-  if not getattr(config, attr, None):
+  if getattr(config, attr, "") == "":
     setattr(config, attr, value)
 
 # Generic config options for all compiler-rt lit tests.


### PR DESCRIPTION
The option added in #174522 breaks simulator tests, since `set_default` overrides `False` values with the default.

Since these options are either string or boolean, this patches set_default to override only un-set or empty string values (empty string is not truth-y and therefore would be overwritten by defaults currently, so this is NFCI)