### PR TITLE
[flang] Do not error when `NAMELIST` found within interface body

### DIFF
--- a/flang/test/Semantics/namelist-interface.f90
+++ b/flang/test/Semantics/namelist-interface.f90
@@ -1,0 +1,12 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+program test
+  real, allocatable :: array(:,:)
+  real, pointer :: array_ptr(:)
+  interface
+     subroutine sub1(array, array_ptr)
+       real array(:,:)
+       real, pointer :: array_ptr(:)
+       namelist /my_namelist/ array, array_ptr
+     end subroutine sub1
+  end interface
+end program test


### PR DESCRIPTION
Flang would error on code like:
```
Program test
  real, allocatable :: array(:,:)
  real, pointer :: array_ptr(:)
  interface
     subroutine sub1( array, array_ptr  )
       real array(:,:)
       real, pointer :: array_ptr(:)
       namelist /my_namelist / array, array_ptr
     End subroutine sub1
  end interface
End Program test
```
with an error like:
```
error: Semantic errors in simple.f90
./simple.f90:8:32: error: Internal: no symbol found for 'array'
         namelist /my_namelist / array, array_ptr
                                 ^^^^^
./simple.f90:8:39: error: Internal: no symbol found for 'array_ptr'
         namelist /my_namelist / array, array_ptr
                                        ^^^^^^^^^
```

What this fix does is suppress an error if a `NAMELIST` is found within an interface.