### PR TITLE
[CI] Enable OpenMP and Offload runtime in premerge

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -162,10 +162,10 @@ PROJECT_CHECK_TARGETS = {
     "libc": "check-libc",
     "libclc": "check-libclc",
     "mlir": "check-mlir",
-    "openmp": "openmp", # Run only build in pre-merge
+    "openmp": "openmp",  # Run only build in pre-merge
     "polly": "check-polly",
     "lit": "check-lit",
-    "offload": "offload", #Run only build in pre-merge
+    "offload": "offload",  # Run only build in pre-merge
 }
 
 RUNTIMES = {

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -25,7 +25,6 @@ PROJECT_DEPENDENCIES = {
     "compiler-rt": {"clang", "lld"},
     "cross-project-tests": {"clang", "lldb", "lld"},
     "libc": {"clang", "lld"},
-    "openmp": {"clang", "lld"},
     "flang": {"llvm", "clang"},
     "flang-rt": {"flang"},
     "lldb": {"llvm", "clang"},
@@ -33,6 +32,8 @@ PROJECT_DEPENDENCIES = {
     "lld": {"llvm"},
     "mlir": {"llvm"},
     "polly": {"llvm"},
+    "openmp": {"clang", "lld"},
+    "offload": {"clang", "lld", "flang"},
 }
 
 # This mapping describes the additional projects that should be tested when a
@@ -67,7 +68,6 @@ DEPENDENTS_TO_TEST = {
         "mlir",
         "polly",
         "flang",
-        "openmp",
     },
 }
 
@@ -75,7 +75,11 @@ DEPENDENTS_TO_TEST = {
 # but not necessarily run for testing. The only case of this currently is lldb
 # which needs some runtimes enabled for tests.
 DEPENDENT_RUNTIMES_TO_BUILD = {
-    "lldb": {"libcxx", "libcxxabi", "libunwind", "compiler-rt"}
+    "lldb": {"libcxx", "libcxxabi", "libunwind", "compiler-rt"},
+    "clang": {"openmp", "offload"},
+    "llvm": {"openmp", "offload"},
+    "lld": {"openmp", "offload"},
+    ".ci": {"openmp", "offload"},
 }
 
 # This mapping describes runtimes that should be tested when the key project is
@@ -89,7 +93,9 @@ DEPENDENT_RUNTIMES_TO_TEST = {
     "compiler-rt": {"compiler-rt"},
     "flang": {"flang-rt"},
     "flang-rt": {"flang-rt"},
-    ".ci": {"compiler-rt", "libc", "flang-rt", "libclc"},
+    "openmp": {"openmp"},
+    "offload": {"offload"},
+    ".ci": {"compiler-rt", "libc", "flang-rt", "libclc", "openmp", "offload"},
 }
 DEPENDENT_RUNTIMES_TO_TEST_NEEDS_RECONFIG = {
     "llvm": {"libcxx", "libcxxabi", "libunwind"},
@@ -98,7 +104,7 @@ DEPENDENT_RUNTIMES_TO_TEST_NEEDS_RECONFIG = {
 }
 
 EXCLUDE_LINUX = {
-    "openmp",  # https://github.com/google/llvm-premerge-checks/issues/410
+    "cross-project-tests",  # TODO(issues/132796): Tests are failing.
 }
 
 # Runtimes configured for cross-compilation using LLVM_RUNTIME_TARGETS.
@@ -116,6 +122,7 @@ EXCLUDE_WINDOWS = {
     "libcxxabi",
     "libunwind",
     "flang-rt",
+    "offload",
 }
 
 # These are projects that we should test if the project itself is changed but
@@ -139,6 +146,7 @@ EXCLUDE_MAC = {
     "libcxx",
     "libcxxabi",
     "libunwind",
+    "offload",
 }
 
 PROJECT_CHECK_TARGETS = {
@@ -159,7 +167,6 @@ PROJECT_CHECK_TARGETS = {
     "libc": "check-libc",
     "libclc": "check-libclc",
     "mlir": "check-mlir",
-    "openmp": "check-openmp",
     "polly": "check-polly",
     "lit": "check-lit",
 }
@@ -172,6 +179,8 @@ RUNTIMES = {
     "libc",
     "flang-rt",
     "libclc",
+    "openmp",
+    "offload",
 }
 
 # Meta projects are projects that need explicit handling but do not reside

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -163,8 +163,10 @@ PROJECT_CHECK_TARGETS = {
     "libc": "check-libc",
     "libclc": "check-libclc",
     "mlir": "check-mlir",
+    "openmp": "check-openmp",
     "polly": "check-polly",
     "lit": "check-lit",
+    "offload": "check-offload",
 }
 
 RUNTIMES = {

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -100,7 +100,6 @@ DEPENDENT_RUNTIMES_TO_TEST_NEEDS_RECONFIG = {
 }
 
 EXCLUDE_LINUX = {
-    "cross-project-tests",  # TODO(issues/132796): Tests are failing.
 }
 
 # Runtimes configured for cross-compilation using LLVM_RUNTIME_TARGETS.
@@ -163,10 +162,10 @@ PROJECT_CHECK_TARGETS = {
     "libc": "check-libc",
     "libclc": "check-libclc",
     "mlir": "check-mlir",
-    "openmp": "openmp",
+    "openmp": "openmp", # Run only build in pre-merge
     "polly": "check-polly",
     "lit": "check-lit",
-    "offload": "offload",
+    "offload": "offload", #Run only build in pre-merge
 }
 
 RUNTIMES = {

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -166,7 +166,7 @@ PROJECT_CHECK_TARGETS = {
     "openmp": "check-openmp",
     "polly": "check-polly",
     "lit": "check-lit",
-    "offload": "check-offload",
+    "offload": "offload",
 }
 
 RUNTIMES = {

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -25,6 +25,7 @@ PROJECT_DEPENDENCIES = {
     "compiler-rt": {"clang", "lld"},
     "cross-project-tests": {"clang", "lldb", "lld"},
     "libc": {"clang", "lld"},
+    "openmp": {"clang", "lld"},
     "flang": {"llvm", "clang"},
     "flang-rt": {"flang"},
     "lldb": {"llvm", "clang"},
@@ -32,7 +33,6 @@ PROJECT_DEPENDENCIES = {
     "lld": {"llvm"},
     "mlir": {"llvm"},
     "polly": {"llvm"},
-    "openmp": {"clang", "lld"},
     "offload": {"clang", "lld", "flang"},
 }
 
@@ -75,11 +75,7 @@ DEPENDENTS_TO_TEST = {
 # but not necessarily run for testing. The only case of this currently is lldb
 # which needs some runtimes enabled for tests.
 DEPENDENT_RUNTIMES_TO_BUILD = {
-    "lldb": {"libcxx", "libcxxabi", "libunwind", "compiler-rt"},
-    "clang": {"openmp", "offload"},
-    "llvm": {"openmp", "offload"},
-    "lld": {"openmp", "offload"},
-    ".ci": {"openmp", "offload"},
+    "lldb": {"libcxx", "libcxxabi", "libunwind", "compiler-rt"}
 }
 
 # This mapping describes runtimes that should be tested when the key project is

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -163,7 +163,7 @@ PROJECT_CHECK_TARGETS = {
     "libc": "check-libc",
     "libclc": "check-libclc",
     "mlir": "check-mlir",
-    "openmp": "check-openmp",
+    "openmp": "openmp",
     "polly": "check-polly",
     "lit": "check-lit",
     "offload": "offload",

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -165,7 +165,7 @@ PROJECT_CHECK_TARGETS = {
     "openmp": "check-openmp",
     "polly": "check-polly",
     "lit": "check-lit",
-    "offload": "check-offload",
+    "offload": "offload",
 }
 
 RUNTIMES = {

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -162,7 +162,7 @@ PROJECT_CHECK_TARGETS = {
     "lld": "check-lld",
     "lldb": "check-lldb",
     "mlir": "check-mlir",
-    "openmp": "check-openmp",
+    "openmp": "openmp",
     "polly": "check-polly",
     "lit": "check-lit",
     "offload": "offload",

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -25,7 +25,6 @@ PROJECT_DEPENDENCIES = {
     "compiler-rt": {"clang", "lld"},
     "cross-project-tests": {"clang", "lldb", "lld"},
     "libc": {"clang", "lld"},
-    "openmp": {"clang", "lld"},
     "flang": {"llvm", "clang"},
     "flang-rt": {"flang"},
     "lldb": {"llvm", "clang"},
@@ -33,6 +32,8 @@ PROJECT_DEPENDENCIES = {
     "lld": {"llvm"},
     "mlir": {"llvm"},
     "polly": {"llvm"},
+    "openmp": {"clang", "lld"},
+    "offload": {"clang", "lld", "flang"},
 }
 
 # This mapping describes the additional projects that should be tested when a
@@ -66,7 +67,6 @@ DEPENDENTS_TO_TEST = {
         "mlir",
         "polly",
         "flang",
-        "openmp",
     },
 }
 
@@ -74,7 +74,11 @@ DEPENDENTS_TO_TEST = {
 # but not necessarily run for testing. The only case of this currently is lldb
 # which needs some runtimes enabled for tests.
 DEPENDENT_RUNTIMES_TO_BUILD = {
-    "lldb": {"libcxx", "libcxxabi", "libunwind", "compiler-rt"}
+    "lldb": {"libcxx", "libcxxabi", "libunwind", "compiler-rt"},
+    "clang": {"openmp", "offload"},
+    "llvm": {"openmp", "offload"},
+    "lld": {"openmp", "offload"},
+    ".ci": {"openmp", "offload"},
 }
 
 # This mapping describes runtimes that should be tested when the key project is
@@ -87,7 +91,9 @@ DEPENDENT_RUNTIMES_TO_TEST = {
     "compiler-rt": {"compiler-rt"},
     "flang": {"flang-rt"},
     "flang-rt": {"flang-rt"},
-    ".ci": {"compiler-rt", "libc", "flang-rt", "libclc"},
+    "openmp": {"openmp"},
+    "offload": {"offload"},
+    ".ci": {"compiler-rt", "libc", "flang-rt", "libclc", "openmp", "offload"},
 }
 DEPENDENT_RUNTIMES_TO_TEST_NEEDS_RECONFIG = {
     "llvm": {"libcxx", "libcxxabi", "libunwind"},
@@ -96,7 +102,7 @@ DEPENDENT_RUNTIMES_TO_TEST_NEEDS_RECONFIG = {
 }
 
 EXCLUDE_LINUX = {
-    "openmp",  # https://github.com/google/llvm-premerge-checks/issues/410
+    "cross-project-tests",  # TODO(issues/132796): Tests are failing.
 }
 
 # Runtimes configured for cross-compilation using LLVM_RUNTIME_TARGETS.
@@ -115,6 +121,7 @@ EXCLUDE_WINDOWS = {
     "libcxxabi",
     "libunwind",
     "flang-rt",
+    "offload",
 }
 
 # These are projects that we should test if the project itself is changed but
@@ -136,6 +143,7 @@ EXCLUDE_MAC = {
     "libcxx",
     "libcxxabi",
     "libunwind",
+    "offload",
 }
 
 PROJECT_CHECK_TARGETS = {
@@ -158,7 +166,6 @@ PROJECT_CHECK_TARGETS = {
     "lld": "check-lld",
     "lldb": "check-lldb",
     "mlir": "check-mlir",
-    "openmp": "check-openmp",
     "polly": "check-polly",
     "lit": "check-lit",
 }
@@ -171,6 +178,8 @@ RUNTIMES = {
     "libc",
     "flang-rt",
     "libclc",
+    "openmp",
+    "offload",
 }
 
 # Meta projects are projects that need explicit handling but do not reside

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -162,8 +162,10 @@ PROJECT_CHECK_TARGETS = {
     "lld": "check-lld",
     "lldb": "check-lldb",
     "mlir": "check-mlir",
+    "openmp": "check-openmp",
     "polly": "check-polly",
     "lit": "check-lit",
+    "offload": "check-offload",
 }
 
 RUNTIMES = {

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -25,6 +25,7 @@ PROJECT_DEPENDENCIES = {
     "compiler-rt": {"clang", "lld"},
     "cross-project-tests": {"clang", "lldb", "lld"},
     "libc": {"clang", "lld"},
+    "openmp": {"clang", "lld"},
     "flang": {"llvm", "clang"},
     "flang-rt": {"flang"},
     "lldb": {"llvm", "clang"},
@@ -32,7 +33,6 @@ PROJECT_DEPENDENCIES = {
     "lld": {"llvm"},
     "mlir": {"llvm"},
     "polly": {"llvm"},
-    "openmp": {"clang", "lld"},
     "offload": {"clang", "lld", "flang"},
 }
 
@@ -74,11 +74,7 @@ DEPENDENTS_TO_TEST = {
 # but not necessarily run for testing. The only case of this currently is lldb
 # which needs some runtimes enabled for tests.
 DEPENDENT_RUNTIMES_TO_BUILD = {
-    "lldb": {"libcxx", "libcxxabi", "libunwind", "compiler-rt"},
-    "clang": {"openmp", "offload"},
-    "llvm": {"openmp", "offload"},
-    "lld": {"openmp", "offload"},
-    ".ci": {"openmp", "offload"},
+    "lldb": {"libcxx", "libcxxabi", "libunwind", "compiler-rt"}
 }
 
 # This mapping describes runtimes that should be tested when the key project is

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -22,7 +22,8 @@ class TestComputeProjects(unittest.TestCase):
             "check-bolt check-clang check-clang-tools check-cross-project check-flang check-lld check-lldb check-llvm check-mlir check-polly",
         )
         self.assertEqual(
-            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind"
+            env_variables["runtimes_to_build"],
+            "libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -91,7 +92,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;libc;libcxx;libcxxabi;libunwind",
+            "compiler-rt;libc;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -169,7 +170,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;libc;libcxx;libcxxabi;libunwind",
+            "compiler-rt;libc;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -310,7 +311,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;flang-rt;libc;libcxx;libcxxabi;libunwind",
+            "compiler-rt;flang-rt;libc;libclc;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -384,7 +385,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;flang-rt;libc;libcxx;libcxxabi;libunwind",
+            "compiler-rt;flang-rt;libc;libclc;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -419,7 +420,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;flang-rt;libc;libcxx;libcxxabi;libunwind",
+            "compiler-rt;flang-rt;libc;libclc;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -443,7 +444,8 @@ class TestComputeProjects(unittest.TestCase):
             "check-bolt check-clang check-clang-tools check-cross-project check-flang check-lit check-lld check-lldb check-llvm check-mlir check-polly",
         )
         self.assertEqual(
-            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind"
+            env_variables["runtimes_to_build"],
+            "libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -22,8 +22,7 @@ class TestComputeProjects(unittest.TestCase):
             "check-bolt check-clang check-clang-tools check-cross-project check-flang check-lld check-lldb check-llvm check-mlir check-polly",
         )
         self.assertEqual(
-            env_variables["runtimes_to_build"],
-            "libcxx;libcxxabi;libunwind",
+            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -444,8 +443,7 @@ class TestComputeProjects(unittest.TestCase):
             "check-bolt check-clang check-clang-tools check-cross-project check-flang check-lit check-lld check-lldb check-llvm check-mlir check-polly",
         )
         self.assertEqual(
-            env_variables["runtimes_to_build"],
-            "libcxx;libcxxabi;libunwind",
+            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -22,7 +22,8 @@ class TestComputeProjects(unittest.TestCase):
             "check-bolt check-clang check-clang-tools check-cross-project check-flang check-lld check-lldb check-llvm check-mlir check-polly",
         )
         self.assertEqual(
-            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind",
+            env_variables["runtimes_to_build"],
+            "libcxx;libcxxabi;libunwind",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -443,7 +444,8 @@ class TestComputeProjects(unittest.TestCase):
             "check-bolt check-clang check-clang-tools check-cross-project check-flang check-lit check-lld check-lldb check-llvm check-mlir check-polly",
         )
         self.assertEqual(
-            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind",
+            env_variables["runtimes_to_build"],
+            "libcxx;libcxxabi;libunwind",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -23,7 +23,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "libcxx;libcxxabi;libunwind;offload;openmp",
+            "libcxx;libcxxabi;libunwind",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -92,7 +92,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;libc;libcxx;libcxxabi;libunwind;offload;openmp",
+            "compiler-rt;libc;libcxx;libcxxabi;libunwind",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -170,7 +170,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;libc;libcxx;libcxxabi;libunwind;offload;openmp",
+            "compiler-rt;libc;libcxx;libcxxabi;libunwind",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -311,7 +311,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;flang-rt;libc;libclc;libcxx;libcxxabi;libunwind;offload;openmp",
+            "compiler-rt;flang-rt;libc;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -385,7 +385,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;flang-rt;libc;libclc;libcxx;libcxxabi;libunwind;offload;openmp",
+            "compiler-rt;flang-rt;libc;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -420,7 +420,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;flang-rt;libc;libclc;libcxx;libcxxabi;libunwind;offload;openmp",
+            "compiler-rt;flang-rt;libc;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -445,7 +445,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "libcxx;libcxxabi;libunwind;offload;openmp",
+            "libcxx;libcxxabi;libunwind",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -315,7 +315,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
-            "check-compiler-rt check-flang-rt check-libc check-libclc",
+            "check-compiler-rt check-flang-rt check-libc check-libclc offload openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets_needs_reconfig"],
@@ -389,7 +389,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
-            "check-compiler-rt check-flang-rt check-libc check-libclc",
+            "check-compiler-rt check-flang-rt check-libc check-libclc offload openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets_needs_reconfig"],
@@ -424,7 +424,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
-            "check-compiler-rt check-flang-rt check-libc check-libclc",
+            "check-compiler-rt check-flang-rt check-libc check-libclc offload openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets_needs_reconfig"],

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -22,7 +22,8 @@ class TestComputeProjects(unittest.TestCase):
             "check-bolt check-clang check-clang-tools check-cross-project check-flang check-lld check-lldb check-llvm check-mlir check-polly",
         )
         self.assertEqual(
-            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind"
+            env_variables["runtimes_to_build"],
+            "libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -90,7 +91,8 @@ class TestComputeProjects(unittest.TestCase):
             "check-clang check-clang-tools check-cross-project check-lldb",
         )
         self.assertEqual(
-            env_variables["runtimes_to_build"], "compiler-rt;libcxx;libcxxabi;libunwind"
+            env_variables["runtimes_to_build"],
+            "compiler-rt;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -165,7 +167,8 @@ class TestComputeProjects(unittest.TestCase):
             "check-clang check-clang-cir check-clang-tools check-cross-project check-lldb",
         )
         self.assertEqual(
-            env_variables["runtimes_to_build"], "compiler-rt;libcxx;libcxxabi;libunwind"
+            env_variables["runtimes_to_build"],
+            "compiler-rt;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -306,7 +309,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;flang-rt;libc;libcxx;libcxxabi;libunwind",
+            "compiler-rt;flang-rt;libc;libclc;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -380,7 +383,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;flang-rt;libc;libcxx;libcxxabi;libunwind",
+            "compiler-rt;flang-rt;libc;libclc;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -415,7 +418,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "compiler-rt;flang-rt;libc;libcxx;libcxxabi;libunwind",
+            "compiler-rt;flang-rt;libc;libclc;libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
@@ -439,7 +442,8 @@ class TestComputeProjects(unittest.TestCase):
             "check-bolt check-clang check-clang-tools check-cross-project check-flang check-lit check-lld check-lldb check-llvm check-mlir check-polly",
         )
         self.assertEqual(
-            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind"
+            env_variables["runtimes_to_build"],
+            "libcxx;libcxxabi;libunwind;offload;openmp",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],


### PR DESCRIPTION
Offload and OpenMP have been disabled in pre-commit build and test for quite some time.

After some changes to the way how LLVM is built in pre-merge, this PR adds both OpenMP and Offload to the premerge CI. The intention is to introduce *build only* of those runtimes and not run any tests.
The test suites appear to still be a bit flaky and many issues we see in the (AMDGPU OpenMP / Offload) buildbots come from simple errors that can be caught with a simple build in pre-merge CI.