### PR TITLE
[VPlan] Strip iterator-invalidation guard in findHeaderMask (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -2822,7 +2822,7 @@ static VPSingleDefRecipe *findHeaderMask(VPlan &Plan) {
   // (ICMP_ULE, WideCanonicalIV, backedge-taken-count).
   VPSingleDefRecipe *HeaderMask = nullptr;
   for (auto *Wide : WideCanonicalIVs) {
-    for (VPUser *U : SmallVector<VPUser *>(Wide->users())) {
+    for (VPUser *U : Wide->users()) {
       auto *VPI = dyn_cast<VPInstruction>(U);
       if (!VPI || !vputils::isHeaderMask(VPI, Plan))
         continue;


### PR DESCRIPTION
It is unnecessary, as the users are never modified.