### PR TITLE
[clang][bytecode] Diagnose unknown reference params pre-C++23

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -7076,6 +7076,10 @@ bool Compiler<Emitter>::visitDeclRef(const ValueDecl *D, const Expr *E) {
 
       return this->emitGetPtrParam(It->second.Offset, E);
     }
+
+    if (!Ctx.getLangOpts().CPlusPlus23 && IsReference)
+      return this->emitInvalidDeclRef(cast<DeclRefExpr>(E),
+                                      /*InitializerFailed=*/false, E);
   }
   // Local variables.
   if (auto It = Locals.find(D); It != Locals.end()) {

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -144,14 +144,19 @@ static bool diagnoseUnknownDecl(InterpState &S, CodePtr OpPC,
   if (isa<ParmVarDecl>(D)) {
     if (D->getType()->isReferenceType()) {
       if (S.inConstantContext() && S.getLangOpts().CPlusPlus &&
-          !S.getLangOpts().CPlusPlus11)
+          !S.getLangOpts().CPlusPlus11) {
         diagnoseNonConstVariable(S, OpPC, D);
-      return false;
+        return false;
+      }
     }
 
     const SourceInfo &Loc = S.Current->getSource(OpPC);
-    if (S.getLangOpts().CPlusPlus11) {
-      S.FFDiag(Loc, diag::note_constexpr_function_param_value_unknown) << D;
+    if (S.getLangOpts().CPlusPlus23) {
+      S.FFDiag(Loc, diag::note_constexpr_access_unknown_variable, 1)
+          << AK_Read << D;
+      S.Note(D->getLocation(), diag::note_declared_at) << D->getSourceRange();
+    } else if (S.getLangOpts().CPlusPlus11) {
+      S.FFDiag(Loc, diag::note_constexpr_function_param_value_unknown, 1) << D;
       S.Note(D->getLocation(), diag::note_declared_at) << D->getSourceRange();
     } else {
       S.FFDiag(Loc);

--- a/clang/test/AST/ByteCode/cxx23.cpp
+++ b/clang/test/AST/ByteCode/cxx23.cpp
@@ -520,3 +520,20 @@ namespace InactiveLocalsInConditionalOp {
 
 }
 #endif
+
+namespace UnknownParams {
+  class X {
+  public:
+    constexpr operator bool(){ return true; }
+  };
+  int foo(X x) {
+    static_assert(x);
+    return 1;
+  }
+
+  int foo2(X &x) { // all20-note {{declared here}}
+    static_assert(x); // all20-error {{not an integral constant expression}} \
+                      // all20-note {{function parameter 'x' with unknown value cannot be used in a constant expression}}
+    return 1;
+  }
+}

--- a/clang/test/SemaCXX/constant-expression-p2280r4.cpp
+++ b/clang/test/SemaCXX/constant-expression-p2280r4.cpp
@@ -35,7 +35,7 @@ constexpr int how_many(Swim& swam) {
   return (p + 1 - 1)->phelps();
 }
 
-void splash(Swim& swam) {                 // nointerpreter-note {{declared here}}
+void splash(Swim& swam) {                 // expected-note {{declared here}}
   static_assert(swam.phelps() == 28);     // ok
   static_assert((&swam)->phelps() == 28); // ok
   Swim* pswam = &swam;                    // expected-note {{declared here}}
@@ -46,7 +46,7 @@ void splash(Swim& swam) {                 // nointerpreter-note {{declared here}
   static_assert(swam.lochte() == 12);     // expected-error {{static assertion expression is not an integral constant expression}} \
                                           // expected-note {{virtual function called on object 'swam' whose dynamic type is not constant}}
   static_assert(swam.coughlin == 12);     // expected-error {{static assertion expression is not an integral constant expression}} \
-                                          // nointerpreter-note {{read of variable 'swam' whose value is not known}}
+                                          // expected-note {{read of variable 'swam' whose value is not known}}
 }
 
 extern Swim dc;
@@ -256,14 +256,14 @@ namespace uninit_reference_used {
 
 namespace param_reference {
   constexpr int arbitrary = -12345;
-  constexpr void f(const int &x = arbitrary) { // nointerpreter-note 3 {{declared here}} interpreter-note {{declared here}}
+  constexpr void f(const int &x = arbitrary) { // expected-note 3{{declared here}}
     constexpr const int &v1 = x; // expected-error {{must be initialized by a constant expression}} \
     // expected-note {{reference to 'x' is not a constant expression}}
     constexpr const int &v2 = (x, arbitrary); // expected-warning {{left operand of comma operator has no effect}}
     constexpr int v3 = x; // expected-error {{must be initialized by a constant expression}} \
-                          // nointerpreter-note {{read of variable 'x' whose value is not known}}
+                          // expected-note {{read of variable 'x' whose value is not known}}
     static_assert(x==arbitrary); // expected-error {{static assertion expression is not an integral constant expression}} \
-                                 // nointerpreter-note {{read of variable 'x' whose value is not known}}
+                                 // expected-note {{read of variable 'x' whose value is not known}}
     static_assert(&x - &x == 0);
   }
 }


### PR DESCRIPTION
Otherwise, we will ultimately create dummy pointers for them and possibly not diagnose anything.