### PR TITLE
[RISCV] Fix name mangling for i64 vectors with riscv_rvv_vector_bits on RV32.

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4190,9 +4190,11 @@ void CXXNameMangler::mangleRISCVFixedRVVVectorType(const VectorType *T) {
     TypeNameOS << "uint32";
     break;
   case BuiltinType::Long:
+  case BuiltinType::LongLong:
     TypeNameOS << "int64";
     break;
   case BuiltinType::ULong:
+  case BuiltinType::ULongLong:
     TypeNameOS << "uint64";
     break;
   case BuiltinType::Float16:

--- a/clang/test/CodeGenCXX/riscv-mangle-rvv-fixed-vectors.cpp
+++ b/clang/test/CodeGenCXX/riscv-mangle-rvv-fixed-vectors.cpp
@@ -1,19 +1,43 @@
-// RUN: %clang_cc1 -triple riscv64-none-linux-gnu %s -emit-llvm -o - \
+// RUN: %clang_cc1 -triple riscv32-none-linux-gnu %s -emit-llvm -o - \
 // RUN:  -target-feature +f -target-feature +d -target-feature +zfh \
 // RUN:  -target-feature +zve64d -target-feature +zvfh -mvscale-min=1 \
 // RUN:   -mvscale-max=1 | FileCheck %s --check-prefix=CHECK-64
 // RUN: %clang_cc1 -triple riscv64-none-linux-gnu %s -emit-llvm -o - \
 // RUN:  -target-feature +f -target-feature +d -target-feature +zfh \
+// RUN:  -target-feature +zve64d -target-feature +zvfh -mvscale-min=1 \
+// RUN:   -mvscale-max=1 | FileCheck %s --check-prefix=CHECK-64
+
+// RUN: %clang_cc1 -triple riscv32-none-linux-gnu %s -emit-llvm -o - \
+// RUN:  -target-feature +f -target-feature +d -target-feature +zfh \
 // RUN:  -target-feature +zve64d -target-feature +zvfh -mvscale-min=2 \
 // RUN:  -mvscale-max=2 | FileCheck %s --check-prefix=CHECK-128
 // RUN: %clang_cc1 -triple riscv64-none-linux-gnu %s -emit-llvm -o - \
+// RUN:  -target-feature +f -target-feature +d -target-feature +zfh \
+// RUN:  -target-feature +zve64d -target-feature +zvfh -mvscale-min=2 \
+// RUN:  -mvscale-max=2 | FileCheck %s --check-prefix=CHECK-128
+
+// RUN: %clang_cc1 -triple riscv32-none-linux-gnu %s -emit-llvm -o - \
 // RUN:  -target-feature +f -target-feature +d -target-feature +zfh \
 // RUN:  -target-feature +zve64d -target-feature +zvfh -mvscale-min=4 \
 // RUN:  -mvscale-max=4 | FileCheck %s --check-prefix=CHECK-256
 // RUN: %clang_cc1 -triple riscv64-none-linux-gnu %s -emit-llvm -o - \
 // RUN:  -target-feature +f -target-feature +d -target-feature +zfh \
+// RUN:  -target-feature +zve64d -target-feature +zvfh -mvscale-min=4 \
+// RUN:  -mvscale-max=4 | FileCheck %s --check-prefix=CHECK-256
+
+// RUN: %clang_cc1 -triple riscv32-none-linux-gnu %s -emit-llvm -o - \
+// RUN:  -target-feature +f -target-feature +d -target-feature +zfh \
 // RUN:  -target-feature +zve64d -target-feature +zvfh -mvscale-min=8 \
 // RUN:  -mvscale-max=8 | FileCheck %s --check-prefix=CHECK-512
+// RUN: %clang_cc1 -triple riscv64-none-linux-gnu %s -emit-llvm -o - \
+// RUN:  -target-feature +f -target-feature +d -target-feature +zfh \
+// RUN:  -target-feature +zve64d -target-feature +zvfh -mvscale-min=8 \
+// RUN:  -mvscale-max=8 | FileCheck %s --check-prefix=CHECK-512
+
+// RUN: %clang_cc1 -triple riscv32-none-linux-gnu %s -emit-llvm -o - \
+// RUN:  -target-feature +f -target-feature +d -target-feature +zfh \
+// RUN:  -target-feature +zve64d -target-feature +zvfh -mvscale-min=16 \
+// RUN:  -mvscale-max=16 | FileCheck %s --check-prefix=CHECK-1024
 // RUN: %clang_cc1 -triple riscv64-none-linux-gnu %s -emit-llvm -o - \
 // RUN:  -target-feature +f -target-feature +d -target-feature +zfh \
 // RUN:  -target-feature +zve64d -target-feature +zvfh -mvscale-min=16 \


### PR DESCRIPTION
On RV32, i64 elements have type 'long long'.

Fixes #174613.