### PR TITLE
[MLIR][docs] Clarify Python version support status

### DIFF
--- a/mlir/docs/Bindings/Python.md
+++ b/mlir/docs/Bindings/Python.md
@@ -8,7 +8,7 @@
 
 ### Pre-requisites
 
-*   A relatively recent Python3 installation
+*   A [non-EOL](https://devguide.python.org/versions/) Python3 installation
 *   Installation of Python dependencies as specified in
     `mlir/python/requirements.txt`
 


### PR DESCRIPTION
According to this RFC (https://discourse.llvm.org/t/rfc-adopt-regularly-scheduled-python-minimum-version-bumps/88841), we no longer support Python versions that have reached EOL. This PR mainly clarifies the somewhat vague wording of “a relatively recent Python 3 installation.”
