### PR TITLE
[CIR] Fold unary operations and simple casts

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -66,6 +66,11 @@ public:
     return cir::ConstantOp::create(*this, loc, cir::IntAttr::get(typ, val));
   }
 
+  mlir::Value getConstAPFloat(mlir::Location loc, mlir::Type typ,
+                              const llvm::APFloat &val) {
+    return cir::ConstantOp::create(*this, loc, cir::FPAttr::get(typ, val));
+  }
+
   cir::ConstantOp getConstant(mlir::Location loc, mlir::TypedAttr attr) {
     return cir::ConstantOp::create(*this, loc, attr);
   }

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -420,6 +420,12 @@ def CIR_ConstantOp : CIR_Op<"const", [
       llvm_unreachable("Expected an IntAttr in ConstantOp");
     }
 
+    llvm::APFloat getFloatValue() {
+      if (const auto fpAttr = getValueAttr<cir::FPAttr>())
+        return fpAttr.getValue();
+      llvm_unreachable("Expected an FPAttr in ConstantOp");
+    }
+
     bool getBoolValue() {
       if (const auto boolAttr = getValueAttr<cir::BoolAttr>())
         return boolAttr.getValue();

--- a/clang/test/CIR/CodeGen/aapcs-volatile-bitfields.c
+++ b/clang/test/CIR/CodeGen/aapcs-volatile-bitfields.c
@@ -179,11 +179,10 @@ void check_store(st2 *s2) {
 }
 
 // CIR:  cir.func {{.*}} @check_store
-// CIR:    [[CONST:%.*]] = cir.const #cir.int<1> : !s32i
-// CIR:    [[CAST:%.*]] = cir.cast integral [[CONST]] : !s32i -> !s16i
+// CIR:    [[CONST:%.*]] = cir.const #cir.int<1> : !s16i
 // CIR:    [[LOAD:%.*]] = cir.load align(8) {{.*}} : !cir.ptr<!cir.ptr<!rec_st2>>, !cir.ptr<!rec_st2>
 // CIR:    [[MEMBER:%.*]] = cir.get_member [[LOAD]][0] {name = "a"} : !cir.ptr<!rec_st2> -> !cir.ptr<!u32i>
-// CIR:    [[SETBF:%.*]] = cir.set_bitfield align(8) (#bfi_a, [[MEMBER]] : !cir.ptr<!u32i>, [[CAST]] : !s16i) {is_volatile} -> !s16i
+// CIR:    [[SETBF:%.*]] = cir.set_bitfield align(8) (#bfi_a, [[MEMBER]] : !cir.ptr<!u32i>, [[CONST]] : !s16i) {is_volatile} -> !s16i
 // CIR:    cir.return
 
 // LLVM:define dso_local void @check_store
@@ -210,11 +209,10 @@ void check_store_exception(st3 *s3) {
 }
 
 // CIR:  cir.func {{.*}} @check_store_exception
-// CIR:    [[CONST:%.*]] = cir.const #cir.int<2> : !s32i
-// CIR:    [[CAST:%.*]] = cir.cast integral [[CONST]] : !s32i -> !u32i
+// CIR:    [[CONST:%.*]] = cir.const #cir.int<2> : !u32i
 // CIR:    [[LOAD:%.*]] = cir.load align(8) {{.*}} : !cir.ptr<!cir.ptr<!rec_st3>>, !cir.ptr<!rec_st3>
 // CIR:    [[MEMBER:%.*]] = cir.get_member [[LOAD]][2] {name = "b"} : !cir.ptr<!rec_st3> -> !cir.ptr<!u8i>
-// CIR:    [[SETBF:%.*]] = cir.set_bitfield align(4) (#bfi_b1, [[MEMBER]] : !cir.ptr<!u8i>, [[CAST]] : !u32i) {is_volatile} -> !u32i
+// CIR:    [[SETBF:%.*]] = cir.set_bitfield align(4) (#bfi_b1, [[MEMBER]] : !cir.ptr<!u8i>, [[CONST]] : !u32i) {is_volatile} -> !u32i
 // CIR:    cir.return
 
 // LLVM:define dso_local void @check_store_exception
@@ -262,11 +260,10 @@ void check_store_second_member (st4 *s4) {
 }
 
 // CIR:  cir.func {{.*}} @check_store_second_member
-// CIR:    [[ONE:%.*]] = cir.const #cir.int<1> : !s32i
-// CIR:    [[CAST:%.*]] = cir.cast integral [[ONE]] : !s32i -> !u64i
+// CIR:    [[ONE:%.*]] = cir.const #cir.int<1> : !u64i
 // CIR:    [[LOAD:%.*]] = cir.load align(8) {{.*}} : !cir.ptr<!cir.ptr<!rec_st4>>, !cir.ptr<!rec_st4>
 // CIR:    [[MEMBER:%.*]] = cir.get_member [[LOAD]][2] {name = "b"} : !cir.ptr<!rec_st4> -> !cir.ptr<!u16i>
-// CIR:    cir.set_bitfield align(8) (#bfi_b2, [[MEMBER]] : !cir.ptr<!u16i>, [[CAST]] : !u64i) {is_volatile} -> !u64i
+// CIR:    cir.set_bitfield align(8) (#bfi_b2, [[MEMBER]] : !cir.ptr<!u16i>, [[ONE]] : !u64i) {is_volatile} -> !u64i
 
 // LLVM: define dso_local void @check_store_second_member
 // LLVM:   [[LOAD:%.*]] = load ptr, ptr {{.*}}, align 8

--- a/clang/test/CIR/CodeGen/assign-operator.cpp
+++ b/clang/test/CIR/CodeGen/assign-operator.cpp
@@ -16,9 +16,8 @@ void a() {
 // CIR: cir.func {{.*}} @_ZN1xaSEi(!cir.ptr<!rec_x>, !s32i)
 // CIR: cir.func{{.*}} @_Z1av()
 // CIR:   %[[A_ADDR:.*]] = cir.alloca !rec_x, !cir.ptr<!rec_x>, ["a"]
-// CIR:   %[[ONE:.*]] = cir.const #cir.int<1> : !u32i
-// CIR:   %[[ONE_CAST:.*]] = cir.cast integral %[[ONE]] : !u32i -> !s32i
-// CIR:   %[[RET:.*]] = cir.call @_ZN1xaSEi(%[[A_ADDR]], %[[ONE_CAST]]) : (!cir.ptr<!rec_x>, !s32i) -> !s32i
+// CIR:   %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+// CIR:   %[[RET:.*]] = cir.call @_ZN1xaSEi(%[[A_ADDR]], %[[ONE]]) : (!cir.ptr<!rec_x>, !s32i) -> !s32i
 
 // LLVM: define{{.*}} @_Z1av(){{.*}}
 // OGCG: define{{.*}} @_Z1av()

--- a/clang/test/CIR/CodeGen/basic.c
+++ b/clang/test/CIR/CodeGen/basic.c
@@ -293,12 +293,9 @@ size_type max_size(void) {
 }
 
 // CIR: cir.func{{.*}} @max_size()
-// CIR:   %0 = cir.alloca !u64i, !cir.ptr<!u64i>, ["__retval"] {alignment = 8 : i64}
-// CIR:   %1 = cir.const #cir.int<0> : !s32i
-// CIR:   %2 = cir.unary(not, %1) : !s32i, !s32i
-// CIR:   %3 = cir.cast integral %2 : !s32i -> !u64i
-// CIR:   %4 = cir.const #cir.int<8> : !u64i
-// CIR:   %5 = cir.binop(div, %3, %4) : !u64i
+// CIR:   %[[NOT_ZERO:.*]] = cir.const #cir.int<18446744073709551615> : !u64i
+// CIR:   %[[SIZE_OF_TP:.*]] = cir.const #cir.int<8> : !u64i
+// CIR:   %[[RESULT:.*]] = cir.binop(div, %[[NOT_ZERO]], %[[SIZE_OF_TP]]) : !u64i
 
 // LLVM: define{{.*}} i64 @max_size()
 // LLVM:   store i64 2305843009213693951, ptr

--- a/clang/test/CIR/CodeGen/basic.cpp
+++ b/clang/test/CIR/CodeGen/basic.cpp
@@ -121,16 +121,9 @@ size_type max_size() {
 }
 
 // CHECK: cir.func{{.*}} @_Z8max_sizev() -> !u64i
-// CHECK:   %0 = cir.alloca !u64i, !cir.ptr<!u64i>, ["__retval"] {alignment = 8 : i64}
-// CHECK:   %1 = cir.const #cir.int<0> : !s32i
-// CHECK:   %2 = cir.unary(not, %1) : !s32i, !s32i
-// CHECK:   %3 = cir.cast integral %2 : !s32i -> !u64i
-// CHECK:   %4 = cir.const #cir.int<8> : !u64i
-// CHECK:   %5 = cir.binop(div, %3, %4) : !u64i
-// CHECK:   cir.store{{.*}} %5, %0 : !u64i, !cir.ptr<!u64i>
-// CHECK:   %6 = cir.load{{.*}} %0 : !cir.ptr<!u64i>, !u64i
-// CHECK:   cir.return %6 : !u64i
-// CHECK:   }
+// CHECK:   %[[NOT_ZERO:.*]] = cir.const #cir.int<18446744073709551615> : !u64i
+// CHECK:   %[[SIZE_OF_TP:.*]] = cir.const #cir.int<8> : !u64i
+// CHECK:   %[[RESULT:.*]] = cir.binop(div, %[[NOT_ZERO]], %[[SIZE_OF_TP]]) : !u64i
 
 void ref_arg(int &x) {
   int y = x;

--- a/clang/test/CIR/CodeGen/binassign.c
+++ b/clang/test/CIR/CodeGen/binassign.c
@@ -24,8 +24,7 @@ void binary_assign(void) {
 // CIR:         %[[I:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i"]
 // CIR:         %[[TRUE:.*]] = cir.const #true
 // CIR:         cir.store{{.*}} %[[TRUE]], %[[B]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:         %[[CHAR_INI_INIT:.*]] = cir.const #cir.int<65> : !s32i
-// CIR:         %[[CHAR_VAL:.*]] = cir.cast integral %[[CHAR_INI_INIT]] : !s32i -> !s8i
+// CIR:         %[[CHAR_VAL:.*]] = cir.const #cir.int<65> : !s8i
 // CIR:         cir.store{{.*}} %[[CHAR_VAL]], %[[C]] : !s8i, !cir.ptr<!s8i>
 // CIR:         %[[FLOAT_VAL:.*]] = cir.const #cir.fp<3.140000e+00> : !cir.float
 // CIR:         cir.store{{.*}} %[[FLOAT_VAL]], %[[F]] : !cir.float, !cir.ptr<!cir.float>

--- a/clang/test/CIR/CodeGen/bitfields_be.c
+++ b/clang/test/CIR/CodeGen/bitfields_be.c
@@ -52,12 +52,11 @@ void load(S* s) {
 
 // field 'a'
 // CIR: cir.func {{.*}} @load
-// CIR:    %[[PTR0:.*]] = cir.alloca !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>, ["s", init] {alignment = 8 : i64} loc(#loc35)
-// CIR:    %[[CONST1:.*]] = cir.const #cir.int<4> : !s32i
-// CIR:    %[[MIN1:.*]] = cir.unary(minus, %[[CONST1]]) nsw : !s32i, !s32i
+// CIR:    %[[PTR0:.*]] = cir.alloca !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>, ["s", init]
+// CIR:    %[[CONST1:.*]] = cir.const #cir.int<-4> : !s32i
 // CIR:    %[[VAL0:.*]] = cir.load align(8) %[[PTR0]] : !cir.ptr<!cir.ptr<!rec_S>>, !cir.ptr<!rec_S>
 // CIR:    %[[GET0:.*]] = cir.get_member %[[VAL0]][0] {name = "a"} : !cir.ptr<!rec_S> -> !cir.ptr<!u32i>
-// CIR:    %[[SET0:.*]] = cir.set_bitfield align(4) (#bfi_a, %[[GET0]] : !cir.ptr<!u32i>, %[[MIN1]] : !s32i) -> !s32i
+// CIR:    %[[SET0:.*]] = cir.set_bitfield align(4) (#bfi_a, %[[GET0]] : !cir.ptr<!u32i>, %[[CONST1]] : !s32i) -> !s32i
 
 // LLVM: define dso_local void @load{{.*}}{{.*}}
 // LLVM:   %[[PTR0:.*]] = load ptr
@@ -94,11 +93,10 @@ void load(S* s) {
 // OGCG:   store i32 %[[OR1]], ptr %[[PTR1]], align 4
 
 // field 'c'
-// CIR:    %[[CONST3:.*]] = cir.const #cir.int<12345> : !s32i
-// CIR:    %[[MIN2:.*]] = cir.unary(minus, %[[CONST3]]) nsw : !s32i, !s32i
+// CIR:    %[[CONST3:.*]] = cir.const #cir.int<-12345> : !s32i
 // CIR:    %[[VAL2:.*]] = cir.load align(8) %[[PTR0]] : !cir.ptr<!cir.ptr<!rec_S>>, !cir.ptr<!rec_S>
 // CIR:    %[[GET2:.*]] = cir.get_member %[[VAL2]][0] {name = "c"} : !cir.ptr<!rec_S> -> !cir.ptr<!u32i>
-// CIR:    %[[SET2:.*]] = cir.set_bitfield align(4) (#bfi_c, %[[GET2]] : !cir.ptr<!u32i>, %[[MIN2]] : !s32i) -> !s32i
+// CIR:    %[[SET2:.*]] = cir.set_bitfield align(4) (#bfi_c, %[[GET2]] : !cir.ptr<!u32i>, %[[CONST3]] : !s32i) -> !s32i
 
 // LLVM:  %[[PTR2:.*]] = load ptr
 // LLVM:  %[[GET2:.*]] = getelementptr %struct.S, ptr  %[[PTR2]], i32 0, i32 0

--- a/clang/test/CIR/CodeGen/comma.c
+++ b/clang/test/CIR/CodeGen/comma.c
@@ -23,8 +23,7 @@ void comma(void) {
 // CIR:         %[[I:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i"]
 // CIR:         %[[TRUE:.*]] = cir.const #true
 // CIR:         cir.store{{.*}} %[[TRUE]], %[[B]] : !cir.bool, !cir.ptr<!cir.bool>
-// CIR:         %[[CHAR_INI_INIT:.*]] = cir.const #cir.int<65> : !s32i
-// CIR:         %[[CHAR_VAL:.*]] = cir.cast integral %[[CHAR_INI_INIT]] : !s32i -> !s8i
+// CIR:         %[[CHAR_VAL:.*]] = cir.const #cir.int<65> : !s8i
 // CIR:         cir.store{{.*}} %[[CHAR_VAL]], %[[C]] : !s8i, !cir.ptr<!s8i>
 // CIR:         %[[FLOAT_VAL:.*]] = cir.const #cir.fp<3.140000e+00> : !cir.float
 // CIR:         cir.store{{.*}} %[[FLOAT_VAL]], %[[F]] : !cir.float, !cir.ptr<!cir.float>

--- a/clang/test/CIR/CodeGen/cxx-default-init.cpp
+++ b/clang/test/CIR/CodeGen/cxx-default-init.cpp
@@ -168,9 +168,8 @@ struct ValueInit {
 // CIR:   %[[FOUR_FIVEI:.*]] = cir.const #cir.const_complex<#cir.fp<6.000000e+00> : !cir.float, #cir.fp<7.000000e+00>
 // CIR:   cir.store{{.*}} %[[FOUR_FIVEI]], %[[C]]
 // CIR:   %[[BF:.*]] = cir.get_member %[[THIS]][4] {name = "bf"}
-// CIR:   %[[FF:.*]] = cir.const #cir.int<255> : !s32i
-// CIR:   %[[FF_CAST:.*]] = cir.cast integral %[[FF]] : !s32i -> !u32i
-// CIR:   %[[BF_VAL:.*]] = cir.set_bitfield{{.*}} (#bfi_bf, %[[BF]] : !cir.ptr<!u8i>, %[[FF_CAST]] : !u32i)
+// CIR:   %[[FF:.*]] = cir.const #cir.int<255> : !u32i
+// CIR:   %[[BF_VAL:.*]] = cir.set_bitfield{{.*}} (#bfi_bf, %[[BF]] : !cir.ptr<!u8i>, %[[FF]] : !u32i)
 
 // LLVM: define{{.*}} void @_ZN9ValueInitC2Ev(ptr %[[THIS_ARG:.*]])
 // LLVM:   %[[THIS_ALLOCA:.*]] = alloca ptr

--- a/clang/test/CIR/CodeGen/enum.cpp
+++ b/clang/test/CIR/CodeGen/enum.cpp
@@ -13,7 +13,7 @@ int f() {
 }
 
 // CHECK: cir.func{{.*}} @_Z1fv
-// CHECK:    cir.const #cir.int<1> : !u32i
+// CHECK:    cir.const #cir.int<1> : !s32i
 
 namespace test {
   using enum Numbers;
@@ -24,4 +24,4 @@ int f2() {
 }
 
 // CHECK: cir.func{{.*}} @_Z2f2v
-// CHECK:    cir.const #cir.int<2> : !u32i
+// CHECK:    cir.const #cir.int<2> : !s32i

--- a/clang/test/CIR/CodeGen/finegrain-bitfield-access.cpp
+++ b/clang/test/CIR/CodeGen/finegrain-bitfield-access.cpp
@@ -69,10 +69,9 @@ void write8_1() {
 }
 
 // CIR-LABEL: @_Z8write8_1v
-// CIR: [[CONST3:%.*]] = cir.const #cir.int<3> : !s32i
-// CIR: [[INT3:%.*]] = cir.cast integral [[CONST3]] : !s32i -> !u32i
+// CIR: [[CONST3:%.*]] = cir.const #cir.int<3> : !u32i
 // CIR: [[MEMBER:%.*]] = cir.get_member {{.*}}[1] {name = "f3"} : !cir.ptr<!rec_S1> -> !cir.ptr<!u8i>
-// CIR: cir.set_bitfield align(1) (#bfi_f3, [[MEMBER]] : !cir.ptr<!u8i>, [[INT3]] : !u32i) -> !u32i
+// CIR: cir.set_bitfield align(1) (#bfi_f3, [[MEMBER]] : !cir.ptr<!u8i>, [[CONST3]] : !u32i) -> !u32i
 
 // LLVM-LABEL: @_Z8write8_1v
 // LLVM:  store i8 3, ptr getelementptr inbounds nuw (i8, ptr {{.*}}, i64 1), align 1
@@ -115,10 +114,9 @@ void write8_2() {
 }
 
 // CIR-LABEL: @_Z8write8_2v
-// CIR: [[CONST3:%.*]] = cir.const #cir.int<3> : !s32i
-// CIR: [[INT3:%.*]] = cir.cast integral [[CONST3]] : !s32i -> !u32i
+// CIR: [[CONST3:%.*]] = cir.const #cir.int<3> : !u32i
 // CIR: [[MEMBER:%.*]] = cir.get_member {{.*}}[2] {name = "f5"} : !cir.ptr<!rec_S1> -> !cir.ptr<!u16i>
-// CIR: cir.set_bitfield align(2) (#bfi_f5, %3 : !cir.ptr<!u16i>, {{.*}} : !u32i) -> !u32i
+// CIR: cir.set_bitfield align(2) (#bfi_f5, [[MEMBER]] : !cir.ptr<!u16i>, [[CONST3]] : !u32i) -> !u32i
 
 // LLVM-LABEL: @_Z8write8_2v
 // LLVM:  [[BFLOAD:%.*]] = load i16, ptr getelementptr inbounds nuw (i8, ptr {{.*}}, i64 2), align 2
@@ -191,10 +189,9 @@ void write16_1() {
 }
 
 // CIR-LABEL: @_Z9write16_1v
-// CIR: [[CONST5:%.*]] = cir.const #cir.int<5> : !s32i
-// CIR: [[INT5:%.*]] = cir.cast integral [[CONST5]] : !s32i -> !u64i
+// CIR: [[CONST5:%.*]] = cir.const #cir.int<5> : !u64i
 // CIR: [[MEMBER:%.*]]  = cir.get_member {{.*}}[0] {name = "f1"} : !cir.ptr<!rec_S2> -> !cir.ptr<!u16i>
-// CIR: cir.set_bitfield align(8) (#bfi_f1, [[MEMBER]] : !cir.ptr<!u16i>, [[INT5]] : !u64i) -> !u64i
+// CIR: cir.set_bitfield align(8) (#bfi_f1, [[MEMBER]] : !cir.ptr<!u16i>, [[CONST5]] : !u64i) -> !u64i
 // CIR: cir.return
 
 // LLVM-LABEL: @_Z9write16_1v
@@ -211,10 +208,9 @@ void write16_2() {
 }
 
 // CIR-LABEL: @_Z9write16_2v
-// CIR: [[CONST5:%.*]] = cir.const #cir.int<5> : !s32i
-// CIR: [[INT5:%.*]] = cir.cast integral [[CONST5]] : !s32i -> !u64i
+// CIR: [[CONST5:%.*]] = cir.const #cir.int<5> : !u64i
 // CIR: [[MEMBER:%.*]] = cir.get_member {{.*}}[1] {name = "f2"} : !cir.ptr<!rec_S2> -> !cir.ptr<!u16i>
-// CIR: cir.set_bitfield align(2) (#bfi_f2, [[MEMBER]] : !cir.ptr<!u16i>, {{.*}} : !u64i) -> !u64i
+// CIR: cir.set_bitfield align(2) (#bfi_f2, [[MEMBER]] : !cir.ptr<!u16i>, [[CONST5]] : !u64i) -> !u64i
 // CIR: cir.return
 
 // LLVM-LABEL: @_Z9write16_2v
@@ -256,10 +252,9 @@ void write32_1() {
 }
 
 // CIR-LABEL: @_Z9write32_1v
-// CIR: [[CONST5:%.*]] = cir.const #cir.int<5> : !s32i
-// CIR: [[INT5:%.*]] = cir.cast integral [[CONST5]] : !s32i -> !u64i
+// CIR: [[CONST5:%.*]] = cir.const #cir.int<5> : !u64i
 // CIR: [[MEMBER:%.*]] = cir.get_member {{.*}}[1] {name = "f3"} : !cir.ptr<!rec_S3> -> !cir.ptr<!u32i>
-// CIR: cir.set_bitfield align(4) (#bfi_f3_1, [[MEMBER]] : !cir.ptr<!u32i>, [[INT5]] : !u64i) -> !u64i
+// CIR: cir.set_bitfield align(4) (#bfi_f3_1, [[MEMBER]] : !cir.ptr<!u32i>, [[CONST5]] : !u64i) -> !u64i
 // CIR: cir.return
 
 // LLVM-LABEL: @_Z9write32_1v

--- a/clang/test/CIR/CodeGen/fold-unary-constants.c
+++ b/clang/test/CIR/CodeGen/fold-unary-constants.c
@@ -1,0 +1,394 @@
+// RUN: %clang_cc1 -std=c23 -triple x86_64-unknown-linux-gnu -Wno-unused-value -Wno-constant-conversion -Wno-literal-conversion -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefixes=CIR,ALL
+// RUN: %clang_cc1 -std=c23 -triple x86_64-unknown-linux-gnu -Wno-unused-value -Wno-constant-conversion -Wno-literal-conversion -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefixes=LLVM_OGCG,ALL
+// RUN: %clang_cc1 -std=c23 -triple x86_64-unknown-linux-gnu -Wno-unused-value -Wno-constant-conversion -Wno-literal-conversion -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=LLVM_OGCG,ALL
+
+void fold_int_lnot() {
+// ALL: fold_int_lnot
+  int n;
+  short s;
+  unsigned u;
+
+  n = !0;
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+
+  n = !1;
+  // CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ZERO]], %{{.*}}
+  // LLVM_OGCG: store i32 0, ptr %{{.*}}
+
+  n = !2;
+  // CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ZERO]], %{{.*}}
+  // LLVM_OGCG: store i32 0, ptr %{{.*}}
+
+  n = !(1 && 0);
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+
+  s = !0;
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i16 1, ptr %{{.*}}
+
+  s = !1;
+  // CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ZERO]], %{{.*}}
+  // LLVM_OGCG: store i16 0, ptr %{{.*}}
+
+  s = !2;
+  // CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ZERO]], %{{.*}}
+  // LLVM_OGCG: store i16 0, ptr %{{.*}}
+
+  s = !(1 && 0);
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i16 1, ptr %{{.*}}
+
+  u = !0;
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+
+  u = !1;
+  // CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ZERO]], %{{.*}}
+  // LLVM_OGCG: store i32 0, ptr %{{.*}}
+
+  u = !2;
+  // CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ZERO]], %{{.*}}
+  // LLVM_OGCG: store i32 0, ptr %{{.*}}
+
+  u = !(1 && 0);
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+}
+
+void fold_int_not() {
+// ALL: fold_int_not
+  int n;
+  short s;
+  unsigned u;
+
+  n = ~0;
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<-1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 -1, ptr %{{.*}}
+
+  n = ~1;
+  // CIR: %[[MINUS_TWO:.*]] = cir.const #cir.int<-2> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_TWO]], %{{.*}}
+  // LLVM_OGCG: store i32 -2, ptr %{{.*}}
+
+  n = ~0xFFFFFFFE;
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+}
+
+void fold_int_plus() {
+// ALL: fold_int_plus
+  int n;
+  short s;
+  unsigned u;
+
+  n = +1;
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+
+  n = +2;
+  // CIR: %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[TWO]], %{{.*}}
+  // LLVM_OGCG: store i32 2, ptr %{{.*}}
+
+  n = +(-3);
+  // CIR: %[[MINUS_THREE:.*]] = cir.const #cir.int<-3> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_THREE]], %{{.*}}
+  // LLVM_OGCG: store i32 -3, ptr %{{.*}}
+
+  n = +(0x1FFFFFFFF);
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<-1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 -1, ptr %{{.*}}
+
+  s = +1;
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i16 1, ptr %{{.*}}
+
+  s = +2;
+  // CIR: %[[TWO:.*]] = cir.const #cir.int<2> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[TWO]], %{{.*}}
+  // LLVM_OGCG: store i16 2, ptr %{{.*}}
+
+  s = +(-3);
+  // CIR: %[[MINUS_THREE:.*]] = cir.const #cir.int<-3> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_THREE]], %{{.*}}
+  // LLVM_OGCG: store i16 -3, ptr %{{.*}}
+
+  s = +(0x1FFFF);
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<-1> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i16 -1, ptr %{{.*}}
+
+  u = +1;
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+
+  u = +2;
+  // CIR: %[[TWO:.*]] = cir.const #cir.int<2> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[TWO]], %{{.*}}
+  // LLVM_OGCG: store i32 2, ptr %{{.*}}
+
+  u = +(-3);
+  // CIR: %[[MINUS_THREE:.*]] = cir.const #cir.int<4294967293> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_THREE]], %{{.*}}
+  // LLVM_OGCG: store i32 -3, ptr %{{.*}}
+
+  u = +(0x1FFFFFFFF);
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<4294967295> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 -1, ptr %{{.*}}
+}
+
+void fold_int_minus() {
+// ALL: fold_int_minus
+  int n;
+  short s;
+  unsigned u;
+
+  n = -1;
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<-1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 -1, ptr %{{.*}}
+
+  n = -2;
+  // CIR: %[[MINUS_TWO:.*]] = cir.const #cir.int<-2> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_TWO]], %{{.*}}
+  // LLVM_OGCG: store i32 -2, ptr %{{.*}}
+
+  n = -(-3);
+  // CIR: %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[THREE]], %{{.*}}
+  // LLVM_OGCG: store i32 3, ptr %{{.*}}
+
+  n = -(0x1FFFFFFFF);
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+
+  s = -1;
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<-1> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i16 -1, ptr %{{.*}}
+
+  s = -2;
+  // CIR: %[[MINUS_TWO:.*]] = cir.const #cir.int<-2> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_TWO]], %{{.*}}
+  // LLVM_OGCG: store i16 -2, ptr %{{.*}}
+
+  s = -(-3);
+  // CIR: %[[THREE:.*]] = cir.const #cir.int<3> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[THREE]], %{{.*}}
+  // LLVM_OGCG: store i16 3, ptr %{{.*}}
+
+  s = -(0x1FFFF);
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i16 1, ptr %{{.*}}
+
+  u = -1;
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<4294967295> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 -1, ptr %{{.*}}
+
+  u = -2;
+  // CIR: %[[MINUS_TWO:.*]] = cir.const #cir.int<4294967294> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_TWO]], %{{.*}}
+  // LLVM_OGCG: store i32 -2, ptr %{{.*}}
+
+  u = -(-3);
+  // CIR: %[[THREE:.*]] = cir.const #cir.int<3> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[THREE]], %{{.*}}
+  // LLVM_OGCG: store i32 3, ptr %{{.*}}
+
+  u = -(0x1FFFFFFFF);
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+}
+
+void fold_float_lnot() {
+// ALL: fold_float_lnot
+  float f;
+  double d;
+
+  f = !0.0; // Intentional double constant
+  // CIR: %[[ONE:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store float 1.000000e+00, ptr %{{.*}}
+
+  f = !2.0f;
+  // CIR: %[[ZERO:.*]] = cir.const #cir.fp<0.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ZERO]], %{{.*}}
+  // LLVM_OGCG: store float 0.000000e+00, ptr %{{.*}}
+
+  f = !(-3.0f);
+  // CIR: %[[ZERO:.*]] = cir.const #cir.fp<0.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ZERO]], %{{.*}}
+  // LLVM_OGCG: store float 0.000000e+00, ptr %{{.*}}
+
+  d = !0.0f; // Intentional float constant
+  // CIR: %[[ONE:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store double 1.000000e+00, ptr %{{.*}}
+
+  d = !2.0;
+  // CIR: %[[ZERO:.*]] = cir.const #cir.fp<0.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ZERO]], %{{.*}}
+  // LLVM_OGCG: store double 0.000000e+00, ptr %{{.*}}
+
+  d = !(-3.0);
+  // CIR: %[[ZERO:.*]] = cir.const #cir.fp<0.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ZERO]], %{{.*}}
+  // LLVM_OGCG: store double 0.000000e+00, ptr %{{.*}}
+}
+
+void fold_float_plus() {
+// ALL: fold_float_plus
+  float f;
+  double d;
+
+  f = +1.0; // Intentional double constant
+  // CIR: %[[ONE:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store float 1.000000e+00, ptr %{{.*}}
+
+  f = +2.0f;
+  // CIR: %[[TWO:.*]] = cir.const #cir.fp<2.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[TWO]], %{{.*}}
+  // LLVM_OGCG: store float 2.000000e+00, ptr %{{.*}}
+
+  f = +(-3.0f);
+  // CIR: %[[MINUS_THREE:.*]] = cir.const #cir.fp<-3.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_THREE]], %{{.*}}
+  // LLVM_OGCG: store float -3.000000e+00, ptr %{{.*}}
+
+  d = +1.0f; // Intentional float constant
+  // CIR: %[[ONE:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store double 1.000000e+00, ptr %{{.*}}
+
+  d = +2.0;
+  // CIR: %[[TWO:.*]] = cir.const #cir.fp<2.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[TWO]], %{{.*}}
+  // LLVM_OGCG: store double 2.000000e+00, ptr %{{.*}}
+
+  d = +(-3.0);
+  // CIR: %[[MINUS_THREE:.*]] = cir.const #cir.fp<-3.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_THREE]], %{{.*}}
+  // LLVM_OGCG: store double -3.000000e+00, ptr %{{.*}}
+}
+
+void fold_float_minus() {
+// ALL: fold_float_minus
+  float f;
+  double d;
+
+  f = -1.0; // Intentional double constant
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.fp<-1.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store float -1.000000e+00, ptr %{{.*}}
+
+  f = -2.0f;
+  // CIR: %[[MINUS_TWO:.*]] = cir.const #cir.fp<-2.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_TWO]], %{{.*}}
+  // LLVM_OGCG: store float -2.000000e+00, ptr %{{.*}}
+
+  f = -(-3.0f);
+  // CIR: %[[THREE:.*]] = cir.const #cir.fp<3.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[THREE]], %{{.*}}
+  // LLVM_OGCG: store float 3.000000e+00, ptr %{{.*}}
+
+  d = -1.0f; // Intentional float constant
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.fp<-1.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store double -1.000000e+00, ptr %{{.*}}
+
+  d = -2.0;
+  // CIR: %[[MINUS_TWO:.*]] = cir.const #cir.fp<-2.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_TWO]], %{{.*}}
+  // LLVM_OGCG: store double -2.000000e+00, ptr %{{.*}}
+
+  d = -(-3.0);
+  // CIR: %[[THREE:.*]] = cir.const #cir.fp<3.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[THREE]], %{{.*}}
+  // LLVM_OGCG: store double 3.000000e+00, ptr %{{.*}}
+}

--- a/clang/test/CIR/CodeGen/goto.cpp
+++ b/clang/test/CIR/CodeGen/goto.cpp
@@ -24,9 +24,8 @@ err:
 // CIR:    cir.return [[RET]] : !s32i
 // CIR:  ^bb2:
 // CIR:    cir.label "err"
-// CIR:    [[ONE:%.*]] = cir.const #cir.int<1> : !s32i
-// CIR:    [[MINUS:%.*]] = cir.unary(minus, [[ONE]]) nsw : !s32i, !s32i
-// CIR:    cir.store [[MINUS]], [[RETVAL]] : !s32i, !cir.ptr<!s32i>
+// CIR:    [[MINUS_ONE:%.*]] = cir.const #cir.int<-1> : !s32i
+// CIR:    cir.store [[MINUS_ONE]], [[RETVAL]] : !s32i, !cir.ptr<!s32i>
 // CIR:    cir.br ^bb1
 
 // LLVM: define dso_local i32 @_Z21shouldNotGenBranchReti

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -344,9 +344,8 @@ void calling_function_with_default_values() {
 // CIR: %[[CONST_1:.*]] = cir.const #cir.int<1> : !s32i
 // CIR: cir.store{{.*}} %[[CONST_1]], %[[ELEM_0_PTR]] : !s32i, !cir.ptr<!s32i>
 // CIR: %[[ELEM_1_PTR:.*]] = cir.get_member %[[AGG_ADDR]][1] {name = "b"} : !cir.ptr<!rec_CompleteS> -> !cir.ptr<!s8i>
-// CIR: %[[CONST_2:.*]] = cir.const #cir.int<2> : !s32i
-// CIR: %[[CONST_2_I8:.*]] = cir.cast integral %[[CONST_2]] : !s32i -> !s8i
-// CIR: cir.store{{.*}} %[[CONST_2_I8]], %[[ELEM_1_PTR]] : !s8i, !cir.ptr<!s8i>
+// CIR: %[[CONST_2:.*]] = cir.const #cir.int<2> : !s8i
+// CIR: cir.store{{.*}} %[[CONST_2]], %[[ELEM_1_PTR]] : !s8i, !cir.ptr<!s8i>
 // CIR: %[[TMP_AGG:.*]] = cir.load{{.*}} %[[AGG_ADDR]] : !cir.ptr<!rec_CompleteS>, !rec_CompleteS
 // CIR: cir.call @_Z31function_arg_with_default_value9CompleteS(%[[TMP_AGG]]) : (!rec_CompleteS) -> ()
 

--- a/clang/test/CIR/CodeGen/switch.cpp
+++ b/clang/test/CIR/CodeGen/switch.cpp
@@ -1218,9 +1218,8 @@ int sw_return_multi_cases(int x) {
 // CIR-NEXT:    cir.return %[[RET2]] : !s32i
 // CIR-NEXT:  }
 // CIR-NEXT:  cir.case(default, []) {
-// CIR:         %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
-// CIR:         %[[NEG:.*]] = cir.unary(minus, %[[ONE]]) {{.*}} : !s32i, !s32i
-// CIR:         cir.store{{.*}} %[[NEG]], %{{.*}} : !s32i, !cir.ptr<!s32i>
+// CIR:         %[[MINUS_ONE:.*]] = cir.const #cir.int<-1> : !s32i
+// CIR:         cir.store{{.*}} %[[MINUS_ONE]], %{{.*}} : !s32i, !cir.ptr<!s32i>
 // CIR:         %[[RETDEF:.*]] = cir.load{{.*}} %{{.*}} : !cir.ptr<!s32i>, !s32i
 // CIR-NEXT:    cir.return %[[RETDEF]] : !s32i
 // CIR-NEXT:  }

--- a/clang/test/CIR/CodeGen/ternary.cpp
+++ b/clang/test/CIR/CodeGen/ternary.cpp
@@ -71,8 +71,7 @@ int foo(int a, int b) {
 // CIR: }) : (!cir.bool) -> !s32i
 // CIR: [[CAST:%.+]] = cir.cast int_to_bool [[TERNARY_RES]] : !s32i -> !cir.bool
 // CIR: cir.if [[CAST]] {
-// CIR: [[ONE:%.+]] = cir.const #cir.int<1> : !s32i
-// CIR: [[MINUS_ONE:%.+]] = cir.unary(minus, [[ONE]]) nsw : !s32i, !s32i
+// CIR: [[MINUS_ONE:%.+]] = cir.const #cir.int<-1> : !s32i
 // CIR: cir.store [[MINUS_ONE]], [[RETVAL]] : !s32i, !cir.ptr<!s32i>
 // CIR: [[RETVAL_VAL:%.+]] = cir.load [[RETVAL]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.return [[RETVAL_VAL]] : !s32i

--- a/clang/test/CIR/CodeGen/union.c
+++ b/clang/test/CIR/CodeGen/union.c
@@ -115,10 +115,9 @@ void shouldGenerateUnionAccess(union U2 u) {
 // CIR:      cir.func{{.*}} @shouldGenerateUnionAccess(%[[ARG:.*]]: !rec_U2
 // CIR-NEXT:   %[[U:.*]] = cir.alloca !rec_U2, !cir.ptr<!rec_U2>, ["u", init] {alignment = 8 : i64}
 // CIR-NEXT:   cir.store{{.*}} %[[ARG]], %[[U]] : !rec_U2, !cir.ptr<!rec_U2>
-// CIR-NEXT:   %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
-// CIR-NEXT:   %[[ZERO_CHAR:.*]] = cir.cast integral %[[ZERO]] : !s32i -> !s8i
+// CIR-NEXT:   %[[ZERO:.*]] = cir.const #cir.int<0> : !s8i
 // CIR-NEXT:   %[[B_PTR:.*]] = cir.get_member %[[U]][0] {name = "b"} : !cir.ptr<!rec_U2> -> !cir.ptr<!s8i>
-// CIR-NEXT:   cir.store{{.*}} %[[ZERO_CHAR]], %[[B_PTR]] : !s8i, !cir.ptr<!s8i>
+// CIR-NEXT:   cir.store{{.*}} %[[ZERO]], %[[B_PTR]] : !s8i, !cir.ptr<!s8i>
 // CIR-NEXT:   %[[B_PTR2:.*]] = cir.get_member %[[U]][0] {name = "b"} : !cir.ptr<!rec_U2> -> !cir.ptr<!s8i>
 // CIR-NEXT:   %[[B_VAL:.*]] = cir.load{{.*}} %[[B_PTR2]] : !cir.ptr<!s8i>, !s8i
 // CIR-NEXT:   %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
@@ -173,12 +172,11 @@ void f3(union U3 u) {
 // CIR:      cir.func{{.*}} @f3(%[[ARG:.*]]: !rec_U3
 // CIR-NEXT:   %[[U:.*]] = cir.alloca !rec_U3, !cir.ptr<!rec_U3>, ["u", init] {alignment = 1 : i64}
 // CIR-NEXT:   cir.store{{.*}} %[[ARG]], %[[U]] : !rec_U3, !cir.ptr<!rec_U3>
-// CIR-NEXT:   %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
-// CIR-NEXT:   %[[ZERO_CHAR:.*]] = cir.cast integral %[[ZERO]] : !s32i -> !s8i
+// CIR-NEXT:   %[[ZERO:.*]] = cir.const #cir.int<0> : !s8i
 // CIR-NEXT:   %[[IDX:.*]] = cir.const #cir.int<2> : !s32i
 // CIR-NEXT:   %[[C_PTR:.*]] = cir.get_member %[[U]][0] {name = "c"} : !cir.ptr<!rec_U3> -> !cir.ptr<!cir.array<!s8i x 5>>
 // CIR-NEXT:   %[[ELEM_PTR:.*]] = cir.get_element %[[C_PTR]][%[[IDX]] : !s32i] : !cir.ptr<!cir.array<!s8i x 5>> -> !cir.ptr<!s8i>
-// CIR-NEXT:   cir.store{{.*}} %[[ZERO_CHAR]], %[[ELEM_PTR]] : !s8i, !cir.ptr<!s8i>
+// CIR-NEXT:   cir.store{{.*}} %[[ZERO]], %[[ELEM_PTR]] : !s8i, !cir.ptr<!s8i>
 // CIR-NEXT:   cir.return
 
 // LLVM:      define{{.*}} void @f3(%union.U3 %[[ARG:.*]])
@@ -203,12 +201,11 @@ void f5(union U4 u) {
 // CIR:      cir.func{{.*}} @f5(%[[ARG:.*]]: !rec_U4
 // CIR-NEXT:   %[[U:.*]] = cir.alloca !rec_U4, !cir.ptr<!rec_U4>, ["u", init] {alignment = 4 : i64}
 // CIR-NEXT:   cir.store{{.*}} %[[ARG]], %[[U]] : !rec_U4, !cir.ptr<!rec_U4>
-// CIR-NEXT:   %[[CHAR_VAL:.*]] = cir.const #cir.int<65> : !s32i
-// CIR-NEXT:   %[[CHAR_CAST:.*]] = cir.cast integral %[[CHAR_VAL]] : !s32i -> !s8i
+// CIR-NEXT:   %[[CHAR_VAL:.*]] = cir.const #cir.int<65> : !s8i
 // CIR-NEXT:   %[[IDX:.*]] = cir.const #cir.int<4> : !s32i
 // CIR-NEXT:   %[[C_PTR:.*]] = cir.get_member %[[U]][0] {name = "c"} : !cir.ptr<!rec_U4> -> !cir.ptr<!cir.array<!s8i x 5>>
 // CIR-NEXT:   %[[ELEM_PTR:.*]] = cir.get_element %[[C_PTR]][%[[IDX]] : !s32i] : !cir.ptr<!cir.array<!s8i x 5>> -> !cir.ptr<!s8i>
-// CIR-NEXT:   cir.store{{.*}} %[[CHAR_CAST]], %[[ELEM_PTR]] : !s8i, !cir.ptr<!s8i>
+// CIR-NEXT:   cir.store{{.*}} %[[CHAR_VAL]], %[[ELEM_PTR]] : !s8i, !cir.ptr<!s8i>
 // CIR-NEXT:   cir.return
 
 // LLVM:      define{{.*}} void @f5(%union.U4 %[[ARG:.*]])


### PR DESCRIPTION
In classic codegen some basic constant folding is performed by the LLVM IRBuilder implementation as instructions are created. In CIR, we don't have such folding, and as a result some expressions like `-1` can end up as a constant, a unary operation, and a cast. This proved to be a problem in a recent builtin implementation, which needed to examine a constant operand to see if it was all ones (i.e. -1).

This change addresses this by performing some basic folding of unary operations and casts as they are created.