### PR TITLE
[MLIR][Python][NFC] Use enum class instead of enum

### DIFF
--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -330,23 +330,24 @@ private:
   MlirLocation loc;
 };
 
-enum PyDiagnosticSeverity : std::underlying_type_t<MlirDiagnosticSeverity> {
-  MlirDiagnosticError = MlirDiagnosticError,
-  MlirDiagnosticWarning = MlirDiagnosticWarning,
-  MlirDiagnosticNote = MlirDiagnosticNote,
-  MlirDiagnosticRemark = MlirDiagnosticRemark
+enum class PyDiagnosticSeverity : std::underlying_type_t<
+    MlirDiagnosticSeverity> {
+  Error = MlirDiagnosticError,
+  Warning = MlirDiagnosticWarning,
+  Note = MlirDiagnosticNote,
+  Remark = MlirDiagnosticRemark
 };
 
-enum PyWalkResult : std::underlying_type_t<MlirWalkResult> {
-  MlirWalkResultAdvance = MlirWalkResultAdvance,
-  MlirWalkResultInterrupt = MlirWalkResultInterrupt,
-  MlirWalkResultSkip = MlirWalkResultSkip
+enum class PyWalkResult : std::underlying_type_t<MlirWalkResult> {
+  Advance = MlirWalkResultAdvance,
+  Interrupt = MlirWalkResultInterrupt,
+  Skip = MlirWalkResultSkip
 };
 
 /// Traversal order for operation walk.
-enum PyWalkOrder : std::underlying_type_t<MlirWalkOrder> {
-  MlirWalkPreOrder = MlirWalkPreOrder,
-  MlirWalkPostOrder = MlirWalkPostOrder
+enum class PyWalkOrder : std::underlying_type_t<MlirWalkOrder> {
+  PreOrder = MlirWalkPreOrder,
+  PostOrder = MlirWalkPostOrder
 };
 
 /// Python class mirroring the C MlirDiagnostic struct. Note that these structs

--- a/mlir/lib/Bindings/Python/DialectSparseTensor.cpp
+++ b/mlir/lib/Bindings/Python/DialectSparseTensor.cpp
@@ -25,21 +25,20 @@ namespace python {
 namespace MLIR_BINDINGS_PYTHON_DOMAIN {
 namespace sparse_tensor {
 
-enum PySparseTensorLevelFormat : std::underlying_type_t<
+enum class PySparseTensorLevelFormat : std::underlying_type_t<
     MlirSparseTensorLevelFormat> {
-  MLIR_SPARSE_TENSOR_LEVEL_DENSE = MLIR_SPARSE_TENSOR_LEVEL_DENSE,
-  MLIR_SPARSE_TENSOR_LEVEL_N_OUT_OF_M = MLIR_SPARSE_TENSOR_LEVEL_N_OUT_OF_M,
-  MLIR_SPARSE_TENSOR_LEVEL_COMPRESSED = MLIR_SPARSE_TENSOR_LEVEL_COMPRESSED,
-  MLIR_SPARSE_TENSOR_LEVEL_SINGLETON = MLIR_SPARSE_TENSOR_LEVEL_SINGLETON,
-  MLIR_SPARSE_TENSOR_LEVEL_LOOSE_COMPRESSED =
-      MLIR_SPARSE_TENSOR_LEVEL_LOOSE_COMPRESSED
+  DENSE = MLIR_SPARSE_TENSOR_LEVEL_DENSE,
+  N_OUT_OF_M = MLIR_SPARSE_TENSOR_LEVEL_N_OUT_OF_M,
+  COMPRESSED = MLIR_SPARSE_TENSOR_LEVEL_COMPRESSED,
+  SINGLETON = MLIR_SPARSE_TENSOR_LEVEL_SINGLETON,
+  LOOSE_COMPRESSED = MLIR_SPARSE_TENSOR_LEVEL_LOOSE_COMPRESSED
 };
 
-enum PySparseTensorLevelPropertyNondefault : std::underlying_type_t<
+enum class PySparseTensorLevelPropertyNondefault : std::underlying_type_t<
     MlirSparseTensorLevelPropertyNondefault> {
-  MLIR_SPARSE_PROPERTY_NON_ORDERED = MLIR_SPARSE_PROPERTY_NON_ORDERED,
-  MLIR_SPARSE_PROPERTY_NON_UNIQUE = MLIR_SPARSE_PROPERTY_NON_UNIQUE,
-  MLIR_SPARSE_PROPERTY_SOA = MLIR_SPARSE_PROPERTY_SOA,
+  NON_ORDERED = MLIR_SPARSE_PROPERTY_NON_ORDERED,
+  NON_UNIQUE = MLIR_SPARSE_PROPERTY_NON_UNIQUE,
+  SOA = MLIR_SPARSE_PROPERTY_SOA,
 };
 
 struct EncodingAttr : PyConcreteAttribute<EncodingAttr> {
@@ -169,16 +168,15 @@ struct EncodingAttr : PyConcreteAttribute<EncodingAttr> {
 static void populateDialectSparseTensorSubmodule(nb::module_ &m) {
   nb::enum_<PySparseTensorLevelFormat>(m, "LevelFormat", nb::is_arithmetic(),
                                        nb::is_flag())
-      .value("dense", MLIR_SPARSE_TENSOR_LEVEL_DENSE)
-      .value("n_out_of_m", MLIR_SPARSE_TENSOR_LEVEL_N_OUT_OF_M)
-      .value("compressed", MLIR_SPARSE_TENSOR_LEVEL_COMPRESSED)
-      .value("singleton", MLIR_SPARSE_TENSOR_LEVEL_SINGLETON)
-      .value("loose_compressed", MLIR_SPARSE_TENSOR_LEVEL_LOOSE_COMPRESSED);
-
+      .value("dense", PySparseTensorLevelFormat::DENSE)
+      .value("n_out_of_m", PySparseTensorLevelFormat::N_OUT_OF_M)
+      .value("compressed", PySparseTensorLevelFormat::COMPRESSED)
+      .value("singleton", PySparseTensorLevelFormat::SINGLETON)
+      .value("loose_compressed", PySparseTensorLevelFormat::LOOSE_COMPRESSED);
   nb::enum_<PySparseTensorLevelPropertyNondefault>(m, "LevelProperty")
-      .value("non_ordered", MLIR_SPARSE_PROPERTY_NON_ORDERED)
-      .value("non_unique", MLIR_SPARSE_PROPERTY_NON_UNIQUE)
-      .value("soa", MLIR_SPARSE_PROPERTY_SOA);
+      .value("non_ordered", PySparseTensorLevelPropertyNondefault::NON_ORDERED)
+      .value("non_unique", PySparseTensorLevelPropertyNondefault::NON_UNIQUE)
+      .value("soa", PySparseTensorLevelPropertyNondefault::SOA);
 
   EncodingAttr::bind(m);
 }

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2792,19 +2792,18 @@ void populateIRCore(nb::module_ &m) {
   // Enums.
   //----------------------------------------------------------------------------
   nb::enum_<PyDiagnosticSeverity>(m, "DiagnosticSeverity")
-      .value("ERROR", MlirDiagnosticError)
-      .value("WARNING", MlirDiagnosticWarning)
-      .value("NOTE", MlirDiagnosticNote)
-      .value("REMARK", MlirDiagnosticRemark);
+      .value("ERROR", PyDiagnosticSeverity::Error)
+      .value("WARNING", PyDiagnosticSeverity::Warning)
+      .value("NOTE", PyDiagnosticSeverity::Note)
+      .value("REMARK", PyDiagnosticSeverity::Remark);
 
   nb::enum_<PyWalkOrder>(m, "WalkOrder")
-      .value("PRE_ORDER", MlirWalkPreOrder)
-      .value("POST_ORDER", MlirWalkPostOrder);
-
+      .value("PRE_ORDER", PyWalkOrder::PreOrder)
+      .value("POST_ORDER", PyWalkOrder::PostOrder);
   nb::enum_<PyWalkResult>(m, "WalkResult")
-      .value("ADVANCE", MlirWalkResultAdvance)
-      .value("INTERRUPT", MlirWalkResultInterrupt)
-      .value("SKIP", MlirWalkResultSkip);
+      .value("ADVANCE", PyWalkResult::Advance)
+      .value("INTERRUPT", PyWalkResult::Interrupt)
+      .value("SKIP", PyWalkResult::Skip);
 
   //----------------------------------------------------------------------------
   // Mapping of Diagnostics.
@@ -3718,7 +3717,7 @@ void populateIRCore(nb::module_ &m) {
             Note:
               After erasing, any Python references to the operation become invalid.)")
       .def("walk", &PyOperationBase::walk, "callback"_a,
-           "walk_order"_a = PyWalkOrder::MlirWalkPostOrder,
+           "walk_order"_a = PyWalkOrder::PostOrder,
            // clang-format off
           nb::sig("def walk(self, callback: Callable[[Operation], WalkResult], walk_order: WalkOrder) -> None"),
            // clang-format on

--- a/mlir/lib/Bindings/Python/Pass.cpp
+++ b/mlir/lib/Bindings/Python/Pass.cpp
@@ -55,9 +55,9 @@ private:
   MlirPassManager passManager;
 };
 
-enum PyMlirPassDisplayMode : std::underlying_type_t<MlirPassDisplayMode> {
-  MLIR_PASS_DISPLAY_MODE_LIST = MLIR_PASS_DISPLAY_MODE_LIST,
-  MLIR_PASS_DISPLAY_MODE_PIPELINE = MLIR_PASS_DISPLAY_MODE_PIPELINE
+enum class PyMlirPassDisplayMode : std::underlying_type_t<MlirPassDisplayMode> {
+  LIST = MLIR_PASS_DISPLAY_MODE_LIST,
+  PIPELINE = MLIR_PASS_DISPLAY_MODE_PIPELINE
 };
 
 struct PyMlirExternalPass : MlirExternalPass {};
@@ -68,8 +68,8 @@ void populatePassManagerSubmodule(nb::module_ &m) {
   // Mapping of enumerated types
   //----------------------------------------------------------------------------
   nb::enum_<PyMlirPassDisplayMode>(m, "PassDisplayMode")
-      .value("LIST", MLIR_PASS_DISPLAY_MODE_LIST)
-      .value("PIPELINE", MLIR_PASS_DISPLAY_MODE_PIPELINE);
+      .value("LIST", PyMlirPassDisplayMode::LIST)
+      .value("PIPELINE", PyMlirPassDisplayMode::PIPELINE);
 
   //----------------------------------------------------------------------------
   // Mapping of MlirExternalPass
@@ -161,7 +161,7 @@ void populatePassManagerSubmodule(nb::module_ &m) {
                 passManager.get(),
                 static_cast<MlirPassDisplayMode>(displayMode));
           },
-          "displayMode"_a = MLIR_PASS_DISPLAY_MODE_PIPELINE,
+          "displayMode"_a = PyMlirPassDisplayMode::PIPELINE,
           "Enable pass statistics.")
       .def_static(
           "parse",

--- a/mlir/lib/Bindings/Python/Rewrite.cpp
+++ b/mlir/lib/Bindings/Python/Rewrite.cpp
@@ -227,23 +227,18 @@ private:
   MlirContext ctx;
 };
 
-enum PyGreedyRewriteStrictness : std::underlying_type_t<
+enum class PyGreedyRewriteStrictness : std::underlying_type_t<
     MlirGreedyRewriteStrictness> {
-  MLIR_GREEDY_REWRITE_STRICTNESS_ANY_OP = MLIR_GREEDY_REWRITE_STRICTNESS_ANY_OP,
-  MLIR_GREEDY_REWRITE_STRICTNESS_EXISTING_AND_NEW_OPS =
-      MLIR_GREEDY_REWRITE_STRICTNESS_EXISTING_AND_NEW_OPS,
-  MLIR_GREEDY_REWRITE_STRICTNESS_EXISTING_OPS =
-      MLIR_GREEDY_REWRITE_STRICTNESS_EXISTING_OPS,
+  ANY_OP = MLIR_GREEDY_REWRITE_STRICTNESS_ANY_OP,
+  EXISTING_AND_NEW_OPS = MLIR_GREEDY_REWRITE_STRICTNESS_EXISTING_AND_NEW_OPS,
+  EXISTING_OPS = MLIR_GREEDY_REWRITE_STRICTNESS_EXISTING_OPS,
 };
 
-enum PyGreedySimplifyRegionLevel : std::underlying_type_t<
+enum class PyGreedySimplifyRegionLevel : std::underlying_type_t<
     MlirGreedySimplifyRegionLevel> {
-  MLIR_GREEDY_SIMPLIFY_REGION_LEVEL_DISABLED =
-      MLIR_GREEDY_SIMPLIFY_REGION_LEVEL_DISABLED,
-  MLIR_GREEDY_SIMPLIFY_REGION_LEVEL_NORMAL =
-      MLIR_GREEDY_SIMPLIFY_REGION_LEVEL_NORMAL,
-  MLIR_GREEDY_SIMPLIFY_REGION_LEVEL_AGGRESSIVE =
-      MLIR_GREEDY_SIMPLIFY_REGION_LEVEL_AGGRESSIVE
+  DISABLED = MLIR_GREEDY_SIMPLIFY_REGION_LEVEL_DISABLED,
+  NORMAL = MLIR_GREEDY_SIMPLIFY_REGION_LEVEL_NORMAL,
+  AGGRESSIVE = MLIR_GREEDY_SIMPLIFY_REGION_LEVEL_AGGRESSIVE
 };
 
 /// Owning Wrapper around a GreedyRewriteDriverConfig.
@@ -330,15 +325,15 @@ private:
 void populateRewriteSubmodule(nb::module_ &m) {
   // Enum definitions
   nb::enum_<PyGreedyRewriteStrictness>(m, "GreedyRewriteStrictness")
-      .value("ANY_OP", MLIR_GREEDY_REWRITE_STRICTNESS_ANY_OP)
+      .value("ANY_OP", PyGreedyRewriteStrictness::ANY_OP)
       .value("EXISTING_AND_NEW_OPS",
-             MLIR_GREEDY_REWRITE_STRICTNESS_EXISTING_AND_NEW_OPS)
-      .value("EXISTING_OPS", MLIR_GREEDY_REWRITE_STRICTNESS_EXISTING_OPS);
+             PyGreedyRewriteStrictness::EXISTING_AND_NEW_OPS)
+      .value("EXISTING_OPS", PyGreedyRewriteStrictness::EXISTING_OPS);
 
   nb::enum_<PyGreedySimplifyRegionLevel>(m, "GreedySimplifyRegionLevel")
-      .value("DISABLED", MLIR_GREEDY_SIMPLIFY_REGION_LEVEL_DISABLED)
-      .value("NORMAL", MLIR_GREEDY_SIMPLIFY_REGION_LEVEL_NORMAL)
-      .value("AGGRESSIVE", MLIR_GREEDY_SIMPLIFY_REGION_LEVEL_AGGRESSIVE);
+      .value("DISABLED", PyGreedySimplifyRegionLevel::DISABLED)
+      .value("NORMAL", PyGreedySimplifyRegionLevel::NORMAL)
+      .value("AGGRESSIVE", PyGreedySimplifyRegionLevel::AGGRESSIVE);
   //----------------------------------------------------------------------------
   // Mapping of the PatternRewriter
   //----------------------------------------------------------------------------


### PR DESCRIPTION
This PR replace `enum`s with `enum class`es in Python bindings. No functional change.