### PR TITLE
[OpenMP][OMPIRBuilder] Attach `Attribute::OptimizeNone` to user-defined (and default) mappers

### DIFF
--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -9158,6 +9158,15 @@ Expected<Function *> OpenMPIRBuilder::emitUserDefinedMapper(
       Function::Create(FnTy, GlobalValue::InternalLinkage, FuncName, M);
   MapperFn->addFnAttr(Attribute::NoInline);
   MapperFn->addFnAttr(Attribute::NoUnwind);
+  // Disabling opts for user-defined mappers since, in some cases (see
+  // `default-mapper-nested-derived-type.f90`), some optimizations and
+  // instrumentations causes runtime crashes on the host. In particular, the
+  // following:
+  // - ths `X86DAGToDAGISel` pass and
+  // - `OptNoneInstrumentation` (TODO zoom in further on passes that use this
+  // instrumention object to find out the exact pass(es) causing the crash).
+  MapperFn->addFnAttr(Attribute::OptimizeNone);
+
   MapperFn->addParamAttr(0, Attribute::NoUndef);
   MapperFn->addParamAttr(1, Attribute::NoUndef);
   MapperFn->addParamAttr(2, Attribute::NoUndef);

--- a/offload/test/offloading/fortran/default-mapper-nested-derived-type.f90
+++ b/offload/test/offloading/fortran/default-mapper-nested-derived-type.f90
@@ -1,0 +1,34 @@
+! Regression test for default mappers emitted for nested derived types. Some 
+! optimization passes and instrumentation callbacks cause crashes in emitted
+! mappers and this test guards against such crashes.
+
+! REQUIRES: flang, amdgpu
+
+! RUN: %libomptarget-compile-fortran-generic
+! RUN: env LIBOMPTARGET_INFO=16 %libomptarget-run-generic 2>&1 | %fcheck-generic
+
+program test_omp_target_map_bug_v5
+  implicit none
+  type nested_type
+    real, allocatable :: alloc_field(:)
+  end type nested_type
+  
+  type nesting_type
+    integer :: int_field
+    type(nested_type) :: derived_field
+  end type nesting_type
+  
+  type(nesting_type) :: config
+
+  allocate(config%derived_field%alloc_field(1))
+  
+  !$OMP TARGET ENTER DATA MAP(TO:config, config%derived_field%alloc_field)
+  
+  !$OMP TARGET
+  config%derived_field%alloc_field(1) = 1.0
+  !$OMP END TARGET
+  
+  deallocate(config%derived_field%alloc_field)
+end program test_omp_target_map_bug_v5
+
+! CHECK:  "PluginInterface" device {{[0-9]+}} info: Launching kernel {{.*}}


### PR DESCRIPTION
Disabling opts for user-defined mappers since, in some cases (see `default-mapper-nested-derived-type.f90`), some optimizations and instrumentations causes runtime crashes on the host. In particular, the following:
- ths `X86DAGToDAGISel` pass and
- `OptNoneInstrumentation` (TODO zoom in further on passes that use this instrumention object to find out the exact pass(es) causing the crash).

I couldn't find a way to fine-tune this for only the problematic passes yet. I am very reluctant to do this, please let me know if there are better solutions.