### PR TITLE
[CIR] Add is_implicit to ReturnOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -714,7 +714,7 @@ def CIR_ReturnOp : CIR_Op<"return", [
 
   // The return operation takes an optional input operand to return. This
   // value must match the return type of the enclosing function.
-  let arguments = (ins Variadic<CIR_AnyType>:$input);
+  let arguments = (ins Variadic<CIR_AnyType>:$input, UnitAttr:$is_implicit);
 
   // The return operation only emits the input in the format if it is present.
   let assemblyFormat = "($input^ `:` type($input))? attr-dict ";

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -702,12 +702,20 @@ def CIR_ReturnOp : CIR_Op<"return", [
     The "return" operation represents a return operation within a function.
     The operation takes an optional operand and produces no results.
     The operand type must match the signature of the function that contains
-    the operation.
+    the operation. 
+
+    The operation also accepts a UnitProp `is_implicit` to indicate if the return 
+    is implicitly created by CIR or not to match C/C++ semantics. The return op 
+    being implicit can occur whether the first operand is present or not.
 
     ```mlir
       func @foo() -> i32 {
         ...
         cir.return %0 : i32
+      }
+      func @bar() -> i32 {
+        ...
+        cir.return %2 : i32 implicit 
       }
     ```
   }];

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -714,10 +714,12 @@ def CIR_ReturnOp : CIR_Op<"return", [
 
   // The return operation takes an optional input operand to return. This
   // value must match the return type of the enclosing function.
-  let arguments = (ins Variadic<CIR_AnyType>:$input, UnitAttr:$is_implicit);
+  let arguments = (ins Variadic<CIR_AnyType>:$input, UnitProp:$is_implicit);
 
   // The return operation only emits the input in the format if it is present.
-  let assemblyFormat = "($input^ `:` type($input))? attr-dict ";
+  let assemblyFormat = [{
+    ($input^ `:` type($input))? (`implicit` $is_implicit^)? attr-dict 
+  }];
 
   // Allow building a ReturnOp with no return operand.
   let builders = [

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -352,7 +352,8 @@ void CIRGenFunction::LexicalScope::cleanup() {
   insertCleanupAndLeave(curBlock);
 }
 
-cir::ReturnOp CIRGenFunction::LexicalScope::emitReturn(mlir::Location loc, bool isImplicit) {
+cir::ReturnOp CIRGenFunction::LexicalScope::emitReturn(mlir::Location loc,
+                                                       bool isImplicit) {
   CIRGenBuilderTy &builder = cgf.getBuilder();
 
   // If we are on a coroutine, add the coro_end builtin call.

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1206,7 +1206,7 @@ public:
       return b;
     }
 
-    cir::ReturnOp emitReturn(mlir::Location loc);
+    cir::ReturnOp emitReturn(mlir::Location loc, bool isImplicit = false);
     void emitImplicitReturn();
 
   public:

--- a/clang/test/CIR/CodeGen/basic.c
+++ b/clang/test/CIR/CodeGen/basic.c
@@ -118,7 +118,7 @@ void f4(void) {
 }
 
 //      CIR: cir.func{{.*}} @f4()
-// CIR-NEXT:   cir.return {is_implicit}
+// CIR-NEXT:   cir.return implicit
 
 //      LLVM: define{{.*}} void @f4()
 // LLVM-NEXT:   ret void
@@ -144,7 +144,7 @@ void f5(void) {
 // CIR-NEXT:        cir.yield
 // CIR-NEXT:      }
 // CIR-NEXT:   }
-// CIR-NEXT:   cir.return {is_implicit}
+// CIR-NEXT:   cir.return implicit 
 // CIR-NEXT: }
 
 // LLVM: define{{.*}} void @f5()
@@ -258,7 +258,7 @@ int f8(int *p) {
 void f9() {}
 
 //      CIR: cir.func{{.*}} @f9()
-// CIR-NEXT:   cir.return {is_implicit}
+// CIR-NEXT:   cir.return implicit
 
 //      LLVM: define{{.*}} void @f9()
 // LLVM-NEXT:   ret void
@@ -272,7 +272,7 @@ void f10(int arg0, ...) {}
 //      CIR: cir.func{{.*}} @f10(%[[ARG0:.*]]: !s32i loc({{.*}}), ...)
 // CIR-NEXT:   %[[ARG0_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["arg0", init] {alignment = 4 : i64}
 // CIR-NEXT:   cir.store{{.*}} %[[ARG0]], %[[ARG0_PTR]] : !s32i, !cir.ptr<!s32i>
-// CIR-NEXT:   cir.return {is_implicit}
+// CIR-NEXT:   cir.return implicit
 
 //      LLVM: define{{.*}} void @f10(i32 %[[ARG0:.*]], ...)
 // LLVM-NEXT:   %[[ARG0_PTR:.*]] = alloca i32, i64 1, align 4

--- a/clang/test/CIR/CodeGen/basic.c
+++ b/clang/test/CIR/CodeGen/basic.c
@@ -94,7 +94,7 @@ int f3(void) {
 // CIR-NEXT:   %[[I:.*]] = cir.load{{.*}} %[[I_PTR]] : !cir.ptr<!s32i>, !s32i
 // CIR-NEXT:   cir.store{{.*}} %[[I]], %[[RV]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT:   %[[R:.*]] = cir.load{{.*}} %[[RV]] : !cir.ptr<!s32i>, !s32i
-// CIR-NEXT:   cir.return %[[R]] : !s32i
+// CIR-NEXT:   cir.return  %[[R]] : !s32i
 
 //      LLVM: define{{.*}} i32 @f3()
 // LLVM-NEXT:   %[[RV:.*]] = alloca i32, i64 1, align 4
@@ -118,7 +118,7 @@ void f4(void) {
 }
 
 //      CIR: cir.func{{.*}} @f4()
-// CIR-NEXT:   cir.return
+// CIR-NEXT:   cir.return {is_implicit}
 
 //      LLVM: define{{.*}} void @f4()
 // LLVM-NEXT:   ret void
@@ -144,7 +144,7 @@ void f5(void) {
 // CIR-NEXT:        cir.yield
 // CIR-NEXT:      }
 // CIR-NEXT:   }
-// CIR-NEXT:   cir.return
+// CIR-NEXT:   cir.return {is_implicit}
 // CIR-NEXT: }
 
 // LLVM: define{{.*}} void @f5()
@@ -258,7 +258,7 @@ int f8(int *p) {
 void f9() {}
 
 //      CIR: cir.func{{.*}} @f9()
-// CIR-NEXT:   cir.return
+// CIR-NEXT:   cir.return {is_implicit}
 
 //      LLVM: define{{.*}} void @f9()
 // LLVM-NEXT:   ret void
@@ -272,7 +272,7 @@ void f10(int arg0, ...) {}
 //      CIR: cir.func{{.*}} @f10(%[[ARG0:.*]]: !s32i loc({{.*}}), ...)
 // CIR-NEXT:   %[[ARG0_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["arg0", init] {alignment = 4 : i64}
 // CIR-NEXT:   cir.store{{.*}} %[[ARG0]], %[[ARG0_PTR]] : !s32i, !cir.ptr<!s32i>
-// CIR-NEXT:   cir.return
+// CIR-NEXT:   cir.return {is_implicit}
 
 //      LLVM: define{{.*}} void @f10(i32 %[[ARG0:.*]], ...)
 // LLVM-NEXT:   %[[ARG0_PTR:.*]] = alloca i32, i64 1, align 4

--- a/clang/test/CIR/CodeGen/basic.c
+++ b/clang/test/CIR/CodeGen/basic.c
@@ -94,7 +94,7 @@ int f3(void) {
 // CIR-NEXT:   %[[I:.*]] = cir.load{{.*}} %[[I_PTR]] : !cir.ptr<!s32i>, !s32i
 // CIR-NEXT:   cir.store{{.*}} %[[I]], %[[RV]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT:   %[[R:.*]] = cir.load{{.*}} %[[RV]] : !cir.ptr<!s32i>, !s32i
-// CIR-NEXT:   cir.return  %[[R]] : !s32i
+// CIR-NEXT:   cir.return %[[R]] : !s32i
 
 //      LLVM: define{{.*}} i32 @f3()
 // LLVM-NEXT:   %[[RV:.*]] = alloca i32, i64 1, align 4

--- a/clang/test/CIR/CodeGen/loop.cpp
+++ b/clang/test/CIR/CodeGen/loop.cpp
@@ -64,7 +64,7 @@ void l1() {
 // CIR-NEXT:       cir.yield
 // CIR-NEXT:     }
 // CIR-NEXT:   }
-// CIR-NEXT:   cir.return
+// CIR-NEXT:   cir.return {is_implicit}
 // CIR-NEXT: }
 
 // LLVM: define{{.*}} void @_Z2l1v(){{.*}}
@@ -114,7 +114,7 @@ void l2() {
 // CIR-NEXT:       cir.yield
 // CIR-NEXT:     }
 // CIR-NEXT:   }
-// CIR-NEXT:   cir.return
+// CIR-NEXT:   cir.return {is_implicit}
 // CIR-NEXT: }
 
 // LLVM: define{{.*}} void @_Z2l2v(){{.*}}
@@ -162,7 +162,7 @@ void l3() {
 // CIR-NEXT:       cir.yield
 // CIR-NEXT:     }
 // CIR-NEXT:   }
-// CIR-NEXT:   cir.return
+// CIR-NEXT:   cir.return {is_implicit}
 // CIR-NEXT: }
 
 // LLVM: define{{.*}} void @_Z2l3v(){{.*}}

--- a/clang/test/CIR/CodeGen/loop.cpp
+++ b/clang/test/CIR/CodeGen/loop.cpp
@@ -64,7 +64,7 @@ void l1() {
 // CIR-NEXT:       cir.yield
 // CIR-NEXT:     }
 // CIR-NEXT:   }
-// CIR-NEXT:   cir.return {is_implicit}
+// CIR-NEXT:   cir.return implicit
 // CIR-NEXT: }
 
 // LLVM: define{{.*}} void @_Z2l1v(){{.*}}
@@ -114,7 +114,7 @@ void l2() {
 // CIR-NEXT:       cir.yield
 // CIR-NEXT:     }
 // CIR-NEXT:   }
-// CIR-NEXT:   cir.return {is_implicit}
+// CIR-NEXT:   cir.return implicit
 // CIR-NEXT: }
 
 // LLVM: define{{.*}} void @_Z2l2v(){{.*}}
@@ -162,7 +162,7 @@ void l3() {
 // CIR-NEXT:       cir.yield
 // CIR-NEXT:     }
 // CIR-NEXT:   }
-// CIR-NEXT:   cir.return {is_implicit}
+// CIR-NEXT:   cir.return implicit
 // CIR-NEXT: }
 
 // LLVM: define{{.*}} void @_Z2l3v(){{.*}}

--- a/clang/test/CIR/CodeGen/member-functions.cpp
+++ b/clang/test/CIR/CodeGen/member-functions.cpp
@@ -14,7 +14,7 @@ void C::f() {}
 // CIR:   %[[THIS_ADDR:.*]] = cir.alloca !cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!rec_C>>, ["this", init]
 // CIR:   cir.store %[[THIS_ARG]], %[[THIS_ADDR]] : !cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!rec_C>>
 // CIR:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_C>>, !cir.ptr<!rec_C>
-// CIR:   cir.return
+// CIR:   cir.return {is_implicit}
 // CIR: }
 
 void C::f2(int a, int b) {}
@@ -27,7 +27,7 @@ void C::f2(int a, int b) {}
 // CIR-NEXT:   cir.store %[[A_ARG]], %[[A_ADDR]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT:   cir.store %[[B_ARG]], %[[B_ADDR]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_C>>, !cir.ptr<!rec_C>
-// CIR-NEXT:   cir.return
+// CIR-NEXT:   cir.return {is_implicit}
 // CIR-NEXT: }
 
 void test1() {
@@ -42,5 +42,5 @@ void test1() {
 // CIR-NEXT:   %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
 // CIR-NEXT:   %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
 // CIR-NEXT:   cir.call @_ZN1C2f2Eii(%[[C_ADDR]], %[[ONE]], %[[TWO]]) : (!cir.ptr<!rec_C>, !s32i, !s32i) -> ()
-// CIR-NEXT:   cir.return
+// CIR-NEXT:   cir.return {is_implicit}
 // CIR-NEXT: }

--- a/clang/test/CIR/CodeGen/member-functions.cpp
+++ b/clang/test/CIR/CodeGen/member-functions.cpp
@@ -14,7 +14,7 @@ void C::f() {}
 // CIR:   %[[THIS_ADDR:.*]] = cir.alloca !cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!rec_C>>, ["this", init]
 // CIR:   cir.store %[[THIS_ARG]], %[[THIS_ADDR]] : !cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!rec_C>>
 // CIR:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_C>>, !cir.ptr<!rec_C>
-// CIR:   cir.return {is_implicit}
+// CIR:   cir.return implicit 
 // CIR: }
 
 void C::f2(int a, int b) {}
@@ -27,7 +27,7 @@ void C::f2(int a, int b) {}
 // CIR-NEXT:   cir.store %[[A_ARG]], %[[A_ADDR]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT:   cir.store %[[B_ARG]], %[[B_ADDR]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_C>>, !cir.ptr<!rec_C>
-// CIR-NEXT:   cir.return {is_implicit}
+// CIR-NEXT:   cir.return implicit
 // CIR-NEXT: }
 
 void test1() {
@@ -42,5 +42,5 @@ void test1() {
 // CIR-NEXT:   %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
 // CIR-NEXT:   %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
 // CIR-NEXT:   cir.call @_ZN1C2f2Eii(%[[C_ADDR]], %[[ONE]], %[[TWO]]) : (!cir.ptr<!rec_C>, !s32i, !s32i) -> ()
-// CIR-NEXT:   cir.return {is_implicit}
+// CIR-NEXT:   cir.return implicit
 // CIR-NEXT: }

--- a/clang/test/CIR/CodeGen/nullptr-init.cpp
+++ b/clang/test/CIR/CodeGen/nullptr-init.cpp
@@ -21,7 +21,7 @@ void t1() {
 // CIR-NEXT:     cir.store{{.*}} %[[NULLPTR2]], %[[P2]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 // CIR-NEXT:     %[[NULLPTR3:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i>
 // CIR-NEXT:     cir.store{{.*}} %[[NULLPTR3]], %[[P3]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
-// CIR-NEXT:     cir.return {is_implicit}
+// CIR-NEXT:     cir.return implicit
 // CIR-NEXT: }
 
 // LLVM:      define{{.*}} @_Z2t1v()

--- a/clang/test/CIR/CodeGen/nullptr-init.cpp
+++ b/clang/test/CIR/CodeGen/nullptr-init.cpp
@@ -21,7 +21,7 @@ void t1() {
 // CIR-NEXT:     cir.store{{.*}} %[[NULLPTR2]], %[[P2]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 // CIR-NEXT:     %[[NULLPTR3:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i>
 // CIR-NEXT:     cir.store{{.*}} %[[NULLPTR3]], %[[P3]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
-// CIR-NEXT:     cir.return
+// CIR-NEXT:     cir.return {is_implicit}
 // CIR-NEXT: }
 
 // LLVM:      define{{.*}} @_Z2t1v()


### PR DESCRIPTION
In CIR, sometimes we create implicit returns in cir but when inspecting the CIR, we wouldn't be able to know that the return is implicit. This PR seeks to add the extra information to the IR.

Future analysis would benefit from this. For example: checking in CIR whether a non-void function returns anything 
