### PR TITLE
[PowerPC] using milicode call for strcpy instead of lib call

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -1278,6 +1278,12 @@ public:
                                                  SDValue Size,
                                                  const CallInst *CI);
 
+  /// Lower a strcpy operation into a target library call and return the
+  /// resulting chain and call result as SelectionDAG SDValues.
+  LLVM_ABI std::pair<SDValue, SDValue> getStrcpy(SDValue Chain, const SDLoc &dl,
+                                                 SDValue Dst, SDValue Src,
+                                                 const CallInst *CI);
+
   /// Lower a strlen operation into a target library call and return the
   /// resulting chain and call result as SelectionDAG SDValues.
   LLVM_ABI std::pair<SDValue, SDValue>

--- a/llvm/include/llvm/CodeGen/SelectionDAGTargetInfo.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGTargetInfo.h
@@ -140,11 +140,10 @@ public:
   /// of the destination string for strcpy, a pointer to the null terminator
   /// for stpcpy) and the second is the chain.  Both SDValues can be null
   /// if a normal libcall should be used.
-  virtual std::pair<SDValue, SDValue>
-  EmitTargetCodeForStrcpy(SelectionDAG &DAG, const SDLoc &DL, SDValue Chain,
-                          SDValue Dest, SDValue Src,
-                          MachinePointerInfo DestPtrInfo,
-                          MachinePointerInfo SrcPtrInfo, bool isStpcpy) const {
+  virtual std::pair<SDValue, SDValue> EmitTargetCodeForStrcpy(
+      SelectionDAG &DAG, const SDLoc &DL, SDValue Chain, SDValue Dest,
+      SDValue Src, MachinePointerInfo DestPtrInfo,
+      MachinePointerInfo SrcPtrInfo, bool isStpcpy, const CallInst *CI) const {
     return std::make_pair(SDValue(), SDValue());
   }
 

--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -3125,6 +3125,7 @@ defset list<RuntimeLibcallImpl> PPC64AIXCallList = {
   def ___memmove64 : RuntimeLibcallImpl<MEMMOVE>;
   def ___memset64 : RuntimeLibcallImpl<MEMSET>;
   def ___bzero64 : RuntimeLibcallImpl<BZERO>;
+  def ___strcpy64 : RuntimeLibcallImpl<STRCPY>;
   def ___strlen64 : RuntimeLibcallImpl<STRLEN>;
 }
 
@@ -3133,6 +3134,7 @@ defset list<RuntimeLibcallImpl> PPC32AIXCallList = {
   def ___memmove : RuntimeLibcallImpl<MEMMOVE>;
   def ___memset : RuntimeLibcallImpl<MEMSET>;
   def ___bzero : RuntimeLibcallImpl<BZERO>;
+  def ___strcpy : RuntimeLibcallImpl<STRCPY>;
   def ___strlen : RuntimeLibcallImpl<STRLEN>;
 }
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -9189,7 +9189,7 @@ std::pair<SDValue, SDValue> SelectionDAG::getStrcpy(SDValue Chain,
       .setChain(Chain)
       .setLibCallee(
           TLI->getLibcallImplCallingConv(LCImpl), CI->getType(),
-          getExternalSymbol(LibCallName, TLI->getPointerTy(getDataLayout())),
+          getExternalSymbol(LCImpl, TLI->getPointerTy(getDataLayout())),
           std::move(Args))
       .setTailCall(IsTailCall);
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -9170,7 +9170,8 @@ std::pair<SDValue, SDValue> SelectionDAG::getStrcpy(SDValue Chain,
                                                     const SDLoc &dl,
                                                     SDValue Dst, SDValue Src,
                                                     const CallInst *CI) {
-  if (TLI->getLibcallImpl(RTLIB::STRCPY) == RTLIB::Unsupported)
+  RTLIB::LibcallImpl LCImpl = TLI->getLibcallImpl(RTLIB::STRCPY);
+  if (LCImpl == RTLIB::Unsupported)
     return {};
 
   const char *LibCallName = TLI->getLibcallName(RTLIB::STRCPY);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -9170,16 +9170,19 @@ std::pair<SDValue, SDValue> SelectionDAG::getStrcpy(SDValue Chain,
                                                     const SDLoc &dl,
                                                     SDValue Dst, SDValue Src,
                                                     const CallInst *CI) {
-  const char *LibCallName = TLI->getLibcallName(RTLIB::STRCPY);
-  if (!LibCallName)
+  if (TLI->getLibcallImpl(RTLIB::STRCPY) == RTLIB::Unsupported)
     return {};
+
+  const char *LibCallName = TLI->getLibcallName(RTLIB::STRCPY);
+  assert(LibCallName &&
+         "The LibCall name for RTLIB::STRCPY should not be empty.");
 
   PointerType *PT = PointerType::getUnqual(*getContext());
   TargetLowering::ArgListTy Args = {{Dst, PT}, {Src, PT}};
 
   TargetLowering::CallLoweringInfo CLI(*this);
   bool IsTailCall =
-      isInTailCallPositionWrapper(CI, this, /*AllowReturnsFirstArg*/ true);
+      isInTailCallPositionWrapper(CI, this, /*AllowReturnsFirstArg=*/true);
 
   CLI.setDebugLoc(dl)
       .setChain(Chain)

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -9174,10 +9174,6 @@ std::pair<SDValue, SDValue> SelectionDAG::getStrcpy(SDValue Chain,
   if (LCImpl == RTLIB::Unsupported)
     return {};
 
-  const char *LibCallName = TLI->getLibcallName(RTLIB::STRCPY);
-  assert(LibCallName &&
-         "The LibCall name for RTLIB::STRCPY should not be empty.");
-
   PointerType *PT = PointerType::getUnqual(*getContext());
   TargetLowering::ArgListTy Args = {{Dst, PT}, {Src, PT}};
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -9188,7 +9188,7 @@ std::pair<SDValue, SDValue> SelectionDAG::getStrcpy(SDValue Chain,
   CLI.setDebugLoc(dl)
       .setChain(Chain)
       .setLibCallee(
-          TLI->getLibcallCallingConv(RTLIB::STRCPY), CI->getType(),
+          TLI->getLibcallImplCallingConv(LCImpl), CI->getType(),
           getExternalSymbol(LibCallName, TLI->getPointerTy(getDataLayout())),
           std::move(Args))
       .setTailCall(IsTailCall);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -9432,11 +9432,9 @@ bool SelectionDAGBuilder::visitStrCpyCall(const CallInst &I, bool isStpcpy) {
   const Value *Arg0 = I.getArgOperand(0), *Arg1 = I.getArgOperand(1);
 
   const SelectionDAGTargetInfo &TSI = DAG.getSelectionDAGInfo();
-  std::pair<SDValue, SDValue> Res =
-    TSI.EmitTargetCodeForStrcpy(DAG, getCurSDLoc(), getRoot(),
-                                getValue(Arg0), getValue(Arg1),
-                                MachinePointerInfo(Arg0),
-                                MachinePointerInfo(Arg1), isStpcpy);
+  std::pair<SDValue, SDValue> Res = TSI.EmitTargetCodeForStrcpy(
+      DAG, getCurSDLoc(), getRoot(), getValue(Arg0), getValue(Arg1),
+      MachinePointerInfo(Arg0), MachinePointerInfo(Arg1), isStpcpy, &I);
   if (Res.first.getNode()) {
     setValue(&I, Res.first);
     DAG.setRoot(Res.second);

--- a/llvm/lib/Target/PowerPC/PPCSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCSelectionDAGInfo.cpp
@@ -81,6 +81,16 @@ std::pair<SDValue, SDValue> PPCSelectionDAGInfo::EmitTargetCodeForMemcmp(
   return DAG.getMemcmp(Chain, dl, Op1, Op2, Op3, CI);
 }
 
+std::pair<SDValue, SDValue> PPCSelectionDAGInfo::EmitTargetCodeForStrcpy(
+    SelectionDAG &DAG, const SDLoc &DL, SDValue Chain, SDValue Dest,
+    SDValue Src, MachinePointerInfo DestPtrInfo, MachinePointerInfo SrcPtrInfo,
+    bool isStpcpy, const CallInst *CI) const {
+  if (isStpcpy)
+    return SelectionDAGTargetInfo::EmitTargetCodeForStrcpy(
+        DAG, DL, Chain, Dest, Src, DestPtrInfo, SrcPtrInfo, isStpcpy, CI);
+  return DAG.getStrcpy(Chain, DL, Dest, Src, CI);
+}
+
 std::pair<SDValue, SDValue>
 PPCSelectionDAGInfo::EmitTargetCodeForStrlen(SelectionDAG &DAG, const SDLoc &DL,
                                              SDValue Chain, SDValue Src,

--- a/llvm/lib/Target/PowerPC/PPCSelectionDAGInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCSelectionDAGInfo.h
@@ -76,6 +76,14 @@ public:
   EmitTargetCodeForMemcmp(SelectionDAG &DAG, const SDLoc &dl, SDValue Chain,
                           SDValue Op1, SDValue Op2, SDValue Op3,
                           const CallInst *CI) const override;
+
+  std::pair<SDValue, SDValue>
+  EmitTargetCodeForStrcpy(SelectionDAG &DAG, const SDLoc &DL, SDValue Chain,
+                          SDValue Dest, SDValue Src,
+                          MachinePointerInfo DestPtrInfo,
+                          MachinePointerInfo SrcPtrInfo, bool isStpcpy,
+                          const CallInst *CI) const override;
+
   std::pair<SDValue, SDValue>
   EmitTargetCodeForStrlen(SelectionDAG &DAG, const SDLoc &DL, SDValue Chain,
                           SDValue Src, const CallInst *CI) const override;

--- a/llvm/lib/Target/SystemZ/SystemZSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZSelectionDAGInfo.cpp
@@ -229,7 +229,7 @@ std::pair<SDValue, SDValue> SystemZSelectionDAGInfo::EmitTargetCodeForMemchr(
 std::pair<SDValue, SDValue> SystemZSelectionDAGInfo::EmitTargetCodeForStrcpy(
     SelectionDAG &DAG, const SDLoc &DL, SDValue Chain, SDValue Dest,
     SDValue Src, MachinePointerInfo DestPtrInfo, MachinePointerInfo SrcPtrInfo,
-    bool isStpcpy) const {
+    bool isStpcpy, const CallInst *CI) const {
   SDVTList VTs = DAG.getVTList(Dest.getValueType(), MVT::Other);
   SDValue EndDest = DAG.getNode(SystemZISD::STPCPY, DL, VTs, Chain, Dest, Src,
                                 DAG.getConstant(0, DL, MVT::i32));

--- a/llvm/lib/Target/SystemZ/SystemZSelectionDAGInfo.h
+++ b/llvm/lib/Target/SystemZ/SystemZSelectionDAGInfo.h
@@ -67,10 +67,12 @@ public:
                           SDValue Src, SDValue Char, SDValue Length,
                           MachinePointerInfo SrcPtrInfo) const override;
 
-  std::pair<SDValue, SDValue> EmitTargetCodeForStrcpy(
-      SelectionDAG &DAG, const SDLoc &DL, SDValue Chain, SDValue Dest,
-      SDValue Src, MachinePointerInfo DestPtrInfo,
-      MachinePointerInfo SrcPtrInfo, bool isStpcpy) const override;
+  std::pair<SDValue, SDValue>
+  EmitTargetCodeForStrcpy(SelectionDAG &DAG, const SDLoc &DL, SDValue Chain,
+                          SDValue Dest, SDValue Src,
+                          MachinePointerInfo DestPtrInfo,
+                          MachinePointerInfo SrcPtrInfo, bool isStpcpy,
+                          const CallInst *CI) const override;
 
   std::pair<SDValue, SDValue>
   EmitTargetCodeForStrcmp(SelectionDAG &DAG, const SDLoc &DL, SDValue Chain,

--- a/llvm/test/CodeGen/PowerPC/milicode32.ll
+++ b/llvm/test/CodeGen/PowerPC/milicode32.ll
@@ -164,13 +164,11 @@ define ptr @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
 ; CHECK-AIX-32-P9-LABEL: strcpy_test:
 ; CHECK-AIX-32-P9:       # %bb.0: # %entry
 ; CHECK-AIX-32-P9-NEXT:    mflr r0
-; CHECK-AIX-32-P9-NEXT:    stwu r1, -80(r1)
-; CHECK-AIX-32-P9-NEXT:    stw r0, 88(r1)
-; CHECK-AIX-32-P9-NEXT:    stw r3, 72(r1)
-; CHECK-AIX-32-P9-NEXT:    stw r4, 64(r1)
+; CHECK-AIX-32-P9-NEXT:    stwu r1, -64(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r0, 72(r1)
 ; CHECK-AIX-32-P9-NEXT:    bl .___strcpy[PR]
 ; CHECK-AIX-32-P9-NEXT:    nop
-; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 80
+; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 64
 ; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)
 ; CHECK-AIX-32-P9-NEXT:    mtlr r0
 ; CHECK-AIX-32-P9-NEXT:    blr
@@ -178,23 +176,15 @@ define ptr @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
 ; CHECK-LINUX32-P9-LABEL: strcpy_test:
 ; CHECK-LINUX32-P9:       # %bb.0: # %entry
 ; CHECK-LINUX32-P9-NEXT:    mflr r0
-; CHECK-LINUX32-P9-NEXT:    stwu r1, -32(r1)
-; CHECK-LINUX32-P9-NEXT:    stw r0, 36(r1)
-; CHECK-LINUX32-P9-NEXT:    stw r3, 24(r1)
-; CHECK-LINUX32-P9-NEXT:    stw r4, 16(r1)
+; CHECK-LINUX32-P9-NEXT:    stwu r1, -16(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r0, 20(r1)
 ; CHECK-LINUX32-P9-NEXT:    bl strcpy
-; CHECK-LINUX32-P9-NEXT:    lwz r0, 36(r1)
-; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 32
+; CHECK-LINUX32-P9-NEXT:    lwz r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 16
 ; CHECK-LINUX32-P9-NEXT:    mtlr r0
 ; CHECK-LINUX32-P9-NEXT:    blr
 entry:
-  %dest.addr = alloca ptr, align 8
-  %src.addr = alloca ptr, align 8
-  store ptr %dest, ptr %dest.addr, align 8
-  store ptr %src, ptr %src.addr, align 8
-  %0 = load ptr, ptr %dest.addr, align 8
-  %1 = load ptr, ptr %src.addr, align 8
-  %call = call ptr @strcpy(ptr noundef %0, ptr noundef %1)
+  %call = call ptr @strcpy(ptr noundef %dest, ptr noundef %src)
   ret ptr %call
 }
 
@@ -204,13 +194,11 @@ define ptr @stpcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
 ; CHECK-AIX-32-P9-LABEL: stpcpy_test:
 ; CHECK-AIX-32-P9:       # %bb.0: # %entry
 ; CHECK-AIX-32-P9-NEXT:    mflr r0
-; CHECK-AIX-32-P9-NEXT:    stwu r1, -80(r1)
-; CHECK-AIX-32-P9-NEXT:    stw r0, 88(r1)
-; CHECK-AIX-32-P9-NEXT:    stw r3, 72(r1)
-; CHECK-AIX-32-P9-NEXT:    stw r4, 64(r1)
+; CHECK-AIX-32-P9-NEXT:    stwu r1, -64(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r0, 72(r1)
 ; CHECK-AIX-32-P9-NEXT:    bl .stpcpy[PR]
 ; CHECK-AIX-32-P9-NEXT:    nop
-; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 80
+; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 64
 ; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)
 ; CHECK-AIX-32-P9-NEXT:    mtlr r0
 ; CHECK-AIX-32-P9-NEXT:    blr
@@ -218,23 +206,15 @@ define ptr @stpcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
 ; CHECK-LINUX32-P9-LABEL: stpcpy_test:
 ; CHECK-LINUX32-P9:       # %bb.0: # %entry
 ; CHECK-LINUX32-P9-NEXT:    mflr r0
-; CHECK-LINUX32-P9-NEXT:    stwu r1, -32(r1)
-; CHECK-LINUX32-P9-NEXT:    stw r0, 36(r1)
-; CHECK-LINUX32-P9-NEXT:    stw r3, 24(r1)
-; CHECK-LINUX32-P9-NEXT:    stw r4, 16(r1)
+; CHECK-LINUX32-P9-NEXT:    stwu r1, -16(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r0, 20(r1)
 ; CHECK-LINUX32-P9-NEXT:    bl stpcpy
-; CHECK-LINUX32-P9-NEXT:    lwz r0, 36(r1)
-; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 32
+; CHECK-LINUX32-P9-NEXT:    lwz r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 16
 ; CHECK-LINUX32-P9-NEXT:    mtlr r0
 ; CHECK-LINUX32-P9-NEXT:    blr
 entry:
-  %dest.addr = alloca ptr, align 8
-  %src.addr = alloca ptr, align 8
-  store ptr %dest, ptr %dest.addr, align 8
-  store ptr %src, ptr %src.addr, align 8
-  %0 = load ptr, ptr %dest.addr, align 8
-  %1 = load ptr, ptr %src.addr, align 8
-  %call = call ptr @stpcpy(ptr noundef %0, ptr noundef %1)
+  %call = call ptr @stpcpy(ptr noundef %dest, ptr noundef %src)
   ret ptr %call
 }
 

--- a/llvm/test/CodeGen/PowerPC/milicode32.ll
+++ b/llvm/test/CodeGen/PowerPC/milicode32.ll
@@ -168,7 +168,7 @@ define void @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
 ; CHECK-AIX-32-P9-NEXT:    stw r0, 88(r1)
 ; CHECK-AIX-32-P9-NEXT:    stw r3, 72(r1)
 ; CHECK-AIX-32-P9-NEXT:    stw r4, 64(r1)
-; CHECK-AIX-32-P9-NEXT:    bl .strcpy[PR]
+; CHECK-AIX-32-P9-NEXT:    bl .___strcpy[PR]
 ; CHECK-AIX-32-P9-NEXT:    nop
 ; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 80
 ; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)

--- a/llvm/test/CodeGen/PowerPC/milicode32.ll
+++ b/llvm/test/CodeGen/PowerPC/milicode32.ll
@@ -160,7 +160,7 @@ entry:
 
 declare void @llvm.memmove.p0.p0.i32(ptr writeonly captures(none), ptr readonly captures(none), i32, i1 immarg)
 
-define void @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
+define ptr @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
 ; CHECK-AIX-32-P9-LABEL: strcpy_test:
 ; CHECK-AIX-32-P9:       # %bb.0: # %entry
 ; CHECK-AIX-32-P9-NEXT:    mflr r0
@@ -195,7 +195,47 @@ entry:
   %0 = load ptr, ptr %dest.addr, align 8
   %1 = load ptr, ptr %src.addr, align 8
   %call = call ptr @strcpy(ptr noundef %0, ptr noundef %1)
-  ret void
+  ret ptr %call
 }
 
 declare ptr @strcpy(ptr noundef, ptr noundef)
+
+define ptr @stpcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
+; CHECK-AIX-32-P9-LABEL: stpcpy_test:
+; CHECK-AIX-32-P9:       # %bb.0: # %entry
+; CHECK-AIX-32-P9-NEXT:    mflr r0
+; CHECK-AIX-32-P9-NEXT:    stwu r1, -80(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r0, 88(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r3, 72(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r4, 64(r1)
+; CHECK-AIX-32-P9-NEXT:    bl .stpcpy[PR]
+; CHECK-AIX-32-P9-NEXT:    nop
+; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 80
+; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)
+; CHECK-AIX-32-P9-NEXT:    mtlr r0
+; CHECK-AIX-32-P9-NEXT:    blr
+;
+; CHECK-LINUX32-P9-LABEL: stpcpy_test:
+; CHECK-LINUX32-P9:       # %bb.0: # %entry
+; CHECK-LINUX32-P9-NEXT:    mflr r0
+; CHECK-LINUX32-P9-NEXT:    stwu r1, -32(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r0, 36(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r3, 24(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r4, 16(r1)
+; CHECK-LINUX32-P9-NEXT:    bl stpcpy
+; CHECK-LINUX32-P9-NEXT:    lwz r0, 36(r1)
+; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 32
+; CHECK-LINUX32-P9-NEXT:    mtlr r0
+; CHECK-LINUX32-P9-NEXT:    blr
+entry:
+  %dest.addr = alloca ptr, align 8
+  %src.addr = alloca ptr, align 8
+  store ptr %dest, ptr %dest.addr, align 8
+  store ptr %src, ptr %src.addr, align 8
+  %0 = load ptr, ptr %dest.addr, align 8
+  %1 = load ptr, ptr %src.addr, align 8
+  %call = call ptr @stpcpy(ptr noundef %0, ptr noundef %1)
+  ret ptr %call
+}
+
+declare ptr @stpcpy(ptr noundef, ptr noundef)

--- a/llvm/test/CodeGen/PowerPC/milicode64.ll
+++ b/llvm/test/CodeGen/PowerPC/milicode64.ll
@@ -180,7 +180,7 @@ entry:
 
 declare void @llvm.memmove.p0.p0.i32(ptr writeonly captures(none), ptr readonly captures(none), i32, i1 immarg)
 
-define dso_local void @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
+define dso_local ptr @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
 ; CHECK-LE-P9-LABEL: strcpy_test:
 ; CHECK-LE-P9:       # %bb.0: # %entry
 ; CHECK-LE-P9-NEXT:    mflr r0
@@ -230,8 +230,64 @@ entry:
   %0 = load ptr, ptr %dest.addr, align 8
   %1 = load ptr, ptr %src.addr, align 8
   %call = call ptr @strcpy(ptr noundef %0, ptr noundef %1)
-  ret void
+  ret ptr %call
 }
 
 
 declare ptr @strcpy(ptr noundef, ptr noundef)
+
+define dso_local ptr @stpcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
+; CHECK-LE-P9-LABEL: stpcpy_test:
+; CHECK-LE-P9:       # %bb.0: # %entry
+; CHECK-LE-P9-NEXT:    mflr r0
+; CHECK-LE-P9-NEXT:    stdu r1, -48(r1)
+; CHECK-LE-P9-NEXT:    std r0, 64(r1)
+; CHECK-LE-P9-NEXT:    std r3, 40(r1)
+; CHECK-LE-P9-NEXT:    std r4, 32(r1)
+; CHECK-LE-P9-NEXT:    bl stpcpy
+; CHECK-LE-P9-NEXT:    nop
+; CHECK-LE-P9-NEXT:    addi r1, r1, 48
+; CHECK-LE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-LE-P9-NEXT:    mtlr r0
+; CHECK-LE-P9-NEXT:    blr
+;
+; CHECK-BE-P9-LABEL: stpcpy_test:
+; CHECK-BE-P9:       # %bb.0: # %entry
+; CHECK-BE-P9-NEXT:    mflr r0
+; CHECK-BE-P9-NEXT:    stdu r1, -128(r1)
+; CHECK-BE-P9-NEXT:    std r0, 144(r1)
+; CHECK-BE-P9-NEXT:    std r3, 120(r1)
+; CHECK-BE-P9-NEXT:    std r4, 112(r1)
+; CHECK-BE-P9-NEXT:    bl stpcpy
+; CHECK-BE-P9-NEXT:    nop
+; CHECK-BE-P9-NEXT:    addi r1, r1, 128
+; CHECK-BE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-BE-P9-NEXT:    mtlr r0
+; CHECK-BE-P9-NEXT:    blr
+;
+; CHECK-AIX-64-P9-LABEL: stpcpy_test:
+; CHECK-AIX-64-P9:       # %bb.0: # %entry
+; CHECK-AIX-64-P9-NEXT:    mflr r0
+; CHECK-AIX-64-P9-NEXT:    stdu r1, -128(r1)
+; CHECK-AIX-64-P9-NEXT:    std r0, 144(r1)
+; CHECK-AIX-64-P9-NEXT:    std r3, 120(r1)
+; CHECK-AIX-64-P9-NEXT:    std r4, 112(r1)
+; CHECK-AIX-64-P9-NEXT:    bl .stpcpy[PR]
+; CHECK-AIX-64-P9-NEXT:    nop
+; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 128
+; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)
+; CHECK-AIX-64-P9-NEXT:    mtlr r0
+; CHECK-AIX-64-P9-NEXT:    blr
+entry:
+  %dest.addr = alloca ptr, align 8
+  %src.addr = alloca ptr, align 8
+  store ptr %dest, ptr %dest.addr, align 8
+  store ptr %src, ptr %src.addr, align 8
+  %0 = load ptr, ptr %dest.addr, align 8
+  %1 = load ptr, ptr %src.addr, align 8
+  %call = call ptr @stpcpy(ptr noundef %0, ptr noundef %1)
+  ret ptr %call
+}
+
+
+declare ptr @stpcpy(ptr noundef, ptr noundef)

--- a/llvm/test/CodeGen/PowerPC/milicode64.ll
+++ b/llvm/test/CodeGen/PowerPC/milicode64.ll
@@ -216,7 +216,7 @@ define dso_local void @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind
 ; CHECK-AIX-64-P9-NEXT:    std r0, 144(r1)
 ; CHECK-AIX-64-P9-NEXT:    std r3, 120(r1)
 ; CHECK-AIX-64-P9-NEXT:    std r4, 112(r1)
-; CHECK-AIX-64-P9-NEXT:    bl .strcpy[PR]
+; CHECK-AIX-64-P9-NEXT:    bl .___strcpy64[PR]
 ; CHECK-AIX-64-P9-NEXT:    nop
 ; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 128
 ; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)

--- a/llvm/test/CodeGen/PowerPC/milicode64.ll
+++ b/llvm/test/CodeGen/PowerPC/milicode64.ll
@@ -184,13 +184,11 @@ define dso_local ptr @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind 
 ; CHECK-LE-P9-LABEL: strcpy_test:
 ; CHECK-LE-P9:       # %bb.0: # %entry
 ; CHECK-LE-P9-NEXT:    mflr r0
-; CHECK-LE-P9-NEXT:    stdu r1, -48(r1)
-; CHECK-LE-P9-NEXT:    std r0, 64(r1)
-; CHECK-LE-P9-NEXT:    std r3, 40(r1)
-; CHECK-LE-P9-NEXT:    std r4, 32(r1)
+; CHECK-LE-P9-NEXT:    stdu r1, -32(r1)
+; CHECK-LE-P9-NEXT:    std r0, 48(r1)
 ; CHECK-LE-P9-NEXT:    bl strcpy
 ; CHECK-LE-P9-NEXT:    nop
-; CHECK-LE-P9-NEXT:    addi r1, r1, 48
+; CHECK-LE-P9-NEXT:    addi r1, r1, 32
 ; CHECK-LE-P9-NEXT:    ld r0, 16(r1)
 ; CHECK-LE-P9-NEXT:    mtlr r0
 ; CHECK-LE-P9-NEXT:    blr
@@ -198,13 +196,11 @@ define dso_local ptr @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind 
 ; CHECK-BE-P9-LABEL: strcpy_test:
 ; CHECK-BE-P9:       # %bb.0: # %entry
 ; CHECK-BE-P9-NEXT:    mflr r0
-; CHECK-BE-P9-NEXT:    stdu r1, -128(r1)
-; CHECK-BE-P9-NEXT:    std r0, 144(r1)
-; CHECK-BE-P9-NEXT:    std r3, 120(r1)
-; CHECK-BE-P9-NEXT:    std r4, 112(r1)
+; CHECK-BE-P9-NEXT:    stdu r1, -112(r1)
+; CHECK-BE-P9-NEXT:    std r0, 128(r1)
 ; CHECK-BE-P9-NEXT:    bl strcpy
 ; CHECK-BE-P9-NEXT:    nop
-; CHECK-BE-P9-NEXT:    addi r1, r1, 128
+; CHECK-BE-P9-NEXT:    addi r1, r1, 112
 ; CHECK-BE-P9-NEXT:    ld r0, 16(r1)
 ; CHECK-BE-P9-NEXT:    mtlr r0
 ; CHECK-BE-P9-NEXT:    blr
@@ -212,27 +208,18 @@ define dso_local ptr @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind 
 ; CHECK-AIX-64-P9-LABEL: strcpy_test:
 ; CHECK-AIX-64-P9:       # %bb.0: # %entry
 ; CHECK-AIX-64-P9-NEXT:    mflr r0
-; CHECK-AIX-64-P9-NEXT:    stdu r1, -128(r1)
-; CHECK-AIX-64-P9-NEXT:    std r0, 144(r1)
-; CHECK-AIX-64-P9-NEXT:    std r3, 120(r1)
-; CHECK-AIX-64-P9-NEXT:    std r4, 112(r1)
+; CHECK-AIX-64-P9-NEXT:    stdu r1, -112(r1)
+; CHECK-AIX-64-P9-NEXT:    std r0, 128(r1)
 ; CHECK-AIX-64-P9-NEXT:    bl .___strcpy64[PR]
 ; CHECK-AIX-64-P9-NEXT:    nop
-; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 128
+; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 112
 ; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)
 ; CHECK-AIX-64-P9-NEXT:    mtlr r0
 ; CHECK-AIX-64-P9-NEXT:    blr
 entry:
-  %dest.addr = alloca ptr, align 8
-  %src.addr = alloca ptr, align 8
-  store ptr %dest, ptr %dest.addr, align 8
-  store ptr %src, ptr %src.addr, align 8
-  %0 = load ptr, ptr %dest.addr, align 8
-  %1 = load ptr, ptr %src.addr, align 8
-  %call = call ptr @strcpy(ptr noundef %0, ptr noundef %1)
+  %call = call ptr @strcpy(ptr noundef %dest, ptr noundef %src)
   ret ptr %call
 }
-
 
 declare ptr @strcpy(ptr noundef, ptr noundef)
 
@@ -240,13 +227,11 @@ define dso_local ptr @stpcpy_test(ptr noundef %dest, ptr noundef %src) nounwind 
 ; CHECK-LE-P9-LABEL: stpcpy_test:
 ; CHECK-LE-P9:       # %bb.0: # %entry
 ; CHECK-LE-P9-NEXT:    mflr r0
-; CHECK-LE-P9-NEXT:    stdu r1, -48(r1)
-; CHECK-LE-P9-NEXT:    std r0, 64(r1)
-; CHECK-LE-P9-NEXT:    std r3, 40(r1)
-; CHECK-LE-P9-NEXT:    std r4, 32(r1)
+; CHECK-LE-P9-NEXT:    stdu r1, -32(r1)
+; CHECK-LE-P9-NEXT:    std r0, 48(r1)
 ; CHECK-LE-P9-NEXT:    bl stpcpy
 ; CHECK-LE-P9-NEXT:    nop
-; CHECK-LE-P9-NEXT:    addi r1, r1, 48
+; CHECK-LE-P9-NEXT:    addi r1, r1, 32
 ; CHECK-LE-P9-NEXT:    ld r0, 16(r1)
 ; CHECK-LE-P9-NEXT:    mtlr r0
 ; CHECK-LE-P9-NEXT:    blr
@@ -254,13 +239,11 @@ define dso_local ptr @stpcpy_test(ptr noundef %dest, ptr noundef %src) nounwind 
 ; CHECK-BE-P9-LABEL: stpcpy_test:
 ; CHECK-BE-P9:       # %bb.0: # %entry
 ; CHECK-BE-P9-NEXT:    mflr r0
-; CHECK-BE-P9-NEXT:    stdu r1, -128(r1)
-; CHECK-BE-P9-NEXT:    std r0, 144(r1)
-; CHECK-BE-P9-NEXT:    std r3, 120(r1)
-; CHECK-BE-P9-NEXT:    std r4, 112(r1)
+; CHECK-BE-P9-NEXT:    stdu r1, -112(r1)
+; CHECK-BE-P9-NEXT:    std r0, 128(r1)
 ; CHECK-BE-P9-NEXT:    bl stpcpy
 ; CHECK-BE-P9-NEXT:    nop
-; CHECK-BE-P9-NEXT:    addi r1, r1, 128
+; CHECK-BE-P9-NEXT:    addi r1, r1, 112
 ; CHECK-BE-P9-NEXT:    ld r0, 16(r1)
 ; CHECK-BE-P9-NEXT:    mtlr r0
 ; CHECK-BE-P9-NEXT:    blr
@@ -268,24 +251,16 @@ define dso_local ptr @stpcpy_test(ptr noundef %dest, ptr noundef %src) nounwind 
 ; CHECK-AIX-64-P9-LABEL: stpcpy_test:
 ; CHECK-AIX-64-P9:       # %bb.0: # %entry
 ; CHECK-AIX-64-P9-NEXT:    mflr r0
-; CHECK-AIX-64-P9-NEXT:    stdu r1, -128(r1)
-; CHECK-AIX-64-P9-NEXT:    std r0, 144(r1)
-; CHECK-AIX-64-P9-NEXT:    std r3, 120(r1)
-; CHECK-AIX-64-P9-NEXT:    std r4, 112(r1)
+; CHECK-AIX-64-P9-NEXT:    stdu r1, -112(r1)
+; CHECK-AIX-64-P9-NEXT:    std r0, 128(r1)
 ; CHECK-AIX-64-P9-NEXT:    bl .stpcpy[PR]
 ; CHECK-AIX-64-P9-NEXT:    nop
-; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 128
+; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 112
 ; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)
 ; CHECK-AIX-64-P9-NEXT:    mtlr r0
 ; CHECK-AIX-64-P9-NEXT:    blr
 entry:
-  %dest.addr = alloca ptr, align 8
-  %src.addr = alloca ptr, align 8
-  store ptr %dest, ptr %dest.addr, align 8
-  store ptr %src, ptr %src.addr, align 8
-  %0 = load ptr, ptr %dest.addr, align 8
-  %1 = load ptr, ptr %src.addr, align 8
-  %call = call ptr @stpcpy(ptr noundef %0, ptr noundef %1)
+  %call = call ptr @stpcpy(ptr noundef %dest, ptr noundef %src)
   ret ptr %call
 }
 


### PR DESCRIPTION
AIX has "millicode" routines, which are functions loaded at boot time into fixed addresses in kernel memory. This allows them to be customized for the processor. The __strcpy routine is a millicode implementation; we use millicode for the strcpy function instead of a library call to improve performance.