### PR TITLE
[llvm][flang] Silence warning, resume -Werror builds of flang

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -37,7 +37,7 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND NOT MSVC_IDE)
           `CMakeFiles'. Please delete them.")
 endif()
 
-option(FLANG_ENABLE_WERROR "Fail and stop building flang if a warning is triggered." OFF)
+option(FLANG_ENABLE_WERROR "Fail and stop building flang if a warning is triggered." ON)
 
 # Check for a standalone build and configure as appropriate from
 # there.

--- a/flang/lib/Evaluate/fold-real.cpp
+++ b/flang/lib/Evaluate/fold-real.cpp
@@ -387,13 +387,7 @@ Expr<Type<TypeCategory::Real, KIND>> FoldIntrinsicFunction(
                 ScalarFunc<T, T, TBY>(
                     [&](const Scalar<T> &x, const Scalar<TBY> &y) -> Scalar<T> {
                       ValueWithRealFlags<Scalar<T>> result{
-                          x.
-// MSVC chokes on the keyword "template" here in a call to a
-// member function template.
-#ifndef _MSC_VER
-                          template
-#endif
-                          SCALE<Scalar<TBY>>(y)};
+                          x.template SCALE<Scalar<TBY>>(y)};
                       if (result.flags.test(RealFlag::Overflow)) {
                         context.Warn(common::UsageWarning::FoldingException,
                             "SCALE/IEEE_SCALB intrinsic folding overflow"_warn_en_US);

--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -211,6 +211,8 @@ protected:
       this->assertSafeToReferenceAfterResize(From, 0);
       this->assertSafeToReferenceAfterResize(To - 1, 0);
     }
+    (void)From;
+    (void)To;
   }
 
   /// Check whether any part of the range will be invalidated by growing.


### PR DESCRIPTION
Add (void) uses of two parameters to dodge a C++ compiler warning that has broken -Werror builds of flang since 9-28-25, and restore that option as the default for flang builds.