### PR TITLE
[bazel] Make CAPIIR depend on TransformsPassIncGen

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -518,6 +518,7 @@ mlir_c_api_cc_library(
         ":IRDLDialect",
         ":InferTypeOpInterface",
         ":Parser",
+        ":TransformsPassIncGen",
     ],
 )
 


### PR DESCRIPTION
CAPIIR includes this in some of its source files, so we need to ensure the header is around.