### PR TITLE
[NFCI][AMDGPU] Update Mode register mask for gfx1250

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIDefines.h
+++ b/llvm/lib/Target/AMDGPU/SIDefines.h
@@ -582,11 +582,11 @@ enum ModeRegisterMasks : uint32_t {
   CSP_MASK = 0x7u << 29, // Bits 29..31
 
   // GFX1250
-  DST_VGPR_MSB = 1 << 12,
-  SRC0_VGPR_MSB = 1 << 13,
-  SRC1_VGPR_MSB = 1 << 14,
-  SRC2_VGPR_MSB = 1 << 15,
-  VGPR_MSB_MASK = 0xf << 12, // Bits 12..15
+  DST_VGPR_MSB = 0x3 << 12,
+  SRC0_VGPR_MSB = 0x3 << 14,
+  SRC1_VGPR_MSB = 0x3 << 16,
+  SRC2_VGPR_MSB = 0x3 << 18,
+  VGPR_MSB_MASK = 0xff << 12, // Bits 12..19
 
   REPLAY_MODE = 1 << 25,
   FLAT_SCRATCH_IS_NV = 1 << 26,


### PR DESCRIPTION
SPG says two bits for each operand.