### PR TITLE
[flang] Make a non-digit in fixed-form label field an error unless -E

### DIFF
--- a/flang/lib/Parser/prescan.h
+++ b/flang/lib/Parser/prescan.h
@@ -90,7 +90,6 @@ public:
   template <typename... A> Message &Say(A &&...a) {
     return messages_.Say(std::forward<A>(a)...);
   }
-
   template <typename... A>
   Message *Warn(common::UsageWarning warning, A &&...a) {
     return messages_.Warn(false, features_, warning, std::forward<A>(a)...);

--- a/flang/test/Driver/Inputs/free-form-test.f90
+++ b/flang/test/Driver/Inputs/free-form-test.f90
@@ -1,2 +1,2 @@
-program FreeForm
-end
+     xy z=1
+      end

--- a/flang/test/Driver/color-diagnostics-scan.f
+++ b/flang/test/Driver/color-diagnostics-scan.f
@@ -22,9 +22,9 @@
 
 ! RUN: not %flang_fc1 -E -Werror %s 2>&1 | FileCheck %s --check-prefix=CHECK_NCD
 
-! CHECK_CD: {{.*}}[0;1;35mwarning: {{.*}}[0mCharacter in fixed-form label field must be a digit
+! CHECK_CD: {{.*}}[0;1;35mwarning: {{.*}}[0mStatement should not begin with a continuation line
 
-! CHECK_NCD: warning: Character in fixed-form label field must be a digit
+! CHECK_NCD: warning: Statement should not begin with a continuation line
 
-1 continue
-end
+     +continue
+      end

--- a/flang/test/Driver/fixed-free-detection.f90
+++ b/flang/test/Driver/fixed-free-detection.f90
@@ -16,14 +16,14 @@
 ! RUN: %flang_fc1 -E -fno-reformat %S/Inputs/fixed-form-test.f  2>&1 | FileCheck %s --check-prefix=FIXEDFORM
 ! RUN: %flang_fc1 -E -fno-reformat %S/Inputs/free-form-test.f90 %S/Inputs/fixed-form-test.f  2>&1 | FileCheck %s --check-prefix=MULTIPLEFORMS
 
-! FREEFORM:program freeform
-! FREEFORM-NOT:programfixedform
+! FREEFORM:y z=1
+! FREEFORM-NOT:yz=1
 
 ! FIXEDFORM:programfixedform
 ! FIXEDFORM-NOT:program freeform
 
-! MULTIPLEFORMS:program freeform
-! MULTIPLEFORMS-NOT:programfixedform
+! MULTIPLEFORMS:xy z=1
+! MULTIPLEFORMS-NOT:xyz=1
 ! MULTIPLEFORMS-NEXT:end
 ! MULTIPLEFORMS-NEXT:programfixedform
 ! MULTIPLEFORMS-NOT:program freeform

--- a/flang/test/Driver/fixed-free-flag.f90
+++ b/flang/test/Driver/fixed-free-flag.f90
@@ -14,4 +14,4 @@
 
 ! FREEFORM: Could not parse
 
-! FIXEDFORM:free-form-test.f90:1:1: warning: Character in fixed-form label field must be a digit
+! FIXEDFORM:free-form-test.f90:1:6: warning: Statement should not begin with a continuation line [-Wscanning]

--- a/flang/test/Driver/werror-scan.f
+++ b/flang/test/Driver/werror-scan.f
@@ -15,5 +15,5 @@
 
 ! WITHOUT-NOT: Could not scan
 
-1 continue
-end
+     +continue
+      end

--- a/flang/test/Parser/badlabel.f
+++ b/flang/test/Parser/badlabel.f
@@ -6,9 +6,7 @@
 ! CHECK-NOT: Label is not in fixed-form label field
       con
      3 tinue
-! CHECK: Character in fixed-form label field must be a digit
-end
+      end
 ! CHECK: 1continue
 ! CHECK: 12continue
-! CHECK: continue
 ! CHECK: end

--- a/flang/test/Parser/bug50563.f
+++ b/flang/test/Parser/bug50563.f
@@ -1,0 +1,4 @@
+!RUN: not %flang -fsyntax-only %s 2>&1 | FileCheck %s
+!CHECK: bug50563.f:3:1: error: Character in fixed-form label field must be a digit
+pi=3
+      end

--- a/flang/test/Preprocessing/pp039.F
+++ b/flang/test/Preprocessing/pp039.F
@@ -1,4 +1,5 @@
 ! RUN: %flang -E %s 2>&1 | FileCheck %s
+! CHECK: warning: Character in fixed-form label field should be a digit
 ! CHECK: res = IFLM
 ! CHECK: (666)
 ! CHECK-NOT: res = ((666)+111)


### PR DESCRIPTION
A character in a fixed-form source line (as opposed to a comment or compiler directive) can't have a non-digit in its label field, columns 1 through 5.  The prescanner presently emits only a warning for this case.  Retain the warning for -E output, but otherwise diagnose an error.

(This change affected a number of tests that relied on this situation being a warning just so that they could test prescanner warnings, and those tests were adjusted to use another warning.)

Fixes https://github.com/llvm/llvm-project/issues/50563.