### PR TITLE
[NFC][SPIRV] Small changes for SPIRVPushConstantAccess

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPushConstantAccess.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPushConstantAccess.cpp
@@ -57,10 +57,7 @@ static bool replacePushConstantAccesses(Module &M, SPIRVGlobalRegistry *GR) {
           NewGV->getType(), Intrinsic::spv_pushconstant_getpointer, {NewGV});
       GR->buildAssignPtr(Builder, GV->getValueType(), GetPointerCall);
 
-      for (unsigned N = 0; N < I->getNumOperands(); ++N) {
-        if (I->getOperand(N) == GV)
-          I->setOperand(N, GetPointerCall);
-      }
+      I->replaceUsesOfWith(GV, GetPointerCall);
     }
 
     GV->eraseFromParent();

--- a/llvm/lib/Target/SPIRV/SPIRVPushConstantAccess.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPushConstantAccess.cpp
@@ -63,7 +63,7 @@ static bool replacePushConstantAccesses(Module &M, SPIRVGlobalRegistry *GR) {
     GV->eraseFromParent();
   }
 
-  return true;
+  return !PushConstants.empty();
 }
 
 PreservedAnalyses SPIRVPushConstantAccess::run(Module &M,

--- a/llvm/lib/Target/SPIRV/SPIRVPushConstantAccess.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPushConstantAccess.cpp
@@ -49,8 +49,7 @@ static bool replacePushConstantAccesses(Module &M, SPIRVGlobalRegistry *GR) {
         /* InsertBefore= */ GV, GV->getThreadLocalMode(), GV->getAddressSpace(),
         GV->isExternallyInitialized());
 
-    SmallVector<User *, 4> Users(GV->user_begin(), GV->user_end());
-    for (User *U : Users) {
+    for (User *U : make_early_inc_range(GV->users())) {
       Instruction *I = cast<Instruction>(U);
       IRBuilder<> Builder(I);
       Value *GetPointerCall = Builder.CreateIntrinsic(


### PR DESCRIPTION
This patch consists of 3 NFC changes:
* Do not always report _changed_, report it only when something was modified
* Replace loop with `replaceUsesOfWith`
* Instead of using a temporary vector, use `make_early_inc_range()` to pre-increment the iterator before erasing the current element.