### PR TITLE
[libc++][NFC] Simplify the implementation of __mul_overflowed

### DIFF
--- a/libcxx/include/__charconv/traits.h
+++ b/libcxx/include/__charconv/traits.h
@@ -113,31 +113,10 @@ struct _LIBCPP_HIDDEN __traits_base<_Tp, __enable_if_t<sizeof(_Tp) == sizeof(__u
 };
 #  endif
 
-template <typename _Tp>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool
-__mul_overflowed(unsigned char __a, _Tp __b, unsigned char& __r) {
-  auto __c = __a * __b;
-  __r      = __c;
-  return __c > numeric_limits<unsigned char>::max();
-}
-
-template <typename _Tp>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool
-__mul_overflowed(unsigned short __a, _Tp __b, unsigned short& __r) {
-  auto __c = __a * __b;
-  __r      = __c;
-  return __c > numeric_limits<unsigned short>::max();
-}
-
-template <typename _Tp>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool __mul_overflowed(_Tp __a, _Tp __b, _Tp& __r) {
-  static_assert(is_unsigned<_Tp>::value, "");
-  return __builtin_mul_overflow(__a, __b, std::addressof(__r));
-}
-
 template <typename _Tp, typename _Up>
-inline _LIBCPP_HIDE_FROM_ABI bool _LIBCPP_CONSTEXPR_SINCE_CXX23 __mul_overflowed(_Tp __a, _Up __b, _Tp& __r) {
-  return __itoa::__mul_overflowed(__a, static_cast<_Tp>(__b), __r);
+_LIBCPP_HIDE_FROM_ABI bool _LIBCPP_CONSTEXPR_SINCE_CXX23 __mul_overflowed(_Tp __a, _Up __b, _Tp& __r) {
+  static_assert(is_unsigned<_Tp>::value);
+  return __builtin_mul_overflow(__a, static_cast<_Tp>(__b), std::addressof(__r));
 }
 
 template <typename _Tp>


### PR DESCRIPTION
`__builtin_mul_overflow` does the right thing, even for `char` and `short`, so the overloads for these types can simply be dropped. We can also merge the remaining two overloads into a single one now, since we don't do any dispatching for `char` and `short` anymore.
