### PR TITLE
[C++20] [Modules] Treat all decls from BMI from named module as used

### DIFF
--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -525,7 +525,10 @@ void ASTDeclWriter::VisitDecl(Decl *D) {
   // store it as 0b001111, which takes 6 bits only now.
   DeclBits.addBits((uint64_t)D->getModuleOwnershipKind(), /*BitWidth=*/3);
   DeclBits.addBit(D->isThisDeclarationReferenced());
-  DeclBits.addBit(D->isUsed(false));
+  // If we're writing a BMI for a named module unit, we can treat all decls as in
+  // the BMI as used. Otherwise, the consumer need to mark it as used again, this
+  // simply waste time.
+  DeclBits.addBit(Writer.isWritingStdCXXNamedModules() ? true : D->isUsed(false));
   DeclBits.addBits(D->getAccess(), /*BitWidth=*/2);
   DeclBits.addBit(D->isImplicit());
   DeclBits.addBit(D->getDeclContext() != D->getLexicalDeclContext());

--- a/clang/test/Modules/class-instantiate-no-change.cppm
+++ b/clang/test/Modules/class-instantiate-no-change.cppm
@@ -1,0 +1,50 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -std=c++20 %t/impl.cppm -emit-reduced-module-interface -o %t/impl.pcm
+// RUN: %clang_cc1 -std=c++20 %t/impl.v2.cppm -emit-reduced-module-interface -o %t/impl.v2.pcm
+// RUN: %clang_cc1 -std=c++20 %t/m.cppm -emit-reduced-module-interface -o %t/m.pcm \
+// RUN:     -fmodule-file=impl=%t/impl.pcm
+// RUN: %clang_cc1 -std=c++20 %t/m.cppm -emit-reduced-module-interface -o %t/m.v2.pcm \
+// RUN:     -fmodule-file=impl=%t/impl.v2.pcm
+
+// Since m only uses impl in the definition, the change in impl shouldn't affect m.
+// RUN: diff %t/m.pcm %t/m.v2.pcm &> /dev/null
+
+//--- impl.cppm
+export module impl;
+export struct Impl {
+    Impl() {}
+    Impl(const Impl &) {}
+    ~Impl() {}
+    int get() {
+        return 43;
+    }
+};
+
+//--- impl.v2.cppm
+export module impl;
+export struct Impl {
+    Impl() {}
+    Impl(const Impl &) {}
+    ~Impl() {}
+    int get() {
+        return 43;
+    }
+};
+
+export struct ImplV2 {
+    int get() {
+        return 43;
+    }
+};
+
+//--- m.cppm
+export module m;
+import impl;
+
+export int interface() {
+    Impl impl;
+    return impl.get();
+};

--- a/clang/test/Modules/malformed-constraint-template-non-type-parm-decl.cpp
+++ b/clang/test/Modules/malformed-constraint-template-non-type-parm-decl.cpp
@@ -30,26 +30,26 @@ auto tan(const Rep& q);
 // expected-no-diagnostics
 import mod;
 
-// CHECK:      |-FunctionTemplateDecl {{.*}} <line:11:1, line:12:22> col:6 imported in mod hidden invalid cos
-// CHECK-NEXT: | |-NonTypeTemplateParmDecl {{.*}} <line:11:10, col:34> col:34 imported in mod hidden referenced invalid 'ReferenceOf<angle> auto' depth 0 index 0 R
-// CHECK-NEXT: | |-TemplateTypeParmDecl {{.*}} <col:37, col:46> col:46 imported in mod hidden referenced typename depth 0 index 1 Rep
+// CHECK:      |-FunctionTemplateDecl {{.*}} <line:11:1, line:12:22> col:6 imported in mod hidden used invalid cos
+// CHECK-NEXT: | |-NonTypeTemplateParmDecl {{.*}} <line:11:10, col:34> col:34 imported in mod hidden used invalid 'ReferenceOf<angle> auto' depth 0 index 0 R
+// CHECK-NEXT: | |-TemplateTypeParmDecl {{.*}} <col:37, col:46> col:46 imported in mod hidden used typename depth 0 index 1 Rep
 // CHECK-NEXT: | |-RequiresExpr {{.*}} <col:60, col:84> 'bool'
-// CHECK-NEXT: | | |-ParmVarDecl {{.*}} <col:69, col:73> col:73 imported in mod hidden referenced v 'Rep'
+// CHECK-NEXT: | | |-ParmVarDecl {{.*}} <col:69, col:73> col:73 imported in mod hidden used v 'Rep'
 // CHECK-NEXT: | | `-SimpleRequirement {{.*}} dependent
 // CHECK-NEXT: | |   `-CallExpr {{.*}} <col:77, col:82> '<dependent type>'
 // CHECK-NEXT: | |     |-UnresolvedLookupExpr {{.*}} <col:77> '<overloaded function type>' lvalue (ADL) = 'cos' empty
 // CHECK-NEXT: | |     `-DeclRefExpr {{.*}} <col:81> 'Rep' lvalue ParmVar {{.*}} 'v' 'Rep' non_odr_use_unevaluated
-// CHECK-NEXT: | `-FunctionDecl {{.*}} <line:12:1, col:22> col:6 imported in mod hidden cos 'auto (const Rep &)'
-// CHECK-NEXT: |   `-ParmVarDecl {{.*}} <col:10, col:21> col:21 imported in mod hidden q 'const Rep &'
+// CHECK-NEXT: | `-FunctionDecl {{.*}} <line:12:1, col:22> col:6 imported in mod hidden used cos 'auto (const Rep &)'
+// CHECK-NEXT: |   `-ParmVarDecl {{.*}} <col:10, col:21> col:21 imported in mod hidden used q 'const Rep &'
 
-// CHECK:      |-FunctionTemplateDecl {{.*}} <line:15:1, line:16:22> col:6 imported in mod hidden invalid tan
-// CHECK-NEXT: | |-NonTypeTemplateParmDecl {{.*}} <line:15:10, col:34> col:34 imported in mod hidden referenced invalid 'ReferenceOf<angle> auto' depth 0 index 0 R
-// CHECK-NEXT: | |-TemplateTypeParmDecl {{.*}} <col:37, col:46> col:46 imported in mod hidden referenced typename depth 0 index 1 Rep
+// CHECK:      |-FunctionTemplateDecl {{.*}} <line:15:1, line:16:22> col:6 imported in mod hidden used invalid tan
+// CHECK-NEXT: | |-NonTypeTemplateParmDecl {{.*}} <line:15:10, col:34> col:34 imported in mod hidden used invalid 'ReferenceOf<angle> auto' depth 0 index 0 R
+// CHECK-NEXT: | |-TemplateTypeParmDecl {{.*}} <col:37, col:46> col:46 imported in mod hidden used typename depth 0 index 1 Rep
 // CHECK-NEXT: | |-RequiresExpr {{.*}} <col:60, col:84> 'bool'
-// CHECK-NEXT: | | |-ParmVarDecl {{.*}} <col:69, col:73> col:73 imported in mod hidden referenced v 'Rep'
+// CHECK-NEXT: | | |-ParmVarDecl {{.*}} <col:69, col:73> col:73 imported in mod hidden used v 'Rep'
 // CHECK-NEXT: | | `-SimpleRequirement {{.*}} dependent
 // CHECK-NEXT: | |   `-CallExpr {{.*}} <col:77, col:82> '<dependent type>'
 // CHECK-NEXT: | |     |-UnresolvedLookupExpr {{.*}} <col:77> '<overloaded function type>' lvalue (ADL) = 'tan' empty
 // CHECK-NEXT: | |     `-DeclRefExpr {{.*}} <col:81> 'Rep' lvalue ParmVar {{.*}} 'v' 'Rep' non_odr_use_unevaluated
-// CHECK-NEXT: | `-FunctionDecl {{.*}} <line:16:1, col:22> col:6 imported in mod hidden tan 'auto (const Rep &)'
-// CHECK-NEXT: |   `-ParmVarDecl {{.*}} <col:10, col:21> col:21 imported in mod hidden q 'const Rep &'
+// CHECK-NEXT: | `-FunctionDecl {{.*}} <line:16:1, col:22> col:6 imported in mod hidden used tan 'auto (const Rep &)'
+// CHECK-NEXT: |   `-ParmVarDecl {{.*}} <col:10, col:21> col:21 imported in mod hidden used q 'const Rep &'


### PR DESCRIPTION

Declarations from named modules are used naturally. Thet are declarations in other TU. We don't need to record the information for updating them.