### PR TITLE
[RISCV] Use ZeroOrNegativeOneBooleanContent for RVV to match P extension.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -790,7 +790,7 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
   }
 
   if (Subtarget.hasVInstructions()) {
-    setBooleanVectorContents(ZeroOrOneBooleanContent);
+    setBooleanVectorContents(ZeroOrNegativeOneBooleanContent);
 
     setOperationAction(ISD::VSCALE, XLenVT, Custom);
 

--- a/llvm/test/CodeGen/RISCV/rvv/vscale-vw-web-simplification.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vscale-vw-web-simplification.ll
@@ -151,42 +151,36 @@ define <vscale x 2 x i64> @vwop_vscale_sext_i32i64_multiple_users(ptr %x, ptr %y
 define <vscale x 2 x i32> @vwop_vscale_sext_i1i32_multiple_users(ptr %x, ptr %y, ptr %z) {
 ; NO_FOLDING-LABEL: vwop_vscale_sext_i1i32_multiple_users:
 ; NO_FOLDING:       # %bb.0:
-; NO_FOLDING-NEXT:    vsetvli a3, zero, e32, m1, ta, mu
-; NO_FOLDING-NEXT:    vlm.v v8, (a0)
-; NO_FOLDING-NEXT:    vmv.v.i v10, 0
-; NO_FOLDING-NEXT:    vmv.v.v v0, v8
-; NO_FOLDING-NEXT:    vmerge.vim v11, v10, -1, v0
+; NO_FOLDING-NEXT:    vsetvli a3, zero, e32, m1, ta, ma
+; NO_FOLDING-NEXT:    vlm.v v0, (a0)
+; NO_FOLDING-NEXT:    vmv.v.i v8, 0
+; NO_FOLDING-NEXT:    vmerge.vim v9, v8, -1, v0
 ; NO_FOLDING-NEXT:    vlm.v v0, (a1)
-; NO_FOLDING-NEXT:    vlm.v v9, (a2)
-; NO_FOLDING-NEXT:    vmerge.vim v12, v10, -1, v0
-; NO_FOLDING-NEXT:    vmv.v.v v0, v9
-; NO_FOLDING-NEXT:    vmerge.vim v9, v10, -1, v0
-; NO_FOLDING-NEXT:    vmul.vv v10, v11, v12
-; NO_FOLDING-NEXT:    vsub.vv v11, v11, v9
-; NO_FOLDING-NEXT:    vmv.v.v v0, v8
-; NO_FOLDING-NEXT:    vadd.vi v9, v9, -1, v0.t
-; NO_FOLDING-NEXT:    vor.vv v8, v10, v9
-; NO_FOLDING-NEXT:    vor.vv v8, v8, v11
+; NO_FOLDING-NEXT:    vmerge.vim v10, v8, -1, v0
+; NO_FOLDING-NEXT:    vlm.v v0, (a2)
+; NO_FOLDING-NEXT:    vmul.vv v10, v9, v10
+; NO_FOLDING-NEXT:    vmerge.vim v8, v8, -1, v0
+; NO_FOLDING-NEXT:    vadd.vv v11, v9, v8
+; NO_FOLDING-NEXT:    vsub.vv v8, v9, v8
+; NO_FOLDING-NEXT:    vor.vv v9, v10, v11
+; NO_FOLDING-NEXT:    vor.vv v8, v9, v8
 ; NO_FOLDING-NEXT:    ret
 ;
 ; FOLDING-LABEL: vwop_vscale_sext_i1i32_multiple_users:
 ; FOLDING:       # %bb.0:
-; FOLDING-NEXT:    vsetvli a3, zero, e32, m1, ta, mu
-; FOLDING-NEXT:    vlm.v v8, (a0)
-; FOLDING-NEXT:    vmv.v.i v10, 0
-; FOLDING-NEXT:    vmv.v.v v0, v8
-; FOLDING-NEXT:    vmerge.vim v11, v10, -1, v0
+; FOLDING-NEXT:    vsetvli a3, zero, e32, m1, ta, ma
+; FOLDING-NEXT:    vlm.v v0, (a0)
+; FOLDING-NEXT:    vmv.v.i v8, 0
+; FOLDING-NEXT:    vmerge.vim v9, v8, -1, v0
 ; FOLDING-NEXT:    vlm.v v0, (a1)
-; FOLDING-NEXT:    vlm.v v9, (a2)
-; FOLDING-NEXT:    vmerge.vim v12, v10, -1, v0
-; FOLDING-NEXT:    vmv.v.v v0, v9
-; FOLDING-NEXT:    vmerge.vim v9, v10, -1, v0
-; FOLDING-NEXT:    vmul.vv v10, v11, v12
-; FOLDING-NEXT:    vsub.vv v11, v11, v9
-; FOLDING-NEXT:    vmv.v.v v0, v8
-; FOLDING-NEXT:    vadd.vi v9, v9, -1, v0.t
-; FOLDING-NEXT:    vor.vv v8, v10, v9
-; FOLDING-NEXT:    vor.vv v8, v8, v11
+; FOLDING-NEXT:    vmerge.vim v10, v8, -1, v0
+; FOLDING-NEXT:    vlm.v v0, (a2)
+; FOLDING-NEXT:    vmul.vv v10, v9, v10
+; FOLDING-NEXT:    vmerge.vim v8, v8, -1, v0
+; FOLDING-NEXT:    vadd.vv v11, v9, v8
+; FOLDING-NEXT:    vsub.vv v8, v9, v8
+; FOLDING-NEXT:    vor.vv v9, v10, v11
+; FOLDING-NEXT:    vor.vv v8, v9, v8
 ; FOLDING-NEXT:    ret
   %a = load <vscale x 2 x i1>, ptr %x
   %b = load <vscale x 2 x i1>, ptr %y
@@ -205,42 +199,36 @@ define <vscale x 2 x i32> @vwop_vscale_sext_i1i32_multiple_users(ptr %x, ptr %y,
 define <vscale x 2 x i8> @vwop_vscale_sext_i1i8_multiple_users(ptr %x, ptr %y, ptr %z) {
 ; NO_FOLDING-LABEL: vwop_vscale_sext_i1i8_multiple_users:
 ; NO_FOLDING:       # %bb.0:
-; NO_FOLDING-NEXT:    vsetvli a3, zero, e8, mf4, ta, mu
-; NO_FOLDING-NEXT:    vlm.v v8, (a0)
-; NO_FOLDING-NEXT:    vmv.v.i v10, 0
-; NO_FOLDING-NEXT:    vmv1r.v v0, v8
-; NO_FOLDING-NEXT:    vmerge.vim v11, v10, -1, v0
+; NO_FOLDING-NEXT:    vsetvli a3, zero, e8, mf4, ta, ma
+; NO_FOLDING-NEXT:    vlm.v v0, (a0)
+; NO_FOLDING-NEXT:    vmv.v.i v8, 0
+; NO_FOLDING-NEXT:    vmerge.vim v9, v8, -1, v0
 ; NO_FOLDING-NEXT:    vlm.v v0, (a1)
-; NO_FOLDING-NEXT:    vlm.v v9, (a2)
-; NO_FOLDING-NEXT:    vmerge.vim v12, v10, -1, v0
-; NO_FOLDING-NEXT:    vmv1r.v v0, v9
-; NO_FOLDING-NEXT:    vmerge.vim v9, v10, -1, v0
-; NO_FOLDING-NEXT:    vmul.vv v10, v11, v12
-; NO_FOLDING-NEXT:    vsub.vv v11, v11, v9
-; NO_FOLDING-NEXT:    vmv1r.v v0, v8
-; NO_FOLDING-NEXT:    vadd.vi v9, v9, -1, v0.t
-; NO_FOLDING-NEXT:    vor.vv v8, v10, v9
-; NO_FOLDING-NEXT:    vor.vv v8, v8, v11
+; NO_FOLDING-NEXT:    vmerge.vim v10, v8, -1, v0
+; NO_FOLDING-NEXT:    vlm.v v0, (a2)
+; NO_FOLDING-NEXT:    vmul.vv v10, v9, v10
+; NO_FOLDING-NEXT:    vmerge.vim v8, v8, -1, v0
+; NO_FOLDING-NEXT:    vadd.vv v11, v9, v8
+; NO_FOLDING-NEXT:    vsub.vv v8, v9, v8
+; NO_FOLDING-NEXT:    vor.vv v9, v10, v11
+; NO_FOLDING-NEXT:    vor.vv v8, v9, v8
 ; NO_FOLDING-NEXT:    ret
 ;
 ; FOLDING-LABEL: vwop_vscale_sext_i1i8_multiple_users:
 ; FOLDING:       # %bb.0:
-; FOLDING-NEXT:    vsetvli a3, zero, e8, mf4, ta, mu
-; FOLDING-NEXT:    vlm.v v8, (a0)
-; FOLDING-NEXT:    vmv.v.i v10, 0
-; FOLDING-NEXT:    vmv1r.v v0, v8
-; FOLDING-NEXT:    vmerge.vim v11, v10, -1, v0
+; FOLDING-NEXT:    vsetvli a3, zero, e8, mf4, ta, ma
+; FOLDING-NEXT:    vlm.v v0, (a0)
+; FOLDING-NEXT:    vmv.v.i v8, 0
+; FOLDING-NEXT:    vmerge.vim v9, v8, -1, v0
 ; FOLDING-NEXT:    vlm.v v0, (a1)
-; FOLDING-NEXT:    vlm.v v9, (a2)
-; FOLDING-NEXT:    vmerge.vim v12, v10, -1, v0
-; FOLDING-NEXT:    vmv1r.v v0, v9
-; FOLDING-NEXT:    vmerge.vim v9, v10, -1, v0
-; FOLDING-NEXT:    vmul.vv v10, v11, v12
-; FOLDING-NEXT:    vsub.vv v11, v11, v9
-; FOLDING-NEXT:    vmv1r.v v0, v8
-; FOLDING-NEXT:    vadd.vi v9, v9, -1, v0.t
-; FOLDING-NEXT:    vor.vv v8, v10, v9
-; FOLDING-NEXT:    vor.vv v8, v8, v11
+; FOLDING-NEXT:    vmerge.vim v10, v8, -1, v0
+; FOLDING-NEXT:    vlm.v v0, (a2)
+; FOLDING-NEXT:    vmul.vv v10, v9, v10
+; FOLDING-NEXT:    vmerge.vim v8, v8, -1, v0
+; FOLDING-NEXT:    vadd.vv v11, v9, v8
+; FOLDING-NEXT:    vsub.vv v8, v9, v8
+; FOLDING-NEXT:    vor.vv v9, v10, v11
+; FOLDING-NEXT:    vor.vv v8, v9, v8
 ; FOLDING-NEXT:    ret
   %a = load <vscale x 2 x i1>, ptr %x
   %b = load <vscale x 2 x i1>, ptr %y
@@ -440,30 +428,36 @@ define <vscale x 2 x i32> @vwop_vscale_zext_i1i32_multiple_users(ptr %x, ptr %y,
 ; NO_FOLDING:       # %bb.0:
 ; NO_FOLDING-NEXT:    vsetvli a3, zero, e32, m1, ta, mu
 ; NO_FOLDING-NEXT:    vlm.v v0, (a0)
-; NO_FOLDING-NEXT:    vmv.v.i v8, 0
-; NO_FOLDING-NEXT:    vmerge.vim v9, v8, 1, v0
-; NO_FOLDING-NEXT:    vlm.v v0, (a2)
-; NO_FOLDING-NEXT:    vmerge.vim v8, v8, 1, v0
-; NO_FOLDING-NEXT:    vlm.v v0, (a1)
-; NO_FOLDING-NEXT:    vadd.vv v10, v9, v8
-; NO_FOLDING-NEXT:    vsub.vv v8, v9, v8
-; NO_FOLDING-NEXT:    vor.vv v10, v10, v9, v0.t
-; NO_FOLDING-NEXT:    vor.vv v8, v10, v8
+; NO_FOLDING-NEXT:    vlm.v v8, (a2)
+; NO_FOLDING-NEXT:    vmv.v.i v9, 0
+; NO_FOLDING-NEXT:    vmerge.vim v10, v9, 1, v0
+; NO_FOLDING-NEXT:    vlm.v v9, (a1)
+; NO_FOLDING-NEXT:    vmv.v.v v11, v10
+; NO_FOLDING-NEXT:    vmv.v.v v0, v8
+; NO_FOLDING-NEXT:    vadd.vi v11, v10, 1, v0.t
+; NO_FOLDING-NEXT:    vmv.v.v v12, v10
+; NO_FOLDING-NEXT:    vadd.vi v12, v10, -1, v0.t
+; NO_FOLDING-NEXT:    vmv.v.v v0, v9
+; NO_FOLDING-NEXT:    vor.vv v11, v11, v10, v0.t
+; NO_FOLDING-NEXT:    vor.vv v8, v11, v12
 ; NO_FOLDING-NEXT:    ret
 ;
 ; FOLDING-LABEL: vwop_vscale_zext_i1i32_multiple_users:
 ; FOLDING:       # %bb.0:
 ; FOLDING-NEXT:    vsetvli a3, zero, e32, m1, ta, mu
 ; FOLDING-NEXT:    vlm.v v0, (a0)
-; FOLDING-NEXT:    vmv.v.i v8, 0
-; FOLDING-NEXT:    vmerge.vim v9, v8, 1, v0
-; FOLDING-NEXT:    vlm.v v0, (a2)
-; FOLDING-NEXT:    vmerge.vim v8, v8, 1, v0
-; FOLDING-NEXT:    vlm.v v0, (a1)
-; FOLDING-NEXT:    vadd.vv v10, v9, v8
-; FOLDING-NEXT:    vsub.vv v8, v9, v8
-; FOLDING-NEXT:    vor.vv v10, v10, v9, v0.t
-; FOLDING-NEXT:    vor.vv v8, v10, v8
+; FOLDING-NEXT:    vlm.v v8, (a2)
+; FOLDING-NEXT:    vmv.v.i v9, 0
+; FOLDING-NEXT:    vmerge.vim v10, v9, 1, v0
+; FOLDING-NEXT:    vlm.v v9, (a1)
+; FOLDING-NEXT:    vmv.v.v v11, v10
+; FOLDING-NEXT:    vmv.v.v v0, v8
+; FOLDING-NEXT:    vadd.vi v11, v10, 1, v0.t
+; FOLDING-NEXT:    vmv.v.v v12, v10
+; FOLDING-NEXT:    vadd.vi v12, v10, -1, v0.t
+; FOLDING-NEXT:    vmv.v.v v0, v9
+; FOLDING-NEXT:    vor.vv v11, v11, v10, v0.t
+; FOLDING-NEXT:    vor.vv v8, v11, v12
 ; FOLDING-NEXT:    ret
   %a = load <vscale x 2 x i1>, ptr %x
   %b = load <vscale x 2 x i1>, ptr %y
@@ -484,30 +478,36 @@ define <vscale x 2 x i8> @vwop_vscale_zext_i1i8_multiple_users(ptr %x, ptr %y, p
 ; NO_FOLDING:       # %bb.0:
 ; NO_FOLDING-NEXT:    vsetvli a3, zero, e8, mf4, ta, mu
 ; NO_FOLDING-NEXT:    vlm.v v0, (a0)
-; NO_FOLDING-NEXT:    vmv.v.i v8, 0
-; NO_FOLDING-NEXT:    vmerge.vim v9, v8, 1, v0
-; NO_FOLDING-NEXT:    vlm.v v0, (a2)
-; NO_FOLDING-NEXT:    vmerge.vim v8, v8, 1, v0
-; NO_FOLDING-NEXT:    vlm.v v0, (a1)
-; NO_FOLDING-NEXT:    vadd.vv v10, v9, v8
-; NO_FOLDING-NEXT:    vsub.vv v8, v9, v8
-; NO_FOLDING-NEXT:    vor.vv v10, v10, v9, v0.t
-; NO_FOLDING-NEXT:    vor.vv v8, v10, v8
+; NO_FOLDING-NEXT:    vlm.v v8, (a2)
+; NO_FOLDING-NEXT:    vmv.v.i v9, 0
+; NO_FOLDING-NEXT:    vmerge.vim v10, v9, 1, v0
+; NO_FOLDING-NEXT:    vlm.v v9, (a1)
+; NO_FOLDING-NEXT:    vmv1r.v v11, v10
+; NO_FOLDING-NEXT:    vmv1r.v v0, v8
+; NO_FOLDING-NEXT:    vadd.vi v11, v10, 1, v0.t
+; NO_FOLDING-NEXT:    vmv1r.v v12, v10
+; NO_FOLDING-NEXT:    vadd.vi v12, v10, -1, v0.t
+; NO_FOLDING-NEXT:    vmv1r.v v0, v9
+; NO_FOLDING-NEXT:    vor.vv v11, v11, v10, v0.t
+; NO_FOLDING-NEXT:    vor.vv v8, v11, v12
 ; NO_FOLDING-NEXT:    ret
 ;
 ; FOLDING-LABEL: vwop_vscale_zext_i1i8_multiple_users:
 ; FOLDING:       # %bb.0:
 ; FOLDING-NEXT:    vsetvli a3, zero, e8, mf4, ta, mu
 ; FOLDING-NEXT:    vlm.v v0, (a0)
-; FOLDING-NEXT:    vmv.v.i v8, 0
-; FOLDING-NEXT:    vmerge.vim v9, v8, 1, v0
-; FOLDING-NEXT:    vlm.v v0, (a2)
-; FOLDING-NEXT:    vmerge.vim v8, v8, 1, v0
-; FOLDING-NEXT:    vlm.v v0, (a1)
-; FOLDING-NEXT:    vadd.vv v10, v9, v8
-; FOLDING-NEXT:    vsub.vv v8, v9, v8
-; FOLDING-NEXT:    vor.vv v10, v10, v9, v0.t
-; FOLDING-NEXT:    vor.vv v8, v10, v8
+; FOLDING-NEXT:    vlm.v v8, (a2)
+; FOLDING-NEXT:    vmv.v.i v9, 0
+; FOLDING-NEXT:    vmerge.vim v10, v9, 1, v0
+; FOLDING-NEXT:    vlm.v v9, (a1)
+; FOLDING-NEXT:    vmv1r.v v11, v10
+; FOLDING-NEXT:    vmv1r.v v0, v8
+; FOLDING-NEXT:    vadd.vi v11, v10, 1, v0.t
+; FOLDING-NEXT:    vmv1r.v v12, v10
+; FOLDING-NEXT:    vadd.vi v12, v10, -1, v0.t
+; FOLDING-NEXT:    vmv1r.v v0, v9
+; FOLDING-NEXT:    vor.vv v11, v11, v10, v0.t
+; FOLDING-NEXT:    vor.vv v8, v11, v12
 ; FOLDING-NEXT:    ret
   %a = load <vscale x 2 x i1>, ptr %x
   %b = load <vscale x 2 x i1>, ptr %y

--- a/llvm/test/CodeGen/RISCV/rvv/vwadd-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vwadd-sdnode.ll
@@ -1618,8 +1618,8 @@ define <vscale x 8 x i32> @vwadd_vx_splat_sext_i1(<vscale x 8 x i1> %va, i16 %b)
 ; RV64-NEXT:    vmv.v.x v8, a0
 ; RV64-NEXT:    vsetvli zero, zero, e16, m2, ta, mu
 ; RV64-NEXT:    vmv.v.x v12, a0
-; RV64-NEXT:    li a0, 1
-; RV64-NEXT:    vwsub.vx v8, v12, a0, v0.t
+; RV64-NEXT:    li a0, -1
+; RV64-NEXT:    vwadd.vx v8, v12, a0, v0.t
 ; RV64-NEXT:    ret
   %sb = sext i16 %b to i32
   %head = insertelement <vscale x 8 x i32> poison, i32 %sb, i32 0


### PR DESCRIPTION
For the most part this doesn't matter for RVV since it has legal i1 vectors. I think this will make it easier for P and RVV to co-exist in LLVM.