### PR TITLE
[cross-project-tests] Unset _FORTIFY_SOURCE when building the LLDB formatter tests

### DIFF
--- a/cross-project-tests/debuginfo-tests/llvm-prettyprinters/lldb/CMakeLists.txt
+++ b/cross-project-tests/debuginfo-tests/llvm-prettyprinters/lldb/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(LLDB_TEST_DEBUG_COMPILE_OPTIONS -g -O0)
+# Unset _FORTIFY_SOURCE since it's incompatible with -O0.
+set(LLDB_TEST_DEBUG_COMPILE_OPTIONS -g -O0 -U_FORTIFY_SOURCE)
 
 add_executable(check-lldb-llvm-support-arrayref arrayref.cpp)
 target_link_libraries(check-lldb-llvm-support-arrayref PRIVATE LLVMSupport)


### PR DESCRIPTION
When building `cross-project-tests` with `_FORTIFY_SOURCE` set, we get following warnings:
```
In file included from /app/gcc/14.2.0/include/c++/14.2.0/x86_64-pc-linux-gnu/bits/os_defines.h:39,
                 from /app/gcc/14.2.0/include/c++/14.2.0/x86_64-pc-linux-gnu/bits/c++config.h:680,
                 from /app/gcc/14.2.0/include/c++/14.2.0/type_traits:38,
                 from ../include/llvm/ADT/ADL.h:12,
                 from ../include/llvm/ADT/Hashing.h:47,
                 from ../include/llvm/ADT/ArrayRef.h:12,
                 from ../../cross-project-tests/debuginfo-tests/llvm-prettyprinters/lldb/arrayref.cpp:1:
/usr/include/features.h:381:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
  381 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
```

This patch works around this by undefining the macro when compiling the LLDB formatter tests.

If this ever becomes an issue we could try to detect `_FORTIFY_SOURCE` and skip the tests if set.