### PR TITLE
[lldb] Add missing locks in SBThread methods

### DIFF
--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -319,6 +319,13 @@ void SBThread::SetThread(const ThreadSP &lldb_object_sp) {
 lldb::tid_t SBThread::GetThreadID() const {
   LLDB_INSTRUMENT_VA(this);
 
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return LLDB_INVALID_THREAD_ID;
+  }
+
   ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
   if (thread_sp)
     return thread_sp->GetID();
@@ -327,6 +334,13 @@ lldb::tid_t SBThread::GetThreadID() const {
 
 uint32_t SBThread::GetIndexID() const {
   LLDB_INSTRUMENT_VA(this);
+
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return LLDB_INVALID_INDEX32;
+  }
 
   ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
   if (thread_sp)
@@ -1315,6 +1329,13 @@ SBThread SBThread::GetExtendedBacktraceThread(const char *type) {
 uint32_t SBThread::GetExtendedBacktraceOriginatingIndexID() {
   LLDB_INSTRUMENT_VA(this);
 
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return LLDB_INVALID_INDEX32;
+  }
+
   ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
   if (thread_sp)
     return thread_sp->GetExtendedBacktraceOriginatingIndexID();
@@ -1323,6 +1344,13 @@ uint32_t SBThread::GetExtendedBacktraceOriginatingIndexID() {
 
 SBValue SBThread::GetCurrentException() {
   LLDB_INSTRUMENT_VA(this);
+
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return SBValue();
+  }
 
   ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
   if (!thread_sp)
@@ -1334,6 +1362,13 @@ SBValue SBThread::GetCurrentException() {
 SBThread SBThread::GetCurrentExceptionBacktrace() {
   LLDB_INSTRUMENT_VA(this);
 
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return SBThread();
+  }
+
   ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
   if (!thread_sp)
     return SBThread();
@@ -1343,6 +1378,13 @@ SBThread SBThread::GetCurrentExceptionBacktrace() {
 
 bool SBThread::SafeToCallFunctions() {
   LLDB_INSTRUMENT_VA(this);
+
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return false;
+  }
 
   ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
   if (thread_sp)
@@ -1362,6 +1404,13 @@ lldb_private::Thread *SBThread::get() {
 
 SBValue SBThread::GetSiginfo() {
   LLDB_INSTRUMENT_VA(this);
+
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return SBValue();
+  }
 
   ThreadSP thread_sp = m_opaque_sp->GetThreadSP();
   if (!thread_sp)


### PR DESCRIPTION
Some of these methods are not acquiring the run lock prior to executing.