### PR TITLE
[lldb] Nominate John Harrison and Ebuka Ezike as lldb-dap maintainers

### DIFF
--- a/lldb/Maintainers.md
+++ b/lldb/Maintainers.md
@@ -227,11 +227,14 @@ pavel@labath.sk (email), [labath](https://github.com/labath) (GitHub), [labath](
 
 #### lldb-dap
 
-Greg Clayton
-gclayton@fb.com (email), [clayborg](https://github.com/clayborg) (GitHub), [clayborg](https://discourse.llvm.org/u/clayborg) (Discourse)
-
 Walter Erquinigo
 a20012251@gmail.com (email), [walter-erquinigo](https://github.com/walter-erquinigo) (GitHub), [wallace](https://discourse.llvm.org/u/wallace) (Discourse), werquinigo (Discord)
+
+Ebuka Ezike
+yerimyah1@gmail.com (email), [da-viper](https://github.com/da-viper) (GitHub), [da-viper](https://discourse.llvm.org/u/da-viper) (Discourse)
+
+John Harrison
+harjohn@google.com (email), [ashgti](https://github.com/ashgti) (GitHub), [ashgti](https://discourse.llvm.org/u/ashgti) (Discourse)
 
 ## Former Maintainers
 


### PR DESCRIPTION
As the lead maintainer, I've been asked by the project council to confirm that we have an up-to-date list of active maintainers for LLDB.

In light of that, I'd like to nominate Ebuka and John as lldb-dap maintainer and replace Greg, who hasn't been active in this area recently. I did not move Greg to "former maintainer" as he's still listed for other components.

As a reminder, our community policies regarding the responsibilities of maintainers can be found here: https://llvm.org/docs/DeveloperPolicy.html#maintainers.