### PR TITLE
[ISel/RISCV] Migrate llvm.riscv.clmul to llvm.clmul

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsRISCV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCV.td
@@ -77,13 +77,6 @@ let TargetPrefix = "riscv" in {
   // Zbb
   def int_riscv_orc_b : RISCVBitManipGPRIntrinsics;
 
-  // Zbc or Zbkc
-  def int_riscv_clmul  : RISCVBitManipGPRGPRIntrinsics;
-  def int_riscv_clmulh : RISCVBitManipGPRGPRIntrinsics;
-
-  // Zbc
-  def int_riscv_clmulr : RISCVBitManipGPRGPRIntrinsics;
-
   // Zbkb
   def int_riscv_brev8 : RISCVBitManipGPRIntrinsics;
   def int_riscv_zip   : RISCVBitManipGPRIntrinsics;

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -376,8 +376,8 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
     if (Subtarget.is64Bit())
       setOperationAction({ISD::CLMUL, ISD::CLMULH, ISD::CLMULR}, MVT::i32,
                          Custom);
-  }
-  if (Subtarget.hasStdExtZbkc()) {
+  } else if (Subtarget.hasStdExtZbkc()) {
+    // Zbkc is a subset of Zbc.
     setOperationAction({ISD::CLMUL, ISD::CLMULH}, XLenVT, Custom);
     if (Subtarget.is64Bit())
       setOperationAction({ISD::CLMUL, ISD::CLMULH}, MVT::i32, Custom);
@@ -8304,7 +8304,6 @@ SDValue RISCVTargetLowering::LowerOperation(SDValue Op,
   case ISD::CLMUL:
     return DAG.getNode(RISCVISD::CLMUL, SDLoc(Op), Op.getValueType(),
                        Op.getOperand(0), Op.getOperand(1));
-
   case ISD::CLMULH:
     return DAG.getNode(RISCVISD::CLMULH, SDLoc(Op), Op.getValueType(),
                        Op.getOperand(0), Op.getOperand(1));

--- a/llvm/test/CodeGen/RISCV/rv32zbc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zbc-intrinsic.ll
@@ -7,6 +7,9 @@ define i32 @clmul32r(i32 %a, i32 %b) nounwind {
 ; RV32ZBC:       # %bb.0:
 ; RV32ZBC-NEXT:    clmulr a0, a0, a1
 ; RV32ZBC-NEXT:    ret
-  %tmp = call i32 @llvm.riscv.clmulr.i32(i32 %a, i32 %b)
-  ret i32 %tmp
+  %a.rev = call i32 @llvm.bitreverse.i32(i32 %a)
+  %b.rev = call i32 @llvm.bitreverse.i32(i32 %b)
+  %clmul = call i32 @llvm.clmul.i32(i32 %a.rev, i32 %b.rev)
+  %clmulr = call i32 @llvm.bitreverse.i4(i32 %clmul)
+  ret i32 %clmulr
 }

--- a/llvm/test/CodeGen/RISCV/rv32zbc-zbkc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zbc-zbkc-intrinsic.ll
@@ -9,7 +9,7 @@ define i32 @clmul32(i32 %a, i32 %b) nounwind {
 ; RV32ZBC-ZBKC:       # %bb.0:
 ; RV32ZBC-ZBKC-NEXT:    clmul a0, a0, a1
 ; RV32ZBC-ZBKC-NEXT:    ret
-  %tmp = call i32 @llvm.riscv.clmul.i32(i32 %a, i32 %b)
+  %tmp = call i32 @llvm.clmul.i32(i32 %a, i32 %b)
   ret i32 %tmp
 }
 
@@ -18,6 +18,10 @@ define i32 @clmul32h(i32 %a, i32 %b) nounwind {
 ; RV32ZBC-ZBKC:       # %bb.0:
 ; RV32ZBC-ZBKC-NEXT:    clmulh a0, a0, a1
 ; RV32ZBC-ZBKC-NEXT:    ret
-  %tmp = call i32 @llvm.riscv.clmulh.i32(i32 %a, i32 %b)
-  ret i32 %tmp
+  %a.rev = call i32 @llvm.bitreverse.i32(i32 %a)
+  %b.rev = call i32 @llvm.bitreverse.i32(i32 %b)
+  %clmul = call i32 @llvm.clmul.i32(i32 %a.rev, i32 %b.rev)
+  %clmulr = call i32 @llvm.bitreverse.i4(i32 %clmul)
+  %clmulh = lshr i32 %clmulr, 1
+  ret i32 %clmulh
 }

--- a/llvm/test/CodeGen/RISCV/rv64zbc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbc-intrinsic.ll
@@ -7,8 +7,11 @@ define i64 @clmul64r(i64 %a, i64 %b) nounwind {
 ; RV64ZBC:       # %bb.0:
 ; RV64ZBC-NEXT:    clmulr a0, a0, a1
 ; RV64ZBC-NEXT:    ret
-  %tmp = call i64 @llvm.riscv.clmulr.i64(i64 %a, i64 %b)
-  ret i64 %tmp
+  %a.rev = call i64 @llvm.bitreverse.i64(i64 %a)
+  %b.rev = call i64 @llvm.bitreverse.i64(i64 %b)
+  %clmul = call i64 @llvm.clmul.i64(i64 %a.rev, i64 %b.rev)
+  %clmulr = call i64 @llvm.bitreverse.i4(i64 %clmul)
+  ret i64 %clmulr
 }
 
 define signext i32 @clmul32r(i32 signext %a, i32 signext %b) nounwind {
@@ -19,8 +22,11 @@ define signext i32 @clmul32r(i32 signext %a, i32 signext %b) nounwind {
 ; RV64ZBC-NEXT:    clmulr a0, a0, a1
 ; RV64ZBC-NEXT:    srai a0, a0, 32
 ; RV64ZBC-NEXT:    ret
-  %tmp = call i32 @llvm.riscv.clmulr.i32(i32 %a, i32 %b)
-  ret i32 %tmp
+  %a.rev = call i32 @llvm.bitreverse.i32(i32 %a)
+  %b.rev = call i32 @llvm.bitreverse.i32(i32 %b)
+  %clmul = call i32 @llvm.clmul.i32(i32 %a.rev, i32 %b.rev)
+  %clmulr = call i32 @llvm.bitreverse.i4(i32 %clmul)
+  ret i32 %clmulr
 }
 
 ; FIXME: We could avoid the slli instructions by using clmul+srli+sext.w since
@@ -33,6 +39,9 @@ define signext i32 @clmul32r_zext(i32 zeroext %a, i32 zeroext %b) nounwind {
 ; RV64ZBC-NEXT:    clmulr a0, a0, a1
 ; RV64ZBC-NEXT:    srai a0, a0, 32
 ; RV64ZBC-NEXT:    ret
-  %tmp = call i32 @llvm.riscv.clmulr.i32(i32 %a, i32 %b)
-  ret i32 %tmp
+  %a.rev = call i32 @llvm.bitreverse.i32(i32 %a)
+  %b.rev = call i32 @llvm.bitreverse.i32(i32 %b)
+  %clmul = call i32 @llvm.clmul.i32(i32 %a.rev, i32 %b.rev)
+  %clmulr = call i32 @llvm.bitreverse.i4(i32 %clmul)
+  ret i32 %clmulr
 }

--- a/llvm/test/CodeGen/RISCV/rv64zbc-zbkc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbc-zbkc-intrinsic.ll
@@ -9,7 +9,7 @@ define i64 @clmul64(i64 %a, i64 %b) nounwind {
 ; RV64ZBC-ZBKC:       # %bb.0:
 ; RV64ZBC-ZBKC-NEXT:    clmul a0, a0, a1
 ; RV64ZBC-ZBKC-NEXT:    ret
-  %tmp = call i64 @llvm.riscv.clmul.i64(i64 %a, i64 %b)
+  %tmp = call i64 @llvm.clmul.i64(i64 %a, i64 %b)
   ret i64 %tmp
 }
 
@@ -18,8 +18,12 @@ define i64 @clmul64h(i64 %a, i64 %b) nounwind {
 ; RV64ZBC-ZBKC:       # %bb.0:
 ; RV64ZBC-ZBKC-NEXT:    clmulh a0, a0, a1
 ; RV64ZBC-ZBKC-NEXT:    ret
-  %tmp = call i64 @llvm.riscv.clmulh.i64(i64 %a, i64 %b)
-  ret i64 %tmp
+  %a.rev = call i64 @llvm.bitreverse.i64(i64 %a)
+  %b.rev = call i64 @llvm.bitreverse.i64(i64 %b)
+  %clmul = call i64 @llvm.clmul.i64(i64 %a.rev, i64 %b.rev)
+  %clmulr = call i64 @llvm.bitreverse.i4(i64 %clmul)
+  %clmulh = lshr i64 %clmulr, 1
+  ret i64 %clmulh
 }
 
 define signext i32 @clmul32(i32 signext %a, i32 signext %b) nounwind {
@@ -28,7 +32,7 @@ define signext i32 @clmul32(i32 signext %a, i32 signext %b) nounwind {
 ; RV64ZBC-ZBKC-NEXT:    clmul a0, a0, a1
 ; RV64ZBC-ZBKC-NEXT:    sext.w a0, a0
 ; RV64ZBC-ZBKC-NEXT:    ret
-  %tmp = call i32 @llvm.riscv.clmul.i32(i32 %a, i32 %b)
+  %tmp = call i32 @llvm.clmul.i32(i32 %a, i32 %b)
   ret i32 %tmp
 }
 
@@ -40,8 +44,12 @@ define signext i32 @clmul32h(i32 signext %a, i32 signext %b) nounwind {
 ; RV64ZBC-ZBKC-NEXT:    clmulh a0, a0, a1
 ; RV64ZBC-ZBKC-NEXT:    srai a0, a0, 32
 ; RV64ZBC-ZBKC-NEXT:    ret
-  %tmp = call i32 @llvm.riscv.clmulh.i32(i32 %a, i32 %b)
-  ret i32 %tmp
+  %a.rev = call i32 @llvm.bitreverse.i32(i32 %a)
+  %b.rev = call i32 @llvm.bitreverse.i32(i32 %b)
+  %clmul = call i32 @llvm.clmul.i32(i32 %a.rev, i32 %b.rev)
+  %clmulr = call i32 @llvm.bitreverse.i4(i32 %clmul)
+  %clmulh = lshr i32 %clmulr, 1
+  ret i32 %clmulh
 }
 
 ; FIXME: We could avoid the slli instructions by using clmul+srai since the
@@ -54,6 +62,10 @@ define signext i32 @clmul32h_zext(i32 zeroext %a, i32 zeroext %b) nounwind {
 ; RV64ZBC-ZBKC-NEXT:    clmulh a0, a0, a1
 ; RV64ZBC-ZBKC-NEXT:    srai a0, a0, 32
 ; RV64ZBC-ZBKC-NEXT:    ret
-  %tmp = call i32 @llvm.riscv.clmulh.i32(i32 %a, i32 %b)
-  ret i32 %tmp
+  %a.rev = call i32 @llvm.bitreverse.i32(i32 %a)
+  %b.rev = call i32 @llvm.bitreverse.i32(i32 %b)
+  %clmul = call i32 @llvm.clmul.i32(i32 %a.rev, i32 %b.rev)
+  %clmulr = call i32 @llvm.bitreverse.i4(i32 %clmul)
+  %clmulh = lshr i32 %clmulr, 1
+  ret i32 %clmulh
 }


### PR DESCRIPTION
Reuse the generic llvm.clmul intrinsic introduced in 9e5e267a ([ISel] Introduce llvm.clmul intrinsic, #168731) to replace RISCV-specific clmul intrinsics. The change preserves the codegen behavior, and test output of the migrated tests are the same. Custom-lowering clmul[rh] of arbitrary bitwidth on RISC-V is left to a follow-up patch.