### PR TITLE
[RISC-V][ELF] Move emitNoteGnuPropertySection to RISCVTargetELFStreamer. [NFCI]

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFStreamer.h
@@ -67,6 +67,7 @@ public:
   void emitDirectiveOptionNoRVC() override;
   void emitDirectiveVariantCC(MCSymbol &Symbol) override;
 
+  void emitNoteGnuPropertySection(const uint32_t Feature1And);
   void finish() override;
 };
 

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.cpp
@@ -61,47 +61,6 @@ void RISCVTargetStreamer::emitIntTextAttribute(unsigned Attribute,
                                                unsigned IntValue,
                                                StringRef StringValue) {}
 
-void RISCVTargetStreamer::emitNoteGnuPropertySection(
-    const uint32_t Feature1And) {
-  MCStreamer &OutStreamer = getStreamer();
-  MCContext &Ctx = OutStreamer.getContext();
-
-  const Triple &Triple = Ctx.getTargetTriple();
-  Align NoteAlign;
-  uint64_t DescSize;
-  if (Triple.isArch64Bit()) {
-    NoteAlign = Align(8);
-    DescSize = 16;
-  } else {
-    assert(Triple.isArch32Bit());
-    NoteAlign = Align(4);
-    DescSize = 12;
-  }
-
-  assert(Ctx.getObjectFileType() == MCContext::Environment::IsELF);
-  MCSection *const NoteSection =
-      Ctx.getELFSection(".note.gnu.property", ELF::SHT_NOTE, ELF::SHF_ALLOC);
-  OutStreamer.pushSection();
-  OutStreamer.switchSection(NoteSection);
-
-  // Emit the note header
-  OutStreamer.emitValueToAlignment(NoteAlign);
-  OutStreamer.emitIntValue(4, 4);                           // n_namsz
-  OutStreamer.emitIntValue(DescSize, 4);                    // n_descsz
-  OutStreamer.emitIntValue(ELF::NT_GNU_PROPERTY_TYPE_0, 4); // n_type
-  OutStreamer.emitBytes(StringRef("GNU", 4));               // n_name
-
-  // Emit n_desc field
-
-  // Emit the feature_1_and property
-  OutStreamer.emitIntValue(ELF::GNU_PROPERTY_RISCV_FEATURE_1_AND, 4); // pr_type
-  OutStreamer.emitIntValue(4, 4);              // pr_datasz
-  OutStreamer.emitIntValue(Feature1And, 4);    // pr_data
-  OutStreamer.emitValueToAlignment(NoteAlign); // pr_padding
-
-  OutStreamer.popSection();
-}
-
 void RISCVTargetStreamer::setTargetABI(RISCVABI::ABI ABI) {
   assert(ABI != RISCVABI::ABI_Unknown && "Improperly initialized target ABI");
   TargetABI = ABI;

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.h
@@ -58,7 +58,6 @@ public:
   virtual void emitTextAttribute(unsigned Attribute, StringRef String);
   virtual void emitIntTextAttribute(unsigned Attribute, unsigned IntValue,
                                     StringRef StringValue);
-  void emitNoteGnuPropertySection(const uint32_t Feature1And);
 
   void emitTargetAttributes(const MCSubtargetInfo &STI, bool EmitStackAlign);
   void setTargetABI(RISCVABI::ABI ABI);

--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -952,7 +952,7 @@ void RISCVAsmPrinter::EmitHwasanMemaccessSymbols(Module &M) {
 }
 
 void RISCVAsmPrinter::emitNoteGnuProperty(const Module &M) {
-  assert(STI->getTargetTriple().isOSBinFormatELF() && "invalid binary format");
+  assert(TM.getTargetTriple().isOSBinFormatELF() && "invalid binary format");
   if (const Metadata *const Flag = M.getModuleFlag("cf-protection-return");
       Flag && !mdconst::extract<ConstantInt>(Flag)->isZero()) {
     RISCVTargetELFStreamer &RTS = static_cast<RISCVTargetELFStreamer &>(

--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "MCTargetDesc/RISCVBaseInfo.h"
+#include "MCTargetDesc/RISCVELFStreamer.h"
 #include "MCTargetDesc/RISCVInstPrinter.h"
 #include "MCTargetDesc/RISCVMCAsmInfo.h"
 #include "MCTargetDesc/RISCVMatInt.h"
@@ -951,10 +952,11 @@ void RISCVAsmPrinter::EmitHwasanMemaccessSymbols(Module &M) {
 }
 
 void RISCVAsmPrinter::emitNoteGnuProperty(const Module &M) {
+  assert(STI->getTargetTriple().isOSBinFormatELF() && "invalid binary format");
   if (const Metadata *const Flag = M.getModuleFlag("cf-protection-return");
       Flag && !mdconst::extract<ConstantInt>(Flag)->isZero()) {
-    RISCVTargetStreamer &RTS =
-        static_cast<RISCVTargetStreamer &>(*OutStreamer->getTargetStreamer());
+    RISCVTargetELFStreamer &RTS = static_cast<RISCVTargetELFStreamer &>(
+        *OutStreamer->getTargetStreamer());
     RTS.emitNoteGnuPropertySection(ELF::GNU_PROPERTY_RISCV_FEATURE_1_CFI_SS);
   }
 }


### PR DESCRIPTION
This function is invoked only for ELF targets, therefore it has been moved to the ELF-specific streamer.

An assertion has been added to catch its invocations outside of an invocation that targets ELF.