### PR TITLE
[SPIR-V] Add clang builtin for group-wide barrier

### DIFF
--- a/clang/include/clang/Basic/BuiltinsSPIRVCommon.td
+++ b/clang/include/clang/Basic/BuiltinsSPIRVCommon.td
@@ -22,4 +22,5 @@ def distance : SPIRVBuiltin<"void(...)", [NoThrow, Const]>;
 def length : SPIRVBuiltin<"void(...)", [NoThrow, Const]>;
 def smoothstep : SPIRVBuiltin<"void(...)", [NoThrow, Const, CustomTypeChecking]>;
 
+def group_barrier : SPIRVBuiltin<"void()", [NoThrow]>;
 def subgroup_ballot : SPIRVBuiltin<"_ExtVector<4, uint32_t>(bool)", [NoThrow, Const]>;

--- a/clang/test/CodeGenSPIRV/Builtins/group.c
+++ b/clang/test/CodeGenSPIRV/Builtins/group.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -O1 -triple spirv64 -fsycl-is-device -x c++ %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK
+// RUN: %clang_cc1 -O1 -triple spirv64 -cl-std=CL3.0 -x cl %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK
+// RUN: %clang_cc1 -O1 -triple spirv32 -cl-std=CL3.0 -x cl %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK
+
+// CHECK-LABEL: define spir_func void @{{.*}}test_group_barrier{{.*}}(
+// CHECK-SAME: ) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    tail call void @llvm.spv.group.memory.barrier.with.group.sync()
+// CHECK-NEXT:    ret void
+//
+[[clang::sycl_external]] void test_group_barrier() {
+  __builtin_spirv_group_barrier();
+}

--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -133,8 +133,8 @@ def int_spv_rsqrt : DefaultAttrsIntrinsic<[LLVMMatchType<0>], [llvm_anyfloat_ty]
       : DefaultAttrsIntrinsic<[llvm_i32_ty], [], [IntrConvergent]>;
   def int_spv_sign : DefaultAttrsIntrinsic<[LLVMScalarOrSameVectorWidth<0, llvm_i32_ty>], [llvm_any_ty], [IntrNoMem]>;
   def int_spv_radians : DefaultAttrsIntrinsic<[LLVMMatchType<0>], [llvm_anyfloat_ty], [IntrNoMem]>;
-  def int_spv_group_memory_barrier_with_group_sync
-      : DefaultAttrsIntrinsic<[], [], [IntrConvergent]>;
+  def int_spv_group_memory_barrier_with_group_sync : ClangBuiltin<"__builtin_spirv_group_barrier">,
+    DefaultAttrsIntrinsic<[], [], [IntrConvergent]>;
   def int_spv_discard : DefaultAttrsIntrinsic<[], [], []>;
   def int_spv_ddx : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>], [IntrNoMem]>;
   def int_spv_ddy : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>], [IntrNoMem]>;


### PR DESCRIPTION
Summary:
This adds a clang builtin for the existing group sync. I was considering
instead exposing a raw barrier operation and chaining it with a
`__scoped_atomic_thread_fence` but this seemed simpler. Right now this
implies a sequentially consistent memory fence. These semantics should
already match with what's implied with CUDA `__syncthreads`. I'm unsure
if there's a situation where we'd need more control. If we want more
control we'd probably just want to match it up with the scoped atomic
scopes.
