### PR TITLE
[SelectionDAG] Expand CLMUL in PromoteIntRes_CLMUL if the operation isn't legal/custom for the promoted type.

### DIFF
--- a/llvm/test/CodeGen/RISCV/clmul.ll
+++ b/llvm/test/CodeGen/RISCV/clmul.ll
@@ -5,7 +5,6 @@
 define i4 @clmul_i4(i4 %a, i4 %b) nounwind {
 ; CHECK-LABEL: clmul_i4:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    andi a0, a0, 15
 ; CHECK-NEXT:    andi a2, a1, 2
 ; CHECK-NEXT:    andi a3, a1, 1
 ; CHECK-NEXT:    andi a4, a1, 4
@@ -25,7 +24,6 @@ define i4 @clmul_i4(i4 %a, i4 %b) nounwind {
 define i8 @clmul_i8(i8 %a, i8 %b) nounwind {
 ; CHECK-LABEL: clmul_i8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    zext.b a0, a0
 ; CHECK-NEXT:    andi a2, a1, 2
 ; CHECK-NEXT:    andi a3, a1, 1
 ; CHECK-NEXT:    andi a4, a1, 4
@@ -43,7 +41,7 @@ define i8 @clmul_i8(i8 %a, i8 %b) nounwind {
 ; CHECK-NEXT:    xor a3, a3, a5
 ; CHECK-NEXT:    xor a2, a2, a4
 ; CHECK-NEXT:    andi a4, a1, 64
-; CHECK-NEXT:    andi a1, a1, 128
+; CHECK-NEXT:    andi a1, a1, -128
 ; CHECK-NEXT:    mul a4, a0, a4
 ; CHECK-NEXT:    xor a3, a3, a4
 ; CHECK-NEXT:    xor a2, a2, a3
@@ -55,123 +53,62 @@ define i8 @clmul_i8(i8 %a, i8 %b) nounwind {
 }
 
 define i16 @clmul_i16(i16 %a, i16 %b) nounwind {
-; RV32IM-LABEL: clmul_i16:
-; RV32IM:       # %bb.0:
-; RV32IM-NEXT:    slli a0, a0, 16
-; RV32IM-NEXT:    andi a2, a1, 2
-; RV32IM-NEXT:    andi a3, a1, 1
-; RV32IM-NEXT:    andi a4, a1, 4
-; RV32IM-NEXT:    andi a5, a1, 8
-; RV32IM-NEXT:    andi a6, a1, 16
-; RV32IM-NEXT:    andi a7, a1, 32
-; RV32IM-NEXT:    srli a0, a0, 16
-; RV32IM-NEXT:    mul a2, a0, a2
-; RV32IM-NEXT:    mul a3, a0, a3
-; RV32IM-NEXT:    xor a2, a3, a2
-; RV32IM-NEXT:    andi a3, a1, 64
-; RV32IM-NEXT:    mul a4, a0, a4
-; RV32IM-NEXT:    mul a5, a0, a5
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    andi a5, a1, 128
-; RV32IM-NEXT:    mul a6, a0, a6
-; RV32IM-NEXT:    mul a7, a0, a7
-; RV32IM-NEXT:    xor a6, a6, a7
-; RV32IM-NEXT:    andi a7, a1, 256
-; RV32IM-NEXT:    mul a5, a0, a5
-; RV32IM-NEXT:    mul a7, a0, a7
-; RV32IM-NEXT:    xor a5, a5, a7
-; RV32IM-NEXT:    andi a7, a1, 512
-; RV32IM-NEXT:    xor a2, a2, a4
-; RV32IM-NEXT:    li a4, 1
-; RV32IM-NEXT:    mul a3, a0, a3
-; RV32IM-NEXT:    xor a3, a6, a3
-; RV32IM-NEXT:    lui a6, 1
-; RV32IM-NEXT:    mul a7, a0, a7
-; RV32IM-NEXT:    xor a5, a5, a7
-; RV32IM-NEXT:    lui a7, 2
-; RV32IM-NEXT:    slli a4, a4, 11
-; RV32IM-NEXT:    and a6, a1, a6
-; RV32IM-NEXT:    and a4, a1, a4
-; RV32IM-NEXT:    mul a6, a0, a6
-; RV32IM-NEXT:    mul a4, a0, a4
-; RV32IM-NEXT:    xor a4, a4, a6
-; RV32IM-NEXT:    lui a6, 4
-; RV32IM-NEXT:    xor a2, a2, a3
-; RV32IM-NEXT:    lui a3, 8
-; RV32IM-NEXT:    and a7, a1, a7
-; RV32IM-NEXT:    and a6, a1, a6
-; RV32IM-NEXT:    and a3, a1, a3
-; RV32IM-NEXT:    andi a1, a1, 1024
-; RV32IM-NEXT:    mul a1, a0, a1
-; RV32IM-NEXT:    xor a1, a5, a1
-; RV32IM-NEXT:    mul a5, a0, a7
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    xor a1, a2, a1
-; RV32IM-NEXT:    mul a2, a0, a6
-; RV32IM-NEXT:    xor a2, a4, a2
-; RV32IM-NEXT:    xor a1, a1, a2
-; RV32IM-NEXT:    mul a0, a0, a3
-; RV32IM-NEXT:    xor a0, a1, a0
-; RV32IM-NEXT:    ret
-;
-; RV64IM-LABEL: clmul_i16:
-; RV64IM:       # %bb.0:
-; RV64IM-NEXT:    slli a0, a0, 48
-; RV64IM-NEXT:    andi a2, a1, 2
-; RV64IM-NEXT:    andi a3, a1, 1
-; RV64IM-NEXT:    andi a4, a1, 4
-; RV64IM-NEXT:    andi a5, a1, 8
-; RV64IM-NEXT:    andi a6, a1, 16
-; RV64IM-NEXT:    andi a7, a1, 32
-; RV64IM-NEXT:    srli a0, a0, 48
-; RV64IM-NEXT:    mul a2, a0, a2
-; RV64IM-NEXT:    mul a3, a0, a3
-; RV64IM-NEXT:    xor a2, a3, a2
-; RV64IM-NEXT:    andi a3, a1, 64
-; RV64IM-NEXT:    mul a4, a0, a4
-; RV64IM-NEXT:    mul a5, a0, a5
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    andi a5, a1, 128
-; RV64IM-NEXT:    mul a6, a0, a6
-; RV64IM-NEXT:    mul a7, a0, a7
-; RV64IM-NEXT:    xor a6, a6, a7
-; RV64IM-NEXT:    andi a7, a1, 256
-; RV64IM-NEXT:    mul a5, a0, a5
-; RV64IM-NEXT:    mul a7, a0, a7
-; RV64IM-NEXT:    xor a5, a5, a7
-; RV64IM-NEXT:    andi a7, a1, 512
-; RV64IM-NEXT:    xor a2, a2, a4
-; RV64IM-NEXT:    li a4, 1
-; RV64IM-NEXT:    mul a3, a0, a3
-; RV64IM-NEXT:    xor a3, a6, a3
-; RV64IM-NEXT:    lui a6, 1
-; RV64IM-NEXT:    mul a7, a0, a7
-; RV64IM-NEXT:    xor a5, a5, a7
-; RV64IM-NEXT:    lui a7, 2
-; RV64IM-NEXT:    slli a4, a4, 11
-; RV64IM-NEXT:    and a6, a1, a6
-; RV64IM-NEXT:    and a4, a1, a4
-; RV64IM-NEXT:    mul a6, a0, a6
-; RV64IM-NEXT:    mul a4, a0, a4
-; RV64IM-NEXT:    xor a4, a4, a6
-; RV64IM-NEXT:    lui a6, 4
-; RV64IM-NEXT:    xor a2, a2, a3
-; RV64IM-NEXT:    lui a3, 8
-; RV64IM-NEXT:    and a7, a1, a7
-; RV64IM-NEXT:    and a6, a1, a6
-; RV64IM-NEXT:    and a3, a1, a3
-; RV64IM-NEXT:    andi a1, a1, 1024
-; RV64IM-NEXT:    mul a1, a0, a1
-; RV64IM-NEXT:    xor a1, a5, a1
-; RV64IM-NEXT:    mul a5, a0, a7
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    xor a1, a2, a1
-; RV64IM-NEXT:    mul a2, a0, a6
-; RV64IM-NEXT:    xor a2, a4, a2
-; RV64IM-NEXT:    xor a1, a1, a2
-; RV64IM-NEXT:    mul a0, a0, a3
-; RV64IM-NEXT:    xor a0, a1, a0
-; RV64IM-NEXT:    ret
+; CHECK-LABEL: clmul_i16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andi a2, a1, 2
+; CHECK-NEXT:    andi a3, a1, 1
+; CHECK-NEXT:    andi a4, a1, 4
+; CHECK-NEXT:    andi a5, a1, 8
+; CHECK-NEXT:    andi a6, a1, 16
+; CHECK-NEXT:    andi a7, a1, 32
+; CHECK-NEXT:    andi t0, a1, 64
+; CHECK-NEXT:    andi t1, a1, 128
+; CHECK-NEXT:    mul a2, a0, a2
+; CHECK-NEXT:    mul a3, a0, a3
+; CHECK-NEXT:    xor a2, a3, a2
+; CHECK-NEXT:    andi a3, a1, 256
+; CHECK-NEXT:    mul a4, a0, a4
+; CHECK-NEXT:    mul a5, a0, a5
+; CHECK-NEXT:    xor a4, a4, a5
+; CHECK-NEXT:    andi a5, a1, 512
+; CHECK-NEXT:    mul a6, a0, a6
+; CHECK-NEXT:    mul a7, a0, a7
+; CHECK-NEXT:    xor a6, a6, a7
+; CHECK-NEXT:    li a7, 1
+; CHECK-NEXT:    mul t1, a0, t1
+; CHECK-NEXT:    mul a3, a0, a3
+; CHECK-NEXT:    xor a3, t1, a3
+; CHECK-NEXT:    lui t1, 1
+; CHECK-NEXT:    xor a2, a2, a4
+; CHECK-NEXT:    lui a4, 2
+; CHECK-NEXT:    mul t0, a0, t0
+; CHECK-NEXT:    xor a6, a6, t0
+; CHECK-NEXT:    lui t0, 4
+; CHECK-NEXT:    mul a5, a0, a5
+; CHECK-NEXT:    xor a3, a3, a5
+; CHECK-NEXT:    lui a5, 1048568
+; CHECK-NEXT:    slli a7, a7, 11
+; CHECK-NEXT:    and t1, a1, t1
+; CHECK-NEXT:    and a4, a1, a4
+; CHECK-NEXT:    and t0, a1, t0
+; CHECK-NEXT:    and a5, a1, a5
+; CHECK-NEXT:    and a7, a1, a7
+; CHECK-NEXT:    andi a1, a1, 1024
+; CHECK-NEXT:    mul a1, a0, a1
+; CHECK-NEXT:    mul t1, a0, t1
+; CHECK-NEXT:    mul a4, a0, a4
+; CHECK-NEXT:    mul t0, a0, t0
+; CHECK-NEXT:    mul a5, a0, a5
+; CHECK-NEXT:    mul a0, a0, a7
+; CHECK-NEXT:    xor a2, a2, a6
+; CHECK-NEXT:    xor a1, a3, a1
+; CHECK-NEXT:    xor a0, a0, t1
+; CHECK-NEXT:    xor a1, a2, a1
+; CHECK-NEXT:    xor a0, a0, a4
+; CHECK-NEXT:    xor a0, a1, a0
+; CHECK-NEXT:    xor a1, t0, a5
+; CHECK-NEXT:    xor a0, a0, a1
+; CHECK-NEXT:    ret
   %res = call i16 @llvm.clmul.i16(i16 %a, i16 %b)
   ret i16 %res
 }
@@ -324,71 +261,71 @@ define i32 @clmul_i32(i32 %a, i32 %b) nounwind {
 ;
 ; RV64IM-LABEL: clmul_i32:
 ; RV64IM:       # %bb.0:
-; RV64IM-NEXT:    addi sp, sp, -128
-; RV64IM-NEXT:    sd ra, 120(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    sd s0, 112(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    sd s1, 104(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    sd s2, 96(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    sd s3, 88(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    sd s4, 80(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    sd s5, 72(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    sd s6, 64(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    sd s7, 56(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    sd s8, 48(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    sd s9, 40(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    sd s10, 32(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    sd s11, 24(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    slli a6, a0, 32
-; RV64IM-NEXT:    andi t1, a1, 2
-; RV64IM-NEXT:    andi t3, a1, 1
-; RV64IM-NEXT:    andi a5, a1, 4
-; RV64IM-NEXT:    andi a7, a1, 8
-; RV64IM-NEXT:    andi a3, a1, 16
-; RV64IM-NEXT:    andi a4, a1, 32
-; RV64IM-NEXT:    andi a0, a1, 64
-; RV64IM-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    andi t0, a1, 128
-; RV64IM-NEXT:    andi t2, a1, 256
-; RV64IM-NEXT:    andi a0, a1, 512
-; RV64IM-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    li a2, 1
-; RV64IM-NEXT:    lui t5, 1
-; RV64IM-NEXT:    lui t6, 2
-; RV64IM-NEXT:    lui s0, 4
-; RV64IM-NEXT:    lui s2, 8
-; RV64IM-NEXT:    lui s3, 16
-; RV64IM-NEXT:    lui s4, 32
-; RV64IM-NEXT:    lui s5, 64
-; RV64IM-NEXT:    lui s6, 128
-; RV64IM-NEXT:    lui s7, 256
-; RV64IM-NEXT:    lui s8, 512
-; RV64IM-NEXT:    lui s9, 1024
-; RV64IM-NEXT:    lui s10, 2048
-; RV64IM-NEXT:    lui s11, 4096
-; RV64IM-NEXT:    lui ra, 8192
-; RV64IM-NEXT:    lui a0, 16384
-; RV64IM-NEXT:    srli s1, a6, 32
-; RV64IM-NEXT:    mul a6, s1, t1
-; RV64IM-NEXT:    mul t1, s1, t3
-; RV64IM-NEXT:    xor a6, t1, a6
-; RV64IM-NEXT:    sd a6, 0(sp) # 8-byte Folded Spill
-; RV64IM-NEXT:    lui t1, 32768
-; RV64IM-NEXT:    mul a5, s1, a5
-; RV64IM-NEXT:    mul a7, s1, a7
-; RV64IM-NEXT:    xor t4, a5, a7
-; RV64IM-NEXT:    lui a7, 65536
-; RV64IM-NEXT:    mul a3, s1, a3
-; RV64IM-NEXT:    mul a4, s1, a4
-; RV64IM-NEXT:    xor a6, a3, a4
-; RV64IM-NEXT:    lui t3, 131072
-; RV64IM-NEXT:    mul a4, s1, t0
-; RV64IM-NEXT:    mul t0, s1, t2
-; RV64IM-NEXT:    xor a5, a4, t0
+; RV64IM-NEXT:    addi sp, sp, -96
+; RV64IM-NEXT:    sd s0, 88(sp) # 8-byte Folded Spill
+; RV64IM-NEXT:    sd s1, 80(sp) # 8-byte Folded Spill
+; RV64IM-NEXT:    sd s2, 72(sp) # 8-byte Folded Spill
+; RV64IM-NEXT:    sd s3, 64(sp) # 8-byte Folded Spill
+; RV64IM-NEXT:    sd s4, 56(sp) # 8-byte Folded Spill
+; RV64IM-NEXT:    sd s5, 48(sp) # 8-byte Folded Spill
+; RV64IM-NEXT:    sd s6, 40(sp) # 8-byte Folded Spill
+; RV64IM-NEXT:    sd s7, 32(sp) # 8-byte Folded Spill
+; RV64IM-NEXT:    sd s8, 24(sp) # 8-byte Folded Spill
+; RV64IM-NEXT:    sd s9, 16(sp) # 8-byte Folded Spill
+; RV64IM-NEXT:    sd s10, 8(sp) # 8-byte Folded Spill
+; RV64IM-NEXT:    andi t6, a1, 2
+; RV64IM-NEXT:    andi s1, a1, 1
+; RV64IM-NEXT:    andi a7, a1, 4
+; RV64IM-NEXT:    andi t2, a1, 8
+; RV64IM-NEXT:    andi t0, a1, 16
+; RV64IM-NEXT:    andi t3, a1, 32
+; RV64IM-NEXT:    andi a2, a1, 64
+; RV64IM-NEXT:    andi t4, a1, 128
+; RV64IM-NEXT:    andi s0, a1, 256
+; RV64IM-NEXT:    andi a3, a1, 512
+; RV64IM-NEXT:    li a4, 1
+; RV64IM-NEXT:    lui a5, 1
+; RV64IM-NEXT:    lui a6, 2
+; RV64IM-NEXT:    lui t1, 4
+; RV64IM-NEXT:    lui t5, 8
+; RV64IM-NEXT:    lui s2, 16
+; RV64IM-NEXT:    lui s3, 32
+; RV64IM-NEXT:    lui s4, 64
+; RV64IM-NEXT:    lui s5, 128
+; RV64IM-NEXT:    lui s6, 256
+; RV64IM-NEXT:    lui s7, 512
+; RV64IM-NEXT:    lui s8, 1024
+; RV64IM-NEXT:    lui s9, 2048
+; RV64IM-NEXT:    lui s10, 4096
+; RV64IM-NEXT:    mulw t6, a0, t6
+; RV64IM-NEXT:    mulw s1, a0, s1
+; RV64IM-NEXT:    xor t6, s1, t6
+; RV64IM-NEXT:    lui s1, 8192
+; RV64IM-NEXT:    mulw a7, a0, a7
+; RV64IM-NEXT:    mulw t2, a0, t2
+; RV64IM-NEXT:    xor a7, a7, t2
+; RV64IM-NEXT:    lui t2, 16384
+; RV64IM-NEXT:    mulw t0, a0, t0
+; RV64IM-NEXT:    mulw t3, a0, t3
+; RV64IM-NEXT:    xor t0, t0, t3
+; RV64IM-NEXT:    lui t3, 32768
+; RV64IM-NEXT:    mulw t4, a0, t4
+; RV64IM-NEXT:    mulw s0, a0, s0
+; RV64IM-NEXT:    xor t4, t4, s0
+; RV64IM-NEXT:    lui s0, 65536
+; RV64IM-NEXT:    xor a7, t6, a7
+; RV64IM-NEXT:    lui t6, 131072
+; RV64IM-NEXT:    mulw a2, a0, a2
+; RV64IM-NEXT:    xor a2, t0, a2
 ; RV64IM-NEXT:    lui t0, 262144
-; RV64IM-NEXT:    slli t2, a2, 11
+; RV64IM-NEXT:    mulw a3, a0, a3
+; RV64IM-NEXT:    xor a3, t4, a3
+; RV64IM-NEXT:    lui t4, 524288
+; RV64IM-NEXT:    slli a4, a4, 11
+; RV64IM-NEXT:    and a5, a1, a5
+; RV64IM-NEXT:    and a6, a1, a6
+; RV64IM-NEXT:    and t1, a1, t1
 ; RV64IM-NEXT:    and t5, a1, t5
-; RV64IM-NEXT:    and t6, a1, t6
-; RV64IM-NEXT:    and s0, a1, s0
 ; RV64IM-NEXT:    and s2, a1, s2
 ; RV64IM-NEXT:    and s3, a1, s3
 ; RV64IM-NEXT:    and s4, a1, s4
@@ -398,85 +335,73 @@ define i32 @clmul_i32(i32 %a, i32 %b) nounwind {
 ; RV64IM-NEXT:    and s8, a1, s8
 ; RV64IM-NEXT:    and s9, a1, s9
 ; RV64IM-NEXT:    and s10, a1, s10
-; RV64IM-NEXT:    and s11, a1, s11
-; RV64IM-NEXT:    and ra, a1, ra
-; RV64IM-NEXT:    and a2, a1, a0
-; RV64IM-NEXT:    and t1, a1, t1
-; RV64IM-NEXT:    and a7, a1, a7
-; RV64IM-NEXT:    and t3, a1, t3
-; RV64IM-NEXT:    and t0, a1, t0
+; RV64IM-NEXT:    and s1, a1, s1
 ; RV64IM-NEXT:    and t2, a1, t2
-; RV64IM-NEXT:    andi a0, a1, 1024
-; RV64IM-NEXT:    srliw a1, a1, 31
-; RV64IM-NEXT:    slli a1, a1, 31
-; RV64IM-NEXT:    ld a3, 16(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    mul a3, s1, a3
-; RV64IM-NEXT:    ld a4, 8(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    mul a4, s1, a4
-; RV64IM-NEXT:    mul a0, s1, a0
-; RV64IM-NEXT:    mul t5, s1, t5
-; RV64IM-NEXT:    mul t6, s1, t6
-; RV64IM-NEXT:    mul s0, s1, s0
-; RV64IM-NEXT:    mul s2, s1, s2
-; RV64IM-NEXT:    mul s3, s1, s3
-; RV64IM-NEXT:    mul s4, s1, s4
-; RV64IM-NEXT:    mul s5, s1, s5
-; RV64IM-NEXT:    mul s6, s1, s6
-; RV64IM-NEXT:    mul s7, s1, s7
-; RV64IM-NEXT:    mul s8, s1, s8
-; RV64IM-NEXT:    mul s9, s1, s9
-; RV64IM-NEXT:    mul s10, s1, s10
-; RV64IM-NEXT:    mul s11, s1, s11
-; RV64IM-NEXT:    mul ra, s1, ra
-; RV64IM-NEXT:    mul a2, s1, a2
-; RV64IM-NEXT:    mul t1, s1, t1
-; RV64IM-NEXT:    mul a7, s1, a7
-; RV64IM-NEXT:    mul t3, s1, t3
-; RV64IM-NEXT:    mul t0, s1, t0
-; RV64IM-NEXT:    mul a1, s1, a1
-; RV64IM-NEXT:    mul t2, s1, t2
-; RV64IM-NEXT:    xor s1, s2, s3
-; RV64IM-NEXT:    xor s2, s8, s9
-; RV64IM-NEXT:    xor a7, a7, t3
-; RV64IM-NEXT:    ld t3, 0(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    xor t3, t3, t4
-; RV64IM-NEXT:    xor a3, a6, a3
-; RV64IM-NEXT:    xor a4, a5, a4
-; RV64IM-NEXT:    xor a5, t2, t5
-; RV64IM-NEXT:    xor a6, s1, s4
-; RV64IM-NEXT:    xor t2, s2, s10
-; RV64IM-NEXT:    xor a7, a7, t0
-; RV64IM-NEXT:    xor a3, t3, a3
-; RV64IM-NEXT:    xor a0, a4, a0
-; RV64IM-NEXT:    xor a4, a5, t6
-; RV64IM-NEXT:    xor a5, a6, s5
-; RV64IM-NEXT:    xor a6, t2, s11
-; RV64IM-NEXT:    xor a0, a3, a0
-; RV64IM-NEXT:    xor a4, a4, s0
-; RV64IM-NEXT:    xor a3, a5, s6
-; RV64IM-NEXT:    xor a5, a6, ra
-; RV64IM-NEXT:    xor a0, a0, a4
-; RV64IM-NEXT:    xor a3, a3, s7
-; RV64IM-NEXT:    xor a2, a5, a2
-; RV64IM-NEXT:    xor a0, a0, a3
-; RV64IM-NEXT:    xor a2, a2, t1
-; RV64IM-NEXT:    xor a0, a0, a2
-; RV64IM-NEXT:    xor a1, a7, a1
+; RV64IM-NEXT:    and t3, a1, t3
+; RV64IM-NEXT:    and s0, a1, s0
+; RV64IM-NEXT:    and t6, a1, t6
+; RV64IM-NEXT:    and t0, a1, t0
+; RV64IM-NEXT:    and t4, a1, t4
+; RV64IM-NEXT:    and a4, a1, a4
+; RV64IM-NEXT:    andi a1, a1, 1024
+; RV64IM-NEXT:    mulw a1, a0, a1
+; RV64IM-NEXT:    mulw a5, a0, a5
+; RV64IM-NEXT:    mulw a6, a0, a6
+; RV64IM-NEXT:    mulw t1, a0, t1
+; RV64IM-NEXT:    mulw t5, a0, t5
+; RV64IM-NEXT:    mulw s2, a0, s2
+; RV64IM-NEXT:    mulw s3, a0, s3
+; RV64IM-NEXT:    mulw s4, a0, s4
+; RV64IM-NEXT:    mulw s5, a0, s5
+; RV64IM-NEXT:    mulw s6, a0, s6
+; RV64IM-NEXT:    mulw s7, a0, s7
+; RV64IM-NEXT:    mulw s8, a0, s8
+; RV64IM-NEXT:    mulw s9, a0, s9
+; RV64IM-NEXT:    mulw s10, a0, s10
+; RV64IM-NEXT:    mulw s1, a0, s1
+; RV64IM-NEXT:    mulw t2, a0, t2
+; RV64IM-NEXT:    mulw t3, a0, t3
+; RV64IM-NEXT:    mulw s0, a0, s0
+; RV64IM-NEXT:    mulw t6, a0, t6
+; RV64IM-NEXT:    mulw t0, a0, t0
+; RV64IM-NEXT:    mulw t4, a0, t4
+; RV64IM-NEXT:    mulw a0, a0, a4
+; RV64IM-NEXT:    xor a4, t1, t5
+; RV64IM-NEXT:    xor t1, s5, s6
+; RV64IM-NEXT:    xor t2, s1, t2
+; RV64IM-NEXT:    xor a2, a7, a2
+; RV64IM-NEXT:    xor a1, a3, a1
+; RV64IM-NEXT:    xor a0, a0, a5
+; RV64IM-NEXT:    xor a3, a4, s2
+; RV64IM-NEXT:    xor a4, t1, s7
+; RV64IM-NEXT:    xor a5, t2, t3
+; RV64IM-NEXT:    xor a1, a2, a1
+; RV64IM-NEXT:    xor a0, a0, a6
+; RV64IM-NEXT:    xor a2, a3, s3
+; RV64IM-NEXT:    xor a3, a4, s8
+; RV64IM-NEXT:    xor a5, a5, s0
+; RV64IM-NEXT:    xor a0, a1, a0
+; RV64IM-NEXT:    xor a1, a2, s4
+; RV64IM-NEXT:    xor a2, a3, s9
+; RV64IM-NEXT:    xor a3, a5, t6
 ; RV64IM-NEXT:    xor a0, a0, a1
-; RV64IM-NEXT:    ld ra, 120(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    ld s0, 112(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    ld s1, 104(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    ld s2, 96(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    ld s3, 88(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    ld s4, 80(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    ld s5, 72(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    ld s6, 64(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    ld s7, 56(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    ld s8, 48(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    ld s9, 40(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    ld s10, 32(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    ld s11, 24(sp) # 8-byte Folded Reload
-; RV64IM-NEXT:    addi sp, sp, 128
+; RV64IM-NEXT:    xor a1, a2, s10
+; RV64IM-NEXT:    xor a2, a3, t0
+; RV64IM-NEXT:    xor a0, a0, a1
+; RV64IM-NEXT:    xor a1, a2, t4
+; RV64IM-NEXT:    xor a0, a0, a1
+; RV64IM-NEXT:    ld s0, 88(sp) # 8-byte Folded Reload
+; RV64IM-NEXT:    ld s1, 80(sp) # 8-byte Folded Reload
+; RV64IM-NEXT:    ld s2, 72(sp) # 8-byte Folded Reload
+; RV64IM-NEXT:    ld s3, 64(sp) # 8-byte Folded Reload
+; RV64IM-NEXT:    ld s4, 56(sp) # 8-byte Folded Reload
+; RV64IM-NEXT:    ld s5, 48(sp) # 8-byte Folded Reload
+; RV64IM-NEXT:    ld s6, 40(sp) # 8-byte Folded Reload
+; RV64IM-NEXT:    ld s7, 32(sp) # 8-byte Folded Reload
+; RV64IM-NEXT:    ld s8, 24(sp) # 8-byte Folded Reload
+; RV64IM-NEXT:    ld s9, 16(sp) # 8-byte Folded Reload
+; RV64IM-NEXT:    ld s10, 8(sp) # 8-byte Folded Reload
+; RV64IM-NEXT:    addi sp, sp, 96
 ; RV64IM-NEXT:    ret
   %res = call i32 @llvm.clmul.i32(i32 %a, i32 %b)
   ret i32 %res


### PR DESCRIPTION
This allows the expand code to see the original size. Previously we relied on computeKnownBits to optimize the code after it is expanded later. This removes the need to zero extend the input during promotion that was needed to make computeKnownBits work.