### PR TITLE
[Clang] Let isAnyArgInstantiationDependent handle Null template arguments

### DIFF
--- a/clang/include/clang/Sema/Template.h
+++ b/clang/include/clang/Sema/Template.h
@@ -188,7 +188,9 @@ enum class TemplateSubstitutionKind : char {
     bool isAnyArgInstantiationDependent() const {
       for (ArgumentListLevel ListLevel : TemplateArgumentLists)
         for (const TemplateArgument &TA : ListLevel.Args)
-          if (TA.isInstantiationDependent())
+          // There might be null template arguments representing unused template
+          // parameter mappings in an MLTAL during concept checking.
+          if (!TA.isNull() && TA.isInstantiationDependent())
             return true;
       return false;
     }

--- a/clang/test/SemaTemplate/concepts.cpp
+++ b/clang/test/SemaTemplate/concepts.cpp
@@ -1703,3 +1703,13 @@ struct : named_unit<"", thermodynamic_temperature, zeroth_kelvin> {
 struct ice_point : relative_point_origin<point<kelvin>> {};
 
 }
+
+namespace GH174667 {
+
+template<class T, class, class U>
+concept C = requires{ requires U(T(1)); };
+
+template<C<void, bool> T> int f();
+void main() { f<int>(); }
+
+}


### PR DESCRIPTION
Unused template parameters, though never referenced during substitution, must remain in the MLTAL to preserve consistent template parameter indices.

The null type placeholder plays this role, while isAnyArgInstantiationDependent() doesn't properly handle this case when checking nested constraints.

There is no release note because this is a regression from concept parameter mapping.

Fixes https://github.com/llvm/llvm-project/issues/174667