### PR TITLE
[SelectionDAG] Add ISD::CTLS to canCreateUndefOrPoison.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5652,6 +5652,7 @@ bool SelectionDAG::canCreateUndefOrPoison(SDValue Op, const APInt &DemandedElts,
   case ISD::BSWAP:
   case ISD::CTTZ:
   case ISD::CTLZ:
+  case ISD::CTLS:
   case ISD::CTPOP:
   case ISD::BITREVERSE:
   case ISD::PARITY:


### PR DESCRIPTION
I'm having trouble coming up with a test case for this. Everything I've tried gets optimized before ctlz is converted to ctls.