### PR TITLE
[AMDGPU] Make AMDGPURewriteAGPRCopyMFMA aware of subreg reload

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -249,6 +249,9 @@ public:
     return SubRegIndexLaneMasks[SubIdx];
   }
 
+  /// Try to find a matching subreg from the given lanemask.
+  unsigned getSubRegIdxFromLaneMask(LaneBitmask LaneMask) const;
+
   /// Try to find one or more subregister indexes to cover \p LaneMask.
   ///
   /// If this is possible, returns true and appends the best matching set of

--- a/llvm/lib/CodeGen/TargetRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/TargetRegisterInfo.cpp
@@ -495,6 +495,16 @@ TargetRegisterInfo::getRegSizeInBits(Register Reg,
   return getRegSizeInBits(*RC);
 }
 
+unsigned
+TargetRegisterInfo::getSubRegIdxFromLaneMask(LaneBitmask LaneMask) const {
+  for (unsigned Idx = 1, E = getNumSubRegIndices(); Idx < E; ++Idx) {
+    if (getSubRegIndexLaneMask(Idx) == LaneMask)
+      return Idx;
+  }
+
+  return 0 /*NoSubRegister*/;
+}
+
 bool TargetRegisterInfo::getCoveringSubRegIndexes(
     const TargetRegisterClass *RC, LaneBitmask LaneMask,
     SmallVectorImpl<unsigned> &NeededIndexes) const {

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -443,9 +443,9 @@ unsigned
 AMDGPURewriteAGPRCopyMFMAImpl::getSubRegFromReload(MachineInstr &MI,
                                                    Register Reg) const {
   unsigned NumRegs = TRI.getRegSizeInBits(*MRI.getRegClass(Reg)) / 32;
-  unsigned SubReg = 0;
+  unsigned SubReg = AMDGPU::NoSubRegister;
   // SubReg accesses for the tuple registers are of interest here.
-  // Note: We don't support 16-bit subreg reloads. If that assuption is
+  // Note: We don't support 16-bit subreg reloads. If that assumption is
   // changed in the future, this function should be revised.
   if (NumRegs == 1)
     return SubReg;

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -116,6 +116,17 @@ public:
   bool tryFoldCopiesToAGPR(Register VReg, MCRegister AssignedAGPR) const;
   bool tryFoldCopiesFromAGPR(Register VReg, MCRegister AssignedAGPR) const;
 
+  /// Derives the subregister index from a spill reload pseudo instruction by
+  /// constructing a lane mask that covers the reloaded portion and finding
+  /// the matching subregister.
+  ///
+  /// \p MI the spill reload pseudo instruction containing the offset and
+  /// spill size info
+  /// \p Reg the original virtual register being spilled (mostly a tuple
+  /// register)
+  /// \return the subregister index corresponding to the reload portion.
+  unsigned getSubRegFromReload(MachineInstr &MI, Register VReg) const;
+
   /// Replace spill instruction \p SpillMI which loads/stores from/to \p SpillFI
   /// with a COPY to the replacement register value \p VReg.
   void replaceSpillWithCopyToVReg(MachineInstr &SpillMI, int SpillFI,
@@ -428,6 +439,33 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::tryFoldCopiesFromAGPR(
   return MadeChange;
 }
 
+unsigned
+AMDGPURewriteAGPRCopyMFMAImpl::getSubRegFromReload(MachineInstr &MI,
+                                                   Register Reg) const {
+  unsigned NumRegs = TRI.getRegSizeInBits(*MRI.getRegClass(Reg)) / 32;
+  unsigned SubReg = 0;
+  // SubReg accesses for the tuple registers are of interest here.
+  // Note: We don't support 16-bit subreg reloads. If that assuption is
+  // changed in the future, this function should be revised.
+  if (NumRegs == 1)
+    return SubReg;
+
+  unsigned NumSpilledRegs = TII.getNumSubRegsForSpillOp(MI);
+  // Skip if the entire tuple is reloaded.
+  if (NumRegs == NumSpilledRegs)
+    return SubReg;
+
+  // Construct the covering lanes for the reloaded portion.
+  unsigned SubRegIdx =
+      TII.getNamedOperand(MI, AMDGPU::OpName::offset)->getImm() / 4;
+  // Subreg lane masks are maintained in terms of regunits and each 32-bit
+  // register consists of two regunits.
+  uint64_t Lanes = (1ULL << NumSpilledRegs * 2) - 1;
+  LaneBitmask CoveringLanes = LaneBitmask(Lanes << SubRegIdx * 2);
+  SubReg = TRI.getSubRegIdxFromLaneMask(CoveringLanes);
+  return SubReg;
+}
+
 void AMDGPURewriteAGPRCopyMFMAImpl::replaceSpillWithCopyToVReg(
     MachineInstr &SpillMI, int SpillFI, Register VReg) const {
   const DebugLoc &DL = SpillMI.getDebugLoc();
@@ -437,9 +475,11 @@ void AMDGPURewriteAGPRCopyMFMAImpl::replaceSpillWithCopyToVReg(
     NewCopy = BuildMI(MBB, SpillMI, DL, TII.get(TargetOpcode::COPY), VReg)
                   .add(SpillMI.getOperand(0));
   } else {
+    // Identify the subregs if SpillMI is really a subreg-load.
+    unsigned SubReg = getSubRegFromReload(SpillMI, VReg);
     NewCopy = BuildMI(MBB, SpillMI, DL, TII.get(TargetOpcode::COPY))
                   .add(SpillMI.getOperand(0))
-                  .addReg(VReg);
+                  .addReg(VReg, 0, SubReg);
   }
 
   LIS.ReplaceMachineInstrInMaps(SpillMI, *NewCopy);

--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -479,7 +479,7 @@ void AMDGPURewriteAGPRCopyMFMAImpl::replaceSpillWithCopyToVReg(
     unsigned SubReg = getSubRegFromReload(SpillMI, VReg);
     NewCopy = BuildMI(MBB, SpillMI, DL, TII.get(TargetOpcode::COPY))
                   .add(SpillMI.getOperand(0))
-                  .addReg(VReg, 0, SubReg);
+                  .addReg(VReg, RegState::NoFlags, SubReg);
   }
 
   LIS.ReplaceMachineInstrInMaps(SpillMI, *NewCopy);


### PR DESCRIPTION
AMDGPURewriteAGPRCopyMFMA pass is currently not subreg-aware.
In particular, the logic that optimizes spills into COPY
instructions assumes full register reloads. This becomes
problematic when the reload instruction partially restores
a tuple register. This patch introduces the necessary changes
to make this pass subreg-aware, for a future patch that
implements subreg reload during RA.