### PR TITLE
[mlir][Interfaces] Simplify and improve errors of `RegionBranchOpInterface` verifier

### DIFF
--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
@@ -173,7 +173,7 @@ LogicalResult verifyRegionBranchWeights(Operation *op);
 
 namespace detail {
 /// Verify that types match along control flow edges described the given op.
-LogicalResult verifyTypesAlongControlFlowEdges(Operation *op);
+LogicalResult verifyRegionBranchOpInterface(Operation *op);
 } //  namespace detail
 
 /// A mapping from successor operands to successor inputs.

--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
@@ -323,7 +323,7 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
   let verify = [{
     static_assert(!ConcreteOp::template hasTrait<OpTrait::ZeroRegions>(),
                   "expected operation to have non-zero regions");
-    return detail::verifyTypesAlongControlFlowEdges($_op);
+    return detail::verifyRegionBranchOpInterface($_op);
   }];
   let verifyWithRegions = 1;
 

--- a/mlir/test/Dialect/SCF/invalid.mlir
+++ b/mlir/test/Dialect/SCF/invalid.mlir
@@ -590,7 +590,7 @@ func.func @while_cross_region_type_mismatch() {
 
 func.func @while_cross_region_type_mismatch() {
   %true = arith.constant true
-  // expected-error@+1 {{op along control flow edge from Operation scf.condition to Region #1: successor operand type #0 'i1' should match successor input type #0 'i32'}}
+  // expected-error@+1 {{along control flow edge from Operation scf.condition to Region #1: successor operand type #0 'i1' should match successor input type #0 'i32'}}
   %0 = scf.while : () -> (i1) {
     // expected-note@+1 {{region branch point}}
     scf.condition(%true) %true : i1

--- a/mlir/test/Dialect/SCF/invalid.mlir
+++ b/mlir/test/Dialect/SCF/invalid.mlir
@@ -404,9 +404,10 @@ func.func @reduceReturn_not_inside_reduce(%arg0 : f32) {
 
 func.func @std_if_incorrect_yield(%arg0: i1, %arg1: f32)
 {
-  // expected-error@+1 {{region control flow edge from Operation scf.yield to parent results: source has 1 operands, but target successor <to parent> needs 2}}
+  // expected-error@+1 {{along control flow edge from Operation scf.yield to parent: region branch point has 1 operands, but region successor needs 2 inputs}}
   %x, %y = scf.if %arg0 -> (f32, f32) {
     %0 = arith.addf %arg1, %arg1 : f32
+    // expected-note@+1 {{region branch point}}
     scf.yield %0 : f32
   } else {
     %0 = arith.subf %arg1, %arg1 : f32
@@ -575,8 +576,9 @@ func.func @while_invalid_terminator() {
 
 func.func @while_cross_region_type_mismatch() {
   %true = arith.constant true
-  // expected-error@+1 {{region control flow edge from Operation scf.condition to Region #1: source has 0 operands, but target successor <to region #1 with 1 inputs> needs 1}}
+  // expected-error@+1 {{along control flow edge from Operation scf.condition to Region #1: region branch point has 0 operands, but region successor needs 1 inputs}}
   scf.while : () -> () {
+    // expected-note@+1 {{region branch point}}
     scf.condition(%true)
   } do {
   ^bb0(%arg0: i32):
@@ -588,8 +590,9 @@ func.func @while_cross_region_type_mismatch() {
 
 func.func @while_cross_region_type_mismatch() {
   %true = arith.constant true
-  // expected-error@+1 {{along control flow edge from Operation scf.condition to Region #1: source type #0 'i1' should match input type #0 'i32'}}
+  // expected-error@+1 {{op along control flow edge from Operation scf.condition to Region #1: successor operand type #0 'i1' should match successor input type #0 'i32'}}
   %0 = scf.while : () -> (i1) {
+    // expected-note@+1 {{region branch point}}
     scf.condition(%true) %true : i1
   } do {
   ^bb0(%arg0: i32):
@@ -601,8 +604,9 @@ func.func @while_cross_region_type_mismatch() {
 
 func.func @while_result_type_mismatch() {
   %true = arith.constant true
-  // expected-error@+1 {{region control flow edge from Operation scf.condition to parent results: source has 1 operands, but target successor <to parent> needs 0}}
+  // expected-error@+1 {{along control flow edge from Operation scf.condition to parent: region branch point has 1 operands, but region successor needs 0 inputs}}
   scf.while : () -> () {
+    // expected-note@+1 {{region branch point}}
     scf.condition(%true) %true : i1
   } do {
   ^bb0(%arg0: i1):


### PR DESCRIPTION
Simplify the `RegionBranchOpInterface` verifier by utilizing new API functions such as `getAllRegionBranchPoints`.

Also improve the error message by using the same terms that are used in the interface definition: `region branch point`, `region successor`, `successor operand`, `successor input`.