### PR TITLE
Add a flag to preserve the old macro behaviour.

### DIFF
--- a/clang/include/clang/Basic/DebugOptions.def
+++ b/clang/include/clang/Basic/DebugOptions.def
@@ -101,6 +101,7 @@ ENUM_DEBUGOPT(DebugInfo, DebugInfoKind, 4,
 DEBUGOPT(MacroDebugInfo, 1, 0, Compatible)
 
 /// Whether to use expansion location for debug info.
+/// TODO: #175249: Remove once testing is complete for sample pgo users.
 DEBUGOPT(DebugInfoMacroExpansionLoc, 1, 0, Compatible)
 
 /// Tune the debug info for this debugger.

--- a/clang/include/clang/Basic/DebugOptions.def
+++ b/clang/include/clang/Basic/DebugOptions.def
@@ -100,6 +100,9 @@ ENUM_DEBUGOPT(DebugInfo, DebugInfoKind, 4,
 /// Whether to generate macro debug info.
 DEBUGOPT(MacroDebugInfo, 1, 0, Compatible)
 
+/// Whether to use expansion location for debug info.
+DEBUGOPT(DebugInfoMacroExpansionLoc, 1, 0, Compatible)
+
 /// Tune the debug info for this debugger.
 ENUM_DEBUGOPT(DebuggerTuning, DebuggerKind, 3,
               DebuggerKind::Default, Compatible)

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -7812,6 +7812,10 @@ let Visibility = [CC1Option, CC1AsOption] in {
 def debug_info_macro : Flag<["-"], "debug-info-macro">,
   HelpText<"Emit macro debug information">,
   MarshallingInfoFlag<CodeGenOpts<"MacroDebugInfo">>;
+def debug_info_macro_expansion_loc
+    : Flag<["-"], "debug-info-macro-expansion-loc">,
+      HelpText<"Use expansion location for debug info for multi line macros">,
+      MarshallingInfoFlag<CodeGenOpts<"DebugInfoMacroExpansionLoc">>;
 def default_function_attr : Separate<["-"], "default-function-attr">,
   HelpText<"Apply given attribute to all functions">,
   MarshallingInfoStringVector<CodeGenOpts<"DefaultFunctionAttrs">>;

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -675,8 +675,8 @@ unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
   if (Loc.isInvalid() && CurLoc.isInvalid())
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc = SM.getPresumedLoc(
-      Loc.isValid() ? getMacroDebugLoc(CGM, Loc) : CurLoc);
+  PresumedLoc PLoc =
+      SM.getPresumedLoc(Loc.isValid() ? getMacroDebugLoc(CGM, Loc) : CurLoc);
   return PLoc.isValid() ? PLoc.getColumn() : 0;
 }
 

--- a/clang/test/DebugInfo/Generic/macro-info.c
+++ b/clang/test/DebugInfo/Generic/macro-info.c
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 %s -debug-info-kind=standalone -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -debug-info-kind=standalone -emit-llvm -o - | FileCheck %s --check-prefix=NEW
+// RUN: %clang_cc1 %s -debug-info-kind=standalone -emit-llvm -mllvm -debug-info-macro-expansion-loc -o - | FileCheck %s --check-prefix=OLD
 
 #define GLOBAL(num) global## num
 #define DECL_GLOBAL(x) int x
@@ -9,11 +10,13 @@
 
 SAME_ORDER(
   int
-// CHECK: DIGlobalVariable(name: "global",{{.*}} line: [[@LINE+1]]
+// NEW: DIGlobalVariable(name: "global",{{.*}} line: [[@LINE+2]]
+// OLD: DIGlobalVariable(name: "global",{{.*}} line: [[@LINE-3]]
     GLOBAL  // <- global
       () = 42,
   const char* s() {
-// CHECK: DIGlobalVariable({{.*}}line: [[@LINE+1]],{{.*}} type: [[TYPEID:![0-9]+]]
+// NEW: DIGlobalVariable({{.*}}line: [[@LINE+2]],{{.*}} type: [[TYPEID:![0-9]+]]
+// OLD: DIGlobalVariable({{.*}}line: [[@LINE-8]],{{.*}} type: [[TYPEID:![0-9]+]]
     return "1234567890";
   }
 )
@@ -21,8 +24,10 @@ SAME_ORDER(
 SWAP_ORDER(
   int GLOBAL(  // <- global2
     2) = 43,
-// CHECK: DIGlobalVariable(name: "global3",{{.*}} line: [[@LINE+3]]
-// CHECK: DIGlobalVariable(name: "global2",{{.*}} line: [[@LINE-3]]
+// NEW: DIGlobalVariable(name: "global3",{{.*}} line: [[@LINE+5]]
+// NEW: DIGlobalVariable(name: "global2",{{.*}} line: [[@LINE-3]]
+// OLD: DIGlobalVariable(name: "global3",{{.*}} line: [[@LINE-5]]
+// OLD: DIGlobalVariable(name: "global2",{{.*}} line: [[@LINE-6]]
   DECL_GLOBAL(
     GLOBAL(  // <- global3
       3)) = 44
@@ -30,6 +35,7 @@ SWAP_ORDER(
 
 
 DECL_GLOBAL(
-// CHECK: DIGlobalVariable(name: "global4",{{.*}} line: [[@LINE+1]]
+// NEW: DIGlobalVariable(name: "global4",{{.*}} line: [[@LINE+2]]
+// OLD: DIGlobalVariable(name: "global4",{{.*}} line: [[@LINE-2]]
   GLOBAL(  // <- global4
     4));

--- a/clang/test/DebugInfo/Generic/macro-info.c
+++ b/clang/test/DebugInfo/Generic/macro-info.c
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 %s -debug-info-kind=standalone -emit-llvm -o - | FileCheck %s --check-prefix=NEW
-// RUN: %clang_cc1 %s -debug-info-kind=standalone -emit-llvm -mllvm -debug-info-macro-expansion-loc -o - | FileCheck %s --check-prefix=OLD
+// RUN: %clang_cc1 %s -debug-info-kind=standalone -emit-llvm -debug-info-macro-expansion-loc -o - | FileCheck %s --check-prefix=OLD
 
 #define GLOBAL(num) global## num
 #define DECL_GLOBAL(x) int x


### PR DESCRIPTION
[Clang][DebugInfo] Add a flag to use expansion loc for macro params.

This patch adds a flag to allow users to preserve the old behaviour - use the macro expansion location for parameters. This is useful for wider testing of sample profile driven PGO which relies on debug information based mapping.