### PR TITLE
[lldb-dap][NFC] Shorten the event thread name

### DIFF
--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -592,7 +592,7 @@ void EventThread(lldb::SBDebugger debugger, lldb::SBBroadcaster broadcaster,
   std::string thread_name =
       llvm::formatv("lldb.DAP.client.{}.event_handler", client_name);
   if (thread_name.length() > llvm::get_max_thread_name_length())
-    thread_name = llvm::formatv("DAP.{}.evnt", client_name);
+    thread_name = llvm::formatv("DAP.{}.evt", client_name);
   llvm::set_thread_name(thread_name);
 
   lldb::SBListener listener = debugger.GetListener();

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -589,7 +589,12 @@ static void HandleDiagnosticEvent(const lldb::SBEvent &event, Log &log) {
 // is required.
 void EventThread(lldb::SBDebugger debugger, lldb::SBBroadcaster broadcaster,
                  llvm::StringRef client_name, Log &log) {
-  llvm::set_thread_name("lldb.DAP.client." + client_name + ".event_handler");
+  std::string thread_name =
+      llvm::formatv("lldb.DAP.client.{}.event_handler", client_name);
+  if (thread_name.length() > llvm::get_max_thread_name_length())
+    thread_name = llvm::formatv("DAP.{}.evnt", client_name);
+  llvm::set_thread_name(thread_name);
+
   lldb::SBListener listener = debugger.GetListener();
   broadcaster.AddListener(listener, eBroadcastBitStopEventThread);
   debugger.GetBroadcaster().AddListener(

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -451,7 +451,7 @@ static llvm::Error serveConnection(
     if (connection_timeout_seconds)
       ResetConnectionTimeout(g_connection_timeout_mutex,
                              g_connection_timeout_time_point);
-    std::string client_name = llvm::formatv("client_{0}", clientCount++).str();
+    const std::string client_name = llvm::formatv("conn{0}", clientCount++);
     lldb::IOObjectSP io(std::move(sock));
 
     // Move the client into a background thread to unblock accepting the next


### PR DESCRIPTION
On linux thread names are limited to 15 characters, shorten the name of the event thread if necessary