### PR TITLE
[AMDGPU][SIInsertWaitcnts] Enable RegistersAreIntervals for AMDGPU

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -2333,6 +2333,7 @@ def AMDGPU : Target {
                                 VOP3_DPPAsmParserVariant];
   let AssemblyWriters = [AMDGPUAsmWriter];
   let AllowRegisterRenaming = 1;
+  let RegistersAreIntervals = 1;
 }
 
 // Dummy Instruction itineraries for pseudo instructions


### PR DESCRIPTION
@nhaehnle @ssahasra @cmc-rep @Sisyph @Pierre-vh Bringing back RegIntervals to SIInsertWaitcnts. I think this is along the lines of what we want, I don't think we need the actual MCRegUnit if it just refers to the 'RegUnit'.