### PR TITLE
[lldb][TypeSystemClang] Set access specifier for EnumConstantDecl's

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -8594,6 +8594,7 @@ clang::EnumConstantDecl *TypeSystemClang::AddEnumerationValueToEnumerationType(
     enumerator_decl->setDeclName(&getASTContext().Idents.get(name));
   enumerator_decl->setType(clang::QualType(enutype, 0));
   enumerator_decl->setInitVal(getASTContext(), value);
+  enumerator_decl->setAccess(AS_public);
   SetMemberOwningModule(enumerator_decl, enum_decl);
 
   if (!enumerator_decl)


### PR DESCRIPTION
LLDB was already setting the access specifier on `EnumDecl`s unconditionally to `AS_public`. But it wasn't doing so for the `EnumConstantDecl`s. This triggered a Clang assertion during auto-completion of expressions (https://github.com/llvm/llvm-project/issues/171913).

Ideally the code-completion accessibility check would honor the `AccessControl` language option, but that change is harder to test/justify. Since this is a pretty straight-forward change I want to land this before trying to do that.

There is no test coverage for this because it relies on the order in which Clang decides to check the decls in scope for auto-completion, which seems fragile. It's also consistent with how we handle access to other decls in `TypeSystemClang`.

Fixes https://github.com/llvm/llvm-project/issues/171913