### PR TITLE
[libc++] Update maintainer list

### DIFF
--- a/libcxx/Maintainers.md
+++ b/libcxx/Maintainers.md
@@ -33,6 +33,11 @@ de34@live.cn (email), [frederick-vs-ja](https://github.com/frederick-vs-ja) (Git
 Hristo Hristov
 hghristov.rmm@gmail.com (email), [H-G-Hristov](https://github.com/H-G-Hristov) (GitHub)
 
+### `<algorithm>`
+
+Nikolas Klauser
+nikolasklauser@berlin.de (email), [philnik777](https://github.com/philnik777) (GitHub)
+
 ### Hardening
 
 Konstantin Varlamov

--- a/libcxx/Maintainers.md
+++ b/libcxx/Maintainers.md
@@ -27,7 +27,7 @@ nikolasklauser@berlin.de (email), [philnik777](https://github.com/philnik777) (G
 
 ### ISO C++ Conformance Status, LWG Issues
 
-A. Jiang
+An Jiang
 de34@live.cn (email), [frederick-vs-ja](https://github.com/frederick-vs-ja) (GitHub)
 
 Hristo Hristov
@@ -43,12 +43,12 @@ varconst@apple.com (email), [var-const](https://github.com/var-const) (GitHub)
 Hui Xie
 hui.xie1990@gmail.com (email), [huixie90](https://github.com/huixie90) (GitHub)
 
-Damien L-G
+Damien Lebrun-Grandie
 dalg24@gmail.com (email), [dalg24](https://github.com/dalg24) (GitHub)
 
 ### `<mdspan>`
 
-Damien L-G
+Damien Lebrun-Grandie
 dalg24@gmail.com (email), [dalg24](https://github.com/dalg24) (GitHub)
 
 ### Flat containers

--- a/libcxx/Maintainers.md
+++ b/libcxx/Maintainers.md
@@ -55,3 +55,24 @@ dalg24@gmail.com (email), [dalg24](https://github.com/dalg24) (GitHub)
 
 Hui Xie
 hui.xie1990@gmail.com (email), [huixie90](https://github.com/huixie90) (GitHub)
+
+### PSTL
+
+Nikolas Klauser
+nikolasklauser@berlin.de (email), [philnik777](https://github.com/philnik777) (GitHub)
+
+Louis Dionne
+ldionne.2@gmail.com (email), [ldionne](https://github.com/ldionne) (GitHub)
+
+### CI
+
+Louis Dionne
+ldionne.2@gmail.com (email), [ldionne](https://github.com/ldionne) (GitHub)
+
+Nikolas Klauser
+nikolasklauser@berlin.de (email), [philnik777](https://github.com/philnik777) (GitHub)
+
+### CMake
+
+Louis Dionne
+ldionne.2@gmail.com (email), [ldionne](https://github.com/ldionne) (GitHub)

--- a/libcxx/Maintainers.md
+++ b/libcxx/Maintainers.md
@@ -4,7 +4,54 @@ This file is a list of the
 [maintainers](https://llvm.org/docs/DeveloperPolicy.html#maintainers) for
 libc++.
 
-# Lead maintainer
+## Lead maintainer
 
-Louis Dionne \
+Responsible for project as a whole, and for any areas not covered by a specific maintainer.
+
+Louis Dionne
 ldionne.2@gmail.com (email), [ldionne](https://github.com/ldionne) (GitHub)
+
+## Components
+
+These maintainers are responsible for particular high-level components within libc++.
+The maintainership is not exclusive, in the sense that most contributors work across
+various components of the library.
+
+### ABI Questions
+
+Louis Dionne
+ldionne.2@gmail.com (email), [ldionne](https://github.com/ldionne) (GitHub)
+
+Nikolas Klauser
+nikolasklauser@berlin.de (email), [philnik777](https://github.com/philnik777) (GitHub)
+
+### ISO C++ Conformance Status, LWG Issues
+
+A. Jiang
+de34@live.cn (email), [frederick-vs-ja](https://github.com/frederick-vs-ja) (GitHub)
+
+Hristo Hristov
+hghristov.rmm@gmail.com (email), [H-G-Hristov](https://github.com/H-G-Hristov) (GitHub)
+
+### Hardening
+
+Konstantin Varlamov
+varconst@apple.com (email), [var-const](https://github.com/var-const) (GitHub)
+
+### Synchronization library and `<atomic>`
+
+Hui Xie
+hui.xie1990@gmail.com (email), [huixie90](https://github.com/huixie90) (GitHub)
+
+Damien L-G
+dalg24@gmail.com (email), [dalg24](https://github.com/dalg24) (GitHub)
+
+### `<mdspan>`
+
+Damien L-G
+dalg24@gmail.com (email), [dalg24](https://github.com/dalg24) (GitHub)
+
+### Flat containers
+
+Hui Xie
+hui.xie1990@gmail.com (email), [huixie90](https://github.com/huixie90) (GitHub)


### PR DESCRIPTION
Libc++ has not had an official list of maintainers beyond its lead maintainer. The LLVM Area Teams are seeking to update the list of maintainers for subprojects, and I thought it would make sense to document the de-facto maintainership status.