### PR TITLE
[lldb][Format] Reject recursive format entities

### DIFF
--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -2716,7 +2716,13 @@ Status FormatEntity::Parse(const llvm::StringRef &format_str, Entry &entry) {
 
 bool FormatEntity::Formatter::IsInvalidRecursiveFormat(Entry::Type type) {
   // It is expected that Scope and Root format entities recursively call Format.
-  if (llvm::is_contained({Entry::Type::Scope, Entry::Type::Root}, type))
+  //
+  // Variable may also be formatted recursively in some special cases. The main
+  // use-case being array summary strings, in which case Format will call itself
+  // with the subrange ValueObject and apply a freshly created Variable entry.
+  // E.g., ${var[1-3]} will format the [1-3] range with ${var%S}.
+  if (llvm::is_contained(
+          {Entry::Type::Scope, Entry::Type::Root, Entry::Type::Variable}, type))
     return false;
 
   return llvm::is_contained(m_entry_type_stack, type);

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -2721,8 +2721,10 @@ bool FormatEntity::Formatter::IsInvalidRecursiveFormat(Entry::Type type) {
   // use-case being array summary strings, in which case Format will call itself
   // with the subrange ValueObject and apply a freshly created Variable entry.
   // E.g., ${var[1-3]} will format the [1-3] range with ${var%S}.
-  if (llvm::is_contained(
-          {Entry::Type::Scope, Entry::Type::Root, Entry::Type::Variable}, type))
+  static constexpr std::array s_permitted_recursive_entities = {
+      Entry::Type::Scope, Entry::Type::Root, Entry::Type::Variable};
+
+  if (llvm::is_contained(s_permitted_recursive_entities, type))
     return false;
 
   return llvm::is_contained(m_entry_type_stack, type);

--- a/lldb/test/Shell/Settings/TestCxxFrameFormatRecursive.test
+++ b/lldb/test/Shell/Settings/TestCxxFrameFormatRecursive.test
@@ -19,5 +19,4 @@ run
 bt
 
 # CHECK: bt
-# CHECK-NOT: custom-frame
-# CHECK: main
+# CHECK: custom-frame 'main

--- a/lldb/test/Shell/Settings/TestCxxFrameFormatRecursive.test
+++ b/lldb/test/Shell/Settings/TestCxxFrameFormatRecursive.test
@@ -1,7 +1,3 @@
-# Flaky on Linux, see https://github.com/llvm/llvm-project/issues/142726
-# UNSUPPORTED: system-linux
-# XFAIL: *
-
 # Test disallowed variables inside the
 # plugin.cplusplus.display.function-name-format setting.
 


### PR DESCRIPTION
Depends on:
* https://github.com/llvm/llvm-project/pull/174618

If a format entity calls back into `Format` and passes it a format entity type that we're already in the process of parsing, we are likely going to run into infinite recursion and blow the stack. I think this is only an issue when a format entity calls Format on a format string provided by the user (otherwise we're in control of the recursion). An example of this can be seen in the test-case adjusted by this patch.

This seems to be causing actual crashes in the field, so this patch adds basic tracking to `Formatter::Format` that checks whether we're recursively parsing the same entity. This may very well be intended by some entities (e.g., `Root` and `Scope`), so there is an escape hatch for those. There's also a special case where `Variable` causes a recursive format (which I pointed out in a source comment).

We could narrow the scope of what kind of recursion is allowed by adding a `UserProvidedFormatChild` (or similar) flag to `Entry`, and only disallow recursing on those kinds of entries. For now I just use an exemption list in `IsInvalidRecursiveFormat`.

Adding a unit-test for this is unfortunately tricky because the only format entity that currently suffers from this is `${function.name-with-args}`, which requires a language plugin and valid target. If we really wanted to we could probably mock all of those, but the shell test provides test coverage for the previously crashing case.

rdar://166890120