### PR TITLE
[GitHub] Add more glob patterns for `mlir:python` label

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -475,6 +475,9 @@ mlir:python:
   - changed-files:
     - any-glob-to-any-file:
       - mlir/python/**/*
+      - mlir/include/mlir/Bindings/Python/**
+      - mlir/lib/Bindings/Python/**
+      - mlir/tools/mlir-tblgen/*Python*
 
 mlir:vectorops:
   - changed-files:


### PR DESCRIPTION
Right now, some paths for `mlir:python` are missing, which means relevant people don’t always get notified. This PR adds those paths.