### PR TITLE
[BOLT] Remove unnecessary dependency. NFC

### DIFF
--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -14,7 +14,6 @@
 #ifndef BOLT_CORE_MCPLUSBUILDER_H
 #define BOLT_CORE_MCPLUSBUILDER_H
 
-#include "bolt/Core/BinaryBasicBlock.h"
 #include "bolt/Core/MCPlus.h"
 #include "bolt/Core/Relocation.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -2042,7 +2041,7 @@ public:
   /// targets).
   virtual std::optional<uint64_t>
   findMemcpySizeInBytes(const BinaryBasicBlock &BB,
-                        BinaryBasicBlock::iterator CallInst) const {
+                        InstructionListType::iterator CallInst) const {
     return std::nullopt;
   }
 

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -2971,7 +2971,7 @@ public:
 
   std::optional<uint64_t>
   findMemcpySizeInBytes(const BinaryBasicBlock &BB,
-                        BinaryBasicBlock::iterator CallInst) const override {
+                        InstructionListType::iterator CallInst) const override {
     MCPhysReg SizeReg = getIntArgRegister(2);
     if (SizeReg == getNoRegister())
       return std::nullopt;


### PR DESCRIPTION
There's no need for a full definition of `BinaryBasicBlock` in `MCPlusBuilder.h`. Use `InstructionListType::iterator` instead of `BinaryBasicBlock::iterator` in `findMemcpySizeInBytes()`.