### PR TITLE
[MLIR][Transform] Add hoist_extract_to_argument transformation

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
@@ -2995,4 +2995,54 @@ def DecomposeWinogradOp : Op<Transform_Dialect,
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Hoist Extract to Linalg Argument
+//===----------------------------------------------------------------------===//
+
+def HoistExtractToArgumentOp : Op<Transform_Dialect, "structured.hoist_extract_to_argument",
+    [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+     TransformOpInterface, TransformEachOpTrait,
+     ReportTrackingListenerFailuresOpTrait]> {
+  let summary = "Hoists a tensor.extract operation from the body of a linalg.generic to an input argument";
+  let description = [{
+    This transform hoists a `tensor.extract` operation from the body of a `linalg.generic`
+    operation to become an input argument of the generic operation. This transformation is
+    applicable when the extract operation's indices can be expressed as affine expressions
+    of the loop induction variables.
+
+    An extract operation is hoistable if all its indices are produced by:
+    - `linalg.index` operations (mapping to loop dimensions)
+    - `arith.constant_index` operations (constant indices)
+    - `arith.index_cast` operations that cast from block arguments corresponding to
+      constant input operands
+
+    #### Return modes
+
+    This operation only applies to `linalg.generic` operations. If the target is not a
+    `linalg.generic`, the transform succeeds but returns the original operation unchanged.
+
+    If no hoistable extract operation is found in the generic's body, the transform succeeds
+    but returns the original operation unchanged.
+
+    If a hoistable extract is found and successfully hoisted, the transform succeeds and
+    returns the transformed `linalg.generic` operation.
+
+    The transform produces a silenceable failure if the hoisting transformation fails for
+    any reason.
+  }];
+
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs TransformHandleTypeInterface:$transformed);
+   let assemblyFormat =
+    "$target attr-dict `:` functional-type($target, results)";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::transform::TransformRewriter &rewriter,
+        ::mlir::linalg::LinalgOp target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 #endif // LINALG_TRANSFORM_OPS

--- a/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
+++ b/mlir/lib/Dialect/Linalg/TransformOps/LinalgTransformOps.cpp
@@ -4550,7 +4550,7 @@ DiagnosedSilenceableFailure transform::DecomposeWinogradOp::applyToOne(
 /// \returns The first hoistable tensor::ExtractOp found, or nullptr if none
 ///          exists
 static tensor::ExtractOp
-findNextHoistableExtract(linalg::GenericOp &genericOp,
+findNextHoistableExtract(linalg::GenericOp genericOp,
                          SmallVector<AffineExpr> &opIndices,
                          OpBuilder &builder) {
   Block &body = genericOp.getRegion().front();
@@ -4638,8 +4638,8 @@ findNextHoistableExtract(linalg::GenericOp &genericOp,
 }
 
 static linalg::GenericOp
-hoistExtractToArgument(tensor::ExtractOp &hoistedOp, OpBuilder &builder,
-                       linalg::GenericOp &genericOp,
+hoistExtractToArgument(tensor::ExtractOp hoistedOp, OpBuilder &builder,
+                       linalg::GenericOp genericOp,
                        SmallVector<AffineExpr> &opIndices,
                        RewriterBase &rewriter) {
   // Get the source tensor that is being extracted from

--- a/mlir/test/Dialect/Linalg/transform-op-hoist-extract-to-argument.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-hoist-extract-to-argument.mlir
@@ -1,0 +1,125 @@
+// RUN: mlir-opt --transform-interpreter %s 2>&1 | FileCheck %s
+
+// CHECK-LABEL: func.func @hoist_1dim_simple(
+// CHECK-SAME:    %[[ARG0:.*]]: tensor<4xf32>, %[[ARG1:.*]]: tensor<4xf32>)
+// CHECK:         %[[RES:.*]] = linalg.generic
+// CHECK-SAME:    ins(%[[ARG0]] : tensor<4xf32>)
+// CHECK-SAME:    outs(%[[ARG1]] : tensor<4xf32>)
+// CHECK:         ^bb0(%[[VAL_IN:.*]]: f32, %[[VAL_OUT:.*]]: f32):
+// CHECK:           linalg.yield %[[VAL_IN]] : f32
+func.func @hoist_1dim_simple(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  } ins(%arg0 : tensor<4xf32>) outs(%arg1 : tensor<4xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+  } -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// CHECK-LABEL: func.func @hoist_1_keep_1(
+// CHECK-SAME:    %[[ARG0:.*]]: tensor<1x1x1290240xi32>, %[[ARG1:.*]]: tensor<1x1x1290240xf32>)
+// CHECK:         %[[EMPTY:.*]] = tensor.empty()
+// CHECK:         %[[RES:.*]] = linalg.generic
+// CHECK-SAME:    ins(%[[ARG0]] : tensor<1x1x1290240xi32>)
+// CHECK-SAME:    outs(%[[EMPTY]] : tensor<1290240xi32>)
+// CHECK:         ^bb0(%[[VAL_IN:.*]]: i32, %[[VAL_OUT:.*]]: i32):
+// CHECK:           %[[ID:.*]] = linalg.index 0
+// CHECK:           %[[CAST:.*]] = arith.index_cast %[[VAL_IN]]
+// CHECK:           %[[EXTRACTED:.*]] = tensor.extract %[[ARG0]][%[[CAST]], {{.*}}, %[[ID]]]
+// CHECK:           linalg.yield %[[EXTRACTED]] : i32
+func.func @hoist_1_keep_1(%arg0: tensor<1x1x1290240xi32>, %arg1: tensor<1x1x1290240xf32>) -> tensor<1290240xi32> {
+  %c0 = arith.constant 0 : index
+  %0 = tensor.empty() : tensor<1290240xi32>
+  %1 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]}
+      outs(%0 : tensor<1290240xi32>) {
+  ^bb0(%out: i32):
+    %id0 = linalg.index 0 : index
+    %extracted = tensor.extract %arg0[%c0, %c0, %id0] : tensor<1x1x1290240xi32>
+    %index = arith.index_cast %extracted : i32 to index
+    %extracted_1 = tensor.extract %arg0[%index, %c0, %id0] : tensor<1x1x1290240xi32>
+    linalg.yield %extracted_1 : i32
+  } -> tensor<1290240xi32>
+  return %1 : tensor<1290240xi32>
+}
+
+// CHECK-LABEL: func.func @hoist_combined_inputs(
+// CHECK-SAME:    %[[ARG0:.*]]: tensor<1x1x1x1290240xf32>)
+// CHECK:         %[[RES:.*]] = linalg.generic
+// CHECK-SAME:    ins({{.*}}, {{.*}}, %[[ARG0]] : i32, tensor<i32>, tensor<1x1x1x1290240xf32>)
+// CHECK:         ^bb0(%{{.*}}, %{{.*}}, %[[VAL_HOISTED:.*]]: f32, %{{.*}}):
+// CHECK:           linalg.yield %[[VAL_HOISTED]] : f32
+func.func @hoist_combined_inputs(%arg0: tensor<1x1x1x1290240xf32>) -> tensor<1290240xf32> {
+  %c0 = arith.constant 0 : i32
+  %ci_0 = arith.constant 0 : index
+  %cd_0 = arith.constant dense<0> : tensor<i32>
+  %output = tensor.empty() : tensor<1290240xf32>
+  %13 = linalg.generic {indexing_maps = [affine_map<(d0) -> ()>, affine_map<(d0) -> ()> , affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]}
+   ins(%c0, %cd_0 : i32, tensor<i32>)
+   outs(%output : tensor<1290240xf32>) {
+  ^bb0(%in: i32, %in1: i32, %out: f32):
+    %not_dense = arith.index_cast %in : i32 to index
+    %dense = arith.index_cast %in1 : i32 to index
+    %id = linalg.index 0 : index
+    %extracted = tensor.extract %arg0[%not_dense, %dense, %ci_0, %id] : tensor<1x1x1x1290240xf32>
+    linalg.yield %extracted : f32
+  } -> tensor<1290240xf32>
+  return %13 : tensor<1290240xf32>
+}
+
+// CHECK-LABEL: func.func @hoist_all_constants(
+// CHECK-SAME:    %[[ARG0:.*]]: tensor<4x4xf32>, %[[ARG1:.*]]: tensor<4xf32>)
+// CHECK:         %[[RES:.*]] = linalg.generic
+// CHECK-SAME:    ins(%[[ARG0]] : tensor<4x4xf32>)
+// CHECK:         ^bb0(%[[VAL_IN:.*]]: f32, %[[VAL_OUT:.*]]: f32):
+// CHECK:           linalg.yield %[[VAL_IN]] : f32
+func.func @hoist_all_constants(%input: tensor<4x4xf32>, %output: tensor<4xf32>) -> tensor<4xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  }
+     outs(%output : tensor<4xf32>) {
+    ^bb0(%out: f32):
+    %extracted = tensor.extract %input[%c0, %c1] : tensor<4x4xf32>
+    linalg.yield %extracted : f32
+  } -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+// CHECK-LABEL: func.func @no_hoist_function_arg_index(
+// CHECK-SAME:    %[[ARG0:.*]]: tensor<4xf32>, %[[IDX:.*]]: index, %[[OUT:.*]]: tensor<4xf32>)
+// CHECK:         %[[RES:.*]] = linalg.generic
+// CHECK-NOT:     ins(
+// CHECK:         ^bb0(%[[VAL_OUT:.*]]: f32):
+// CHECK:           %[[EXTRACTED:.*]] = tensor.extract %[[ARG0]][%[[IDX]]]
+// CHECK:           linalg.yield %[[EXTRACTED]] : f32
+func.func @no_hoist_function_arg_index(%input: tensor<4xf32>, %idx: index, %output: tensor<4xf32>) -> tensor<4xf32> {
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]
+  }
+     outs(%output : tensor<4xf32>) {
+    ^bb0(%out: f32):
+    %id0 = linalg.index 0 : index
+    %extracted = tensor.extract %input[%idx] : tensor<4xf32>
+    linalg.yield %extracted : f32
+  } -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match interface{LinalgOp} in %arg1 
+      : (!transform.any_op) -> !transform.any_op
+    
+    %1 = transform.structured.hoist_extract_to_argument %0 
+      : (!transform.any_op) -> !transform.any_op
+    
+    transform.yield
+  }
+}


### PR DESCRIPTION
This PR implements the transformation to hoist tensor.extract operations from the body of a linalg.generic op into the ins operands list.

As discussed in the RFC (link below), performing this hoisting simplifies the payload and makes data dependencies more explicit, which can help with subsequent bufferization and vectorization passes.

RFC: [Hoisting tensor.extract to linalg.generic operands](https://discourse.llvm.org/t/rfc-hoisting-tensor-extract-to-linalg-generic-operands/89193)