### PR TITLE
[RISCV] Simplify testcases in xqcibi-redundant-copy-elim.ll. NFC.

### DIFF
--- a/llvm/test/CodeGen/RISCV/xqcibi-redundant-copy-elim.ll
+++ b/llvm/test/CodeGen/RISCV/xqcibi-redundant-copy-elim.ll
@@ -6,63 +6,28 @@
 ; RUN: llc -mtriple=riscv32 -mattr=+xqcibi,+xqcili -verify-machineinstrs < %s \
 ; RUN:   | FileCheck %s -check-prefixes=RV32IXQCIBILI
 
-@bytes = dso_local global [5 x i8] zeroinitializer, align 1
-@halfwords = dso_local global [5 x i16] zeroinitializer, align 1
-
-define dso_local i32 @test_beqi() nounwind {
+define dso_local i32 @test_beqi(i32 %a) nounwind {
 ; RV32I-LABEL: test_beqi:
 ; RV32I:       # %bb.0: # %entry
-; RV32I-NEXT:    lui a0, %hi(bytes)
-; RV32I-NEXT:    addi a0, a0, %lo(bytes)
-; RV32I-NEXT:    lbu a1, 0(a0)
-; RV32I-NEXT:    li a2, 136
-; RV32I-NEXT:    bne a1, a2, .LBB0_3
-; RV32I-NEXT:  # %bb.1: # %entry
-; RV32I-NEXT:    lbu a0, 200(a0)
 ; RV32I-NEXT:    li a1, 7
-; RV32I-NEXT:    bne a0, a1, .LBB0_3
-; RV32I-NEXT:  # %bb.2: # %if.end
+; RV32I-NEXT:    bne a0, a1, .LBB0_2
+; RV32I-NEXT:  # %bb.1: # %if.end
 ; RV32I-NEXT:    li a0, 7
 ; RV32I-NEXT:    ret
-; RV32I-NEXT:  .LBB0_3: # %if.then
+; RV32I-NEXT:  .LBB0_2: # %if.then
 ; RV32I-NEXT:    li a0, 1
 ; RV32I-NEXT:    ret
 ;
-; RV32IXQCIBI-LABEL: test_beqi:
-; RV32IXQCIBI:       # %bb.0: # %entry
-; RV32IXQCIBI-NEXT:    lui a0, %hi(bytes)
-; RV32IXQCIBI-NEXT:    addi a0, a0, %lo(bytes)
-; RV32IXQCIBI-NEXT:    lbu a1, 0(a0)
-; RV32IXQCIBI-NEXT:    qc.e.bnei a1, 136, .LBB0_3
-; RV32IXQCIBI-NEXT:  # %bb.1: # %entry
-; RV32IXQCIBI-NEXT:    lbu a0, 200(a0)
-; RV32IXQCIBI-NEXT:    qc.bnei a0, 7, .LBB0_3
-; RV32IXQCIBI-NEXT:  # %bb.2: # %if.end
-; RV32IXQCIBI-NEXT:    ret
-; RV32IXQCIBI-NEXT:  .LBB0_3: # %if.then
-; RV32IXQCIBI-NEXT:    li a0, 1
-; RV32IXQCIBI-NEXT:    ret
-;
-; RV32IXQCIBILI-LABEL: test_beqi:
-; RV32IXQCIBILI:       # %bb.0: # %entry
-; RV32IXQCIBILI-NEXT:    qc.e.li a0, bytes
-; RV32IXQCIBILI-NEXT:    lbu a1, 0(a0)
-; RV32IXQCIBILI-NEXT:    qc.e.bnei a1, 136, .LBB0_3
-; RV32IXQCIBILI-NEXT:  # %bb.1: # %entry
-; RV32IXQCIBILI-NEXT:    lbu a0, 200(a0)
-; RV32IXQCIBILI-NEXT:    qc.bnei a0, 7, .LBB0_3
-; RV32IXQCIBILI-NEXT:  # %bb.2: # %if.end
-; RV32IXQCIBILI-NEXT:    ret
-; RV32IXQCIBILI-NEXT:  .LBB0_3: # %if.then
-; RV32IXQCIBILI-NEXT:    li a0, 1
-; RV32IXQCIBILI-NEXT:    ret
+; RV32IXQC-LABEL: test_beqi:
+; RV32IXQC:       # %bb.0: # %entry
+; RV32IXQC-NEXT:    qc.beqi a0, 7, .LBB0_2
+; RV32IXQC-NEXT:  # %bb.1: # %if.then
+; RV32IXQC-NEXT:    li a0, 1
+; RV32IXQC-NEXT:  .LBB0_2: # %if.end
+; RV32IXQC-NEXT:    ret
 entry:
-  %0 = load i8, ptr @bytes, align 1
-  %cmp = icmp eq i8 %0, -120
-  %1 = load i8, ptr getelementptr inbounds ([5 x i8], ptr @bytes, i32 0, i32 200), align 1
-  %cmp3 = icmp eq i8 %1, 7
-  %or.cond = and i1 %cmp, %cmp3
-  br i1 %or.cond, label %if.end, label %if.then
+  %cmp = icmp eq i32 %a, 7
+  br i1 %cmp, label %if.end, label %if.then
 
 if.then:
   ret i32 1
@@ -70,60 +35,28 @@ if.end:
   ret i32 7
 }
 
-define dso_local i32 @test_e_beqi() nounwind {
+define dso_local i32 @test_e_beqi(i32 %a) nounwind {
 ; RV32I-LABEL: test_e_beqi:
 ; RV32I:       # %bb.0: # %entry
-; RV32I-NEXT:    lui a0, %hi(bytes)
-; RV32I-NEXT:    addi a0, a0, %lo(bytes)
-; RV32I-NEXT:    lbu a1, 0(a0)
-; RV32I-NEXT:    li a2, 136
-; RV32I-NEXT:    bne a1, a2, .LBB1_3
-; RV32I-NEXT:  # %bb.1: # %entry
-; RV32I-NEXT:    lbu a0, 200(a0)
 ; RV32I-NEXT:    li a1, 40
-; RV32I-NEXT:    bne a0, a1, .LBB1_3
-; RV32I-NEXT:  # %bb.2: # %if.end
+; RV32I-NEXT:    bne a0, a1, .LBB1_2
+; RV32I-NEXT:  # %bb.1: # %if.end
 ; RV32I-NEXT:    li a0, 40
 ; RV32I-NEXT:    ret
-; RV32I-NEXT:  .LBB1_3: # %if.then
+; RV32I-NEXT:  .LBB1_2: # %if.then
 ; RV32I-NEXT:    li a0, 1
 ; RV32I-NEXT:    ret
 ;
-; RV32IXQCIBI-LABEL: test_e_beqi:
-; RV32IXQCIBI:       # %bb.0: # %entry
-; RV32IXQCIBI-NEXT:    lui a0, %hi(bytes)
-; RV32IXQCIBI-NEXT:    addi a0, a0, %lo(bytes)
-; RV32IXQCIBI-NEXT:    lbu a1, 0(a0)
-; RV32IXQCIBI-NEXT:    qc.e.bnei a1, 136, .LBB1_3
-; RV32IXQCIBI-NEXT:  # %bb.1: # %entry
-; RV32IXQCIBI-NEXT:    lbu a0, 200(a0)
-; RV32IXQCIBI-NEXT:    qc.e.bnei a0, 40, .LBB1_3
-; RV32IXQCIBI-NEXT:  # %bb.2: # %if.end
-; RV32IXQCIBI-NEXT:    ret
-; RV32IXQCIBI-NEXT:  .LBB1_3: # %if.then
-; RV32IXQCIBI-NEXT:    li a0, 1
-; RV32IXQCIBI-NEXT:    ret
-;
-; RV32IXQCIBILI-LABEL: test_e_beqi:
-; RV32IXQCIBILI:       # %bb.0: # %entry
-; RV32IXQCIBILI-NEXT:    qc.e.li a0, bytes
-; RV32IXQCIBILI-NEXT:    lbu a1, 0(a0)
-; RV32IXQCIBILI-NEXT:    qc.e.bnei a1, 136, .LBB1_3
-; RV32IXQCIBILI-NEXT:  # %bb.1: # %entry
-; RV32IXQCIBILI-NEXT:    lbu a0, 200(a0)
-; RV32IXQCIBILI-NEXT:    qc.e.bnei a0, 40, .LBB1_3
-; RV32IXQCIBILI-NEXT:  # %bb.2: # %if.end
-; RV32IXQCIBILI-NEXT:    ret
-; RV32IXQCIBILI-NEXT:  .LBB1_3: # %if.then
-; RV32IXQCIBILI-NEXT:    li a0, 1
-; RV32IXQCIBILI-NEXT:    ret
+; RV32IXQC-LABEL: test_e_beqi:
+; RV32IXQC:       # %bb.0: # %entry
+; RV32IXQC-NEXT:    qc.e.beqi a0, 40, .LBB1_2
+; RV32IXQC-NEXT:  # %bb.1: # %if.then
+; RV32IXQC-NEXT:    li a0, 1
+; RV32IXQC-NEXT:  .LBB1_2: # %if.end
+; RV32IXQC-NEXT:    ret
 entry:
-  %0 = load i8, ptr @bytes, align 1
-  %cmp = icmp eq i8 %0, -120
-  %1 = load i8, ptr getelementptr inbounds ([5 x i8], ptr @bytes, i32 0, i32 200), align 1
-  %cmp3 = icmp eq i8 %1, 40
-  %or.cond = and i1 %cmp, %cmp3
-  br i1 %or.cond, label %if.end, label %if.then
+  %cmp = icmp eq i32 %a, 40
+  br i1 %cmp, label %if.end, label %if.then
 
 if.then:
   ret i32 1
@@ -131,62 +64,40 @@ if.end:
   ret i32 40
 }
 
-define dso_local i32 @test_e_beqi_li() nounwind {
+define dso_local i32 @test_e_beqi_li(i32 %a) nounwind {
 ; RV32I-LABEL: test_e_beqi_li:
 ; RV32I:       # %bb.0: # %entry
-; RV32I-NEXT:    lui a0, %hi(halfwords)
-; RV32I-NEXT:    addi a0, a0, %lo(halfwords)
-; RV32I-NEXT:    lhu a1, 0(a0)
-; RV32I-NEXT:    li a2, 2000
-; RV32I-NEXT:    bne a1, a2, .LBB2_3
-; RV32I-NEXT:  # %bb.1: # %entry
-; RV32I-NEXT:    lhu a1, 400(a0)
-; RV32I-NEXT:    lui a0, 1
-; RV32I-NEXT:    addi a0, a0, -96
-; RV32I-NEXT:    bne a1, a0, .LBB2_3
-; RV32I-NEXT:  # %bb.2: # %if.end
+; RV32I-NEXT:    lui a1, 1
+; RV32I-NEXT:    addi a1, a1, -96
+; RV32I-NEXT:    bne a0, a1, .LBB2_2
+; RV32I-NEXT:  # %bb.1: # %if.end
+; RV32I-NEXT:    mv a0, a1
 ; RV32I-NEXT:    ret
-; RV32I-NEXT:  .LBB2_3: # %if.then
+; RV32I-NEXT:  .LBB2_2: # %if.then
 ; RV32I-NEXT:    li a0, 1
 ; RV32I-NEXT:    ret
 ;
 ; RV32IXQCIBI-LABEL: test_e_beqi_li:
 ; RV32IXQCIBI:       # %bb.0: # %entry
-; RV32IXQCIBI-NEXT:    lui a0, %hi(halfwords)
-; RV32IXQCIBI-NEXT:    addi a0, a0, %lo(halfwords)
-; RV32IXQCIBI-NEXT:    lhu a1, 0(a0)
-; RV32IXQCIBI-NEXT:    qc.e.bnei a1, 2000, .LBB2_3
-; RV32IXQCIBI-NEXT:  # %bb.1: # %entry
-; RV32IXQCIBI-NEXT:    lhu a0, 400(a0)
-; RV32IXQCIBI-NEXT:    qc.e.bnei a0, 4000, .LBB2_3
-; RV32IXQCIBI-NEXT:  # %bb.2: # %if.end
+; RV32IXQCIBI-NEXT:    qc.e.bnei a0, 4000, .LBB2_2
+; RV32IXQCIBI-NEXT:  # %bb.1: # %if.end
 ; RV32IXQCIBI-NEXT:    lui a0, 1
 ; RV32IXQCIBI-NEXT:    addi a0, a0, -96
 ; RV32IXQCIBI-NEXT:    ret
-; RV32IXQCIBI-NEXT:  .LBB2_3: # %if.then
+; RV32IXQCIBI-NEXT:  .LBB2_2: # %if.then
 ; RV32IXQCIBI-NEXT:    li a0, 1
 ; RV32IXQCIBI-NEXT:    ret
 ;
 ; RV32IXQCIBILI-LABEL: test_e_beqi_li:
 ; RV32IXQCIBILI:       # %bb.0: # %entry
-; RV32IXQCIBILI-NEXT:    qc.e.li a0, halfwords
-; RV32IXQCIBILI-NEXT:    lhu a1, 0(a0)
-; RV32IXQCIBILI-NEXT:    qc.e.bnei a1, 2000, .LBB2_3
-; RV32IXQCIBILI-NEXT:  # %bb.1: # %entry
-; RV32IXQCIBILI-NEXT:    lhu a0, 400(a0)
-; RV32IXQCIBILI-NEXT:    qc.e.bnei a0, 4000, .LBB2_3
-; RV32IXQCIBILI-NEXT:  # %bb.2: # %if.end
-; RV32IXQCIBILI-NEXT:    ret
-; RV32IXQCIBILI-NEXT:  .LBB2_3: # %if.then
+; RV32IXQCIBILI-NEXT:    qc.e.beqi a0, 4000, .LBB2_2
+; RV32IXQCIBILI-NEXT:  # %bb.1: # %if.then
 ; RV32IXQCIBILI-NEXT:    li a0, 1
+; RV32IXQCIBILI-NEXT:  .LBB2_2: # %if.end
 ; RV32IXQCIBILI-NEXT:    ret
 entry:
-  %0 = load i16, ptr @halfwords, align 2
-  %cmp = icmp eq i16 %0, 2000
-  %1 = load i16, ptr getelementptr inbounds ([5 x i16], ptr @halfwords, i32 0, i32 200), align 2
-  %cmp3 = icmp eq i16 %1, 4000
-  %or.cond = and i1 %cmp, %cmp3
-  br i1 %or.cond, label %if.end, label %if.then
+  %cmp = icmp eq i32 %a, 4000
+  br i1 %cmp, label %if.end, label %if.then
 
 if.then:
   ret i32 1


### PR DESCRIPTION
Remove unneeded load instructions and only remain one comparison instruction.