### PR TITLE
[DirectX] Update DXILValueEnumerator for the new SwitchInst format

### DIFF
--- a/llvm/lib/Target/DirectX/DXILWriter/DXILValueEnumerator.cpp
+++ b/llvm/lib/Target/DirectX/DXILWriter/DXILValueEnumerator.cpp
@@ -193,6 +193,9 @@ static OrderMap orderModule(const Module &M) {
             orderValue(Op, OM);
         if (auto *SVI = dyn_cast<ShuffleVectorInst>(&I))
           orderValue(SVI->getShuffleMaskForBitcode(), OM);
+        if (auto *SI = dyn_cast<SwitchInst>(&I))
+          for (const auto &Case : SI->cases())
+            orderValue(Case.getCaseValue(), OM);
       }
     for (const BasicBlock &BB : F)
       for (const Instruction &I : BB)
@@ -1053,6 +1056,9 @@ void ValueEnumerator::incorporateFunction(const Function &F) {
       }
       if (auto *SVI = dyn_cast<ShuffleVectorInst>(&I))
         EnumerateValue(SVI->getShuffleMaskForBitcode());
+      if (auto *SI = dyn_cast<SwitchInst>(&I))
+        for (const auto &Case : SI->cases())
+          EnumerateValue(Case.getCaseValue());
     }
     BasicBlocks.push_back(&BB);
     ValueMap[&BB] = BasicBlocks.size();

--- a/llvm/lib/Target/DirectX/DXILWriter/DXILValueEnumerator.cpp
+++ b/llvm/lib/Target/DirectX/DXILWriter/DXILValueEnumerator.cpp
@@ -193,9 +193,10 @@ static OrderMap orderModule(const Module &M) {
             orderValue(Op, OM);
         if (auto *SVI = dyn_cast<ShuffleVectorInst>(&I))
           orderValue(SVI->getShuffleMaskForBitcode(), OM);
-        if (auto *SI = dyn_cast<SwitchInst>(&I))
+        if (auto *SI = dyn_cast<SwitchInst>(&I)) {
           for (const auto &Case : SI->cases())
             orderValue(Case.getCaseValue(), OM);
+        }
       }
     for (const BasicBlock &BB : F)
       for (const Instruction &I : BB)
@@ -1056,9 +1057,10 @@ void ValueEnumerator::incorporateFunction(const Function &F) {
       }
       if (auto *SVI = dyn_cast<ShuffleVectorInst>(&I))
         EnumerateValue(SVI->getShuffleMaskForBitcode());
-      if (auto *SI = dyn_cast<SwitchInst>(&I))
+      if (auto *SI = dyn_cast<SwitchInst>(&I)) {
         for (const auto &Case : SI->cases())
           EnumerateValue(Case.getCaseValue());
+      }
     }
     BasicBlocks.push_back(&BB);
     ValueMap[&BB] = BasicBlocks.size();

--- a/llvm/test/tools/dxil-dis/switch.ll
+++ b/llvm/test/tools/dxil-dis/switch.ll
@@ -1,0 +1,39 @@
+; RUN: llc --filetype=obj %s -o - | dxil-dis -o - | FileCheck %s
+target triple = "dxil-unknown-shadermodel6.7-library"
+
+define i32 @test_switch(i32 %i, i32 %a, i32 %b) #0 {
+; CHECK: define i32 @test_switch(i32 [[I:%.*]], i32 [[A:%.*]], i32 [[B:%.*]])
+; CHECK: [[ENTRY:.*]]:
+; CHECK-NEXT: switch i32 [[I]], label %[[DEFAULT:.*]] [
+; CHECK-NEXT:   i32 0, label %[[RETURN:.*]]
+; CHECK-NEXT:   i32 1, label %[[BB1:.*]]
+; CHECK-NEXT: ]
+; 
+; CHECK: [[BB1]]:
+; CHECK-NEXT: br label %[[RETURN]]
+; 
+; CHECK: [[DEFAULT]]:
+; CHECK-NEXT: br label %[[RETURN]]
+; 
+; CHECK: [[RETURN]]
+; CHECK-NEXT: [[RETVAL:%.*]] = phi i32 [ -1, %[[DEFAULT]] ], [ [[B]], %[[BB1]] ], [ [[A]], %[[ENTRY]] ]
+; CHECK-NEXT: ret i32 [[RETVAL]]
+; 
+entry:
+  switch i32 %i, label %sw.default [
+    i32 0, label %return
+    i32 1, label %sw.bb1
+  ]
+
+sw.bb1:                                           ; preds = %entry
+  br label %return
+
+sw.default:                                       ; preds = %entry
+  br label %return
+
+return:                                           ; preds = %entry, %sw.default, %sw.bb1
+  %retval.0 = phi i32 [ -1, %sw.default ], [ %b, %sw.bb1 ], [ %a, %entry ]
+  ret i32 %retval.0
+}
+
+attributes #0 = { nounwind memory(none) }


### PR DESCRIPTION
Fixes #174485

This PR replicates the changes to `llvm/lib/Bitcode/Writer/ValueEnumerator.cpp` from #170984 into `llvm/lib/Target/DirectX/DXILWriter/DXILValueEnumerator.cpp` to support the changes made to the SwitchInst format.

This PR also adds a new dxil-dis test to ensure that SwitchInst is being successfully written to DXIL.