### PR TITLE
[DirectX] Specify NegZero as signed

### DIFF
--- a/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
+++ b/llvm/lib/Target/DirectX/DXILIntrinsicExpansion.cpp
@@ -486,7 +486,8 @@ static Value *expandIsFPClass(CallInst *Orig) {
   switch (TCI->getZExtValue()) {
   case FPClassTest::fcNegZero: {
     Value *NegZero =
-        ConstantInt::get(Builder.getIntNTy(BitWidth), 1 << (BitWidth - 1));
+        ConstantInt::get(Builder.getIntNTy(BitWidth), 1 << (BitWidth - 1),
+                         /*IsSigned=*/true);
     Value *RetVal;
     if (FNumElem) {
       Value *NegZeroSplat = Builder.CreateVectorSplat(FNumElem, NegZero);


### PR DESCRIPTION
#171456 set `ImplicitTrunc` to false by default. So `NegZero` value was no longer being created as a signed integer.

This caused a similar crash during `DXILIntrinsicExpansion` as reported here: https://github.com/llvm/llvm-project/pull/171456#issuecomment-3718690088.

This change fixes the test case from crashing in the DirectX backend by manually specifying it as a signed integer.