### PR TITLE
[flang-rt][build] Disable two build-time warning of '-Wmaybe-uninitialized' from g++ compiler

### DIFF
--- a/flang-rt/lib/runtime/character.cpp
+++ b/flang-rt/lib/runtime/character.cpp
@@ -155,6 +155,11 @@ static RT_API_ATTRS void Adjust(CHAR *to, const CHAR *from, std::size_t chars) {
   }
 }
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 template <typename CHAR, bool ADJUSTR>
 static RT_API_ATTRS void AdjustLRHelper(Descriptor &result,
     const Descriptor &string, const Terminator &terminator) {
@@ -182,6 +187,10 @@ static RT_API_ATTRS void AdjustLRHelper(Descriptor &result,
         string.Element<const CHAR>(stringAt), elementBytes >> shift<CHAR>);
   }
 }
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 template <bool ADJUSTR>
 RT_API_ATTRS void AdjustLR(Descriptor &result, const Descriptor &string,
@@ -211,6 +220,11 @@ inline RT_API_ATTRS std::size_t LenTrim(const CHAR *x, std::size_t chars) {
   return chars;
 }
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 template <typename INT, typename CHAR>
 static RT_API_ATTRS void LenTrim(Descriptor &result, const Descriptor &string,
     const Terminator &terminator) {
@@ -237,6 +251,10 @@ static RT_API_ATTRS void LenTrim(Descriptor &result, const Descriptor &string,
         LenTrim(string.Element<CHAR>(stringAt), stringElementChars);
   }
 }
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 template <typename CHAR>
 static RT_API_ATTRS void LenTrimKind(Descriptor &result,


### PR DESCRIPTION
When building the flang-rt project with the g++ compiler on Linux-X86_64 machine, the compiler gives the following warning:

```
llvm-project/flang-rt/lib/runtime/character.cpp:171:19: warning: ‘ub’ may be used uninitialized [-Wmaybe-uninitialized]
   171 |   result.Establish(string.type(), elementBytes, nullptr, rank, ub,
       |   ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   172 |       CFI_attribute_allocatable);
       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~

llvm-project/flang-rt/lib/runtime/character.cpp:225:19: warning: ‘ub’ may be used uninitialized [-Wmaybe-uninitialized]
   225 |   result.Establish(TypeCategory::Integer, sizeof(INT), nullptr, rank, ub,
       |   ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   226 |       CFI_attribute_allocatable);
       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~

```

All the discussion records see: https://github.com/llvm/llvm-project/pull/173955