### PR TITLE
[libc] Add hdrgen --proxy mode

### DIFF
--- a/libc/utils/hdrgen/hdrgen/main.py
+++ b/libc/utils/hdrgen/hdrgen/main.py
@@ -50,6 +50,12 @@ def main():
         default=False,
     )
     parser.add_argument(
+        "--proxy",
+        help="Generate a libc/hdr proxy header of a public header",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "-e",
         "--entry-point",
         help="Entry point to include; may be given many times",
@@ -116,9 +122,12 @@ def main():
     else:
         [yaml_file] = args.yaml_file
         header = load_header(yaml_file)
-        # The header_template path is relative to the containing YAML file.
-        template = header.template(yaml_file.parent, files_read)
-        contents = fill_public_api(header.public_api(), template)
+        if args.proxy:
+            contents = header.proxy_contents()
+        else:
+            # The header_template path is relative to the containing YAML file.
+            template = header.template(yaml_file.parent, files_read)
+            contents = fill_public_api(header.public_api(), template)
 
     write_depfile()
 

--- a/libc/utils/hdrgen/tests/expected_output/test_small_proxy.h
+++ b/libc/utils/hdrgen/tests/expected_output/test_small_proxy.h
@@ -1,0 +1,27 @@
+//===-- Implementation proxy header for <test_small.h> --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TEST_SMALL_PROXY_H
+#define LLVM_LIBC_HDR_TEST_SMALL_PROXY_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "llvm-libc-macros/CONST_FUNC_A.h"
+#include "llvm-libc-macros/test_more-macros.h"
+#include "llvm-libc-macros/test_small-macros.h"
+#include "llvm-libc-types/float128.h"
+#include "llvm-libc-types/type_a.h"
+#include "llvm-libc-types/type_b.h"
+
+#else // Overlay mode
+
+#include <test_small.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TEST_SMALL_PROXY_H

--- a/libc/utils/hdrgen/tests/test_integration.py
+++ b/libc/utils/hdrgen/tests/test_integration.py
@@ -82,6 +82,12 @@ class TestHeaderGenIntegration(unittest.TestCase):
         self.run_script(yaml_file, output_file)
         self.compare_files(output_file, expected_output_file)
 
+    def test_generate_header(self):
+        yaml_file = self.source_dir / "input/test_small.yaml"
+        expected_output_file = self.source_dir / "expected_output/test_small_proxy.h"
+        output_file = self.output_dir / "test_small.h"
+        self.run_script(yaml_file, output_file, switches=["--proxy"])
+        self.compare_files(output_file, expected_output_file)
 
 def main():
     parser = argparse.ArgumentParser(description="TestHeaderGenIntegration arguments")


### PR DESCRIPTION
This adds the --proxy switch to generate headers like go
into libc/src/hdr/foo-proxy.h instead of public headers.
