### PR TITLE
Remove poison from Value Fast-Math Flags

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -4134,19 +4134,17 @@ following flags to enable otherwise unsafe floating-point transformations.
    imparts no additional semantics from using all of them.
 
 ``nnan``
-   No NaNs - Allow optimizations to assume the arguments and result are not
-   NaN. If an argument is a nan, or the result would be a nan, it produces
-   a :ref:`poison value <poisonvalues>` instead.
+   Neglect NaNs - Allow neglecting the case of NaN arguments and results
+   when determining if an optimization is legal.
 
 ``ninf``
-   No Infs - Allow optimizations to assume the arguments and result are not
-   +/-Inf. If an argument is +/-Inf, or the result would be +/-Inf, it
-   produces a :ref:`poison value <poisonvalues>` instead.
+   Neglect Infinities - Allow neglecting the case of +/- Inf arguments
+   and results when determining if an optimization is legal.
 
 ``nsz``
-   No Signed Zeros - Allow optimizations to treat the sign of a zero
-   argument or zero result as insignificant. This does not imply that -0.0
-   is poison and/or guaranteed to not exist in the operation.
+   Neglect Signed Zeros - Allow neglecting the difference between +0 and -0 in
+   arguments and results when determining if an optimization is legal.
+
 
 Note: For :ref:`phi <i_phi>`, :ref:`select <i_select>`, and :ref:`call <i_call>`
 instructions, the following return types are considered to be floating-point

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -5077,17 +5077,27 @@ static Value *simplifySelectInst(Value *Cond, Value *TrueVal, Value *FalseVal,
       return ConstantInt::getFalse(Cond->getType());
   }
 
+  auto NegligiblePerFMF = [Q](Value *V) -> bool {
+    if (!isa_and_nonnull<FPMathOperator>(Q.CxtI)) {
+      return false;
+    }
+    FastMathFlags FMF = Q.CxtI->getFastMathFlags();
+    return (FMF.noNaNs() && match(V, m_NaN())) ||
+           (FMF.noInfs() && match(V, m_Inf()));
+  };
+
   // If the true or false value is poison, we can fold to the other value.
+  // Ditto for values that are negligible per FMF flags.
   // If the true or false value is undef, we can fold to the other value as
   // long as the other value isn't poison.
   // select ?, poison, X -> X
   // select ?, undef,  X -> X
-  if (isa<PoisonValue>(TrueVal) ||
+  if (isa<PoisonValue>(TrueVal) || NegligiblePerFMF(TrueVal) ||
       (Q.isUndefValue(TrueVal) && impliesPoison(FalseVal, Cond)))
     return FalseVal;
   // select ?, X, poison -> X
   // select ?, X, undef  -> X
-  if (isa<PoisonValue>(FalseVal) ||
+  if (isa<PoisonValue>(FalseVal) || NegligiblePerFMF(FalseVal) ||
       (Q.isUndefValue(FalseVal) && impliesPoison(TrueVal, Cond)))
     return TrueVal;
 
@@ -5810,17 +5820,7 @@ static Constant *simplifyFPOp(ArrayRef<Value *> Ops, FastMathFlags FMF,
 
   for (Value *V : Ops) {
     bool IsNan = match(V, m_NaN());
-    bool IsInf = match(V, m_Inf());
     bool IsUndef = Q.isUndefValue(V);
-
-    // If this operation has 'nnan' or 'ninf' and at least 1 disallowed operand
-    // (an undef operand can be chosen to be Nan/Inf), then the result of
-    // this operation is poison.
-    if (FMF.noNaNs() && (IsNan || IsUndef))
-      return PoisonValue::get(V->getType());
-    if (FMF.noInfs() && (IsInf || IsUndef))
-      return PoisonValue::get(V->getType());
-
     if (isDefaultFPEnvironment(ExBehavior, Rounding)) {
       // Undef does not propagate because undef means that all bits can take on
       // any value. If this is undef * NaN for example, then the result values
@@ -6110,10 +6110,6 @@ simplifyFDivInst(Value *Op0, Value *Op1, FastMathFlags FMF,
     if (match(Op0, m_FNegNSZ(m_Specific(Op1))) ||
         match(Op1, m_FNegNSZ(m_Specific(Op0))))
       return ConstantFP::get(Op0->getType(), -1.0);
-
-    // nnan ninf X / [-]0.0 -> poison
-    if (FMF.noInfs() && match(Op1, m_AnyZeroFP()))
-      return PoisonValue::get(Op1->getType());
   }
 
   return nullptr;

--- a/llvm/test/Transforms/InstSimplify/fdiv.ll
+++ b/llvm/test/Transforms/InstSimplify/fdiv.ll
@@ -64,7 +64,8 @@ define <2 x i1> @pr6096() {
 ; https://alive2.llvm.org/ce/z/JxX5in
 define float @fdiv_nnan_ninf_by_zero_f32(float %x) {
 ; CHECK-LABEL: @fdiv_nnan_ninf_by_zero_f32(
-; CHECK-NEXT:    ret float poison
+; CHECK:         %fdiv = fdiv nnan ninf float %x, 0.0
+; CHECK-NEXT:    ret float %fdiv
 ;
   %fdiv = fdiv nnan ninf float %x, 0.0
   ret float %fdiv
@@ -72,7 +73,8 @@ define float @fdiv_nnan_ninf_by_zero_f32(float %x) {
 
 define float @fdiv_nnan_ninf_by_negzero_f32(float %x) {
 ; CHECK-LABEL: @fdiv_nnan_ninf_by_negzero_f32(
-; CHECK-NEXT:    ret float poison
+; CHECK:         %fdiv = fdiv nnan ninf float %x, -0.0
+; CHECK-NEXT:    ret float %fdiv
 ;
   %fdiv = fdiv nnan ninf float %x, -0.0
   ret float %fdiv
@@ -80,7 +82,7 @@ define float @fdiv_nnan_ninf_by_negzero_f32(float %x) {
 
 define float @fdiv_nnan_ninf_by_undef_f32(float %x) {
 ; CHECK-LABEL: @fdiv_nnan_ninf_by_undef_f32(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %fdiv = fdiv nnan ninf float %x, undef
   ret float %fdiv
@@ -96,7 +98,8 @@ define float @fdiv_nnan_ninf_by_poison_f32(float %x) {
 
 define <2 x float> @fdiv_nnan_ninf_by_zero_v2f32(<2 x float> %x) {
 ; CHECK-LABEL: @fdiv_nnan_ninf_by_zero_v2f32(
-; CHECK-NEXT:    ret <2 x float> poison
+; CHECK:         %fdiv = fdiv nnan ninf <2 x float> %x, zeroinitializer
+; CHECK-NEXT:    ret <2 x float> %fdiv
 ;
   %fdiv = fdiv nnan ninf <2 x float> %x, zeroinitializer
   ret <2 x float> %fdiv
@@ -104,7 +107,7 @@ define <2 x float> @fdiv_nnan_ninf_by_zero_v2f32(<2 x float> %x) {
 
 define <2 x float> @fdiv_nnan_ninf_by_undef_v2f32(<2 x float> %x) {
 ; CHECK-LABEL: @fdiv_nnan_ninf_by_undef_v2f32(
-; CHECK-NEXT:    ret <2 x float> poison
+; CHECK-NEXT:    ret <2 x float> splat (float 0x7FF8000000000000)
 ;
   %fdiv = fdiv nnan ninf <2 x float> %x, undef
   ret <2 x float> %fdiv
@@ -112,7 +115,8 @@ define <2 x float> @fdiv_nnan_ninf_by_undef_v2f32(<2 x float> %x) {
 
 define <2 x float> @fdiv_nnan_ninf_by_zero_poison_v2f32(<2 x float> %x) {
 ; CHECK-LABEL: @fdiv_nnan_ninf_by_zero_poison_v2f32(
-; CHECK-NEXT:    ret <2 x float> poison
+; CHECK:         %fdiv = fdiv nnan ninf <2 x float> %x, <float 0.000000e+00, float poison>
+; CHECK-NEXT:    ret <2 x float> %fdiv
 ;
   %fdiv = fdiv nnan ninf <2 x float> %x, <float 0.0, float poison>
   ret <2 x float> %fdiv

--- a/llvm/test/Transforms/InstSimplify/fp-nan.ll
+++ b/llvm/test/Transforms/InstSimplify/fp-nan.ll
@@ -253,10 +253,12 @@ define <vscale x 1 x double> @unary_fneg_nan_2_scalable_vec_1() {
 }
 
 ; Repeat all tests with fast-math-flags. Alternate 'nnan' and 'fast' for more coverage.
+; Note: these cases used to result in poison values. Now that this isn't the case
+; anymore, these may be redundant.
 
 define float @fadd_nan_op0_nnan(float %x) {
 ; CHECK-LABEL: @fadd_nan_op0_nnan(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fadd nnan float 0x7FF8000000000000, %x
   ret float %r
@@ -264,7 +266,7 @@ define float @fadd_nan_op0_nnan(float %x) {
 
 define float @fadd_nan_op1_fast(float %x) {
 ; CHECK-LABEL: @fadd_nan_op1_fast(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fadd fast float %x, 0x7FF8000000000000
   ret float %r
@@ -272,7 +274,7 @@ define float @fadd_nan_op1_fast(float %x) {
 
 define float @fsub_nan_op0_fast(float %x) {
 ; CHECK-LABEL: @fsub_nan_op0_fast(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fsub fast float 0x7FF8000000000000, %x
   ret float %r
@@ -280,7 +282,7 @@ define float @fsub_nan_op0_fast(float %x) {
 
 define float @fsub_nan_op1_nnan(float %x) {
 ; CHECK-LABEL: @fsub_nan_op1_nnan(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fsub nnan float %x, 0x7FF8000000000000
   ret float %r
@@ -288,7 +290,7 @@ define float @fsub_nan_op1_nnan(float %x) {
 
 define float @fmul_nan_op0_nnan(float %x) {
 ; CHECK-LABEL: @fmul_nan_op0_nnan(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fmul nnan float 0x7FF8000000000000, %x
   ret float %r
@@ -296,7 +298,7 @@ define float @fmul_nan_op0_nnan(float %x) {
 
 define float @fmul_nan_op1_fast(float %x) {
 ; CHECK-LABEL: @fmul_nan_op1_fast(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fmul fast float %x, 0x7FF8000000000000
   ret float %r
@@ -304,7 +306,7 @@ define float @fmul_nan_op1_fast(float %x) {
 
 define float @fdiv_nan_op0_fast(float %x) {
 ; CHECK-LABEL: @fdiv_nan_op0_fast(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fdiv fast float 0x7FF8000000000000, %x
   ret float %r
@@ -312,7 +314,7 @@ define float @fdiv_nan_op0_fast(float %x) {
 
 define float @fdiv_nan_op1_nnan(float %x) {
 ; CHECK-LABEL: @fdiv_nan_op1_nnan(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fdiv nnan float %x, 0x7FF8000000000000
   ret float %r
@@ -320,7 +322,7 @@ define float @fdiv_nan_op1_nnan(float %x) {
 
 define float @frem_nan_op0_nnan(float %x) {
 ; CHECK-LABEL: @frem_nan_op0_nnan(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = frem nnan float 0x7FF8000000000000, %x
   ret float %r
@@ -328,7 +330,7 @@ define float @frem_nan_op0_nnan(float %x) {
 
 define float @frem_nan_op1_fast(float %x) {
 ; CHECK-LABEL: @frem_nan_op1_fast(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = frem fast float %x, 0x7FF8000000000000
   ret float %r

--- a/llvm/test/Transforms/InstSimplify/fp-undef-poison.ll
+++ b/llvm/test/Transforms/InstSimplify/fp-undef-poison.ll
@@ -162,10 +162,12 @@ define float @frem_poison_op1(float %x) {
 }
 
 ; Repeat all tests with fast-math-flags. Alternate 'nnan' and 'fast' for more coverage.
+; Note: these cases used to result in poison values. Now that this isn't the case
+; anymore, these may be redundant.
 
 define float @fadd_undef_op0_nnan(float %x) {
 ; CHECK-LABEL: @fadd_undef_op0_nnan(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fadd nnan float undef, %x
   ret float %r
@@ -173,7 +175,7 @@ define float @fadd_undef_op0_nnan(float %x) {
 
 define float @fadd_undef_op1_fast(float %x) {
 ; CHECK-LABEL: @fadd_undef_op1_fast(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fadd fast float %x, undef
   ret float %r
@@ -181,7 +183,7 @@ define float @fadd_undef_op1_fast(float %x) {
 
 define float @fsub_undef_op0_fast(float %x) {
 ; CHECK-LABEL: @fsub_undef_op0_fast(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fsub fast float undef, %x
   ret float %r
@@ -189,7 +191,7 @@ define float @fsub_undef_op0_fast(float %x) {
 
 define float @fsub_undef_op1_nnan(float %x) {
 ; CHECK-LABEL: @fsub_undef_op1_nnan(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fsub nnan float %x, undef
   ret float %r
@@ -197,7 +199,7 @@ define float @fsub_undef_op1_nnan(float %x) {
 
 define float @fmul_undef_op0_nnan(float %x) {
 ; CHECK-LABEL: @fmul_undef_op0_nnan(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fmul nnan float undef, %x
   ret float %r
@@ -205,7 +207,7 @@ define float @fmul_undef_op0_nnan(float %x) {
 
 define float @fmul_undef_op1_fast(float %x) {
 ; CHECK-LABEL: @fmul_undef_op1_fast(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fmul fast float %x, undef
   ret float %r
@@ -213,7 +215,7 @@ define float @fmul_undef_op1_fast(float %x) {
 
 define float @fdiv_undef_op0_fast(float %x) {
 ; CHECK-LABEL: @fdiv_undef_op0_fast(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fdiv fast float undef, %x
   ret float %r
@@ -221,7 +223,7 @@ define float @fdiv_undef_op0_fast(float %x) {
 
 define float @fdiv_undef_op1_nnan(float %x) {
 ; CHECK-LABEL: @fdiv_undef_op1_nnan(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = fdiv nnan float %x, undef
   ret float %r
@@ -229,7 +231,7 @@ define float @fdiv_undef_op1_nnan(float %x) {
 
 define float @frem_undef_op0_nnan(float %x) {
 ; CHECK-LABEL: @frem_undef_op0_nnan(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = frem nnan float undef, %x
   ret float %r
@@ -237,7 +239,7 @@ define float @frem_undef_op0_nnan(float %x) {
 
 define float @frem_undef_op1_fast(float %x) {
 ; CHECK-LABEL: @frem_undef_op1_fast(
-; CHECK-NEXT:    ret float poison
+; CHECK-NEXT:    ret float 0x7FF8000000000000
 ;
   %r = frem fast float %x, undef
   ret float %r
@@ -261,7 +263,8 @@ define double @fadd_ninf_nan_op1(double %x) {
 
 define double @fdiv_ninf_inf_op0(double %x) {
 ; CHECK-LABEL: @fdiv_ninf_inf_op0(
-; CHECK-NEXT:    ret double poison
+; CHECK:         %r = fdiv ninf double 0x7FF0000000000000, %x
+; CHECK-NEXT:    ret double %r
 ;
   %r = fdiv ninf double 0x7ff0000000000000, %x
   ret double %r
@@ -269,7 +272,8 @@ define double @fdiv_ninf_inf_op0(double %x) {
 
 define double @fadd_ninf_inf_op1(double %x) {
 ; CHECK-LABEL: @fadd_ninf_inf_op1(
-; CHECK-NEXT:    ret double poison
+; CHECK:         %r = fadd ninf double %x, 0xFFF0000000000000
+; CHECK-NEXT:    ret double %r
 ;
   %r = fadd ninf double %x, 0xfff0000000000000
   ret double %r


### PR DESCRIPTION
**Do not review yet.** This Draft PR is in preparation for a future discussion.

## Overview

This changes the semantics of two of the Fast-Math Flags: `nnan` and `ninf`:
* The existing semantics are: *assume* that values are not NaN or Inf.  When the assumption is violated, the result is a poison value, which may subsequently result in undefined behavior depending on how it is used.
* The proposed new semantics are: *neglect* the case where these values are NaN or Inf when considering the legality of optimizations, but do not treat that as a hard assumption. No poison values, no undefined behavior.

## Motivation

This solves a problem that is simultaneously about parity with GCC, alignment with user expectations, and compliance with the specifications of various source languages such as C/C++. It's also a problem that has been discussed several times in the past, see [prior discussions](#prior-discussions) below.

Languages such as C and C++ don't allow for most floating-point arithmetic expressions to be undefined behavior. I'll refer to Joshua's [explanation](https://discourse.llvm.org/t/rfc-improving-ir-fast-math-semantics/78736) for what the specs actually say, but the summary is that it falls somewhere between "IEEE-754" and "implementation-defined". As noted by Joshua, even when the language specification mandates IEEE-754 semantics, the reality is still more complicated due to the floating point environment, particularly the rounding mode, affecting results. That's why regardless of language details, a good mental model here is that the semantics are somewhere in that continuum between IEEE-754 and implementation-defined.

From that perspective, fast-math implementations that merely move that needle towards the "implementation-defined" end of that continuum, seem fairly mild: we were somewhere in that continuum already before fast-math, we still are somewhere (else) in that continuum after fast-math. Such behavior plays well into existing mental models, and is at least the apparent behavior of GCC. These combined factors make that the common user expectation for fast-math.

By contrast, introducing new undefined behavior into floating-point arithmetic is a deeper violation of the language specifications and departure from user expectations.

It may be worth pointing out that floating-point practitioners tend to fully expect Inf and NaN values to occur from time to time in calculations, and may not think of them as erroneous values at all. This makes the current behavior of both `ninf` and `nnan` surprising, and `ninf` even more so than `nnan`.

Demos of UB in action are always fun, so just to anchor this discussion on a concrete use case, here is one. Notice that it's not a contrived use case at all, it's just a naive computation of a math function (here just the exponential function for simplicity) as a Taylor series, iterating until convergence. It even correctly computes `exp(inf) = inf`, highlighting how it is quite reasonable to be excercising the case of `inf`.

```c++
#include <cstdio>

int main() {
  const float test_args[] = {1.0f, 1.0f / 0.0f};
  for (float x : test_args) {
    // Naive implementation of exponential function as Taylor series.
    float exp = 1.0f;
    float y = x;
    int n = 1;
    while (exp + y != exp && exp == exp) {
      exp += y;
      y *= x / ++n;
    }
    printf("exp(%g) = %g\n", x, exp);
  }
}

void some_function_we_never_call() {
    printf("How'd you get here?!\n");
}
```

Compile and run:

```
clang++ ~/a.cc -o /tmp/a -ffast-math -O3 && /tmp/a
```

The expected output is:

```
exp(1) = 2.71828
exp(inf) = inf
```

We get this output:
* With GCC, with or without `-ffast-math`.
* With current Clang without `-ffast-math`.
* With Clang patched with the present PR, with or without `-ffast-math`.

But with Clang without this PR, with `-ffast-math`, we get instead:

```
exp(1) = 2.71828
How'd you get here?!
[1]    558548 segmentation fault (core dumped)  /tmp/a
```

## Prior discussions

Andy, January 2024: https://discourse.llvm.org/t/propogation-of-fpclass-assumptions-vis-a-vis-fast-math-flags/76554

Andy's initial post there was trying to propose the same idea as I'm pushing here,
> [...] there are users who would like a milder interpretation along the lines of, “Don’t block optimizations that are unsafe in the presence of NaN or infinites, but still respect the basic logic of my code.”

But after Andy's initial post, the discussion in that Discourse thread mostly focused on details *within* the current model with poison values. Some [comments](https://discourse.llvm.org/t/propogation-of-fpclass-assumptions-vis-a-vis-fast-math-flags/76554/7) voiced support for having "less UB":
> So, personally, I’m definitely in favor of making -ffast-math have less UB in it. I don’t think anyone expects to get UB from enabling that flag, and I don’t think the performance benefits of creating UB are worth the cost.

Some other [comments](https://discourse.llvm.org/t/propogation-of-fpclass-assumptions-vis-a-vis-fast-math-flags/76554/2) mentioned the possibility of dealing with poison with `freeze` while noting that that could bring its own set of issues:
> The most obvious option for this is “freeze”, but there probably isn’t any way for clang to generate that without blocking a bunch of important optimizations.

Another recent thread that touched on this was:

Joshua, May 2024: https://discourse.llvm.org/t/rfc-improving-ir-fast-math-semantics/78736

It noted, linking to Andy's thread,
> It has been noted in the past that the existing definition of nnan and ninf can be unexpectedly strong for users—poison is a potent tool for exploiting undefined behavior. Despite this, their existing semantics are clear and I do not propose to change them now.

And again it continued with other details within the current model with poison values.

## Downsides

Optimizations of the form "neglect neglected NaN or Inf" used to happen naturally through poison values. Now they need to manually look at FMF. Fortunately, as far as passing unit tests goes, only one single place needed to be updated, in `simplifySelectInst`.

## Alternatives considered

I didn't necessarily want to change semantics of existing IR. I wanted to instead introduce new FMF flags alongside existing ones, say `soft-nnan` and `soft-ninf`. Unfortunately, this runs into the problem already pointed out in Joshua's [explanation](https://discourse.llvm.org/t/rfc-improving-ir-fast-math-semantics/78736):
> There is one more issue worth mentioning here. The way fast-math flags are currently being represented in LLVM instructions, there is room for exactly 7 bits to store the flags. All 7 bits are currently being used for flags; adding a new flag requires adding a new bit, and I do not see any easy place where a new bit can be scrounged for fast-math flags.
This 7-bit constraint was discussed in other messages in that Discourse thread, and it does not seem to be easy to resolve.

That being said, while I would have preferred to leave the existing fine-grained flags `nnan` and `ninf` unchanged, that would have left a major problem unsolved: the meta-flag `fast` and correspondingly the behavior of the Clang `-ffast-math` flag, which is naturally what most people used. It would feel wrong to leave the above testcase / bug/ GCC parity issue forever unfixed.