### PR TITLE
[lldb-dap][ext] Add script to only run extension unittests

### DIFF
--- a/lldb/tools/lldb-dap/extension/package.json
+++ b/lldb/tools/lldb-dap/extension/package.json
@@ -65,6 +65,8 @@
     "compile": "tsc -p ./",
     "publish": "vsce publish",
     "pretest": "npm run compile",
+    "preunittest": "npm run pretest",
+    "unittest": "mocha --ui tdd ./out/test/unit",
     "test": "vscode-test",
     "vscode-uninstall": "code --uninstall-extension llvm-vs-code-extensions.lldb-dap",
     "vscode-install": "code --install-extension ./out/lldb-dap.vsix"


### PR DESCRIPTION
`vscode-test` requirest a GUI or something that emulates one. Use the Mocha test library directly for unitest

Run unittests using `npm run unittest`