### PR TITLE
[libc++][chrono] Applied `[[nodiscard]]` to The Civil Calendar

### DIFF
--- a/libcxx/include/__chrono/day.h
+++ b/libcxx/include/__chrono/day.h
@@ -55,7 +55,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr day& operator+=(const days& __dd) noexcept;
   _LIBCPP_HIDE_FROM_ABI constexpr day& operator-=(const days& __dd) noexcept;
   _LIBCPP_HIDE_FROM_ABI explicit inline constexpr operator unsigned() const noexcept { return __d_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __d_ >= 1 && __d_ <= 31; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __d_ >= 1 && __d_ <= 31; }
 };
 
 _LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(const day& __lhs, const day& __rhs) noexcept {
@@ -66,19 +66,19 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr strong_ordering operator<=>(const day& __
   return static_cast<unsigned>(__lhs) <=> static_cast<unsigned>(__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr day operator+(const day& __lhs, const days& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr day operator+(const day& __lhs, const days& __rhs) noexcept {
   return day(static_cast<unsigned>(__lhs) + __rhs.count());
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr day operator+(const days& __lhs, const day& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr day operator+(const days& __lhs, const day& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr day operator-(const day& __lhs, const days& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr day operator-(const day& __lhs, const days& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr days operator-(const day& __lhs, const day& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr days operator-(const day& __lhs, const day& __rhs) noexcept {
   return days(static_cast<int>(static_cast<unsigned>(__lhs)) - static_cast<int>(static_cast<unsigned>(__rhs)));
 }
 
@@ -98,7 +98,9 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr day& day::operator-=(const days& __dd) no
 
 template <>
 struct hash<chrono::day> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::day& __d) noexcept { return static_cast<unsigned>(__d); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::day& __d) noexcept {
+    return static_cast<unsigned>(__d);
+  }
 };
 
 #  endif // _LIBCPP_STD_VER >= 26

--- a/libcxx/include/__chrono/hh_mm_ss.h
+++ b/libcxx/include/__chrono/hh_mm_ss.h
@@ -59,13 +59,13 @@ public:
         __s_(chrono::duration_cast<chrono::seconds>(chrono::abs(__d) - hours() - minutes())),
         __f_(chrono::duration_cast<precision>(chrono::abs(__d) - hours() - minutes() - seconds())) {}
 
-  _LIBCPP_HIDE_FROM_ABI constexpr bool is_negative() const noexcept { return __is_neg_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr chrono::hours hours() const noexcept { return __h_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr chrono::minutes minutes() const noexcept { return __m_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr chrono::seconds seconds() const noexcept { return __s_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr precision subseconds() const noexcept { return __f_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool is_negative() const noexcept { return __is_neg_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::hours hours() const noexcept { return __h_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::minutes minutes() const noexcept { return __m_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::seconds seconds() const noexcept { return __s_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr precision subseconds() const noexcept { return __f_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr precision to_duration() const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr precision to_duration() const noexcept {
     auto __dur = __h_ + __m_ + __s_ + __f_;
     return __is_neg_ ? -__dur : __dur;
   }
@@ -81,14 +81,14 @@ private:
 };
 _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(hh_mm_ss);
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool is_am(const hours& __h) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_am(const hours& __h) noexcept {
   return __h >= hours(0) && __h < hours(12);
 }
-_LIBCPP_HIDE_FROM_ABI inline constexpr bool is_pm(const hours& __h) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_pm(const hours& __h) noexcept {
   return __h >= hours(12) && __h < hours(24);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr hours make12(const hours& __h) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr hours make12(const hours& __h) noexcept {
   if (__h == hours(0))
     return hours(12);
   else if (__h <= hours(12))
@@ -97,7 +97,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr hours make12(const hours& __h) noexcept {
     return __h - hours(12);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr hours make24(const hours& __h, bool __is_pm) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr hours make24(const hours& __h, bool __is_pm) noexcept {
   if (__is_pm)
     return __h == hours(12) ? __h : __h + hours(12);
   else

--- a/libcxx/include/__chrono/literals.h
+++ b/libcxx/include/__chrono/literals.h
@@ -24,11 +24,11 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 inline namespace literals {
 inline namespace chrono_literals {
-_LIBCPP_HIDE_FROM_ABI constexpr chrono::day operator""d(unsigned long long __d) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::day operator""d(unsigned long long __d) noexcept {
   return chrono::day(static_cast<unsigned>(__d));
 }
 
-_LIBCPP_HIDE_FROM_ABI constexpr chrono::year operator""y(unsigned long long __y) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::year operator""y(unsigned long long __y) noexcept {
   return chrono::year(static_cast<int>(__y));
 }
 } // namespace chrono_literals

--- a/libcxx/include/__chrono/month.h
+++ b/libcxx/include/__chrono/month.h
@@ -55,7 +55,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr month& operator+=(const months& __m1) noexcept;
   _LIBCPP_HIDE_FROM_ABI constexpr month& operator-=(const months& __m1) noexcept;
   _LIBCPP_HIDE_FROM_ABI explicit inline constexpr operator unsigned() const noexcept { return __m_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __m_ >= 1 && __m_ <= 12; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __m_ >= 1 && __m_ <= 12; }
 };
 
 _LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(const month& __lhs, const month& __rhs) noexcept {
@@ -66,21 +66,21 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr strong_ordering operator<=>(const month& 
   return static_cast<unsigned>(__lhs) <=> static_cast<unsigned>(__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month operator+(const month& __lhs, const months& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month operator+(const month& __lhs, const months& __rhs) noexcept {
   auto const __mu = static_cast<long long>(static_cast<unsigned>(__lhs)) + (__rhs.count() - 1);
   auto const __yr = (__mu >= 0 ? __mu : __mu - 11) / 12;
   return month{static_cast<unsigned>(__mu - __yr * 12 + 1)};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month operator+(const months& __lhs, const month& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month operator+(const months& __lhs, const month& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month operator-(const month& __lhs, const months& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month operator-(const month& __lhs, const months& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr months operator-(const month& __lhs, const month& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr months operator-(const month& __lhs, const month& __rhs) noexcept {
   auto const __dm = static_cast<unsigned>(__lhs) - static_cast<unsigned>(__rhs);
   return months(__dm <= 11 ? __dm : __dm + 12);
 }
@@ -114,7 +114,7 @@ inline constexpr month December{12};
 
 template <>
 struct hash<chrono::month> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month& __m) noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month& __m) noexcept {
     return static_cast<unsigned>(__m);
   }
 };

--- a/libcxx/include/__chrono/month_weekday.h
+++ b/libcxx/include/__chrono/month_weekday.h
@@ -35,9 +35,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr month_weekday(const chrono::month& __mval,
                                                 const chrono::weekday_indexed& __wdival) noexcept
       : __m_{__mval}, __wdi_{__wdival} {}
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday_indexed weekday_indexed() const noexcept { return __wdi_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __m_.ok() && __wdi_.ok(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday_indexed weekday_indexed() const noexcept {
+    return __wdi_;
+  }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __m_.ok() && __wdi_.ok(); }
 };
 
 _LIBCPP_HIDE_FROM_ABI inline constexpr bool
@@ -45,21 +47,23 @@ operator==(const month_weekday& __lhs, const month_weekday& __rhs) noexcept {
   return __lhs.month() == __rhs.month() && __lhs.weekday_indexed() == __rhs.weekday_indexed();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday
 operator/(const month& __lhs, const weekday_indexed& __rhs) noexcept {
   return month_weekday{__lhs, __rhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday operator/(int __lhs, const weekday_indexed& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday
+operator/(int __lhs, const weekday_indexed& __rhs) noexcept {
   return month_weekday{month(__lhs), __rhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday
 operator/(const weekday_indexed& __lhs, const month& __rhs) noexcept {
   return month_weekday{__rhs, __lhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday operator/(const weekday_indexed& __lhs, int __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday
+operator/(const weekday_indexed& __lhs, int __rhs) noexcept {
   return month_weekday{month(__rhs), __lhs};
 }
 
@@ -71,9 +75,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr month_weekday_last(const chrono::month& __mval,
                                                      const chrono::weekday_last& __wdlval) noexcept
       : __m_{__mval}, __wdl_{__wdlval} {}
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday_last weekday_last() const noexcept { return __wdl_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __m_.ok() && __wdl_.ok(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday_last weekday_last() const noexcept {
+    return __wdl_;
+  }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __m_.ok() && __wdl_.ok(); }
 };
 
 _LIBCPP_HIDE_FROM_ABI inline constexpr bool
@@ -81,21 +87,23 @@ operator==(const month_weekday_last& __lhs, const month_weekday_last& __rhs) noe
   return __lhs.month() == __rhs.month() && __lhs.weekday_last() == __rhs.weekday_last();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last
 operator/(const month& __lhs, const weekday_last& __rhs) noexcept {
   return month_weekday_last{__lhs, __rhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last operator/(int __lhs, const weekday_last& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last
+operator/(int __lhs, const weekday_last& __rhs) noexcept {
   return month_weekday_last{month(__lhs), __rhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last
 operator/(const weekday_last& __lhs, const month& __rhs) noexcept {
   return month_weekday_last{__rhs, __lhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last operator/(const weekday_last& __lhs, int __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last
+operator/(const weekday_last& __lhs, int __rhs) noexcept {
   return month_weekday_last{month(__rhs), __lhs};
 }
 } // namespace chrono
@@ -104,7 +112,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr month_weekday_last operator/(const weekda
 
 template <>
 struct hash<chrono::month_weekday> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month_weekday& __mw) noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month_weekday& __mw) noexcept {
     return std::__hash_combine(
         hash<chrono::month>{}(__mw.month()), hash<chrono::weekday_indexed>{}(__mw.weekday_indexed()));
   }
@@ -112,7 +120,7 @@ struct hash<chrono::month_weekday> {
 
 template <>
 struct hash<chrono::month_weekday_last> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month_weekday_last& __mwl) noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month_weekday_last& __mwl) noexcept {
     return std::__hash_combine(
         hash<chrono::month>{}(__mwl.month()), hash<chrono::weekday_last>{}(__mwl.weekday_last()));
   }

--- a/libcxx/include/__chrono/monthday.h
+++ b/libcxx/include/__chrono/monthday.h
@@ -37,9 +37,9 @@ public:
   month_day() = default;
   _LIBCPP_HIDE_FROM_ABI constexpr month_day(const chrono::month& __mval, const chrono::day& __dval) noexcept
       : __m_{__mval}, __d_{__dval} {}
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::day day() const noexcept { return __d_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr bool ok() const noexcept;
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::day day() const noexcept { return __d_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool ok() const noexcept;
 };
 
 _LIBCPP_HIDE_FROM_ABI inline constexpr bool month_day::ok() const noexcept {
@@ -70,23 +70,25 @@ operator<=>(const month_day& __lhs, const month_day& __rhs) noexcept {
   return __lhs.day() <=> __rhs.day();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_day operator/(const month& __lhs, const day& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day
+operator/(const month& __lhs, const day& __rhs) noexcept {
   return month_day{__lhs, __rhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_day operator/(const day& __lhs, const month& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day
+operator/(const day& __lhs, const month& __rhs) noexcept {
   return __rhs / __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_day operator/(const month& __lhs, int __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day operator/(const month& __lhs, int __rhs) noexcept {
   return __lhs / day(__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_day operator/(int __lhs, const day& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day operator/(int __lhs, const day& __rhs) noexcept {
   return month(__lhs) / __rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_day operator/(const day& __lhs, int __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day operator/(const day& __lhs, int __rhs) noexcept {
   return month(__rhs) / __lhs;
 }
 
@@ -96,8 +98,8 @@ private:
 
 public:
   _LIBCPP_HIDE_FROM_ABI explicit constexpr month_day_last(const chrono::month& __val) noexcept : __m_{__val} {}
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __m_.ok(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __m_.ok(); }
 };
 
 _LIBCPP_HIDE_FROM_ABI inline constexpr bool
@@ -110,19 +112,19 @@ operator<=>(const month_day_last& __lhs, const month_day_last& __rhs) noexcept {
   return __lhs.month() <=> __rhs.month();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(const month& __lhs, last_spec) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(const month& __lhs, last_spec) noexcept {
   return month_day_last{__lhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(last_spec, const month& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(last_spec, const month& __rhs) noexcept {
   return month_day_last{__rhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(int __lhs, last_spec) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(int __lhs, last_spec) noexcept {
   return month_day_last{month(__lhs)};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(last_spec, int __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(last_spec, int __rhs) noexcept {
   return month_day_last{month(__rhs)};
 }
 
@@ -132,14 +134,14 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr month_day_last operator/(last_spec, int _
 
 template <>
 struct hash<chrono::month_day> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month_day& __md) noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month_day& __md) noexcept {
     return std::__hash_combine(hash<chrono::month>{}(__md.month()), hash<chrono::day>{}(__md.day()));
   }
 };
 
 template <>
 struct hash<chrono::month_day_last> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month_day_last& __mdl) noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::month_day_last& __mdl) noexcept {
     return hash<chrono::month>{}(__mdl.month());
   }
 };

--- a/libcxx/include/__chrono/weekday.h
+++ b/libcxx/include/__chrono/weekday.h
@@ -65,11 +65,13 @@ public:
   }
   _LIBCPP_HIDE_FROM_ABI constexpr weekday& operator+=(const days& __dd) noexcept;
   _LIBCPP_HIDE_FROM_ABI constexpr weekday& operator-=(const days& __dd) noexcept;
-  _LIBCPP_HIDE_FROM_ABI inline constexpr unsigned c_encoding() const noexcept { return __wd_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr unsigned iso_encoding() const noexcept { return __wd_ == 0u ? 7 : __wd_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __wd_ <= 6; }
-  _LIBCPP_HIDE_FROM_ABI constexpr weekday_indexed operator[](unsigned __index) const noexcept;
-  _LIBCPP_HIDE_FROM_ABI constexpr weekday_last operator[](last_spec) const noexcept;
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr unsigned c_encoding() const noexcept { return __wd_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr unsigned iso_encoding() const noexcept {
+    return __wd_ == 0u ? 7 : __wd_;
+  }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __wd_ <= 6; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr weekday_indexed operator[](unsigned __index) const noexcept;
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr weekday_last operator[](last_spec) const noexcept;
 };
 
 // https://howardhinnant.github.io/date_algorithms.html#weekday_from_days
@@ -81,21 +83,25 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(const weekday& __lhs, con
   return __lhs.c_encoding() == __rhs.c_encoding();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr weekday operator+(const weekday& __lhs, const days& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr weekday
+operator+(const weekday& __lhs, const days& __rhs) noexcept {
   auto const __mu = static_cast<long long>(__lhs.c_encoding()) + __rhs.count();
   auto const __yr = (__mu >= 0 ? __mu : __mu - 6) / 7;
   return weekday{static_cast<unsigned>(__mu - __yr * 7)};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr weekday operator+(const days& __lhs, const weekday& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr weekday
+operator+(const days& __lhs, const weekday& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr weekday operator-(const weekday& __lhs, const days& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr weekday
+operator-(const weekday& __lhs, const days& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr days operator-(const weekday& __lhs, const weekday& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr days
+operator-(const weekday& __lhs, const weekday& __rhs) noexcept {
   const int __wdu = __lhs.c_encoding() - __rhs.c_encoding();
   const int __wk  = (__wdu >= 0 ? __wdu : __wdu - 6) / 7;
   return days{__wdu - __wk * 7};
@@ -120,9 +126,11 @@ public:
   weekday_indexed() = default;
   _LIBCPP_HIDE_FROM_ABI inline constexpr weekday_indexed(const chrono::weekday& __wdval, unsigned __idxval) noexcept
       : __wd_{__wdval}, __idx_(__idxval) {}
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday weekday() const noexcept { return __wd_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr unsigned index() const noexcept { return __idx_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __wd_.ok() && __idx_ >= 1 && __idx_ <= 5; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday weekday() const noexcept { return __wd_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr unsigned index() const noexcept { return __idx_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept {
+    return __wd_.ok() && __idx_ >= 1 && __idx_ <= 5;
+  }
 };
 
 _LIBCPP_HIDE_FROM_ABI inline constexpr bool
@@ -136,8 +144,8 @@ private:
 
 public:
   _LIBCPP_HIDE_FROM_ABI explicit constexpr weekday_last(const chrono::weekday& __val) noexcept : __wd_{__val} {}
-  _LIBCPP_HIDE_FROM_ABI constexpr chrono::weekday weekday() const noexcept { return __wd_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr bool ok() const noexcept { return __wd_.ok(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::weekday weekday() const noexcept { return __wd_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool ok() const noexcept { return __wd_.ok(); }
 };
 
 _LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(const weekday_last& __lhs, const weekday_last& __rhs) noexcept {
@@ -166,19 +174,21 @@ inline constexpr weekday Saturday{6};
 
 template <>
 struct hash<chrono::weekday> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::weekday& __w) noexcept { return __w.c_encoding(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::weekday& __w) noexcept {
+    return __w.c_encoding();
+  }
 };
 
 template <>
 struct hash<chrono::weekday_indexed> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::weekday_indexed& __wi) noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::weekday_indexed& __wi) noexcept {
     return std::__hash_combine(hash<chrono::weekday>{}(__wi.weekday()), __wi.index());
   }
 };
 
 template <>
 struct hash<chrono::weekday_last> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::weekday_last& __wl) noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::weekday_last& __wl) noexcept {
     return hash<chrono::weekday>{}(__wl.weekday());
   }
 };

--- a/libcxx/include/__chrono/year.h
+++ b/libcxx/include/__chrono/year.h
@@ -58,16 +58,16 @@ public:
   }
   _LIBCPP_HIDE_FROM_ABI constexpr year& operator+=(const years& __dy) noexcept;
   _LIBCPP_HIDE_FROM_ABI constexpr year& operator-=(const years& __dy) noexcept;
-  _LIBCPP_HIDE_FROM_ABI inline constexpr year operator+() const noexcept { return *this; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr year operator-() const noexcept { return year{-__y_}; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year operator+() const noexcept { return *this; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year operator-() const noexcept { return year{-__y_}; }
 
-  _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_leap() const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool is_leap() const noexcept {
     return __y_ % 4 == 0 && (__y_ % 100 != 0 || __y_ % 400 == 0);
   }
   _LIBCPP_HIDE_FROM_ABI explicit inline constexpr operator int() const noexcept { return __y_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr bool ok() const noexcept;
-  _LIBCPP_HIDE_FROM_ABI static inline constexpr year min() noexcept { return year{-32767}; }
-  _LIBCPP_HIDE_FROM_ABI static inline constexpr year max() noexcept { return year{32767}; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool ok() const noexcept;
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static inline constexpr year min() noexcept { return year{-32767}; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static inline constexpr year max() noexcept { return year{32767}; }
 };
 
 _LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(const year& __lhs, const year& __rhs) noexcept {
@@ -78,19 +78,19 @@ _LIBCPP_HIDE_FROM_ABI constexpr strong_ordering operator<=>(const year& __lhs, c
   return static_cast<int>(__lhs) <=> static_cast<int>(__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year operator+(const year& __lhs, const years& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year operator+(const year& __lhs, const years& __rhs) noexcept {
   return year(static_cast<int>(__lhs) + __rhs.count());
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year operator+(const years& __lhs, const year& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year operator+(const years& __lhs, const year& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year operator-(const year& __lhs, const years& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year operator-(const year& __lhs, const years& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr years operator-(const year& __lhs, const year& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr years operator-(const year& __lhs, const year& __rhs) noexcept {
   return years{static_cast<int>(__lhs) - static_cast<int>(__rhs)};
 }
 
@@ -115,7 +115,9 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool year::ok() const noexcept {
 
 template <>
 struct hash<chrono::year> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year& __y) noexcept { return static_cast<int>(__y); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year& __y) noexcept {
+    return static_cast<int>(__y);
+  }
 };
 
 #  endif // _LIBCPP_STD_VER >= 26

--- a/libcxx/include/__chrono/year_month.h
+++ b/libcxx/include/__chrono/year_month.h
@@ -36,20 +36,20 @@ public:
   year_month() = default;
   _LIBCPP_HIDE_FROM_ABI constexpr year_month(const chrono::year& __yval, const chrono::month& __mval) noexcept
       : __y_{__yval}, __m_{__mval} {}
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
   _LIBCPP_HIDE_FROM_ABI inline constexpr year_month& operator+=(const months& __dm) noexcept;
   _LIBCPP_HIDE_FROM_ABI inline constexpr year_month& operator-=(const months& __dm) noexcept;
   _LIBCPP_HIDE_FROM_ABI inline constexpr year_month& operator+=(const years& __dy) noexcept;
   _LIBCPP_HIDE_FROM_ABI inline constexpr year_month& operator-=(const years& __dy) noexcept;
-  _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __y_.ok() && __m_.ok(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __y_.ok() && __m_.ok(); }
 };
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month operator/(const year& __y, const month& __m) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month operator/(const year& __y, const month& __m) noexcept {
   return year_month{__y, __m};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month operator/(const year& __y, int __m) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month operator/(const year& __y, int __m) noexcept {
   return year_month{__y, month(__m)};
 }
 
@@ -64,35 +64,42 @@ operator<=>(const year_month& __lhs, const year_month& __rhs) noexcept {
   return __lhs.month() <=> __rhs.month();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month operator+(const year_month& __lhs, const months& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month
+operator+(const year_month& __lhs, const months& __rhs) noexcept {
   int __dmi      = static_cast<int>(static_cast<unsigned>(__lhs.month())) - 1 + __rhs.count();
   const int __dy = (__dmi >= 0 ? __dmi : __dmi - 11) / 12;
   __dmi          = __dmi - __dy * 12 + 1;
   return (__lhs.year() + years(__dy)) / month(static_cast<unsigned>(__dmi));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month operator+(const months& __lhs, const year_month& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month
+operator+(const months& __lhs, const year_month& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month operator+(const year_month& __lhs, const years& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month
+operator+(const year_month& __lhs, const years& __rhs) noexcept {
   return (__lhs.year() + __rhs) / __lhs.month();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month operator+(const years& __lhs, const year_month& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month
+operator+(const years& __lhs, const year_month& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr months operator-(const year_month& __lhs, const year_month& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr months
+operator-(const year_month& __lhs, const year_month& __rhs) noexcept {
   return (__lhs.year() - __rhs.year()) +
          months(static_cast<unsigned>(__lhs.month()) - static_cast<unsigned>(__rhs.month()));
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month operator-(const year_month& __lhs, const months& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month
+operator-(const year_month& __lhs, const months& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month operator-(const year_month& __lhs, const years& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month
+operator-(const year_month& __lhs, const years& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
@@ -122,7 +129,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr year_month& year_month::operator-=(const 
 
 template <>
 struct hash<chrono::year_month> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month& __ym) noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month& __ym) noexcept {
     return std::__hash_combine(hash<chrono::year>{}(__ym.year()), hash<chrono::month>{}(__ym.month()));
   }
 };

--- a/libcxx/include/__chrono/year_month_day.h
+++ b/libcxx/include/__chrono/year_month_day.h
@@ -59,15 +59,15 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr year_month_day& operator+=(const years& __dy) noexcept;
   _LIBCPP_HIDE_FROM_ABI constexpr year_month_day& operator-=(const years& __dy) noexcept;
 
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::day day() const noexcept { return __d_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::day day() const noexcept { return __d_; }
   _LIBCPP_HIDE_FROM_ABI inline constexpr operator sys_days() const noexcept { return sys_days{__to_days()}; }
   _LIBCPP_HIDE_FROM_ABI inline explicit constexpr operator local_days() const noexcept {
     return local_days{__to_days()};
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr bool ok() const noexcept;
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool ok() const noexcept;
 
   _LIBCPP_HIDE_FROM_ABI static constexpr year_month_day __from_days(days __d) noexcept;
   _LIBCPP_HIDE_FROM_ABI constexpr days __to_days() const noexcept;
@@ -119,56 +119,62 @@ operator<=>(const year_month_day& __lhs, const year_month_day& __rhs) noexcept {
   return __lhs.day() <=> __rhs.day();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day operator/(const year_month& __lhs, const day& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
+operator/(const year_month& __lhs, const day& __rhs) noexcept {
   return year_month_day{__lhs.year(), __lhs.month(), __rhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day operator/(const year_month& __lhs, int __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
+operator/(const year_month& __lhs, int __rhs) noexcept {
   return __lhs / day(__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day operator/(const year& __lhs, const month_day& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
+operator/(const year& __lhs, const month_day& __rhs) noexcept {
   return __lhs / __rhs.month() / __rhs.day();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day operator/(int __lhs, const month_day& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
+operator/(int __lhs, const month_day& __rhs) noexcept {
   return year(__lhs) / __rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day operator/(const month_day& __lhs, const year& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
+operator/(const month_day& __lhs, const year& __rhs) noexcept {
   return __rhs / __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day operator/(const month_day& __lhs, int __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
+operator/(const month_day& __lhs, int __rhs) noexcept {
   return year(__rhs) / __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
 operator+(const year_month_day& __lhs, const months& __rhs) noexcept {
   return (__lhs.year() / __lhs.month() + __rhs) / __lhs.day();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
 operator+(const months& __lhs, const year_month_day& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
 operator-(const year_month_day& __lhs, const months& __rhs) noexcept {
   return __lhs + -__rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
 operator+(const year_month_day& __lhs, const years& __rhs) noexcept {
   return (__lhs.year() + __rhs) / __lhs.month() / __lhs.day();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
 operator+(const years& __lhs, const year_month_day& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day
 operator-(const year_month_day& __lhs, const years& __rhs) noexcept {
   return __lhs + -__rhs;
 }
@@ -204,17 +210,19 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr year_month_day_last& operator+=(const years& __y) noexcept;
   _LIBCPP_HIDE_FROM_ABI constexpr year_month_day_last& operator-=(const years& __y) noexcept;
 
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __mdl_.month(); }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month_day_last month_day_last() const noexcept { return __mdl_; }
-  _LIBCPP_HIDE_FROM_ABI constexpr chrono::day day() const noexcept;
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __mdl_.month(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month_day_last month_day_last() const noexcept {
+    return __mdl_;
+  }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr chrono::day day() const noexcept;
   _LIBCPP_HIDE_FROM_ABI inline constexpr operator sys_days() const noexcept {
     return sys_days{year() / month() / day()};
   }
   _LIBCPP_HIDE_FROM_ABI inline explicit constexpr operator local_days() const noexcept {
     return local_days{year() / month() / day()};
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __y_.ok() && __mdl_.ok(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __y_.ok() && __mdl_.ok(); }
 };
 
 _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::day year_month_day_last::day() const noexcept {
@@ -248,54 +256,57 @@ operator<=>(const year_month_day_last& __lhs, const year_month_day_last& __rhs) 
   return __lhs.month_day_last() <=> __rhs.month_day_last();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last operator/(const year_month& __lhs, last_spec) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+operator/(const year_month& __lhs, last_spec) noexcept {
   return year_month_day_last{__lhs.year(), month_day_last{__lhs.month()}};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
 operator/(const year& __lhs, const month_day_last& __rhs) noexcept {
   return year_month_day_last{__lhs, __rhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last operator/(int __lhs, const month_day_last& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+operator/(int __lhs, const month_day_last& __rhs) noexcept {
   return year_month_day_last{year{__lhs}, __rhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
 operator/(const month_day_last& __lhs, const year& __rhs) noexcept {
   return __rhs / __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last operator/(const month_day_last& __lhs, int __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+operator/(const month_day_last& __lhs, int __rhs) noexcept {
   return year{__rhs} / __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
 operator+(const year_month_day_last& __lhs, const months& __rhs) noexcept {
   return (__lhs.year() / __lhs.month() + __rhs) / last;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
 operator+(const months& __lhs, const year_month_day_last& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
 operator-(const year_month_day_last& __lhs, const months& __rhs) noexcept {
   return __lhs + (-__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
 operator+(const year_month_day_last& __lhs, const years& __rhs) noexcept {
   return year_month_day_last{__lhs.year() + __rhs, __lhs.month_day_last()};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
 operator+(const years& __lhs, const year_month_day_last& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_day_last
 operator-(const year_month_day_last& __lhs, const years& __rhs) noexcept {
   return __lhs + (-__rhs);
 }
@@ -336,7 +347,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr bool year_month_day::ok() const noexcept 
 
 template <>
 struct hash<chrono::year_month_day> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month_day& __ymd) noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month_day& __ymd) noexcept {
     return std::__hash_combine(
         hash<chrono::year>{}(__ymd.year()),
         std::__hash_combine(hash<chrono::month>{}(__ymd.month()), hash<chrono::day>{}(__ymd.day())));
@@ -345,7 +356,7 @@ struct hash<chrono::year_month_day> {
 
 template <>
 struct hash<chrono::year_month_day_last> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month_day_last& __ymdl) noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month_day_last& __ymdl) noexcept {
     return std::__hash_combine(
         hash<chrono::year>{}(__ymdl.year()), hash<chrono::month_day_last>{}(__ymdl.month_day_last()));
   }

--- a/libcxx/include/__chrono/year_month_weekday.h
+++ b/libcxx/include/__chrono/year_month_weekday.h
@@ -54,17 +54,21 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday& operator+=(const years&) noexcept;
   _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday& operator-=(const years&) noexcept;
 
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday weekday() const noexcept { return __wdi_.weekday(); }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr unsigned index() const noexcept { return __wdi_.index(); }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday_indexed weekday_indexed() const noexcept { return __wdi_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday weekday() const noexcept {
+    return __wdi_.weekday();
+  }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr unsigned index() const noexcept { return __wdi_.index(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday_indexed weekday_indexed() const noexcept {
+    return __wdi_;
+  }
 
   _LIBCPP_HIDE_FROM_ABI inline constexpr operator sys_days() const noexcept { return sys_days{__to_days()}; }
   _LIBCPP_HIDE_FROM_ABI inline explicit constexpr operator local_days() const noexcept {
     return local_days{__to_days()};
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept {
     if (!__y_.ok() || !__m_.ok() || !__wdi_.ok())
       return false;
     if (__wdi_.index() <= 4)
@@ -96,55 +100,57 @@ operator==(const year_month_weekday& __lhs, const year_month_weekday& __rhs) noe
          __lhs.weekday_indexed() == __rhs.weekday_indexed();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
 operator/(const year_month& __lhs, const weekday_indexed& __rhs) noexcept {
   return year_month_weekday{__lhs.year(), __lhs.month(), __rhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
 operator/(const year& __lhs, const month_weekday& __rhs) noexcept {
   return year_month_weekday{__lhs, __rhs.month(), __rhs.weekday_indexed()};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday operator/(int __lhs, const month_weekday& __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+operator/(int __lhs, const month_weekday& __rhs) noexcept {
   return year(__lhs) / __rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
 operator/(const month_weekday& __lhs, const year& __rhs) noexcept {
   return __rhs / __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday operator/(const month_weekday& __lhs, int __rhs) noexcept {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+operator/(const month_weekday& __lhs, int __rhs) noexcept {
   return year(__rhs) / __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
 operator+(const year_month_weekday& __lhs, const months& __rhs) noexcept {
   return (__lhs.year() / __lhs.month() + __rhs) / __lhs.weekday_indexed();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
 operator+(const months& __lhs, const year_month_weekday& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
 operator-(const year_month_weekday& __lhs, const months& __rhs) noexcept {
   return __lhs + (-__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
 operator+(const year_month_weekday& __lhs, const years& __rhs) noexcept {
   return year_month_weekday{__lhs.year() + __rhs, __lhs.month(), __lhs.weekday_indexed()};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
 operator+(const years& __lhs, const year_month_weekday& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday
 operator-(const year_month_weekday& __lhs, const years& __rhs) noexcept {
   return __lhs + (-__rhs);
 }
@@ -181,15 +187,21 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday_last& operator+=(const years& __dy) noexcept;
   _LIBCPP_HIDE_FROM_ABI constexpr year_month_weekday_last& operator-=(const years& __dy) noexcept;
 
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday weekday() const noexcept { return __wdl_.weekday(); }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday_last weekday_last() const noexcept { return __wdl_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::year year() const noexcept { return __y_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::month month() const noexcept { return __m_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday weekday() const noexcept {
+    return __wdl_.weekday();
+  }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr chrono::weekday_last weekday_last() const noexcept {
+    return __wdl_;
+  }
   _LIBCPP_HIDE_FROM_ABI inline constexpr operator sys_days() const noexcept { return sys_days{__to_days()}; }
   _LIBCPP_HIDE_FROM_ABI inline explicit constexpr operator local_days() const noexcept {
     return local_days{__to_days()};
   }
-  _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept { return __y_.ok() && __m_.ok() && __wdl_.ok(); }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr bool ok() const noexcept {
+    return __y_.ok() && __m_.ok() && __wdl_.ok();
+  }
 
   _LIBCPP_HIDE_FROM_ABI constexpr days __to_days() const noexcept;
 };
@@ -204,57 +216,57 @@ operator==(const year_month_weekday_last& __lhs, const year_month_weekday_last& 
   return __lhs.year() == __rhs.year() && __lhs.month() == __rhs.month() && __lhs.weekday_last() == __rhs.weekday_last();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
 operator/(const year_month& __lhs, const weekday_last& __rhs) noexcept {
   return year_month_weekday_last{__lhs.year(), __lhs.month(), __rhs};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
 operator/(const year& __lhs, const month_weekday_last& __rhs) noexcept {
   return year_month_weekday_last{__lhs, __rhs.month(), __rhs.weekday_last()};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
 operator/(int __lhs, const month_weekday_last& __rhs) noexcept {
   return year(__lhs) / __rhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
 operator/(const month_weekday_last& __lhs, const year& __rhs) noexcept {
   return __rhs / __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
 operator/(const month_weekday_last& __lhs, int __rhs) noexcept {
   return year(__rhs) / __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
 operator+(const year_month_weekday_last& __lhs, const months& __rhs) noexcept {
   return (__lhs.year() / __lhs.month() + __rhs) / __lhs.weekday_last();
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
 operator+(const months& __lhs, const year_month_weekday_last& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
 operator-(const year_month_weekday_last& __lhs, const months& __rhs) noexcept {
   return __lhs + (-__rhs);
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
 operator+(const year_month_weekday_last& __lhs, const years& __rhs) noexcept {
   return year_month_weekday_last{__lhs.year() + __rhs, __lhs.month(), __lhs.weekday_last()};
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
 operator+(const years& __lhs, const year_month_weekday_last& __rhs) noexcept {
   return __rhs + __lhs;
 }
 
-_LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI inline constexpr year_month_weekday_last
 operator-(const year_month_weekday_last& __lhs, const years& __rhs) noexcept {
   return __lhs + (-__rhs);
 }
@@ -286,7 +298,7 @@ year_month_weekday_last::operator-=(const years& __dy) noexcept {
 
 template <>
 struct hash<chrono::year_month_weekday> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month_weekday& __ymw) noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month_weekday& __ymw) noexcept {
     return std::__hash_combine(
         hash<chrono::year>{}(__ymw.year()),
         std::__hash_combine(
@@ -296,7 +308,7 @@ struct hash<chrono::year_month_weekday> {
 
 template <>
 struct hash<chrono::year_month_weekday_last> {
-  _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month_weekday_last& __ymwl) noexcept {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI static size_t operator()(const chrono::year_month_weekday_last& __ymwl) noexcept {
     return std::__hash_combine(
         hash<chrono::year>{}(__ymwl.year()),
         std::__hash_combine(

--- a/libcxx/test/libcxx/time/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/time/nodiscard.verify.cpp
@@ -203,6 +203,37 @@ void test_duration() { // [time.duration]
 #endif
 }
 
+#if TEST_STD_VER >= 20
+void test_hh_mm_ss() { // [time.hms]
+  const std::chrono::hh_mm_ss<std::chrono::seconds> hms;
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  hms.is_negative();
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  hms.hours();
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  hms.minutes();
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  hms.seconds();
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  hms.subseconds();
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  hms.to_duration();
+
+  using namespace std::chrono_literals;
+
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::chrono::is_am(1h);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::chrono::is_pm(1h);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::chrono::make12(1h);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::chrono::make24(1h, false);
+}
+#endif
+
 void test_time_point() { // [time.point]
   std::chrono::time_point<std::chrono::system_clock> tp;
   std::chrono::duration<double, std::ratio<1, 30> > dr;
@@ -327,3 +358,575 @@ void test_clocks() { // [time.clock]
   }
 #endif // TEST_STD_VER >= 20
 }
+
+#if TEST_STD_VER >= 20
+void test_calendar() { // [time.cal]
+
+  { // [time.cal.day]
+    const std::chrono::day day{};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    day.ok();
+
+    std::chrono::days days;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    day + days;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    days + day;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    day - days;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    day - day;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::day> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(day);
+#  endif
+  }
+
+  {
+    using namespace std::chrono_literals;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    94d;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    82y;
+  }
+
+  { // [time.cal.month]
+    const std::chrono::month month{};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    month.ok();
+
+    std::chrono::months months;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    month + months;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    months + month;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    month - months;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    month - month;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::month> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(month);
+#  endif
+  }
+
+  { // [time.cal.mwd]
+    std::chrono::month month;
+    std::chrono::weekday_indexed wdidx;
+
+    const std::chrono::month_weekday mwd{month, wdidx};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mwd.month();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mwd.weekday_indexed();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mwd.ok();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    month / wdidx;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    94 / wdidx;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wdidx / month;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wdidx / 82;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::month_weekday> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(mwd);
+#  endif
+  }
+
+  { // [time.cal.mwdlast]
+    std::chrono::month month;
+    std::chrono::weekday_last wdl{{}};
+
+    const std::chrono::month_weekday_last mwdl{month, wdl};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mwdl.month();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mwdl.weekday_last();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mwdl.ok();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    month / wdl;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    94 / wdl;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wdl / month;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wdl / 82;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::month_weekday_last> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(mwdl);
+#  endif
+  }
+
+  { // [time.cal.md]
+    const std::chrono::month_day md{};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    md.month();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    md.day();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    md.ok();
+
+    std::chrono::month month;
+    std::chrono::day day;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    month / day;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    day / month;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    month / 94;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    82 / day;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    day / 49;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::month_day> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(md);
+#  endif
+  }
+
+  { // [time.cal.mdlast]
+    std::chrono::month month;
+
+    const std::chrono::month_day_last mdl{month};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mdl.month();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mdl.ok();
+
+    std::chrono::last_spec ls;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    month / ls;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ls / month;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    94 / ls;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ls / 82;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::month_day_last> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(mdl);
+#  endif
+  }
+
+  { // [time.cal.wd]
+    const std::chrono::weekday wd{};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wd.c_encoding();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wd.iso_encoding();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wd.ok();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wd[0];
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wd[std::chrono::last_spec{}];
+
+    std::chrono::days days;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wd + days;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    days + wd;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wd - days;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wd - wd;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::weekday> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(wd);
+#  endif
+  }
+
+  { // [time.cal.wdidx]
+    const std::chrono::weekday_indexed wdidx{};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wdidx.weekday();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wdidx.index();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wdidx.ok();
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::weekday_indexed> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(wdidx);
+#  endif
+  }
+
+  { // [time.cal.wdlast]
+    const std::chrono::weekday_last wdl{std::chrono::weekday{}};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wdl.weekday();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    wdl.ok();
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::weekday_last> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(wdl);
+#  endif
+  }
+
+  { // [time.cal.year]
+    const std::chrono::year year{};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    +year;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    -year;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year.is_leap();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year.ok();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year.min();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year.max();
+
+    std::chrono::years years;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year + years;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    years + year;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year - years;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year - year;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::year> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(year);
+#  endif
+  }
+
+  { // [time.cal.ym]
+    const std::chrono::year_month ym{};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym.year();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym.month();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym.ok();
+
+    std::chrono::year year;
+    std::chrono::month month;
+    std::chrono::months months;
+    std::chrono::years years;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year / month;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year / 94;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym + months;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    months + ym;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym + years;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    years + ym;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym - ym;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym - months;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym - years;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::year_month> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(ym);
+#  endif
+  }
+
+  { // [time.cal.ymd]
+    const std::chrono::year_month_day ymd{};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymd.year();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymd.month();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymd.day();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymd.ok();
+
+    std::chrono::year_month ym;
+    std::chrono::day day;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym / day;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym / 94;
+
+    std::chrono::year year;
+    std::chrono::month_day md;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year / md;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    82 / md;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    md / year;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    md / 49;
+
+    std::chrono::months months;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymd + months;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    months + ymd;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymd - months;
+
+    std::chrono::years years;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymd + years;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    years + ymd;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymd - years;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::year_month_day> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(ymd);
+#  endif
+  }
+
+  { // [time.cal.ymdlast]
+    std::chrono::year year;
+    std::chrono::month_day_last mdl{{}};
+
+    const std::chrono::year_month_day_last ymdl{year, mdl};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymdl.year();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymdl.month();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymdl.month_day_last();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymdl.day();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymdl.ok();
+
+    std::chrono::year_month ym;
+    std::chrono::last_spec ls;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym / ls;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year / mdl;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    94 / mdl;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mdl / year;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mdl / 82;
+
+    std::chrono::months months;
+    std::chrono::years years;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymdl + months;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    months + ymdl;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymdl - months;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymdl + years;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    years + ymdl;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymdl - years;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::year_month_day_last> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(ymdl);
+#  endif
+  }
+
+  { // [time.cal.ymwd]
+    const std::chrono::year_month_weekday ymwd{};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwd.year();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwd.month();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwd.weekday();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwd.index();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwd.weekday_indexed();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwd.ok();
+
+    std::chrono::year_month ym;
+    std::chrono::weekday_indexed wdidx;
+    std::chrono::year year;
+    std::chrono::month_weekday mw{std::chrono::month{}, wdidx};
+    std::chrono::months months;
+    std::chrono::years years;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym / wdidx;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year / mw;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    94 / mw;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mw / year;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mw / 82;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwd + months;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    months + ymwd;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwd - months;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwd + years;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    years + ymwd;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwd - years;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::year_month_weekday> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(ymwd);
+#  endif
+  }
+
+  { // [time.cal.ymwdlast]
+    std::chrono::year year;
+    std::chrono::month month;
+    std::chrono::weekday_last wdl{std::chrono::weekday{}};
+
+    const std::chrono::year_month_weekday_last ymwdl{year, month, wdl};
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwdl.year();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwdl.month();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwdl.weekday();
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwdl.weekday_last();
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwdl.ok();
+
+    std::chrono::year_month ym;
+    std::chrono::month_weekday_last mwdl{std::chrono::month{}, std::chrono::weekday_last{std::chrono::weekday{}}};
+    std::chrono::months months;
+    std::chrono::years years;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ym / wdl;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    year / mwdl;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    94 / mwdl;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mwdl / year;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    mwdl / 82;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwdl + months;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    months + ymwdl;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwdl - months;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwdl + years;
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    years + ymwdl;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    ymwdl - years;
+
+#  if TEST_STD_VER >= 26
+    std::hash<std::chrono::year_month_weekday_last> hash;
+
+    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+    hash(ymwdl);
+#  endif
+  }
+}
+#endif


### PR DESCRIPTION
- https://libcxx.llvm.org/CodingGuidelines.html
- https://wg21.link/time.cal

Towards #172124