### PR TITLE
[flang] [flang-rt] Address invalid runtime abort on intrinsic assignment from ZLA

### DIFF
--- a/flang-rt/lib/runtime/assign.cpp
+++ b/flang-rt/lib/runtime/assign.cpp
@@ -451,7 +451,7 @@ RT_API_ATTRS int AssignTicket::Continue(WorkQueue &workQueue) {
   std::size_t toElements{to_.InlineElements()};
   if (from_->rank() > 0) {
     std::size_t fromElements{from_->InlineElements()};
-    if (toElements != fromElements) {
+    if (fromElements && toElements != fromElements) {
       workQueue.terminator().Crash("Assign: mismatching element counts in "
                                    "array assignment (to %zd, from %zd)",
           toElements, fromElements);

--- a/flang-rt/test/Runtime/zero_len_blank_pad01.f90
+++ b/flang-rt/test/Runtime/zero_len_blank_pad01.f90
@@ -1,0 +1,22 @@
+! Test intrinsic assignments with zero-len source arrays.
+! The resulting LHS should be blank-padded - not retain its original value.
+! UNSUPPORTED: offload-cuda
+! RUN: %flang -L"%libdir" %s -o %t
+! RUN: env LD_LIBRARY_PATH="$LD_LIBRARY_PATH:%libdir" %t | FileCheck %s
+! CHECK: #                                        #
+! CHECK: PASS
+program zero_len_blank_pad01
+  INTEGER CALLED
+  CHARACTER (LEN=0) , DIMENSION(0)  :: ZEROZERO
+  CHARACTER (LEN=4),  DIMENSION(10) :: TENTEN
+  ZEROZERO = ""
+  TENTEN = "ABCD"
+  TENTEN(1:) = ZEROZERO(CALLED(1):)(:CALLED(0))
+  print *, "#", TENTEN, "#"
+  print *, "PASS"
+end
+
+INTEGER FUNCTION CALLED(I)
+  integer, intent(in) :: I
+  CALLED = I
+END

--- a/flang-rt/test/Runtime/zero_len_blank_pad01.f90
+++ b/flang-rt/test/Runtime/zero_len_blank_pad01.f90
@@ -6,17 +6,21 @@
 ! CHECK: #                                        #
 ! CHECK: PASS
 program zero_len_blank_pad01
-  INTEGER CALLED
-  CHARACTER (LEN=0) , DIMENSION(0)  :: ZEROZERO
-  CHARACTER (LEN=4),  DIMENSION(10) :: TENTEN
-  ZEROZERO = ""
-  TENTEN = "ABCD"
-  TENTEN(1:) = ZEROZERO(CALLED(1):)(:CALLED(0))
-  print *, "#", TENTEN, "#"
+  implicit none
+  character(len=0), dimension(0)  :: zla
+  character(len=4), dimension(10) :: dest
+  zla = ""
+  dest = "ABCD"
+  dest(1:) = zla(called(1):)(:called(0))
+  print *, "#", dest, "#"
   print *, "PASS"
+
+contains
+
+  pure integer function called(i)
+    integer, intent(in) :: i
+    called = i
+  END
+
 end
 
-INTEGER FUNCTION CALLED(I)
-  integer, intent(in) :: I
-  CALLED = I
-END


### PR DESCRIPTION
Intrinsic assignment from a zero-length character array should result in the destination being blank-padded (10.2.1.3).