### PR TITLE
[BOLT] Fix label in epilogue-determination.s test

### DIFF
--- a/bolt/test/AArch64/epilogue-determination.s
+++ b/bolt/test/AArch64/epilogue-determination.s
@@ -48,7 +48,7 @@ _L2:
   .type _goo, %function
 _goo:
   ldr w8, [sp]
-  adr x10, _jmptbl2
+  adr x10, _jmptbl
   ldrsw x9, [x10, x9, lsl #2]
   add x10, x10, x9
   str x30, [sp, #-0x10]!


### PR DESCRIPTION
On RHEL8 we get the following error that may originate from the changed typo:
```
clang: warning: argument unused during compilation: '-ffreestanding' [-Wunused-command-line-argument]
ld.lld: error: relocation R_AARCH64_ADR_PREL_LO21 cannot be used against symbol '_jmptbl2'; recompile with -fPIC
>>> defined in /tmp/epilogue-determination-7bd9d4.o
>>> referenced by /tmp/epilogue-determination-7bd9d4.o:(.text+0x54)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```