### PR TITLE
InstCombine: Handle fadd in SimplifyDemandedFPClass

### DIFF
--- a/llvm/include/llvm/ADT/FloatingPointMode.h
+++ b/llvm/include/llvm/ADT/FloatingPointMode.h
@@ -164,6 +164,23 @@ struct DenormalMode {
            Output == DenormalModeKind::PositiveZero;
   }
 
+  /// Return true if output denormals may be implicitly treated as 0.
+  constexpr bool outputsMayBeZero() const {
+    return outputsAreZero() || Output == DenormalMode::Dynamic;
+  }
+
+  /// Return true if input denormals could be flushed to +0.
+  constexpr bool inputsMayBePositiveZero() const {
+    return Input == DenormalMode::PositiveZero ||
+           Input == DenormalMode::Dynamic;
+  }
+
+  /// Return true if output denormals could be flushed to +0.
+  constexpr bool outputsMayBePositiveZero() const {
+    return Output == DenormalMode::PositiveZero ||
+           Output == DenormalMode::Dynamic;
+  }
+
   /// Get the effective denormal mode if the mode if this caller calls into a
   /// function with \p Callee. This promotes dynamic modes to the mode of the
   /// caller.

--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -202,6 +202,16 @@ struct KnownFPClass {
   canonicalize(const KnownFPClass &Src,
                DenormalMode DenormMode = DenormalMode::getDynamic());
 
+  /// Report known values for fadd
+  LLVM_ABI static KnownFPClass
+  fadd(const KnownFPClass &LHS, const KnownFPClass &RHS,
+       DenormalMode Mode = DenormalMode::getDynamic());
+
+  /// Report known values for fadd x, x
+  LLVM_ABI static KnownFPClass
+  fadd_self(const KnownFPClass &Src,
+            DenormalMode Mode = DenormalMode::getDynamic());
+
   /// Report known values for fmul
   LLVM_ABI static KnownFPClass
   fmul(const KnownFPClass &LHS, const KnownFPClass &RHS,

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -269,8 +269,7 @@ KnownFPClass KnownFPClass::fadd_self(const KnownFPClass &KnownSrc,
 
   // Doubling 0 will give the same 0.
   if (KnownSrc.isKnownNeverLogicalPosZero(Mode) &&
-      (Mode.Output == DenormalMode::IEEE ||
-       Mode.Output == DenormalMode::PreserveSign))
+      Mode.Output == DenormalMode::IEEE)
     Known.knownNot(fcPosZero);
 
   return Known;

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -268,8 +268,11 @@ KnownFPClass KnownFPClass::fadd_self(const KnownFPClass &KnownSrc,
   KnownFPClass Known = fadd(KnownSrc, KnownSrc, Mode);
 
   // Doubling 0 will give the same 0.
-  if (KnownSrc.isKnownNeverLogicalPosZero(Mode))
+  if (KnownSrc.isKnownNeverLogicalPosZero(Mode) &&
+      (Mode.Output == DenormalMode::IEEE ||
+       Mode.Output == DenormalMode::PreserveSign))
     Known.knownNot(fcPosZero);
+
   if (KnownSrc.isKnownNeverLogicalNegZero(Mode))
     Known.knownNot(fcNegZero);
   return Known;

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -273,8 +273,6 @@ KnownFPClass KnownFPClass::fadd_self(const KnownFPClass &KnownSrc,
        Mode.Output == DenormalMode::PreserveSign))
     Known.knownNot(fcPosZero);
 
-  if (KnownSrc.isKnownNeverLogicalNegZero(Mode))
-    Known.knownNot(fcNegZero);
   return Known;
 }
 

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -268,8 +268,12 @@ KnownFPClass KnownFPClass::fadd_self(const KnownFPClass &KnownSrc,
   KnownFPClass Known = fadd(KnownSrc, KnownSrc, Mode);
 
   // Doubling 0 will give the same 0.
-  if (KnownSrc.isKnownNeverLogicalPosZero(Mode) &&
-      Mode.Output == DenormalMode::IEEE)
+  if (KnownRHS.isKnownNeverLogicalPosZero(Mode) &&
+      (Mode.Output == DenormalMode::IEEE ||
+       (Mode.Output == DenormalMode::PreserveSign &&
+        KnownRHS.isKnownNeverPosSubnormal()) ||
+       (Mode.Output == DenormalMode::PositiveZero &&
+        KnownRHS.isKnownNeverSubnormal())))
     Known.knownNot(fcPosZero);
 
   return Known;

--- a/llvm/lib/Support/KnownFPClass.cpp
+++ b/llvm/lib/Support/KnownFPClass.cpp
@@ -268,12 +268,12 @@ KnownFPClass KnownFPClass::fadd_self(const KnownFPClass &KnownSrc,
   KnownFPClass Known = fadd(KnownSrc, KnownSrc, Mode);
 
   // Doubling 0 will give the same 0.
-  if (KnownRHS.isKnownNeverLogicalPosZero(Mode) &&
+  if (KnownSrc.isKnownNeverLogicalPosZero(Mode) &&
       (Mode.Output == DenormalMode::IEEE ||
        (Mode.Output == DenormalMode::PreserveSign &&
-        KnownRHS.isKnownNeverPosSubnormal()) ||
+        KnownSrc.isKnownNeverPosSubnormal()) ||
        (Mode.Output == DenormalMode::PositiveZero &&
-        KnownRHS.isKnownNeverSubnormal())))
+        KnownSrc.isKnownNeverSubnormal())))
     Known.knownNot(fcPosZero);
 
   return Known;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2033,6 +2033,25 @@ static Constant *getFPClassConstant(Type *Ty, FPClassTest Mask,
   }
 }
 
+/// Try to set an inferred no-nans or no-infs in \p FMF. \p
+/// ValidResults is a mask of known valid results for the operator
+/// (already computed from the result, and the known operand inputs,
+/// \p KnownLHS and \p KnownRHS)
+static FastMathFlags
+inferFastMathValueFlagsBinOp(FastMathFlags FMF, FPClassTest ValidResults,
+                             const KnownFPClass &KnownLHS,
+                             const KnownFPClass &KnownRHS) {
+  if (!FMF.noNaNs() && (ValidResults & fcNan) == fcNone &&
+      KnownLHS.isKnownNeverNaN() && KnownRHS.isKnownNeverNaN())
+    FMF.setNoNaNs();
+
+  if (!FMF.noInfs() && (ValidResults & fcInf) == fcNone &&
+      KnownLHS.isKnownNeverInfinity() && KnownRHS.isKnownNeverInfinity())
+    FMF.setNoInfs();
+
+  return FMF;
+}
+
 Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
                                                     FPClassTest DemandedMask,
                                                     KnownFPClass &Known,
@@ -2061,6 +2080,86 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       return I;
     Known.fneg();
     break;
+  }
+  case Instruction::FAdd: {
+    KnownFPClass KnownLHS, KnownRHS;
+
+    const SimplifyQuery &SQ = getSimplifyQuery();
+
+    // fadd x, x can be handled more aggressively.
+    if (I->getOperand(0) == I->getOperand(1) &&
+        isGuaranteedNotToBeUndef(I->getOperand(0), SQ.AC, CxtI, SQ.DT,
+                                 Depth + 1)) {
+      FPClassTest SrcDemandedMask = DemandedMask;
+
+      // Doubling a subnormal could have resulted in a normal value.
+      if (DemandedMask & fcPosNormal)
+        SrcDemandedMask |= fcPosSubnormal;
+      if (DemandedMask & fcNegNormal)
+        SrcDemandedMask |= fcNegSubnormal;
+
+      // Doubling a normal could have resulted in an infinity.
+      if (DemandedMask & fcPosInf)
+        SrcDemandedMask |= fcPosNormal;
+      if (DemandedMask & fcNegInf)
+        SrcDemandedMask |= fcNegNormal;
+
+      if (SimplifyDemandedFPClass(I, 0, SrcDemandedMask, KnownLHS, Depth + 1))
+        return I;
+
+      Type *EltTy = VTy->getScalarType();
+      DenormalMode Mode = F.getDenormalMode(EltTy->getFltSemantics());
+      Known = KnownFPClass::fadd_self(KnownLHS, Mode);
+      KnownRHS = KnownLHS;
+    } else {
+      FPClassTest SrcDemandedMask = fcFinite;
+
+      // inf + (-inf) = nan
+      if (DemandedMask & fcNan)
+        SrcDemandedMask |= fcNan | fcInf;
+
+      if (DemandedMask & fcInf)
+        SrcDemandedMask |= fcInf;
+
+      if (SimplifyDemandedFPClass(I, 1, SrcDemandedMask, KnownRHS, Depth + 1) ||
+          SimplifyDemandedFPClass(I, 0, SrcDemandedMask, KnownLHS, Depth + 1))
+        return I;
+
+      Type *EltTy = VTy->getScalarType();
+      DenormalMode Mode = F.getDenormalMode(EltTy->getFltSemantics());
+      Known = KnownFPClass::fadd(KnownLHS, KnownRHS, Mode);
+    }
+
+    FPClassTest ValidResults = DemandedMask & Known.KnownFPClasses;
+    if (Constant *SingleVal =
+            getFPClassConstant(VTy, ValidResults, /*IsCanonicalizing=*/true))
+      return SingleVal;
+
+    // Propagate known result to simplify edge case checks.
+    bool ResultNotNan = (DemandedMask & fcNan) == fcNone;
+    if (ResultNotNan) {
+      KnownLHS.knownNot(fcNan);
+      KnownRHS.knownNot(fcNan);
+    }
+
+    // With nnan: X + {+/-}Inf --> {+/-}Inf
+    if (KnownRHS.isKnownAlways(fcInf | fcNan) &&
+        (ResultNotNan || KnownLHS.isKnownNever(fcNan)))
+      return I->getOperand(1);
+
+    // With nnan: {+/-}Inf + X --> {+/-}Inf
+    if (KnownLHS.isKnownAlways(fcInf | fcNan) &&
+        (ResultNotNan || KnownRHS.isKnownNever(fcNan)))
+      return I->getOperand(0);
+
+    FastMathFlags InferredFMF =
+        inferFastMathValueFlagsBinOp(FMF, ValidResults, KnownLHS, KnownRHS);
+    if (InferredFMF != FMF) {
+      I->setFastMathFlags(InferredFMF);
+      return I;
+    }
+
+    return nullptr;
   }
   case Instruction::FMul: {
     KnownFPClass KnownLHS, KnownRHS;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2144,12 +2144,12 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
 
     // With nnan: X + {+/-}Inf --> {+/-}Inf
     if (KnownRHS.isKnownAlways(fcInf | fcNan) &&
-        (ResultNotNan || KnownLHS.isKnownNever(fcNan)))
+        KnownLHS.isKnownNever(fcNan))
       return I->getOperand(1);
 
     // With nnan: {+/-}Inf + X --> {+/-}Inf
     if (KnownLHS.isKnownAlways(fcInf | fcNan) &&
-        (ResultNotNan || KnownRHS.isKnownNever(fcNan)))
+        KnownRHS.isKnownNever(fcNan))
       return I->getOperand(0);
 
     FastMathFlags InferredFMF =

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fadd.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fadd.ll
@@ -1638,7 +1638,8 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__ftz_d
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__ftz_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[SUB]], [[SUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -1650,7 +1651,8 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__ftz_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[NSUB]], [[NSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1674,7 +1676,8 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__ftz_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[PSUB]], [[PSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1699,7 +1702,8 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__ieee_
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__ieee_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR2:[0-9]+]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[SUB]], [[SUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -1711,7 +1715,8 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__ieee_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[NSUB]], [[NSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1735,7 +1740,8 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__ieee_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[PSUB]], [[PSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1760,7 +1766,8 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__ftz_i
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__ftz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR3:[0-9]+]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[SUB]], [[SUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -1772,7 +1779,8 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__ftz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[NSUB]], [[NSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1796,7 +1804,8 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__ftz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[PSUB]], [[PSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1821,7 +1830,8 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__dynam
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__dynamic_dynamic(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[SUB]], [[SUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -1833,7 +1843,8 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__dynamic_dynamic(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[NSUB]], [[NSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1857,7 +1868,8 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__dynamic_dynamic(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[PSUB]], [[PSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1869,7 +1881,8 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_nsub_source__fadd_self__dynamic_dynamic(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[NSUB]], [[NSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1882,7 +1895,8 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__ieee_
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__ieee_dapz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR4:[0-9]+]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[SUB]], [[SUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -1894,7 +1908,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__ieee_dapz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR4]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    ret half 0xHFC00
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1918,7 +1932,8 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__ieee_dapz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR4]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[PSUB]], [[PSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1931,7 +1946,8 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_nsub_source__fadd_self__ieee_dapz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR4]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[NSUB]], [[NSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1944,7 +1960,8 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__ftpz_
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__ftpz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR5:[0-9]+]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[SUB]], [[SUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -1956,7 +1973,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__ftpz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR5]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    ret half 0xHFC00
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1980,7 +1997,8 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__ftpz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR5]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[PSUB]], [[PSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1993,7 +2011,8 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_nsub_source__fadd_self__ftpz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR5]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half poison
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd nnan half [[NSUB]], [[NSUB]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fadd.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fadd.ll
@@ -34,8 +34,7 @@ declare void @use(half)
 define nofpclass(inf zero sub norm) half @ret_only_nan(half %x, half %y) {
 ; CHECK-LABEL: define nofpclass(inf zero sub norm) half @ret_only_nan(
 ; CHECK-SAME: half [[X:%.*]], half [[Y:%.*]]) {
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half 0xH7E00
 ;
   %add = fadd half %x, %y
   ret half %add
@@ -64,7 +63,7 @@ define nofpclass(qnan inf zero sub norm) half @ret_only_snan(half %x, half %y) {
 define nofpclass(nan inf sub norm) half @ret_only_zero(half %x, half %y) {
 ; CHECK-LABEL: define nofpclass(nan inf sub norm) half @ret_only_zero(
 ; CHECK-SAME: half [[X:%.*]], half [[Y:%.*]]) {
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %add = fadd half %x, %y
@@ -92,7 +91,7 @@ define nofpclass(nan inf pzero sub norm) half @ret_only_nzero(half %x, half %y) 
 define nofpclass(nan zero sub norm) half @ret_only_inf(half %x, half %y) {
 ; CHECK-LABEL: define nofpclass(nan zero sub norm) half @ret_only_inf(
 ; CHECK-SAME: half [[X:%.*]], half [[Y:%.*]]) {
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %add = fadd half %x, %y
@@ -216,9 +215,7 @@ define nofpclass(nan inf) half @ret_nofpclass_inf_nan__fadd_select_unknown_or_in
 ; CHECK-SAME: i1 [[COND:%.*]], half [[X:%.*]], half [[Y:%.*]]) {
 ; CHECK-NEXT:    [[INF0:%.*]] = call half @returns_inf()
 ; CHECK-NEXT:    [[INF1:%.*]] = call half @returns_inf()
-; CHECK-NEXT:    [[X_OR_INF:%.*]] = select i1 [[COND]], half [[X]], half [[INF0]]
-; CHECK-NEXT:    [[Y_OR_INF:%.*]] = select i1 [[COND]], half [[Y]], half [[INF1]]
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X_OR_INF]], [[Y_OR_INF]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %inf0 = call half @returns_inf()
@@ -234,7 +231,7 @@ define nofpclass(inf sub norm) half @nan_result_demands_inf_input_lhs(i1 %cond, 
 ; CHECK-LABEL: define nofpclass(inf sub norm) half @nan_result_demands_inf_input_lhs(
 ; CHECK-SAME: i1 [[COND:%.*]], half nofpclass(zero) [[X:%.*]], half nofpclass(nan inf zero) [[Y:%.*]]) {
 ; CHECK-NEXT:    [[PINF:%.*]] = call half @returns_pinf()
-; CHECK-NEXT:    [[X_OR_INF:%.*]] = select i1 [[COND]], half [[X]], half [[PINF]]
+; CHECK-NEXT:    [[X_OR_INF:%.*]] = select i1 [[COND]], half [[X]], half 0xH7C00
 ; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X_OR_INF]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
@@ -249,7 +246,7 @@ define nofpclass(inf sub norm) half @nan_result_demands_inf_input_rhs(i1 %cond, 
 ; CHECK-LABEL: define nofpclass(inf sub norm) half @nan_result_demands_inf_input_rhs(
 ; CHECK-SAME: i1 [[COND:%.*]], half nofpclass(zero) [[X:%.*]], half [[Y:%.*]]) {
 ; CHECK-NEXT:    [[PINF:%.*]] = call half @returns_pinf()
-; CHECK-NEXT:    [[Y_OR_INF:%.*]] = select i1 [[COND]], half [[Y]], half [[PINF]]
+; CHECK-NEXT:    [[Y_OR_INF:%.*]] = select i1 [[COND]], half [[Y]], half 0xH7C00
 ; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y_OR_INF]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
@@ -265,7 +262,7 @@ define nofpclass(nan sub norm zero) half @inf_result_demands_inf_input_lhs(i1 %c
 ; CHECK-SAME: i1 [[COND:%.*]], half nofpclass(zero) [[X:%.*]], half nofpclass(zero) [[Y:%.*]]) {
 ; CHECK-NEXT:    [[INF:%.*]] = call half @returns_inf()
 ; CHECK-NEXT:    [[X_OR_INF:%.*]] = select i1 [[COND]], half [[X]], half [[INF]]
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X_OR_INF]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X_OR_INF]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %inf = call half @returns_inf()
@@ -280,7 +277,7 @@ define nofpclass(nan sub norm zero) half @inf_result_demands_inf_input_rhs(i1 %c
 ; CHECK-SAME: i1 [[COND:%.*]], half nofpclass(zero) [[X:%.*]], half nofpclass(zero) [[Y:%.*]]) {
 ; CHECK-NEXT:    [[INF:%.*]] = call half @returns_inf()
 ; CHECK-NEXT:    [[Y_OR_INF:%.*]] = select i1 [[COND]], half [[Y]], half [[INF]]
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y_OR_INF]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y_OR_INF]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %inf = call half @returns_inf()
@@ -294,8 +291,8 @@ define nofpclass(nan sub norm zero) half @inf_result_demands_pinf_input_lhs(i1 %
 ; CHECK-LABEL: define nofpclass(nan zero sub norm) half @inf_result_demands_pinf_input_lhs(
 ; CHECK-SAME: i1 [[COND:%.*]], half nofpclass(zero) [[X:%.*]], half nofpclass(zero) [[Y:%.*]]) {
 ; CHECK-NEXT:    [[PINF:%.*]] = call half @returns_pinf()
-; CHECK-NEXT:    [[X_OR_INF:%.*]] = select i1 [[COND]], half [[X]], half [[PINF]]
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X_OR_INF]], [[Y]]
+; CHECK-NEXT:    [[X_OR_INF:%.*]] = select i1 [[COND]], half [[X]], half 0xH7C00
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X_OR_INF]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %pinf = call half @returns_pinf()
@@ -309,8 +306,8 @@ define nofpclass(nan sub norm zero) half @inf_result_demands_pinf_input_rhs(i1 %
 ; CHECK-LABEL: define nofpclass(nan zero sub norm) half @inf_result_demands_pinf_input_rhs(
 ; CHECK-SAME: i1 [[COND:%.*]], half nofpclass(zero) [[X:%.*]], half nofpclass(zero) [[Y:%.*]]) {
 ; CHECK-NEXT:    [[PINF:%.*]] = call half @returns_pinf()
-; CHECK-NEXT:    [[Y_OR_INF:%.*]] = select i1 [[COND]], half [[Y]], half [[PINF]]
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y_OR_INF]]
+; CHECK-NEXT:    [[Y_OR_INF:%.*]] = select i1 [[COND]], half [[Y]], half 0xH7C00
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y_OR_INF]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %pinf = call half @returns_pinf()
@@ -324,8 +321,8 @@ define nofpclass(nan sub norm zero) half @inf_result_demands_ninf_input_lhs(i1 %
 ; CHECK-LABEL: define nofpclass(nan zero sub norm) half @inf_result_demands_ninf_input_lhs(
 ; CHECK-SAME: i1 [[COND:%.*]], half nofpclass(zero) [[X:%.*]], half nofpclass(zero) [[Y:%.*]]) {
 ; CHECK-NEXT:    [[NINF:%.*]] = call half @returns_ninf()
-; CHECK-NEXT:    [[X_OR_INF:%.*]] = select i1 [[COND]], half [[X]], half [[NINF]]
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X_OR_INF]], [[Y]]
+; CHECK-NEXT:    [[X_OR_INF:%.*]] = select i1 [[COND]], half [[X]], half 0xHFC00
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X_OR_INF]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %ninf = call half @returns_ninf()
@@ -339,8 +336,8 @@ define nofpclass(nan sub norm zero) half @inf_result_demands_ninf_input_rhs(i1 %
 ; CHECK-LABEL: define nofpclass(nan zero sub norm) half @inf_result_demands_ninf_input_rhs(
 ; CHECK-SAME: i1 [[COND:%.*]], half nofpclass(zero) [[X:%.*]], half nofpclass(zero) [[Y:%.*]]) {
 ; CHECK-NEXT:    [[NINF:%.*]] = call half @returns_ninf()
-; CHECK-NEXT:    [[Y_OR_INF:%.*]] = select i1 [[COND]], half [[Y]], half [[NINF]]
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y_OR_INF]]
+; CHECK-NEXT:    [[Y_OR_INF:%.*]] = select i1 [[COND]], half [[Y]], half 0xHFC00
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y_OR_INF]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %ninf = call half @returns_ninf()
@@ -365,7 +362,7 @@ define nofpclass(snan) half @no_nans_inputs(half nofpclass(nan) %x, half nofpcla
 define nofpclass(nan) half @no_nans_input_and_output(half nofpclass(nan) %x, half nofpclass(nan) %y) {
 ; CHECK-LABEL: define nofpclass(nan) half @no_nans_input_and_output(
 ; CHECK-SAME: half nofpclass(nan) [[X:%.*]], half nofpclass(nan) [[Y:%.*]]) {
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %add = fadd half %x, %y
@@ -388,7 +385,7 @@ define nofpclass(snan) half @no_infs_inputs(half nofpclass(inf) %x, half nofpcla
 define nofpclass(inf) half @no_infs_inputs_and_outputs(half nofpclass(inf) %x, half nofpclass(inf) %y) {
 ; CHECK-LABEL: define nofpclass(inf) half @no_infs_inputs_and_outputs(
 ; CHECK-SAME: half nofpclass(inf) [[X:%.*]], half nofpclass(inf) [[Y:%.*]]) {
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd ninf half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %add = fadd half %x, %y
@@ -399,7 +396,7 @@ define nofpclass(inf) half @no_infs_inputs_and_outputs(half nofpclass(inf) %x, h
 define nofpclass(snan) half @no_nans_infs_inputs(half nofpclass(nan inf) %x, half nofpclass(nan inf) %y) {
 ; CHECK-LABEL: define nofpclass(snan) half @no_nans_infs_inputs(
 ; CHECK-SAME: half nofpclass(nan inf) [[X:%.*]], half nofpclass(nan inf) [[Y:%.*]]) {
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %add = fadd half %x, %y
@@ -410,7 +407,7 @@ define nofpclass(snan) half @no_nans_infs_inputs(half nofpclass(nan inf) %x, hal
 define nofpclass(inf) half @no_nans_infs_inputs__noinfs_output(half nofpclass(nan inf) %x, half nofpclass(nan inf) %y) {
 ; CHECK-LABEL: define nofpclass(inf) half @no_nans_infs_inputs__noinfs_output(
 ; CHECK-SAME: half nofpclass(nan inf) [[X:%.*]], half nofpclass(nan inf) [[Y:%.*]]) {
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan ninf half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %add = fadd half %x, %y
@@ -421,7 +418,7 @@ define nofpclass(inf) half @no_nans_infs_inputs__noinfs_output(half nofpclass(na
 define nofpclass(nan) half @no_nans_infs_inputs__nonans_output(half nofpclass(nan inf) %x, half nofpclass(nan inf) %y) {
 ; CHECK-LABEL: define nofpclass(nan) half @no_nans_infs_inputs__nonans_output(
 ; CHECK-SAME: half nofpclass(nan inf) [[X:%.*]], half nofpclass(nan inf) [[Y:%.*]]) {
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %add = fadd half %x, %y
@@ -432,7 +429,7 @@ define nofpclass(nan) half @no_nans_infs_inputs__nonans_output(half nofpclass(na
 define nofpclass(nzero) half @inferred_nan_output__noinfs_only_lhs(half nofpclass(nan inf) %x, half nofpclass(nan) %y) {
 ; CHECK-LABEL: define nofpclass(nzero) half @inferred_nan_output__noinfs_only_lhs(
 ; CHECK-SAME: half nofpclass(nan inf) [[X:%.*]], half nofpclass(nan) [[Y:%.*]]) {
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %add = fadd half %x, %y
@@ -443,7 +440,7 @@ define nofpclass(nzero) half @inferred_nan_output__noinfs_only_lhs(half nofpclas
 define nofpclass(nzero) half @inferred_nan_output__noinfs_only_rhs(half nofpclass(nan) %x, half nofpclass(nan inf) %y) {
 ; CHECK-LABEL: define nofpclass(nzero) half @inferred_nan_output__noinfs_only_rhs(
 ; CHECK-SAME: half nofpclass(nan) [[X:%.*]], half nofpclass(nan inf) [[Y:%.*]]) {
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[X]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %add = fadd half %x, %y
@@ -515,7 +512,7 @@ define nofpclass(nan) half @ret_nonan_fabs_fadd_known_positive_or_nan_sources() 
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan_fabs_fadd_known_positive_or_nan_sources() {
 ; CHECK-NEXT:    [[POSITIVE_OR_NAN0:%.*]] = call half @returns_positive_or_nan()
 ; CHECK-NEXT:    [[POSITIVE_OR_NAN1:%.*]] = call half @returns_positive_or_nan()
-; CHECK-NEXT:    [[KNOWN_POSITIVE_ADD:%.*]] = fadd half [[POSITIVE_OR_NAN0]], [[POSITIVE_OR_NAN1]]
+; CHECK-NEXT:    [[KNOWN_POSITIVE_ADD:%.*]] = fadd nnan half [[POSITIVE_OR_NAN0]], [[POSITIVE_OR_NAN1]]
 ; CHECK-NEXT:    ret half [[KNOWN_POSITIVE_ADD]]
 ;
   %positive.or.nan0 = call half @returns_positive_or_nan()
@@ -530,7 +527,7 @@ define nofpclass(nan) half @ret_nonan_fabs_fadd_known_positive_sources() {
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan_fabs_fadd_known_positive_sources() {
 ; CHECK-NEXT:    [[POSITIVE0:%.*]] = call half @returns_positive()
 ; CHECK-NEXT:    [[POSITIVE1:%.*]] = call half @returns_positive()
-; CHECK-NEXT:    [[KNOWN_POSITIVE_ADD:%.*]] = fadd half [[POSITIVE1]], [[POSITIVE1]]
+; CHECK-NEXT:    [[KNOWN_POSITIVE_ADD:%.*]] = fadd nnan half [[POSITIVE1]], [[POSITIVE1]]
 ; CHECK-NEXT:    ret half [[KNOWN_POSITIVE_ADD]]
 ;
   %positive0 = call half @returns_positive()
@@ -592,8 +589,7 @@ define nofpclass(nan) half @ret_nonan__unknown__fadd__inf(half %unknown) {
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__unknown__fadd__inf(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF:%.*]] = call half @returns_inf()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[UNKNOWN]], [[INF]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[INF]]
 ;
   %inf = call half @returns_inf()
   %add = fadd half %unknown, %inf
@@ -604,8 +600,7 @@ define nofpclass(nan) half @ret_nonan__inf__fadd__unknown(half %unknown) {
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__inf__fadd__unknown(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF:%.*]] = call half @returns_inf()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[INF]], [[UNKNOWN]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[INF]]
 ;
   %inf = call half @returns_inf()
   %add = fadd half %inf, %unknown
@@ -616,8 +611,7 @@ define nofpclass(nan) half @ret_nonan__unknown__fadd__inf_or_nan(half %unknown) 
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__unknown__fadd__inf_or_nan(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call half @returns_inf_or_nan()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[UNKNOWN]], [[INF_OR_NAN]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[INF_OR_NAN]]
 ;
   %inf.or.nan = call half @returns_inf_or_nan()
   %add = fadd half %unknown, %inf.or.nan
@@ -628,8 +622,7 @@ define nofpclass(nan) half @ret_nonan__inf_or_nan__fadd__unknown(half %unknown) 
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__inf_or_nan__fadd__unknown(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call half @returns_inf_or_nan()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[INF_OR_NAN]], [[UNKNOWN]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[INF_OR_NAN]]
 ;
   %inf.or.nan = call half @returns_inf_or_nan()
   %add = fadd half %inf.or.nan, %unknown
@@ -664,7 +657,7 @@ define nofpclass(nan) half @ret_nonan__unknown__fadd__zero(half %unknown) {
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__unknown__fadd__zero(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[ZERO:%.*]] = call half @returns_zero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[UNKNOWN]], [[ZERO]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[UNKNOWN]], [[ZERO]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %zero = call half @returns_zero()
@@ -676,7 +669,7 @@ define nofpclass(nan) half @ret_nonan__zero__fadd__unknown(half %unknown) {
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__zero__fadd__unknown(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[ZERO:%.*]] = call half @returns_zero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[ZERO]], [[UNKNOWN]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[ZERO]], [[UNKNOWN]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %zero = call half @returns_zero()
@@ -688,7 +681,7 @@ define nofpclass(snan) half @unknown__fadd__pzero(half %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) half @unknown__fadd__pzero(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[UNKNOWN]], [[PZERO]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[UNKNOWN]], 0xH0000
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %pzero = call half @returns_pzero()
@@ -700,7 +693,7 @@ define nofpclass(snan) half @pzero__fadd__unknown(half %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) half @pzero__fadd__unknown(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[PZERO]], [[UNKNOWN]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[UNKNOWN]], 0xH0000
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %pzero = call half @returns_pzero()
@@ -712,7 +705,7 @@ define nofpclass(nan) half @ret_nonan__unknown__fadd__pzero(half %unknown) {
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__unknown__fadd__pzero(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[UNKNOWN]], [[PZERO]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[UNKNOWN]], 0xH0000
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %pzero = call half @returns_pzero()
@@ -724,7 +717,7 @@ define nofpclass(nan) half @ret_nonan__pzero__fadd__unknown(half %unknown) {
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__pzero__fadd__unknown(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[PZERO]], [[UNKNOWN]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[UNKNOWN]], 0xH0000
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %pzero = call half @returns_pzero()
@@ -736,8 +729,7 @@ define nofpclass(snan) half @unknown__fadd__nzero(half %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) half @unknown__fadd__nzero(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NZERO:%.*]] = call half @returns_nzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[UNKNOWN]], [[NZERO]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[UNKNOWN]]
 ;
   %nzero = call half @returns_nzero()
   %add = fadd half %unknown, %nzero
@@ -748,8 +740,7 @@ define nofpclass(snan) half @nzero__fadd__unknown(half %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) half @nzero__fadd__unknown(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NZERO:%.*]] = call half @returns_nzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[NZERO]], [[UNKNOWN]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[UNKNOWN]]
 ;
   %nzero = call half @returns_nzero()
   %add = fadd half %nzero, %unknown
@@ -784,8 +775,7 @@ define nofpclass(nan) half @ret_nonan__unknown__fadd__nzero(half %unknown) {
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__unknown__fadd__nzero(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NZERO:%.*]] = call half @returns_nzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[UNKNOWN]], [[NZERO]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[UNKNOWN]]
 ;
   %nzero = call half @returns_nzero()
   %add = fadd half %unknown, %nzero
@@ -796,8 +786,7 @@ define nofpclass(nan) half @ret_nonan__nzero__fadd__unknown(half %unknown) {
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__nzero__fadd__unknown(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NZERO:%.*]] = call half @returns_nzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[NZERO]], [[UNKNOWN]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[UNKNOWN]]
 ;
   %nzero = call half @returns_nzero()
   %add = fadd half %nzero, %unknown
@@ -832,8 +821,7 @@ define nofpclass(snan) half @not_nzero__fadd__pzero(half nofpclass(nzero) %not.n
 ; CHECK-LABEL: define nofpclass(snan) half @not_nzero__fadd__pzero(
 ; CHECK-SAME: half nofpclass(nzero) [[NOT_NZERO:%.*]]) {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[NOT_NZERO]], [[PZERO]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[NOT_NZERO]]
 ;
   %pzero = call half @returns_pzero()
   %add = fadd half %not.nzero, %pzero
@@ -844,8 +832,7 @@ define nofpclass(snan) half @pzero__fadd__not_nzero(half nofpclass(nzero) %not.n
 ; CHECK-LABEL: define nofpclass(snan) half @pzero__fadd__not_nzero(
 ; CHECK-SAME: half nofpclass(nzero) [[NOT_NZERO:%.*]]) {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[PZERO]], [[NOT_NZERO]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[NOT_NZERO]]
 ;
   %pzero = call half @returns_pzero()
   %add = fadd half %pzero, %not.nzero
@@ -904,8 +891,7 @@ define nofpclass(snan) half @unknown__fadd_nsz__pzero(half %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) half @unknown__fadd_nsz__pzero(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd nsz half [[UNKNOWN]], [[PZERO]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[UNKNOWN]]
 ;
   %pzero = call half @returns_pzero()
   %add = fadd nsz half %unknown, %pzero
@@ -916,8 +902,7 @@ define nofpclass(snan) half @pzero__fadd_nsz__unknown(half %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) half @pzero__fadd_nsz__unknown(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd nsz half [[PZERO]], [[UNKNOWN]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[UNKNOWN]]
 ;
   %pzero = call half @returns_pzero()
   %add = fadd nsz half %pzero, %unknown
@@ -928,8 +913,7 @@ define nofpclass(snan) half @unknown__fadd_nsz__pzero_or_nan(half %unknown) {
 ; CHECK-LABEL: define nofpclass(snan) half @unknown__fadd_nsz__pzero_or_nan(
 ; CHECK-SAME: half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PZERO_OR_NAN:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd nsz half [[UNKNOWN]], [[PZERO_OR_NAN]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[UNKNOWN]]
 ;
   %pzero.or.nan = call half @returns_pzero()
   %add = fadd nsz half %unknown, %pzero.or.nan
@@ -1028,8 +1012,7 @@ define nofpclass(snan) half @not_nzero__fadd__pzero__daz(half nofpclass(nzero) %
 ; CHECK-LABEL: define nofpclass(snan) half @not_nzero__fadd__pzero__daz(
 ; CHECK-SAME: half nofpclass(nzero) [[NOT_NZERO:%.*]]) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[NOT_NZERO]], [[PZERO]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[NOT_NZERO]]
 ;
   %pzero = call half @returns_pzero()
   %add = fadd half %not.nzero, %pzero
@@ -1040,8 +1023,7 @@ define nofpclass(snan) half @pzero__fadd__not_nzero__daz(half nofpclass(nzero) %
 ; CHECK-LABEL: define nofpclass(snan) half @pzero__fadd__not_nzero__daz(
 ; CHECK-SAME: half nofpclass(nzero) [[NOT_NZERO:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[PZERO]], [[NOT_NZERO]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[NOT_NZERO]]
 ;
   %pzero = call half @returns_pzero()
   %add = fadd half %pzero, %not.nzero
@@ -1052,8 +1034,7 @@ define nofpclass(snan) half @not_nzero__fadd__pzero__dynamic(half nofpclass(nzer
 ; CHECK-LABEL: define nofpclass(snan) half @not_nzero__fadd__pzero__dynamic(
 ; CHECK-SAME: half nofpclass(nzero) [[NOT_NZERO:%.*]]) #[[ATTR1:[0-9]+]] {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[NOT_NZERO]], [[PZERO]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[NOT_NZERO]]
 ;
   %pzero = call half @returns_pzero()
   %add = fadd half %not.nzero, %pzero
@@ -1064,8 +1045,7 @@ define nofpclass(snan) half @pzero__fadd__not_nzero__dynamic(half nofpclass(nzer
 ; CHECK-LABEL: define nofpclass(snan) half @pzero__fadd__not_nzero__dynamic(
 ; CHECK-SAME: half nofpclass(nzero) [[NOT_NZERO:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[PZERO]], [[NOT_NZERO]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[NOT_NZERO]]
 ;
   %pzero = call half @returns_pzero()
   %add = fadd half %pzero, %not.nzero
@@ -1076,8 +1056,7 @@ define nofpclass(snan) half @not_nzero_nsub__fadd__pzero__daz(half nofpclass(nze
 ; CHECK-LABEL: define nofpclass(snan) half @not_nzero_nsub__fadd__pzero__daz(
 ; CHECK-SAME: half nofpclass(nzero nsub) [[NOT_NZERO_NSUB:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[NOT_NZERO_NSUB]], [[PZERO]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[NOT_NZERO_NSUB]]
 ;
   %pzero = call half @returns_pzero()
   %add = fadd half %not.nzero.nsub, %pzero
@@ -1088,8 +1067,7 @@ define nofpclass(snan) half @pzero__fadd__not_nzero_nsub__daz(half nofpclass(nze
 ; CHECK-LABEL: define nofpclass(snan) half @pzero__fadd__not_nzero_nsub__daz(
 ; CHECK-SAME: half nofpclass(nzero nsub) [[NOT_NZERO_NSUB:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[PZERO]], [[NOT_NZERO_NSUB]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[NOT_NZERO_NSUB]]
 ;
   %pzero = call half @returns_pzero()
   %add = fadd half %pzero, %not.nzero.nsub
@@ -1100,8 +1078,7 @@ define nofpclass(snan) half @not_nzero_nsub__fadd__pzero__dynamic(half nofpclass
 ; CHECK-LABEL: define nofpclass(snan) half @not_nzero_nsub__fadd__pzero__dynamic(
 ; CHECK-SAME: half nofpclass(nzero nsub) [[NOT_NZERO_NSUB:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[NOT_NZERO_NSUB]], [[PZERO]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[NOT_NZERO_NSUB]]
 ;
   %pzero = call half @returns_pzero()
   %add = fadd half %not.nzero.nsub, %pzero
@@ -1112,8 +1089,7 @@ define nofpclass(snan) half @pzero__fadd__not_nzero_nsub__dynamic(half nofpclass
 ; CHECK-LABEL: define nofpclass(snan) half @pzero__fadd__not_nzero_nsub__dynamic(
 ; CHECK-SAME: half nofpclass(nzero nsub) [[NOT_NZERO_NSUB:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[PZERO:%.*]] = call half @returns_pzero()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[PZERO]], [[NOT_NZERO_NSUB]]
-; CHECK-NEXT:    ret half [[ADD]]
+; CHECK-NEXT:    ret half [[NOT_NZERO_NSUB]]
 ;
   %pzero = call half @returns_pzero()
   %add = fadd half %pzero, %not.nzero.nsub
@@ -1286,8 +1262,7 @@ define nofpclass(nan) half @ret_nonan__fadd_self__nonan(i1 %cond, half noundef %
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__fadd_self__nonan(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NAN:%.*]] = call noundef half @returns_nan()
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[NAN]], half [[UNKNOWN]]
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[SELECT]], [[SELECT]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[UNKNOWN]], [[UNKNOWN]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %nan = call noundef half @returns_nan()
@@ -1300,8 +1275,7 @@ define nofpclass(nan) half @ret_nonan__fadd_self__nonan_maybe_undef0(i1 %cond, h
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__fadd_self__nonan_maybe_undef0(
 ; CHECK-SAME: i1 [[COND:%.*]], half [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NAN:%.*]] = call noundef half @returns_nan()
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[NAN]], half [[UNKNOWN]]
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[SELECT]], [[SELECT]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[UNKNOWN]], [[UNKNOWN]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %nan = call noundef half @returns_nan()
@@ -1314,8 +1288,7 @@ define nofpclass(nan) half @ret_nonan__fadd_self__nonan_maybe_undef1(i1 %cond, h
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan__fadd_self__nonan_maybe_undef1(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NAN:%.*]] = call half @returns_nan()
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[NAN]], half [[UNKNOWN]]
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[SELECT]], [[SELECT]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[UNKNOWN]], [[UNKNOWN]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %nan = call half @returns_nan()
@@ -1330,7 +1303,7 @@ define nofpclass(nan) half @ret_nonan__fadd_self__nonan__other_use(i1 %cond, hal
 ; CHECK-NEXT:    [[NAN:%.*]] = call noundef half @returns_nan()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[NAN]], half [[UNKNOWN]]
 ; CHECK-NEXT:    call void @use(half [[SELECT]])
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[SELECT]], [[SELECT]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[UNKNOWN]], [[UNKNOWN]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %nan = call noundef half @returns_nan()
@@ -1485,7 +1458,7 @@ define nofpclass(nan ninf nnorm nsub nzero) half @ret_nonegative_nonan__fadd_sel
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NEGATIVE_OR_NAN:%.*]] = call noundef half @returns_negative_or_nan()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[NEGATIVE_OR_NAN]], half [[UNKNOWN]]
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[SELECT]], [[SELECT]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[SELECT]], [[SELECT]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %negative.or.nan = call noundef half @returns_negative_or_nan()
@@ -1499,7 +1472,7 @@ define nofpclass(nan pinf pnorm psub pzero) half @ret_nopositive_nonan__fadd_sel
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[POSITIVE_OR_NAN:%.*]] = call noundef half @returns_positive_or_nan()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], half [[POSITIVE_OR_NAN]], half [[UNKNOWN]]
-; CHECK-NEXT:    [[ADD:%.*]] = fadd half [[SELECT]], [[SELECT]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[SELECT]], [[SELECT]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %positive.or.nan = call noundef half @returns_positive_or_nan()
@@ -1512,7 +1485,7 @@ define nofpclass(nan) half @ret_nonan_fneg_fabs_fadd_known_negative_or_nan_sourc
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan_fneg_fabs_fadd_known_negative_or_nan_sources() {
 ; CHECK-NEXT:    [[NEGATIVE_OR_NAN0:%.*]] = call half @returns_negative_or_nan()
 ; CHECK-NEXT:    [[NEGATIVE_OR_NAN1:%.*]] = call half @returns_negative_or_nan()
-; CHECK-NEXT:    [[KNOWN_NEGATIVE_ADD:%.*]] = fadd half [[NEGATIVE_OR_NAN0]], [[NEGATIVE_OR_NAN1]]
+; CHECK-NEXT:    [[KNOWN_NEGATIVE_ADD:%.*]] = fadd nnan half [[NEGATIVE_OR_NAN0]], [[NEGATIVE_OR_NAN1]]
 ; CHECK-NEXT:    [[FABS:%.*]] = call half @llvm.fabs.f16(half [[KNOWN_NEGATIVE_ADD]])
 ; CHECK-NEXT:    [[NEG_FABS:%.*]] = fneg half [[FABS]]
 ; CHECK-NEXT:    ret half [[NEG_FABS]]
@@ -1529,7 +1502,7 @@ define nofpclass(nan) half @ret_nonan_fneg_fabs_fadd_known_negative_sources() {
 ; CHECK-LABEL: define nofpclass(nan) half @ret_nonan_fneg_fabs_fadd_known_negative_sources() {
 ; CHECK-NEXT:    [[NEGATIVE0:%.*]] = call half @returns_negative()
 ; CHECK-NEXT:    [[NEGATIVE1:%.*]] = call half @returns_negative()
-; CHECK-NEXT:    [[KNOWN_NEGATIVE_OP:%.*]] = fadd half [[NEGATIVE0]], [[NEGATIVE1]]
+; CHECK-NEXT:    [[KNOWN_NEGATIVE_OP:%.*]] = fadd nnan half [[NEGATIVE0]], [[NEGATIVE1]]
 ; CHECK-NEXT:    [[FABS:%.*]] = call half @llvm.fabs.f16(half [[KNOWN_NEGATIVE_OP]])
 ; CHECK-NEXT:    [[NEG_FABS:%.*]] = fneg half [[FABS]]
 ; CHECK-NEXT:    ret half [[NEG_FABS]]
@@ -1603,8 +1576,7 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__ieee(
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[SUB]], [[SUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -1616,7 +1588,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half 0xHFC00
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1628,7 +1600,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_psub_source__fadd_self__ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    ret half 0xH7C00
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1640,7 +1612,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    ret half 0xH7C00
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1652,7 +1624,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_nsub_source__fadd_self__ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half 0xHFC00
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1666,8 +1638,7 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__ftz_d
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__ftz_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[SUB]], [[SUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -1679,8 +1650,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__ftz_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[NSUB]], [[NSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1692,8 +1662,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_psub_source__fadd_self__ftz_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[PSUB]], [[PSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1705,8 +1674,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__ftz_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[PSUB]], [[PSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1718,7 +1686,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_nsub_source__fadd_self__ftz_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half 0xHFC00
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1731,8 +1699,7 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__ieee_
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__ieee_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR2:[0-9]+]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[SUB]], [[SUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -1744,8 +1711,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__ieee_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[NSUB]], [[NSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1757,7 +1723,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_psub_source__fadd_self__ieee_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    ret half 0xH7C00
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1769,8 +1735,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__ieee_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[PSUB]], [[PSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1782,7 +1747,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_nsub_source__fadd_self__ieee_daz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half 0xHFC00
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1795,8 +1760,7 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__ftz_i
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__ftz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR3:[0-9]+]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[SUB]], [[SUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -1808,8 +1772,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__ftz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[NSUB]], [[NSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1821,8 +1784,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_psub_source__fadd_self__ftz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[PSUB]], [[PSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1834,8 +1796,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__ftz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[PSUB]], [[PSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1847,7 +1808,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_nsub_source__fadd_self__ftz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half 0xHFC00
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1860,8 +1821,7 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__dynam
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__dynamic_dynamic(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[SUB]], [[SUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -1873,8 +1833,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__dynamic_dynamic(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[NSUB]], [[NSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1886,8 +1845,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_psub_source__fadd__dy
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_psub_source__fadd__dynamic_dynamic(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[PSUB]], [[PSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1899,8 +1857,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__dynamic_dynamic(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[PSUB]], [[PSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1912,8 +1869,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_nsub_source__fadd_self__dynamic_dynamic(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[NSUB]], [[NSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1926,8 +1882,7 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__ieee_
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__ieee_dapz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR4:[0-9]+]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[SUB]], [[SUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -1939,7 +1894,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__ieee_dapz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR4]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half 0xHFC00
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1951,7 +1906,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_psub_source__fadd_self__ieee_dapz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR4]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    ret half 0xH7C00
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1963,8 +1918,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__ieee_dapz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR4]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[PSUB]], [[PSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -1977,8 +1931,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_nsub_source__fadd_self__ieee_dapz(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR4]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[NSUB]], [[NSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -1991,8 +1944,7 @@ define nofpclass(norm sub) half @demand_zero_select_sub_source__fadd_self__ftpz_
 ; CHECK-LABEL: define nofpclass(sub norm) half @demand_zero_select_sub_source__fadd_self__ftpz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR5:[0-9]+]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call noundef half @returns_sub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[SUB]], [[SUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %sub = call noundef half @returns_sub()
   %select = select i1 %cond, half %unknown, half %sub
@@ -2004,7 +1956,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_nsub_source__fadd_self__ftpz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR5]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    ret half 0xHFC00
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub
@@ -2016,7 +1968,7 @@ define nofpclass(norm sub pzero) half @demand_nzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(pzero sub norm) half @demand_nzero_select_psub_source__fadd_self__ftpz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR5]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    ret half 0xH7C00
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -2028,8 +1980,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_psub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_psub_source__fadd_self__ftpz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR5]] {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call noundef half @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[PSUB]], [[PSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %psub = call noundef half @returns_psub()
   %select = select i1 %cond, half %unknown, half %psub
@@ -2042,8 +1993,7 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_nsub_source__fadd_sel
 ; CHECK-LABEL: define nofpclass(nzero sub norm) half @demand_pzero_select_nsub_source__fadd_self__ftpz_ieee(
 ; CHECK-SAME: i1 [[COND:%.*]], half noundef [[UNKNOWN:%.*]]) #[[ATTR5]] {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call noundef half @returns_nsub()
-; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[NSUB]], [[NSUB]]
-; CHECK-NEXT:    ret half [[RESULT]]
+; CHECK-NEXT:    ret half poison
 ;
   %nsub = call noundef half @returns_nsub()
   %select = select i1 %cond, half %unknown, half %nsub


### PR DESCRIPTION
Note some of the tests currently fail with alive, but not
due to this patch. Namely, when performing the fadd x, 0 -> x
simplification in functions with non-IEEE denormal handling.
The existing instsimplify ignores the denormals-are-zero hazard by
checking cannotBeNegativeZero instead of isKnownNeverLogicalZero.

Also note the self handling doesn't really do anything yet, other
than propagate consistent known-fpclass information until there is
multiple use support.

This also leaves behind the original ValueTracking support, without
switching to the new KnownFPClass:fadd utility. This will be easier
to clean up after the subsequent fsub support patch.