### PR TITLE
[PseudoProbe] Add switch to control illegal guid warnings

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/PseudoProbePrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/PseudoProbePrinter.cpp
@@ -25,6 +25,16 @@
 
 using namespace llvm;
 
+#ifndef NDEBUG
+// Deprecated with ThinLTO. For some modules compiled with ThinLTO, certain
+// pseudo probe descriptors may not be imported, resulting in false positive
+// warning.
+static cl::opt<bool> VerifyGuidExistence(
+    "pseudo-probe-verify-guid-existence-in-desc",
+    cl::desc("Verify whether GUID exists in the .pseudo_probe_desc."),
+    cl::Hidden, cl::init(false));
+#endif
+
 void PseudoProbeHandler::emitPseudoProbe(uint64_t Guid, uint64_t Index,
                                          uint64_t Type, uint64_t Attr,
                                          const DILocation *DebugLoc) {
@@ -41,7 +51,8 @@ void PseudoProbeHandler::emitPseudoProbe(uint64_t Guid, uint64_t Index,
     if (!CallerGuid)
       CallerGuid = Function::getGUIDAssumingExternalLinkage(Name);
 #ifndef NDEBUG
-    verifyGuidExistenceInDesc(CallerGuid, Name);
+    if (VerifyGuidExistence)
+      verifyGuidExistenceInDesc(CallerGuid, Name);
 #endif
     uint64_t CallerProbeId = PseudoProbeDwarfDiscriminator::extractProbeIndex(
         InlinedAt->getDiscriminator());
@@ -60,8 +71,9 @@ void PseudoProbeHandler::emitPseudoProbe(uint64_t Guid, uint64_t Index,
   Asm->OutStreamer->emitPseudoProbe(Guid, Index, Type, Attr, Discriminator,
                                     InlineStack, Asm->CurrentFnSym);
 #ifndef NDEBUG
-  verifyGuidExistenceInDesc(
-      Guid, DebugLoc ? DebugLoc->getSubprogramLinkageName() : "");
+  if (VerifyGuidExistence)
+    verifyGuidExistenceInDesc(
+        Guid, DebugLoc ? DebugLoc->getSubprogramLinkageName() : "");
 #endif
 }
 

--- a/llvm/test/CodeGen/X86/pseudo-probe-desc-check.ll
+++ b/llvm/test/CodeGen/X86/pseudo-probe-desc-check.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: asserts
-; RUN: llc -mtriple=x86_64-unknown-linux-gnu < %s -o /dev/null 2>&1 | FileCheck %s
-; RUN: llc -mtriple=x86_64-unknown-windows-msvc < %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -pseudo-probe-verify-guid-existence-in-desc < %s -o /dev/null 2>&1 | FileCheck %s
+; RUN: llc -mtriple=x86_64-unknown-windows-msvc -pseudo-probe-verify-guid-existence-in-desc < %s -o /dev/null 2>&1 | FileCheck %s
 
 ; CHECK: warning: Guid:8314849053352128226 Name:inlinee does not exist in pseudo probe desc
 ; CHECK: warning: Guid:6492337042787843907 Name:extract2 does not exist in pseudo probe desc


### PR DESCRIPTION
Do not verify GUID existence in pseudo probe desc by default since it
generates false positive warnings with ThinLTO.
User can use -pseudo-probe-verify-guid-existence-in-desc to verify it
explicitly.