### PR TITLE
[cross-project-tests][formatters] Add a LIT feature that tests for a compatible LLDB version

### DIFF
--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -340,7 +340,7 @@ if lldb_version_string:
         config.available_features.add("lldb-formatters-compatibility")
     else:
         print(
-            f'Marking LLDB LLVM data-formatter tests as unsupported: using version {lldb_version_string} whereas a version >= 1900.0 is required',
+            f'Marking some LLDB LLVM data-formatter tests as unsupported: using version {lldb_version_string} whereas a version >= 1900.0 is required',
             file=sys.stderr,
         )
 

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -309,6 +309,7 @@ def get_lldb_version_string():
         return None
     return match.group(1)
 
+
 def set_lldb_formatters_compatibility_feature():
     lldb_version_string = get_lldb_version_string()
     if lldb_version_string is None:
@@ -321,10 +322,11 @@ def set_lldb_formatters_compatibility_feature():
         return False
 
     if version.parse(lldb_version_string) < version.parse("1900.0"):
-        return False;
+        return False
 
     config.available_features.add("lldb-formatters-compatibility")
     return True
+
 
 # Some cross-project-tests use gdb, but not all versions of gdb are compatible
 # with clang's dwarf. Add feature `gdb-clang-incompatibility` to signal that

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -302,7 +302,7 @@ def get_lldb_version_string():
     if len(lldb_vers_lines) < 1:
         print("Unkown LLDB version format (too few lines)", file=sys.stderr)
         return None
-    match = re.search(r"lldb.*-((\d|\.)+)", lldb_vers_lines[0].strip())
+    match = re.search(r"lldb.*[ -]((\d|\.)+)", lldb_vers_lines[0].strip())
     if match is None:
         print(f"Unkown LLDB version format: {lldb_vers_lines[0]}", file=sys.stderr)
         return None
@@ -336,11 +336,11 @@ if lldb_version_string:
         from packaging import version
     except:
         lit_config.fatal("Running lldb tests requires the packaging package")
-    if version.parse(lldb_version_string) >= version.parse("19.0"):
+    if version.parse(lldb_version_string) >= version.parse("1900.0"):
         config.available_features.add("lldb-formatters-compatibility")
     else:
         print(
-            "Marking LLDB LLVM data-formatter tests as unsupported: use LLDB version >= 19.0 to restore test coverage",
+            f'Marking LLDB LLVM data-formatter tests as unsupported: using version {lldb_version_string} whereas a version >= 1900.0 is required',
             file=sys.stderr,
         )
 

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -109,6 +109,7 @@ if lldb_dap_path is not None:
 if llvm_config.use_llvm_tool("llvm-ar"):
     config.available_features.add("llvm-ar")
 
+
 def configure_dexter_substitutions():
     """Configure substitutions for host platform and return list of dependencies"""
     # Produce dexter path, lldb path, and combine into the %dexter substitution
@@ -340,7 +341,7 @@ if lldb_version_string:
         config.available_features.add("lldb-formatters-compatibility")
     else:
         print(
-            f'Marking some LLDB LLVM data-formatter tests as unsupported: using version {lldb_version_string} whereas a version >= 1900.0 is required',
+            f"Marking some LLDB LLVM data-formatter tests as unsupported: using version {lldb_version_string} whereas a version >= 1900.0 is required",
             file=sys.stderr,
         )
 


### PR DESCRIPTION
Most of this logic is similar to how we add the `gdb-clang-incompatibility` attribute.

Some LLVM LLDB formatters will rely on LLDB features not available in older versions of LLDB. This feature will allow those tests to add a `REQUIRES: lldb-formatters-compatibility`, which will then mark the test `UNSUPPORTED` for incompatible LLDB versions. I picked `19.0` pretty arbitrarily based on when approximately the `SBType::FindDirectNestedType` API was added to LLDB (which a future formatter will require).