### PR TITLE
[SPIRV] Improve vector legalization and type deduction

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
@@ -195,6 +195,78 @@ static SPIRVType *deduceTypeFromUses(Register Reg, MachineFunction &MF,
   return nullptr;
 }
 
+static SPIRVType *deduceGEPType(MachineInstr *I, SPIRVGlobalRegistry *GR,
+                                MachineIRBuilder &MIB) {
+  LLVM_DEBUG(dbgs() << "Deducing GEP type for: " << *I);
+  Register PtrReg = I->getOperand(3).getReg();
+  SPIRVType *PtrType = GR->getSPIRVTypeForVReg(PtrReg);
+  if (!PtrType) {
+    LLVM_DEBUG(dbgs() << "  Could not get type for pointer operand.\n");
+    return nullptr;
+  }
+
+  SPIRVType *PointeeType = GR->getPointeeType(PtrType);
+  if (!PointeeType) {
+    LLVM_DEBUG(dbgs() << "  Could not get pointee type from pointer type.\n");
+    return nullptr;
+  }
+
+  MachineRegisterInfo *MRI = MIB.getMRI();
+
+  // The first index (operand 4) steps over the pointer, so the type doesn't
+  // change.
+  for (unsigned i = 5; i < I->getNumOperands(); ++i) {
+    LLVM_DEBUG(dbgs() << "  Traversing index " << i
+                      << ", current type: " << *PointeeType);
+    switch (PointeeType->getOpcode()) {
+    case SPIRV::OpTypeArray:
+    case SPIRV::OpTypeRuntimeArray:
+    case SPIRV::OpTypeVector: {
+      Register ElemTypeReg = PointeeType->getOperand(1).getReg();
+      PointeeType = GR->getSPIRVTypeForVReg(ElemTypeReg);
+      break;
+    }
+    case SPIRV::OpTypeStruct: {
+      MachineOperand &IdxOp = I->getOperand(i);
+      if (!IdxOp.isReg()) {
+        LLVM_DEBUG(dbgs() << "  Index is not a register.\n");
+        return nullptr;
+      }
+      MachineInstr *Def = MRI->getVRegDef(IdxOp.getReg());
+      if (!Def) {
+        LLVM_DEBUG(
+            dbgs() << "  Could not find definition for index register.\n");
+        return nullptr;
+      }
+
+      uint64_t IndexVal = foldImm(IdxOp, MRI);
+      if (IndexVal >= PointeeType->getNumOperands() - 1) {
+        LLVM_DEBUG(dbgs() << "  Struct index out of bounds.\n");
+        return nullptr;
+      }
+
+      Register MemberTypeReg = PointeeType->getOperand(IndexVal + 1).getReg();
+      PointeeType = GR->getSPIRVTypeForVReg(MemberTypeReg);
+      break;
+    }
+    default:
+      LLVM_DEBUG(dbgs() << "  Unknown type opcode for GEP traversal.\n");
+      return nullptr;
+    }
+
+    if (!PointeeType) {
+      LLVM_DEBUG(dbgs() << "  Could not resolve next pointee type.\n");
+      return nullptr;
+    }
+  }
+  LLVM_DEBUG(dbgs() << "  Final pointee type: " << *PointeeType);
+
+  SPIRV::StorageClass::StorageClass SC = GR->getPointerStorageClass(PtrType);
+  SPIRVType *Res = GR->getOrCreateSPIRVPointerType(PointeeType, MIB, SC);
+  LLVM_DEBUG(dbgs() << "  Deduced GEP type: " << *Res);
+  return Res;
+}
+
 static SPIRVType *deduceResultTypeFromOperands(MachineInstr *I,
                                                SPIRVGlobalRegistry *GR,
                                                MachineIRBuilder &MIB) {
@@ -207,12 +279,23 @@ static SPIRVType *deduceResultTypeFromOperands(MachineInstr *I,
     return deduceTypeFromOperandRange(I, MIB, GR, 1, I->getNumOperands());
   case TargetOpcode::G_SHUFFLE_VECTOR:
     return deduceTypeFromOperandRange(I, MIB, GR, 1, 3);
+  case TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS:
+  case TargetOpcode::G_INTRINSIC: {
+    auto IntrinsicID = cast<GIntrinsic>(I)->getIntrinsicID();
+    if (IntrinsicID == Intrinsic::spv_gep)
+      return deduceGEPType(I, GR, MIB);
+    break;
+  }
+  case TargetOpcode::G_LOAD: {
+    SPIRVType *PtrType = deduceTypeFromSingleOperand(I, MIB, GR, 1);
+    return PtrType ? GR->getPointeeType(PtrType) : nullptr;
+  }
   default:
     if (I->getNumDefs() == 1 && I->getNumOperands() > 1 &&
         I->getOperand(1).isReg())
       return deduceTypeFromSingleOperand(I, MIB, GR, 1);
-    return nullptr;
   }
+  return nullptr;
 }
 
 static bool deduceAndAssignTypeForGUnmerge(MachineInstr *I, MachineFunction &MF,

--- a/llvm/test/CodeGen/SPIRV/legalization/spv-extractelt-legalization.ll
+++ b/llvm/test/CodeGen/SPIRV/legalization/spv-extractelt-legalization.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
 
 ; CHECK-DAG: %[[#Int:]] = OpTypeInt 32 0
 ; CHECK-DAG: %[[#Const0:]] = OpConstant %[[#Int]] 0
@@ -15,15 +16,16 @@
 ; CHECK-DAG: %[[#Const60:]] = OpConstant %[[#Int]] 60
 ; CHECK-DAG: %[[#Arr:]] = OpTypeArray %[[#Int]] %[[#]]
 ; CHECK-DAG: %[[#PtrArr:]] = OpTypePointer Function %[[#Arr]]
+; CHECK-DAG: %[[#PtrPriv:]] = OpTypePointer Private %[[#Int]]
 
-@G = addrspace(1) global i32 0, align 4
+@G = internal addrspace(10) global i32 0, align 4
 
 define void @main() #0 {
 entry:
 ; CHECK: %[[#Var:]] = OpVariable %[[#PtrArr]] Function
 
 ; CHECK: %[[#Idx:]] = OpLoad %[[#Int]]
-  %idx = load i32, ptr addrspace(1) @G, align 4
+  %idx = load i32, ptr addrspace(10) @G, align 4
 
 
 ; CHECK: %[[#PtrElt0:]] = OpInBoundsAccessChain %[[#]] %[[#Var]] %[[#Const0]]
@@ -55,12 +57,8 @@ entry:
   %res = extractelement <6 x i32> %vec6, i32 %idx
   
 ; CHECK: OpStore {{.*}} %[[#Ld]]
-  store i32 %res, ptr addrspace(1) @G, align 4
+  store i32 %res, ptr addrspace(10) @G, align 4
   ret void
 }
 
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
-
-
-
-

--- a/llvm/test/CodeGen/SPIRV/legalization/vector-index-scalarization.ll
+++ b/llvm/test/CodeGen/SPIRV/legalization/vector-index-scalarization.ll
@@ -124,7 +124,7 @@ define void @test_undef() #0 {
   %idx = load i32, ptr addrspace(10) @idx
   %val = load i32, ptr addrspace(10) @val
   %idx64 = zext i32 %idx to i64
-  %inserted = insertelement <6 x i32> undef, i32 %val, i64 %idx64
+  %inserted = insertelement <6 x i32> poison, i32 %val, i64 %idx64
   %extracted = extractelement <6 x i32> %inserted, i64 0
   store i32 %extracted, ptr addrspace(10) @out
   ret void

--- a/llvm/test/CodeGen/SPIRV/legalization/vector-index-scalarization.ll
+++ b/llvm/test/CodeGen/SPIRV/legalization/vector-index-scalarization.ll
@@ -1,0 +1,166 @@
+; RUN: llc -O0 -mtriple=spirv1.6-unknown-vulkan1.3-compute %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv1.6-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val --target-env vulkan1.3 %}
+
+; CHECK-DAG: %[[#int:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#c6:]] = OpConstant %[[#int]] 6
+; CHECK-DAG: %[[#arr6int:]] = OpTypeArray %[[#int]] %[[#c6]]
+; CHECK-DAG: %[[#ptr_arr6int:]] = OpTypePointer Function %[[#arr6int]]
+; CHECK-DAG: %[[#ptr_f_int:]] = OpTypePointer Function %[[#int]]
+; CHECK-DAG: %[[#ptr_p_int:]] = OpTypePointer Private %[[#int]]
+; CHECK-DAG: %[[#c0:]] = OpConstant %[[#int]] 0
+; CHECK-DAG: %[[#c1:]] = OpConstant %[[#int]] 1
+; CHECK-DAG: %[[#c2:]] = OpConstant %[[#int]] 2
+; CHECK-DAG: %[[#c3:]] = OpConstant %[[#int]] 3
+; CHECK-DAG: %[[#c4:]] = OpConstant %[[#int]] 4
+; CHECK-DAG: %[[#c5:]] = OpConstant %[[#int]] 5
+; CHECK-DAG: %[[#undef:]] = OpUndef %[[#int]]
+
+; CHECK-DAG: %[[#out:]] = OpVariable %[[#ptr_p_int]] Private
+
+
+@out = internal addrspace(10) global i32 0
+@idx = internal addrspace(10) global i32 0
+@idx2 = internal addrspace(10) global i32 0
+@val = internal addrspace(10) global i32 0
+
+; CHECK: %[[#test_full:]] = OpFunction %[[#]] None %[[#]]
+define void @test_full() #0 {
+  ; CHECK:      %[[#label:]] = OpLabel
+  ; CHECK-DAG:  %[[#V_INS:]] = OpVariable %[[#ptr_arr6int]] Function
+  ; CHECK-DAG:  %[[#V_EXT:]] = OpVariable %[[#ptr_arr6int]] Function
+  ; CHECK-DAG:  %[[#]] = OpLoad %[[#int]] %[[#]]
+  ; CHECK-DAG:  %[[#]] = OpLoad %[[#int]] %[[#]]
+  ; CHECK-DAG:  %[[#VAL:]] = OpLoad %[[#int]] %[[#]]
+  ; CHECK-DAG:  %[[#IDX64:]] = OpUConvert %[[#]] %[[#]]
+  ; CHECK-DAG:  %[[#IDX2_64:]] = OpUConvert %[[#]] %[[#]]
+
+
+  %idx = load i32, ptr addrspace(10) @idx
+  %idx2 = load i32, ptr addrspace(10) @idx2
+  %val = load i32, ptr addrspace(10) @val
+
+  %ptr = alloca <6 x i32>
+  %loaded = load <6 x i32>, ptr %ptr
+  %idx64 = zext i32 %idx to i64
+  %idx2_64 = zext i32 %idx2 to i64
+
+  ; Insertelement with dynamic index spills to stack
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#c0]]
+; CHECK:  OpStore %[[#]] %[[#undef]] Aligned 32
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#c1]]
+; CHECK:  OpStore %[[#]] %[[#undef]] Aligned 4
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#c2]]
+; CHECK:  OpStore %[[#]] %[[#undef]] Aligned 8
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#c3]]
+; CHECK:  OpStore %[[#]] %[[#undef]] Aligned 4
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#c4]]
+; CHECK:  OpStore %[[#]] %[[#undef]] Aligned 16
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#c5]]
+; CHECK:  OpStore %[[#]] %[[#undef]] Aligned 4
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#IDX64]]
+; CHECK:  OpStore %[[#]] %[[#VAL]] Aligned 4
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#c0]]
+; CHECK:  %[[#V0:]] = OpLoad %[[#int]] %[[#]] Aligned 32
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#c1]]
+; CHECK:  %[[#V1:]] = OpLoad %[[#int]] %[[#]] Aligned 4
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#c2]]
+; CHECK:  %[[#V2:]] = OpLoad %[[#int]] %[[#]] Aligned 8
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#c3]]
+; CHECK:  %[[#V3:]] = OpLoad %[[#int]] %[[#]] Aligned 4
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#c4]]
+; CHECK:  %[[#V4:]] = OpLoad %[[#int]] %[[#]] Aligned 16
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_INS]] %[[#c5]]
+; CHECK:  %[[#V5:]] = OpLoad %[[#int]] %[[#]] Aligned 4
+  %inserted = insertelement <6 x i32> %loaded, i32 %val, i64 %idx64
+
+  ; Extractelement with dynamic index spills to stack
+
+
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_EXT]] %[[#c0]]
+; CHECK:  OpStore %[[#]] %[[#V0]] Aligned 32
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_EXT]] %[[#c1]]
+; CHECK:  OpStore %[[#]] %[[#V1]] Aligned 4
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_EXT]] %[[#c2]]
+; CHECK:  OpStore %[[#]] %[[#V2]] Aligned 8
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_EXT]] %[[#c3]]
+; CHECK:  OpStore %[[#]] %[[#V3]] Aligned 4
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_EXT]] %[[#c4]]
+; CHECK:  OpStore %[[#]] %[[#V4]] Aligned 16
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_EXT]] %[[#c5]]
+; CHECK:  OpStore %[[#]] %[[#V5]] Aligned 4
+; CHECK:  %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_EXT]] %[[#IDX2_64]]
+; CHECK:  %[[#EXTRACTED:]] = OpLoad %[[#int]] %[[#]] Aligned 4
+  %extracted = extractelement <6 x i32> %inserted, i64 %idx2_64
+
+  ; CHECK: OpStore %[[#out]] %[[#EXTRACTED]]
+  store i32 %extracted, ptr addrspace(10) @out
+  ret void
+}
+
+; CHECK: %[[#test_undef:]] = OpFunction %[[#]] None %[[#]]
+define void @test_undef() #0 {
+  ; CHECK:      %[[#label:]] = OpLabel
+  ; CHECK:      %[[#V_UNDEF:]] = OpVariable %[[#ptr_arr6int]] Function
+  ; CHECK-DAG:  %[[#IDX:]] = OpLoad %[[#int]] %[[#]]
+  ; CHECK-DAG:  %[[#VAL:]] = OpLoad %[[#int]] %[[#]]
+  ; CHECK:      %[[#IDX64:]] = OpUConvert %[[#]] %[[#IDX]]
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_UNDEF]] %[[#c0]]
+  ; CHECK:      OpStore %[[#]] %[[#undef]] Aligned 32
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_UNDEF]] %[[#c1]]
+  ; CHECK:      OpStore %[[#]] %[[#undef]] Aligned 4
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_UNDEF]] %[[#c2]]
+  ; CHECK:      OpStore %[[#]] %[[#undef]] Aligned 8
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_UNDEF]] %[[#c3]]
+  ; CHECK:      OpStore %[[#]] %[[#undef]] Aligned 4
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_UNDEF]] %[[#c4]]
+  ; CHECK:      OpStore %[[#]] %[[#undef]] Aligned 16
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_UNDEF]] %[[#c5]]
+  ; CHECK:      OpStore %[[#]] %[[#undef]] Aligned 4
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_UNDEF]] %[[#IDX64]]
+  ; CHECK:      OpStore %[[#]] %[[#VAL]] Aligned 4
+  ; CHECK:      %[[#PTR0:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_UNDEF]] %[[#c0]]
+  ; CHECK:      %[[#RES:]] = OpLoad %[[#int]] %[[#PTR0]] Aligned 32
+  ; CHECK:      OpStore %[[#out]] %[[#RES]]
+  %idx = load i32, ptr addrspace(10) @idx
+  %val = load i32, ptr addrspace(10) @val
+  %idx64 = zext i32 %idx to i64
+  %inserted = insertelement <6 x i32> undef, i32 %val, i64 %idx64
+  %extracted = extractelement <6 x i32> %inserted, i64 0
+  store i32 %extracted, ptr addrspace(10) @out
+  ret void
+}
+
+; CHECK: %[[#test_zero:]] = OpFunction %[[#]] None %[[#]]
+define void @test_zero() #0 {
+  ; CHECK:      %[[#label:]] = OpLabel
+  ; CHECK:      %[[#V_ZERO:]] = OpVariable %[[#ptr_arr6int]] Function
+  ; CHECK-DAG:  %[[#IDX:]] = OpLoad %[[#int]] %[[#]]
+  ; CHECK-DAG:  %[[#VAL:]] = OpLoad %[[#int]] %[[#]]
+  ; CHECK:      %[[#IDX64:]] = OpUConvert %[[#]] %[[#IDX]]
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_ZERO]] %[[#c0]]
+  ; CHECK:      OpStore %[[#]] %[[#c0]] Aligned 32
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_ZERO]] %[[#c1]]
+  ; CHECK:      OpStore %[[#]] %[[#c0]] Aligned 4
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_ZERO]] %[[#c2]]
+  ; CHECK:      OpStore %[[#]] %[[#c0]] Aligned 8
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_ZERO]] %[[#c3]]
+  ; CHECK:      OpStore %[[#]] %[[#c0]] Aligned 4
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_ZERO]] %[[#c4]]
+  ; CHECK:      OpStore %[[#]] %[[#c0]] Aligned 16
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_ZERO]] %[[#c5]]
+  ; CHECK:      OpStore %[[#]] %[[#c0]] Aligned 4
+  ; CHECK:      %[[#]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_ZERO]] %[[#IDX64]]
+  ; CHECK:      OpStore %[[#]] %[[#VAL]] Aligned 4
+  ; CHECK:      %[[#PTR0:]] = OpInBoundsAccessChain %[[#ptr_f_int]] %[[#V_ZERO]] %[[#c0]]
+  ; CHECK:      %[[#RES:]] = OpLoad %[[#int]] %[[#PTR0]] Aligned 32
+  ; CHECK:      OpStore %[[#out]] %[[#RES]]
+  %idx = load i32, ptr addrspace(10) @idx
+  %val = load i32, ptr addrspace(10) @val
+  %idx64 = zext i32 %idx to i64
+  %inserted = insertelement <6 x i32> zeroinitializer, i32 %val, i64 %idx64
+  %extracted = extractelement <6 x i32> %inserted, i64 0
+  store i32 %extracted, ptr addrspace(10) @out
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }


### PR DESCRIPTION
This patch adds support for scalarizing vector loads in the legalizer and
implements legalization for the spv_const_composite intrinsic. It also
refactors stack temporary creation for vector operations to ensure correct
SPIR-V types are assigned. Additionally, type deduction in the
PostLegalizer is improved to handle GEP and Load instructions.

Fixes https://github.com/llvm/llvm-project/issues/170534
