### PR TITLE
[LLD] [MinGW] Add the --fat-lto-objects flag

### DIFF
--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -518,6 +518,10 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
     add("-thinlto-object-suffix-replace:" + StringRef(arg->getValue()));
   if (auto *arg = args.getLastArg(OPT_thinlto_prefix_replace_eq))
     add("-thinlto-prefix-replace:" + StringRef(arg->getValue()));
+  if (args.hasFlag(OPT_fat_lto_objects, OPT_no_fat_lto_objects, false))
+    add("-fat-lto-objects");
+  else
+    add("-fat-lto-objects:no");
 
   for (auto *a : args.filtered(OPT_plugin_opt_eq_minus))
     add("-mllvm:-" + StringRef(a->getValue()));

--- a/lld/MinGW/Options.td
+++ b/lld/MinGW/Options.td
@@ -39,6 +39,11 @@ multiclass B<string name, string help1, string help2> {
   def no_ # NAME: Flag<["--", "-"], "no-" # name>, HelpText<help2>;
 }
 
+multiclass BB<string name, string help1, string help2> {
+  def NAME: Flag<["--"], name>, HelpText<help1>;
+  def no_ # NAME: Flag<["--"], "no-" # name>, HelpText<help2>;
+}
+
 multiclass B_disable<string name, string help1, string help2> {
   def NAME: Flag<["--", "-"], name>, HelpText<help1>;
   def disable_ # NAME: Flag<["--", "-"], "disable-" # name>, HelpText<help2>;
@@ -166,6 +171,9 @@ def lto_emit_asm: FF<"lto-emit-asm">,
   HelpText<"Emit assembly code">;
 def lto_sample_profile: JJ<"lto-sample-profile=">,
   HelpText<"Sample profile file path">;
+defm fat_lto_objects: BB<"fat-lto-objects",
+    "Use the .llvm.lto section, which contains LLVM bitcode, in fat LTO object files to perform LTO.",
+    "Ignore the .llvm.lto section in relocatable object files (default).">;
 
 def thinlto_cache_dir: JJ<"thinlto-cache-dir=">,
   HelpText<"Path to ThinLTO cached object file directory">;

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -430,7 +430,7 @@ RUN: ld.lld -### foo.o -m i386pe --thinlto-prefix-replace=_foo 2>&1 | FileCheck 
 THINLTO_PREFIX_REPLACE: -thinlto-prefix-replace:_foo
 
 RUN: ld.lld -### foo.o -m i386pep -plugin-opt=mcpu=x86-64 -plugin-opt=-emulated-tls -plugin-opt=thinlto -plugin-opt=O2 -plugin-opt=dwo_dir=foo -plugin-opt=cs-profile-generate -plugin-opt=cs-profile-path=bar 2>&1 | FileCheck -check-prefix=LTO_OPTS %s
-LTO_OPTS: -mllvm:-mcpu=x86-64 -opt:lldlto=2 -dwodir:foo -lto-cs-profile-generate -lto-cs-profile-file:bar -mllvm:-emulated-tls
+LTO_OPTS: -mllvm:-mcpu=x86-64 -opt:lldlto=2 -dwodir:foo -lto-cs-profile-generate -lto-cs-profile-file:bar -fat-lto-objects:no -mllvm:-emulated-tls
 
 RUN: ld.lld -### foo.o -m i386pep --lto-O2 --lto-CGO1 --lto-cs-profile-generate --lto-cs-profile-file=foo 2>&1 | FileCheck -check-prefix=LTO_OPTS2 %s
 LTO_OPTS2:-opt:lldlto=2 -opt:lldltocgo=1 -lto-cs-profile-generate -lto-cs-profile-file:foo
@@ -478,3 +478,10 @@ WARN_RPATH: warning: parameter -{{-?}}rpath has no effect on PE/COFF targets
 
 RUN: ld.lld -### foo.o -m i386pe --dependent-load-flag=0x800 2>&1 | FileCheck -check-prefix=DEPENDENT_LOAD_FLAG %s
 DEPENDENT_LOAD_FLAG: -dependentloadflag:0x800
+
+RUN: ld.lld -### -m i386pep foo.o 2>&1 | FileCheck -check-prefix NO-FAT-LTO %s
+RUN: ld.lld -### -m i386pep foo.o --fat-lto-objects --no-fat-lto-objects 2>&1 | FileCheck -check-prefix NO-FAT-LTO %s
+NO-FAT-LTO: -fat-lto-objects:no
+
+RUN: ld.lld -### -m i386pep foo.o --no-fat-lto-objects --fat-lto-objects 2>&1 | FileCheck -check-prefix FAT-LTO %s
+FAT-LTO: -fat-lto-objects{{ }}


### PR DESCRIPTION
This uses the same syntax as the ELF linker (added in 14e3bec8fc3e1f10c3dc57277ae3dbf9a4087b1c), mapping it to the recently added COFF linker flag in
759fb0a224e85c01fffcd42b1e71a4bea6fc757e.