### PR TITLE
[lldb] Automatic indexing for synthetic children of collections

### DIFF
--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -315,19 +315,6 @@ PyObject *lldb_private::python::SWIGBridge::LLDBSwigPython_GetChildAtIndex(PyObj
   return result.release();
 }
 
-static uint32_t ParseIndex(PyObject *implementor, llvm::StringRef name) {
-  unsigned long long retval;
-  if (name.consume_front("[") && !name.consumeInteger(10, retval) && name == "]") {
-    // Lazily calculate the number of children (capped to one past the given index).
-    uint32_t max = retval + 1;
-    size_t num_children =
-      lldb_private::python::SWIGBridge::LLDBSwigPython_CalculateNumChildren(implementor, max);
-    if (retval < num_children)
-      return (uint32_t)retval;
-  }
-  return UINT32_MAX;
-}
-
 uint32_t lldb_private::python::SWIGBridge::LLDBSwigPython_GetIndexOfChildWithName(
     PyObject * implementor, const char *child_name) {
   PyErr_Cleaner py_err_cleaner(true);
@@ -336,7 +323,7 @@ uint32_t lldb_private::python::SWIGBridge::LLDBSwigPython_GetIndexOfChildWithNam
   auto pfunc = self.ResolveName<PythonCallable>("get_child_index");
 
   if (!pfunc.IsAllocated())
-    return ParseIndex(implementor, child_name);
+    return UINT32_MAX;
 
   llvm::Expected<PythonObject> result = pfunc.Call(PythonString(child_name));
 
@@ -345,7 +332,7 @@ uint32_t lldb_private::python::SWIGBridge::LLDBSwigPython_GetIndexOfChildWithNam
 
   if (PyErr_Occurred()) {
     PyErr_Clear(); // FIXME print this? do something else
-    return ParseIndex(implementor, child_name);
+    return UINT32_MAX;
   }
 
   if (retval >= 0)

--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -315,6 +315,19 @@ PyObject *lldb_private::python::SWIGBridge::LLDBSwigPython_GetChildAtIndex(PyObj
   return result.release();
 }
 
+static uint32_t ParseIndex(PyObject *implementor, llvm::StringRef name) {
+  unsigned long long retval;
+  if (name.consume_front("[") && !name.consumeInteger(10, retval) && name == "]") {
+    // Lazily calculate the number of children (capped to one past the given index).
+    uint32_t max = retval + 1;
+    size_t num_children =
+      lldb_private::python::SWIGBridge::LLDBSwigPython_CalculateNumChildren(implementor, max);
+    if (retval < num_children)
+      return (uint32_t)retval;
+  }
+  return UINT32_MAX;
+}
+
 uint32_t lldb_private::python::SWIGBridge::LLDBSwigPython_GetIndexOfChildWithName(
     PyObject * implementor, const char *child_name) {
   PyErr_Cleaner py_err_cleaner(true);
@@ -323,7 +336,7 @@ uint32_t lldb_private::python::SWIGBridge::LLDBSwigPython_GetIndexOfChildWithNam
   auto pfunc = self.ResolveName<PythonCallable>("get_child_index");
 
   if (!pfunc.IsAllocated())
-    return UINT32_MAX;
+    return ParseIndex(implementor, child_name);
 
   llvm::Expected<PythonObject> result = pfunc.Call(PythonString(child_name));
 
@@ -332,7 +345,7 @@ uint32_t lldb_private::python::SWIGBridge::LLDBSwigPython_GetIndexOfChildWithNam
 
   if (PyErr_Occurred()) {
     PyErr_Clear(); // FIXME print this? do something else
-    return UINT32_MAX;
+    return ParseIndex(implementor, child_name);
   }
 
   if (retval >= 0)

--- a/lldb/docs/use/variable.rst
+++ b/lldb/docs/use/variable.rst
@@ -958,7 +958,8 @@ be implemented by the Python class):
       def get_child_index(self, name: str) -> int:
          """
          This call should return the index of the synthetic child whose name is
-         given as the argument.
+         given as the argument. Array subscripting, names in the form "[N]", is
+         automatically supported.
          Return -1 if there is no child at the index.
          """
 

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -47,7 +47,10 @@ public:
 
   virtual lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) = 0;
 
-  virtual llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) = 0;
+  virtual llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) {
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  }
 
   /// This function is assumed to always succeed and if it fails, the front-end
   /// should know to deal with it in the correct way (most probably, by refusing

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -47,6 +47,10 @@ public:
 
   virtual lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) = 0;
 
+  /// Determine the index of a named child. Subscript names ("[N]") are, by
+  /// default, handled automatically. For data types which need custom
+  /// subscripting behavior - for example a sparse array, disable automatic
+  /// subscripting with TypeOptions::eTypeOptionCustomSubscripting.
   virtual llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) {
     return llvm::createStringError("Type has no child named '%s'",
                                    name.AsCString());

--- a/lldb/include/lldb/DataFormatters/TypeSynthetic.h
+++ b/lldb/include/lldb/DataFormatters/TypeSynthetic.h
@@ -226,6 +226,18 @@ public:
       return *this;
     }
 
+    bool GetCustomSubscripting() const {
+      return m_flags & lldb::eTypeOptionCustomSubscripting;
+    }
+
+    Flags &SetCustomSubscripting(bool value = true) {
+      if (value)
+        m_flags |= lldb::eTypeOptionCustomSubscripting;
+      else
+        m_flags &= ~lldb::eTypeOptionCustomSubscripting;
+      return *this;
+    }
+
     uint32_t GetValue() { return m_flags; }
 
     void SetValue(uint32_t value) { m_flags = value; }
@@ -247,6 +259,8 @@ public:
   bool NonCacheable() const { return m_flags.GetNonCacheable(); }
 
   bool WantsDereference() const { return m_flags.GetFrontEndWantsDereference();}
+
+  bool CustomSubscripting() const { return m_flags.GetCustomSubscripting(); }
 
   void SetCascades(bool value) { m_flags.SetCascades(value); }
 

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -926,7 +926,8 @@ FLAGS_ENUM(TypeOptions){eTypeOptionNone = (0u),
                         eTypeOptionHideNames = (1u << 6),
                         eTypeOptionNonCacheable = (1u << 7),
                         eTypeOptionHideEmptyAggregates = (1u << 8),
-                        eTypeOptionFrontEndWantsDereference = (1u << 9)};
+                        eTypeOptionFrontEndWantsDereference = (1u << 9),
+                        eTypeOptionCustomSubscripting = (1u << 10)};
 
 /// This is the return value for frame comparisons.  If you are comparing frame
 /// A to frame B the following cases arise:

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -271,19 +271,6 @@ public:
     return lldb::ChildCacheState::eRefetch;
   }
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto optional_idx = ExtractIndexFromString(name.AsCString());
-    if (!optional_idx) {
-      return llvm::createStringError("Type has no child named '%s'",
-                                     name.AsCString());
-    }
-    uint32_t idx = *optional_idx;
-    if (idx >= CalculateNumChildrenIgnoringErrors())
-      return llvm::createStringError("Type has no child named '%s'",
-                                     name.AsCString());
-    return idx;
-  }
-
 private:
   lldb::Format m_parent_format = eFormatInvalid;
   lldb::Format m_item_format = eFormatInvalid;

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
@@ -28,15 +28,6 @@ public:
 
   GenericBitsetFrontEnd(ValueObject &valobj, StdLib stdlib);
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (!optional_idx) {
-      return llvm::createStringError("Type has no child named '%s'",
-                                     name.AsCString());
-    }
-    return *optional_idx;
-  }
-
   lldb::ChildCacheState Update() override;
   llvm::Expected<uint32_t> CalculateNumChildren() override {
     return m_elements.size();

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericList.cpp
@@ -124,14 +124,6 @@ private:
 template <StlType Stl>
 class AbstractListFrontEnd : public SyntheticChildrenFrontEnd {
 public:
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (!optional_idx) {
-      return llvm::createStringError("Type has no child named '%s'",
-                                     name.AsCString());
-    }
-    return *optional_idx;
-  }
   lldb::ChildCacheState Update() override;
 
 protected:

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
@@ -41,12 +41,8 @@ public:
   llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
     if (name == "$$dereference$$")
       return 0;
-    auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (!optional_idx) {
-      return llvm::createStringError("Type has no child named '%s'",
-                                     name.AsCString());
-    }
-    return *optional_idx;
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   }
 
   llvm::Expected<uint32_t> CalculateNumChildren() override {

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -197,8 +197,6 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
-
 private:
   llvm::Expected<uint32_t>
   CalculateNumChildrenForOldCompressedPairLayout(ValueObject &pair);
@@ -388,16 +386,6 @@ lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::Update() {
       m_tree->GetCompilerType().GetDirectNestedTypeWithName("__node_pointer");
 
   return lldb::ChildCacheState::eRefetch;
-}
-
-llvm::Expected<size_t> lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::
-    GetIndexOfChildWithName(ConstString name) {
-  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  return *optional_idx;
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
@@ -20,15 +20,6 @@ public:
     Update();
   }
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (!optional_idx) {
-      return llvm::createStringError("Type has no child named '%s'",
-                                     name.AsCString());
-    }
-    return *optional_idx;
-  }
-
   lldb::ChildCacheState Update() override;
   llvm::Expected<uint32_t> CalculateNumChildren() override {
     return m_elements.size();

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -40,8 +40,6 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
-
 private:
   CompilerType GetNodeType();
   CompilerType GetElementType(CompilerType table_type);
@@ -283,17 +281,6 @@ lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::Update() {
     m_next_element = m_tree;
 
   return lldb::ChildCacheState::eRefetch;
-}
-
-llvm::Expected<size_t>
-lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
-    GetIndexOfChildWithName(ConstString name) {
-  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  return *optional_idx;
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
@@ -202,15 +202,6 @@ public:
     Update();
   }
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (!optional_idx) {
-      return llvm::createStringError("Type has no child named '%s'",
-                                     name.AsCString());
-    }
-    return *optional_idx;
-  }
-
   lldb::ChildCacheState Update() override;
   llvm::Expected<uint32_t> CalculateNumChildren() override { return m_size; }
   ValueObjectSP GetChildAtIndex(uint32_t idx) override;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
@@ -32,8 +32,6 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
-
 private:
   // The lifetime of a ValueObject and all its derivative ValueObjects
   // (children, clones, etc.) is managed by a ClusterManager. These
@@ -96,16 +94,6 @@ LibStdcppTupleSyntheticFrontEnd::GetChildAtIndex(uint32_t idx) {
 llvm::Expected<uint32_t>
 LibStdcppTupleSyntheticFrontEnd::CalculateNumChildren() {
   return m_members.size();
-}
-
-llvm::Expected<size_t>
-LibStdcppTupleSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  return *optional_idx;
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTree.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTree.cpp
@@ -187,8 +187,6 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
-
 private:
   /// Returns the ValueObject for the _Tree_node at index \ref idx.
   ///
@@ -333,17 +331,6 @@ lldb_private::formatters::MsvcStlTreeSyntheticFrontEnd::Update() {
   m_begin_node = m_tree->GetChildAtNamePath({"_Myhead", "_Left"}).get();
 
   return lldb::ChildCacheState::eRefetch;
-}
-
-llvm::Expected<size_t>
-lldb_private::formatters::MsvcStlTreeSyntheticFrontEnd::GetIndexOfChildWithName(
-    ConstString name) {
-  auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  return *optional_idx;
 }
 
 lldb::ChildCacheState MsvcStlTreeIterSyntheticFrontEnd::Update() {

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTuple.cpp
@@ -20,15 +20,6 @@ public:
     Update();
   }
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (!optional_idx) {
-      return llvm::createStringError("Type has no child named '%s'",
-                                     name.AsCString());
-    }
-    return *optional_idx;
-  }
-
   lldb::ChildCacheState Update() override;
   llvm::Expected<uint32_t> CalculateNumChildren() override {
     return m_elements.size();

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVariant.cpp
@@ -147,15 +147,6 @@ public:
     Update();
   }
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto optional_idx = formatters::ExtractIndexFromString(name.GetCString());
-    if (!optional_idx) {
-      return llvm::createStringError("Type has no child named '%s'",
-                                     name.AsCString());
-    }
-    return *optional_idx;
-  }
-
   lldb::ChildCacheState Update() override;
   llvm::Expected<uint32_t> CalculateNumChildren() override { return m_size; }
   ValueObjectSP GetChildAtIndex(uint32_t idx) override;

--- a/lldb/source/Plugins/Language/ObjC/NSArray.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSArray.cpp
@@ -56,8 +56,6 @@ public:
 
   lldb::ChildCacheState Update() override = 0;
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
-
 protected:
   virtual lldb::addr_t GetDataAddress() = 0;
 
@@ -217,8 +215,6 @@ public:
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
 
   lldb::ChildCacheState Update() override;
-
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   ExecutionContextRef m_exe_ctx_ref;
@@ -526,20 +522,6 @@ lldb_private::formatters::GenericNSArrayMSyntheticFrontEnd<D32, D64>::Update() {
                          : lldb::ChildCacheState::eRefetch;
 }
 
-llvm::Expected<size_t> lldb_private::formatters::NSArrayMSyntheticFrontEndBase::
-    GetIndexOfChildWithName(ConstString name) {
-  auto optional_idx = ExtractIndexFromString(name.AsCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  return idx;
-}
-
 template <typename D32, typename D64>
 lldb_private::formatters::GenericNSArrayMSyntheticFrontEnd<D32, D64>::
     GenericNSArrayMSyntheticFrontEnd::~GenericNSArrayMSyntheticFrontEnd() {
@@ -613,22 +595,6 @@ lldb_private::formatters::GenericNSArrayISyntheticFrontEnd<D32, D64, Inline>::
   m_data_32 = nullptr;
   delete m_data_64;
   m_data_64 = nullptr;
-}
-
-template <typename D32, typename D64, bool Inline>
-llvm::Expected<size_t>
-lldb_private::formatters::GenericNSArrayISyntheticFrontEnd<
-    D32, D64, Inline>::GetIndexOfChildWithName(ConstString name) {
-  auto optional_idx = ExtractIndexFromString(name.AsCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  return idx;
 }
 
 template <typename D32, typename D64, bool Inline>

--- a/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSDictionary.cpp
@@ -109,8 +109,6 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
-
 private:
   struct DataDescriptor_32 {
     uint32_t _used : 26;
@@ -148,8 +146,6 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
-
 private:
   ExecutionContextRef m_exe_ctx_ref;
   CompilerType m_pair_type;
@@ -177,8 +173,6 @@ public:
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
 
   lldb::ChildCacheState Update() override;
-
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   struct DictionaryItemDescriptor {
@@ -228,8 +222,6 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
-
 private:
   struct DictionaryItemDescriptor {
     lldb::addr_t key_ptr;
@@ -258,8 +250,6 @@ namespace Foundation1100 {
     lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
 
     lldb::ChildCacheState Update() override;
-
-    llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
   private:
     struct DataDescriptor_32 {
@@ -585,20 +575,6 @@ lldb_private::formatters::NSDictionaryISyntheticFrontEnd::
   m_data_64 = nullptr;
 }
 
-llvm::Expected<size_t> lldb_private::formatters::
-    NSDictionaryISyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  auto optional_idx = ExtractIndexFromString(name.AsCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  return idx;
-}
-
 llvm::Expected<uint32_t> lldb_private::formatters::
     NSDictionaryISyntheticFrontEnd::CalculateNumChildren() {
   if (!m_data_32 && !m_data_64)
@@ -723,20 +699,6 @@ lldb_private::formatters::NSCFDictionarySyntheticFrontEnd::
     : SyntheticChildrenFrontEnd(*valobj_sp), m_exe_ctx_ref(), m_hashtable(),
       m_pair_type() {}
 
-llvm::Expected<size_t> lldb_private::formatters::
-    NSCFDictionarySyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  auto optional_idx = ExtractIndexFromString(name.AsCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  return idx;
-}
-
 llvm::Expected<uint32_t> lldb_private::formatters::
     NSCFDictionarySyntheticFrontEnd::CalculateNumChildren() {
   if (!m_hashtable.IsValid())
@@ -858,21 +820,6 @@ lldb_private::formatters::NSCFDictionarySyntheticFrontEnd::GetChildAtIndex(
 lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
     NSConstantDictionarySyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
     : SyntheticChildrenFrontEnd(*valobj_sp) {}
-
-llvm::Expected<size_t>
-lldb_private::formatters::NSConstantDictionarySyntheticFrontEnd::
-    GetIndexOfChildWithName(ConstString name) {
-  auto optional_idx = ExtractIndexFromString(name.AsCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  return idx;
-}
 
 llvm::Expected<uint32_t> lldb_private::formatters::
     NSConstantDictionarySyntheticFrontEnd::CalculateNumChildren() {
@@ -1064,22 +1011,6 @@ lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
 }
 
 template <typename D32, typename D64>
-llvm::Expected<size_t>
-lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
-    D32, D64>::GetIndexOfChildWithName(ConstString name) {
-  auto optional_idx = ExtractIndexFromString(name.AsCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  return idx;
-}
-
-template <typename D32, typename D64>
 llvm::Expected<uint32_t>
 lldb_private::formatters::GenericNSDictionaryMSyntheticFrontEnd<
     D32, D64>::CalculateNumChildren() {
@@ -1225,20 +1156,6 @@ lldb_private::formatters::Foundation1100::
   m_data_32 = nullptr;
   delete m_data_64;
   m_data_64 = nullptr;
-}
-
-llvm::Expected<size_t> lldb_private::formatters::Foundation1100::
-    NSDictionaryMSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
-  auto optional_idx = ExtractIndexFromString(name.AsCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  return idx;
 }
 
 llvm::Expected<uint32_t> lldb_private::formatters::Foundation1100::

--- a/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSIndexPath.cpp
@@ -126,19 +126,6 @@ public:
 
   bool MightHaveChildren() override { return m_impl.m_mode != Mode::Invalid; }
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
-    auto optional_idx = ExtractIndexFromString(name.AsCString());
-    if (!optional_idx) {
-      return llvm::createStringError("Type has no child named '%s'",
-                                     name.AsCString());
-    }
-    uint32_t idx = *optional_idx;
-    if (idx >= CalculateNumChildrenIgnoringErrors())
-      return llvm::createStringError("Type has no child named '%s'",
-                                     name.AsCString());
-    return idx;
-  }
-
   lldb::ValueObjectSP GetSyntheticValue() override { return nullptr; }
 
 protected:

--- a/lldb/source/Plugins/Language/ObjC/NSSet.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSSet.cpp
@@ -52,8 +52,6 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
-
 private:
   struct DataDescriptor_32 {
     uint32_t _used : 26;
@@ -88,8 +86,6 @@ public:
 
   lldb::ChildCacheState Update() override;
 
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
-
 private:
   struct SetItemDescriptor {
     lldb::addr_t item_ptr;
@@ -118,8 +114,6 @@ public:
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
 
   lldb::ChildCacheState Update() override;
-
-  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
 
@@ -386,21 +380,6 @@ lldb_private::formatters::NSSetISyntheticFrontEnd::~NSSetISyntheticFrontEnd() {
   m_data_64 = nullptr;
 }
 
-llvm::Expected<size_t>
-lldb_private::formatters::NSSetISyntheticFrontEnd::GetIndexOfChildWithName(
-    ConstString name) {
-  auto optional_idx = ExtractIndexFromString(name.AsCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  return idx;
-}
-
 llvm::Expected<uint32_t>
 lldb_private::formatters::NSSetISyntheticFrontEnd::CalculateNumChildren() {
   if (!m_data_32 && !m_data_64)
@@ -521,21 +500,6 @@ lldb_private::formatters::NSCFSetSyntheticFrontEnd::NSCFSetSyntheticFrontEnd(
     lldb::ValueObjectSP valobj_sp)
     : SyntheticChildrenFrontEnd(*valobj_sp), m_exe_ctx_ref(), m_hashtable(),
       m_pair_type() {}
-
-llvm::Expected<size_t>
-lldb_private::formatters::NSCFSetSyntheticFrontEnd::GetIndexOfChildWithName(
-    ConstString name) {
-  auto optional_idx = ExtractIndexFromString(name.AsCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  return idx;
-}
 
 llvm::Expected<uint32_t>
 lldb_private::formatters::NSCFSetSyntheticFrontEnd::CalculateNumChildren() {
@@ -659,21 +623,6 @@ lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<D32, D64>::
   m_data_32 = nullptr;
   delete m_data_64;
   m_data_64 = nullptr;
-}
-
-template <typename D32, typename D64>
-llvm::Expected<size_t> lldb_private::formatters::GenericNSSetMSyntheticFrontEnd<
-    D32, D64>::GetIndexOfChildWithName(ConstString name) {
-  auto optional_idx = ExtractIndexFromString(name.AsCString());
-  if (!optional_idx) {
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  }
-  uint32_t idx = *optional_idx;
-  if (idx >= CalculateNumChildrenIgnoringErrors())
-    return llvm::createStringError("Type has no child named '%s'",
-                                   name.AsCString());
-  return idx;
 }
 
 template <typename D32, typename D64>

--- a/lldb/source/ValueObject/ValueObjectSynthetic.cpp
+++ b/lldb/source/ValueObject/ValueObjectSynthetic.cpp
@@ -366,10 +366,10 @@ ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
       index = *index_or_err;
     } else {
       // Provide automatic support for subscript child names ("[N]").
-      auto maybe_subscript = ParseSubscriptIndex(*this, name);
-      if (!maybe_subscript)
+      auto maybe_index = ParseSubscriptIndex(*this, name);
+      if (!maybe_index)
         return index_or_err.takeError();
-      index = *maybe_subscript;
+      index = *maybe_index;
       llvm::consumeError(index_or_err.takeError());
     }
     std::lock_guard<std::mutex> guard(m_child_mutex);

--- a/lldb/source/ValueObject/ValueObjectSynthetic.cpp
+++ b/lldb/source/ValueObject/ValueObjectSynthetic.cpp
@@ -356,16 +356,16 @@ ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
         // The child name was not of the form "[N]", return the original error.
         return index_or_err.takeError();
 
+      // Subscripting succeeded, ignore the original error.
+      llvm::consumeError(index_or_err.takeError());
       index = *maybe_index;
+
       // Prevent unnecessary work by limiting max to one past the index.
       uint32_t max = index + 1;
       auto num_children = GetNumChildrenIgnoringErrors(max);
       if (index >= num_children)
         return llvm::createStringError("Subscript index out of range: %zu",
                                        index);
-
-      // Subscripting succeeded, ignore the original error.
-      llvm::consumeError(index_or_err.takeError());
     }
     std::lock_guard<std::mutex> guard(m_child_mutex);
     m_name_toindex[name.GetCString()] = index;

--- a/lldb/source/ValueObject/ValueObjectSynthetic.cpp
+++ b/lldb/source/ValueObject/ValueObjectSynthetic.cpp
@@ -364,7 +364,7 @@ ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
     size_t index = SIZE_MAX;
     if (auto index_or_err = m_synth_filter_up->GetIndexOfChildWithName(name)) {
       index = *index_or_err;
-    } else {
+    } else if (!m_synth_sp->CustomSubscripting()) {
       // Provide automatic support for subscript child names ("[N]").
       auto maybe_index = ParseSubscriptIndex(*this, name);
       if (!maybe_index)

--- a/lldb/source/ValueObject/ValueObjectSynthetic.cpp
+++ b/lldb/source/ValueObject/ValueObjectSynthetic.cpp
@@ -331,21 +331,6 @@ ValueObjectSynthetic::GetChildMemberWithName(llvm::StringRef name,
   return GetChildAtIndex(*index_or_err, can_create);
 }
 
-static std::optional<uint32_t> ParseSubscriptIndex(ValueObjectSynthetic &valobj,
-                                                   llvm::StringRef name) {
-  auto maybe_index = formatters::ExtractIndexFromString(name.data());
-  if (!maybe_index)
-    return std::nullopt;
-
-  auto idx = *maybe_index;
-  // Prevent unnecessary work by limiting max to one past the index.
-  uint32_t max = idx + 1;
-  auto num_children = valobj.GetNumChildrenIgnoringErrors(max);
-  if (idx >= num_children)
-    return std::nullopt;
-  return idx;
-}
-
 llvm::Expected<size_t>
 ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
   UpdateValueIfNeeded();
@@ -366,10 +351,20 @@ ValueObjectSynthetic::GetIndexOfChildWithName(llvm::StringRef name_ref) {
       index = *index_or_err;
     } else if (!m_synth_sp->CustomSubscripting()) {
       // Provide automatic support for subscript child names ("[N]").
-      auto maybe_index = ParseSubscriptIndex(*this, name);
+      auto maybe_index = formatters::ExtractIndexFromString(name.GetCString());
       if (!maybe_index)
+        // The child name was not of the form "[N]", return the original error.
         return index_or_err.takeError();
+
       index = *maybe_index;
+      // Prevent unnecessary work by limiting max to one past the index.
+      uint32_t max = index + 1;
+      auto num_children = GetNumChildrenIgnoringErrors(max);
+      if (index >= num_children)
+        return llvm::createStringError("Subscript index out of range: %zu",
+                                       index);
+
+      // Subscripting succeeded, ignore the original error.
       llvm::consumeError(index_or_err.takeError());
     }
     std::lock_guard<std::mutex> guard(m_child_mutex);

--- a/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
@@ -96,7 +96,7 @@ class TestFrameVarDILArraySubscript(TestBase):
 
     def test_subscript_synthetic(self):
         self.build()
-        lldbutil.run_to_source_breakpoint(
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(
             self, "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
         )
 
@@ -115,3 +115,11 @@ class TestFrameVarDILArraySubscript(TestBase):
             "frame var 'ma_ptr[0]'",
             substrs=["(myArray) ma_ptr[0] = ([0] = 7, [1] = 8, [2] = 9, [3] = 10)"],
         )
+
+        frame = process.selected_thread.selected_frame
+        my_array = frame.var("ma")
+        for i in range(my_array.num_children):
+            idx = my_array.GetIndexOfChildWithName(f"[{i}]")
+            self.assertEqual(idx, i)
+        idx = my_array.GetIndexOfChildWithName(f"[{my_array.num_children + 1}]")
+        self.assertEqual(idx, lldb.UINT32_MAX)

--- a/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
@@ -96,7 +96,7 @@ class TestFrameVarDILArraySubscript(TestBase):
 
     def test_subscript_synthetic(self):
         self.build()
-        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+        lldbutil.run_to_source_breakpoint(
             self, "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
         )
 
@@ -115,11 +115,3 @@ class TestFrameVarDILArraySubscript(TestBase):
             "frame var 'ma_ptr[0]'",
             substrs=["(myArray) ma_ptr[0] = ([0] = 7, [1] = 8, [2] = 9, [3] = 10)"],
         )
-
-        frame = process.selected_thread.selected_frame
-        my_array = frame.var("ma")
-        for i in range(my_array.num_children):
-            idx = my_array.GetIndexOfChildWithName(f"[{i}]")
-            self.assertEqual(idx, i)
-        idx = my_array.GetIndexOfChildWithName(f"[{my_array.num_children + 1}]")
-        self.assertEqual(idx, lldb.UINT32_MAX)

--- a/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/myArraySynthProvider.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/myArraySynthProvider.py
@@ -20,3 +20,14 @@ class myArraySynthProvider:
         if index >= max_idx:
             return None
         return arr.GetChildAtIndex(index)
+
+    def get_child_index(self, name):
+        if name == "[0]":
+            return 0
+        if name == "[1]":
+            return 1
+        if name == "[2]":
+            return 2
+        if name == "[3]":
+            return 3
+        return -1

--- a/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/myArraySynthProvider.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/myArraySynthProvider.py
@@ -20,14 +20,3 @@ class myArraySynthProvider:
         if index >= max_idx:
             return None
         return arr.GetChildAtIndex(index)
-
-    def get_child_index(self, name):
-        if name == "[0]":
-            return 0
-        if name == "[1]":
-            return
-        if name == "[2]":
-            return 2
-        if name == "[3]":
-            return 3
-        return -1

--- a/lldb/test/API/functionalities/data-formatter/synthetic_subscript/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/synthetic_subscript/Makefile
@@ -1,0 +1,2 @@
+C_SOURCES := main.c
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/synthetic_subscript/TestSyntheticSubscript.py
+++ b/lldb/test/API/functionalities/data-formatter/synthetic_subscript/TestSyntheticSubscript.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        self.build()
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.c")
+        )
+        self.runCmd("command script import thing_formatter.py")
+        frame = process.selected_thread.selected_frame
+        x = frame.var("x")
+        names = ("zero", "one")
+        for i in range(x.num_children):
+            idx = x.GetIndexOfChildWithName(f"[{i}]")
+            self.assertEqual(idx, i)
+            child = x.GetChildAtIndex(idx)
+            self.assertEqual(child.name, names[idx])
+        idx = x.GetIndexOfChildWithName(f"[{x.num_children + 1}]")
+        self.assertEqual(idx, lldb.UINT32_MAX)

--- a/lldb/test/API/functionalities/data-formatter/synthetic_subscript/main.c
+++ b/lldb/test/API/functionalities/data-formatter/synthetic_subscript/main.c
@@ -1,0 +1,12 @@
+struct Thing {
+  int zero;
+  int one;
+};
+
+int main() {
+  struct Thing x;
+  x.zero = 1;
+  x.one = 2;
+  __builtin_printf("break here\n");
+  return 0;
+}

--- a/lldb/test/API/functionalities/data-formatter/synthetic_subscript/thing_formatter.py
+++ b/lldb/test/API/functionalities/data-formatter/synthetic_subscript/thing_formatter.py
@@ -1,0 +1,15 @@
+class ThingSynthetic:
+    def __init__(self, valobj, _) -> None:
+        self.valobj = valobj
+
+    def num_children(self):
+        return self.valobj.num_children
+
+    def get_child_at_index(self, idx):
+        return self.valobj.GetChildAtIndex(idx)
+
+    # Use default implementation of get_child_index.
+
+
+def __lldb_init_module(dbg, _):
+    dbg.HandleCommand(f"type synthetic add -l {__name__}.ThingSynthetic Thing")


### PR DESCRIPTION
Synthetic providers for collection types use a child name format of "[N]".

This `ValueObjectSynthetic` to automatically convert child names in this convention to the index embedded in the subscript string. With this change, synthetic formatters for collections will only need to implement `GetIndexOfChildWithName` or `get_child_index` for non-indexed collection children. Some examples of non-indexed children are `$$dereference$$` support, or "hidden" children.

The automatic conversion applies to N values that are less than the number of children reported by the synthetic provider.
