### PR TITLE
[AMDGPU] VGPR instruction placement should be aware of exec mask prol…

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -2166,6 +2166,12 @@ public:
     return false;
   }
 
+  /// Get the insertion point for a live range split copy at the beginning of
+  /// a basic block. This is used by the register allocator's live range
+  /// splitting logic.
+  virtual MachineBasicBlock::iterator
+  getExecAwareInsertPoint(MachineBasicBlock &MBB, Register Reg) const;
+
   /// Allows targets to use appropriate copy instruction while spilitting live
   /// range of a register in register allocation.
   virtual unsigned getLiveRangeSplitOpcode(Register Reg,

--- a/llvm/lib/CodeGen/SplitKit.cpp
+++ b/llvm/lib/CodeGen/SplitKit.cpp
@@ -842,8 +842,8 @@ SlotIndex SplitEditor::leaveIntvAtTop(MachineBasicBlock &MBB) {
 
   unsigned RegIdx = 0;
   Register Reg = LIS.getInterval(Edit->get(RegIdx)).reg();
-  VNInfo *VNI = defFromParent(RegIdx, ParentVNI, Start, MBB,
-                              MBB.SkipPHIsLabelsAndDebug(MBB.begin(), Reg));
+  MachineBasicBlock::iterator InsertPt = TII.getExecAwareInsertPoint(MBB, Reg);
+  VNInfo *VNI = defFromParent(RegIdx, ParentVNI, Start, MBB, InsertPt);
   RegAssign.insert(Start, VNI->def, OpenIdx);
   LLVM_DEBUG(dump());
   return VNI->def;

--- a/llvm/lib/CodeGen/TargetInstrInfo.cpp
+++ b/llvm/lib/CodeGen/TargetInstrInfo.cpp
@@ -2222,3 +2222,9 @@ bool TargetInstrInfo::isGlobalMemoryObject(const MachineInstr *MI) const {
   return MI->isCall() || MI->hasUnmodeledSideEffects() ||
          (MI->hasOrderedMemoryRef() && !MI->isDereferenceableInvariantLoad());
 }
+
+MachineBasicBlock::iterator
+TargetInstrInfo::getExecAwareInsertPoint(MachineBasicBlock &MBB,
+                                         Register Reg) const {
+  return MBB.SkipPHIsLabelsAndDebug(MBB.begin(), Reg);
+}

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1579,6 +1579,9 @@ public:
   bool isBasicBlockPrologue(const MachineInstr &MI,
                             Register Reg = Register()) const override;
 
+  MachineBasicBlock::iterator
+  getExecAwareInsertPoint(MachineBasicBlock &MBB, Register Reg) const override;
+
   MachineInstr *createPHIDestinationCopy(MachineBasicBlock &MBB,
                                          MachineBasicBlock::iterator InsPt,
                                          const DebugLoc &DL, Register Src,


### PR DESCRIPTION
…ogues.

This patch changes the insertion logic for VGPR modifying instruction to skip to after the exec mask is reset, if such an instruction is present in the basic block. It is used to prevent placement of scratch store/load for VGPRs before the exec mask is reset on AMDGPUs.