### PR TITLE
[NFC][lldb][windows] extract the InitializeProcThreadAttributeList logic

### DIFF
--- a/lldb/include/lldb/Host/windows/ProcessLauncherWindows.h
+++ b/lldb/include/lldb/Host/windows/ProcessLauncherWindows.h
@@ -17,6 +17,52 @@ namespace lldb_private {
 
 class ProcessLaunchInfo;
 
+/// This class manages the lifetime of a PROC_THREAD_ATTRIBUTE_LIST, which is
+/// used with STARTUPINFOEX.
+///
+/// The attribute list is automatically cleaned up when this object is
+/// destroyed.
+class ProcThreadAttributeList {
+public:
+  /// Allocate memory for the attribute list, initialize it, and sets the
+  /// lpAttributeList member of STARTUPINFOEXW structure.
+  ///
+  /// \param[in,out] startupinfoex
+  ///     The STARTUPINFOEXW structure whose lpAttributeList member will be set
+  ///     to point to the attribute list. The caller must ensure
+  ///     this structure remains valid for the lifetime of the returned object.
+  ///
+  /// \return
+  ///     A ProcThreadAttributeList object on success, or an error code on
+  ///     failure.
+  static llvm::ErrorOr<ProcThreadAttributeList>
+  Create(STARTUPINFOEXW &startupinfoex);
+
+  ~ProcThreadAttributeList() {
+    if (lpAttributeList) {
+      DeleteProcThreadAttributeList(lpAttributeList);
+      free(lpAttributeList);
+    }
+  }
+
+  /// ProcThreadAttributeList is not copyable.
+  /// @{
+  ProcThreadAttributeList(const ProcThreadAttributeList &) = delete;
+  ProcThreadAttributeList &operator=(const ProcThreadAttributeList &) = delete;
+  /// @}
+
+  ProcThreadAttributeList(ProcThreadAttributeList &&other) noexcept
+      : lpAttributeList(other.lpAttributeList) {
+    other.lpAttributeList = nullptr;
+  }
+
+private:
+  explicit ProcThreadAttributeList(LPPROC_THREAD_ATTRIBUTE_LIST list)
+      : lpAttributeList(list) {}
+
+  LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList;
+};
+
 class ProcessLauncherWindows : public ProcessLauncher {
 public:
   HostProcess LaunchProcess(const ProcessLaunchInfo &launch_info,


### PR DESCRIPTION
This NFC change refactors how `LPPROC_THREAD_ATTRIBUTE_LIST` is managed.

`ProcThreadAttributeList::Create` now returns an object which owns `LPPROC_THREAD_ATTRIBUTE_LIST` and will free it correctly when it goes out of scope.

This is a prelude to https://github.com/llvm/llvm-project/pull/174635.