### PR TITLE
[ORC][JITLink] Fix generated perf jitdump file's invalid header Flags

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderPerf.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderPerf.cpp
@@ -247,6 +247,7 @@ static Expected<Header> FillMachine(PerfState &State) {
   Hdr.TotalSize = sizeof(Hdr);
   Hdr.Pid = State.Pid;
   Hdr.Timestamp = perf_get_timestamp();
+  Hdr.Flags = 0;
 
   char Id[16];
   struct {


### PR DESCRIPTION
When generating the header of perf jitdump file, the header is allocated from the stack, but the Flags field isn't initialized, which leads to trash data on the stack being used and written to the jitdump file, and then perf will complain.

Fix this by explicitly set Flags to 0.