### PR TITLE
[AArch64] Lower bfloat FADD/SUB to BFMLAL top/bottom instructions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -1883,22 +1883,36 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
         !Subtarget->isNonStreamingSVEorSME2Available()) {
       for (MVT VT : {MVT::nxv2bf16, MVT::nxv4bf16, MVT::nxv8bf16}) {
         MVT PromotedVT = VT.changeVectorElementType(MVT::f32);
-        setOperationPromotedToType(ISD::FADD, VT, PromotedVT);
         setOperationPromotedToType(ISD::FMA, VT, PromotedVT);
         setOperationPromotedToType(ISD::FMAXIMUM, VT, PromotedVT);
         setOperationPromotedToType(ISD::FMAXNUM, VT, PromotedVT);
         setOperationPromotedToType(ISD::FMINIMUM, VT, PromotedVT);
         setOperationPromotedToType(ISD::FMINNUM, VT, PromotedVT);
-        setOperationPromotedToType(ISD::FSUB, VT, PromotedVT);
 
-        if (VT != MVT::nxv2bf16 && Subtarget->hasBF16())
-          setOperationAction(ISD::FMUL, VT, Custom);
-        else
-          setOperationPromotedToType(ISD::FMUL, VT, PromotedVT);
+        if (Subtarget->hasBF16()) {
+          // These operations can be lowered to BFMLAT/B. Note: nxv2bf16 is not
+          // supported to avoid performing fp operations on inactive lanes (as
+          // BFMLAT/B is unpredicated).
+          if (VT != MVT::nxv2bf16)
+            setOperationAction(ISD::FMUL, VT, Custom);
+          else
+            setOperationPromotedToType(ISD::FMUL, VT, PromotedVT);
+          // Limit ADD/SUB to nxv8bf16 (it's not an improvement for other types)
+          if (VT == MVT::nxv8bf16) {
+            setOperationAction(ISD::FADD, VT, Custom);
+            setOperationAction(ISD::FSUB, VT, Custom);
+          } else {
+            setOperationPromotedToType(ISD::FADD, VT, PromotedVT);
+            setOperationPromotedToType(ISD::FSUB, VT, PromotedVT);
+          }
+        }
       }
 
-      if (Subtarget->hasBF16() && Subtarget->isNeonAvailable())
+      if (Subtarget->hasBF16() && Subtarget->isNeonAvailable()) {
         setOperationAction(ISD::FMUL, MVT::v8bf16, Custom);
+        setOperationAction(ISD::FADD, MVT::v8bf16, Custom);
+        setOperationAction(ISD::FSUB, MVT::v8bf16, Custom);
+      }
     }
 
     setOperationAction(ISD::INTRINSIC_WO_CHAIN, MVT::i8, Custom);
@@ -7988,17 +8002,23 @@ SDValue AArch64TargetLowering::LowerINIT_TRAMPOLINE(SDValue Op,
                      EndOfTrmp);
 }
 
-SDValue AArch64TargetLowering::LowerFMUL(SDValue Op, SelectionDAG &DAG) const {
+SDValue
+AArch64TargetLowering::LowerBFloatArithToBFMLAL(SDValue Op,
+                                                SelectionDAG &DAG) const {
   SDLoc DL(Op);
+  unsigned Opcode = Op.getOpcode();
+  assert((Opcode == ISD::FADD || Opcode == ISD::FSUB || Opcode == ISD::FMUL) &&
+         "Unexpected operation");
+
   EVT VT = Op.getValueType();
   if (VT.getScalarType() != MVT::bf16 ||
       (Subtarget->hasSVEB16B16() &&
        Subtarget->isNonStreamingSVEorSME2Available()))
-    return LowerToPredicatedOp(Op, DAG, AArch64ISD::FMUL_PRED);
+    return SDValue();
 
-  assert(Subtarget->hasBF16() && "Expected +bf16 for custom FMUL lowering");
+  assert(Subtarget->hasBF16() && "Expected +bf16 for custom FMUL/ADD lowering");
   assert((VT == MVT::nxv4bf16 || VT == MVT::nxv8bf16 || VT == MVT::v8bf16) &&
-         "Unexpected FMUL VT");
+         "Unexpected VT");
 
   auto MakeGetIntrinsic = [&](Intrinsic::ID IID) {
     return [&, IID](EVT VT, auto... Ops) {
@@ -8032,15 +8052,40 @@ SDValue AArch64TargetLowering::LowerFMUL(SDValue Op, SelectionDAG &DAG) const {
                                     : Intrinsic::aarch64_neon_bfmlalt);
 
   EVT AccVT = UseSVEBFMLAL ? MVT::nxv4f32 : MVT::v4f32;
-  bool IgnoreZeroSign = DAG.canIgnoreSignBitOfZero(Op);
-  SDValue Zero = DAG.getConstantFP(IgnoreZeroSign ? +0.0F : -0.0F, DL, AccVT);
   SDValue Pg = getPredicateForVector(DAG, DL, AccVT);
+  SDValue BottomAcc, TopAcc, LHS, RHS;
 
-  // Lower bf16 FMUL as a pair (VT == [nx]v8bf16) of BFMLAL top/bottom
-  // instructions. These result in two f32 vectors, which can be converted back
-  // to bf16 with FCVT and FCVTNT.
-  SDValue LHS = Op.getOperand(0);
-  SDValue RHS = Op.getOperand(1);
+  if (Opcode == ISD::FMUL) {
+    bool IgnoreZeroSign = DAG.canIgnoreSignBitOfZero(Op);
+    // Set both accumulators to zero.
+    BottomAcc = TopAcc =
+        DAG.getConstantFP(IgnoreZeroSign ? +0.0F : -0.0F, DL, AccVT);
+    // Lower bf16 FMUL as a pair (VT == [nx]v8bf16) of BFMLAL top/bottom
+    // instructions. These result in two f32 vectors, which can be converted
+    // back to bf16 with FCVT and FCVTNT.
+    LHS = Op.getOperand(0);
+    RHS = Op.getOperand(1);
+  } else if (Opcode == ISD::FADD || Opcode == ISD::FSUB) {
+    // Lower FADD/SUB by extending the LHS to be used as the accumulator, and
+    // multiplying the RHS by 1.0F (or -1.0F for FSUB).
+    if (VT != MVT::nxv4bf16) {
+      SDValue Zero = DAG.getConstantFP(+0.0, DL, VT);
+      // Note: This extends the even/odd lanes to f32. TRN1/2 is used as the
+      // zero is likely cheap/hoisted and can be used to extend the odd lanes.
+      BottomAcc = DAG.getNode(
+          AArch64ISD::NVCAST, DL, AccVT,
+          DAG.getNode(AArch64ISD::TRN1, DL, VT, Zero, Op.getOperand(0)));
+      TopAcc = DAG.getNode(
+          AArch64ISD::NVCAST, DL, AccVT,
+          DAG.getNode(AArch64ISD::TRN2, DL, VT, Zero, Op.getOperand(0)));
+    } else {
+      BottomAcc = DAG.getNode(ISD::FP_EXTEND, DL, AccVT, Op.getOperand(0));
+    }
+    LHS = Op.getOperand(1);
+    RHS = DAG.getConstantFP(Opcode == ISD::FSUB ? -1.0F : 1.0F, DL, VT);
+  } else {
+    return SDValue();
+  }
 
   // All SVE intrinsics expect to operate on full bf16 vector types.
   if (UseSVEBFMLAL) {
@@ -8048,14 +8093,15 @@ SDValue AArch64TargetLowering::LowerFMUL(SDValue Op, SelectionDAG &DAG) const {
     RHS = Reinterpret(RHS, MVT::nxv8bf16);
   }
 
-  SDValue BottomF32 = Reinterpret(BFMLALB(AccVT, Zero, LHS, RHS), MVT::nxv4f32);
+  SDValue BottomF32 =
+      Reinterpret(BFMLALB(AccVT, BottomAcc, LHS, RHS), MVT::nxv4f32);
   SDValue BottomBF16 =
       FCVT(MVT::nxv8bf16, DAG.getPOISON(MVT::nxv8bf16), Pg, BottomF32);
   // Note: nxv4bf16 only uses even lanes.
   if (VT == MVT::nxv4bf16)
     return Reinterpret(BottomBF16, VT);
 
-  SDValue TopF32 = Reinterpret(BFMLALT(AccVT, Zero, LHS, RHS), MVT::nxv4f32);
+  SDValue TopF32 = Reinterpret(BFMLALT(AccVT, TopAcc, LHS, RHS), MVT::nxv4f32);
   SDValue TopBF16 = FCVTNT(MVT::nxv8bf16, BottomBF16, Pg, TopF32);
   return Reinterpret(TopBF16, VT);
 }
@@ -8199,11 +8245,17 @@ SDValue AArch64TargetLowering::LowerOperation(SDValue Op,
   case ISD::UMULO:
     return LowerXALUO(Op, DAG);
   case ISD::FADD:
+    if (SDValue Result = LowerBFloatArithToBFMLAL(Op, DAG))
+      return Result;
     return LowerToPredicatedOp(Op, DAG, AArch64ISD::FADD_PRED);
   case ISD::FSUB:
+    if (SDValue Result = LowerBFloatArithToBFMLAL(Op, DAG))
+      return Result;
     return LowerToPredicatedOp(Op, DAG, AArch64ISD::FSUB_PRED);
   case ISD::FMUL:
-    return LowerFMUL(Op, DAG);
+    if (SDValue Result = LowerBFloatArithToBFMLAL(Op, DAG))
+      return Result;
+    return LowerToPredicatedOp(Op, DAG, AArch64ISD::FMUL_PRED);
   case ISD::FMA:
     return LowerFMA(Op, DAG);
   case ISD::FDIV:

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -636,7 +636,6 @@ private:
   SDValue LowerSTORE(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerStore128(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerABS(SDValue Op, SelectionDAG &DAG) const;
-  SDValue LowerFMUL(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFMA(SDValue Op, SelectionDAG &DAG) const;
 
   SDValue LowerMGATHER(SDValue Op, SelectionDAG &DAG) const;
@@ -649,6 +648,8 @@ private:
   SDValue LowerINTRINSIC_W_CHAIN(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerINTRINSIC_WO_CHAIN(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerINTRINSIC_VOID(SDValue Op, SelectionDAG &DAG) const;
+
+  SDValue LowerBFloatArithToBFMLAL(SDValue Op, SelectionDAG &DAG) const;
 
   bool
   isEligibleForTailCallOptimization(const CallLoweringInfo &CLI) const;

--- a/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
@@ -30,17 +30,31 @@ define <8 x bfloat> @add_h(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; CHECK-CVT-NEXT:    uzp2 v0.8h, v0.8h, v2.8h
 ; CHECK-CVT-NEXT:    ret
 ;
-; CHECK-BF16-LABEL: add_h:
-; CHECK-BF16:       // %bb.0: // %entry
-; CHECK-BF16-NEXT:    shll v2.4s, v1.4h, #16
-; CHECK-BF16-NEXT:    shll v3.4s, v0.4h, #16
-; CHECK-BF16-NEXT:    shll2 v1.4s, v1.8h, #16
-; CHECK-BF16-NEXT:    shll2 v0.4s, v0.8h, #16
-; CHECK-BF16-NEXT:    fadd v2.4s, v3.4s, v2.4s
-; CHECK-BF16-NEXT:    fadd v1.4s, v0.4s, v1.4s
-; CHECK-BF16-NEXT:    bfcvtn v0.4h, v2.4s
-; CHECK-BF16-NEXT:    bfcvtn2 v0.8h, v1.4s
-; CHECK-BF16-NEXT:    ret
+; CHECK-NOSVE-BF16-LABEL: add_h:
+; CHECK-NOSVE-BF16:       // %bb.0: // %entry
+; CHECK-NOSVE-BF16-NEXT:    shll v2.4s, v1.4h, #16
+; CHECK-NOSVE-BF16-NEXT:    shll v3.4s, v0.4h, #16
+; CHECK-NOSVE-BF16-NEXT:    shll2 v1.4s, v1.8h, #16
+; CHECK-NOSVE-BF16-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-NOSVE-BF16-NEXT:    fadd v2.4s, v3.4s, v2.4s
+; CHECK-NOSVE-BF16-NEXT:    fadd v1.4s, v0.4s, v1.4s
+; CHECK-NOSVE-BF16-NEXT:    bfcvtn v0.4h, v2.4s
+; CHECK-NOSVE-BF16-NEXT:    bfcvtn2 v0.8h, v1.4s
+; CHECK-NOSVE-BF16-NEXT:    ret
+;
+; CHECK-SVE-BF16-LABEL: add_h:
+; CHECK-SVE-BF16:       // %bb.0: // %entry
+; CHECK-SVE-BF16-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-SVE-BF16-NEXT:    mov z4.h, #16256 // =0x3f80
+; CHECK-SVE-BF16-NEXT:    ptrue p0.s, vl4
+; CHECK-SVE-BF16-NEXT:    trn1 v3.8h, v2.8h, v0.8h
+; CHECK-SVE-BF16-NEXT:    trn2 v2.8h, v2.8h, v0.8h
+; CHECK-SVE-BF16-NEXT:    bfmlalb v3.4s, v1.8h, v4.8h
+; CHECK-SVE-BF16-NEXT:    bfmlalt v2.4s, v1.8h, v4.8h
+; CHECK-SVE-BF16-NEXT:    bfcvt z0.h, p0/m, z3.s
+; CHECK-SVE-BF16-NEXT:    bfcvtnt z0.h, p0/m, z2.s
+; CHECK-SVE-BF16-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-SVE-BF16-NEXT:    ret
 entry:
   %0 = fadd <8 x bfloat> %a, %b
   ret <8 x bfloat> %0
@@ -74,17 +88,32 @@ define <8 x bfloat> @sub_h(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; CHECK-CVT-NEXT:    uzp2 v0.8h, v0.8h, v2.8h
 ; CHECK-CVT-NEXT:    ret
 ;
-; CHECK-BF16-LABEL: sub_h:
-; CHECK-BF16:       // %bb.0: // %entry
-; CHECK-BF16-NEXT:    shll v2.4s, v1.4h, #16
-; CHECK-BF16-NEXT:    shll v3.4s, v0.4h, #16
-; CHECK-BF16-NEXT:    shll2 v1.4s, v1.8h, #16
-; CHECK-BF16-NEXT:    shll2 v0.4s, v0.8h, #16
-; CHECK-BF16-NEXT:    fsub v2.4s, v3.4s, v2.4s
-; CHECK-BF16-NEXT:    fsub v1.4s, v0.4s, v1.4s
-; CHECK-BF16-NEXT:    bfcvtn v0.4h, v2.4s
-; CHECK-BF16-NEXT:    bfcvtn2 v0.8h, v1.4s
-; CHECK-BF16-NEXT:    ret
+; CHECK-NOSVE-BF16-LABEL: sub_h:
+; CHECK-NOSVE-BF16:       // %bb.0: // %entry
+; CHECK-NOSVE-BF16-NEXT:    shll v2.4s, v1.4h, #16
+; CHECK-NOSVE-BF16-NEXT:    shll v3.4s, v0.4h, #16
+; CHECK-NOSVE-BF16-NEXT:    shll2 v1.4s, v1.8h, #16
+; CHECK-NOSVE-BF16-NEXT:    shll2 v0.4s, v0.8h, #16
+; CHECK-NOSVE-BF16-NEXT:    fsub v2.4s, v3.4s, v2.4s
+; CHECK-NOSVE-BF16-NEXT:    fsub v1.4s, v0.4s, v1.4s
+; CHECK-NOSVE-BF16-NEXT:    bfcvtn v0.4h, v2.4s
+; CHECK-NOSVE-BF16-NEXT:    bfcvtn2 v0.8h, v1.4s
+; CHECK-NOSVE-BF16-NEXT:    ret
+;
+; CHECK-SVE-BF16-LABEL: sub_h:
+; CHECK-SVE-BF16:       // %bb.0: // %entry
+; CHECK-SVE-BF16-NEXT:    movi v2.2d, #0000000000000000
+; CHECK-SVE-BF16-NEXT:    mov w8, #49024 // =0xbf80
+; CHECK-SVE-BF16-NEXT:    ptrue p0.s, vl4
+; CHECK-SVE-BF16-NEXT:    dup v4.8h, w8
+; CHECK-SVE-BF16-NEXT:    trn1 v3.8h, v2.8h, v0.8h
+; CHECK-SVE-BF16-NEXT:    trn2 v2.8h, v2.8h, v0.8h
+; CHECK-SVE-BF16-NEXT:    bfmlalb v3.4s, v1.8h, v4.8h
+; CHECK-SVE-BF16-NEXT:    bfmlalt v2.4s, v1.8h, v4.8h
+; CHECK-SVE-BF16-NEXT:    bfcvt z0.h, p0/m, z3.s
+; CHECK-SVE-BF16-NEXT:    bfcvtnt z0.h, p0/m, z2.s
+; CHECK-SVE-BF16-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-SVE-BF16-NEXT:    ret
 entry:
   %0 = fsub <8 x bfloat> %a, %b
   ret <8 x bfloat> %0

--- a/llvm/test/CodeGen/AArch64/fixed-length-bf16-arith.ll
+++ b/llvm/test/CodeGen/AArch64/fixed-length-bf16-arith.ll
@@ -54,14 +54,16 @@ define <4 x bfloat> @fadd_v4bf16(<4 x bfloat> %a, <4 x bfloat> %b) {
 define <8 x bfloat> @fadd_v8bf16(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; NOB16B16-LABEL: fadd_v8bf16:
 ; NOB16B16:       // %bb.0:
-; NOB16B16-NEXT:    shll v2.4s, v1.4h, #16
-; NOB16B16-NEXT:    shll v3.4s, v0.4h, #16
-; NOB16B16-NEXT:    shll2 v1.4s, v1.8h, #16
-; NOB16B16-NEXT:    shll2 v0.4s, v0.8h, #16
-; NOB16B16-NEXT:    fadd v2.4s, v3.4s, v2.4s
-; NOB16B16-NEXT:    fadd v1.4s, v0.4s, v1.4s
-; NOB16B16-NEXT:    bfcvtn v0.4h, v2.4s
-; NOB16B16-NEXT:    bfcvtn2 v0.8h, v1.4s
+; NOB16B16-NEXT:    movi v2.2d, #0000000000000000
+; NOB16B16-NEXT:    mov z4.h, #16256 // =0x3f80
+; NOB16B16-NEXT:    ptrue p0.s, vl4
+; NOB16B16-NEXT:    trn1 v3.8h, v2.8h, v0.8h
+; NOB16B16-NEXT:    trn2 v2.8h, v2.8h, v0.8h
+; NOB16B16-NEXT:    bfmlalb v3.4s, v1.8h, v4.8h
+; NOB16B16-NEXT:    bfmlalt v2.4s, v1.8h, v4.8h
+; NOB16B16-NEXT:    bfcvt z0.h, p0/m, z3.s
+; NOB16B16-NEXT:    bfcvtnt z0.h, p0/m, z2.s
+; NOB16B16-NEXT:    // kill: def $q0 killed $q0 killed $z0
 ; NOB16B16-NEXT:    ret
 ;
 ; B16B16-LABEL: fadd_v8bf16:
@@ -943,14 +945,17 @@ define <4 x bfloat> @fsub_v4bf16(<4 x bfloat> %a, <4 x bfloat> %b) {
 define <8 x bfloat> @fsub_v8bf16(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; NOB16B16-LABEL: fsub_v8bf16:
 ; NOB16B16:       // %bb.0:
-; NOB16B16-NEXT:    shll v2.4s, v1.4h, #16
-; NOB16B16-NEXT:    shll v3.4s, v0.4h, #16
-; NOB16B16-NEXT:    shll2 v1.4s, v1.8h, #16
-; NOB16B16-NEXT:    shll2 v0.4s, v0.8h, #16
-; NOB16B16-NEXT:    fsub v2.4s, v3.4s, v2.4s
-; NOB16B16-NEXT:    fsub v1.4s, v0.4s, v1.4s
-; NOB16B16-NEXT:    bfcvtn v0.4h, v2.4s
-; NOB16B16-NEXT:    bfcvtn2 v0.8h, v1.4s
+; NOB16B16-NEXT:    movi v2.2d, #0000000000000000
+; NOB16B16-NEXT:    mov w8, #49024 // =0xbf80
+; NOB16B16-NEXT:    ptrue p0.s, vl4
+; NOB16B16-NEXT:    dup v4.8h, w8
+; NOB16B16-NEXT:    trn1 v3.8h, v2.8h, v0.8h
+; NOB16B16-NEXT:    trn2 v2.8h, v2.8h, v0.8h
+; NOB16B16-NEXT:    bfmlalb v3.4s, v1.8h, v4.8h
+; NOB16B16-NEXT:    bfmlalt v2.4s, v1.8h, v4.8h
+; NOB16B16-NEXT:    bfcvt z0.h, p0/m, z3.s
+; NOB16B16-NEXT:    bfcvtnt z0.h, p0/m, z2.s
+; NOB16B16-NEXT:    // kill: def $q0 killed $q0 killed $z0
 ; NOB16B16-NEXT:    ret
 ;
 ; B16B16-LABEL: fsub_v8bf16:

--- a/llvm/test/CodeGen/AArch64/sve-bf16-arith.ll
+++ b/llvm/test/CodeGen/AArch64/sve-bf16-arith.ll
@@ -83,25 +83,36 @@ define <vscale x 4 x bfloat> @fadd_nxv4bf16(<vscale x 4 x bfloat> %a, <vscale x 
 }
 
 define <vscale x 8 x bfloat> @fadd_nxv8bf16(<vscale x 8 x bfloat> %a, <vscale x 8 x bfloat> %b) {
-; NOB16B16-LABEL: fadd_nxv8bf16:
-; NOB16B16:       // %bb.0:
-; NOB16B16-NEXT:    movi v2.2d, #0000000000000000
-; NOB16B16-NEXT:    ptrue p0.s
-; NOB16B16-NEXT:    zip2 z3.h, z2.h, z1.h
-; NOB16B16-NEXT:    zip2 z4.h, z2.h, z0.h
-; NOB16B16-NEXT:    zip1 z1.h, z2.h, z1.h
-; NOB16B16-NEXT:    zip1 z0.h, z2.h, z0.h
-; NOB16B16-NEXT:    fadd z2.s, z4.s, z3.s
-; NOB16B16-NEXT:    fadd z0.s, z0.s, z1.s
-; NOB16B16-NEXT:    bfcvt z1.h, p0/m, z2.s
-; NOB16B16-NEXT:    bfcvt z0.h, p0/m, z0.s
-; NOB16B16-NEXT:    uzp1 z0.h, z0.h, z1.h
-; NOB16B16-NEXT:    ret
+; NOB16B16-NONSTREAMING-LABEL: fadd_nxv8bf16:
+; NOB16B16-NONSTREAMING:       // %bb.0:
+; NOB16B16-NONSTREAMING-NEXT:    movi v2.2d, #0000000000000000
+; NOB16B16-NONSTREAMING-NEXT:    fmov z3.h, #1.87500000
+; NOB16B16-NONSTREAMING-NEXT:    ptrue p0.s
+; NOB16B16-NONSTREAMING-NEXT:    trn1 z4.h, z2.h, z0.h
+; NOB16B16-NONSTREAMING-NEXT:    trn2 z2.h, z2.h, z0.h
+; NOB16B16-NONSTREAMING-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; NOB16B16-NONSTREAMING-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; NOB16B16-NONSTREAMING-NEXT:    bfcvt z0.h, p0/m, z4.s
+; NOB16B16-NONSTREAMING-NEXT:    bfcvtnt z0.h, p0/m, z2.s
+; NOB16B16-NONSTREAMING-NEXT:    ret
 ;
 ; B16B16-LABEL: fadd_nxv8bf16:
 ; B16B16:       // %bb.0:
 ; B16B16-NEXT:    bfadd z0.h, z0.h, z1.h
 ; B16B16-NEXT:    ret
+;
+; NOB16B16-STREAMING-LABEL: fadd_nxv8bf16:
+; NOB16B16-STREAMING:       // %bb.0:
+; NOB16B16-STREAMING-NEXT:    mov z2.h, #0 // =0x0
+; NOB16B16-STREAMING-NEXT:    fmov z3.h, #1.87500000
+; NOB16B16-STREAMING-NEXT:    ptrue p0.s
+; NOB16B16-STREAMING-NEXT:    trn1 z4.h, z2.h, z0.h
+; NOB16B16-STREAMING-NEXT:    trn2 z2.h, z2.h, z0.h
+; NOB16B16-STREAMING-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; NOB16B16-STREAMING-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; NOB16B16-STREAMING-NEXT:    bfcvt z0.h, p0/m, z4.s
+; NOB16B16-STREAMING-NEXT:    bfcvtnt z0.h, p0/m, z2.s
+; NOB16B16-STREAMING-NEXT:    ret
   %res = fadd <vscale x 8 x bfloat> %a, %b
   ret <vscale x 8 x bfloat> %res
 }
@@ -714,25 +725,36 @@ define <vscale x 4 x bfloat> @fsub_nxv4bf16(<vscale x 4 x bfloat> %a, <vscale x 
 }
 
 define <vscale x 8 x bfloat> @fsub_nxv8bf16(<vscale x 8 x bfloat> %a, <vscale x 8 x bfloat> %b) {
-; NOB16B16-LABEL: fsub_nxv8bf16:
-; NOB16B16:       // %bb.0:
-; NOB16B16-NEXT:    movi v2.2d, #0000000000000000
-; NOB16B16-NEXT:    ptrue p0.s
-; NOB16B16-NEXT:    zip2 z3.h, z2.h, z1.h
-; NOB16B16-NEXT:    zip2 z4.h, z2.h, z0.h
-; NOB16B16-NEXT:    zip1 z1.h, z2.h, z1.h
-; NOB16B16-NEXT:    zip1 z0.h, z2.h, z0.h
-; NOB16B16-NEXT:    fsub z2.s, z4.s, z3.s
-; NOB16B16-NEXT:    fsub z0.s, z0.s, z1.s
-; NOB16B16-NEXT:    bfcvt z1.h, p0/m, z2.s
-; NOB16B16-NEXT:    bfcvt z0.h, p0/m, z0.s
-; NOB16B16-NEXT:    uzp1 z0.h, z0.h, z1.h
-; NOB16B16-NEXT:    ret
+; NOB16B16-NONSTREAMING-LABEL: fsub_nxv8bf16:
+; NOB16B16-NONSTREAMING:       // %bb.0:
+; NOB16B16-NONSTREAMING-NEXT:    movi v2.2d, #0000000000000000
+; NOB16B16-NONSTREAMING-NEXT:    fmov z3.h, #-1.87500000
+; NOB16B16-NONSTREAMING-NEXT:    ptrue p0.s
+; NOB16B16-NONSTREAMING-NEXT:    trn1 z4.h, z2.h, z0.h
+; NOB16B16-NONSTREAMING-NEXT:    trn2 z2.h, z2.h, z0.h
+; NOB16B16-NONSTREAMING-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; NOB16B16-NONSTREAMING-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; NOB16B16-NONSTREAMING-NEXT:    bfcvt z0.h, p0/m, z4.s
+; NOB16B16-NONSTREAMING-NEXT:    bfcvtnt z0.h, p0/m, z2.s
+; NOB16B16-NONSTREAMING-NEXT:    ret
 ;
 ; B16B16-LABEL: fsub_nxv8bf16:
 ; B16B16:       // %bb.0:
 ; B16B16-NEXT:    bfsub z0.h, z0.h, z1.h
 ; B16B16-NEXT:    ret
+;
+; NOB16B16-STREAMING-LABEL: fsub_nxv8bf16:
+; NOB16B16-STREAMING:       // %bb.0:
+; NOB16B16-STREAMING-NEXT:    mov z2.h, #0 // =0x0
+; NOB16B16-STREAMING-NEXT:    fmov z3.h, #-1.87500000
+; NOB16B16-STREAMING-NEXT:    ptrue p0.s
+; NOB16B16-STREAMING-NEXT:    trn1 z4.h, z2.h, z0.h
+; NOB16B16-STREAMING-NEXT:    trn2 z2.h, z2.h, z0.h
+; NOB16B16-STREAMING-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; NOB16B16-STREAMING-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; NOB16B16-STREAMING-NEXT:    bfcvt z0.h, p0/m, z4.s
+; NOB16B16-STREAMING-NEXT:    bfcvtnt z0.h, p0/m, z2.s
+; NOB16B16-STREAMING-NEXT:    ret
   %res = fsub <vscale x 8 x bfloat> %a, %b
   ret <vscale x 8 x bfloat> %res
 }

--- a/llvm/test/CodeGen/AArch64/sve-bf16-combines.ll
+++ b/llvm/test/CodeGen/AArch64/sve-bf16-combines.ll
@@ -289,16 +289,14 @@ define <vscale x 8 x bfloat> @fadd_sel_nxv8bf16(<vscale x 8 x bfloat> %a, <vscal
 ; SVE-LABEL: fadd_sel_nxv8bf16:
 ; SVE:       // %bb.0:
 ; SVE-NEXT:    movi v2.2d, #0000000000000000
+; SVE-NEXT:    fmov z3.h, #1.87500000
 ; SVE-NEXT:    ptrue p1.s
-; SVE-NEXT:    zip2 z3.h, z2.h, z1.h
-; SVE-NEXT:    zip2 z4.h, z2.h, z0.h
-; SVE-NEXT:    zip1 z1.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z2.h, z2.h, z0.h
-; SVE-NEXT:    fadd z3.s, z4.s, z3.s
-; SVE-NEXT:    fadd z1.s, z2.s, z1.s
-; SVE-NEXT:    bfcvt z2.h, p1/m, z3.s
-; SVE-NEXT:    bfcvt z1.h, p1/m, z1.s
-; SVE-NEXT:    uzp1 z1.h, z1.h, z2.h
+; SVE-NEXT:    trn1 z4.h, z2.h, z0.h
+; SVE-NEXT:    trn2 z2.h, z2.h, z0.h
+; SVE-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; SVE-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; SVE-NEXT:    bfcvt z1.h, p1/m, z4.s
+; SVE-NEXT:    bfcvtnt z1.h, p1/m, z2.s
 ; SVE-NEXT:    mov z0.h, p0/m, z1.h
 ; SVE-NEXT:    ret
 ;
@@ -315,16 +313,14 @@ define <vscale x 8 x bfloat> @fsub_sel_nxv8bf16(<vscale x 8 x bfloat> %a, <vscal
 ; SVE-LABEL: fsub_sel_nxv8bf16:
 ; SVE:       // %bb.0:
 ; SVE-NEXT:    movi v2.2d, #0000000000000000
+; SVE-NEXT:    fmov z3.h, #-1.87500000
 ; SVE-NEXT:    ptrue p1.s
-; SVE-NEXT:    zip2 z3.h, z2.h, z1.h
-; SVE-NEXT:    zip2 z4.h, z2.h, z0.h
-; SVE-NEXT:    zip1 z1.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z2.h, z2.h, z0.h
-; SVE-NEXT:    fsub z3.s, z4.s, z3.s
-; SVE-NEXT:    fsub z1.s, z2.s, z1.s
-; SVE-NEXT:    bfcvt z2.h, p1/m, z3.s
-; SVE-NEXT:    bfcvt z1.h, p1/m, z1.s
-; SVE-NEXT:    uzp1 z1.h, z1.h, z2.h
+; SVE-NEXT:    trn1 z4.h, z2.h, z0.h
+; SVE-NEXT:    trn2 z2.h, z2.h, z0.h
+; SVE-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; SVE-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; SVE-NEXT:    bfcvt z1.h, p1/m, z4.s
+; SVE-NEXT:    bfcvtnt z1.h, p1/m, z2.s
 ; SVE-NEXT:    mov z0.h, p0/m, z1.h
 ; SVE-NEXT:    ret
 ;
@@ -341,16 +337,14 @@ define <vscale x 8 x bfloat> @fadd_sel_negzero_nxv8bf16(<vscale x 8 x bfloat> %a
 ; SVE-LABEL: fadd_sel_negzero_nxv8bf16:
 ; SVE:       // %bb.0:
 ; SVE-NEXT:    movi v2.2d, #0000000000000000
+; SVE-NEXT:    fmov z3.h, #1.87500000
 ; SVE-NEXT:    ptrue p1.s
-; SVE-NEXT:    zip2 z3.h, z2.h, z1.h
-; SVE-NEXT:    zip2 z4.h, z2.h, z0.h
-; SVE-NEXT:    zip1 z1.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z2.h, z2.h, z0.h
-; SVE-NEXT:    fadd z3.s, z4.s, z3.s
-; SVE-NEXT:    fadd z1.s, z2.s, z1.s
-; SVE-NEXT:    bfcvt z2.h, p1/m, z3.s
-; SVE-NEXT:    bfcvt z1.h, p1/m, z1.s
-; SVE-NEXT:    uzp1 z1.h, z1.h, z2.h
+; SVE-NEXT:    trn1 z4.h, z2.h, z0.h
+; SVE-NEXT:    trn2 z2.h, z2.h, z0.h
+; SVE-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; SVE-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; SVE-NEXT:    bfcvt z1.h, p1/m, z4.s
+; SVE-NEXT:    bfcvtnt z1.h, p1/m, z2.s
 ; SVE-NEXT:    mov z0.h, p0/m, z1.h
 ; SVE-NEXT:    ret
 ;
@@ -368,16 +362,14 @@ define <vscale x 8 x bfloat> @fsub_sel_negzero_nxv8bf16(<vscale x 8 x bfloat> %a
 ; SVE-LABEL: fsub_sel_negzero_nxv8bf16:
 ; SVE:       // %bb.0:
 ; SVE-NEXT:    movi v2.2d, #0000000000000000
+; SVE-NEXT:    fmov z3.h, #-1.87500000
 ; SVE-NEXT:    ptrue p1.s
-; SVE-NEXT:    zip2 z3.h, z2.h, z1.h
-; SVE-NEXT:    zip2 z4.h, z2.h, z0.h
-; SVE-NEXT:    zip1 z1.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z2.h, z2.h, z0.h
-; SVE-NEXT:    fsub z3.s, z4.s, z3.s
-; SVE-NEXT:    fsub z1.s, z2.s, z1.s
-; SVE-NEXT:    bfcvt z2.h, p1/m, z3.s
-; SVE-NEXT:    bfcvt z1.h, p1/m, z1.s
-; SVE-NEXT:    uzp1 z1.h, z1.h, z2.h
+; SVE-NEXT:    trn1 z4.h, z2.h, z0.h
+; SVE-NEXT:    trn2 z2.h, z2.h, z0.h
+; SVE-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; SVE-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; SVE-NEXT:    bfcvt z1.h, p1/m, z4.s
+; SVE-NEXT:    bfcvtnt z1.h, p1/m, z2.s
 ; SVE-NEXT:    mov z0.h, p0/m, z1.h
 ; SVE-NEXT:    ret
 ;
@@ -401,17 +393,15 @@ define <vscale x 8 x bfloat> @fadd_sel_fmul_nxv8bf16(<vscale x 8 x bfloat> %a, <
 ; SVE-NEXT:    bfmlalt z4.s, z1.h, z2.h
 ; SVE-NEXT:    movi v2.2d, #0000000000000000
 ; SVE-NEXT:    bfcvt z1.h, p1/m, z3.s
+; SVE-NEXT:    fmov z3.h, #1.87500000
 ; SVE-NEXT:    bfcvtnt z1.h, p1/m, z4.s
-; SVE-NEXT:    zip2 z4.h, z2.h, z0.h
-; SVE-NEXT:    zip1 z0.h, z2.h, z0.h
+; SVE-NEXT:    trn1 z4.h, z2.h, z0.h
 ; SVE-NEXT:    sel z1.h, p0, z1.h, z2.h
-; SVE-NEXT:    zip2 z3.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z1.h, z2.h, z1.h
-; SVE-NEXT:    fadd z2.s, z4.s, z3.s
-; SVE-NEXT:    fadd z0.s, z0.s, z1.s
-; SVE-NEXT:    bfcvt z1.h, p1/m, z2.s
-; SVE-NEXT:    bfcvt z0.h, p1/m, z0.s
-; SVE-NEXT:    uzp1 z0.h, z0.h, z1.h
+; SVE-NEXT:    trn2 z2.h, z2.h, z0.h
+; SVE-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; SVE-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; SVE-NEXT:    bfcvt z0.h, p1/m, z4.s
+; SVE-NEXT:    bfcvtnt z0.h, p1/m, z2.s
 ; SVE-NEXT:    ret
 ;
 ; SVE-B16B16-LABEL: fadd_sel_fmul_nxv8bf16:
@@ -437,16 +427,14 @@ define <vscale x 8 x bfloat> @fsub_sel_fmul_nxv8bf16(<vscale x 8 x bfloat> %a, <
 ; SVE-NEXT:    bfmlalt z4.s, z1.h, z2.h
 ; SVE-NEXT:    movi v2.2d, #0000000000000000
 ; SVE-NEXT:    bfcvt z1.h, p1/m, z3.s
+; SVE-NEXT:    fmov z3.h, #-1.87500000
 ; SVE-NEXT:    bfcvtnt z1.h, p1/m, z4.s
-; SVE-NEXT:    zip2 z4.h, z2.h, z0.h
-; SVE-NEXT:    zip2 z3.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z1.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z2.h, z2.h, z0.h
-; SVE-NEXT:    fsub z3.s, z4.s, z3.s
-; SVE-NEXT:    fsub z1.s, z2.s, z1.s
-; SVE-NEXT:    bfcvt z2.h, p1/m, z3.s
-; SVE-NEXT:    bfcvt z1.h, p1/m, z1.s
-; SVE-NEXT:    uzp1 z1.h, z1.h, z2.h
+; SVE-NEXT:    trn1 z4.h, z2.h, z0.h
+; SVE-NEXT:    trn2 z2.h, z2.h, z0.h
+; SVE-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; SVE-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; SVE-NEXT:    bfcvt z1.h, p1/m, z4.s
+; SVE-NEXT:    bfcvtnt z1.h, p1/m, z2.s
 ; SVE-NEXT:    mov z0.h, p0/m, z1.h
 ; SVE-NEXT:    ret
 ;
@@ -470,16 +458,14 @@ define <vscale x 8 x bfloat> @fadd_sel_fmul_nsz_nxv8bf16(<vscale x 8 x bfloat> %
 ; SVE-NEXT:    bfmlalt z4.s, z1.h, z2.h
 ; SVE-NEXT:    movi v2.2d, #0000000000000000
 ; SVE-NEXT:    bfcvt z1.h, p1/m, z3.s
+; SVE-NEXT:    fmov z3.h, #1.87500000
 ; SVE-NEXT:    bfcvtnt z1.h, p1/m, z4.s
-; SVE-NEXT:    zip2 z4.h, z2.h, z0.h
-; SVE-NEXT:    zip2 z3.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z1.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z2.h, z2.h, z0.h
-; SVE-NEXT:    fadd z3.s, z4.s, z3.s
-; SVE-NEXT:    fadd z1.s, z2.s, z1.s
-; SVE-NEXT:    bfcvt z2.h, p1/m, z3.s
-; SVE-NEXT:    bfcvt z1.h, p1/m, z1.s
-; SVE-NEXT:    uzp1 z1.h, z1.h, z2.h
+; SVE-NEXT:    trn1 z4.h, z2.h, z0.h
+; SVE-NEXT:    trn2 z2.h, z2.h, z0.h
+; SVE-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; SVE-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; SVE-NEXT:    bfcvt z1.h, p1/m, z4.s
+; SVE-NEXT:    bfcvtnt z1.h, p1/m, z2.s
 ; SVE-NEXT:    mov z0.h, p0/m, z1.h
 ; SVE-NEXT:    ret
 ;
@@ -503,16 +489,14 @@ define <vscale x 8 x bfloat> @fsub_sel_fmul_nsz_nxv8bf16(<vscale x 8 x bfloat> %
 ; SVE-NEXT:    bfmlalt z4.s, z1.h, z2.h
 ; SVE-NEXT:    movi v2.2d, #0000000000000000
 ; SVE-NEXT:    bfcvt z1.h, p1/m, z3.s
+; SVE-NEXT:    fmov z3.h, #-1.87500000
 ; SVE-NEXT:    bfcvtnt z1.h, p1/m, z4.s
-; SVE-NEXT:    zip2 z4.h, z2.h, z0.h
-; SVE-NEXT:    zip2 z3.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z1.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z2.h, z2.h, z0.h
-; SVE-NEXT:    fsub z3.s, z4.s, z3.s
-; SVE-NEXT:    fsub z1.s, z2.s, z1.s
-; SVE-NEXT:    bfcvt z2.h, p1/m, z3.s
-; SVE-NEXT:    bfcvt z1.h, p1/m, z1.s
-; SVE-NEXT:    uzp1 z1.h, z1.h, z2.h
+; SVE-NEXT:    trn1 z4.h, z2.h, z0.h
+; SVE-NEXT:    trn2 z2.h, z2.h, z0.h
+; SVE-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; SVE-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; SVE-NEXT:    bfcvt z1.h, p1/m, z4.s
+; SVE-NEXT:    bfcvtnt z1.h, p1/m, z2.s
 ; SVE-NEXT:    mov z0.h, p0/m, z1.h
 ; SVE-NEXT:    ret
 ;
@@ -536,16 +520,14 @@ define <vscale x 8 x bfloat> @fadd_sel_fmul_negzero_nxv8bf16(<vscale x 8 x bfloa
 ; SVE-NEXT:    bfmlalt z4.s, z1.h, z2.h
 ; SVE-NEXT:    movi v2.2d, #0000000000000000
 ; SVE-NEXT:    bfcvt z1.h, p1/m, z3.s
+; SVE-NEXT:    fmov z3.h, #1.87500000
 ; SVE-NEXT:    bfcvtnt z1.h, p1/m, z4.s
-; SVE-NEXT:    zip2 z4.h, z2.h, z0.h
-; SVE-NEXT:    zip2 z3.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z1.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z2.h, z2.h, z0.h
-; SVE-NEXT:    fadd z3.s, z4.s, z3.s
-; SVE-NEXT:    fadd z1.s, z2.s, z1.s
-; SVE-NEXT:    bfcvt z2.h, p1/m, z3.s
-; SVE-NEXT:    bfcvt z1.h, p1/m, z1.s
-; SVE-NEXT:    uzp1 z1.h, z1.h, z2.h
+; SVE-NEXT:    trn1 z4.h, z2.h, z0.h
+; SVE-NEXT:    trn2 z2.h, z2.h, z0.h
+; SVE-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; SVE-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; SVE-NEXT:    bfcvt z1.h, p1/m, z4.s
+; SVE-NEXT:    bfcvtnt z1.h, p1/m, z2.s
 ; SVE-NEXT:    mov z0.h, p0/m, z1.h
 ; SVE-NEXT:    ret
 ;
@@ -572,16 +554,14 @@ define <vscale x 8 x bfloat> @fsub_sel_fmul_negzero_nxv8bf16(<vscale x 8 x bfloa
 ; SVE-NEXT:    bfcvt z1.h, p1/m, z3.s
 ; SVE-NEXT:    movi v3.2d, #0000000000000000
 ; SVE-NEXT:    bfcvtnt z1.h, p1/m, z4.s
-; SVE-NEXT:    zip2 z4.h, z3.h, z0.h
-; SVE-NEXT:    zip1 z0.h, z3.h, z0.h
+; SVE-NEXT:    trn1 z4.h, z3.h, z0.h
+; SVE-NEXT:    trn2 z3.h, z3.h, z0.h
 ; SVE-NEXT:    sel z1.h, p0, z1.h, z2.h
-; SVE-NEXT:    zip2 z2.h, z3.h, z1.h
-; SVE-NEXT:    zip1 z1.h, z3.h, z1.h
-; SVE-NEXT:    fsub z2.s, z4.s, z2.s
-; SVE-NEXT:    fsub z0.s, z0.s, z1.s
-; SVE-NEXT:    bfcvt z1.h, p1/m, z2.s
-; SVE-NEXT:    bfcvt z0.h, p1/m, z0.s
-; SVE-NEXT:    uzp1 z0.h, z0.h, z1.h
+; SVE-NEXT:    fmov z2.h, #-1.87500000
+; SVE-NEXT:    bfmlalb z4.s, z1.h, z2.h
+; SVE-NEXT:    bfmlalt z3.s, z1.h, z2.h
+; SVE-NEXT:    bfcvt z0.h, p1/m, z4.s
+; SVE-NEXT:    bfcvtnt z0.h, p1/m, z3.s
 ; SVE-NEXT:    ret
 ;
 ; SVE-B16B16-LABEL: fsub_sel_fmul_negzero_nxv8bf16:
@@ -608,16 +588,14 @@ define <vscale x 8 x bfloat> @fadd_sel_fmul_negzero_nsz_nxv8bf16(<vscale x 8 x b
 ; SVE-NEXT:    bfmlalt z4.s, z1.h, z2.h
 ; SVE-NEXT:    movi v2.2d, #0000000000000000
 ; SVE-NEXT:    bfcvt z1.h, p1/m, z3.s
+; SVE-NEXT:    fmov z3.h, #1.87500000
 ; SVE-NEXT:    bfcvtnt z1.h, p1/m, z4.s
-; SVE-NEXT:    zip2 z4.h, z2.h, z0.h
-; SVE-NEXT:    zip2 z3.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z1.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z2.h, z2.h, z0.h
-; SVE-NEXT:    fadd z3.s, z4.s, z3.s
-; SVE-NEXT:    fadd z1.s, z2.s, z1.s
-; SVE-NEXT:    bfcvt z2.h, p1/m, z3.s
-; SVE-NEXT:    bfcvt z1.h, p1/m, z1.s
-; SVE-NEXT:    uzp1 z1.h, z1.h, z2.h
+; SVE-NEXT:    trn1 z4.h, z2.h, z0.h
+; SVE-NEXT:    trn2 z2.h, z2.h, z0.h
+; SVE-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; SVE-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; SVE-NEXT:    bfcvt z1.h, p1/m, z4.s
+; SVE-NEXT:    bfcvtnt z1.h, p1/m, z2.s
 ; SVE-NEXT:    mov z0.h, p0/m, z1.h
 ; SVE-NEXT:    ret
 ;
@@ -642,16 +620,14 @@ define <vscale x 8 x bfloat> @fsub_sel_fmul_negzero_nsz_nxv8bf16(<vscale x 8 x b
 ; SVE-NEXT:    bfmlalt z4.s, z1.h, z2.h
 ; SVE-NEXT:    movi v2.2d, #0000000000000000
 ; SVE-NEXT:    bfcvt z1.h, p1/m, z3.s
+; SVE-NEXT:    fmov z3.h, #-1.87500000
 ; SVE-NEXT:    bfcvtnt z1.h, p1/m, z4.s
-; SVE-NEXT:    zip2 z4.h, z2.h, z0.h
-; SVE-NEXT:    zip2 z3.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z1.h, z2.h, z1.h
-; SVE-NEXT:    zip1 z2.h, z2.h, z0.h
-; SVE-NEXT:    fsub z3.s, z4.s, z3.s
-; SVE-NEXT:    fsub z1.s, z2.s, z1.s
-; SVE-NEXT:    bfcvt z2.h, p1/m, z3.s
-; SVE-NEXT:    bfcvt z1.h, p1/m, z1.s
-; SVE-NEXT:    uzp1 z1.h, z1.h, z2.h
+; SVE-NEXT:    trn1 z4.h, z2.h, z0.h
+; SVE-NEXT:    trn2 z2.h, z2.h, z0.h
+; SVE-NEXT:    bfmlalb z4.s, z1.h, z3.h
+; SVE-NEXT:    bfmlalt z2.s, z1.h, z3.h
+; SVE-NEXT:    bfcvt z1.h, p1/m, z4.s
+; SVE-NEXT:    bfcvtnt z1.h, p1/m, z2.s
 ; SVE-NEXT:    mov z0.h, p0/m, z1.h
 ; SVE-NEXT:    ret
 ;


### PR DESCRIPTION
Assuming all constant/invariant operations are hoisted, this lowering could improve throughput for Neon and SVE.

Neon: https://godbolt.org/z/eM7qEfExv
SVE: https://godbolt.org/z/8jv19eGf3

This lowering works by extending the even/odd lanes of the LHS to be used in the accumulators of the BFMLAL instructions. The RHS is then used as one of the operands to the BFMLAL with the other a constant 1.0 (or -1.0 for FSUB).