### PR TITLE
[CIR][NFC] Generate ABI lowering patterns with TableGen

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -79,6 +79,8 @@ class LLVMLoweringInfo {
 
 class CIR_Op<string mnemonic, list<Trait> traits = []> :
     Op<CIR_Dialect, mnemonic, traits>, LLVMLoweringInfo {
+  // Should we generate an ABI lowering pattern for this op?
+  bit hasCXXABILowering = false;
   // Should we generate an LLVM lowering pattern for this op?
   bit hasLLVMLowering = true;
   // Is the LLVM lowering pattern for this operation recursive?
@@ -451,6 +453,7 @@ def CIR_ConstantOp : CIR_Op<"const", [
 
   let hasFolder = 1;
 
+  let hasCXXABILowering = true;
   let isLLVMLoweringRecursive = true;
 }
 
@@ -571,6 +574,8 @@ def CIR_AllocaOp : CIR_Op<"alloca", [
     `]`
     ($annotations^)? attr-dict
   }];
+
+  let hasCXXABILowering = true;
 }
 
 //===----------------------------------------------------------------------===//
@@ -2251,6 +2256,8 @@ def CIR_GlobalOp : CIR_Op<"global", [
 
   let hasVerifier = 1;
 
+  let hasCXXABILowering = true;
+
   let isLLVMLoweringRecursive = true;
   let extraLLVMLoweringPatternDecl = [{
     mlir::LogicalResult matchAndRewriteRegionInitializedGlobal(
@@ -3008,6 +3015,8 @@ def CIR_FuncOp : CIR_Op<"func", [
 
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
+
+  let hasCXXABILowering = true;
 
   let extraLLVMLoweringPatternDecl = [{
     static mlir::StringRef getLinkageAttrNameString() { return "linkage"; }
@@ -3785,6 +3794,7 @@ def CIR_GetRuntimeMemberOp : CIR_Op<"get_runtime_member"> {
 
   let hasVerifier = 1;
 
+  let hasCXXABILowering = true;
   let hasLLVMLowering = false;
 }
 

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -31,38 +31,9 @@ namespace mlir {
 
 namespace {
 
-template <typename Op>
-class CIROpCXXABILoweringPattern : public mlir::OpConversionPattern<Op> {
-protected:
-  mlir::DataLayout *dataLayout;
-  cir::LowerModule *lowerModule;
-
-public:
-  CIROpCXXABILoweringPattern(mlir::MLIRContext *context,
-                             const mlir::TypeConverter &typeConverter,
-                             mlir::DataLayout &dataLayout,
-                             cir::LowerModule &lowerModule)
-      : mlir::OpConversionPattern<Op>(typeConverter, context),
-        dataLayout(&dataLayout), lowerModule(&lowerModule) {}
-};
-
-// TODO(cir): Use TableGen to generate these patterns.
-#define CIR_CXXABI_LOWERING_PATTERN(name, operation)                           \
-  struct name : CIROpCXXABILoweringPattern<operation> {                        \
-    using CIROpCXXABILoweringPattern<operation>::CIROpCXXABILoweringPattern;   \
-                                                                               \
-    mlir::LogicalResult                                                        \
-    matchAndRewrite(operation op, OpAdaptor adaptor,                           \
-                    mlir::ConversionPatternRewriter &rewriter) const override; \
-  }
-
-CIR_CXXABI_LOWERING_PATTERN(CIRAllocaOpABILowering, cir::AllocaOp);
-CIR_CXXABI_LOWERING_PATTERN(CIRConstantOpABILowering, cir::ConstantOp);
-CIR_CXXABI_LOWERING_PATTERN(CIRFuncOpABILowering, cir::FuncOp);
-CIR_CXXABI_LOWERING_PATTERN(CIRGetRuntimeMemberOpABILowering,
-                            cir::GetRuntimeMemberOp);
-CIR_CXXABI_LOWERING_PATTERN(CIRGlobalOpABILowering, cir::GlobalOp);
-#undef CIR_CXXABI_LOWERING_PATTERN
+#define GET_ABI_LOWERING_PATTERNS
+#include "clang/CIR/Dialect/IR/CIRLowering.inc"
+#undef GET_ABI_LOWERING_PATTERNS
 
 struct CXXABILoweringPass
     : public impl::CXXABILoweringBase<CXXABILoweringPass> {
@@ -346,13 +317,9 @@ void CXXABILoweringPass::runOnOperation() {
   patterns.add<CIRGenericCXXABILoweringPattern>(patterns.getContext(),
                                                 typeConverter);
   patterns.add<
-      // clang-format off
-      CIRAllocaOpABILowering,
-      CIRConstantOpABILowering,
-      CIRFuncOpABILowering,
-      CIRGetRuntimeMemberOpABILowering,
-      CIRGlobalOpABILowering
-      // clang-format on
+#define GET_ABI_LOWERING_PATTERNS_LIST
+#include "clang/CIR/Dialect/IR/CIRLowering.inc"
+#undef GET_ABI_LOWERING_PATTERNS_LIST
       >(patterns.getContext(), typeConverter, dataLayout, *lowerModule);
 
   mlir::ConversionTarget target(*ctx);


### PR DESCRIPTION
This patch teaches clang-tblgen to start emitting ABI lowering pattern declarations.