### PR TITLE
[RISC-V] Ensure MCTargetStreamer is initialized.

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
@@ -119,7 +119,7 @@ createRISCVObjectTargetStreamer(MCStreamer &S, const MCSubtargetInfo &STI) {
   const Triple &TT = STI.getTargetTriple();
   if (TT.isOSBinFormatELF())
     return new RISCVTargetELFStreamer(S, STI);
-  return nullptr;
+  return new RISCVTargetStreamer(S);
 }
 
 static MCStreamer *

--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -549,6 +549,8 @@ void RISCVAsmPrinter::emitSled(const MachineInstr *MI, SledKind Kind) {
 }
 
 void RISCVAsmPrinter::emitStartOfAsmFile(Module &M) {
+  assert(OutStreamer->getTargetStreamer() &&
+         "target streamer is uninitialized");
   RISCVTargetStreamer &RTS =
       static_cast<RISCVTargetStreamer &>(*OutStreamer->getTargetStreamer());
   if (const MDString *ModuleTargetABI =


### PR DESCRIPTION
Fixes a failure on llc for ubsan builds:

    ../lib/Target/RISCV/RISCVAsmPrinter.cpp:552:7: runtime error: downcast of null pointer of type 'RISCVTargetStreamer'
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../lib/Target/RISCV/RISCVAsmPrinter.cpp:552:7