### PR TITLE
[ARM] Add tablegen patterns for vsdot and vudot high index.

### DIFF
--- a/llvm/lib/Target/ARM/ARMInstrNEON.td
+++ b/llvm/lib/Target/ARM/ARMInstrNEON.td
@@ -115,6 +115,13 @@ def VectorIndex64 : Operand<i32>, ImmLeaf<i32, [{
   let PrintMethod = "printVectorIndex";
 }
 
+def VectorIndex32_Hi_XForm  : SDNodeXForm<imm, [{
+  return CurDAG->getTargetConstant(N->getZExtValue() - 2, SDLoc(N), MVT::i32);
+}]>;
+def VectorIndex32_Hi : ImmLeaf<i32, [{
+  return ((uint64_t)Imm) >= 2 && ((uint64_t)Imm) < 4;
+}], VectorIndex32_Hi_XForm>;
+
 // Register list of one D register.
 def VecListOneDAsmOperand : AsmOperandClass {
   let Name = "VecListOneD";
@@ -4879,6 +4886,23 @@ defm VUDOTQI : DOTI<"vudot", "u8", 0b1, 0b1, QPR, v4i32, v16i8,
                     int_arm_neon_udot, (EXTRACT_SUBREG QPR:$Vm, dsub_0)>;
 defm VSDOTQI : DOTI<"vsdot", "s8", 0b1, 0b0, QPR, v4i32, v16i8,
                     int_arm_neon_sdot, (EXTRACT_SUBREG QPR:$Vm, dsub_0)>;
+
+let Predicates = [HasDotProd, IsLE] in {
+  def : Pat<(v4i32 (int_arm_neon_sdot (v4i32 QPR:$Vd),
+                        (v16i8 QPR:$Vn),
+                        (v16i8 (bitconvert (v4i32
+                                    (ARMvduplane (v4i32 QPR:$Vm),
+                                                  VectorIndex32_Hi:$lane)))))),
+            (VSDOTQI QPR:$Vd, QPR:$Vn,
+                      (EXTRACT_SUBREG QPR:$Vm, dsub_1), VectorIndex32_Hi:$lane)>;
+  def : Pat<(v4i32 (int_arm_neon_udot (v4i32 QPR:$Vd),
+                        (v16i8 QPR:$Vn),
+                        (v16i8 (bitconvert (v4i32
+                                    (ARMvduplane (v4i32 QPR:$Vm),
+                                                  VectorIndex32_Hi:$lane)))))),
+            (VUDOTQI QPR:$Vd, QPR:$Vn,
+                      (EXTRACT_SUBREG QPR:$Vm, dsub_1), VectorIndex32_Hi:$lane)>;
+}
 
 // v8.6A matrix multiplication extension
 let Predicates = [HasMatMulInt8] in {

--- a/llvm/test/CodeGen/ARM/neon-dot-product.ll
+++ b/llvm/test/CodeGen/ARM/neon-dot-product.ll
@@ -97,11 +97,9 @@ define <4 x i32> @sdot_multi(<4 x i32> %vacc0x0123, <16 x i8> %va, <16 x i8> %vb
 ; CHECK-LABEL: sdot_multi:
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    vsdot.s8 q0, q2, d2[0]
-; CHECK-NEXT:    vdup.32 q8, d3[0]
 ; CHECK-NEXT:    vsdot.s8 q0, q2, d2[1]
-; CHECK-NEXT:    vdup.32 q9, d3[1]
-; CHECK-NEXT:    vsdot.s8 q0, q2, q8
-; CHECK-NEXT:    vsdot.s8 q0, q2, q9
+; CHECK-NEXT:    vsdot.s8 q0, q2, d3[0]
+; CHECK-NEXT:    vsdot.s8 q0, q2, d3[1]
 ; CHECK-NEXT:    bx lr
 entry:
   %0 = bitcast <16 x i8> %va to <4 x i32>
@@ -125,11 +123,9 @@ define <4 x i32> @udot_multi(<4 x i32> %vacc0x0123, <16 x i8> %va, <16 x i8> %vb
 ; CHECK-LABEL: udot_multi:
 ; CHECK:       @ %bb.0: @ %entry
 ; CHECK-NEXT:    vudot.u8 q0, q2, d2[0]
-; CHECK-NEXT:    vdup.32 q8, d3[0]
 ; CHECK-NEXT:    vudot.u8 q0, q2, d2[1]
-; CHECK-NEXT:    vdup.32 q9, d3[1]
-; CHECK-NEXT:    vudot.u8 q0, q2, q8
-; CHECK-NEXT:    vudot.u8 q0, q2, q9
+; CHECK-NEXT:    vudot.u8 q0, q2, d3[0]
+; CHECK-NEXT:    vudot.u8 q0, q2, d3[1]
 ; CHECK-NEXT:    bx lr
 entry:
   %0 = bitcast <16 x i8> %va to <4 x i32>


### PR DESCRIPTION
The index on a vsdot and vudot instruction can be 0/1 from a D-reg, not 0/1/2/3
from a Q reg as would be expected. Add a pattern to allow extracting from the
high half of the input vector.

Fixes #174688