### PR TITLE
[BOLT][AArch64] Avoid UB due to shift of negative value.

### DIFF
--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -2274,7 +2274,7 @@ public:
         !I->getOperand(1).isImm() || I->getOperand(0).getReg() != AArch64::X16)
       return 0;
     TargetHiBits = &*I;
-    Addr |= (Address + ((int64_t)I->getOperand(1).getImm() << 12)) &
+    Addr |= (Address + ((uint64_t)I->getOperand(1).getImm() << 12)) &
             0xFFFFFFFFFFFFF000ULL;
     Target = Addr;
     return 3;


### PR DESCRIPTION
A build with LLVM_USE_SANITIZER=Undefined showed:

  bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp:2277:60:
  runtime error: left shift of negative value -32768

This showed up in bolt/test/AArch64/veneer-lite-mode.s.

It is valid for ADRP's operand to be negative, and not valid to shift it like that. To perform this shift reliably, cast the value to unsigned.