### PR TITLE
[BOLT][BTI] Disallow instrumenting BTI binaries

### DIFF
--- a/bolt/lib/Passes/Instrumentation.cpp
+++ b/bolt/lib/Passes/Instrumentation.cpp
@@ -600,6 +600,22 @@ void Instrumentation::instrumentFunction(BinaryFunction &Function,
 }
 
 Error Instrumentation::runOnFunctions(BinaryContext &BC) {
+  if (BC.usesBTI())
+    return createFatalBOLTError(
+        "BOLT-ERROR: instrumenting binaries using BTI is not supported.\n");
+  /* BTI TODO:
+   Instrumentation functions add indirect branches into the .text.injected
+   section, see:
+   - __bolt_instr_ind_call_handler
+   - __bolt_instr_ind_tail_call_handler
+   - __bolt_instr_ind_tailcall_handler_func
+   - __bolt_start_trampoline
+   - __bolt_fini_trampoline
+   We cannot add BTIs to their targets when they are created, because the
+   instrumentation snippets get added later to these targets, and the added BTI
+   instruction will not be the first (rendering it useless).
+   */
+
   const unsigned Flags = BinarySection::getFlags(/*IsReadOnly=*/false,
                                                  /*IsText=*/false,
                                                  /*IsAllocatable=*/true);

--- a/bolt/test/runtime/AArch64/instrumentation-ind-call-bti.c
+++ b/bolt/test/runtime/AArch64/instrumentation-ind-call-bti.c
@@ -1,5 +1,5 @@
 // Copy of instrumentation-ind-call.c, but checking that BOLT refuses the
-// instrumentation becuase of BTI.
+// instrumentation because of BTI.
 // TODO: once instrumentation support for BTI is added, update this to check the
 // same as instrumentation-ind-call.c
 

--- a/bolt/test/runtime/AArch64/instrumentation-ind-call-bti.c
+++ b/bolt/test/runtime/AArch64/instrumentation-ind-call-bti.c
@@ -1,0 +1,30 @@
+// Copy of instrumentation-ind-call.c, but checking that BOLT refuses the
+// instrumentation becuase of BTI.
+// TODO: once instrumentation support for BTI is added, update this to check the
+// same as instrumentation-ind-call.c
+
+#include <stdio.h>
+
+typedef int (*func_ptr)(int, int);
+
+int add(int a, int b) { return a + b; }
+
+int main() {
+  func_ptr fun;
+  fun = add;
+  int sum = fun(10, 20); // indirect call to 'add'
+  printf("The sum is: %d\n", sum);
+  return 0;
+}
+/*
+REQUIRES: system-linux,bolt-runtime
+
+RUN: %clang %cflags %s -o %t.exe -Wl,-q -no-pie -fpie \
+RUN: -mbranch-protection=standard -Wl,-z,force-bti
+
+RUN: not llvm-bolt %t.exe --instrument --instrumentation-file=%t.fdata \
+RUN:   -o %t.instrumented 2>&1 | FileCheck %s
+
+CHECK: binary is using BTI
+CHECK: FATAL BOLT-ERROR: instrumenting binaries using BTI is not supported
+*/


### PR DESCRIPTION
Until instrumentation support is added, the feature should be
disabled for BTI binaries. An error message is added to explain
the situation.
Meanwhile, users can choose sampling-based profiling methods.

Added a TODO comment explaining missing steps.