### PR TITLE
[mlir][spirv][nfc] Escape < and > with ` in description and summary

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVControlFlowOps.td
@@ -249,20 +249,20 @@ def SPIRV_SwitchOp : SPIRV_Op<"Switch",
      DeclareOpInterfaceMethods<BranchOpInterface, ["getSuccessorForOperands"]>,
      Pure, Terminator]> {
   let summary = [{
-    Multi-way branch to one of the operand label <id>.
+    Multi-way branch to one of the operand label `<id>`.
   }];
 
   let description = [{
     Selector must have a type of OpTypeInt. Selector is compared for equality to
     the Target literals.
 
-    Default must be the <id> of a label. If Selector does not equal any of the
-    Target literals, control flow branches to the Default label <id>.
+    Default must be the `<id>` of a label. If Selector does not equal any of the
+    Target literals, control flow branches to the Default label `<id>`.
 
-    Target must be alternating scalar integer literals and the <id> of a label.
+    Target must be alternating scalar integer literals and the `<id>` of a label.
     If Selector equals a literal, control flow branches to the following label
-    <id>. It is invalid for any two literal to be equal to each other. If Selector
-    does not equal any literal, control flow branches to the Default label <id>.
+    `<id>`. It is invalid for any two literal to be equal to each other. If Selector
+    does not equal any literal, control flow branches to the Default label `<id>`.
     Each literal is interpreted with the type of Selector: The bit width of
     Selector’s type is the width of each literal’s type. If this width is not a
     multiple of 32-bits and the OpTypeInt Signedness is set to 1, the literal values

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGraphOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGraphOps.td
@@ -163,7 +163,7 @@ def SPIRV_GraphEntryPointARMOp : SPIRV_GraphARMOp<"GraphEntryPoint", [InModuleSc
   }];
 
   let description = [{
-    Graph Entry Point must be the Result <id> of an OpGraphARM instruction.
+    Graph Entry Point must be the Result `<id>` of an OpGraphARM instruction.
 
     Name is a name string for the graphentry point. A module cannot have two
     OpGraphEntryPointARM instructions with the same Name string.

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMemoryOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMemoryOps.td
@@ -84,7 +84,7 @@ def SPIRV_AccessChainOp : SPIRV_Op<"AccessChain", [Pure]> {
 def SPIRV_CopyMemoryOp : SPIRV_Op<"CopyMemory", [DeclareOpInterfaceMethods<AlignmentAttrOpInterface>]> {
   let summary = [{
     Copy from the memory pointed to by Source to the memory pointed to by
-    Target. Both operands must be non-void pointers and having the same <id>
+    Target. Both operands must be non-void pointers and having the same `<id>`
     Type operand in their OpTypePointer type declaration.  Matching Storage
     Class is not required.  The amount of memory copied is the size of the
     type pointed to. The copied type must have a fixed size; i.e., it must
@@ -381,7 +381,7 @@ def SPIRV_VariableOp : SPIRV_Op<"Variable", []> {
 
     Initializer is optional. If Initializer is present, it will be the
     initial value of the variable's memory content. Initializer must be an
-    <id> from a constant instruction or a global (module scope) OpVariable
+    `<id>` from a constant instruction or a global (module scope) OpVariable
     instruction. Initializer must have the same type as the type pointed to
     by Result Type.
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMiscOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMiscOps.td
@@ -62,7 +62,7 @@ def SPIRV_UndefOp : SPIRV_Op<"Undef", [Pure]> {
   let description = [{
     Result Type is the type of object to make.
 
-    Each consumption of Result <id> yields an arbitrary, possibly different
+    Each consumption of Result `<id>` yields an arbitrary, possibly different
     bit pattern or abstract value resulting in possibly different concrete,
     abstract, or opaque values.
 

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVStructureOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVStructureOps.td
@@ -187,7 +187,7 @@ def SPIRV_EntryPointOp : SPIRV_Op<"EntryPoint", [InModuleScope]> {
     Execution Model is the execution model for the entry point and its
     static call tree. See Execution Model.
 
-    Entry Point must be the Result <id> of an OpFunction instruction.
+    Entry Point must be the Result `<id>` of an OpFunction instruction.
 
     Name is a name string for the entry point. A module cannot have two
     OpEntryPoint instructions with the same Execution Model and the same
@@ -244,14 +244,14 @@ def SPIRV_ExecutionModeOp : SPIRV_Op<"ExecutionMode", [InModuleScope]> {
   let summary = "Declare an execution mode for an entry point.";
 
   let description = [{
-    Entry Point must be the Entry Point <id> operand of an OpEntryPoint
+    Entry Point must be the Entry Point `<id>` operand of an OpEntryPoint
     instruction.
 
     Mode is the execution mode. See Execution Mode.
 
     This instruction is only valid when the Mode operand is an execution
     mode that takes no Extra Operands, or takes Extra Operands that are not
-    <id> operands.
+    `<id>` operands.
 
     <!-- End of AutoGen section -->
 


### PR DESCRIPTION
Not escaping < and > was causing the text not to get displayed in the documentation.