### PR TITLE
MIPS: expandDivRem add a NOP after BNE

### DIFF
--- a/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
+++ b/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
@@ -4301,6 +4301,7 @@ bool MipsAsmParser::expandDivRem(MCInst &Inst, SMLoc IDLoc, MCStreamer &Out,
       LabelOp =
           MCOperand::createExpr(MCSymbolRefExpr::create(BrTarget, Context));
       TOut.emitRRX(Mips::BNE, RtReg, ZeroReg, LabelOp, IDLoc, STI);
+      TOut.emitNop(IDLoc, STI);
     }
 
     if (!UseTraps)

--- a/llvm/test/CodeGen/Mips/divrem-inline-asm.ll
+++ b/llvm/test/CodeGen/Mips/divrem-inline-asm.ll
@@ -27,6 +27,7 @@ define i32 @inline_asm_div() {
 ; ACC64-TRAP-EMPTY:
 ; ACC64-TRAP-NEXT:    div $zero, $2, $3
 ; ACC64-TRAP-NEXT:    bnez $3, .Ltmp0
+; ACC64-TRAP-NEXT:    nop
 ; ACC64-TRAP-NEXT:    break 7
 ; ACC64-TRAP-NEXT:  .Ltmp0:
 ; ACC64-TRAP-NEXT:    mflo $2
@@ -71,6 +72,7 @@ define i32 @inline_asm_rem() {
 ; ACC64-TRAP-EMPTY:
 ; ACC64-TRAP-NEXT:    div $zero, $2, $3
 ; ACC64-TRAP-NEXT:    bnez $3, .Ltmp1
+; ACC64-TRAP-NEXT:    nop
 ; ACC64-TRAP-NEXT:    break 7
 ; ACC64-TRAP-NEXT:  .Ltmp1:
 ; ACC64-TRAP-NEXT:    mfhi $2
@@ -115,6 +117,7 @@ define i64 @inline_asm_ddiv() {
 ; ACC64-TRAP-EMPTY:
 ; ACC64-TRAP-NEXT:    ddiv $zero, $2, $3
 ; ACC64-TRAP-NEXT:    bne $3, $zero, .Ltmp2
+; ACC64-TRAP-NEXT:    nop
 ; ACC64-TRAP-NEXT:    break 7
 ; ACC64-TRAP-NEXT:  .Ltmp2:
 ; ACC64-TRAP-NEXT:    mflo $2
@@ -159,6 +162,7 @@ define i64 @inline_asm_drem() {
 ; ACC64-TRAP-EMPTY:
 ; ACC64-TRAP-NEXT:    ddiv $zero, $2, $3
 ; ACC64-TRAP-NEXT:    bne $3, $zero, .Ltmp3
+; ACC64-TRAP-NEXT:    nop
 ; ACC64-TRAP-NEXT:    break 7
 ; ACC64-TRAP-NEXT:  .Ltmp3:
 ; ACC64-TRAP-NEXT:    mfhi $2
@@ -203,6 +207,7 @@ define i32 @inline_asm_divu() {
 ; ACC64-TRAP-EMPTY:
 ; ACC64-TRAP-NEXT:    divu $zero, $2, $3
 ; ACC64-TRAP-NEXT:    bnez $3, .Ltmp4
+; ACC64-TRAP-NEXT:    nop
 ; ACC64-TRAP-NEXT:    break 7
 ; ACC64-TRAP-NEXT:  .Ltmp4:
 ; ACC64-TRAP-NEXT:    mflo $2
@@ -247,6 +252,7 @@ define i32 @inline_asm_remu() {
 ; ACC64-TRAP-EMPTY:
 ; ACC64-TRAP-NEXT:    divu $zero, $2, $3
 ; ACC64-TRAP-NEXT:    bnez $3, .Ltmp5
+; ACC64-TRAP-NEXT:    nop
 ; ACC64-TRAP-NEXT:    break 7
 ; ACC64-TRAP-NEXT:  .Ltmp5:
 ; ACC64-TRAP-NEXT:    mfhi $2
@@ -291,6 +297,7 @@ define i64 @inline_asm_ddivu() {
 ; ACC64-TRAP-EMPTY:
 ; ACC64-TRAP-NEXT:    ddivu $zero, $2, $3
 ; ACC64-TRAP-NEXT:    bne $3, $zero, .Ltmp6
+; ACC64-TRAP-NEXT:    nop
 ; ACC64-TRAP-NEXT:    break 7
 ; ACC64-TRAP-NEXT:  .Ltmp6:
 ; ACC64-TRAP-NEXT:    mflo $2
@@ -335,6 +342,7 @@ define i64 @inline_asm_dremu() {
 ; ACC64-TRAP-EMPTY:
 ; ACC64-TRAP-NEXT:    ddivu $zero, $2, $3
 ; ACC64-TRAP-NEXT:    bne $3, $zero, .Ltmp7
+; ACC64-TRAP-NEXT:    nop
 ; ACC64-TRAP-NEXT:    break 7
 ; ACC64-TRAP-NEXT:  .Ltmp7:
 ; ACC64-TRAP-NEXT:    mfhi $2

--- a/llvm/test/MC/Mips/macro-ddiv.s
+++ b/llvm/test/MC/Mips/macro-ddiv.s
@@ -7,6 +7,7 @@
 // CHECK-NOTRAP: ddiv	$zero, $25, $11                 # encoding: [0x03,0x2b,0x00,0x1e]
 // CHECK-NOTRAP: bne	$11, $zero, .Ltmp0              # encoding: [0x15,0x60,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp0-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: .Ltmp0:
 // CHECK-NOTRAP: mflo	$25                             # encoding: [0x00,0x00,0xc8,0x12]
@@ -19,6 +20,7 @@
 // CHECK-NOTRAP: ddiv	$zero, $24, $12                 # encoding: [0x03,0x0c,0x00,0x1e]
 // CHECK-NOTRAP: bne	$12, $zero, .Ltmp1              # encoding: [0x15,0x80,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp1-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: .Ltmp1:
 // CHECK-NOTRAP: mflo	$24                             # encoding: [0x00,0x00,0xc0,0x12]
@@ -35,6 +37,7 @@
 // CHECK-NOTRAP: ddiv	$zero, $zero, $9                # encoding: [0x00,0x09,0x00,0x1e]
 // CHECK-NOTRAP: bne	$9, $zero, .Ltmp2               # encoding: [0x15,0x20,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp2-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: .Ltmp2:
 // CHECK-NOTRAP: mflo	$zero                           # encoding: [0x00,0x00,0x00,0x12]
@@ -166,6 +169,7 @@
 // CHECK-NOTRAP: ddiv	$zero, $5, $6                   # encoding: [0x00,0xa6,0x00,0x1e]
 // CHECK-NOTRAP: bne	$6, $zero, .Ltmp3               # encoding: [0x14,0xc0,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp3-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: .Ltmp3:
 // CHECK-NOTRAP: mflo	$4                              # encoding: [0x00,0x00,0x20,0x12]

--- a/llvm/test/MC/Mips/macro-ddivu.s
+++ b/llvm/test/MC/Mips/macro-ddivu.s
@@ -8,6 +8,7 @@
 // CHECK-NOTRAP: ddivu	$zero, $25, $11                 # encoding: [0x03,0x2b,0x00,0x1f]
 // CHECK-NOTRAP: bne	$11, $zero, .Ltmp0              # encoding: [0x15,0x60,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp0-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: .Ltmp0:
 // CHECK-NOTRAP: mflo	$25                             # encoding: [0x00,0x00,0xc8,0x12]
@@ -19,6 +20,7 @@
 // CHECK-NOTRAP: ddivu	$zero, $24, $12                 # encoding: [0x03,0x0c,0x00,0x1f]
 // CHECK-NOTRAP: bne	$12, $zero, .Ltmp1              # encoding: [0x15,0x80,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp1-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: .Ltmp1:
 // CHECK-NOTRAP: mflo	$24                             # encoding: [0x00,0x00,0xc0,0x12]
@@ -34,6 +36,7 @@
 // CHECK-NOTRAP: ddivu	$zero, $zero, $9                # encoding: [0x00,0x09,0x00,0x1f]
 // CHECK-NOTRAP: bne	$9, $zero, .Ltmp2               # encoding: [0x15,0x20,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp2-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: .Ltmp2:
 // CHECK-NOTRAP: mflo	$zero                           # encoding: [0x00,0x00,0x00,0x12]
@@ -159,6 +162,7 @@
 // CHECK-NOTRAP: ddivu	$zero, $5, $6                   # encoding: [0x00,0xa6,0x00,0x1f]
 // CHECK-NOTRAP: bne	$6, $zero, .Ltmp3               # encoding: [0x14,0xc0,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp3-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: .Ltmp3:
 // CHECK-NOTRAP: mflo	$4                              # encoding: [0x00,0x00,0x20,0x12]

--- a/llvm/test/MC/Mips/macro-div.s
+++ b/llvm/test/MC/Mips/macro-div.s
@@ -7,6 +7,7 @@
 // CHECK-NOTRAP: div	$zero, $25, $11                 # encoding: [0x03,0x2b,0x00,0x1a]
 // CHECK-NOTRAP: bnez	$11, $tmp0                      # encoding: [0x15,0x60,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp0-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: $tmp0:
 // CHECK-NOTRAP: mflo	$25                             # encoding: [0x00,0x00,0xc8,0x12]
@@ -18,6 +19,7 @@
 // CHECK-NOTRAP: div	$zero, $24, $12                 # encoding: [0x03,0x0c,0x00,0x1a]
 // CHECK-NOTRAP: bnez	$12, $tmp1                      # encoding: [0x15,0x80,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp1-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: $tmp1:
 // CHECK-NOTRAP: mflo	$24                             # encoding: [0x00,0x00,0xc0,0x12]
@@ -99,6 +101,7 @@
 // CHECK-NOTRAP: div	$zero, $5, $6                   # encoding: [0x00,0xa6,0x00,0x1a]
 // CHECK-NOTRAP: bnez	$6, $tmp2                       # encoding: [0x14,0xc0,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp2-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: $tmp2:
 // CHECK-NOTRAP: mflo	$4                              # encoding: [0x00,0x00,0x20,0x12]

--- a/llvm/test/MC/Mips/macro-divu.s
+++ b/llvm/test/MC/Mips/macro-divu.s
@@ -7,6 +7,7 @@
 // CHECK-NOTRAP: divu	$zero, $25, $11                 # encoding: [0x03,0x2b,0x00,0x1b]
 // CHECK-NOTRAP: bnez	$11, $tmp0                      # encoding: [0x15,0x60,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp0-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: $tmp0:
 // CHECK-NOTRAP: mflo	$25                             # encoding: [0x00,0x00,0xc8,0x12]
@@ -18,6 +19,7 @@
 // CHECK-NOTRAP: divu	$zero, $24, $12                 # encoding: [0x03,0x0c,0x00,0x1b]
 // CHECK-NOTRAP: bnez	$12, $tmp1                      # encoding: [0x15,0x80,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp1-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: $tmp1:
 // CHECK-NOTRAP: mflo	$24                             # encoding: [0x00,0x00,0xc0,0x12]
@@ -41,6 +43,7 @@
 // CHECK-NOTRAP: divu	$zero, $5, $6                   # encoding: [0x00,0xa6,0x00,0x1b]
 // CHECK-NOTRAP: bnez	$6, $tmp2                       # encoding: [0x14,0xc0,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp2-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: $tmp2:
 // CHECK-NOTRAP: mflo	$4                              # encoding: [0x00,0x00,0x20,0x12]
@@ -64,6 +67,7 @@
 // CHECK-NOTRAP: divu	$zero, $25, $11                 # encoding: [0x03,0x2b,0x00,0x1b]
 // CHECK-NOTRAP: bnez	$11, $tmp3                      # encoding: [0x15,0x60,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp3-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: $tmp3:
 // CHECK-NOTRAP: mflo	$25                             # encoding: [0x00,0x00,0xc8,0x12]
@@ -75,6 +79,7 @@
 // CHECK-NOTRAP: divu	$zero, $24, $12                 # encoding: [0x03,0x0c,0x00,0x1b]
 // CHECK-NOTRAP: bnez	$12, $tmp4                      # encoding: [0x15,0x80,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp4-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: $tmp4:
 // CHECK-NOTRAP: mflo	$24                             # encoding: [0x00,0x00,0xc0,0x12]
@@ -98,6 +103,7 @@
 // CHECK-NOTRAP: divu	$zero, $5, $6                   # encoding: [0x00,0xa6,0x00,0x1b]
 // CHECK-NOTRAP: bnez	$6, $tmp5                       # encoding: [0x14,0xc0,A,A]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp5-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x00,0x07,0x00,0x0d]
 // CHECK-NOTRAP: $tmp5:
 // CHECK-NOTRAP: mflo	$4                              # encoding: [0x00,0x00,0x20,0x12]

--- a/llvm/test/MC/Mips/macro-drem.s
+++ b/llvm/test/MC/Mips/macro-drem.s
@@ -7,6 +7,7 @@
 // CHECK-NOTRAP: ddiv	$zero, $4, $5                   # encoding: [0x1e,0x00,0x85,0x00]
 // CHECK-NOTRAP: bne	$5, $zero, .Ltmp0               # encoding: [A,A,0xa0,0x14]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp0-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x0d,0x00,0x07,0x00]
 // CHECK-NOTRAP: .Ltmp0:
 // CHECK-NOTRAP: mfhi	$4                              # encoding: [0x10,0x20,0x00,0x00]
@@ -80,6 +81,7 @@
 // CHECK-NOTRAP: ddiv	$zero, $5, $6                   # encoding: [0x1e,0x00,0xa6,0x00]
 // CHECK-NOTRAP: bne	$6, $zero, .Ltmp1               # encoding: [A,A,0xc0,0x14]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp1-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x0d,0x00,0x07,0x00]
 // CHECK-NOTRAP: .Ltmp1:
 // CHECK-NOTRAP: mfhi	$4                              # encoding: [0x10,0x20,0x00,0x00]
@@ -165,6 +167,7 @@
 // CHECK-NOTRAP: ddiv	$zero, $4, $5                   # encoding: [0x1e,0x00,0x85,0x00]
 // CHECK-NOTRAP: bne	$5, $zero, .Ltmp2               # encoding: [A,A,0xa0,0x14]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp2-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x0d,0x00,0x07,0x00]
 // CHECK-NOTRAP: .Ltmp2:
 // CHECK-NOTRAP: mfhi	$4                              # encoding: [0x10,0x20,0x00,0x00]
@@ -238,6 +241,7 @@
 // CHECK-NOTRAP: ddiv	$zero, $5, $6                   # encoding: [0x1e,0x00,0xa6,0x00]
 // CHECK-NOTRAP: bne	$6, $zero, .Ltmp3               # encoding: [A,A,0xc0,0x14]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp3-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x0d,0x00,0x07,0x00]
 // CHECK-NOTRAP: .Ltmp3:
 // CHECK-NOTRAP: mfhi	$4                              # encoding: [0x10,0x20,0x00,0x00]

--- a/llvm/test/MC/Mips/macro-dremu.s
+++ b/llvm/test/MC/Mips/macro-dremu.s
@@ -7,6 +7,7 @@
 // CHECK-NOTRAP: ddivu	$zero, $4, $5                   # encoding: [0x1f,0x00,0x85,0x00]
 // CHECK-NOTRAP: bne	$5, $zero, .Ltmp0               # encoding: [A,A,0xa0,0x14]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp0-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x0d,0x00,0x07,0x00]
 // CHECK-NOTRAP: .Ltmp0:
 // CHECK-NOTRAP: mfhi	$4                              # encoding: [0x10,0x20,0x00,0x00]
@@ -84,6 +85,7 @@
 // CHECK-NOTRAP: ddivu	$zero, $5, $6                   # encoding: [0x1f,0x00,0xa6,0x00]
 // CHECK-NOTRAP: bne	$6, $zero, .Ltmp1               # encoding: [A,A,0xc0,0x14]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: .Ltmp1-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x0d,0x00,0x07,0x00]
 // CHECK-NOTRAP: .Ltmp1:
 // CHECK-NOTRAP: mfhi	$4                              # encoding: [0x10,0x20,0x00,0x00]

--- a/llvm/test/MC/Mips/macro-rem.s
+++ b/llvm/test/MC/Mips/macro-rem.s
@@ -7,6 +7,7 @@
 // CHECK-NOTRAP: div	$zero, $4, $5                   # encoding: [0x1a,0x00,0x85,0x00]
 // CHECK-NOTRAP: bnez	$5, $tmp0                       # encoding: [A,A,0xa0,0x14]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp0-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x0d,0x00,0x07,0x00]
 // CHECK-NOTRAP: $tmp0:
 // CHECK-NOTRAP: mfhi	$4                              # encoding: [0x10,0x20,0x00,0x00]
@@ -81,6 +82,7 @@
 // CHECK-NOTRAP: div	$zero, $5, $6                   # encoding: [0x1a,0x00,0xa6,0x00]
 // CHECK-NOTRAP: bnez	$6, $tmp1                       # encoding: [A,A,0xc0,0x14]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp1-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x0d,0x00,0x07,0x00]
 // CHECK-NOTRAP: $tmp1:
 // CHECK-NOTRAP: mfhi	$4                              # encoding: [0x10,0x20,0x00,0x00]

--- a/llvm/test/MC/Mips/macro-remu.s
+++ b/llvm/test/MC/Mips/macro-remu.s
@@ -7,6 +7,7 @@
 // CHECK-NOTRAP: divu	$zero, $4, $5                   # encoding: [0x1b,0x00,0x85,0x00]
 // CHECK-NOTRAP: bnez	$5, $tmp0                       # encoding: [A,A,0xa0,0x14]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp0-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x0d,0x00,0x07,0x00]
 // CHECK-NOTRAP: $tmp0:
 // CHECK-NOTRAP: mfhi	$4                              # encoding: [0x10,0x20,0x00,0x00]
@@ -85,6 +86,7 @@
 // CHECK-NOTRAP: divu	$zero, $5, $6                   # encoding: [0x1b,0x00,0xa6,0x00]
 // CHECK-NOTRAP: bnez	$6, $tmp1                       # encoding: [A,A,0xc0,0x14]
 // CHECK-NOTRAP: #   fixup A - offset: 0, value: $tmp1-4, kind: fixup_Mips_PC16
+// CHECK-NOTRAP: nop                                    # encoding: [0x00,0x00,0x00,0x00]
 // CHECK-NOTRAP: break	7                               # encoding: [0x0d,0x00,0x07,0x00]
 // CHECK-NOTRAP: $tmp1:
 // CHECK-NOTRAP: mfhi	$4                              # encoding: [0x10,0x20,0x00,0x00]


### PR DESCRIPTION
If we compile a C code or IR file directly, the delay slot of BNE emit by us won't be filled with a NOP.

We should fill it ourself, otherwise, the break instruction may be used as the delay slot.