### PR TITLE
[VPlan] Mark variable unused in release build [[maybe_unused]]

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -291,7 +291,7 @@ struct Recipe_match {
       return false;
 
     if (R->getNumOperands() != std::tuple_size_v<Ops_t>) {
-      auto *RepR = dyn_cast<VPReplicateRecipe>(R);
+      [[maybe_unused]] auto *RepR = dyn_cast<VPReplicateRecipe>(R);
       assert((Opcode == Instruction::PHI ||
               (RepR && std::tuple_size_v<Ops_t> ==
                            RepR->getNumOperands() - RepR->isPredicated())) &&


### PR DESCRIPTION
To prevent compiler warnings when building without assertions turned on.