### PR TITLE
[RISCV] Bail out of combineNarrowableShiftedLoad for types other than scalar int

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -16704,7 +16704,10 @@ static SDValue reduceANDOfAtomicLoad(SDNode *N,
 // hidden by the intermediate shift. Detect that case and commute the
 // shift/and in order to enable load narrowing.
 static SDValue combineNarrowableShiftedLoad(SDNode *N, SelectionDAG &DAG) {
-  // (and (shl (load ...), ShiftAmt), Mask)
+  EVT VT = N->getValueType(0);
+  if (!VT.isScalarInteger())
+    return SDValue();
+
   using namespace SDPatternMatch;
   SDValue LoadNode;
   APInt MaskVal, ShiftVal;
@@ -16716,7 +16719,6 @@ static SDValue combineNarrowableShiftedLoad(SDNode *N, SelectionDAG &DAG) {
     return SDValue();
   }
 
-  EVT VT = N->getValueType(0);
   uint64_t ShiftAmt = ShiftVal.getZExtValue();
 
   if (ShiftAmt >= VT.getSizeInBits())


### PR DESCRIPTION
Introduced in #170483 this was only ever meant to trigger for scalar types. We get an error on rv32gcv for some inputs "Cannot implicitly convert a scalable size to a fixed-width size in `TypeSize::operator ScalarTy()`".

While we're editing this function, delete an accidentally repeated comment.

Minimal reproducer:
```
define <vscale x 4 x ptr> @ham() {
bb:
  %load = load <vscale x 4 x i32>, ptr null, align 4
  %ashr = ashr <vscale x 4 x i32> %load, splat (i32 1)
  %getelementptr = getelementptr i32, ptr null, <vscale x 4 x i32> %ashr
  ret <vscale x 4 x ptr> %getelementptr
}
```
---
Although I have a reproducer I haven't added it, largely because I'm not sure where it should live. Adding it to load-narrow-shift-mask-combine.ll would require changing the CHECK line names RV32I => RV32 and RV64I => RV64 and adding -mattr=+v with a comment for the test. Alternatively I add a new file named after whatever PR number this has. Or we decide it's a trivial fix that doesn't really need an explicit test. (This case was found via llvm-test-suite rv32gcv - once this batch of fixes lands we will get continual coverage of that in CI).