### PR TITLE
[flang] Fix bad attributes on type parameter symbols

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -6534,6 +6534,9 @@ void DeclarationVisitor::Post(const parser::DerivedTypeStmt &x) {
   if (!paramNames.empty()) {
     set_inPDTDefinition(true);
   }
+  // Clear the attributes so that the attributes of the derived type
+  // (ABSTRACT, PUBLIC/PRIVATE, &c.) don't apply to the type's parameters.
+  EndAttrs(), BeginAttrs();
   if (auto *details{symbol.detailsIf<DerivedTypeDetails>()}) {
     for (const auto &name : paramNames) {
       if (Symbol * symbol{MakeTypeSymbol(name, TypeParamDetails{})}) {

--- a/flang/test/Semantics/bug174859.f90
+++ b/flang/test/Semantics/bug174859.f90
@@ -1,0 +1,14 @@
+! RUN: %python %S/test_modfile.py %s %flang_fc1
+! Attributes of the derived type were also applied to type parameters.
+module m
+  type, abstract, public :: t(k)
+    integer, kind :: k
+  end type
+end
+
+!Expect: m.mod
+!module m
+!type,abstract::t(k)
+!integer(4),kind::k
+!end type
+!end


### PR DESCRIPTION
When creating new symbols for a derived type's type parameters, the attributes that accumulated for the type itself were also being applied to the parameters' symbols.  This led to those attributes being emitted to the module file, rendering it unparseable.

Fixes https://github.com/llvm/llvm-project/issues/174859.