### PR TITLE
[clang-doc] Add protected members to class template

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -657,7 +657,7 @@ static void serializeInfo(const RecordInfo &I, json::Object &Obj,
     if (!PubMembersArrayRef.empty())
       insertArray(Obj, PublicMembersArray, "PublicMembers");
     if (!ProtMembersArrayRef.empty())
-      Obj["ProtectedMembers"] = ProtectedMembersArray;
+      insertArray(Obj, ProtectedMembersArray, "ProtectedMembers");
     if (!PrivateMembersArrayRef.empty())
       insertArray(Obj, PrivateMembersArray, "PrivateMembers");
   }

--- a/clang-tools-extra/clang-doc/assets/class-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/class-template.mustache
@@ -31,22 +31,22 @@
                         </details>
                     </li>
                     {{/HasPublicMembers}}
-                    {{#ProtectedMembers}}
+                    {{#HasProtectedMembers}}
                     <li>
                         <details open>
                             <summary class="sidebar-section">
-                                <a class="sidebar-item" href="#PublicMethods">Protected Members</a>
+                                <a class="sidebar-item" href="#ProtectedMembers">Protected Members</a>
                             </summary>
                             <ul>
-                                {{#Obj}}
+                                {{#ProtectedMembers}}
                                 <li class="sidebar-item-container">
                                     <a class="sidebar-item" href="#{{Name}}">{{Name}}</a>
                                 </li>
-                                {{/Obj}}
+                                {{/ProtectedMembers}}
                             </ul>
                         </details>
                     </li>
-                    {{/ProtectedMembers}}
+                    {{/HasProtectedMembers}}
                     {{#HasPublicFunctions}}
                     <li>
                         <details open>
@@ -178,23 +178,18 @@
                     </div>
                 </section>
                 {{/HasPublicMembers}}
-                {{#ProtectedMembers}}
+                {{#HasProtectedMembers}}
                 <section id="ProtectedMembers" class="section-container">
                     <h2>Protected Members</h2>
                     <div>
-                        {{#Obj}}
+                        {{#ProtectedMembers}}
                         <div id="{{Name}}" class="delimiter-container">
                             <pre><code class="language-cpp code-clang-doc" >{{#IsStatic}}static {{/IsStatic}}{{Type}} {{Name}}</code></pre>
-                            {{#MemberComments}}
-                            <div>
-                                {{>Comments}}
-                            </div>
-                            {{/MemberComments}}
                         </div>
-                        {{/Obj}}
+                        {{/ProtectedMembers}}
                     </div>
                 </section>
-                {{/ProtectedMembers}}
+                {{/HasProtectedMembers}}
                 {{#HasPublicFunctions}}
                 <section id="PublicMethods" class="section-container">
                     <h2>Public Methods</h2>

--- a/clang-tools-extra/test/clang-doc/json/class.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class.cpp
@@ -170,6 +170,7 @@ private:
 // CHECK-NEXT:    "HasEnums": true,
 // CHECK-NEXT:    "HasFriends": true,
 // CHECK-NEXT:    "HasPrivateMembers": true,
+// CHECK-NEXT:    "HasProtectedMembers": true,
 // CHECK-NEXT:    "HasPublicFunctions": true,
 // CHECK-NEXT:    "HasPublicMembers": true,
 // CHECK-NEXT:    "HasRecords": true,
@@ -320,6 +321,14 @@ private:
 // HTML-NEXT:         </li>
 // HTML-NEXT:     </ul>
 // HTML-NEXT: </details>
+// HTML:      <section id="ProtectedMembers" class="section-container">
+// HTML-NEXT:     <h2>Protected Members</h2>
+// HTML-NEXT:     <div>
+// HTML-NEXT:         <div id="ProtectedField" class="delimiter-container">
+// HTML-NEXT:             <pre><code class="language-cpp code-clang-doc" >int ProtectedField</code></pre>
+// HTML-NEXT:         </div>
+// HTML-NEXT:     </div>
+// HTML-NEXT: </section>
 // HTML:      <section id="Classes" class="section-container">
 // HTML-NEXT:     <h2>Inner Classes</h2>
 // HTML-NEXT:     <ul class="class-container">

--- a/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
@@ -117,6 +117,7 @@ TEST_F(JSONGeneratorTest, emitRecordJSON) {
   ],
   "HasEnums": true,
   "HasParents": true,
+  "HasProtectedMembers": true,
   "HasPublicFunctions": true,
   "HasRecords": true,
   "HasVirtualParents": true,


### PR DESCRIPTION
There were already tags for protected members in the Mustache template,
but didn't use the proper tags for the newer JSON scheme.