### PR TITLE
[lldb-dap][NFC] Ignore extension built test artefacts.

### DIFF
--- a/lldb/tools/lldb-dap/extension/.gitignore
+++ b/lldb/tools/lldb-dap/extension/.gitignore
@@ -1,5 +1,6 @@
 out
 bin
 node_modules
+.vscode-test
 *.vsix
 !.vscode


### PR DESCRIPTION
Testing LLDB-DAP vscode extension creates files in the .vscode-test folder ignore them.