### PR TITLE
DeveloperPolicy: Add note about legacy bitcode performance

### DIFF
--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -793,6 +793,9 @@ for llvm users and not imposing a big burden on llvm developers:
   it is to drop it. That is not very user friendly and a bit more effort is
   expected, but no promises are made.
 
+* Legacy bitcode may have degraded performance when compared to
+  the compiled output with the legacy compiler.
+
 C API Changes
 -------------
 


### PR DESCRIPTION
Note that bitcode does not attempt to guarantee performance
parity with upgraded bitcode.