### PR TITLE
[HIP] Suppress verbose clang printing for all HIP on the new driver

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9162,9 +9162,9 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     return TC.HasNativeLLVMSupport() || A->getOption().getID() != OPT_mllvm;
   };
   auto ShouldForward = [&](const llvm::DenseSet<unsigned> &Set, Arg *A,
-                           const ToolChain &TC) {
-    // CMake hack to avoid printing verbose informatoin for HIP non-RDC mode.
-    if (A->getOption().matches(OPT_v) && JA.getType() == types::TY_HIP_FATBIN)
+                           const ToolChain &TC, Action::OffloadKind Kind) {
+    // CMake hack to avoid printing verbose informatoin for HIP.
+    if (A->getOption().matches(OPT_v) && Kind == Action::OFK_HIP)
       return false;
     return (Set.contains(A->getOption().getID()) ||
             (A->getOption().getGroup().isValid() &&
@@ -9188,9 +9188,9 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       for (Arg *A : ToolChainArgs) {
         if (A->getOption().matches(OPT_Zlinker_input))
           LinkerArgs.emplace_back(A->getValue());
-        else if (ShouldForward(CompilerOptions, A, *TC))
+        else if (ShouldForward(CompilerOptions, A, *TC, Kind))
           A->render(Args, CompilerArgs);
-        else if (ShouldForward(LinkerOptions, A, *TC))
+        else if (ShouldForward(LinkerOptions, A, *TC, Kind))
           A->render(Args, LinkerArgs);
       }
 

--- a/clang/test/Driver/hip-toolchain-rdc.hip
+++ b/clang/test/Driver/hip-toolchain-rdc.hip
@@ -183,3 +183,9 @@
 // RUN: not %clang -### -fgpu-rdc --offload-arch=gfx90a -nogpulib -nogpuinc --no-offload-new-driver \
 // RUN:   -L. -foffload-lto -flto-partitions=0 %s 2>&1 | FileCheck -check-prefix=LTO_PARTS_INV1 %s
 // LTO_PARTS_INV1: clang: error: invalid integral value '0' in '-flto-partitions=0'
+
+// Check verbose printing with the new driver.
+// RUN: %clang -### --target=x86_64-linux-gnu -fgpu-rdc -nogpulib -nogpuinc \
+// RUN:   --offload-new-driver --offload-arch=gfx908 -v %s 2>&1 | FileCheck %s --check-prefix=VERBOSE
+// VERBOSE: clang-linker-wrapper
+// VERBOSE-NOT: --device-compiler=amdgcn-amd-amdhsa=-v


### PR DESCRIPTION
Summary:
We've had issues with the CMake linker detection script incorrectly
firing off based off the linker wrapper results. This was fixed for
no-rdc mode but it seems like the issue persists. Just disable it for
all HIP compilations. Users will still see the embedded `clang`
invocation, they can choose to add `-v` themselves.
