### PR TITLE
[AllocToken] Fix attribute mismatch in AllocTokenPass

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AllocToken.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AllocToken.cpp
@@ -541,9 +541,9 @@ FunctionCallee AllocToken::getTokenAllocFunction(const CallBase &CB,
     NewParams.push_back(IntPtrTy); // token ID
   TokenAllocName += Callee->getName();
   FunctionType *NewFTy = FunctionType::get(RetTy, NewParams, false);
-  FunctionCallee TokenAlloc = Mod.getOrInsertFunction(TokenAllocName, NewFTy);
-  if (Function *F = dyn_cast<Function>(TokenAlloc.getCallee()))
-    F->copyAttributesFrom(Callee); // preserve attrs
+  AttributeList NewAttrs = Callee->getAttributes();
+  FunctionCallee TokenAlloc =
+      Mod.getOrInsertFunction(TokenAllocName, NewFTy, NewAttrs);
 
   if (Key.has_value())
     TokenAllocFunctions[*Key] = TokenAlloc;


### PR DESCRIPTION
Fixes an attribute mismatch error in `AllocTokenPass` that occurs during ThinLTO builds at OptimizationLevel::O0.

The `getTokenAllocFunction` in `AllocTokenPass` was incorrectly copying attributes from the instrumented function (`Callee`) to an *existing* `void()` alloc-token function retrieved by `Mod.getOrInsertFunction`. This resulted in arg attributes being added to a function with no parameters, causing `VerifyPass` to fail with "Attribute after last parameter!".

The fix modifies `getTokenAllocFunction` to pass the `Callee`'s attributes directly to the `Mod.getOrInsertFunction` overload. This ensures attributes are only applied when the alloc-token function is *newly inserted*, preventing unintended attribute modifications on already existing function declarations.

See https://g-issues.chromium.org/issues/474289092 for detailed reproduction steps and analysis.