### PR TITLE
[lldb] skip the python interactive I/O test on windows

### DIFF
--- a/lldb/test/API/python_api/file_handle/TestFileHandle.py
+++ b/lldb/test/API/python_api/file_handle/TestFileHandle.py
@@ -680,6 +680,7 @@ class FileHandleTestCase(lldbtest.TestBase):
             lines = [x for x in f.read().strip().split() if x != "7"]
             self.assertEqual(lines, ["foobar"])
 
+    @skipIfWindows
     def test_stdout_file_interactive(self):
         """Ensure when we read stdin from a file, outputs from python goes to the right I/O stream."""
         with open(self.in_filename, "w") as f:

--- a/lldb/test/API/python_api/file_handle/TestFileHandle.py
+++ b/lldb/test/API/python_api/file_handle/TestFileHandle.py
@@ -2,7 +2,6 @@
 Test lldb Python API for file handles.
 """
 
-
 import os
 import io
 import re
@@ -680,7 +679,7 @@ class FileHandleTestCase(lldbtest.TestBase):
             lines = [x for x in f.read().strip().split() if x != "7"]
             self.assertEqual(lines, ["foobar"])
 
-    @skipIfWindows
+    @skipIf(hostoslist=["windows"])
     def test_stdout_file_interactive(self):
         """Ensure when we read stdin from a file, outputs from python goes to the right I/O stream."""
         with open(self.in_filename, "w") as f:

--- a/lldb/test/Shell/ScriptInterpreter/Python/io.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/io.test
@@ -1,3 +1,5 @@
+# UNSUPPORTED: system-windows
+
 # RUN: rm -rf %t.stdout %t.stderr
 # RUN: cat %s | %lldb --script-language python > %t.stdout 2> %t.stderr
 # RUN: cat %t.stdout | FileCheck %s --check-prefix STDOUT


### PR DESCRIPTION
There is no indication this ever worked on windows as this is the first test that checks python interactive console from a file.

Looking at the error from the CI, It closed the interpreter before running any python commands. 
Will reconfirm this tomorrow when I have access to a windows machine. 

Unblocks CI

From https://github.com/llvm/llvm-project/pull/174216