### PR TITLE
[lld][COFF] Add /linkreprofullpathrsp flag

### DIFF
--- a/lld/COFF/Driver.h
+++ b/lld/COFF/Driver.h
@@ -88,11 +88,13 @@ public:
   void enqueueArchiveMember(const Archive::Child &c, const Archive::Symbol &sym,
                             StringRef parentName);
 
-  void enqueuePDB(StringRef Path) { enqueuePath(Path, false, false); }
+  enum class InputOpt { None, DefaultLib, WholeArchive };
+  void enqueuePDB(StringRef Path) { enqueuePath(Path, false); }
 
   MemoryBufferRef takeBuffer(std::unique_ptr<MemoryBuffer> mb);
 
-  void enqueuePath(StringRef path, bool wholeArchive, bool lazy);
+  void enqueuePath(StringRef path, bool lazy,
+                   InputOpt inputOpt = InputOpt::None);
 
   // Returns a list of chunks of selected symbols.
   std::vector<Chunk *> getChunks() const;
@@ -137,6 +139,10 @@ private:
   //    LIB | {value}        | {value}.dll         | {output name}.dll
   //
   std::string getImportName(bool asLib);
+
+  // Write fullly resolved path to repro file if /linkreprofullpathrsp
+  // is specified.
+  void handleReproFile(StringRef path, InputOpt inputOpt);
 
   void createImportLibrary(bool asLib);
 
@@ -192,6 +198,9 @@ private:
   llvm::SmallString<128> universalCRTLibPath;
   int sdkMajor = 0;
   llvm::SmallString<128> windowsSdkLibPath;
+
+  // For linkreprofullpathrsp
+  std::unique_ptr<llvm::raw_fd_ostream> reproFile;
 
   // Functions below this line are defined in DriverUtils.cpp.
 

--- a/lld/COFF/Options.td
+++ b/lld/COFF/Options.td
@@ -75,6 +75,9 @@ def link : F<"link">, HelpText<"Ignored for compatibility">;
 def linkrepro : Joined<["/", "-", "/?", "-?"], "linkrepro:">,
     MetaVarName<"directory">,
     HelpText<"Write repro.tar containing inputs and command to reproduce link">;
+def linkreprofullpathrsp : Joined<["/", "-", "/?", "-?"], "linkreprofullpathrsp:">,
+    MetaVarName<"directory">,
+    HelpText<"Write .rsp file containing inputs used to link with full paths">;
 def lldignoreenv : F<"lldignoreenv">,
     HelpText<"Ignore environment variables like %LIB%">;
 def lldltocache : P<"lldltocache",

--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -40,6 +40,8 @@ COFF Improvements
 
 * ``/fat-lto-objects`` addded to support FatLTO. Without ``/fat-lto-objects`` or with ``/fat-lto-objects:no``, LLD will link LLVM FatLTO objects using the relocatable object file.
   (`#165529 <https://github.com/llvm/llvm-project/pull/165529>`_)
+* ``/linkreprofullpathrsp`` prints the full path to each object passed to the link line to a file.
+  (`#165449 <https://github.com/llvm/llvm-project/pull/165449>`_)
 
 MinGW Improvements
 ------------------

--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -41,7 +41,7 @@ COFF Improvements
 * ``/fat-lto-objects`` addded to support FatLTO. Without ``/fat-lto-objects`` or with ``/fat-lto-objects:no``, LLD will link LLVM FatLTO objects using the relocatable object file.
   (`#165529 <https://github.com/llvm/llvm-project/pull/165529>`_)
 * ``/linkreprofullpathrsp`` prints the full path to each object passed to the link line to a file.
-  (`#165449 <https://github.com/llvm/llvm-project/pull/165449>`_)
+  (`#174971 <https://github.com/llvm/llvm-project/pull/165449>`_)
 
 MinGW Improvements
 ------------------

--- a/lld/test/COFF/linkreprofullpathrsp.test
+++ b/lld/test/COFF/linkreprofullpathrsp.test
@@ -1,0 +1,43 @@
+# REQUIRES: x86
+
+# RUN: rm -rf %t.dir %t.obj
+# RUN: yaml2obj %p/Inputs/hello32.yaml -o %t.obj
+# RUN: yaml2obj %p/Inputs/empty.yaml -o %t.archive.obj
+# RUN: rm -f %t.archive.lib
+# RUN: llvm-ar rcs %t.archive.lib %t.archive.obj
+# RUN: llvm-pdbutil yaml2pdb %S/Inputs/pdb-type-server-simple-ts.yaml -pdb %t.pdb
+
+
+Test link.exe-style /linkreprofullpathrsp: flag.
+# RUN: mkdir -p %t.dir/build1
+# RUN: cd %t.dir/build1
+# RUN: lld-link /subsystem:console %t.obj %p/Inputs/std32.lib /defaultlib:%p/Inputs/library.lib \
+# RUN:  /libpath:%p/Inputs /defaultlib:std64.lib ret42.lib /entry:main@0 /linkreprofullpathrsp:%t.rsp \
+# RUN:   %t.pdb /wholearchive:%t.archive.lib /out:%t.exe
+# # RUN: FileCheck %s --check-prefix=RSP -DT=%t -DP=%p < %t.rsp
+
+# RUN: lld-link /subsystem:console @%t.rsp /out:%t2.exe /entry:main@0
+# RUN: diff %t.exe %t2.exe
+
+# RSP: "[[T]].obj"
+# RSP-NEXT: "[[P]]{{[/\\]}}Inputs{{[/\\]}}std32.lib"
+# RSP-NEXT: "[[P]]{{[/\\]}}Inputs{{[/\\]}}ret42.lib"
+# RSP-NEXT: "[[T]].pdb"
+# RSP-NEXT: "/wholearchive:[[T]].archive.lib"
+# RSP-NEXT: "/defaultlib:[[P]]{{[/\\]}}Inputs{{[/\\]}}library.lib"
+# RSP-NEXT: "/defaultlib:[[P]]{{[/\\]}}Inputs{{[/\\]}}std64.lib"
+
+#--- drectve.s
+        .section .drectve, "yn"
+        .ascii "/defaultlib:std32"
+
+#--- archive.s
+	.text
+	.intel_syntax noprefix
+	.globl	exportfn3
+	.p2align	4
+exportfn3:
+	ret
+
+	.section	.drectve,"yni"
+	.ascii	" /EXPORT:exportfn3"

--- a/lld/test/COFF/linkreprofullpathrsp.test
+++ b/lld/test/COFF/linkreprofullpathrsp.test
@@ -13,10 +13,10 @@ Test link.exe-style /linkreprofullpathrsp: flag.
 # RUN: cd %t.dir/build1
 # RUN: lld-link /subsystem:console %t.obj %p/Inputs/std32.lib /defaultlib:%p/Inputs/library.lib \
 # RUN:  /libpath:%p/Inputs /defaultlib:std64.lib ret42.lib /entry:main@0 /linkreprofullpathrsp:%t.rsp \
-# RUN:   %t.pdb /wholearchive:%t.archive.lib /out:%t.exe
+# RUN:   %t.pdb /wholearchive:%t.archive.lib /out:%t.exe /timestamp:0
 # # RUN: FileCheck %s --check-prefix=RSP -DT=%t -DP=%p < %t.rsp
 
-# RUN: lld-link /subsystem:console @%t.rsp /out:%t2.exe /entry:main@0
+# RUN: lld-link /subsystem:console @%t.rsp /out:%t2.exe /entry:main@0 /timestamp:0
 # RUN: diff %t.exe %t2.exe
 
 # RSP: "[[T]].obj"


### PR DESCRIPTION
This patch adds the /linkreprofullpathrsp flag with the same behaviour as link.exe. This flag emits a file containing the full paths to each object passed to the link line.

This is used in particular when linking Arm64X binaries, as you need the full path to all the Arm64 objects that were used in a standard Arm64 build.

See:
https://learn.microsoft.com/en-us/cpp/build/reference/link-repro-full-path-rsp for the Microsoft documentation of the flag.

Relands #165449