### PR TITLE
[WebAssembly] Skip WASM-specific InstCombine tests properly

### DIFF
--- a/llvm/test/Transforms/InstCombine/WebAssembly/lit.local.cfg
+++ b/llvm/test/Transforms/InstCombine/WebAssembly/lit.local.cfg
@@ -1,0 +1,2 @@
+if not "WebAssembly" in config.root.targets:
+    config.unsupported = True


### PR DESCRIPTION
Un-breaks the build after https://github.com/llvm/llvm-project/pull/169110.