### PR TITLE
[lldb-dap][windows] fix lldb-dap executable name in test

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -566,7 +566,9 @@ def setupSysPath():
 
     lldbDir = os.path.dirname(lldbtest_config.lldbExec)
 
-    lldbDAPExec = os.path.join(lldbDir, "lldb-dap")
+    lldbDAPExec = os.path.join(
+        lldbDir, "lldb-dap.exe" if sys.platform == "win32" else "lldb-dap"
+    )
     if is_exe(lldbDAPExec):
         os.environ["LLDBDAP_EXEC"] = lldbDAPExec
 


### PR DESCRIPTION
This patch fixes an incorrect name of the `lldb-dap` process on Windows by appending `.exe` to the name.

This is a prelude to https://github.com/llvm/llvm-project/pull/174635.