### PR TITLE
[clang-doc] Don't serialize non-existant locations in HTML

### DIFF
--- a/clang-tools-extra/clang-doc/assets/function-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/function-template.mustache
@@ -17,5 +17,7 @@
             {{>Comments}}
         </div>
         {{/Description}}
-        <p>Defined at line {{Location.LineNumber}} of file {{Location.Filename}}</p>
+        {{#Location}}
+        <p>Defined at line {{LineNumber}} of file {{Filename}}</p>
+        {{/Location}}
 </div>

--- a/clang-tools-extra/test/clang-doc/json/class.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class.cpp
@@ -335,7 +335,6 @@ private:
 // HTML-NEXT:     <div>
 // HTML-NEXT:         <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // HTML-NEXT:                 <pre><code class="language-cpp code-clang-doc">int protectedMethod ()</code></pre>
-// HTML-NEXT:                 <p>Defined at line  of file </p>
 // HTML-NEXT:         </div>
 // HTML-NEXT:     </div>
 // HTML-NEXT: </section>

--- a/clang-tools-extra/test/clang-doc/templates.cpp
+++ b/clang-tools-extra/test/clang-doc/templates.cpp
@@ -79,8 +79,6 @@ void ParamPackFunction(T... args);
 
 // HTML:        <pre><code class="language-cpp code-clang-doc">template &lt;class... T&gt;</code></pre>
 // HTML-NEXT:      <pre><code class="language-cpp code-clang-doc">void ParamPackFunction (T... args)</code></pre>
-// COM:            FIXME: Omit defined line if not defined, or emit declaration line.
-// HTML-NEXT:      <p>Defined at line of file </p>
 // HTML-NEXT:  </div>
 
 template <typename T, int U = 1>


### PR DESCRIPTION
The function template didn't check to see if a `Location` existed before
emitting the definition location line.