### PR TITLE
[MLIR][Python] Forward the name of MLIR types to Python side

### DIFF
--- a/mlir/include/mlir-c/BuiltinTypes.h
+++ b/mlir/include/mlir-c/BuiltinTypes.h
@@ -33,6 +33,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAInteger(MlirType type);
 MLIR_CAPI_EXPORTED MlirType mlirIntegerTypeGet(MlirContext ctx,
                                                unsigned bitwidth);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirIntegerTypeGetName(void);
+
 /// Creates a signed integer type of the given bitwidth in the context. The type
 /// is owned by the context.
 MLIR_CAPI_EXPORTED MlirType mlirIntegerTypeSignedGet(MlirContext ctx,
@@ -69,6 +71,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAIndex(MlirType type);
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirIndexTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirIndexTypeGetName(void);
+
 //===----------------------------------------------------------------------===//
 // Floating-point types.
 //===----------------------------------------------------------------------===//
@@ -89,6 +93,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAFloat4E2M1FN(MlirType type);
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirFloat4E2M1FNTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirFloat4E2M1FNTypeGetName(void);
+
 /// Returns the typeID of an Float6E2M3FN type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat6E2M3FNTypeGetTypeID(void);
 
@@ -98,6 +104,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAFloat6E2M3FN(MlirType type);
 /// Creates an f6E2M3FN type in the given context. The type is owned by the
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirFloat6E2M3FNTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirFloat6E2M3FNTypeGetName(void);
 
 /// Returns the typeID of an Float6E3M2FN type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat6E3M2FNTypeGetTypeID(void);
@@ -109,6 +117,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAFloat6E3M2FN(MlirType type);
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirFloat6E3M2FNTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirFloat6E3M2FNTypeGetName(void);
+
 /// Returns the typeID of an Float8E5M2 type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat8E5M2TypeGetTypeID(void);
 
@@ -118,6 +128,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAFloat8E5M2(MlirType type);
 /// Creates an f8E5M2 type in the given context. The type is owned by the
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirFloat8E5M2TypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirFloat8E5M2TypeGetName(void);
 
 /// Returns the typeID of an Float8E4M3 type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat8E4M3TypeGetTypeID(void);
@@ -129,6 +141,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAFloat8E4M3(MlirType type);
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirFloat8E4M3TypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirFloat8E4M3TypeGetName(void);
+
 /// Returns the typeID of an Float8E4M3FN type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat8E4M3FNTypeGetTypeID(void);
 
@@ -138,6 +152,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAFloat8E4M3FN(MlirType type);
 /// Creates an f8E4M3FN type in the given context. The type is owned by the
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirFloat8E4M3FNTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirFloat8E4M3FNTypeGetName(void);
 
 /// Returns the typeID of an Float8E5M2FNUZ type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat8E5M2FNUZTypeGetTypeID(void);
@@ -149,6 +165,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAFloat8E5M2FNUZ(MlirType type);
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirFloat8E5M2FNUZTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirFloat8E5M2FNUZTypeGetName(void);
+
 /// Returns the typeID of an Float8E4M3FNUZ type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat8E4M3FNUZTypeGetTypeID(void);
 
@@ -158,6 +176,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAFloat8E4M3FNUZ(MlirType type);
 /// Creates an f8E4M3FNUZ type in the given context. The type is owned by the
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirFloat8E4M3FNUZTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirFloat8E4M3FNUZTypeGetName(void);
 
 /// Returns the typeID of an Float8E4M3B11FNUZ type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat8E4M3B11FNUZTypeGetTypeID(void);
@@ -169,6 +189,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAFloat8E4M3B11FNUZ(MlirType type);
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirFloat8E4M3B11FNUZTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirFloat8E4M3B11FNUZTypeGetName(void);
+
 /// Returns the typeID of an Float8E3M4 type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat8E3M4TypeGetTypeID(void);
 
@@ -178,6 +200,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAFloat8E3M4(MlirType type);
 /// Creates an f8E3M4 type in the given context. The type is owned by the
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirFloat8E3M4TypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirFloat8E3M4TypeGetName(void);
 
 /// Returns the typeID of an Float8E8M0FNU type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat8E8M0FNUTypeGetTypeID(void);
@@ -189,6 +213,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAFloat8E8M0FNU(MlirType type);
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirFloat8E8M0FNUTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirFloat8E8M0FNUTypeGetName(void);
+
 /// Returns the typeID of an BFloat16 type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirBFloat16TypeGetTypeID(void);
 
@@ -198,6 +224,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsABF16(MlirType type);
 /// Creates a bf16 type in the given context. The type is owned by the
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirBF16TypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirBF16TypeGetName(void);
 
 /// Returns the typeID of an Float16 type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat16TypeGetTypeID(void);
@@ -209,6 +237,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAF16(MlirType type);
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirF16TypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirF16TypeGetName(void);
+
 /// Returns the typeID of an Float32 type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat32TypeGetTypeID(void);
 
@@ -218,6 +248,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAF32(MlirType type);
 /// Creates an f32 type in the given context. The type is owned by the
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirF32TypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirF32TypeGetName(void);
 
 /// Returns the typeID of an Float64 type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloat64TypeGetTypeID(void);
@@ -229,6 +261,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAF64(MlirType type);
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirF64TypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirF64TypeGetName(void);
+
 /// Returns the typeID of a TF32 type.
 MLIR_CAPI_EXPORTED MlirTypeID mlirFloatTF32TypeGetTypeID(void);
 
@@ -238,6 +272,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsATF32(MlirType type);
 /// Creates a TF32 type in the given context. The type is owned by the
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirTF32TypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirTF32TypeGetName(void);
 
 //===----------------------------------------------------------------------===//
 // None type.
@@ -253,6 +289,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsANone(MlirType type);
 /// context.
 MLIR_CAPI_EXPORTED MlirType mlirNoneTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirNoneTypeGetName(void);
+
 //===----------------------------------------------------------------------===//
 // Complex type.
 //===----------------------------------------------------------------------===//
@@ -266,6 +304,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAComplex(MlirType type);
 /// Creates a complex type with the given element type in the same context as
 /// the element type. The type is owned by the context.
 MLIR_CAPI_EXPORTED MlirType mlirComplexTypeGet(MlirType elementType);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirComplexTypeGetName(void);
 
 /// Returns the element type of the given complex type.
 MLIR_CAPI_EXPORTED MlirType mlirComplexTypeGetElementType(MlirType type);
@@ -341,6 +381,8 @@ MLIR_CAPI_EXPORTED MlirType mlirVectorTypeGet(intptr_t rank,
                                               const int64_t *shape,
                                               MlirType elementType);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirVectorTypeGetName(void);
+
 /// Same as "mlirVectorTypeGet" but returns a nullptr wrapping MlirType on
 /// illegal arguments, emitting appropriate diagnostics.
 MLIR_CAPI_EXPORTED MlirType mlirVectorTypeGetChecked(MlirLocation loc,
@@ -402,6 +444,8 @@ MLIR_CAPI_EXPORTED MlirType mlirRankedTensorTypeGet(intptr_t rank,
                                                     MlirType elementType,
                                                     MlirAttribute encoding);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirRankedTensorTypeGetName(void);
+
 /// Same as "mlirRankedTensorTypeGet" but returns a nullptr wrapping MlirType on
 /// illegal arguments, emitting appropriate diagnostics.
 MLIR_CAPI_EXPORTED MlirType mlirRankedTensorTypeGetChecked(
@@ -415,6 +459,8 @@ MLIR_CAPI_EXPORTED MlirAttribute mlirRankedTensorTypeGetEncoding(MlirType type);
 /// Creates an unranked tensor type with the given element type in the same
 /// context as the element type. The type is owned by the context.
 MLIR_CAPI_EXPORTED MlirType mlirUnrankedTensorTypeGet(MlirType elementType);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirUnrankedTensorTypeGetName(void);
 
 /// Same as "mlirUnrankedTensorTypeGet" but returns a nullptr wrapping MlirType
 /// on illegal arguments, emitting appropriate diagnostics.
@@ -446,6 +492,8 @@ MLIR_CAPI_EXPORTED MlirType mlirMemRefTypeGet(MlirType elementType,
                                               MlirAttribute layout,
                                               MlirAttribute memorySpace);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirMemRefTypeGetName(void);
+
 /// Same as "mlirMemRefTypeGet" but returns a nullptr-wrapping MlirType o
 /// illegal arguments, emitting appropriate diagnostics.
 MLIR_CAPI_EXPORTED MlirType mlirMemRefTypeGetChecked(
@@ -470,6 +518,8 @@ MLIR_CAPI_EXPORTED MlirType mlirMemRefTypeContiguousGetChecked(
 /// memory space. The type is owned by the context of element type.
 MLIR_CAPI_EXPORTED MlirType
 mlirUnrankedMemRefTypeGet(MlirType elementType, MlirAttribute memorySpace);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirUnrankedMemRefTypeGetName(void);
 
 /// Same as "mlirUnrankedMemRefTypeGet" but returns a nullptr wrapping
 /// MlirType on illegal arguments, emitting appropriate diagnostics.
@@ -511,6 +561,8 @@ MLIR_CAPI_EXPORTED MlirType mlirTupleTypeGet(MlirContext ctx,
                                              intptr_t numElements,
                                              MlirType const *elements);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirTupleTypeGetName(void);
+
 /// Returns the number of types contained in a tuple.
 MLIR_CAPI_EXPORTED intptr_t mlirTupleTypeGetNumTypes(MlirType type);
 
@@ -533,6 +585,8 @@ MLIR_CAPI_EXPORTED MlirType mlirFunctionTypeGet(MlirContext ctx,
                                                 MlirType const *inputs,
                                                 intptr_t numResults,
                                                 MlirType const *results);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirFunctionTypeGetName(void);
 
 /// Returns the number of input types.
 MLIR_CAPI_EXPORTED intptr_t mlirFunctionTypeGetNumInputs(MlirType type);
@@ -564,6 +618,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAOpaque(MlirType type);
 MLIR_CAPI_EXPORTED MlirType mlirOpaqueTypeGet(MlirContext ctx,
                                               MlirStringRef dialectNamespace,
                                               MlirStringRef typeData);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirOpaqueTypeGetName(void);
 
 /// Returns the namespace of the dialect with which the given opaque type
 /// is associated. The namespace string is owned by the context.

--- a/mlir/include/mlir-c/Dialect/AMDGPU.h
+++ b/mlir/include/mlir-c/Dialect/AMDGPU.h
@@ -29,6 +29,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirAMDGPUTDMBaseTypeGetTypeID();
 MLIR_CAPI_EXPORTED MlirType mlirAMDGPUTDMBaseTypeGet(MlirContext ctx,
                                                      MlirType elementType);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirAMDGPUTDMBaseTypeGetName(void);
+
 //===---------------------------------------------------------------------===//
 // TDMDescriptorType
 //===---------------------------------------------------------------------===//
@@ -38,6 +40,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAAMDGPUTDMDescriptorType(MlirType type);
 MLIR_CAPI_EXPORTED MlirTypeID mlirAMDGPUTDMDescriptorTypeGetTypeID();
 
 MLIR_CAPI_EXPORTED MlirType mlirAMDGPUTDMDescriptorTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirAMDGPUTDMDescriptorTypeGetName(void);
 
 //===---------------------------------------------------------------------===//
 // TDMGatherBaseType
@@ -50,6 +54,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirAMDGPUTDMGatherBaseTypeGetTypeID();
 MLIR_CAPI_EXPORTED MlirType mlirAMDGPUTDMGatherBaseTypeGet(MlirContext ctx,
                                                            MlirType elementType,
                                                            MlirType indexType);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirAMDGPUTDMGatherBaseTypeGetName(void);
 
 #ifdef __cplusplus
 }

--- a/mlir/include/mlir-c/Dialect/EmitC.h
+++ b/mlir/include/mlir-c/Dialect/EmitC.h
@@ -41,6 +41,8 @@ MLIR_CAPI_EXPORTED MlirType mlirEmitCArrayTypeGet(intptr_t nDims,
                                                   int64_t *shape,
                                                   MlirType elementType);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirEmitCArrayTypeGetName(void);
+
 //===---------------------------------------------------------------------===//
 // LValueType
 //===---------------------------------------------------------------------===//
@@ -50,6 +52,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAEmitCLValueType(MlirType type);
 MLIR_CAPI_EXPORTED MlirTypeID mlirEmitCLValueTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirEmitCLValueTypeGet(MlirType valueType);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirEmitCLValueTypeGetName(void);
 
 //===---------------------------------------------------------------------===//
 // OpaqueType
@@ -62,6 +66,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirEmitCOpaqueTypeGetTypeID(void);
 MLIR_CAPI_EXPORTED MlirType mlirEmitCOpaqueTypeGet(MlirContext ctx,
                                                    MlirStringRef value);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirEmitCOpaqueTypeGetName(void);
+
 //===---------------------------------------------------------------------===//
 // PointerType
 //===---------------------------------------------------------------------===//
@@ -71,6 +77,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAEmitCPointerType(MlirType type);
 MLIR_CAPI_EXPORTED MlirTypeID mlirEmitCPointerTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirEmitCPointerTypeGet(MlirType pointee);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirEmitCPointerTypeGetName(void);
 
 //===---------------------------------------------------------------------===//
 // PtrDiffTType
@@ -82,6 +90,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirEmitCPtrDiffTTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirEmitCPtrDiffTTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirEmitCPtrDiffTTypeGetName(void);
+
 //===---------------------------------------------------------------------===//
 // SignedSizeTType
 //===---------------------------------------------------------------------===//
@@ -92,6 +102,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirEmitCSignedSizeTTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirEmitCSignedSizeTTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirEmitCSignedSizeTTypeGetName(void);
+
 //===---------------------------------------------------------------------===//
 // SizeTType
 //===---------------------------------------------------------------------===//
@@ -101,6 +113,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAEmitCSizeTType(MlirType type);
 MLIR_CAPI_EXPORTED MlirTypeID mlirEmitCSizeTTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirEmitCSizeTTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirEmitCSizeTTypeGetName(void);
 
 //===----------------------------------------------------------------------===//
 // CmpPredicate attribute.

--- a/mlir/include/mlir-c/Dialect/GPU.h
+++ b/mlir/include/mlir-c/Dialect/GPU.h
@@ -27,6 +27,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAGPUAsyncTokenType(MlirType type);
 
 MLIR_CAPI_EXPORTED MlirType mlirGPUAsyncTokenTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirGPUAsyncTokenTypeGetName(void);
+
 //===---------------------------------------------------------------------===//
 // ObjectAttr
 //===---------------------------------------------------------------------===//

--- a/mlir/include/mlir-c/Dialect/LLVM.h
+++ b/mlir/include/mlir-c/Dialect/LLVM.h
@@ -23,6 +23,8 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(LLVM, llvm);
 MLIR_CAPI_EXPORTED MlirType mlirLLVMPointerTypeGet(MlirContext ctx,
                                                    unsigned addressSpace);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirLLVMPointerTypeGetName(void);
+
 MLIR_CAPI_EXPORTED MlirTypeID mlirLLVMPointerTypeGetTypeID(void);
 
 /// Returns `true` if the type is an LLVM dialect pointer type.
@@ -35,9 +37,13 @@ mlirLLVMPointerTypeGetAddressSpace(MlirType pointerType);
 /// Creates an llmv.void type.
 MLIR_CAPI_EXPORTED MlirType mlirLLVMVoidTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirLLVMVoidTypeGetName(void);
+
 /// Creates an llvm.array type.
 MLIR_CAPI_EXPORTED MlirType mlirLLVMArrayTypeGet(MlirType elementType,
                                                  unsigned numElements);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirLLVMArrayTypeGetName(void);
 
 /// Returns the element type of the llvm.array type.
 MLIR_CAPI_EXPORTED MlirType mlirLLVMArrayTypeGetElementType(MlirType type);
@@ -46,6 +52,8 @@ MLIR_CAPI_EXPORTED MlirType mlirLLVMArrayTypeGetElementType(MlirType type);
 MLIR_CAPI_EXPORTED MlirType
 mlirLLVMFunctionTypeGet(MlirType resultType, intptr_t nArgumentTypes,
                         MlirType const *argumentTypes, bool isVarArg);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirLLVMFunctionTypeGetName(void);
 
 /// Returns the number of input types.
 MLIR_CAPI_EXPORTED intptr_t mlirLLVMFunctionTypeGetNumInputs(MlirType type);

--- a/mlir/include/mlir-c/Dialect/LLVM.h
+++ b/mlir/include/mlir-c/Dialect/LLVM.h
@@ -70,6 +70,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsALLVMStructType(MlirType type);
 
 MLIR_CAPI_EXPORTED MlirTypeID mlirLLVMStructTypeGetTypeID(void);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirLLVMStructTypeGetName(void);
+
 /// Returns `true` if the type is a literal (unnamed) LLVM struct type.
 MLIR_CAPI_EXPORTED bool mlirLLVMStructTypeIsLiteral(MlirType type);
 

--- a/mlir/include/mlir-c/Dialect/NVGPU.h
+++ b/mlir/include/mlir-c/Dialect/NVGPU.h
@@ -29,6 +29,8 @@ MLIR_CAPI_EXPORTED MlirType mlirNVGPUTensorMapDescriptorTypeGet(
     MlirContext ctx, MlirType tensorMemrefType, int swizzle, int l2promo,
     int oobFill, int interleave);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirNVGPUTensorMapDescriptorTypeGetName(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mlir/include/mlir-c/Dialect/PDL.h
+++ b/mlir/include/mlir-c/Dialect/PDL.h
@@ -34,6 +34,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirPDLAttributeTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirPDLAttributeTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirPDLAttributeTypeGetName(void);
+
 //===---------------------------------------------------------------------===//
 // OperationType
 //===---------------------------------------------------------------------===//
@@ -44,6 +46,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirPDLOperationTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirPDLOperationTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirPDLOperationTypeGetName(void);
+
 //===---------------------------------------------------------------------===//
 // RangeType
 //===---------------------------------------------------------------------===//
@@ -53,6 +57,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAPDLRangeType(MlirType type);
 MLIR_CAPI_EXPORTED MlirTypeID mlirPDLRangeTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirPDLRangeTypeGet(MlirType elementType);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirPDLRangeTypeGetName(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirPDLRangeTypeGetElementType(MlirType type);
 
@@ -66,6 +72,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirPDLTypeTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirPDLTypeTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirPDLTypeTypeGetName(void);
+
 //===---------------------------------------------------------------------===//
 // ValueType
 //===---------------------------------------------------------------------===//
@@ -75,6 +83,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsAPDLValueType(MlirType type);
 MLIR_CAPI_EXPORTED MlirTypeID mlirPDLValueTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirPDLValueTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirPDLValueTypeGetName(void);
 
 #ifdef __cplusplus
 }

--- a/mlir/include/mlir-c/Dialect/Quant.h
+++ b/mlir/include/mlir-c/Dialect/Quant.h
@@ -206,7 +206,8 @@ MLIR_CAPI_EXPORTED MlirType mlirUniformQuantizedSubChannelTypeGet(
     intptr_t blockSizeInfoLength, int32_t *quantizedDimensions,
     int64_t *blockSizes, int64_t storageTypeMin, int64_t storageTypeMax);
 
-MLIR_CAPI_EXPORTED MlirStringRef mlirUniformQuantizedSubChannelTypeGetName(void);
+MLIR_CAPI_EXPORTED MlirStringRef
+mlirUniformQuantizedSubChannelTypeGetName(void);
 
 /// Returns the number of block sizes provided in type.
 MLIR_CAPI_EXPORTED intptr_t

--- a/mlir/include/mlir-c/Dialect/Quant.h
+++ b/mlir/include/mlir-c/Dialect/Quant.h
@@ -114,6 +114,8 @@ MLIR_CAPI_EXPORTED MlirType mlirAnyQuantizedTypeGet(unsigned flags,
                                                     int64_t storageTypeMin,
                                                     int64_t storageTypeMax);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirAnyQuantizedTypeGetName(void);
+
 //===---------------------------------------------------------------------===//
 // UniformQuantizedType
 //===---------------------------------------------------------------------===//
@@ -129,6 +131,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirUniformQuantizedTypeGetTypeID(void);
 MLIR_CAPI_EXPORTED MlirType mlirUniformQuantizedTypeGet(
     unsigned flags, MlirType storageType, MlirType expressedType, double scale,
     int64_t zeroPoint, int64_t storageTypeMin, int64_t storageTypeMax);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirUniformQuantizedTypeGetName(void);
 
 /// Returns the scale of the given uniform quantized type.
 MLIR_CAPI_EXPORTED double mlirUniformQuantizedTypeGetScale(MlirType type);
@@ -156,6 +160,8 @@ MLIR_CAPI_EXPORTED MlirType mlirUniformQuantizedPerAxisTypeGet(
     unsigned flags, MlirType storageType, MlirType expressedType,
     intptr_t nDims, double *scales, int64_t *zeroPoints,
     int32_t quantizedDimension, int64_t storageTypeMin, int64_t storageTypeMax);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirUniformQuantizedPerAxisTypeGetName(void);
 
 /// Returns the number of axes in the given quantized per-axis type.
 MLIR_CAPI_EXPORTED intptr_t
@@ -200,6 +206,8 @@ MLIR_CAPI_EXPORTED MlirType mlirUniformQuantizedSubChannelTypeGet(
     intptr_t blockSizeInfoLength, int32_t *quantizedDimensions,
     int64_t *blockSizes, int64_t storageTypeMin, int64_t storageTypeMax);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirUniformQuantizedSubChannelTypeGetName(void);
+
 /// Returns the number of block sizes provided in type.
 MLIR_CAPI_EXPORTED intptr_t
 mlirUniformQuantizedSubChannelTypeGetNumBlockSizes(MlirType type);
@@ -235,6 +243,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirCalibratedQuantizedTypeGetTypeID(void);
 /// by the context.
 MLIR_CAPI_EXPORTED MlirType
 mlirCalibratedQuantizedTypeGet(MlirType expressedType, double min, double max);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirCalibratedQuantizedTypeGetName(void);
 
 /// Returns the min value of the given calibrated quantized type.
 MLIR_CAPI_EXPORTED double mlirCalibratedQuantizedTypeGetMin(MlirType type);

--- a/mlir/include/mlir-c/Dialect/SMT.h
+++ b/mlir/include/mlir-c/Dialect/SMT.h
@@ -46,17 +46,23 @@ MLIR_CAPI_EXPORTED bool mlirSMTTypeIsABitVector(MlirType type);
 MLIR_CAPI_EXPORTED MlirType mlirSMTTypeGetBitVector(MlirContext ctx,
                                                     int32_t width);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirSMTBitVectorTypeGetName(void);
+
 /// Checks if the given type is a smt::BoolType.
 MLIR_CAPI_EXPORTED bool mlirSMTTypeIsABool(MlirType type);
 
 /// Creates a smt::BoolType.
 MLIR_CAPI_EXPORTED MlirType mlirSMTTypeGetBool(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirSMTBoolTypeGetName(void);
+
 /// Checks if the given type is a smt::IntType.
 MLIR_CAPI_EXPORTED bool mlirSMTTypeIsAInt(MlirType type);
 
 /// Creates a smt::IntType.
 MLIR_CAPI_EXPORTED MlirType mlirSMTTypeGetInt(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirSMTIntTypeGetName(void);
 
 /// Checks if the given type is a smt::FuncType.
 MLIR_CAPI_EXPORTED bool mlirSMTTypeIsASMTFunc(MlirType type);

--- a/mlir/include/mlir-c/Dialect/Transform.h
+++ b/mlir/include/mlir-c/Dialect/Transform.h
@@ -29,6 +29,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirTransformAnyOpTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirTransformAnyOpTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirTransformAnyOpTypeGetName(void);
+
 //===---------------------------------------------------------------------===//
 // AnyParamType
 //===---------------------------------------------------------------------===//
@@ -38,6 +40,8 @@ MLIR_CAPI_EXPORTED bool mlirTypeIsATransformAnyParamType(MlirType type);
 MLIR_CAPI_EXPORTED MlirTypeID mlirTransformAnyParamTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirTransformAnyParamTypeGet(MlirContext ctx);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirTransformAnyParamTypeGetName(void);
 
 //===---------------------------------------------------------------------===//
 // AnyValueType
@@ -49,6 +53,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirTransformAnyValueTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirTransformAnyValueTypeGet(MlirContext ctx);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirTransformAnyValueTypeGetName(void);
+
 //===---------------------------------------------------------------------===//
 // OperationType
 //===---------------------------------------------------------------------===//
@@ -59,6 +65,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirTransformOperationTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType
 mlirTransformOperationTypeGet(MlirContext ctx, MlirStringRef operationName);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirTransformOperationTypeGetName(void);
 
 MLIR_CAPI_EXPORTED MlirStringRef
 mlirTransformOperationTypeGetOperationName(MlirType type);
@@ -73,6 +81,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirTransformParamTypeGetTypeID(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirTransformParamTypeGet(MlirContext ctx,
                                                       MlirType type);
+
+MLIR_CAPI_EXPORTED MlirStringRef mlirTransformParamTypeGetName(void);
 
 MLIR_CAPI_EXPORTED MlirType mlirTransformParamTypeGetType(MlirType type);
 

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -991,7 +991,7 @@ public:
     }
 
     if (DerivedTy::name.length != 0) {
-      cls.def("type_name", [](nanobind::object & /*self*/) {
+      cls.def_prop_ro_static("type_name", [](nanobind::object & /*self*/) {
         return nanobind::str(DerivedTy::name.data, DerivedTy::name.length);
       });
     }

--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -24,6 +24,7 @@
 #include "mlir-c/Diagnostics.h"
 #include "mlir-c/IR.h"
 #include "mlir-c/IntegerSet.h"
+#include "mlir-c/Support.h"
 #include "mlir-c/Transforms.h"
 #include "mlir/Bindings/Python/Nanobind.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
@@ -933,6 +934,7 @@ public:
   using GetTypeIDFunctionTy = MlirTypeID (*)();
   using Base = PyConcreteType;
   static constexpr GetTypeIDFunctionTy getTypeIdFunction = nullptr;
+  static inline const MlirStringRef name{};
 
   PyConcreteType() = default;
   PyConcreteType(PyMlirContextRef contextRef, MlirType t)
@@ -986,6 +988,12 @@ public:
           nanobind::cast<nanobind::callable>(nanobind::cpp_function(
               [](PyType pyType) -> DerivedTy { return pyType; })),
           /*replace*/ true);
+    }
+
+    if (DerivedTy::name.length != 0) {
+      cls.def("type_name", [](nanobind::object & /*self*/) {
+        return nanobind::str(DerivedTy::name.data, DerivedTy::name.length);
+      });
     }
 
     DerivedTy::bindDerived(cls);

--- a/mlir/include/mlir/Bindings/Python/IRTypes.h
+++ b/mlir/include/mlir/Bindings/Python/IRTypes.h
@@ -41,6 +41,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirIndexTypeGetTypeID;
   static constexpr const char *pyClassName = "IndexType";
+  static inline const MlirStringRef name = mlirIndexTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -64,6 +65,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat4E2M1FNTypeGetTypeID;
   static constexpr const char *pyClassName = "Float4E2M1FNType";
+  static inline const MlirStringRef name = mlirFloat4E2M1FNTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -77,6 +79,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat6E2M3FNTypeGetTypeID;
   static constexpr const char *pyClassName = "Float6E2M3FNType";
+  static inline const MlirStringRef name = mlirFloat6E2M3FNTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -90,6 +93,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat6E3M2FNTypeGetTypeID;
   static constexpr const char *pyClassName = "Float6E3M2FNType";
+  static inline const MlirStringRef name = mlirFloat6E3M2FNTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -103,6 +107,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E4M3FNTypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E4M3FNType";
+  static inline const MlirStringRef name = mlirFloat8E4M3FNTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -116,6 +121,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E5M2TypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E5M2Type";
+  static inline const MlirStringRef name = mlirFloat8E5M2TypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -129,6 +135,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E4M3TypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E4M3Type";
+  static inline const MlirStringRef name = mlirFloat8E4M3TypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -142,6 +149,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E4M3FNUZTypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E4M3FNUZType";
+  static inline const MlirStringRef name = mlirFloat8E4M3FNUZTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -155,6 +163,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E4M3B11FNUZTypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E4M3B11FNUZType";
+  static inline const MlirStringRef name = mlirFloat8E4M3B11FNUZTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -168,6 +177,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E5M2FNUZTypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E5M2FNUZType";
+  static inline const MlirStringRef name = mlirFloat8E5M2FNUZTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -181,6 +191,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E3M4TypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E3M4Type";
+  static inline const MlirStringRef name = mlirFloat8E3M4TypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -194,6 +205,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat8E8M0FNUTypeGetTypeID;
   static constexpr const char *pyClassName = "Float8E8M0FNUType";
+  static inline const MlirStringRef name = mlirFloat8E8M0FNUTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -207,6 +219,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirBFloat16TypeGetTypeID;
   static constexpr const char *pyClassName = "BF16Type";
+  static inline const MlirStringRef name = mlirBF16TypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -220,6 +233,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat16TypeGetTypeID;
   static constexpr const char *pyClassName = "F16Type";
+  static inline const MlirStringRef name = mlirF16TypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -233,6 +247,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloatTF32TypeGetTypeID;
   static constexpr const char *pyClassName = "FloatTF32Type";
+  static inline const MlirStringRef name = mlirTF32TypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -246,6 +261,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat32TypeGetTypeID;
   static constexpr const char *pyClassName = "F32Type";
+  static inline const MlirStringRef name = mlirF32TypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -259,6 +275,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloat64TypeGetTypeID;
   static constexpr const char *pyClassName = "F64Type";
+  static inline const MlirStringRef name = mlirF64TypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -271,6 +288,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirNoneTypeGetTypeID;
   static constexpr const char *pyClassName = "NoneType";
+  static inline const MlirStringRef name = mlirNoneTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -284,6 +302,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirComplexTypeGetTypeID;
   static constexpr const char *pyClassName = "ComplexType";
+  static inline const MlirStringRef name = mlirComplexTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -311,6 +330,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirVectorTypeGetTypeID;
   static constexpr const char *pyClassName = "VectorType";
+  static inline const MlirStringRef name = mlirVectorTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -336,6 +356,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirRankedTensorTypeGetTypeID;
   static constexpr const char *pyClassName = "RankedTensorType";
+  static inline const MlirStringRef name = mlirRankedTensorTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -349,6 +370,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirUnrankedTensorTypeGetTypeID;
   static constexpr const char *pyClassName = "UnrankedTensorType";
+  static inline const MlirStringRef name = mlirUnrankedTensorTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -362,6 +384,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirMemRefTypeGetTypeID;
   static constexpr const char *pyClassName = "MemRefType";
+  static inline const MlirStringRef name = mlirMemRefTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -375,6 +398,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirUnrankedMemRefTypeGetTypeID;
   static constexpr const char *pyClassName = "UnrankedMemRefType";
+  static inline const MlirStringRef name = mlirUnrankedMemRefTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -388,6 +412,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirTupleTypeGetTypeID;
   static constexpr const char *pyClassName = "TupleType";
+  static inline const MlirStringRef name = mlirTupleTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -401,6 +426,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFunctionTypeGetTypeID;
   static constexpr const char *pyClassName = "FunctionType";
+  static inline const MlirStringRef name = mlirFunctionTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);
@@ -414,6 +440,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirOpaqueTypeGetTypeID;
   static constexpr const char *pyClassName = "OpaqueType";
+  static inline const MlirStringRef name = mlirOpaqueTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   static void bindDerived(ClassTy &c);

--- a/mlir/include/mlir/Bindings/Python/IRTypes.h
+++ b/mlir/include/mlir/Bindings/Python/IRTypes.h
@@ -10,6 +10,7 @@
 #define MLIR_BINDINGS_PYTHON_IRTYPES_H
 
 #include "mlir-c/BuiltinTypes.h"
+#include "mlir/Bindings/Python/IRCore.h"
 
 namespace mlir {
 namespace python {
@@ -24,6 +25,7 @@ public:
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirIntegerTypeGetTypeID;
   static constexpr const char *pyClassName = "IntegerType";
+  static inline const MlirStringRef name = mlirIntegerTypeGetName();
   using PyConcreteType::PyConcreteType;
 
   enum Signedness { Signless, Signed, Unsigned };

--- a/mlir/lib/Bindings/Python/DialectAMDGPU.cpp
+++ b/mlir/lib/Bindings/Python/DialectAMDGPU.cpp
@@ -26,6 +26,7 @@ struct TDMBaseType : PyConcreteType<TDMBaseType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirAMDGPUTDMBaseTypeGetTypeID;
   static constexpr const char *pyClassName = "TDMBaseType";
+  static inline const MlirStringRef name = mlirAMDGPUTDMBaseTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -47,6 +48,8 @@ struct TDMDescriptorType : PyConcreteType<TDMDescriptorType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirAMDGPUTDMDescriptorTypeGetTypeID;
   static constexpr const char *pyClassName = "TDMDescriptorType";
+  static inline const MlirStringRef name =
+    mlirAMDGPUTDMDescriptorTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -68,6 +71,8 @@ struct TDMGatherBaseType : PyConcreteType<TDMGatherBaseType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirAMDGPUTDMGatherBaseTypeGetTypeID;
   static constexpr const char *pyClassName = "TDMGatherBaseType";
+  static inline const MlirStringRef name =
+    mlirAMDGPUTDMGatherBaseTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectAMDGPU.cpp
+++ b/mlir/lib/Bindings/Python/DialectAMDGPU.cpp
@@ -48,8 +48,7 @@ struct TDMDescriptorType : PyConcreteType<TDMDescriptorType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirAMDGPUTDMDescriptorTypeGetTypeID;
   static constexpr const char *pyClassName = "TDMDescriptorType";
-  static inline const MlirStringRef name =
-    mlirAMDGPUTDMDescriptorTypeGetName();
+  static inline const MlirStringRef name = mlirAMDGPUTDMDescriptorTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -71,8 +70,7 @@ struct TDMGatherBaseType : PyConcreteType<TDMGatherBaseType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirAMDGPUTDMGatherBaseTypeGetTypeID;
   static constexpr const char *pyClassName = "TDMGatherBaseType";
-  static inline const MlirStringRef name =
-    mlirAMDGPUTDMGatherBaseTypeGetName();
+  static inline const MlirStringRef name = mlirAMDGPUTDMGatherBaseTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectGPU.cpp
+++ b/mlir/lib/Bindings/Python/DialectGPU.cpp
@@ -29,6 +29,7 @@ namespace gpu {
 struct AsyncTokenType : PyConcreteType<AsyncTokenType> {
   static constexpr IsAFunctionTy isaFunction = mlirTypeIsAGPUAsyncTokenType;
   static constexpr const char *pyClassName = "AsyncTokenType";
+  static inline const MlirStringRef name = mlirGPUAsyncTokenTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectLLVM.cpp
+++ b/mlir/lib/Bindings/Python/DialectLLVM.cpp
@@ -169,6 +169,7 @@ struct PointerType : PyConcreteType<PointerType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirLLVMPointerTypeGetTypeID;
   static constexpr const char *pyClassName = "PointerType";
+  static inline const MlirStringRef name = mlirLLVMPointerTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectLLVM.cpp
+++ b/mlir/lib/Bindings/Python/DialectLLVM.cpp
@@ -37,6 +37,7 @@ struct StructType : PyConcreteType<StructType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirLLVMStructTypeGetTypeID;
   static constexpr const char *pyClassName = "StructType";
+  static inline const MlirStringRef name = mlirLLVMStructTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectNVGPU.cpp
+++ b/mlir/lib/Bindings/Python/DialectNVGPU.cpp
@@ -24,6 +24,8 @@ struct TensorMapDescriptorType : PyConcreteType<TensorMapDescriptorType> {
   static constexpr IsAFunctionTy isaFunction =
       mlirTypeIsANVGPUTensorMapDescriptorType;
   static constexpr const char *pyClassName = "TensorMapDescriptorType";
+  static inline const MlirStringRef name =
+      mlirNVGPUTensorMapDescriptorTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectPDL.cpp
+++ b/mlir/lib/Bindings/Python/DialectPDL.cpp
@@ -42,6 +42,7 @@ struct AttributeType : PyConcreteType<AttributeType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirPDLAttributeTypeGetTypeID;
   static constexpr const char *pyClassName = "AttributeType";
+  static inline const MlirStringRef name = mlirPDLAttributeTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -65,6 +66,7 @@ struct OperationType : PyConcreteType<OperationType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirPDLOperationTypeGetTypeID;
   static constexpr const char *pyClassName = "OperationType";
+  static inline const MlirStringRef name = mlirPDLOperationTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -88,6 +90,7 @@ struct RangeType : PyConcreteType<RangeType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirPDLRangeTypeGetTypeID;
   static constexpr const char *pyClassName = "RangeType";
+  static inline const MlirStringRef name = mlirPDLRangeTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -118,6 +121,7 @@ struct TypeType : PyConcreteType<TypeType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirPDLTypeTypeGetTypeID;
   static constexpr const char *pyClassName = "TypeType";
+  static inline const MlirStringRef name = mlirPDLTypeTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -141,6 +145,7 @@ struct ValueType : PyConcreteType<ValueType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirPDLValueTypeGetTypeID;
   static constexpr const char *pyClassName = "ValueType";
+  static inline const MlirStringRef name = mlirPDLValueTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectQuant.cpp
+++ b/mlir/lib/Bindings/Python/DialectQuant.cpp
@@ -286,7 +286,7 @@ struct UniformQuantizedPerAxisType
       mlirUniformQuantizedPerAxisTypeGetTypeID;
   static constexpr const char *pyClassName = "UniformQuantizedPerAxisType";
   static inline const MlirStringRef name =
-    mlirUniformQuantizedPerAxisTypeGetName();
+      mlirUniformQuantizedPerAxisTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -374,7 +374,7 @@ struct UniformQuantizedSubChannelType
       mlirUniformQuantizedSubChannelTypeGetTypeID;
   static constexpr const char *pyClassName = "UniformQuantizedSubChannelType";
   static inline const MlirStringRef name =
-    mlirUniformQuantizedSubChannelTypeGetName();
+      mlirUniformQuantizedSubChannelTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -468,8 +468,7 @@ struct CalibratedQuantizedType
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirCalibratedQuantizedTypeGetTypeID;
   static constexpr const char *pyClassName = "CalibratedQuantizedType";
-  static inline const MlirStringRef name =
-    mlirCalibratedQuantizedTypeGetName();
+  static inline const MlirStringRef name = mlirCalibratedQuantizedTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectQuant.cpp
+++ b/mlir/lib/Bindings/Python/DialectQuant.cpp
@@ -198,6 +198,7 @@ struct AnyQuantizedType : PyConcreteType<AnyQuantizedType, QuantizedType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirAnyQuantizedTypeGetTypeID;
   static constexpr const char *pyClassName = "AnyQuantizedType";
+  static inline const MlirStringRef name = mlirAnyQuantizedTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -229,6 +230,7 @@ struct UniformQuantizedType
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirUniformQuantizedTypeGetTypeID;
   static constexpr const char *pyClassName = "UniformQuantizedType";
+  static inline const MlirStringRef name = mlirUniformQuantizedTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -283,6 +285,8 @@ struct UniformQuantizedPerAxisType
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirUniformQuantizedPerAxisTypeGetTypeID;
   static constexpr const char *pyClassName = "UniformQuantizedPerAxisType";
+  static inline const MlirStringRef name =
+    mlirUniformQuantizedPerAxisTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -369,6 +373,8 @@ struct UniformQuantizedSubChannelType
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirUniformQuantizedSubChannelTypeGetTypeID;
   static constexpr const char *pyClassName = "UniformQuantizedSubChannelType";
+  static inline const MlirStringRef name =
+    mlirUniformQuantizedSubChannelTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -462,6 +468,8 @@ struct CalibratedQuantizedType
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirCalibratedQuantizedTypeGetTypeID;
   static constexpr const char *pyClassName = "CalibratedQuantizedType";
+  static inline const MlirStringRef name =
+    mlirCalibratedQuantizedTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectSMT.cpp
+++ b/mlir/lib/Bindings/Python/DialectSMT.cpp
@@ -30,6 +30,7 @@ namespace smt {
 struct BoolType : PyConcreteType<BoolType> {
   static constexpr IsAFunctionTy isaFunction = mlirSMTTypeIsABool;
   static constexpr const char *pyClassName = "BoolType";
+  static inline const MlirStringRef name = mlirSMTBoolTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -46,6 +47,7 @@ struct BoolType : PyConcreteType<BoolType> {
 struct BitVectorType : PyConcreteType<BitVectorType> {
   static constexpr IsAFunctionTy isaFunction = mlirSMTTypeIsABitVector;
   static constexpr const char *pyClassName = "BitVectorType";
+  static inline const MlirStringRef name = mlirSMTBitVectorTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -63,6 +65,7 @@ struct BitVectorType : PyConcreteType<BitVectorType> {
 struct IntType : PyConcreteType<IntType> {
   static constexpr IsAFunctionTy isaFunction = mlirSMTTypeIsAInt;
   static constexpr const char *pyClassName = "IntType";
+  static inline const MlirStringRef name = mlirSMTIntTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/Bindings/Python/DialectTransform.cpp
+++ b/mlir/lib/Bindings/Python/DialectTransform.cpp
@@ -31,6 +31,7 @@ struct AnyOpType : PyConcreteType<AnyOpType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirTransformAnyOpTypeGetTypeID;
   static constexpr const char *pyClassName = "AnyOpType";
+  static inline const MlirStringRef name = mlirTransformAnyOpTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -54,6 +55,7 @@ struct AnyParamType : PyConcreteType<AnyParamType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirTransformAnyParamTypeGetTypeID;
   static constexpr const char *pyClassName = "AnyParamType";
+  static inline const MlirStringRef name = mlirTransformAnyParamTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -77,6 +79,7 @@ struct AnyValueType : PyConcreteType<AnyValueType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirTransformAnyValueTypeGetTypeID;
   static constexpr const char *pyClassName = "AnyValueType";
+  static inline const MlirStringRef name = mlirTransformAnyValueTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -101,6 +104,7 @@ struct OperationType : PyConcreteType<OperationType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirTransformOperationTypeGetTypeID;
   static constexpr const char *pyClassName = "OperationType";
+  static inline const MlirStringRef name = mlirTransformOperationTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {
@@ -136,6 +140,7 @@ struct ParamType : PyConcreteType<ParamType> {
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirTransformParamTypeGetTypeID;
   static constexpr const char *pyClassName = "ParamType";
+  static inline const MlirStringRef name = mlirTransformParamTypeGetName();
   using Base::Base;
 
   static void bindDerived(ClassTy &c) {

--- a/mlir/lib/CAPI/Dialect/AMDGPU.cpp
+++ b/mlir/lib/CAPI/Dialect/AMDGPU.cpp
@@ -32,6 +32,10 @@ MlirType mlirAMDGPUTDMBaseTypeGet(MlirContext ctx, MlirType elementType) {
   return wrap(amdgpu::TDMBaseType::get(unwrap(ctx), unwrap(elementType)));
 }
 
+MlirStringRef mlirAMDGPUTDMBaseTypeGetName(void) {
+  return wrap(amdgpu::TDMBaseType::name);
+}
+
 //===---------------------------------------------------------------------===//
 // TDMDescriptorType
 //===---------------------------------------------------------------------===//
@@ -46,6 +50,10 @@ MlirTypeID mlirAMDGPUTDMDescriptorTypeGetTypeID() {
 
 MlirType mlirAMDGPUTDMDescriptorTypeGet(MlirContext ctx) {
   return wrap(amdgpu::TDMDescriptorType::get(unwrap(ctx)));
+}
+
+MlirStringRef mlirAMDGPUTDMDescriptorTypeGetName(void) {
+  return wrap(amdgpu::TDMDescriptorType::name);
 }
 
 //===---------------------------------------------------------------------===//
@@ -64,4 +72,8 @@ MlirType mlirAMDGPUTDMGatherBaseTypeGet(MlirContext ctx, MlirType elementType,
                                         MlirType indexType) {
   return wrap(amdgpu::TDMGatherBaseType::get(unwrap(ctx), unwrap(elementType),
                                              unwrap(indexType)));
+}
+
+MlirStringRef mlirAMDGPUTDMGatherBaseTypeGetName(void) {
+  return wrap(amdgpu::TDMGatherBaseType::name);
 }

--- a/mlir/lib/CAPI/Dialect/EmitC.cpp
+++ b/mlir/lib/CAPI/Dialect/EmitC.cpp
@@ -49,6 +49,10 @@ MlirType mlirEmitCArrayTypeGet(intptr_t nDims, int64_t *shape,
       emitc::ArrayType::get(llvm::ArrayRef(shape, nDims), unwrap(elementType)));
 }
 
+MlirStringRef mlirEmitCArrayTypeGetName(void) {
+  return wrap(emitc::ArrayType::name);
+}
+
 //===---------------------------------------------------------------------===//
 // LValueType
 //===---------------------------------------------------------------------===//
@@ -63,6 +67,10 @@ MlirTypeID mlirEmitCLValueTypeGetTypeID(void) {
 
 MlirType mlirEmitCLValueTypeGet(MlirType valueType) {
   return wrap(emitc::LValueType::get(unwrap(valueType)));
+}
+
+MlirStringRef mlirEmitCLValueTypeGetName(void) {
+  return wrap(emitc::LValueType::name);
 }
 
 //===---------------------------------------------------------------------===//
@@ -81,6 +89,10 @@ MlirType mlirEmitCOpaqueTypeGet(MlirContext ctx, MlirStringRef value) {
   return wrap(emitc::OpaqueType::get(unwrap(ctx), unwrap(value)));
 }
 
+MlirStringRef mlirEmitCOpaqueTypeGetName(void) {
+  return wrap(emitc::OpaqueType::name);
+}
+
 //===---------------------------------------------------------------------===//
 // PointerType
 //===---------------------------------------------------------------------===//
@@ -95,6 +107,10 @@ MlirTypeID mlirEmitCPointerTypeGetTypeID(void) {
 
 MlirType mlirEmitCPointerTypeGet(MlirType pointee) {
   return wrap(emitc::PointerType::get(unwrap(pointee)));
+}
+
+MlirStringRef mlirEmitCPointerTypeGetName(void) {
+  return wrap(emitc::PointerType::name);
 }
 
 //===---------------------------------------------------------------------===//
@@ -113,6 +129,10 @@ MlirType mlirEmitCPtrDiffTTypeGet(MlirContext ctx) {
   return wrap(emitc::PtrDiffTType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirEmitCPtrDiffTTypeGetName(void) {
+  return wrap(emitc::PtrDiffTType::name);
+}
+
 //===---------------------------------------------------------------------===//
 // SignedSizeTType
 //===---------------------------------------------------------------------===//
@@ -129,6 +149,10 @@ MlirType mlirEmitCSignedSizeTTypeGet(MlirContext ctx) {
   return wrap(emitc::SignedSizeTType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirEmitCSignedSizeTTypeGetName(void) {
+  return wrap(emitc::SignedSizeTType::name);
+}
+
 //===---------------------------------------------------------------------===//
 // SizeTType
 //===---------------------------------------------------------------------===//
@@ -143,6 +167,10 @@ MlirTypeID mlirEmitCSizeTTypeGetTypeID(void) {
 
 MlirType mlirEmitCSizeTTypeGet(MlirContext ctx) {
   return wrap(emitc::SizeTType::get(unwrap(ctx)));
+}
+
+MlirStringRef mlirEmitCSizeTTypeGetName(void) {
+  return wrap(emitc::SizeTType::name);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/CAPI/Dialect/GPU.cpp
+++ b/mlir/lib/CAPI/Dialect/GPU.cpp
@@ -27,6 +27,10 @@ MlirType mlirGPUAsyncTokenTypeGet(MlirContext ctx) {
   return wrap(gpu::AsyncTokenType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirGPUAsyncTokenTypeGetName(void) {
+  return wrap(gpu::AsyncTokenType::name);
+}
+
 //===---------------------------------------------------------------------===//
 // ObjectAttr
 //===---------------------------------------------------------------------===//

--- a/mlir/lib/CAPI/Dialect/LLVM.cpp
+++ b/mlir/lib/CAPI/Dialect/LLVM.cpp
@@ -27,6 +27,10 @@ MlirType mlirLLVMPointerTypeGet(MlirContext ctx, unsigned addressSpace) {
   return wrap(LLVMPointerType::get(unwrap(ctx), addressSpace));
 }
 
+MlirStringRef mlirLLVMPointerTypeGetName(void) {
+  return wrap(LLVM::LLVMPointerType::name);
+}
+
 MlirTypeID mlirLLVMPointerTypeGetTypeID() {
   return wrap(LLVM::LLVMPointerType::getTypeID());
 }
@@ -43,8 +47,14 @@ MlirType mlirLLVMVoidTypeGet(MlirContext ctx) {
   return wrap(LLVMVoidType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirLLVMVoidTypeGetName(void) { return wrap(LLVMVoidType::name); }
+
 MlirType mlirLLVMArrayTypeGet(MlirType elementType, unsigned numElements) {
   return wrap(LLVMArrayType::get(unwrap(elementType), numElements));
+}
+
+MlirStringRef mlirLLVMArrayTypeGetName(void) {
+  return wrap(LLVMArrayType::name);
 }
 
 MlirType mlirLLVMArrayTypeGetElementType(MlirType type) {
@@ -57,6 +67,10 @@ MlirType mlirLLVMFunctionTypeGet(MlirType resultType, intptr_t nArgumentTypes,
   return wrap(LLVMFunctionType::get(
       unwrap(resultType),
       unwrapList(nArgumentTypes, argumentTypes, argumentStorage), isVarArg));
+}
+
+MlirStringRef mlirLLVMFunctionTypeGetName(void) {
+  return wrap(LLVMFunctionType::name);
 }
 
 intptr_t mlirLLVMFunctionTypeGetNumInputs(MlirType type) {

--- a/mlir/lib/CAPI/Dialect/LLVM.cpp
+++ b/mlir/lib/CAPI/Dialect/LLVM.cpp
@@ -95,6 +95,10 @@ MlirTypeID mlirLLVMStructTypeGetTypeID() {
   return wrap(LLVM::LLVMStructType::getTypeID());
 }
 
+MlirStringRef mlirLLVMStructTypeGetName(void) {
+  return wrap(LLVM::LLVMStructType::name);
+}
+
 bool mlirLLVMStructTypeIsLiteral(MlirType type) {
   return !cast<LLVM::LLVMStructType>(unwrap(type)).isIdentified();
 }

--- a/mlir/lib/CAPI/Dialect/NVGPU.cpp
+++ b/mlir/lib/CAPI/Dialect/NVGPU.cpp
@@ -29,3 +29,7 @@ MlirType mlirNVGPUTensorMapDescriptorTypeGet(MlirContext ctx,
       TensorMapSwizzleKind(swizzle), TensorMapL2PromoKind(l2promo),
       TensorMapOOBKind(oobFill), TensorMapInterleaveKind(interleave)));
 }
+
+MlirStringRef mlirNVGPUTensorMapDescriptorTypeGetName(void) {
+  return wrap(nvgpu::TensorMapDescriptorType::name);
+}

--- a/mlir/lib/CAPI/Dialect/PDL.cpp
+++ b/mlir/lib/CAPI/Dialect/PDL.cpp
@@ -40,6 +40,10 @@ MlirType mlirPDLAttributeTypeGet(MlirContext ctx) {
   return wrap(pdl::AttributeType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirPDLAttributeTypeGetName(void) {
+  return wrap(pdl::AttributeType::name);
+}
+
 //===---------------------------------------------------------------------===//
 // OperationType
 //===---------------------------------------------------------------------===//
@@ -54,6 +58,10 @@ MlirTypeID mlirPDLOperationTypeGetTypeID(void) {
 
 MlirType mlirPDLOperationTypeGet(MlirContext ctx) {
   return wrap(pdl::OperationType::get(unwrap(ctx)));
+}
+
+MlirStringRef mlirPDLOperationTypeGetName(void) {
+  return wrap(pdl::OperationType::name);
 }
 
 //===---------------------------------------------------------------------===//
@@ -71,6 +79,8 @@ MlirTypeID mlirPDLRangeTypeGetTypeID(void) {
 MlirType mlirPDLRangeTypeGet(MlirType elementType) {
   return wrap(pdl::RangeType::get(unwrap(elementType)));
 }
+
+MlirStringRef mlirPDLRangeTypeGetName(void) { return wrap(pdl::RangeType::name); }
 
 MlirType mlirPDLRangeTypeGetElementType(MlirType type) {
   return wrap(cast<pdl::RangeType>(unwrap(type)).getElementType());
@@ -92,6 +102,8 @@ MlirType mlirPDLTypeTypeGet(MlirContext ctx) {
   return wrap(pdl::TypeType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirPDLTypeTypeGetName(void) { return wrap(pdl::TypeType::name); }
+
 //===---------------------------------------------------------------------===//
 // ValueType
 //===---------------------------------------------------------------------===//
@@ -107,3 +119,5 @@ MlirTypeID mlirPDLValueTypeGetTypeID(void) {
 MlirType mlirPDLValueTypeGet(MlirContext ctx) {
   return wrap(pdl::ValueType::get(unwrap(ctx)));
 }
+
+MlirStringRef mlirPDLValueTypeGetName(void) { return wrap(pdl::ValueType::name); }

--- a/mlir/lib/CAPI/Dialect/PDL.cpp
+++ b/mlir/lib/CAPI/Dialect/PDL.cpp
@@ -80,7 +80,9 @@ MlirType mlirPDLRangeTypeGet(MlirType elementType) {
   return wrap(pdl::RangeType::get(unwrap(elementType)));
 }
 
-MlirStringRef mlirPDLRangeTypeGetName(void) { return wrap(pdl::RangeType::name); }
+MlirStringRef mlirPDLRangeTypeGetName(void) {
+  return wrap(pdl::RangeType::name);
+}
 
 MlirType mlirPDLRangeTypeGetElementType(MlirType type) {
   return wrap(cast<pdl::RangeType>(unwrap(type)).getElementType());
@@ -120,4 +122,6 @@ MlirType mlirPDLValueTypeGet(MlirContext ctx) {
   return wrap(pdl::ValueType::get(unwrap(ctx)));
 }
 
-MlirStringRef mlirPDLValueTypeGetName(void) { return wrap(pdl::ValueType::name); }
+MlirStringRef mlirPDLValueTypeGetName(void) {
+  return wrap(pdl::ValueType::name);
+}

--- a/mlir/lib/CAPI/Dialect/Quant.cpp
+++ b/mlir/lib/CAPI/Dialect/Quant.cpp
@@ -125,6 +125,10 @@ MlirType mlirAnyQuantizedTypeGet(unsigned flags, MlirType storageType,
                                            storageTypeMin, storageTypeMax));
 }
 
+MlirStringRef mlirAnyQuantizedTypeGetName(void) {
+  return wrap(quant::AnyQuantizedType::name);
+}
+
 //===---------------------------------------------------------------------===//
 // UniformQuantizedType
 //===---------------------------------------------------------------------===//
@@ -144,6 +148,10 @@ MlirType mlirUniformQuantizedTypeGet(unsigned flags, MlirType storageType,
   return wrap(quant::UniformQuantizedType::get(
       flags, unwrap(storageType), unwrap(expressedType), scale, zeroPoint,
       storageTypeMin, storageTypeMax));
+}
+
+MlirStringRef mlirUniformQuantizedTypeGetName(void) {
+  return wrap(quant::UniformQuantizedType::name);
 }
 
 double mlirUniformQuantizedTypeGetScale(MlirType type) {
@@ -179,6 +187,10 @@ MlirType mlirUniformQuantizedPerAxisTypeGet(
       flags, unwrap(storageType), unwrap(expressedType),
       llvm::ArrayRef(scales, nDims), llvm::ArrayRef(zeroPoints, nDims),
       quantizedDimension, storageTypeMin, storageTypeMax));
+}
+
+MlirStringRef mlirUniformQuantizedPerAxisTypeGetName(void) {
+  return wrap(quant::UniformQuantizedPerAxisType::name);
 }
 
 intptr_t mlirUniformQuantizedPerAxisTypeGetNumDims(MlirType type) {
@@ -238,6 +250,10 @@ MlirType mlirUniformQuantizedSubChannelTypeGet(
       storageTypeMax));
 }
 
+MlirStringRef mlirUniformQuantizedSubChannelTypeGetName(void) {
+  return wrap(quant::UniformQuantizedSubChannelType::name);
+}
+
 intptr_t mlirUniformQuantizedSubChannelTypeGetNumBlockSizes(MlirType type) {
   return cast<quant::UniformQuantizedSubChannelType>(unwrap(type))
       .getBlockSizes()
@@ -282,6 +298,10 @@ MlirType mlirCalibratedQuantizedTypeGet(MlirType expressedType, double min,
                                         double max) {
   return wrap(
       quant::CalibratedQuantizedType::get(unwrap(expressedType), min, max));
+}
+
+MlirStringRef mlirCalibratedQuantizedTypeGetName(void) {
+  return wrap(quant::CalibratedQuantizedType::name);
 }
 
 double mlirCalibratedQuantizedTypeGetMin(MlirType type) {

--- a/mlir/lib/CAPI/Dialect/SMT.cpp
+++ b/mlir/lib/CAPI/Dialect/SMT.cpp
@@ -49,17 +49,25 @@ MlirType mlirSMTTypeGetBitVector(MlirContext ctx, int32_t width) {
   return wrap(BitVectorType::get(unwrap(ctx), width));
 }
 
+MlirStringRef mlirSMTBitVectorTypeGetName(void) {
+  return wrap(BitVectorType::name);
+}
+
 bool mlirSMTTypeIsABool(MlirType type) { return isa<BoolType>(unwrap(type)); }
 
 MlirType mlirSMTTypeGetBool(MlirContext ctx) {
   return wrap(BoolType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirSMTBoolTypeGetName(void) { return wrap(BoolType::name); }
+
 bool mlirSMTTypeIsAInt(MlirType type) { return isa<IntType>(unwrap(type)); }
 
 MlirType mlirSMTTypeGetInt(MlirContext ctx) {
   return wrap(IntType::get(unwrap(ctx)));
 }
+
+MlirStringRef mlirSMTIntTypeGetName(void) { return wrap(IntType::name); }
 
 bool mlirSMTTypeIsASMTFunc(MlirType type) {
   return isa<SMTFuncType>(unwrap(type));

--- a/mlir/lib/CAPI/Dialect/Transform.cpp
+++ b/mlir/lib/CAPI/Dialect/Transform.cpp
@@ -33,6 +33,10 @@ MlirType mlirTransformAnyOpTypeGet(MlirContext ctx) {
   return wrap(transform::AnyOpType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirTransformAnyOpTypeGetName(void) {
+  return wrap(transform::AnyOpType::name);
+}
+
 //===---------------------------------------------------------------------===//
 // AnyParamType
 //===---------------------------------------------------------------------===//
@@ -49,6 +53,10 @@ MlirType mlirTransformAnyParamTypeGet(MlirContext ctx) {
   return wrap(transform::AnyParamType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirTransformAnyParamTypeGetName(void) {
+  return wrap(transform::AnyParamType::name);
+}
+
 //===---------------------------------------------------------------------===//
 // AnyValueType
 //===---------------------------------------------------------------------===//
@@ -63,6 +71,10 @@ MlirTypeID mlirTransformAnyValueTypeGetTypeID(void) {
 
 MlirType mlirTransformAnyValueTypeGet(MlirContext ctx) {
   return wrap(transform::AnyValueType::get(unwrap(ctx)));
+}
+
+MlirStringRef mlirTransformAnyValueTypeGetName(void) {
+  return wrap(transform::AnyValueType::name);
 }
 
 //===---------------------------------------------------------------------===//
@@ -83,6 +95,10 @@ MlirType mlirTransformOperationTypeGet(MlirContext ctx,
       transform::OperationType::get(unwrap(ctx), unwrap(operationName)));
 }
 
+MlirStringRef mlirTransformOperationTypeGetName(void) {
+  return wrap(transform::OperationType::name);
+}
+
 MlirStringRef mlirTransformOperationTypeGetOperationName(MlirType type) {
   return wrap(cast<transform::OperationType>(unwrap(type)).getOperationName());
 }
@@ -101,6 +117,10 @@ MlirTypeID mlirTransformParamTypeGetTypeID(void) {
 
 MlirType mlirTransformParamTypeGet(MlirContext ctx, MlirType type) {
   return wrap(transform::ParamType::get(unwrap(ctx), unwrap(type)));
+}
+
+MlirStringRef mlirTransformParamTypeGetName(void) {
+  return wrap(transform::ParamType::name);
 }
 
 MlirType mlirTransformParamTypeGetType(MlirType type) {

--- a/mlir/lib/CAPI/IR/BuiltinTypes.cpp
+++ b/mlir/lib/CAPI/IR/BuiltinTypes.cpp
@@ -35,6 +35,8 @@ MlirType mlirIntegerTypeGet(MlirContext ctx, unsigned bitwidth) {
   return wrap(IntegerType::get(unwrap(ctx), bitwidth));
 }
 
+MlirStringRef mlirIntegerTypeGetName(void) { return wrap(IntegerType::name); }
+
 MlirType mlirIntegerTypeSignedGet(MlirContext ctx, unsigned bitwidth) {
   return wrap(IntegerType::get(unwrap(ctx), bitwidth, IntegerType::Signed));
 }
@@ -73,6 +75,8 @@ MlirType mlirIndexTypeGet(MlirContext ctx) {
   return wrap(IndexType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirIndexTypeGetName(void) { return wrap(IndexType::name); }
+
 //===----------------------------------------------------------------------===//
 // Floating-point types.
 //===----------------------------------------------------------------------===//
@@ -97,6 +101,10 @@ MlirType mlirFloat4E2M1FNTypeGet(MlirContext ctx) {
   return wrap(Float4E2M1FNType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirFloat4E2M1FNTypeGetName(void) {
+  return wrap(Float4E2M1FNType::name);
+}
+
 MlirTypeID mlirFloat6E2M3FNTypeGetTypeID() {
   return wrap(Float6E2M3FNType::getTypeID());
 }
@@ -107,6 +115,10 @@ bool mlirTypeIsAFloat6E2M3FN(MlirType type) {
 
 MlirType mlirFloat6E2M3FNTypeGet(MlirContext ctx) {
   return wrap(Float6E2M3FNType::get(unwrap(ctx)));
+}
+
+MlirStringRef mlirFloat6E2M3FNTypeGetName(void) {
+  return wrap(Float6E2M3FNType::name);
 }
 
 MlirTypeID mlirFloat6E3M2FNTypeGetTypeID() {
@@ -121,6 +133,10 @@ MlirType mlirFloat6E3M2FNTypeGet(MlirContext ctx) {
   return wrap(Float6E3M2FNType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirFloat6E3M2FNTypeGetName(void) {
+  return wrap(Float6E3M2FNType::name);
+}
+
 MlirTypeID mlirFloat8E5M2TypeGetTypeID() {
   return wrap(Float8E5M2Type::getTypeID());
 }
@@ -131,6 +147,10 @@ bool mlirTypeIsAFloat8E5M2(MlirType type) {
 
 MlirType mlirFloat8E5M2TypeGet(MlirContext ctx) {
   return wrap(Float8E5M2Type::get(unwrap(ctx)));
+}
+
+MlirStringRef mlirFloat8E5M2TypeGetName(void) {
+  return wrap(Float8E5M2Type::name);
 }
 
 MlirTypeID mlirFloat8E4M3TypeGetTypeID() {
@@ -145,6 +165,10 @@ MlirType mlirFloat8E4M3TypeGet(MlirContext ctx) {
   return wrap(Float8E4M3Type::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirFloat8E4M3TypeGetName(void) {
+  return wrap(Float8E4M3Type::name);
+}
+
 MlirTypeID mlirFloat8E4M3FNTypeGetTypeID() {
   return wrap(Float8E4M3FNType::getTypeID());
 }
@@ -155,6 +179,10 @@ bool mlirTypeIsAFloat8E4M3FN(MlirType type) {
 
 MlirType mlirFloat8E4M3FNTypeGet(MlirContext ctx) {
   return wrap(Float8E4M3FNType::get(unwrap(ctx)));
+}
+
+MlirStringRef mlirFloat8E4M3FNTypeGetName(void) {
+  return wrap(Float8E4M3FNType::name);
 }
 
 MlirTypeID mlirFloat8E5M2FNUZTypeGetTypeID() {
@@ -169,6 +197,10 @@ MlirType mlirFloat8E5M2FNUZTypeGet(MlirContext ctx) {
   return wrap(Float8E5M2FNUZType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirFloat8E5M2FNUZTypeGetName(void) {
+  return wrap(Float8E5M2FNUZType::name);
+}
+
 MlirTypeID mlirFloat8E4M3FNUZTypeGetTypeID() {
   return wrap(Float8E4M3FNUZType::getTypeID());
 }
@@ -179,6 +211,10 @@ bool mlirTypeIsAFloat8E4M3FNUZ(MlirType type) {
 
 MlirType mlirFloat8E4M3FNUZTypeGet(MlirContext ctx) {
   return wrap(Float8E4M3FNUZType::get(unwrap(ctx)));
+}
+
+MlirStringRef mlirFloat8E4M3FNUZTypeGetName(void) {
+  return wrap(Float8E4M3FNUZType::name);
 }
 
 MlirTypeID mlirFloat8E4M3B11FNUZTypeGetTypeID() {
@@ -193,6 +229,10 @@ MlirType mlirFloat8E4M3B11FNUZTypeGet(MlirContext ctx) {
   return wrap(Float8E4M3B11FNUZType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirFloat8E4M3B11FNUZTypeGetName(void) {
+  return wrap(Float8E4M3B11FNUZType::name);
+}
+
 MlirTypeID mlirFloat8E3M4TypeGetTypeID() {
   return wrap(Float8E3M4Type::getTypeID());
 }
@@ -203,6 +243,10 @@ bool mlirTypeIsAFloat8E3M4(MlirType type) {
 
 MlirType mlirFloat8E3M4TypeGet(MlirContext ctx) {
   return wrap(Float8E3M4Type::get(unwrap(ctx)));
+}
+
+MlirStringRef mlirFloat8E3M4TypeGetName(void) {
+  return wrap(Float8E3M4Type::name);
 }
 
 MlirTypeID mlirFloat8E8M0FNUTypeGetTypeID() {
@@ -217,6 +261,10 @@ MlirType mlirFloat8E8M0FNUTypeGet(MlirContext ctx) {
   return wrap(Float8E8M0FNUType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirFloat8E8M0FNUTypeGetName(void) {
+  return wrap(Float8E8M0FNUType::name);
+}
+
 MlirTypeID mlirBFloat16TypeGetTypeID() {
   return wrap(BFloat16Type::getTypeID());
 }
@@ -229,6 +277,8 @@ MlirType mlirBF16TypeGet(MlirContext ctx) {
   return wrap(BFloat16Type::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirBF16TypeGetName(void) { return wrap(BFloat16Type::name); }
+
 MlirTypeID mlirFloat16TypeGetTypeID() { return wrap(Float16Type::getTypeID()); }
 
 bool mlirTypeIsAF16(MlirType type) {
@@ -238,6 +288,8 @@ bool mlirTypeIsAF16(MlirType type) {
 MlirType mlirF16TypeGet(MlirContext ctx) {
   return wrap(Float16Type::get(unwrap(ctx)));
 }
+
+MlirStringRef mlirF16TypeGetName(void) { return wrap(Float16Type::name); }
 
 MlirTypeID mlirFloatTF32TypeGetTypeID() {
   return wrap(FloatTF32Type::getTypeID());
@@ -251,6 +303,8 @@ MlirType mlirTF32TypeGet(MlirContext ctx) {
   return wrap(FloatTF32Type::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirTF32TypeGetName(void) { return wrap(FloatTF32Type::name); }
+
 MlirTypeID mlirFloat32TypeGetTypeID() { return wrap(Float32Type::getTypeID()); }
 
 bool mlirTypeIsAF32(MlirType type) {
@@ -261,6 +315,8 @@ MlirType mlirF32TypeGet(MlirContext ctx) {
   return wrap(Float32Type::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirF32TypeGetName(void) { return wrap(Float32Type::name); }
+
 MlirTypeID mlirFloat64TypeGetTypeID() { return wrap(Float64Type::getTypeID()); }
 
 bool mlirTypeIsAF64(MlirType type) {
@@ -270,6 +326,8 @@ bool mlirTypeIsAF64(MlirType type) {
 MlirType mlirF64TypeGet(MlirContext ctx) {
   return wrap(Float64Type::get(unwrap(ctx)));
 }
+
+MlirStringRef mlirF64TypeGetName(void) { return wrap(Float64Type::name); }
 
 //===----------------------------------------------------------------------===//
 // None type.
@@ -285,6 +343,8 @@ MlirType mlirNoneTypeGet(MlirContext ctx) {
   return wrap(NoneType::get(unwrap(ctx)));
 }
 
+MlirStringRef mlirNoneTypeGetName(void) { return wrap(NoneType::name); }
+
 //===----------------------------------------------------------------------===//
 // Complex type.
 //===----------------------------------------------------------------------===//
@@ -298,6 +358,8 @@ bool mlirTypeIsAComplex(MlirType type) {
 MlirType mlirComplexTypeGet(MlirType elementType) {
   return wrap(ComplexType::get(unwrap(elementType)));
 }
+
+MlirStringRef mlirComplexTypeGetName(void) { return wrap(ComplexType::name); }
 
 MlirType mlirComplexTypeGetElementType(MlirType type) {
   return wrap(llvm::cast<ComplexType>(unwrap(type)).getElementType());
@@ -380,6 +442,8 @@ MlirType mlirVectorTypeGet(intptr_t rank, const int64_t *shape,
                               unwrap(elementType)));
 }
 
+MlirStringRef mlirVectorTypeGetName(void) { return wrap(VectorType::name); }
+
 MlirType mlirVectorTypeGetChecked(MlirLocation loc, intptr_t rank,
                                   const int64_t *shape, MlirType elementType) {
   return wrap(VectorType::getChecked(
@@ -443,6 +507,10 @@ MlirType mlirRankedTensorTypeGet(intptr_t rank, const int64_t *shape,
                             unwrap(elementType), unwrap(encoding)));
 }
 
+MlirStringRef mlirRankedTensorTypeGetName(void) {
+  return wrap(RankedTensorType::name);
+}
+
 MlirType mlirRankedTensorTypeGetChecked(MlirLocation loc, intptr_t rank,
                                         const int64_t *shape,
                                         MlirType elementType,
@@ -458,6 +526,10 @@ MlirAttribute mlirRankedTensorTypeGetEncoding(MlirType type) {
 
 MlirType mlirUnrankedTensorTypeGet(MlirType elementType) {
   return wrap(UnrankedTensorType::get(unwrap(elementType)));
+}
+
+MlirStringRef mlirUnrankedTensorTypeGetName(void) {
+  return wrap(UnrankedTensorType::name);
 }
 
 MlirType mlirUnrankedTensorTypeGetChecked(MlirLocation loc,
@@ -485,6 +557,8 @@ MlirType mlirMemRefTypeGet(MlirType elementType, intptr_t rank,
           : llvm::cast<MemRefLayoutAttrInterface>(unwrap(layout)),
       unwrap(memorySpace)));
 }
+
+MlirStringRef mlirMemRefTypeGetName(void) { return wrap(MemRefType::name); }
 
 MlirType mlirMemRefTypeGetChecked(MlirLocation loc, MlirType elementType,
                                   intptr_t rank, const int64_t *shape,
@@ -554,6 +628,10 @@ MlirType mlirUnrankedMemRefTypeGet(MlirType elementType,
       UnrankedMemRefType::get(unwrap(elementType), unwrap(memorySpace)));
 }
 
+MlirStringRef mlirUnrankedMemRefTypeGetName(void) {
+  return wrap(UnrankedMemRefType::name);
+}
+
 MlirType mlirUnrankedMemRefTypeGetChecked(MlirLocation loc,
                                           MlirType elementType,
                                           MlirAttribute memorySpace) {
@@ -581,6 +659,8 @@ MlirType mlirTupleTypeGet(MlirContext ctx, intptr_t numElements,
   ArrayRef<Type> typeRef = unwrapList(numElements, elements, types);
   return wrap(TupleType::get(unwrap(ctx), typeRef));
 }
+
+MlirStringRef mlirTupleTypeGetName(void) { return wrap(TupleType::name); }
 
 intptr_t mlirTupleTypeGetNumTypes(MlirType type) {
   return llvm::cast<TupleType>(unwrap(type)).size();
@@ -612,6 +692,8 @@ MlirType mlirFunctionTypeGet(MlirContext ctx, intptr_t numInputs,
   (void)unwrapList(numResults, results, resultsList);
   return wrap(FunctionType::get(unwrap(ctx), inputsList, resultsList));
 }
+
+MlirStringRef mlirFunctionTypeGetName(void) { return wrap(FunctionType::name); }
 
 intptr_t mlirFunctionTypeGetNumInputs(MlirType type) {
   return llvm::cast<FunctionType>(unwrap(type)).getNumInputs();
@@ -649,6 +731,8 @@ MlirType mlirOpaqueTypeGet(MlirContext ctx, MlirStringRef dialectNamespace,
       OpaqueType::get(StringAttr::get(unwrap(ctx), unwrap(dialectNamespace)),
                       unwrap(typeData)));
 }
+
+MlirStringRef mlirOpaqueTypeGetName(void) { return wrap(OpaqueType::name); }
 
 MlirStringRef mlirOpaqueTypeGetDialectNamespace(MlirType type) {
   return wrap(

--- a/mlir/test/python/ir/builtin_types.py
+++ b/mlir/test/python/ir/builtin_types.py
@@ -759,6 +759,49 @@ def testTypeIDs():
         print(ShapedType(vector_type).typeid == vector_type.typeid)
 
 
+# CHECK-LABEL: TEST: testTypeName
+@run
+def testTypeName():
+    with Context():
+        # CHECK: builtin.integer
+        print(IntegerType.type_name)
+        # CHECK: builtin.index
+        print(IndexType.type_name)
+
+        # CHECK: builtin.f32
+        print(F32Type.type_name)
+        # CHECK: builtin.bf16
+        print(BF16Type.type_name)
+
+        # CHECK: builtin.none
+        print(NoneType.type_name)
+
+        # CHECK: builtin.complex
+        print(ComplexType.type_name)
+
+        # CHECK: builtin.vector
+        print(VectorType.type_name)
+
+        # CHECK: builtin.tensor
+        print(RankedTensorType.type_name)
+        # CHECK: builtin.unranked_tensor
+        print(UnrankedTensorType.type_name)
+
+        # CHECK: builtin.memref
+        print(MemRefType.type_name)
+        # CHECK: builtin.unranked_memref
+        print(UnrankedMemRefType.type_name)
+
+        # CHECK: builtin.tuple
+        print(TupleType.type_name)
+
+        # CHECK: builtin.function
+        print(FunctionType.type_name)
+
+        # CHECK: builtin.opaque
+        print(OpaqueType.type_name)
+
+
 # CHECK-LABEL: TEST: testConcreteTypesRoundTrip
 @run
 def testConcreteTypesRoundTrip():


### PR DESCRIPTION
In this PR, I added a C API for each (upstream) MLIR type to retrieve its type name (for example, `IntegerType` -> `mlirIntegerTypeGetName()` -> `"builtin.integer"`), and exposed a corresponding `type_name` class attribute in the Python bindings (e.g., `IntegerType.type_name` -> `"builtin.integer"`). This can be used in various places to avoid hard-coded strings, such as eliminating the manual string in `irdl.base("!builtin.integer")`.

Note that parts of this PR (mainly mechanical changes) were produced via GitHub Copilot and GPT-5.2. I have manually reviewed the changes and verified them with tests to ensure correctness.
