### PR TITLE
[InstCombine] Restrain folding switch condition operation into case to one-use

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -4347,8 +4347,9 @@ Instruction *InstCombinerImpl::visitSwitchInst(SwitchInst &SI) {
     return nullptr;
   };
 
-  // Attempt to invert and simplify the switch condition.
-  if (auto InvertFn = MaybeInvertible(Cond); InvertFn) {
+  // Attempt to invert and simplify the switch condition, as long as the
+  // condition is not used further, as it may not be profitable otherwise.
+  if (auto InvertFn = MaybeInvertible(Cond); InvertFn && Cond->hasOneUse()) {
     for (auto &Case : SI.cases()) {
       const APInt &New = InvertFn(Case.getCaseValue()->getValue(), *CondOpC);
       Case.setValue(ConstantInt::get(SI.getContext(), New));

--- a/llvm/test/Transforms/InstCombine/switch-xor.ll
+++ b/llvm/test/Transforms/InstCombine/switch-xor.ll
@@ -66,10 +66,10 @@ define i1 @test_switch_with_xor_condition_multiple_uses(i32 %x) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[X]], 2
 ; CHECK-NEXT:    call void @opaque(i32 [[XOR]])
-; CHECK-NEXT:    switch i32 [[X]], label %[[SW_DEFAULT:.*]] [
-; CHECK-NEXT:      i32 3, label %[[SW_BB:.*]]
-; CHECK-NEXT:      i32 0, label %[[SW_BB]]
-; CHECK-NEXT:      i32 1, label %[[SW_BB]]
+; CHECK-NEXT:    switch i32 [[XOR]], label %[[SW_DEFAULT:.*]] [
+; CHECK-NEXT:      i32 1, label %[[SW_BB:.*]]
+; CHECK-NEXT:      i32 2, label %[[SW_BB]]
+; CHECK-NEXT:      i32 3, label %[[SW_BB]]
 ; CHECK-NEXT:    ]
 ; CHECK:       [[SW_BB]]:
 ; CHECK-NEXT:    ret i1 true


### PR DESCRIPTION
It may be profitable to simplify the switch condition operation into their cases if such a condition is used only by the switch.