### PR TITLE
[flang-rt][build] Disable build-time warning of '-Wshift-count-negative' from g++ compiler and remove unsupported floating-point data.

### DIFF
--- a/flang-rt/lib/runtime/extensions.cpp
+++ b/flang-rt/lib/runtime/extensions.cpp
@@ -449,10 +449,8 @@ float RTNAME(Rand)(int *i, const char *sourceFile, int line) {
   unsigned mask = 0;
   constexpr int radix = std::numeric_limits<float>::radix;
   constexpr int digits = std::numeric_limits<float>::digits;
-  if (radix == 2) {
+  if constexpr (radix == 2) {
     mask = ~(unsigned)0u << (32 - digits + 1);
-  } else if (radix == 16) {
-    mask = ~(unsigned)0u << ((8 - digits) * 4 + 1);
   } else {
     Terminator terminator{sourceFile, line};
     terminator.Crash("Radix unknown value.");


### PR DESCRIPTION
When building the flang-rt project with the g++ compiler on  Linux-X86_64 machine, the compiler gives the following warning:

```
llvm-project/flang-rt/lib/runtime/extensions.cpp:455:26: warning: left shift count is negative [-Wshift-count-negative]
   455 |     mask = ~(unsigned)0u << ((8 - digits) * 4 + 1);
       |            ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~

```

All the discussion records see: https://github.com/llvm/llvm-project/pull/173955