### PR TITLE
[LLDB][NFC] Remove excessive use of `auto` from MSVC STL formatters

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlAtomic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlAtomic.cpp
@@ -99,11 +99,11 @@ lldb_private::formatters::MsvcStlAtomicSyntheticFrontEndCreator(
 
 bool lldb_private::formatters::MsvcStlAtomicSummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  auto synth_sp = valobj.GetSyntheticValue();
+  ValueObjectSP synth_sp = valobj.GetSyntheticValue();
   if (!synth_sp)
     return false;
 
-  auto value_sp = synth_sp->GetChildAtIndex(0);
+  ValueObjectSP value_sp = synth_sp->GetChildAtIndex(0);
   std::string summary;
   if (value_sp->GetSummaryAsCString(summary, options) && !summary.empty()) {
     stream << summary;

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
@@ -96,25 +96,27 @@ lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::Update() {
   m_map = nullptr;
   m_element_type.Clear();
 
-  auto storage_sp = m_backend.GetChildAtNamePath({"_Mypair", "_Myval2"});
+  ValueObjectSP storage_sp =
+      m_backend.GetChildAtNamePath({"_Mypair", "_Myval2"});
   if (!storage_sp)
     return lldb::eRefetch;
 
-  auto deque_type = m_backend.GetCompilerType();
+  CompilerType deque_type = m_backend.GetCompilerType();
   if (!deque_type)
     return lldb::eRefetch;
 
-  auto block_size_decl = deque_type.GetStaticFieldWithName("_Block_size");
+  CompilerDecl block_size_decl =
+      deque_type.GetStaticFieldWithName("_Block_size");
   if (!block_size_decl)
     return lldb::eRefetch;
-  auto block_size = block_size_decl.GetConstantValue();
+  Scalar block_size = block_size_decl.GetConstantValue();
   if (!block_size.IsValid())
     return lldb::eRefetch;
 
-  auto offset_sp = storage_sp->GetChildMemberWithName("_Myoff");
-  auto map_size_sp = storage_sp->GetChildMemberWithName("_Mapsize");
-  auto map_sp = storage_sp->GetChildMemberWithName("_Map");
-  auto size_sp = storage_sp->GetChildMemberWithName("_Mysize");
+  ValueObjectSP offset_sp = storage_sp->GetChildMemberWithName("_Myoff");
+  ValueObjectSP map_size_sp = storage_sp->GetChildMemberWithName("_Mapsize");
+  ValueObjectSP map_sp = storage_sp->GetChildMemberWithName("_Map");
+  ValueObjectSP size_sp = storage_sp->GetChildMemberWithName("_Mysize");
   if (!offset_sp || !map_size_sp || !map_sp || !size_sp)
     return lldb::eRefetch;
 
@@ -131,7 +133,7 @@ lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::Update() {
   if (!ok)
     return lldb::eRefetch;
 
-  auto element_type = deque_type.GetTypeTemplateArgument(0);
+  CompilerType element_type = deque_type.GetTypeTemplateArgument(0);
   if (!element_type) {
     // PDB doesn't have the template type, so use the type of _Map (T**).
     element_type = map_sp->GetCompilerType().GetPointeeType().GetPointeeType();

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
@@ -147,11 +147,12 @@ lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEnd::Update() {
   if (!valobj_sp)
     return lldb::ChildCacheState::eRefetch;
 
-  auto ptr_obj_sp = valobj_sp->GetChildMemberWithName("_Ptr");
+  ValueObjectSP ptr_obj_sp = valobj_sp->GetChildMemberWithName("_Ptr");
   if (!ptr_obj_sp)
     return lldb::ChildCacheState::eRefetch;
 
-  auto cast_ptr_sp = GetDesugaredSmartPointerValue(*ptr_obj_sp, *valobj_sp);
+  ValueObjectSP cast_ptr_sp =
+      GetDesugaredSmartPointerValue(*ptr_obj_sp, *valobj_sp);
   if (!cast_ptr_sp)
     return lldb::ChildCacheState::eRefetch;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTree.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTree.cpp
@@ -348,7 +348,7 @@ lldb_private::formatters::MsvcStlTreeSyntheticFrontEnd::GetIndexOfChildWithName(
 
 lldb::ChildCacheState MsvcStlTreeIterSyntheticFrontEnd::Update() {
   m_inner_sp = nullptr;
-  auto node_sp = m_backend.GetChildMemberWithName("_Ptr");
+  ValueObjectSP node_sp = m_backend.GetChildMemberWithName("_Ptr");
   if (!node_sp)
     return lldb::eRefetch;
 


### PR DESCRIPTION
Some MSVC STL formatters made excessive use of `auto`, especially the `std::deque` one (https://github.com/llvm/llvm-project/pull/172360#pullrequestreview-3639850321). This PR replaces the uses with the concrete type.