### PR TITLE
[lldb] Add Get(Non)SyntheticValue formatter bytecodes

### DIFF
--- a/lldb/docs/resources/formatterbytecode.rst
+++ b/lldb/docs/resources/formatterbytecode.rst
@@ -154,6 +154,8 @@ Sel.  Mnemonic                         Stack Effect                             
 0x15  ``get_type``                      ``(Object @get_type -> Type)``                          ``SBValue::GetType``
 0x16  ``get_template_argument_type``    ``(Object UInt @get_template_argument_type -> Type)``   ``SBValue::GetTemplateArgumentType``
 0x17  ``cast``                          ``(Object Type @cast -> Object)``                       ``SBValue::Cast``
+0x18  ``get_synthetic_value``           ``(Object @get_synthetic_value -> Object)``             ``SBValue::GetSyntheticValue``
+0x19  ``get_non_synthetic_value``       ``(Object @get_non_synthetic_value -> Object)``         ``SBValue::GetNonSyntheticValue``
 0x20  ``get_value``                     ``(Object @get_value -> Object)``                       ``SBValue::GetValue``
 0x21  ``get_value_as_unsigned``         ``(Object @get_value_as_unsigned -> UInt)``             ``SBValue::GetValueAsUnsigned``
 0x22  ``get_value_as_signed``           ``(Object @get_value_as_signed -> Int)``                ``SBValue::GetValueAsSigned``
@@ -237,4 +239,3 @@ Error handling
 ~~~~~~~~~~~~~~
 
 In version 1 errors are unrecoverable, the entire expression will fail if any kind of error is encountered.
-

--- a/lldb/examples/python/formatter_bytecode.py
+++ b/lldb/examples/python/formatter_bytecode.py
@@ -95,6 +95,8 @@ define_selector(0x13, "get_child_index")
 define_selector(0x15, "get_type")
 define_selector(0x16, "get_template_argument_type")
 define_selector(0x17, "cast")
+define_selector(0x18, "get_synthetic_value")
+define_selector(0x19, "get_non_synthetic_value")
 define_selector(0x20, "get_value")
 define_selector(0x21, "get_value_as_unsigned")
 define_selector(0x22, "get_value_as_signed")
@@ -437,6 +439,10 @@ def interpret(bytecode: bytearray, control: list, data: list, tracing: bool = Fa
                 n = data.pop()
                 valobj = data.pop()
                 data.append(valobj.GetTemplateArgumentType(n))
+            elif sel == sel_get_synthetic_value:
+                data.append(data.pop().GetSyntheticValue())
+            elif sel == sel_get_non_synthetic_value:
+                data.append(data.pop().GetNonSyntheticValue())
             elif sel == sel_get_value:
                 data.append(data.pop().GetValue())
             elif sel == sel_get_value_as_unsigned:

--- a/lldb/include/lldb/DataFormatters/FormatterBytecode.def
+++ b/lldb/include/lldb/DataFormatters/FormatterBytecode.def
@@ -71,6 +71,8 @@ DEFINE_SELECTOR(0x13, get_child_index)
 DEFINE_SELECTOR(0x15, get_type)
 DEFINE_SELECTOR(0x16, get_template_argument_type)
 DEFINE_SELECTOR(0x17, cast)
+DEFINE_SELECTOR(0x18, get_synthetic_value)
+DEFINE_SELECTOR(0x19, get_non_synthetic_value)
 
 DEFINE_SELECTOR(0x20, get_value)
 DEFINE_SELECTOR(0x21, get_value_as_unsigned)

--- a/lldb/source/DataFormatters/FormatterBytecode.cpp
+++ b/lldb/source/DataFormatters/FormatterBytecode.cpp
@@ -511,6 +511,18 @@ llvm::Error Interpret(ControlStack &control, DataStack &data, Signatures sig) {
         data.Push(type.GetTypeTemplateArgument(index, true));
         break;
       }
+      case sel_get_synthetic_value: {
+        TYPE_CHECK(Object);
+        POP_VALOBJ(valobj);
+        data.Push(valobj->GetSyntheticValue());
+        break;
+      }
+      case sel_get_non_synthetic_value: {
+        TYPE_CHECK(Object);
+        POP_VALOBJ(valobj);
+        data.Push(valobj->GetNonSyntheticValue());
+        break;
+      }
       case sel_get_value: {
         TYPE_CHECK(Object);
         POP_VALOBJ(valobj);


### PR DESCRIPTION
`GetSyntheticValue` in synthetic providers which need to operate on raw root values, but will often want to use the synthetic value of children, or nested children.