### PR TITLE
[offload][lit] XFAIL all failing tests on the Level Zero plugin

### DIFF
--- a/offload/test/api/assert.c
+++ b/offload/test/api/assert.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <stdio.h>

--- a/offload/test/api/omp_device_alloc.c
+++ b/offload/test/api/omp_device_alloc.c
@@ -2,6 +2,7 @@
 
 // UNSUPPORTED: nvidiagpu
 // UNSUPPORTED: amdgpu
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/api/omp_device_managed_memory.c
+++ b/offload/test/api/omp_device_managed_memory.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_device_managed_memory_alloc.c
+++ b/offload/test/api/omp_device_managed_memory_alloc.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_device_memory.c
+++ b/offload/test/api/omp_device_memory.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_device_uid.c
+++ b/offload/test/api/omp_device_uid.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_dynamic_shared_memory.c
+++ b/offload/test/api/omp_dynamic_shared_memory.c
@@ -7,6 +7,7 @@
 // RUN:   %libomptarget-run-generic | %fcheck-generic
 
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_env_vars.c
+++ b/offload/test/api/omp_env_vars.c
@@ -2,6 +2,7 @@
 // RUN: env OMP_NUM_TEAMS=1 OMP_TEAMS_THREAD_LIMIT=1 LIBOMPTARGET_INFO=16 \
 // RUN:   %libomptarget-run-generic 2>&1 | %fcheck-generic
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #define N 256
 

--- a/offload/test/api/omp_get_device_num.c
+++ b/offload/test/api/omp_get_device_num.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_get_mapped_ptr.c
+++ b/offload/test/api/omp_get_mapped_ptr.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-and-run-generic
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/api/omp_get_num_devices.c
+++ b/offload/test/api/omp_get_num_devices.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_get_num_procs.c
+++ b/offload/test/api/omp_get_num_procs.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/api/omp_host_call.c
+++ b/offload/test/api/omp_host_call.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/api/omp_host_pinned_memory.c
+++ b/offload/test/api/omp_host_pinned_memory.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_host_pinned_memory_alloc.c
+++ b/offload/test/api/omp_host_pinned_memory_alloc.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/omp_indirect_call.c
+++ b/offload/test/api/omp_indirect_call.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <stdio.h>

--- a/offload/test/api/omp_indirect_call_table_manual.c
+++ b/offload/test/api/omp_indirect_call_table_manual.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 #include <assert.h>
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/api/ompx_3d.c
+++ b/offload/test/api/ompx_3d.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <ompx.h>

--- a/offload/test/api/ompx_3d.cpp
+++ b/offload/test/api/ompx_3d.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <ompx.h>

--- a/offload/test/api/ompx_sync.c
+++ b/offload/test/api/ompx_sync.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <ompx.h>

--- a/offload/test/api/ompx_sync.cpp
+++ b/offload/test/api/ompx_sync.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <ompx.h>

--- a/offload/test/env/base_ptr_ref_count.c
+++ b/offload/test/env/base_ptr_ref_count.c
@@ -1,5 +1,8 @@
+// clang-format off
 // RUN: %libomptarget-compile-generic && env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 | %fcheck-generic
 // REQUIRES: libomptarget-debug
+// XFAIL: intelgpu
+// clang-format on
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/env/omp_target_debug.c
+++ b/offload/test/env/omp_target_debug.c
@@ -1,6 +1,9 @@
+// clang-format off
 // RUN: %libomptarget-compile-generic && env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 | %fcheck-generic -allow-empty -check-prefix=DEBUG
 // RUN: %libomptarget-compile-generic && env LIBOMPTARGET_DEBUG=0 %libomptarget-run-generic 2>&1 | %fcheck-generic -allow-empty -check-prefix=NDEBUG
 // REQUIRES: libomptarget-debug
+// XFAIL: intelgpu
+// clang-format on
 
 int main(void) {
 #pragma omp target

--- a/offload/test/jit/empty_kernel_lvl1.c
+++ b/offload/test/jit/empty_kernel_lvl1.c
@@ -29,5 +29,6 @@
 // clang-format on
 
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include "empty_kernel.inc"

--- a/offload/test/jit/empty_kernel_lvl2.c
+++ b/offload/test/jit/empty_kernel_lvl2.c
@@ -24,5 +24,6 @@
 // clang-format on
 
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include "empty_kernel.inc"

--- a/offload/test/jit/type_punning.c
+++ b/offload/test/jit/type_punning.c
@@ -9,6 +9,7 @@
 // clang-format on
 
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 // Ensure that there is only the kernel function left, not any outlined
 // parallel regions.

--- a/offload/test/libc/malloc_parallel.c
+++ b/offload/test/libc/malloc_parallel.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -199,6 +199,9 @@ if config.libomptarget_current_target.startswith('nvptx'):
 if config.libomptarget_current_target.startswith('amdgcn'):
     config.available_features.add('gpu')
     config.available_features.add('amdgpu')
+if config.libomptarget_current_target.startswith('spirv64-intel'):
+    config.available_features.add('gpu')
+    config.available_features.add('intelgpu')
 if config.libomptarget_current_target in host_targets:
     config.available_features.add('host')
 
@@ -212,6 +215,9 @@ def remove_suffix_if_present(name):
 
 def add_libraries(source):
     if "gpu" not in config.available_features:
+        return source
+    if "intelgpu" in config.available_features:
+        # There is no DeviceRTL for Intel yet and libc doesn't work.
         return source
     if config.libomptarget_has_libc:
         return source + " -Xoffload-linker -lc " + \

--- a/offload/test/mapping/array_section_implicit_capture.c
+++ b/offload/test/mapping/array_section_implicit_capture.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-generic
 // RUN: %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/mapping/chained_containing_structs_1.cc
+++ b/offload/test/mapping/chained_containing_structs_1.cc
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <cstdlib>
 #include <cstdio>

--- a/offload/test/mapping/chained_containing_structs_2.cc
+++ b/offload/test/mapping/chained_containing_structs_2.cc
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <cstdlib>
 #include <cstdio>

--- a/offload/test/mapping/chained_containing_structs_3.cc
+++ b/offload/test/mapping/chained_containing_structs_3.cc
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <cstdlib>
 #include <cstdio>

--- a/offload/test/mapping/data_member_ref.cpp
+++ b/offload/test/mapping/data_member_ref.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/declare_mapper_nested_default_mappers.cpp
+++ b/offload/test/mapping/declare_mapper_nested_default_mappers.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <cstdio>
 #include <cstdlib>

--- a/offload/test/mapping/declare_mapper_nested_default_mappers_1.cpp
+++ b/offload/test/mapping/declare_mapper_nested_default_mappers_1.cpp
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// XFAIL: intelgpu
 
 extern "C" int printf(const char *, ...);
 

--- a/offload/test/mapping/declare_mapper_nested_mappers.cpp
+++ b/offload/test/mapping/declare_mapper_nested_mappers.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <cstdio>
 #include <cstdlib>

--- a/offload/test/mapping/declare_mapper_target.cpp
+++ b/offload/test/mapping/declare_mapper_target.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <cstdio>
 #include <cstdlib>

--- a/offload/test/mapping/declare_mapper_target_data.cpp
+++ b/offload/test/mapping/declare_mapper_target_data.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <cstdio>
 #include <cstdlib>

--- a/offload/test/mapping/declare_mapper_target_data_enter_exit.cpp
+++ b/offload/test/mapping/declare_mapper_target_data_enter_exit.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <cstdio>
 #include <cstdlib>

--- a/offload/test/mapping/declare_mapper_target_update.cpp
+++ b/offload/test/mapping/declare_mapper_target_update.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <cstdio>
 #include <cstdlib>

--- a/offload/test/mapping/delete_inf_refcount.c
+++ b/offload/test/mapping/delete_inf_refcount.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/device_ptr_update.c
+++ b/offload/test/mapping/device_ptr_update.c
@@ -2,6 +2,7 @@
 // RUN: env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic -check-prefix=DEBUG -check-prefix=CHECK
 // REQUIRES: libomptarget-debug
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/duplicate_mappings_1.cpp
+++ b/offload/test/mapping/duplicate_mappings_1.cpp
@@ -1,5 +1,6 @@
 // clang-format off
 // RUN: %libomptarget-compilexx-generic -Wno-openmp-mapping && %libomptarget-run-generic
+// XFAIL: intelgpu
 
 // clang-format on
 

--- a/offload/test/mapping/duplicate_mappings_2.cpp
+++ b/offload/test/mapping/duplicate_mappings_2.cpp
@@ -1,5 +1,6 @@
 // clang-format off
 // RUN: %libomptarget-compilexx-generic -Wno-openmp-mapping && %libomptarget-run-generic
+// XFAIL: intelgpu
 
 #include <assert.h>
 

--- a/offload/test/mapping/firstprivate_aligned.cpp
+++ b/offload/test/mapping/firstprivate_aligned.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-generic -O3 && %libomptarget-run-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/has_device_addr.cpp
+++ b/offload/test/mapping/has_device_addr.cpp
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compilexx-generic -fopenmp-version=51
 // RUN: %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <iostream>

--- a/offload/test/mapping/implicit_device_ptr.c
+++ b/offload/test/mapping/implicit_device_ptr.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/is_accessible.cpp
+++ b/offload/test/mapping/is_accessible.cpp
@@ -8,6 +8,7 @@
 
 // REQUIRES: unified_shared_memory
 // XFAIL: nvptx
+// XFAIL: intelgpu
 
 // CHECK: SUCCESS
 // NO_USM: Not accessible

--- a/offload/test/mapping/is_device_ptr.cpp
+++ b/offload/test/mapping/is_device_ptr.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <iostream>

--- a/offload/test/mapping/lambda_by_value.cpp
+++ b/offload/test/mapping/lambda_by_value.cpp
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compileopt-generic -fno-exceptions
 // RUN: %libomptarget-run-generic 2>&1 | %fcheck-generic
+// XFAIL: intelgpu
 
 #include <stdint.h>
 #include <stdio.h>

--- a/offload/test/mapping/low_alignment.c
+++ b/offload/test/mapping/low_alignment.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_both_pointer_pointee.c
+++ b/offload/test/mapping/map_both_pointer_pointee.c
@@ -5,6 +5,7 @@
 //
 // FIXME: https://github.com/llvm/llvm-project/issues/161265
 // XFAIL: nvidiagpu
+// XFAIL: intelgpu
 
 #pragma omp declare target
 int *ptr1;

--- a/offload/test/mapping/map_ptr_and_star_local.c
+++ b/offload/test/mapping/map_ptr_and_star_local.c
@@ -4,6 +4,7 @@
 //
 // FIXME: https://github.com/llvm/llvm-project/issues/161265
 // XFAIL: gpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_ptr_and_star_local.c
+++ b/offload/test/mapping/map_ptr_and_star_local.c
@@ -4,7 +4,6 @@
 //
 // FIXME: https://github.com/llvm/llvm-project/issues/161265
 // XFAIL: gpu
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_structptr_and_member_global.c
+++ b/offload/test/mapping/map_structptr_and_member_global.c
@@ -4,6 +4,7 @@
 //
 // FIXME: https://github.com/llvm/llvm-project/issues/161265
 // XFAIL: gpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_structptr_and_member_global.c
+++ b/offload/test/mapping/map_structptr_and_member_global.c
@@ -4,7 +4,6 @@
 //
 // FIXME: https://github.com/llvm/llvm-project/issues/161265
 // XFAIL: gpu
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_structptr_and_member_local.c
+++ b/offload/test/mapping/map_structptr_and_member_local.c
@@ -4,6 +4,7 @@
 //
 // FIXME: https://github.com/llvm/llvm-project/issues/161265
 // XFAIL: gpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_structptr_and_member_local.c
+++ b/offload/test/mapping/map_structptr_and_member_local.c
@@ -4,7 +4,6 @@
 //
 // FIXME: https://github.com/llvm/llvm-project/issues/161265
 // XFAIL: gpu
-// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/ompx_hold/struct.c
+++ b/offload/test/mapping/ompx_hold/struct.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-generic -fopenmp-extensions
 // RUN: %libomptarget-run-generic | %fcheck-generic -strict-whitespace
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/ompx_hold/target.c
+++ b/offload/test/mapping/ompx_hold/target.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-generic -fopenmp-extensions
 // RUN: %libomptarget-run-generic | %fcheck-generic -strict-whitespace
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/pr38704.c
+++ b/offload/test/mapping/pr38704.c
@@ -3,6 +3,7 @@
 // Clang 6.0 doesn't use the new map interface, undefined behavior when
 // the compiler emits "old" interface code for structures.
 // UNSUPPORTED: clang-6
+// XFAIL: intelgpu
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/mapping/prelock.cpp
+++ b/offload/test/mapping/prelock.cpp
@@ -4,6 +4,7 @@
 // REQUIRES: gpu
 // UNSUPPORTED: nvidiagpu
 // UNSUPPORTED: amdgpu
+// XFAIL: intelgpu
 
 #include <cstdio>
 

--- a/offload/test/mapping/present/target.c
+++ b/offload/test/mapping/present/target.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-generic
 // RUN: %libomptarget-run-fail-generic 2>&1 \
 // RUN: | %fcheck-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/present/target_array_extension.c
+++ b/offload/test/mapping/present/target_array_extension.c
@@ -15,6 +15,7 @@
 // RUN:   -DEXTENDS=AFTER
 // RUN: %libomptarget-run-fail-generic 2>&1 \
 // RUN: | %fcheck-generic
+// XFAIL: intelgpu
 
 // END.
 

--- a/offload/test/mapping/present/unified_shared_memory.c
+++ b/offload/test/mapping/present/unified_shared_memory.c
@@ -3,6 +3,7 @@
 // RUN: | %fcheck-generic
 
 // REQUIRES: unified_shared_memory
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/present/zero_length_array_section.c
+++ b/offload/test/mapping/present/zero_length_array_section.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-generic
 // RUN: %libomptarget-run-fail-generic 2>&1 \
 // RUN: | %fcheck-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/private_mapping.c
+++ b/offload/test/mapping/private_mapping.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <stdio.h>

--- a/offload/test/mapping/ptr_and_obj_motion.c
+++ b/offload/test/mapping/ptr_and_obj_motion.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/reduction_implicit_map.cpp
+++ b/offload/test/mapping/reduction_implicit_map.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/mapping/target_data_array_extension_at_exit.c
+++ b/offload/test/mapping/target_data_array_extension_at_exit.c
@@ -15,6 +15,7 @@
 // RUN:   -DEXTENDS=AFTER
 // RUN: %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic
+// XFAIL: intelgpu
 
 // END.
 

--- a/offload/test/mapping/target_derefence_array_pointrs.cpp
+++ b/offload/test/mapping/target_derefence_array_pointrs.cpp
@@ -6,6 +6,7 @@
 // UNSUPPORTED: amdgcn-amd-amdhsa
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// XFAIL: intelgpu
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/mapping/target_has_device_addr.c
+++ b/offload/test/mapping/target_has_device_addr.c
@@ -3,6 +3,7 @@
 // RUN: | %fcheck-generic
 
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/target_implicit_partial_map.c
+++ b/offload/test/mapping/target_implicit_partial_map.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-generic
 // RUN: %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic
+// XFAIL: intelgpu
 
 // END.
 

--- a/offload/test/mapping/target_map_for_member_data.cpp
+++ b/offload/test/mapping/target_map_for_member_data.cpp
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-generic -fopenmp-version=51
 // RUN: %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic
+// XFAIL: intelgpu
 
 extern "C" int printf(const char *, ...);
 template <typename T> class A {

--- a/offload/test/mapping/target_uses_allocator.c
+++ b/offload/test/mapping/target_uses_allocator.c
@@ -4,6 +4,7 @@
 // UNSUPPORTED: amdgcn-amd-amdhsa
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/use_device_addr/target_use_device_addr.c
+++ b/offload/test/mapping/use_device_addr/target_use_device_addr.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-generic -fopenmp-version=51
 // RUN: %libomptarget-run-generic 2>&1 \
 // RUN: | %fcheck-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 int main() {

--- a/offload/test/offloading/CUDA/basic_launch.cu
+++ b/offload/test/offloading/CUDA/basic_launch.cu
@@ -9,6 +9,7 @@
 // UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/CUDA/basic_launch_blocks_and_threads.cu
+++ b/offload/test/offloading/CUDA/basic_launch_blocks_and_threads.cu
@@ -9,6 +9,7 @@
 // UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/CUDA/basic_launch_multi_arg.cu
+++ b/offload/test/offloading/CUDA/basic_launch_multi_arg.cu
@@ -6,6 +6,7 @@
 // clang-format on
 
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/CUDA/launch_tu.cu
+++ b/offload/test/offloading/CUDA/launch_tu.cu
@@ -9,6 +9,7 @@
 // UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
 // UNSUPPORTED: x86_64-unknown-linux-gnu
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/assert.cpp
+++ b/offload/test/offloading/assert.cpp
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compilexx-generic && %libomptarget-run-fail-generic
 // RUN: %libomptarget-compileoptxx-generic && %libomptarget-run-fail-generic
+// XFAIL: intelgpu
 
 int main(int argc, char *argv[]) {
 #pragma omp target

--- a/offload/test/offloading/atomic-compare-signedness.c
+++ b/offload/test/offloading/atomic-compare-signedness.c
@@ -7,6 +7,7 @@
 // RUN: %libomptarget-run-generic | %fcheck-generic
 // RUN: %libomptarget-compileopt-generic -fopenmp-version=51
 // RUN: %libomptarget-run-generic | %fcheck-generic
+// XFAIL: intelgpu
 
 // High parallelism increases our chances of detecting a lack of atomicity.
 #define NUM_THREADS_TRY 256

--- a/offload/test/offloading/back2back_distribute.c
+++ b/offload/test/offloading/back2back_distribute.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomptarget-compile-generic -O3 && %libomptarget-run-generic | %fcheck-generic
-
+// XFAIL: intelgpu
+// clang-format on
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/bug47654.cpp
+++ b/offload/test/offloading/bug47654.cpp
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 // RUN: %libomptarget-compileoptxx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <cassert>
 #include <iostream>

--- a/offload/test/offloading/bug49021.cpp
+++ b/offload/test/offloading/bug49021.cpp
@@ -1,7 +1,10 @@
+// clang-format off
 // RUN: %libomptarget-compilexx-generic -O3 && %libomptarget-run-generic
 // RUN: %libomptarget-compilexx-generic -O3 -ffast-math && %libomptarget-run-generic
 // RUN: %libomptarget-compileoptxx-generic -O3 && %libomptarget-run-generic
 // RUN: %libomptarget-compileoptxx-generic -O3 -ffast-math && %libomptarget-run-generic
+// XFAIL: intelgpu
+// clang-format on
 
 #include <iostream>
 

--- a/offload/test/offloading/bug49334.cpp
+++ b/offload/test/offloading/bug49334.cpp
@@ -8,6 +8,7 @@
 // REQUIRES: gpu
 // UNSUPPORTED: nvidiagpu
 // UNSUPPORTED: amdgpu
+// XFAIL: intelgpu
 
 #include <cassert>
 #include <cmath>

--- a/offload/test/offloading/bug49779.cpp
+++ b/offload/test/offloading/bug49779.cpp
@@ -5,6 +5,7 @@
 
 // We need malloc/global_alloc support
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// XFAIL: intelgpu
 
 #include <cassert>
 #include <iostream>

--- a/offload/test/offloading/bug50022.cpp
+++ b/offload/test/offloading/bug50022.cpp
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compilexx-and-run-generic
 // RUN: %libomptarget-compileoptxx-and-run-generic
+// XFAIL: intelgpu
 
 #include <cassert>
 #include <iostream>

--- a/offload/test/offloading/bug51781.c
+++ b/offload/test/offloading/bug51781.c
@@ -33,6 +33,7 @@
 // RUN: %fcheck-nvptx64-nvidia-cuda -check-prefix=CUSTOM -input-file=%t.custom
 // RUN: %fcheck-amdgcn-amd-amdhsa -check-prefix=CUSTOM -input-file=%t.custom
 // RUN: %libomptarget-run-generic 2>&1 | %fcheck-generic
+// XFAIL: intelgpu
 //
 // CUSTOM: Rewriting generic-mode kernel with a customized state machine.
 

--- a/offload/test/offloading/bug51982.c
+++ b/offload/test/offloading/bug51982.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-generic -O2 && %libomptarget-run-generic
 // -O2 to run openmp-opt
 // RUN: %libomptarget-compileopt-generic -O2 && %libomptarget-run-generic
+// XFAIL: intelgpu
 
 int main(void) {
   long int aa = 0;

--- a/offload/test/offloading/bug53727.cpp
+++ b/offload/test/offloading/bug53727.cpp
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compilexx-and-run-generic
 // RUN: %libomptarget-compileoptxx-and-run-generic
+// XFAIL: intelgpu
 
 #include <cassert>
 #include <iostream>

--- a/offload/test/offloading/bug64959.c
+++ b/offload/test/offloading/bug64959.c
@@ -6,6 +6,7 @@
 // UNSUPPORTED: amdgcn-amd-amdhsa
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/bug64959_compile_only.c
+++ b/offload/test/offloading/bug64959_compile_only.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-generic
 // RUN: %libomptarget-compileopt-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 #define N 10

--- a/offload/test/offloading/bug74582.c
+++ b/offload/test/offloading/bug74582.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-generic && %libomptarget-run-generic
 // RUN: %libomptarget-compileopt-generic && %libomptarget-run-generic
+// XFAIL: intelgpu
 
 // Verify we do not read bits in the image that are not there (nobits section).
 

--- a/offload/test/offloading/complex_reduction.cpp
+++ b/offload/test/offloading/complex_reduction.cpp
@@ -1,5 +1,8 @@
+// clang-format off
 // RUN: %libomptarget-compilexx-generic -O3 && %libomptarget-run-generic
 // RUN: %libomptarget-compilexx-generic -O3 -ffast-math && %libomptarget-run-generic
+// XFAIL: intelgpu
+// clang-format on
 
 #include <complex>
 #include <iostream>

--- a/offload/test/offloading/ctor_dtor.cpp
+++ b/offload/test/offloading/ctor_dtor.cpp
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 // RUN: %libomptarget-compileoptxx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <cstdio>
 struct S {

--- a/offload/test/offloading/ctor_dtor_api.cpp
+++ b/offload/test/offloading/ctor_dtor_api.cpp
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 // RUN: %libomptarget-compileoptxx-run-and-check-generic
+// UNSUPPORTED: intelgpu
 
 #include <cstdio>
 #include <omp.h>

--- a/offload/test/offloading/ctor_dtor_lazy.cpp
+++ b/offload/test/offloading/ctor_dtor_lazy.cpp
@@ -4,6 +4,7 @@
 // RUN: %not --crash %libomptarget-run-generic
 // RUN: %libomptarget-compilexx-generic -DCTOR_API
 // RUN: %not --crash %libomptarget-run-generic
+// XFAIL: intelgpu
 
 #include <cstdio>
 #include <omp.h>

--- a/offload/test/offloading/cuda_no_devices.c
+++ b/offload/test/offloading/cuda_no_devices.c
@@ -5,6 +5,7 @@
 // RUN: %libomptarget-compile-generic
 // RUN: env CUDA_VISIBLE_DEVICES= \
 // RUN:   %libomptarget-run-generic 2>&1 | %fcheck-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/d2d_memcpy.c
+++ b/offload/test/offloading/d2d_memcpy.c
@@ -4,6 +4,7 @@
 // RUN: %libomptarget-compileopt-generic && \
 // RUN: env OMP_MAX_ACTIVE_LEVELS=2 %libomptarget-run-generic | \
 // RUN: %fcheck-generic -allow-empty
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/offloading/default_thread_limit.c
+++ b/offload/test/offloading/default_thread_limit.c
@@ -7,6 +7,7 @@
 // RUN:   %libomptarget-run-generic 2>&1 | %fcheck-generic --check-prefix=DEFAULT
 
 // REQUIRES: amdgpu
+// XFAIL: intelgpu
 
 __attribute__((optnone)) int optnone() { return 1; }
 

--- a/offload/test/offloading/dynamic_module.c
+++ b/offload/test/offloading/dynamic_module.c
@@ -1,9 +1,12 @@
+// clang-format off
 // RUN: %libomptarget-compile-generic -DSHARED -fPIC -shared -o %t.so && \
 // RUN: %libomptarget-compile-generic %t.so && %libomptarget-run-generic 2>&1 | %fcheck-generic
 // RUN: %libomptarget-compileopt-generic -DSHARED -fPIC -shared -o %t.so && \
 // RUN: %libomptarget-compileopt-generic %t.so && %libomptarget-run-generic 2>&1 | %fcheck-generic
 //
 // REQUIRES: gpu
+// XFAIL: intelgpu
+// clang-format on
 
 #ifdef SHARED
 void foo() {}

--- a/offload/test/offloading/dynamic_module_load.c
+++ b/offload/test/offloading/dynamic_module_load.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomptarget-compile-generic -DSHARED -fPIC -shared -o %t.so && %clang %flags %s -o %t -ldl && %libomptarget-run-generic %t.so 2>&1 | %fcheck-generic
-
+// XFAIL: intelgpu
+// clang-format on
 #ifdef SHARED
 #include <stdio.h>
 int foo() {

--- a/offload/test/offloading/extern.c
+++ b/offload/test/offloading/extern.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomptarget-compile-generic -DVAR -c -o %t.o
 // RUN: %libomptarget-compile-generic %t.o && %libomptarget-run-generic | %fcheck-generic
-
+// XFAIL: intelgpu
+// clang-format on
 #ifdef VAR
 int x = 1;
 #else

--- a/offload/test/offloading/force-usm.cpp
+++ b/offload/test/offloading/force-usm.cpp
@@ -10,6 +10,7 @@
 //
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// XFAIL: intelgpu
 // clang-format on
 
 #include <cassert>

--- a/offload/test/offloading/fortran/basic-target-parallel-do.f90
+++ b/offload/test/offloading/fortran/basic-target-parallel-do.f90
@@ -3,6 +3,7 @@
 
 ! RUN: %libomptarget-compile-fortran-generic
 ! RUN: env LIBOMPTARGET_INFO=16 %libomptarget-run-generic 2>&1 | %fcheck-generic
+! XFAIL: intelgpu
 program main
    use omp_lib
    integer :: x(100)

--- a/offload/test/offloading/fortran/basic-target-parallel-region.f90
+++ b/offload/test/offloading/fortran/basic-target-parallel-region.f90
@@ -2,6 +2,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
    use omp_lib
    integer :: x

--- a/offload/test/offloading/fortran/basic-target-region-3D-array.f90
+++ b/offload/test/offloading/fortran/basic-target-region-3D-array.f90
@@ -5,6 +5,7 @@
 ! UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     integer :: x(2,2,2)
     integer :: i, j, k

--- a/offload/test/offloading/fortran/double-target-call-with-declare-target.f90
+++ b/offload/test/offloading/fortran/double-target-call-with-declare-target.f90
@@ -4,6 +4,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 module test_0
     implicit none
     integer :: sp(10) = (/0,0,0,0,0,0,0,0,0,0/)

--- a/offload/test/offloading/fortran/dump_map_tables.f90
+++ b/offload/test/offloading/fortran/dump_map_tables.f90
@@ -9,6 +9,7 @@
 ! UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 
 program map_dump_example
   INTERFACE

--- a/offload/test/offloading/fortran/target-map-derived-type-full-1.f90
+++ b/offload/test/offloading/fortran/target-map-derived-type-full-1.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     type :: scalar
     integer(4) :: ix = 0

--- a/offload/test/offloading/fortran/target-map-derived-type-full-2.f90
+++ b/offload/test/offloading/fortran/target-map-derived-type-full-2.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     type :: scalar
     integer(4) :: ix = 0

--- a/offload/test/offloading/fortran/target-map-dtype-explicit-individual-array-member.f90
+++ b/offload/test/offloading/fortran/target-map-dtype-explicit-individual-array-member.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
 type :: scalar_array
     real(4) :: break_0

--- a/offload/test/offloading/fortran/target-map-dtype-multi-explicit-array-3D-member-bounds.f90
+++ b/offload/test/offloading/fortran/target-map-dtype-multi-explicit-array-3D-member-bounds.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     type :: scalar_array
     real(4) :: break_0

--- a/offload/test/offloading/fortran/target-map-dtype-multi-explicit-array-member-bounds.f90
+++ b/offload/test/offloading/fortran/target-map-dtype-multi-explicit-array-member-bounds.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     type :: scalar_array
     real(4) :: break_0

--- a/offload/test/offloading/fortran/target-map-dtype-multi-explicit-array-member.f90
+++ b/offload/test/offloading/fortran/target-map-dtype-multi-explicit-array-member.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     type :: scalar_array
     real(4) :: break_0

--- a/offload/test/offloading/fortran/target-map-dtype-multi-explicit-member.f90
+++ b/offload/test/offloading/fortran/target-map-dtype-multi-explicit-member.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     type :: scalar
       integer(4) :: ix = 0

--- a/offload/test/offloading/fortran/target-map-enter-exit-array.f90
+++ b/offload/test/offloading/fortran/target-map-enter-exit-array.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     integer :: A(10)
 

--- a/offload/test/offloading/fortran/target-map-enter-exit-scalar.f90
+++ b/offload/test/offloading/fortran/target-map-enter-exit-scalar.f90
@@ -2,6 +2,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     integer :: scalar
     scalar = 10

--- a/offload/test/offloading/fortran/target-map-individual-dtype-member-map.f90
+++ b/offload/test/offloading/fortran/target-map-individual-dtype-member-map.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     real :: test
     type :: scalar

--- a/offload/test/offloading/fortran/target-map-nested-dtype-complex-member.f90
+++ b/offload/test/offloading/fortran/target-map-nested-dtype-complex-member.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     type :: bottom_layer
       real(8) :: i2

--- a/offload/test/offloading/fortran/target-map-nested-dtype-derived-member.f90
+++ b/offload/test/offloading/fortran/target-map-nested-dtype-derived-member.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     type :: bottom_layer
       real(8) :: i2

--- a/offload/test/offloading/fortran/target-map-nested-dtype-multi-member.f90
+++ b/offload/test/offloading/fortran/target-map-nested-dtype-multi-member.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     type :: bottom_layer
       real(8) :: i2

--- a/offload/test/offloading/fortran/target-map-pointer-target-array-section-3d-bounds.f90
+++ b/offload/test/offloading/fortran/target-map-pointer-target-array-section-3d-bounds.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     integer, pointer :: inArray(:,:,:)
     integer, pointer :: outArray(:,:,:)

--- a/offload/test/offloading/fortran/target-map-two-dtype-explicit-member.f90
+++ b/offload/test/offloading/fortran/target-map-two-dtype-explicit-member.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     type :: scalar_array
         real(4) :: break_0

--- a/offload/test/offloading/fortran/target-no-loop.f90
+++ b/offload/test/offloading/fortran/target-no-loop.f90
@@ -3,6 +3,7 @@
 
 ! RUN: %libomptarget-compile-fortran-generic -O3  -fopenmp-assume-threads-oversubscription -fopenmp-assume-teams-oversubscription
 ! RUN: env LIBOMPTARGET_INFO=16 OMP_NUM_TEAMS=16 OMP_TEAMS_THREAD_LIMIT=16 %libomptarget-run-generic 2>&1 | %fcheck-generic
+! XFAIL: intelgpu
 function check_errors(array) result (errors)
    integer, intent(in) :: array(1024)
    integer :: errors

--- a/offload/test/offloading/fortran/target-region-implicit-array.f90
+++ b/offload/test/offloading/fortran/target-region-implicit-array.f90
@@ -3,6 +3,7 @@
 ! REQUIRES: flang, amdgpu
 
 ! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! XFAIL: intelgpu
 program main
     integer :: x(10) = (/0,0,0,0,0,0,0,0,0,0/)
     integer :: i = 1

--- a/offload/test/offloading/generic_multiple_parallel_regions.c
+++ b/offload/test/offloading/generic_multiple_parallel_regions.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/global_constructor.cpp
+++ b/offload/test/offloading/global_constructor.cpp
@@ -1,4 +1,7 @@
+// clang-format off
 // RUN: %libomptarget-compilexx-generic && %libomptarget-run-generic | %fcheck-generic
+// XFAIL: intelgpu
+// clang-format on
 
 #include <cstdio>
 

--- a/offload/test/offloading/high_trip_count_block_limit.cpp
+++ b/offload/test/offloading/high_trip_count_block_limit.cpp
@@ -8,6 +8,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO 
 // UNSUPPORTED: s390x-ibm-linux-gnu 
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/offloading/host_as_target.c
+++ b/offload/test/offloading/host_as_target.c
@@ -6,6 +6,7 @@
 // - Works whether it's specified directly or as the default device.
 
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/indirect_fp_mapping.c
+++ b/offload/test/offloading/indirect_fp_mapping.c
@@ -2,6 +2,7 @@
 // RUN: %libomptarget-run-generic | %fcheck-generic
 // RUN: %libomptarget-compileopt-generic -fopenmp-version=51
 // RUN: %libomptarget-run-generic | %fcheck-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/info.c
+++ b/offload/test/offloading/info.c
@@ -7,6 +7,7 @@
 
 // FIXME: Fails due to optimized debugging in 'ptxas'.
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/interop-print.c
+++ b/offload/test/offloading/interop-print.c
@@ -9,6 +9,7 @@
 // REQUIRES: gpu
 // XFAIL: nvptx64-nvidia-cuda
 // XFAIL: nvptx64-nvidia-cuda-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/interop.c
+++ b/offload/test/offloading/interop.c
@@ -1,7 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 
-// XFAIL: *
-// UNSUPPORTED: intelgpu
+// XFAIL: !intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/offloading/interop.c
+++ b/offload/test/offloading/interop.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 
 // XFAIL: *
+// UNSUPPORTED: intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/offloading/looptripcnt.c
+++ b/offload/test/offloading/looptripcnt.c
@@ -1,5 +1,8 @@
+// clang-format off
 // RUN: %libomptarget-compile-generic && env LIBOMPTARGET_DEBUG=1 %libomptarget-run-generic 2>&1 | %fcheck-generic -allow-empty -check-prefix=DEBUG
 // REQUIRES: libomptarget-debug
+// XFAIL: intelgpu
+// clang-format on
 
 /*
   Test for looptripcount being popped from runtime stack.

--- a/offload/test/offloading/malloc.c
+++ b/offload/test/offloading/malloc.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-generic && %libomptarget-run-generic
 // RUN: %libomptarget-compileopt-generic && %libomptarget-run-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/memory_manager.cpp
+++ b/offload/test/offloading/memory_manager.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/offloading/multiple_reductions_simple.c
+++ b/offload/test/offloading/multiple_reductions_simple.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/offloading_success.c
+++ b/offload/test/offloading/offloading_success.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/offloading_success.cpp
+++ b/offload/test/offloading/offloading_success.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/ompx_bare.c
+++ b/offload/test/offloading/ompx_bare.c
@@ -3,6 +3,7 @@
 // RUN:   %fcheck-generic
 //
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <ompx.h>

--- a/offload/test/offloading/ompx_bare_ballot_sync.c
+++ b/offload/test/offloading/ompx_bare_ballot_sync.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 //
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <ompx.h>

--- a/offload/test/offloading/ompx_bare_multi_dim.cpp
+++ b/offload/test/offloading/ompx_bare_multi_dim.cpp
@@ -1,6 +1,9 @@
+// clang-format off
 // RUN: %libomptarget-compilexx-generic
 // RUN: env LIBOMPTARGET_INFO=63 %libomptarget-run-generic 2>&1 | %fcheck-generic
 // REQUIRES: gpu
+// XFAIL: intelgpu
+// clang-format on
 
 #include <ompx.h>
 

--- a/offload/test/offloading/ompx_bare_shfl_down_sync.cpp
+++ b/offload/test/offloading/ompx_bare_shfl_down_sync.cpp
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 //
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <cassert>
 #include <cmath>

--- a/offload/test/offloading/ompx_coords.c
+++ b/offload/test/offloading/ompx_coords.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compileopt-run-and-check-generic
 //
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <ompx.h>

--- a/offload/test/offloading/ompx_saxpy_mixed.c
+++ b/offload/test/offloading/ompx_saxpy_mixed.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compileopt-run-and-check-generic
 //
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <math.h>
 #include <omp.h>

--- a/offload/test/offloading/parallel_offloading_map.cpp
+++ b/offload/test/offloading/parallel_offloading_map.cpp
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
 
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <cassert>
 #include <iostream>

--- a/offload/test/offloading/parallel_target_teams_reduction.cpp
+++ b/offload/test/offloading/parallel_target_teams_reduction.cpp
@@ -3,6 +3,7 @@
 
 // FIXME: This is a bug in host offload, this should run fine.
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <iostream>
 #include <vector>

--- a/offload/test/offloading/parallel_target_teams_reduction_max.cpp
+++ b/offload/test/offloading/parallel_target_teams_reduction_max.cpp
@@ -3,6 +3,7 @@
 
 // FIXME: This is a bug in host offload, this should run fine.
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 // This test validates that the OpenMP target reductions to find a maximum work
 // as intended for a few common data types.

--- a/offload/test/offloading/parallel_target_teams_reduction_min.cpp
+++ b/offload/test/offloading/parallel_target_teams_reduction_min.cpp
@@ -3,6 +3,7 @@
 
 // FIXME: This is a bug in host offload, this should run fine.
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 // This test validates that the OpenMP target reductions to find a minimum work
 // as intended for a few common data types.

--- a/offload/test/offloading/requires.c
+++ b/offload/test/offloading/requires.c
@@ -1,6 +1,7 @@
 // clang-format off
 // RUN: %libomptarget-compile-generic -DREQ=1 && %libomptarget-run-generic 2>&1 | %fcheck-generic -check-prefix=GOOD
 // RUN: %libomptarget-compile-generic -DREQ=2 && %not --crash %libomptarget-run-generic 2>&1 | %fcheck-generic -check-prefix=BAD
+// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/offloading/shared_lib_fp_mapping.c
+++ b/offload/test/offloading/shared_lib_fp_mapping.c
@@ -3,6 +3,7 @@
 // RUN: %clang-generic -fPIC -shared %S/../Inputs/declare_indirect_func.c -o %t.testdir/libslfm.so  -fopenmp-version=51
 // RUN: %libomptarget-compile-generic -rpath %t.testdir -L %t.testdir -l slfm -o %t  -fopenmp-version=51
 // RUN: env LIBOMPTARGET_INFO=32 %t 2>&1 | %fcheck-generic
+// XFAIL: intelgpu
 // clang-format on
 
 #include <stdio.h>

--- a/offload/test/offloading/small_trip_count.c
+++ b/offload/test/offloading/small_trip_count.c
@@ -6,6 +6,7 @@
 // RUN:   %libomptarget-run-generic 2>&1 | %fcheck-generic --check-prefix=EIGHT
 
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #define N 128
 

--- a/offload/test/offloading/small_trip_count_thread_limit.cpp
+++ b/offload/test/offloading/small_trip_count_thread_limit.cpp
@@ -4,6 +4,7 @@
 // RUN:   %libomptarget-run-generic 2>&1 | %fcheck-generic
 
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 int main(int argc, char *argv[]) {
   constexpr const int block_size = 256;

--- a/offload/test/offloading/spmdization.c
+++ b/offload/test/offloading/spmdization.c
@@ -9,6 +9,7 @@
 // clang-format on
 
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/static_linking.c
+++ b/offload/test/offloading/static_linking.c
@@ -1,6 +1,9 @@
+// clang-format off
 // RUN: %libomptarget-compile-generic -DLIBRARY -c -o %t.o
 // RUN: ar rcs %t.a %t.o
 // RUN: %libomptarget-compile-generic %t.a && %libomptarget-run-generic 2>&1 | %fcheck-generic
+// XFAIL: intelgpu
+// clang-format on
 
 #ifdef LIBRARY
 int x = 42;

--- a/offload/test/offloading/std_complex_arithmetic.cpp
+++ b/offload/test/offloading/std_complex_arithmetic.cpp
@@ -7,6 +7,7 @@
 //        needed math functions in the GPU `libm` and require the GPU C library.
 // UNSUPPORTED: amdgcn-amd-amdhsa
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// XFAIL: intelgpu
 
 #include <cassert>
 #include <complex>

--- a/offload/test/offloading/strided_multiple_update.c
+++ b/offload/test/offloading/strided_multiple_update.c
@@ -3,6 +3,7 @@
 // from the device to the host.
 
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 #include <omp.h>
 #include <stdio.h>
 

--- a/offload/test/offloading/strided_partial_update.c
+++ b/offload/test/offloading/strided_partial_update.c
@@ -3,6 +3,7 @@
 // across the array
 
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 #include <omp.h>
 #include <stdio.h>
 

--- a/offload/test/offloading/strided_ptr_multiple_update_from.c
+++ b/offload/test/offloading/strided_ptr_multiple_update_from.c
@@ -3,6 +3,7 @@
 // from the device to the host using dynamically allocated memory.
 
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/strided_ptr_multiple_update_to.c
+++ b/offload/test/offloading/strided_ptr_multiple_update_to.c
@@ -3,6 +3,7 @@
 // from the host to the device using dynamically allocated memory.
 
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/strided_ptr_partial_update_from.c
+++ b/offload/test/offloading/strided_ptr_partial_update_from.c
@@ -3,6 +3,7 @@
 // across the array using dynamically allocated memory.
 
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/strided_ptr_partial_update_to.c
+++ b/offload/test/offloading/strided_ptr_partial_update_to.c
@@ -3,6 +3,7 @@
 // across the array using dynamically allocated memory.
 
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 #include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/strided_update.c
+++ b/offload/test/offloading/strided_update.c
@@ -4,6 +4,7 @@
 // other element (stride 2) from the device to the host
 
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 #include <omp.h>
 #include <stdio.h>
 

--- a/offload/test/offloading/struct_mapping_with_pointers.cpp
+++ b/offload/test/offloading/struct_mapping_with_pointers.cpp
@@ -6,6 +6,7 @@
 
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// XFAIL: intelgpu
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/offload/test/offloading/target-teams-atomic.c
+++ b/offload/test/offloading/target-teams-atomic.c
@@ -3,6 +3,7 @@
 // default.
 
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdbool.h>

--- a/offload/test/offloading/target-tile.c
+++ b/offload/test/offloading/target-tile.c
@@ -3,6 +3,7 @@
 
 // RUN: %libomptarget-compile-generic -fopenmp-version=51
 // RUN: %libomptarget-run-generic 2>&1 | %fcheck-generic
+// XFAIL: intelgpu
 
 #include <stdio.h>
 

--- a/offload/test/offloading/target_constexpr_mapping.cpp
+++ b/offload/test/offloading/target_constexpr_mapping.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compileoptxx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/target_critical_region.cpp
+++ b/offload/test/offloading/target_critical_region.cpp
@@ -4,6 +4,7 @@
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/target_depend_nowait.cpp
+++ b/offload/test/offloading/target_depend_nowait.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/target_map_for_member_data.cpp
+++ b/offload/test/offloading/target_map_for_member_data.cpp
@@ -3,6 +3,7 @@
 // clang-format on
 
 // REQUIRES: libomptarget-debug
+// XFAIL: intelgpu
 
 struct DataTy {
   float a;

--- a/offload/test/offloading/target_nowait_target.cpp
+++ b/offload/test/offloading/target_nowait_target.cpp
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compilexx-and-run-generic
 // RUN: %libomptarget-compileoptxx-and-run-generic
+// XFAIL: intelgpu
 
 #include <cassert>
 

--- a/offload/test/offloading/target_update_from.c
+++ b/offload/test/offloading/target_update_from.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 // This test checks that "update from" clause in OpenMP supports strided
 // sections. #pragma omp target update from(result[0:N/2:2]) updates every other
 // element from device

--- a/offload/test/offloading/target_update_strided_struct_from.c
+++ b/offload/test/offloading/target_update_strided_struct_from.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 // This test checks that "update from" with user-defined mapper supports strided
 // sections using fixed-size arrays in structs.
 

--- a/offload/test/offloading/target_update_strided_struct_multiple_from.c
+++ b/offload/test/offloading/target_update_strided_struct_multiple_from.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 // This test checks that #pragma omp target update from(s1.data[0:6:2],
 // s2.data[0:4:3]) correctly updates strided sections covering the full arrays
 // from device to host.

--- a/offload/test/offloading/target_update_strided_struct_multiple_to.c
+++ b/offload/test/offloading/target_update_strided_struct_multiple_to.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 // This test checks that #pragma omp target update to(s1.data[0:6:2],
 // s2.data[0:4:3]) correctly updates strided sections covering the full arrays
 // from host to device.

--- a/offload/test/offloading/target_update_strided_struct_partial_from.c
+++ b/offload/test/offloading/target_update_strided_struct_partial_from.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 // This test checks that #pragma omp target update from(s.data[0:2:3]) correctly
 // updates every third element (stride 3) from the device to the host
 // using a struct with fixed-size array member.

--- a/offload/test/offloading/target_update_strided_struct_partial_to.c
+++ b/offload/test/offloading/target_update_strided_struct_partial_to.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 // This test checks that #pragma omp target update to(s.data[0:2:3]) correctly
 // updates every third element (stride 3) from the host to the device
 // for struct member arrays.

--- a/offload/test/offloading/target_update_strided_struct_to.c
+++ b/offload/test/offloading/target_update_strided_struct_to.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 // This test checks that "update to" with struct member arrays supports strided
 // sections using fixed-size arrays in structs.
 

--- a/offload/test/offloading/target_update_to.c
+++ b/offload/test/offloading/target_update_to.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 // This test checks that "update to" clause in OpenMP supports strided sections.
 // #pragma omp target update to(result[0:8:2]) updates every other element
 // (stride 2)

--- a/offload/test/offloading/task_in_reduction_target.c
+++ b/offload/test/offloading/task_in_reduction_target.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-generic && \
 // RUN: %libomptarget-run-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/taskloop_offload_nowait.cpp
+++ b/offload/test/offloading/taskloop_offload_nowait.cpp
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compilexx-and-run-generic
 
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <cmath>
 #include <cstdlib>

--- a/offload/test/offloading/test_libc.cpp
+++ b/offload/test/offloading/test_libc.cpp
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <algorithm>
 

--- a/offload/test/offloading/thread_limit.c
+++ b/offload/test/offloading/thread_limit.c
@@ -6,6 +6,7 @@
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 int main() {
   int n = 1 << 20;

--- a/offload/test/offloading/thread_state_1.c
+++ b/offload/test/offloading/thread_state_1.c
@@ -1,5 +1,6 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // RUN: %libomptarget-compileopt-run-and-check-generic
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/offloading/thread_state_2.c
+++ b/offload/test/offloading/thread_state_2.c
@@ -1,5 +1,6 @@
 // This fails when optimized for now.
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
 // XUN: %libomptarget-compileopt-run-and-check-generic
 
 #include <omp.h>

--- a/offload/test/offloading/weak.c
+++ b/offload/test/offloading/weak.c
@@ -2,6 +2,7 @@
 // RUN: %libomptarget-compile-generic -DB -c -o %t-b.o
 // RUN: %libomptarget-compile-generic %t-a.o %t-b.o && \
 // RUN:   %libomptarget-run-generic | %fcheck-generic
+// XFAIL: intelgpu
 
 #if defined(A)
 __attribute__((weak)) int x = 999;

--- a/offload/test/offloading/workshare_chunk.c
+++ b/offload/test/offloading/workshare_chunk.c
@@ -2,6 +2,7 @@
 // RUN: %libomptarget-compileopt-run-and-check-generic
 
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 // clang-format off
 

--- a/offload/test/offloading/wtime.c
+++ b/offload/test/offloading/wtime.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compileopt-and-run-generic
 
 // UNSUPPORTED: amdgcn-amd-amdhsa
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/ompt/veccopy.c
+++ b/offload/test/ompt/veccopy.c
@@ -2,6 +2,7 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
 // REQUIRES: gpu
+// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_data.c
+++ b/offload/test/ompt/veccopy_data.c
@@ -2,6 +2,7 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
 // REQUIRES: gpu
+// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_disallow_both.c
+++ b/offload/test/ompt/veccopy_disallow_both.c
@@ -2,6 +2,7 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
 // REQUIRES: gpu
+// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_emi.c
+++ b/offload/test/ompt/veccopy_emi.c
@@ -2,6 +2,7 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
 // REQUIRES: gpu
+// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_emi_map.c
+++ b/offload/test/ompt/veccopy_emi_map.c
@@ -2,6 +2,7 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
 // REQUIRES: gpu
+// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_map.c
+++ b/offload/test/ompt/veccopy_map.c
@@ -2,6 +2,7 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
 // REQUIRES: gpu
+// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_no_device_init.c
+++ b/offload/test/ompt/veccopy_no_device_init.c
@@ -1,6 +1,7 @@
 // clang-format off
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
+// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/ompt/veccopy_wrong_return.c
+++ b/offload/test/ompt/veccopy_wrong_return.c
@@ -1,6 +1,7 @@
 // clang-format off
 // RUN: %libomptarget-compile-run-and-check-generic
 // REQUIRES: ompt
+// XFAIL: intelgpu
 // clang-format on
 
 /*

--- a/offload/test/sanitizer/double_free.c
+++ b/offload/test/sanitizer/double_free.c
@@ -11,6 +11,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/double_free_racy.c
+++ b/offload/test/sanitizer/double_free_racy.c
@@ -11,6 +11,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// UNSUPPORTED: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/free_host_ptr.c
+++ b/offload/test/sanitizer/free_host_ptr.c
@@ -11,6 +11,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/free_wrong_ptr_kind.c
+++ b/offload/test/sanitizer/free_wrong_ptr_kind.c
@@ -11,6 +11,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/free_wrong_ptr_kind.cpp
+++ b/offload/test/sanitizer/free_wrong_ptr_kind.cpp
@@ -11,6 +11,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/kernel_crash.c
+++ b/offload/test/sanitizer/kernel_crash.c
@@ -15,6 +15,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/kernel_crash_async.c
+++ b/offload/test/sanitizer/kernel_crash_async.c
@@ -15,6 +15,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/kernel_crash_many.c
+++ b/offload/test/sanitizer/kernel_crash_many.c
@@ -13,6 +13,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/kernel_crash_single.c
+++ b/offload/test/sanitizer/kernel_crash_single.c
@@ -15,6 +15,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/kernel_trap.c
+++ b/offload/test/sanitizer/kernel_trap.c
@@ -16,6 +16,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/kernel_trap.cpp
+++ b/offload/test/sanitizer/kernel_trap.cpp
@@ -16,6 +16,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 
 struct S {};
 

--- a/offload/test/sanitizer/kernel_trap_async.c
+++ b/offload/test/sanitizer/kernel_trap_async.c
@@ -16,6 +16,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/kernel_trap_many.c
+++ b/offload/test/sanitizer/kernel_trap_many.c
@@ -13,6 +13,7 @@
 // UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
 // UNSUPPORTED: s390x-ibm-linux-gnu
 // UNSUPPORTED: s390x-ibm-linux-gnu-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/ptr_outside_alloc_1.c
+++ b/offload/test/sanitizer/ptr_outside_alloc_1.c
@@ -9,6 +9,7 @@
 // UNSUPPORTED: nvidiagpu
 //
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/ptr_outside_alloc_2.c
+++ b/offload/test/sanitizer/ptr_outside_alloc_2.c
@@ -7,6 +7,7 @@
 // UNSUPPORTED: nvidiagpu
 //
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/use_after_free_1.c
+++ b/offload/test/sanitizer/use_after_free_1.c
@@ -9,6 +9,7 @@
 // UNSUPPORTED: nvidiagpu
 //
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 #include <omp.h>
 

--- a/offload/test/sanitizer/use_after_free_2.c
+++ b/offload/test/sanitizer/use_after_free_2.c
@@ -7,6 +7,7 @@
 // UNSUPPORTED: nvidiagpu
 //
 // REQUIRES: gpu
+// XFAIL: intelgpu
 
 // If offload memory pooling is enabled for a large allocation, reuse error is
 // not detected. UNSUPPORTED: large_allocation_memory_pool

--- a/offload/test/tools/llvm-omp-device-info.c
+++ b/offload/test/tools/llvm-omp-device-info.c
@@ -1,4 +1,5 @@
 // RUN: %offload-device-info | %fcheck-generic
+// XFAIL: intelgpu
 //
 // Just check any device was found and something is printed
 //

--- a/offload/test/unified_shared_memory/api.c
+++ b/offload/test/unified_shared_memory/api.c
@@ -5,6 +5,7 @@
 // XFAIL: nvptx64-nvidia-cuda-LTO
 
 // REQUIRES: unified_shared_memory
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/unified_shared_memory/associate_ptr.c
+++ b/offload/test/unified_shared_memory/associate_ptr.c
@@ -2,6 +2,7 @@
 
 // REQUIRES: unified_shared_memory
 // UNSUPPORTED: clang-6, clang-7, clang-8, clang-9
+// XFAIL: intelgpu
 
 #include <assert.h>
 #include <omp.h>

--- a/offload/test/unified_shared_memory/close_enter_exit.c
+++ b/offload/test/unified_shared_memory/close_enter_exit.c
@@ -8,6 +8,7 @@
 // Fails on nvptx with error: an illegal memory access was encountered
 // XFAIL: nvptx64-nvidia-cuda
 // XFAIL: nvptx64-nvidia-cuda-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/unified_shared_memory/close_manual.c
+++ b/offload/test/unified_shared_memory/close_manual.c
@@ -1,6 +1,7 @@
 // RUN: %libomptarget-compile-run-and-check-generic
 
 // REQUIRES: unified_shared_memory
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/unified_shared_memory/close_member.c
+++ b/offload/test/unified_shared_memory/close_member.c
@@ -2,6 +2,7 @@
 
 // REQUIRES: unified_shared_memory
 // UNSUPPORTED: clang-6, clang-7, clang-8, clang-9
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/unified_shared_memory/close_modifier.c
+++ b/offload/test/unified_shared_memory/close_modifier.c
@@ -8,6 +8,7 @@
 // UNSUPPORTED: amdgcn-amd-amdhsa
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/unified_shared_memory/shared_update.c
+++ b/offload/test/unified_shared_memory/shared_update.c
@@ -7,6 +7,7 @@
 // UNSUPPORTED: amdgcn-amd-amdhsa
 // UNSUPPORTED: nvptx64-nvidia-cuda
 // UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+// XFAIL: intelgpu
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
We finally got our buildbot added (to staging, at least) so we want to start running L0 tests in CI.
We need `check-offload` to pass though, so XFAIL everything failing.
There's a couple `UNSUPPORTED` as well, those are for sporadic fails.

Also make set the `gpu` and `intelgpu` LIT variables when testing the `spirv64-intel` triple.

We have no DeviceRTL yet so basically everything fails, but we manage to get 

```
Total Discovered Tests: 432
Unsupported      : 169 (39.12%)
Passed           :  67 (15.51%)
Expectedly Failed: 196 (45.37%)
```

We still don't build the level zero plugin by default and these tests don't run unless the plugin was built, so this has no effect on most builds.