### PR TITLE
[llvm-jitlink] Fix perf support error message

### DIFF
--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -1215,7 +1215,7 @@ Session::Session(std::unique_ptr<ExecutorProcessControl> EPC, Error &Err)
 
   if (PerfSupport && TT.isOSBinFormatELF()) {
     if (!ProcessSymsJD) {
-      Err = make_error<StringError>("MachO debugging requires process symbols",
+      Err = make_error<StringError>("ELF perf profiling requires process symbols",
                                     inconvertibleErrorCode());
       return;
     }


### PR DESCRIPTION
When perf support is enabled without process symbols, llvm-jitlink will output "MachO debugging requires process symbols" error. 
Fix the error message to "ELF perf profiling requires process symbols".