### PR TITLE
[clang-doc] Add protected methods to class template

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -628,7 +628,7 @@ static void serializeInfo(const RecordInfo &I, json::Object &Obj,
     if (!PubFunctionsArrayRef.empty())
       insertArray(Obj, PubFunctionsArray, "PublicFunctions");
     if (!ProtFunctionsArrayRef.empty())
-      Obj["ProtectedFunctions"] = ProtFunctionsArray;
+      insertArray(Obj, ProtFunctionsArray, "ProtectedFunctions");
   }
 
   if (!I.Members.empty()) {

--- a/clang-tools-extra/clang-doc/assets/class-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/class-template.mustache
@@ -63,22 +63,22 @@
                         </details>
                     </li>
                     {{/HasPublicFunctions}}
-                    {{#ProtectedFunction}}
+                    {{#HasProtectedFunctions}}
                     <li>
                         <details open>
                             <summary class="sidebar-section">
-                                <a class="sidebar-item" href="#ProtectedFunction">Protected Method</a>
+                                <a class="sidebar-item" href="#ProtectedMethods">Protected Methods</a>
                             </summary>
                             <ul>
-                                {{#Obj}}
+                                {{#ProtectedFunctions}}
                                 <li class="sidebar-item-container">
-                                    <a class="sidebar-item" href="#{{ID}}">{{Name}}</a>
+                                    <a class="sidebar-item" href="#{{USR}}">{{Name}}</a>
                                 </li>
-                                {{/Obj}}
+                                {{/ProtectedFunctions}}
                             </ul>
                         </details>
                     </li>
-                    {{/ProtectedFunction}}
+                    {{/HasProtectedFunctions}}
                     {{#HasEnums}}
                     <li>
                         <details open>
@@ -198,18 +198,16 @@
                     {{/PublicFunctions}}
                 </section>
                 {{/PublicFunctions}}
-                {{#ProtectedFunction}}
-                <li class="sidebar-section">
-                    <a class="sidebar-item" href="#ProtectedFunction">Protected Method</a>
-                </li>
-                <ul>
-                    {{#Obj}}
-                    <li class="sidebar-item-container">
-                        <a class="sidebar-item" href="#{{ID}}">{{Name}}</a>
-                    </li>
-                    {{/Obj}}
-                </ul>
-                {{/ProtectedFunction}}
+                {{#HasProtectedFunctions}}
+                <section id="ProtectedMethods" class="section-container">
+                    <h2>Protected Methods</h2>
+                    <div>
+                        {{#ProtectedFunctions}}
+                        {{>FunctionPartial}}
+                        {{/ProtectedFunctions}}
+                    </div>
+                </section>
+                {{/HasProtectedFunctions}}
                 {{#HasEnums}}
                 <section id="Enums" class="section-container">
                     <h2>Enumerations</h2>

--- a/clang-tools-extra/test/clang-doc/json/class.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class.cpp
@@ -170,6 +170,7 @@ private:
 // CHECK-NEXT:    "HasEnums": true,
 // CHECK-NEXT:    "HasFriends": true,
 // CHECK-NEXT:    "HasPrivateMembers": true,
+// CHECK-NEXT:    "HasProtectedFunctions": true,
 // CHECK-NEXT:    "HasProtectedMembers": true,
 // CHECK-NEXT:    "HasPublicFunctions": true,
 // CHECK-NEXT:    "HasPublicMembers": true,
@@ -326,6 +327,15 @@ private:
 // HTML-NEXT:     <div>
 // HTML-NEXT:         <div id="ProtectedField" class="delimiter-container">
 // HTML-NEXT:             <pre><code class="language-cpp code-clang-doc" >int ProtectedField</code></pre>
+// HTML-NEXT:         </div>
+// HTML-NEXT:     </div>
+// HTML-NEXT: </section>
+// HTML:      <section id="ProtectedMethods" class="section-container">
+// HTML-NEXT:     <h2>Protected Methods</h2>
+// HTML-NEXT:     <div>
+// HTML-NEXT:         <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
+// HTML-NEXT:                 <pre><code class="language-cpp code-clang-doc">int protectedMethod ()</code></pre>
+// HTML-NEXT:                 <p>Defined at line  of file </p>
 // HTML-NEXT:         </div>
 // HTML-NEXT:     </div>
 // HTML-NEXT: </section>


### PR DESCRIPTION
Protected method tags already existed in the class template, but they didn't conform to the current JSON scheme.