### PR TITLE
[flang-rt][build] Disable two build-time warning of '-Wuninitialized' from g++ compiler

### DIFF
--- a/flang-rt/include/flang-rt/runtime/numeric-templates.h
+++ b/flang-rt/include/flang-rt/runtime/numeric-templates.h
@@ -49,6 +49,11 @@ struct MaxOrMinIdentity<TypeCategory::Integer, 16, IS_MAXVAL> {
   }
 };
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
+
 #if HAS_FLOAT128
 // std::numeric_limits<> may not support __float128.
 //
@@ -87,6 +92,10 @@ struct MaxOrMinIdentity<TypeCategory::Real, 16, IS_MAXVAL,
 };
 #endif // HAS_FLOAT128
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 // Minimum finite representable value.
 // For floating-point types, returns minimum positive normalized value.
 template <int PREC, typename T> struct MinValue {
@@ -96,6 +105,11 @@ template <typename T> struct MinValue<11, T> {
   // TINY(0._2)
   static constexpr RT_API_ATTRS T get() { return 0.00006103515625E-04; }
 };
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
 
 #if HAS_FLOAT128
 template <> struct MinValue<113, CppTypeFor<TypeCategory::Real, 16>> {
@@ -122,6 +136,10 @@ template <> struct MinValue<113, CppTypeFor<TypeCategory::Real, 16>> {
   }
 };
 #endif // HAS_FLOAT128
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 template <typename T> struct ABSTy {
   static constexpr RT_API_ATTRS T compute(T x) { return std::abs(x); }


### PR DESCRIPTION
When building the flang-rt project with the g++ compiler on Linux-X86_64 machine, the compiler gives the following warning:

```

llvm-project/flang-rt/include/flang-rt/runtime/numeric-templates.h:112:9: warning: ‘data’ is used uninitialized [-Wuninitialized]
   112 |     if (*reinterpret_cast<std::uint64_t *>(data) != 0 ||
       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
llvm-project/flang-rt/include/flang-rt/runtime/numeric-templates.h:107:29: note: ‘data’ declared here
   107 |     alignas(alignment) char data[sizeof(Type)];
       |                             ^~~~

llvm-project/flang-rt/include/flang-rt/runtime/numeric-templates.h:75:50: warning: ‘data’ is used uninitialized [-Wuninitialized]
    75 |     if (*reinterpret_cast<std::uint64_t *>(data) != 0 ||
       |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
llvm-tools/llvm-project/flang-rt/include/flang-rt/runtime/numeric-templates.h:70:29: note: ‘data’ declared here
    70 |     alignas(alignment) char data[sizeof(Type)];
       |                             ^~~~

```

All the discussion records see: https://github.com/llvm/llvm-project/pull/173955