### PR TITLE
[BOLT] Avoid UB due to misaligned access.

### DIFF
--- a/bolt/lib/Core/DebugNames.cpp
+++ b/bolt/lib/Core/DebugNames.cpp
@@ -648,9 +648,9 @@ void DWARF5AcceleratorTable::writeEntries() {
         if (const auto Iter = EntryRelativeOffsets.find(*ParentOffset);
             Iter != EntryRelativeOffsets.end()) {
           const uint64_t PatchOffset = Entry->getPatchOffset();
-          uint32_t *Ptr =
-              reinterpret_cast<uint32_t *>(&EntriesBuffer->data()[PatchOffset]);
-          *Ptr = Iter->second;
+          uint32_t RelativeOffset = Iter->second;
+          memcpy(&EntriesBuffer->data()[PatchOffset], &RelativeOffset,
+                 sizeof(uint32_t));
         } else {
           BC.errs() << "BOLT-WARNING: [internal-dwarf-warning]: Could not find "
                        "entry with offset "


### PR DESCRIPTION
There is no guarantee that PatchOffset is suitably aligned for uint32_t, and in BOLT's own tests, it is not aligned for uint32_t.

Fixes test failures seen with LLVM_USE_SANITIZER=Undefined.