### PR TITLE
[lldb] Nominate Charles Zablit and Nerixyz as Windows maintainers

### DIFF
--- a/lldb/Maintainers.md
+++ b/lldb/Maintainers.md
@@ -208,6 +208,12 @@ david.spickett@arm.com (email), [DavidSpickett](https://github.com/DavidSpickett
 Omair Javaid
 omair.javaid@linaro.org (email), [omjavaid](https://github.com/omjavaid) (GitHub), [omjavaid](https://discourse.llvm.org/u/omjavaid) (Discourse), omjavaid#9902 (Discord)
 
+Charles Zablit
+c_zablit@apple.com (email), [charles-zablit](https://github.com/charles-zablit) (GitHub), [charles-zablit](https://discourse.llvm.org/u/charles-zablit/) (Discourse)
+
+Nerixyz
+nerixdev@outlook.de (email), [Nerixyz](https://github.com/Nerixyz) (GitHub), [Nerixyz](https://discourse.llvm.org/u/Nerixyz/) (Discourse)
+
 ### Tools
 
 The following people are responsible for decisions involving specific tools.


### PR DESCRIPTION
As the lead maintainer, I've been asked by the project council to confirm that we have an up-to-date list of active maintainers for LLDB.

In light of that, I'd like to nominate Charles and Nerixyz as Windows maintainers.

As a reminder, our community policies regarding the responsibilities of maintainers can be found here:
https://llvm.org/docs/DeveloperPolicy.html#maintainers.