### PR TITLE
[LLDB] Fix buildbot breakage

### DIFF
--- a/lldb/test/API/commands/frame/var-dil/basics/LocalVars/TestFrameVarDILLocalVars.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/LocalVars/TestFrameVarDILLocalVars.py
@@ -28,5 +28,4 @@ class TestFrameVarDILLocalVars(TestBase):
         self.expect_var_path("a", value="1")
         self.expect_var_path("b", value="2")
         self.expect_var_path("c", value="'\\xfd'")
-        self.expect_var_path("(int)c", value="-3")
         self.expect_var_path("s", value="4")


### PR DESCRIPTION
Remove DIL type-cast test that's failing on aarch64. Test makes assumption that's not valid on that architecture.