### PR TITLE
[CodeGen][EarlyIfConversion] Fix loop invariant operands check

### DIFF
--- a/llvm/lib/CodeGen/EarlyIfConversion.cpp
+++ b/llvm/lib/CodeGen/EarlyIfConversion.cpp
@@ -942,9 +942,9 @@ bool EarlyIfConverter::shouldConvertIf() {
                all_of(Def->operands(), [&](MachineOperand &Op) {
                  if (Op.isImm())
                    return true;
-                 if (!MO.isReg() || !MO.isUse())
-                   return false;
-                 Register Reg = MO.getReg();
+                 if (!Op.isReg() || !Op.isUse())
+                   return true;
+                 Register Reg = Op.getReg();
                  if (Reg.isPhysical())
                    return false;
 

--- a/llvm/test/CodeGen/AArch64/early-ifcvt-likely-predictable.mir
+++ b/llvm/test/CodeGen/AArch64/early-ifcvt-likely-predictable.mir
@@ -17,6 +17,11 @@
   entry:
     ret void
   }
+
+  define void @test_cond_def_inside_loop_with_invariant_operands() {
+  entry:
+    ret void
+  }
 ...
 ---
 name:            test_cond_is_load_with_invariant_ops
@@ -240,6 +245,63 @@ body:             |
     STRBBui %4, %7, 0 :: (store (s8))
     early-clobber %21:gpr64sp = STRBBpost %3, %0, 1 :: (store (s8))
     %5:gpr64all = COPY %21
+    B %bb.1
+
+...
+---
+name:            test_cond_def_inside_loop_with_invariant_operands
+alignment:       4
+tracksRegLiveness: true
+body:             |
+  ; CHECK-LABEL: name: test_cond_def_inside_loop_with_invariant_operands
+  ; CHECK: bb.0:
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT:   liveins: $x0, $x1, $x2
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:gpr64common = COPY $x0
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:gpr64common = COPY $x1
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gpr64common = COPY $x2
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[LDRWui:%[0-9]+]]:gpr32 = LDRWui [[COPY]], 0 :: (load (s32))
+  ; CHECK-NEXT:   [[LDRWui1:%[0-9]+]]:gpr32 = LDRWui [[COPY1]], 0 :: (load (s32))
+  ; CHECK-NEXT:   [[SUBSWrs:%[0-9]+]]:gpr32common = SUBSWrs [[LDRWui]], [[LDRWui1]], 0, implicit-def $nzcv
+  ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:gpr32all = COPY $wzr
+  ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:gpr32 = COPY [[COPY3]]
+  ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:gpr32common = COPY [[LDRWui]]
+  ; CHECK-NEXT:   [[ADDWri:%[0-9]+]]:gpr32common = ADDWri [[COPY5]], 1, 0
+  ; CHECK-NEXT:   [[COPY6:%[0-9]+]]:gpr32all = COPY [[ADDWri]]
+  ; CHECK-NEXT:   $wzr = SUBSWri [[SUBSWrs]], 0, 0, implicit-def $nzcv
+  ; CHECK-NEXT:   [[CSINCWr:%[0-9]+]]:gpr32 = CSINCWr [[COPY4]], [[COPY5]], 0, implicit $nzcv
+  ; CHECK-NEXT:   STRWui [[CSINCWr]], [[COPY2]], 0 :: (store (s32))
+  ; CHECK-NEXT:   B %bb.1
+  bb.0:
+    liveins: $x0, $x1, $x2
+    %3:gpr64common = COPY $x0
+    %4:gpr64common = COPY $x1
+    %12:gpr64common = COPY $x2
+
+  bb.1:
+    successors: %bb.3(0x30000000), %bb.2(0x50000000)
+
+    %5:gpr32 = LDRWui %3, 0 :: (load (s32))
+    %6:gpr32 = LDRWui %4, 0 :: (load (s32))
+    %7:gpr32 = SUBSWrs %5, %6, 0, implicit-def $nzcv
+    %8:gpr32all = COPY $wzr
+    %9:gpr32all = COPY %8
+    CBZW killed %7, %bb.3
+    B %bb.2
+
+  bb.2:
+    %10:gpr32sp = COPY %5
+    %11:gpr32common = ADDWri %10, 1, 0
+    %0:gpr32all = COPY %11
+
+  bb.3:
+    %1:gpr32 = PHI %9, %bb.1, %0, %bb.2
+    STRWui %1, %12, 0 :: (store (s32))
     B %bb.1
 
 ...

--- a/llvm/test/CodeGen/AArch64/early-ifcvt-likely-predictable.mir
+++ b/llvm/test/CodeGen/AArch64/early-ifcvt-likely-predictable.mir
@@ -263,19 +263,28 @@ body:             |
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gpr64common = COPY $x2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
-  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT:   successors: %bb.3(0x30000000), %bb.2(0x50000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[LDRWui:%[0-9]+]]:gpr32 = LDRWui [[COPY]], 0 :: (load (s32))
   ; CHECK-NEXT:   [[LDRWui1:%[0-9]+]]:gpr32 = LDRWui [[COPY1]], 0 :: (load (s32))
-  ; CHECK-NEXT:   [[SUBSWrs:%[0-9]+]]:gpr32common = SUBSWrs [[LDRWui]], [[LDRWui1]], 0, implicit-def $nzcv
+  ; CHECK-NEXT:   [[SUBSWrs:%[0-9]+]]:gpr32 = SUBSWrs [[LDRWui]], [[LDRWui1]], 0, implicit-def $nzcv
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:gpr32all = COPY $wzr
-  ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:gpr32 = COPY [[COPY3]]
-  ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:gpr32common = COPY [[LDRWui]]
+  ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:gpr32all = COPY [[COPY3]]
+  ; CHECK-NEXT:   CBZW killed [[SUBSWrs]], %bb.3
+  ; CHECK-NEXT:   B %bb.2
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  ; CHECK-NEXT:   successors: %bb.3(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:gpr32sp = COPY [[LDRWui]]
   ; CHECK-NEXT:   [[ADDWri:%[0-9]+]]:gpr32common = ADDWri [[COPY5]], 1, 0
   ; CHECK-NEXT:   [[COPY6:%[0-9]+]]:gpr32all = COPY [[ADDWri]]
-  ; CHECK-NEXT:   $wzr = SUBSWri [[SUBSWrs]], 0, 0, implicit-def $nzcv
-  ; CHECK-NEXT:   [[CSINCWr:%[0-9]+]]:gpr32 = CSINCWr [[COPY4]], [[COPY5]], 0, implicit $nzcv
-  ; CHECK-NEXT:   STRWui [[CSINCWr]], [[COPY2]], 0 :: (store (s32))
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.3:
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:gpr32 = PHI [[COPY4]], %bb.1, [[COPY6]], %bb.2
+  ; CHECK-NEXT:   STRWui [[PHI]], [[COPY2]], 0 :: (store (s32))
   ; CHECK-NEXT:   B %bb.1
   bb.0:
     liveins: $x0, $x1, $x2


### PR DESCRIPTION
There were two bugs in the existing check which prevented walking up the operands of the branch condition:

1. Typo inside the inner lambda which was reusing the outer operand instead of the operand's operands
2. The check would return `false` for the operands defining op, but because we are iterating on all the operands it would always return false because the first operand can be the result operand.