### PR TITLE
[VPlan] Refine some types to VPIRValue (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -130,9 +130,7 @@ const VPRecipeBase *VPValue::getDefiningRecipe() const {
   return cast<VPRecipeBase>(DefValue->Def);
 }
 
-Value *VPValue::getLiveInIRValue() const {
-  return cast<VPIRValue>(this)->getValue();
-}
+Value *VPValue::getIRValue() const { return cast<VPIRValue>(this)->getValue(); }
 
 Type *VPIRValue::getType() const { return getUnderlyingValue()->getType(); }
 
@@ -296,7 +294,7 @@ Value *VPTransformState::get(const VPValue *Def, bool NeedsScalar) {
   };
 
   if (!hasScalarValue(Def, {0})) {
-    Value *IRV = Def->getLiveInIRValue();
+    Value *IRV = Def->getIRValue();
     Value *B = GetBroadcastInstrs(IRV);
     set(Def, B);
     return B;
@@ -893,7 +891,7 @@ VPlan::~VPlan() {
     }
     delete VPB;
   }
-  for (VPValue *VPV : getLiveIns())
+  for (VPIRValue *VPV : getLiveIns())
     delete VPV;
   delete BackedgeTakenCount;
 }
@@ -1478,7 +1476,7 @@ void VPSlotTracker::assignNames(const VPlan &Plan) {
   assignName(&Plan.VectorTripCount);
   if (Plan.BackedgeTakenCount)
     assignName(Plan.BackedgeTakenCount);
-  for (VPValue *LI : Plan.getLiveIns())
+  for (VPIRValue *LI : Plan.getLiveIns())
     assignName(LI);
 
   ReversePostOrderTraversal<VPBlockDeepTraversalWrapper<const VPBlockBase *>>

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -1731,9 +1731,8 @@ public:
       : VPRecipeWithIRFlags(VPDef::VPWidenCallSC, CallArguments, Flags, DL),
         VPIRMetadata(Metadata), Variant(Variant) {
     setUnderlyingValue(UV);
-    assert(
-        isa<Function>(getOperand(getNumOperands() - 1)->getLiveInIRValue()) &&
-        "last operand must be the called function");
+    assert(isa<Function>(getOperand(getNumOperands() - 1)->getIRValue()) &&
+           "last operand must be the called function");
   }
 
   ~VPWidenCallRecipe() override = default;
@@ -1753,7 +1752,7 @@ public:
                               VPCostContext &Ctx) const override;
 
   Function *getCalledScalarFunction() const {
-    return cast<Function>(getOperand(getNumOperands() - 1)->getLiveInIRValue());
+    return cast<Function>(getOperand(getNumOperands() - 1)->getIRValue());
   }
 
   operand_range args() { return drop_end(operands()); }
@@ -3103,7 +3102,8 @@ public:
     assert(Red->getRecurrenceKind() == RecurKind::Add &&
            "Expected an add reduction");
     assert(getNumOperands() >= 3 && "Expected at least three operands");
-    [[maybe_unused]] auto *SubConst = dyn_cast<ConstantInt>(getOperand(2)->getLiveInIRValue());
+    [[maybe_unused]] auto *SubConst =
+        dyn_cast<ConstantInt>(getOperand(2)->getIRValue());
     assert(SubConst && SubConst->getValue() == 0 &&
            Sub->getOpcode() == Instruction::Sub && "Expected a negating sub");
   }

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
@@ -171,7 +171,7 @@ Type *VPTypeAnalysis::inferScalarTypeForRecipe(const VPWidenRecipe *R) {
   case Instruction::ExtractValue: {
     assert(R->getNumOperands() == 2 && "expected single level extractvalue");
     auto *StructTy = cast<StructType>(inferScalarType(R->getOperand(0)));
-    auto *CI = cast<ConstantInt>(R->getOperand(1)->getLiveInIRValue());
+    auto *CI = cast<ConstantInt>(R->getOperand(1)->getIRValue());
     return StructTy->getTypeAtIndex(CI->getZExtValue());
   }
   case Instruction::Select:
@@ -217,7 +217,7 @@ Type *VPTypeAnalysis::inferScalarTypeForRecipe(const VPReplicateRecipe *R) {
   switch (Opcode) {
   case Instruction::Call: {
     unsigned CallIdx = R->getNumOperands() - (R->isPredicated() ? 2 : 1);
-    return cast<Function>(R->getOperand(CallIdx)->getLiveInIRValue())
+    return cast<Function>(R->getOperand(CallIdx)->getIRValue())
         ->getReturnType();
   }
   case Instruction::Select: {

--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -863,7 +863,7 @@ struct IntrinsicID_match {
     auto MatchCalleeIntrinsic = [&](VPValue *CalleeOp) {
       if (!isa<VPIRValue>(CalleeOp))
         return false;
-      auto *F = cast<Function>(CalleeOp->getLiveInIRValue());
+      auto *F = cast<Function>(CalleeOp->getIRValue());
       return F->getIntrinsicID() == ID;
     };
     if (const auto *R = dyn_cast<VPReplicateRecipe>(V))

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -393,7 +393,7 @@ VPUnrollPartAccessor<PartOpIdx>::getUnrollPartOperand(const VPUser &U) const {
 template <unsigned PartOpIdx>
 unsigned VPUnrollPartAccessor<PartOpIdx>::getUnrollPart(const VPUser &U) const {
   if (auto *UnrollPartOp = getUnrollPartOperand(U))
-    return cast<ConstantInt>(UnrollPartOp->getLiveInIRValue())->getZExtValue();
+    return cast<ConstantInt>(UnrollPartOp->getIRValue())->getZExtValue();
   return 0;
 }
 
@@ -579,7 +579,7 @@ Value *VPInstruction::generate(VPTransformState &State) {
                                Name);
 
     ElementCount EC = State.VF.multiplyCoefficientBy(
-        cast<ConstantInt>(getOperand(2)->getLiveInIRValue())->getZExtValue());
+        cast<ConstantInt>(getOperand(2)->getIRValue())->getZExtValue());
     auto *PredTy = VectorType::get(Builder.getInt1Ty(), EC);
     return Builder.CreateIntrinsic(Intrinsic::get_active_lane_mask,
                                    {PredTy, ScalarTC->getType()},
@@ -696,7 +696,7 @@ Value *VPInstruction::generate(VPTransformState &State) {
     // If this start vector is scaled then it should produce a vector with fewer
     // elements than the VF.
     ElementCount VF = State.VF.divideCoefficientBy(
-        cast<ConstantInt>(getOperand(2)->getLiveInIRValue())->getZExtValue());
+        cast<ConstantInt>(getOperand(2)->getIRValue())->getZExtValue());
     auto *Iden = Builder.CreateVectorSplat(VF, State.get(getOperand(1), true));
     return Builder.CreateInsertElement(Iden, State.get(getOperand(0), true),
                                        Builder.getInt32(0));
@@ -740,7 +740,7 @@ Value *VPInstruction::generate(VPTransformState &State) {
                                       State.get(getOperand(3 + Part)));
 
     Value *Start = State.get(getOperand(1), true);
-    Value *Sentinel = getOperand(2)->getLiveInIRValue();
+    Value *Sentinel = getOperand(2)->getIRValue();
 
     // Reduce the vector to a scalar.
     bool IsFindLast = RecurrenceDescriptor::isFindLastIVRecurrenceKind(RK);
@@ -1209,7 +1209,7 @@ InstructionCost VPInstruction::computeCost(ElementCount VF,
   case VPInstruction::ActiveLaneMask: {
     Type *ArgTy = Ctx.Types.inferScalarType(getOperand(0));
     unsigned Multiplier =
-        cast<ConstantInt>(getOperand(2)->getLiveInIRValue())->getZExtValue();
+        cast<ConstantInt>(getOperand(2)->getIRValue())->getZExtValue();
     Type *RetTy = toVectorTy(Type::getInt1Ty(Ctx.LLVMCtx), VF * Multiplier);
     IntrinsicCostAttributes Attrs(Intrinsic::get_active_lane_mask, RetTy,
                                   {ArgTy, ArgTy});
@@ -2193,7 +2193,7 @@ void VPWidenRecipe::execute(VPTransformState &State) {
   case Instruction::ExtractValue: {
     assert(getNumOperands() == 2 && "expected single level extractvalue");
     Value *Op = State.get(getOperand(0));
-    auto *CI = cast<ConstantInt>(getOperand(1)->getLiveInIRValue());
+    auto *CI = cast<ConstantInt>(getOperand(1)->getIRValue());
     Value *Extract = Builder.CreateExtractValue(Op, CI->getZExtValue());
     State.set(this, Extract);
     break;
@@ -3259,7 +3259,7 @@ InstructionCost VPReplicateRecipe::computeCost(ElementCount VF,
     return 0;
   case Instruction::Call: {
     auto *CalledFn =
-        cast<Function>(getOperand(getNumOperands() - 1)->getLiveInIRValue());
+        cast<Function>(getOperand(getNumOperands() - 1)->getIRValue());
 
     SmallVector<const VPValue *> ArgOps(drop_end(operands()));
     SmallVector<Type *, 4> Tys;
@@ -4353,7 +4353,7 @@ void VPWidenCanonicalIVRecipe::printRecipe(raw_ostream &O, const Twine &Indent,
 void VPFirstOrderRecurrencePHIRecipe::execute(VPTransformState &State) {
   auto &Builder = State.Builder;
   // Create a vector from the initial value.
-  auto *VectorInit = getStartValue()->getLiveInIRValue();
+  auto *VectorInit = getStartValue()->getIRValue();
 
   Type *VecTy = State.VF.isScalar()
                     ? VectorInit->getType()

--- a/llvm/lib/Transforms/Vectorize/VPlanUnroll.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUnroll.cpp
@@ -68,7 +68,7 @@ class UnrollState {
   void unrollWidenInductionByUF(VPWidenInductionRecipe *IV,
                                 VPBasicBlock::iterator InsertPtForPhi);
 
-  VPValue *getConstantInt(unsigned Part) {
+  VPIRValue *getConstantInt(unsigned Part) {
     Type *CanIVIntTy = Plan.getVectorLoopRegion()->getCanonicalIVType();
     return Plan.getConstantInt(CanIVIntTy, Part);
   }
@@ -491,7 +491,7 @@ cloneForLane(VPlan &Plan, VPBuilder &Builder, Type *IdxTy,
     if (LaneDefs != Def2LaneDefs.end())
       return LaneDefs->second[Lane.getKnownLane()];
 
-    VPValue *Idx = Plan.getConstantInt(IdxTy, Lane.getKnownLane());
+    VPIRValue *Idx = Plan.getConstantInt(IdxTy, Lane.getKnownLane());
     return Builder.createNaryOp(Instruction::ExtractElement, {Op, Idx});
   }
 
@@ -527,7 +527,7 @@ cloneForLane(VPlan &Plan, VPBuilder &Builder, Type *IdxTy,
           cast<VPInstruction>(Op)->getOperand(Lane.getKnownLane()));
       continue;
     }
-    VPValue *Idx = Plan.getConstantInt(IdxTy, Lane.getKnownLane());
+    VPIRValue *Idx = Plan.getConstantInt(IdxTy, Lane.getKnownLane());
     VPValue *Ext = Builder.createNaryOp(Instruction::ExtractElement, {Op, Idx});
     NewOps.push_back(Ext);
   }

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -72,7 +72,7 @@ public:
   Value *getUnderlyingValue() const { return UnderlyingVal; }
 
   /// Return the underlying IR value for a VPIRValue.
-  Value *getLiveInIRValue() const;
+  Value *getIRValue() const;
 
   /// An enumeration for keeping track of the concrete subclass of VPValue that
   /// are actually instantiated.


### PR DESCRIPTION
Follow up on 31b93d6e ([VPlan] Add specialized VPValue subclasses for different types (NFC), #172758) to refine the types of some VPValues to VPIRValues. While at it, rename getLiveInIRValue to getIRValue.