### PR TITLE
[clang][driver][darwin] Report bad SDKSettings as a fatal error rather than unreachable

### DIFF
--- a/clang/lib/Basic/DarwinSDKInfo.cpp
+++ b/clang/lib/Basic/DarwinSDKInfo.cpp
@@ -112,7 +112,9 @@ parsePlatformInfos(const llvm::json::Object &Obj, VersionTuple Version) {
                                llvm::Triple::UnknownEnvironment,
                                llvm::Triple::MachO, "/System/DriverKit"});
     } else {
-      llvm_unreachable("Unrecognized Xcode platform");
+      llvm::reportFatalUsageError(
+          "Unrecognized CanonicalName in SDKSettings.json. SupportedTargets is "
+          "expected, or a recognized CanonicalName.");
     }
     return PlatformInfos;
   }


### PR DESCRIPTION
Fatal error is more appropriate than unreachable when the SDKSettings is not in a recognized form (encountered in a few tests with incomplete SDKSettings.json).