### PR TITLE
[lldb] Correct version -v output for booleans

### DIFF
--- a/lldb/source/Commands/CommandObjectVersion.cpp
+++ b/lldb/source/Commands/CommandObjectVersion.cpp
@@ -55,7 +55,7 @@ static void dump(const StructuredData::Dictionary &config, Stream &s) {
 
         s << "  " << key << ": ";
         if (StructuredData::Boolean *boolean = value_sp->GetAsBoolean())
-          s << (boolean ? "yes" : "no");
+          s << (boolean->GetValue() ? "yes" : "no");
         else if (StructuredData::Array *array = value_sp->GetAsArray())
           dump(*array, s);
         s << '\n';


### PR DESCRIPTION
We were checking whether the structured data value could be got as a boolean, not what value that boolean had. This meant we were incorrectly showing "yes" for everything.