### PR TITLE
[mlir][Bytecode] Fix infinite loop by tracking type/attribute in deferred worklist

### DIFF
--- a/mlir/test/Bytecode/op_with_properties_deeply_nested_attr.mlir
+++ b/mlir/test/Bytecode/op_with_properties_deeply_nested_attr.mlir
@@ -9,6 +9,6 @@ func.func @deeply_nested_attribute() -> i32 {
 // Make sure bytecode reader doesn't get stuck in an infinite loop when
 // parsing a specific deeply nested attribute structure.
 func.func @deeply_nested_infinite_loop() -> i32 {
-  %0 = "test.constant"() {value = [[[[[[1]]]]]]} : () -> i32
+  %0 = "test.constant"() {value = [[[[[[1 : i64]]]]]]} : () -> i32
   return %0 : i32
 }

--- a/mlir/test/Bytecode/op_with_properties_deeply_nested_attr.mlir
+++ b/mlir/test/Bytecode/op_with_properties_deeply_nested_attr.mlir
@@ -1,6 +1,14 @@
-// RUN: mlir-opt %s  --verify-roundtrip
+// RUN: mlir-opt %s --verify-roundtrip  --split-input-file
 
 func.func @deeply_nested_attribute() -> i32 {
   %0 = "test.constant"() {value = [[[[[[[[[[[[1]]]]]]]]]]]]} : () -> i32
+  return %0 : i32
+}
+
+// -----
+// Make sure bytecode reader doesn't get stuck in an infinite loop when
+// parsing a specific deeply nested attribute structure.
+func.func @deeply_nested_infinite_loop() -> i32 {
+  %0 = "test.constant"() {value = [[[[[[1]]]]]]} : () -> i32
   return %0 : i32
 }


### PR DESCRIPTION
The bytecode reader could enter an infinite loop when parsing deeply nested attributes containing type references. The deferred worklist stored only indices without distinguishing between attributes and types, causing type indexes to be misinterpreted as attributes.

This patch changes the deferred worklist to store pairs of (index, kind) to track whether each deferred entry is a type or attribute. The worklist processing logic is updated to resolve the correct entry type.

https://github.com/llvm/llvm-project/pull/170993#issuecomment-3717224879 is the context.