### PR TITLE
Add time trace scopes to addToCallGraph & getCFG

### DIFF
--- a/clang/include/clang/Analysis/CallGraph.h
+++ b/clang/include/clang/Analysis/CallGraph.h
@@ -26,6 +26,7 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator_range.h"
+#include "llvm/Support/TimeProfiler.h"
 #include <memory>
 
 namespace clang {
@@ -61,6 +62,7 @@ public:
   ///
   /// Recursively walks the declaration to find all the dependent Decls as well.
   void addToCallGraph(Decl *D) {
+    llvm::TimeTraceScope TimeProfile("AddToCallGraph");
     TraverseDecl(D);
   }
 

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -42,6 +42,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/SaveAndRestore.h"
+#include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <memory>
@@ -218,6 +219,7 @@ CFG *AnalysisDeclContext::getCFG() {
     return getUnoptimizedCFG();
 
   if (!builtCFG) {
+    llvm::TimeTraceScope TimeProfile("BuildCFG");
     cfg = CFG::buildCFG(D, getBody(), &D->getASTContext(), cfgBuildOptions);
     // Even when the cfg is not successfully built, we don't
     // want to try building it again.

--- a/clang/lib/Analysis/AnalysisDeclContext.cpp
+++ b/clang/lib/Analysis/AnalysisDeclContext.cpp
@@ -42,7 +42,6 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/SaveAndRestore.h"
-#include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <memory>
@@ -219,7 +218,6 @@ CFG *AnalysisDeclContext::getCFG() {
     return getUnoptimizedCFG();
 
   if (!builtCFG) {
-    llvm::TimeTraceScope TimeProfile("BuildCFG");
     cfg = CFG::buildCFG(D, getBody(), &D->getASTContext(), cfgBuildOptions);
     // Even when the cfg is not successfully built, we don't
     // want to try building it again.

--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -52,6 +52,7 @@
 #include "llvm/Support/Format.h"
 #include "llvm/Support/GraphWriter.h"
 #include "llvm/Support/SaveAndRestore.h"
+#include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <memory>
@@ -5359,6 +5360,7 @@ CFGBlock *CFG::createBlock() {
 /// buildCFG - Constructs a CFG from an AST.
 std::unique_ptr<CFG> CFG::buildCFG(const Decl *D, Stmt *Statement,
                                    ASTContext *C, const BuildOptions &BO) {
+  llvm::TimeTraceScope TimeProfile("BuildCFG");
   CFGBuilder Builder(C, BO);
   return Builder.buildCFG(D, Statement);
 }

--- a/clang/unittests/Support/TimeProfilerTest.cpp
+++ b/clang/unittests/Support/TimeProfilerTest.cpp
@@ -333,8 +333,10 @@ Frontend (test.cc)
 | | InstantiateFunction (fooA<int>, a.h:7)
 | | | InstantiateFunction (fooB<int>, b.h:8)
 | | | | DeferInstantiation (fooC<int>)
+| | | | BuildCFG
 | | | DeferInstantiation (fooMTA<int>)
 | | | InstantiateFunction (fooC<int>, b.h:3)
+| | | | BuildCFG
 | | | InstantiateFunction (fooMTA<int>, a.h:4)
 )",
             buildTraceGraph(Json));


### PR DESCRIPTION
his PR adds performance instrumentation to `clang::CallGraph` and `clang::AnalysisDeclContext` to aid in benchmarking the overhead of call graph construction and CFG rebuilding.

Changes
- `clang/include/clang/Analysis/CallGraph.h`: Added a TimeTraceScope labeled `AddToCallGraph` to instrument the discovery of function nodes and call edges across the Translation Unit.
- `clang/lib/Analysis/AnalysisDeclContext.cpp`: Added a TimeTraceScope labeled `BuildCFG` inside `getCFG()`. The scope is placed within the `!builtCFG` block to measure the actual construction time.

This aims to facilitate benchmarking on large codebases like LLVM to ensure that the performance impact of new analysis-based warnings remains within acceptable regressions.