### PR TITLE
[AMDGPU] Remove some redundant SubtargetPredicate settings. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOPCInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOPCInstructions.td
@@ -422,7 +422,6 @@ multiclass VOPC_Pseudos <string opName,
 
 }
 
-let SubtargetPredicate = HasSdstCMPX in {
 multiclass VOPCX_Pseudos <string opName,
                           VOPC_Profile P, VOPC_Profile P_NoSDst,
                           SDPatternOperator cond = COND_NULL,
@@ -486,7 +485,6 @@ multiclass VOPCX_Pseudos <string opName,
     }
   } // end SubtargetPredicate = isGFX11Plus
 }
-} // End SubtargetPredicate = HasSdstCMPX
 
 defm VOPC_I1_F16_F16 : VOPC_Profile_t16<[Write32Bit], f16>;
 def VOPC_I1_F32_F32 : VOPC_Profile<[Write32Bit], f32>;
@@ -1114,7 +1112,6 @@ multiclass VOPC_Class_Pseudos <string opName, VOPC_Profile p, bit DefExec,
   } // end SubtargetPredicate = isGFX11Plus
 }
 
-let SubtargetPredicate = HasSdstCMPX in {
 multiclass VOPCX_Class_Pseudos <string opName,
                                 VOPC_Profile P,
                                 VOPC_Profile P_NoSDst> :
@@ -1164,7 +1161,6 @@ multiclass VOPCX_Class_Pseudos <string opName,
     }
   } // end SubtargetPredicate = isGFX11Plus
 }
-} // End SubtargetPredicate = HasSdstCMPX
 } // End ReadsModeReg = 0, mayRaiseFPException = 0
 
 defm VOPC_I1_F16_I16 : VOPC_Class_Profile_t16<[Write32Bit]>;


### PR DESCRIPTION
Setting SubtargetPredicate around these multiclasses is redundant since
it is always explicitly overridden for every def inside the multiclass.
