### PR TITLE
[mlir][dataflow] Delete dead code in `visitRegionSuccessors` (NFC)

### DIFF
--- a/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
@@ -319,7 +319,7 @@ void AbstractSparseForwardDataFlowAnalysis::visitRegionSuccessors(
     }
 
     for (auto [lattice, operand] :
-         llvm::zip_equal(lattices.drop_front(firstIndex), *operands))
+         llvm::zip(lattices.drop_front(firstIndex), *operands))
       join(lattice, *getLatticeElementFor(point, operand));
   }
 }


### PR DESCRIPTION
When the lattices of the predecessor's operands are joined to the lattices of the regionOp's results, their sizes are equal. Therefore, the code inside the 'if' statement will never be executed in this case.https://github.com/llvm/llvm-project/blob/8da7c05933bd6056320479e074050b55ccd34aaa/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp#L181 and https://github.com/llvm/llvm-project/blob/8da7c05933bd6056320479e074050b55ccd34aaa/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp#L132 we call visitRegionSuccessors.