### PR TITLE
[llvm-c] Expose perf support for LLJIT in Orc C-API bindings

### DIFF
--- a/llvm/include/llvm-c/LLJITUtils.h
+++ b/llvm/include/llvm-c/LLJITUtils.h
@@ -45,6 +45,11 @@ LLVM_C_EXTERN_C_BEGIN
 LLVM_C_ABI LLVMErrorRef LLVMOrcLLJITEnableDebugSupport(LLVMOrcLLJITRef J);
 
 /**
+ * Install the plugin to log perf jitdump events for each object.
+ */
+LLVM_C_ABI LLVMErrorRef LLVMOrcLLJITEnablePerfSupport(LLVMOrcLLJITRef J);
+
+/**
  * @}
  */
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/Debugging/PerfSupport.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Debugging/PerfSupport.h
@@ -1,0 +1,29 @@
+//===-- PerfSupport.h - Utils for enabling debugger support --*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities for enabling perf support.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_ORC_PERFSUPPORT_H
+#define LLVM_EXECUTIONENGINE_ORC_PERFSUPPORT_H
+
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/Error.h"
+
+namespace llvm {
+namespace orc {
+
+class LLJIT;
+
+LLVM_ABI Error enablePerfSupport(LLJIT &J);
+
+} // namespace orc
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_ORC_PERFSUPPORT_H

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/CMakeLists.txt
@@ -8,6 +8,7 @@ add_llvm_component_library(LLVMOrcDebugging
   DebuggerSupportPlugin.cpp
   ELFDebugObjectPlugin.cpp
   LLJITUtilsCBindings.cpp
+  PerfSupport.cpp
   PerfSupportPlugin.cpp
   VTuneSupportPlugin.cpp
 

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/LLJITUtilsCBindings.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/LLJITUtilsCBindings.cpp
@@ -10,6 +10,7 @@
 #include "llvm-c/LLJITUtils.h"
 
 #include "llvm/ExecutionEngine/Orc/Debugging/DebuggerSupport.h"
+#include "llvm/ExecutionEngine/Orc/Debugging/PerfSupport.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 
 using namespace llvm;
@@ -19,4 +20,8 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(LLJIT, LLVMOrcLLJITRef)
 
 LLVMErrorRef LLVMOrcLLJITEnableDebugSupport(LLVMOrcLLJITRef J) {
   return wrap(llvm::orc::enableDebuggerSupport(*unwrap(J)));
+}
+
+LLVMErrorRef LLVMOrcLLJITEnablePerfSupport(LLVMOrcLLJITRef J) {
+  return wrap(llvm::orc::enablePerfSupport(*unwrap(J)));
 }

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/PerfSupport.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/PerfSupport.cpp
@@ -1,0 +1,55 @@
+//===------ PerfSupport.cpp - Utils for enabling perf support -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/Orc/Debugging/DebugInfoSupport.h"
+#include "llvm/ExecutionEngine/Orc/Debugging/PerfSupport.h"
+#include "llvm/ExecutionEngine/Orc/Debugging/PerfSupportPlugin.h"
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+
+#define DEBUG_TYPE "orc"
+
+using namespace llvm;
+using namespace llvm::orc;
+
+namespace llvm::orc {
+
+Error enablePerfSupport(LLJIT &J) {
+  auto *ObjLinkingLayer = dyn_cast<ObjectLinkingLayer>(&J.getObjLinkingLayer());
+  if (!ObjLinkingLayer)
+    return make_error<StringError>("Cannot enable LLJIT perf support: "
+                                   "Perf support requires JITLink",
+                                   inconvertibleErrorCode());
+  auto ProcessSymsJD = J.getProcessSymbolsJITDylib();
+  if (!ProcessSymsJD)
+    return make_error<StringError>("Cannot enable LLJIT perf support: "
+                                   "Process symbols are not available",
+                                   inconvertibleErrorCode());
+
+  auto &ES = J.getExecutionSession();
+  const auto &TT = J.getTargetTriple();
+
+  switch (TT.getObjectFormat()) {
+  case Triple::ELF: {
+    ObjLinkingLayer->addPlugin(std::make_unique<DebugInfoPreservationPlugin>());
+    auto PS = PerfSupportPlugin::Create(
+        ES.getExecutorProcessControl(), *ProcessSymsJD, true, true);
+    if (!PS)
+      return PS.takeError();
+    ObjLinkingLayer->addPlugin(std::move(*PS));
+    return Error::success();
+  }
+  default:
+    return make_error<StringError>(
+        "Cannot enable LLJIT perf support: " +
+            Triple::getObjectFormatTypeName(TT.getObjectFormat()) +
+            " is not supported",
+        inconvertibleErrorCode());
+  }
+}
+
+} // namespace llvm::orc


### PR DESCRIPTION
This is the equivalent of https://github.com/llvm/llvm-project/pull/73257 for perf support. It allows C-API users to enable perf dump for their JITed code.