### PR TITLE
[lldb] Add zlib to version -v output

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1200,6 +1200,10 @@ def skipIfFBSDVMCoreSupportMissing(func):
     return _get_bool_config_skip_if_decorator("fbsdvmcore")(func)
 
 
+def skipIfZLIBSupportMissing(func):
+    return _get_bool_config_skip_if_decorator("zlib")(func)
+
+
 def skipIfLLVMTargetMissing(target):
     config = lldb.SBDebugger.GetBuildConfiguration()
     targets = config.GetValueForKey("targets").GetValueForKey("value")

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -2483,6 +2483,9 @@ StructuredData::DictionarySP Debugger::GetBuildConfiguration() {
                      "A boolean value that indicates if editline wide "
                      "characters support is enabled in LLDB");
   AddBoolConfigEntry(
+      *config_up, "zlib", LLVM_ENABLE_ZLIB,
+      "A boolean value that indicates if zlib support is enabled in LLDB");
+  AddBoolConfigEntry(
       *config_up, "lzma", LLDB_ENABLE_LZMA,
       "A boolean value that indicates if lzma support is enabled in LLDB");
   AddBoolConfigEntry(

--- a/lldb/test/API/python_api/section/TestSectionAPI.py
+++ b/lldb/test/API/python_api/section/TestSectionAPI.py
@@ -53,6 +53,7 @@ class SectionAPITestCase(TestBase):
 
     @no_debug_info_test
     @skipIfXmlSupportMissing
+    @skipIfZLIBSupportMissing
     def test_compressed_section_data(self):
         exe = self.getBuildArtifact("compressed-sections.out")
         self.yaml2obj("compressed-sections.yaml", exe)


### PR DESCRIPTION
I know this is required for at least one feature, because TestSectionAPI.py has failures if zlib isn't enabled. So I think it's useful for users to be able to check.

Now that it's in the config, I have also used it to make a test annotation so we don't get the failure in TestSectionAPI.py when zlib is disabled.

Which for future reference was:
Traceback (most recent call last):
  File "/home/davspi01/llvm-project/lldb/packages/Python/lldbsuite/test/decorators.py", line 452, in wrapper
    return func(self, *args, **kwargs)
  File "/home/davspi01/llvm-project/lldb/test/API/python_api/section/TestSectionAPI.py", line 67, in test_compressed_section_data
    self.assertEqual(section_data, [0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90])
AssertionError: Lists differ: [] != [32, 48, 64, 80, 96, 112, 128, 144]

As it failed to decode the compressed section.