### PR TITLE
[lldb] Fix null pointer dereference in parsed command completion

### DIFF
--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -2037,7 +2037,8 @@ public:
     // option_element_vector:
 
     Options *options = GetOptions();
-    auto defs = options->GetDefinitions();
+    auto defs = options ? options->GetDefinitions()
+                        : llvm::ArrayRef<OptionDefinition>();
 
     std::unordered_set<size_t> option_slots;
     for (const auto &elem : option_vec) {

--- a/lldb/test/API/commands/command/script/add/TestAddParsedCommand.py
+++ b/lldb/test/API/commands/command/script/add/TestAddParsedCommand.py
@@ -305,6 +305,13 @@ class ParsedCommandTestCase(TestBase):
         matches.AppendList(["answer ", "correct_answer"], 2)
         self.handle_completion(cmd_str, 1, matches, descriptions, False)
 
+        # Test completion for a command with arguments but NO options:
+        cmd_str = "one-arg-no-opt nonexistent_file_xyz"
+        matches.Clear()
+        descriptions.Clear()
+        matches.AppendString("")
+        self.handle_completion(cmd_str, 0, matches, descriptions, False)
+
         # Now make sure get_repeat_command works properly:
 
         # no-args turns off auto-repeat


### PR DESCRIPTION
Fix a crash when tab-completing arguments for parsed commands that have arguments but no options.

In `HandleArgumentCompletion`, `GetOptions()` returns `nullptr` when a command has no options defined. The code was dereferencing this pointer without a null check, causing a segfault when attempting tab completion.