### PR TITLE
Move the ObjC layout bitmap to the cstring section.

### DIFF
--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -730,6 +730,7 @@ enum class ObjCLabelType {
   MethodVarName,
   MethodVarType,
   PropertyName,
+  LayoutBitMap,
 };
 
 class CGObjCCommonMac : public CodeGen::CGObjCRuntime {
@@ -4048,6 +4049,9 @@ CGObjCCommonMac::CreateCStringLiteral(StringRef Name, ObjCLabelType Type,
   case ObjCLabelType::PropertyName:
     Label = "OBJC_PROP_NAME_ATTR_";
     break;
+  case ObjCLabelType::LayoutBitMap:
+    Label = "OBJC_LAYOUT_BITMAP_";
+    break;
   }
 
   bool NonFragile = ForceNonFragileABI || isNonFragileABI();
@@ -4069,6 +4073,9 @@ CGObjCCommonMac::CreateCStringLiteral(StringRef Name, ObjCLabelType Type,
   case ObjCLabelType::PropertyName:
     Section = NonFragile ? "__TEXT,__objc_methname,cstring_literals"
                          : "__TEXT,__cstring,cstring_literals";
+    break;
+  case ObjCLabelType::LayoutBitMap:
+    Section = "__TEXT,__cstring,cstring_literals";
     break;
   }
 
@@ -5421,7 +5428,7 @@ IvarLayoutBuilder::buildBitmap(CGObjCCommonMac &CGObjC,
   buffer.push_back(0);
 
   auto *Entry = CGObjC.CreateCStringLiteral(
-      reinterpret_cast<char *>(buffer.data()), ObjCLabelType::ClassName);
+      reinterpret_cast<char *>(buffer.data()), ObjCLabelType::LayoutBitMap);
   return getConstantGEP(CGM.getLLVMContext(), Entry, 0, 0);
 }
 

--- a/clang/test/CodeGenObjC/fragile-arc.m
+++ b/clang/test/CodeGenObjC/fragile-arc.m
@@ -16,9 +16,9 @@
 
 // GLOBALS-LABEL: @OBJC_METACLASS_A
 //  Strong layout: scan the first word.
-// GLOBALS: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant [2 x i8] c"\01\00"
+// GLOBALS: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant [2 x i8] c"\01\00"
 //  Weak layout: skip the first word, scan the second word.
-// GLOBALS: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant [2 x i8] c"\11\00"
+// GLOBALS: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant [2 x i8] c"\11\00"
 
 //  0x04002001
 //     ^ is compiled by ARC (controls interpretation of layouts)
@@ -95,9 +95,9 @@
 // GLOBALS-LABEL: @OBJC_METACLASS_C
 //  Strong layout: skip five, scan four, skip three, scan seven
 //    'T' == 0x54, '7' == 0x37
-// GLOBALS: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant [3 x i8] c"T7\00"
+// GLOBALS: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant [3 x i8] c"T7\00"
 //  Weak layout: skip nine, scan three
-// GLOBALS: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant [2 x i8] c"\93\00"
+// GLOBALS: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant [2 x i8] c"\93\00"
 
 extern void useBlock(void (^block)(void));
 

--- a/clang/test/CodeGenObjC/ivar-layout-64.m
+++ b/clang/test/CodeGenObjC/ivar-layout-64.m
@@ -34,8 +34,8 @@ __weak B *f2;
 @end
 
 // CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"C\00"
-// CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"\11p\00"
-// CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"!`\00"
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} c"\11p\00"
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} c"!`\00"
 
 
 @implementation C
@@ -49,8 +49,8 @@ __weak B *f2;
 @end
 
 // CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"A\00"
-// CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"\11q\10\00"
-// CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"!q\00"
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} c"\11q\10\00"
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} c"!q\00"
 
 @implementation A
 @synthesize p0 = _p0;
@@ -63,8 +63,8 @@ __weak B *f2;
 @end
 
 // CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"D\00"
-// CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"\11\A0\00"
-// CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"!\90\00"
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} c"\11\A0\00"
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} c"!\90\00"
 
 @implementation D
 @synthesize p3 = _p3;
@@ -90,7 +90,7 @@ typedef unsigned int FSCatalogInfoBitmap;
 @end
 
 // CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"NSFileLocationComponent\00"
-// CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"\01\14\00"
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} c"\01\14\00"
 
 @implementation NSFileLocationComponent @end
 
@@ -109,7 +109,7 @@ typedef unsigned int FSCatalogInfoBitmap;
 @end
 
 // CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"Foo\00"
-// CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"\02\10\00"
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} c"\02\10\00"
 
 @implementation Foo @end
 
@@ -125,7 +125,7 @@ struct __attribute__((packed)) PackedStruct {
 @end
 @implementation Packed @end
 // CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"Packed\00"
-// CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"\01 \00"
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} c"\01 \00"
 //  ' ' == 0x20
 
 // Ensure that layout descends into anonymous unions and structs.
@@ -143,7 +143,7 @@ struct __attribute__((packed)) PackedStruct {
 @end
 @implementation AnonymousUnion @end
 // CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"AnonymousUnion\00"
-// CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"\02\00"
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} c"\02\00"
 
 @interface AnonymousStruct : NSObject {
   struct {
@@ -156,6 +156,6 @@ struct __attribute__((packed)) PackedStruct {
 @end
 @implementation AnonymousStruct @end
 // CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"AnonymousStruct\00"
-// CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"\02\10\00"
-// CHECK: @OBJC_CLASS_NAME_{{.*}} = private unnamed_addr constant {{.*}} c"!\00"
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} c"\02\10\00"
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} c"!\00"
 //  '!' == 0x21

--- a/clang/test/CodeGenObjC/ivar-layout-array0-struct.m
+++ b/clang/test/CodeGenObjC/ivar-layout-array0-struct.m
@@ -18,5 +18,5 @@ typedef struct {
 @end
 
 @implementation Test @end
-// CHECK-LP64: L_OBJC_CLASS_NAME_.4:
+// CHECK-LP64: L_OBJC_LAYOUT_BITMAP_:
 // CHECK-LP64-NEXT: .asciz      "\001\020"

--- a/clang/test/CodeGenObjC/ivar-layout-no-optimize.m
+++ b/clang/test/CodeGenObjC/ivar-layout-no-optimize.m
@@ -16,5 +16,5 @@
 @implementation AllPointers
 @end
 
-// CHECK-LP64: L_OBJC_CLASS_NAME_.6:
+// CHECK-LP64: OBJC_LAYOUT_BITMAP_:
 // CHECK-LP64-NEXT: .asciz	"\004"

--- a/clang/test/CodeGenObjC/mrc-weak.m
+++ b/clang/test/CodeGenObjC/mrc-weak.m
@@ -14,10 +14,10 @@
 @end
 // CHECK-MODERN: @"OBJC_IVAR_$_HighlyAlignedSubclass.ivar2" ={{.*}} global i64 24,
 // CHECK-MODERN: @"OBJC_IVAR_$_HighlyAlignedSubclass.ivar" ={{.*}} global i64 16,
-// CHECK-MODERN: @OBJC_CLASS_NAME_{{.*}} = {{.*}} c"\02\00"
+// CHECK-MODERN: @OBJC_LAYOUT_BITMAP_{{.*}} = {{.*}} c"\02\00"
 // CHECK-MODERN: @"_OBJC_CLASS_RO_$_HighlyAlignedSubclass" = {{.*}} {
 // CHECK-FRAGILE: @OBJC_INSTANCE_VARIABLES_HighlyAlignedSubclass = {{.*}}, i32 8 }, {{.*}}, i32 12 }]
-// CHECK-FRAGILE: @OBJC_CLASS_NAME_{{.*}} = {{.*}} c"\02\00"
+// CHECK-FRAGILE: @OBJC_LAYOUT_BITMAP_{{.*}} = {{.*}} c"\02\00"
 // CHECK-FRAGILE: @OBJC_CLASS_HighlyAlignedSubclass
 @interface HighlyAlignedSubclass : HighlyAligned {
   __weak id ivar;
@@ -26,14 +26,14 @@
 @end
 @implementation HighlyAlignedSubclass @end
 
-// CHECK-MODERN: @OBJC_CLASS_NAME_{{.*}} = {{.*}} c"\01\00"
+// CHECK-MODERN: @OBJC_LAYOUT_BITMAP_{{.*}} = {{.*}} c"\01\00"
 // CHECK-MODERN: @"_OBJC_CLASS_RO_$_Foo" = {{.*}} { i32 772
 //   772 == 0x304
 //            ^ HasMRCWeakIvars
 //            ^ HasCXXDestructorOnly
 //              ^ HasCXXStructors
 
-// CHECK-FRAGILE: @OBJC_CLASS_NAME_{{.*}} = {{.*}} c"\01\00"
+// CHECK-FRAGILE: @OBJC_LAYOUT_BITMAP_{{.*}} = {{.*}} c"\01\00"
 // CHECK-FRAGILE: @OBJC_CLASS_Foo = {{.*}} i32 134225921,
 //   134225921 == 0x08002001
 //                   ^ HasMRCWeakIvars

--- a/clang/test/CodeGenObjCXX/mrc-weak.mm
+++ b/clang/test/CodeGenObjCXX/mrc-weak.mm
@@ -6,14 +6,14 @@
 - (void) run;
 @end
 
-// CHECK-MODERN: @OBJC_CLASS_NAME_{{.*}} = {{.*}} c"\01\00"
+// CHECK-MODERN: @OBJC_LAYOUT_BITMAP_{{.*}} = {{.*}} c"\01\00"
 // CHECK-MODERN: @"_OBJC_CLASS_RO_$_Foo" = {{.*}} { i32 772
 //   772 == 0x304
 //            ^ HasMRCWeakIvars
 //            ^ HasCXXDestructorOnly
 //              ^ HasCXXStructors
 
-// CHECK-FRAGILE: @OBJC_CLASS_NAME_{{.*}} = {{.*}} c"\01\00"
+// CHECK-FRAGILE: @OBJC_LAYOUT_BITMAP_{{.*}} = {{.*}} c"\01\00"
 // CHECK-FRAGILE: @OBJC_CLASS_Foo = {{.*}} i32 134225921,
 //   134225921 == 0x08002001
 //                   ^ HasMRCWeakIvars


### PR DESCRIPTION
Currently the layout bitmap is emitted as a "class name" but its not actually a name at all.  This moves the bitmap to the regular cstring section for now.

In Apple, our linker and other tools try to optimize sections such as objc strings.  As layout bitmaps aren't really strings at all, they block some optimizations.  We don't currently try to optimize sections such as cstring, which is why that is the section i used here for now.