### PR TITLE
[mlir][Python] fix namespace shadowing on MSVC

### DIFF
--- a/mlir/include/mlir/Bindings/Python/IRCore.h
+++ b/mlir/include/mlir/Bindings/Python/IRCore.h
@@ -947,7 +947,7 @@ public:
     if (!DerivedTy::isaFunction(orig)) {
       auto origRepr =
           nanobind::cast<std::string>(nanobind::repr(nanobind::cast(orig)));
-      throw nanobind::value_error((llvm::Twine("Cannot cast type to ") +
+      throw nanobind::value_error((::llvm::Twine("Cannot cast type to ") +
                                    DerivedTy::pyClassName + " (from " +
                                    origRepr + ")")
                                       .str()
@@ -966,7 +966,7 @@ public:
           if (DerivedTy::getTypeIdFunction)
             return PyTypeID(DerivedTy::getTypeIdFunction());
           throw nanobind::attribute_error(
-              (DerivedTy::pyClassName + llvm::Twine(" has no typeid."))
+              (DerivedTy::pyClassName + ::llvm::Twine(" has no typeid."))
                   .str()
                   .c_str());
         },
@@ -1080,7 +1080,7 @@ public:
     if (!DerivedTy::isaFunction(orig)) {
       auto origRepr =
           nanobind::cast<std::string>(nanobind::repr(nanobind::cast(orig)));
-      throw nanobind::value_error((llvm::Twine("Cannot cast attribute to ") +
+      throw nanobind::value_error((::llvm::Twine("Cannot cast attribute to ") +
                                    DerivedTy::pyClassName + " (from " +
                                    origRepr + ")")
                                       .str()
@@ -1110,7 +1110,7 @@ public:
           if (DerivedTy::getTypeIdFunction)
             return PyTypeID(DerivedTy::getTypeIdFunction());
           throw nanobind::attribute_error(
-              (DerivedTy::pyClassName + llvm::Twine(" has no typeid."))
+              (DerivedTy::pyClassName + ::llvm::Twine(" has no typeid."))
                   .str()
                   .c_str());
         },
@@ -1324,7 +1324,7 @@ private:
 /// Custom exception that allows access to error diagnostic information. This is
 /// converted to the `ir.MLIRError` python exception when thrown.
 struct MLIR_PYTHON_API_EXPORTED MLIRError {
-  MLIRError(llvm::Twine message,
+  MLIRError(::llvm::Twine message,
             std::vector<PyDiagnostic::DiagnosticInfo> &&errorDiagnostics = {})
       : message(message.str()), errorDiagnostics(std::move(errorDiagnostics)) {}
   std::string message;
@@ -1544,7 +1544,7 @@ public:
     if (!DerivedTy::isaFunction(orig.get())) {
       auto origRepr =
           nanobind::cast<std::string>(nanobind::repr(nanobind::cast(orig)));
-      throw nanobind::value_error((Twine("Cannot cast value to ") +
+      throw nanobind::value_error((::llvm::Twine("Cannot cast value to ") +
                                    DerivedTy::pyClassName + " (from " +
                                    origRepr + ")")
                                       .str()
@@ -1555,11 +1555,11 @@ public:
 
   /// Binds the Python module objects to functions of this class.
   static void bind(nanobind::module_ &m) {
-    auto cls = ClassTy(
-        m, DerivedTy::pyClassName, nanobind::is_generic(),
-        nanobind::sig((Twine("class ") + DerivedTy::pyClassName + "(Value[_T])")
-                          .str()
-                          .c_str()));
+    auto cls = ClassTy(m, DerivedTy::pyClassName, nanobind::is_generic(),
+                       nanobind::sig((::llvm::Twine("class ") +
+                                      DerivedTy::pyClassName + "(Value[_T])")
+                                         .str()
+                                         .c_str()));
     cls.def(nanobind::init<PyValue &>(), nanobind::keep_alive<0, 1>(),
             nanobind::arg("value"));
     cls.def(


### PR DESCRIPTION
If you set `MLIR_PYTHON_BINDINGS_DOMAIN=mlir`, you get namespace nesting like `mlir::python::mlir` and then `mlir::Twine` shadows `llvm::Twine` (but only on MSVC). So prefix with `::llvm` to have the correct root namespace.
 