### PR TITLE
[llvm][llvm-readobj] Add AArch64 NT_ARM_POE note type

### DIFF
--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -1788,6 +1788,7 @@ enum : unsigned {
   NT_ARM_ZA = 0x40c,
   NT_ARM_ZT = 0x40d,
   NT_ARM_FPMR = 0x40e,
+  NT_ARM_POE = 0x40f,
   NT_ARM_GCS = 0x410,
 
   NT_FILE = 0x46494c45,

--- a/llvm/lib/ObjectYAML/ELFYAML.cpp
+++ b/llvm/lib/ObjectYAML/ELFYAML.cpp
@@ -135,6 +135,7 @@ void ScalarEnumerationTraits<ELFYAML::ELF_NT>::enumeration(
   ECase(NT_ARM_ZA);
   ECase(NT_ARM_ZT);
   ECase(NT_ARM_FPMR);
+  ECase(NT_ARM_POE);
   ECase(NT_ARM_GCS);
   ECase(NT_FILE);
   ECase(NT_PRXFPREG);

--- a/llvm/test/tools/llvm-readobj/ELF/note-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-core.test
@@ -265,6 +265,11 @@
 # RUN: llvm-readelf --notes %t_nt_arm_fpmr.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_FPMR (AArch64 Floating Point Mode Register)"
 # RUN: llvm-readobj --notes %t_nt_arm_fpmr.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_FPMR (AArch64 Floating Point Mode Register)"
 
+## Check ELF::NT_ARM_POE
+# RUN: yaml2obj %s -DTYPE=0x40f -o %t_nt_arm_poe.o
+# RUN: llvm-readelf --notes %t_nt_arm_poe.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_POE (AArch64 Permission Overlay Extension Registers)"
+# RUN: llvm-readobj --notes %t_nt_arm_poe.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_POE (AArch64 Permission Overlay Extension Registers)"
+
 ## Check ELF::NT_ARM_GCS
 # RUN: yaml2obj %s -DTYPE=0x410 -o %t_nt_arm_gcs.o
 # RUN: llvm-readelf --notes %t_nt_arm_gcs.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_GCS (AArch64 Guarded Control Stack state)"

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -6205,6 +6205,8 @@ const NoteType CoreNoteTypes[] = {
     {ELF::NT_ARM_ZA, "NT_ARM_ZA (AArch64 SME ZA registers)"},
     {ELF::NT_ARM_ZT, "NT_ARM_ZT (AArch64 SME ZT registers)"},
     {ELF::NT_ARM_FPMR, "NT_ARM_FPMR (AArch64 Floating Point Mode Register)"},
+    {ELF::NT_ARM_POE,
+     "NT_ARM_POE (AArch64 Permission Overlay Extension Registers)"},
     {ELF::NT_ARM_GCS, "NT_ARM_GCS (AArch64 Guarded Control Stack state)"},
 
     {ELF::NT_FILE, "NT_FILE (mapped files)"},


### PR DESCRIPTION
This note contains register values for the AArch64 Permission Overlay Extension (POE).