### PR TITLE
[C++20] [Modules] Avoid infinite loop when checking TU local exposures

### DIFF
--- a/clang/lib/Sema/SemaModule.cpp
+++ b/clang/lib/Sema/SemaModule.cpp
@@ -18,6 +18,7 @@
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/SemaInternal.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringExtras.h"
 
 using namespace clang;
@@ -1140,6 +1141,7 @@ public:
 private:
   llvm::DenseSet<const NamedDecl *> ExposureSet;
   llvm::DenseSet<const NamedDecl *> KnownNonExposureSet;
+  llvm::DenseSet<const NamedDecl *> CheckingDecls;
 };
 
 bool ExposureChecker::isTULocal(QualType Ty) {
@@ -1225,6 +1227,12 @@ bool ExposureChecker::isTULocal(const NamedDecl *D) {
       break;
     }
   }
+
+  // Avoid recursions.
+  if (CheckingDecls.count(D))
+    return false;
+  CheckingDecls.insert(D);
+  llvm::scope_exit RemoveCheckingDecls([&] { CheckingDecls.erase(D); });
 
   // [basic.link]p15.5
   // - a specialization of a template whose (possibly instantiated) declaration

--- a/clang/test/Modules/pr174543.cppm
+++ b/clang/test/Modules/pr174543.cppm
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+// expected-no-diagnostics
+export module m;
+template < typename T >
+void fun(T)
+{
+    fun(9);
+}


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/174543

The root cause of the problem is that the recursion in the code pattern triggers infinite loop in the checking process for TU local exposure.