### PR TITLE
[flang] Silence "used but undefined" warning for LOC(x)

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -776,7 +776,8 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
         }
       }
     } else if (dummy.intent != common::Intent::In ||
-        (dummyIsPointer && !actualIsPointer)) {
+        (dummyIsPointer && !actualIsPointer) ||
+        (intrinsic && intrinsic->name == "loc")) {
       if (auto named{evaluate::ExtractNamedEntity(actual)}) {
         context.NoteDefinedSymbol(named->GetFirstSymbol());
       }

--- a/flang/test/Semantics/bug2021.f90
+++ b/flang/test/Semantics/bug2021.f90
@@ -1,0 +1,8 @@
+!RUN: %flang -fc1 -fsyntax-only -pedantic %s 2>&1 | FileCheck %s
+!CHECK-NOT: warning: Value of uninitialized local variable 'b' is used but never defined [-Wused-undefined-variable]
+real :: a, b
+pointer(p,a)
+p = loc(b)
+a = 2.0
+print *, b
+end


### PR DESCRIPTION
When a variable appears as the argument of the extension intrinsic function LOC(x), assume that it's defined for the purposes of the warning about variables that are used but never defined, since the result of the LOC() can be used to define a based Cray pointer.