### PR TITLE
[compiler-rt] [Darwin] VerifyMemoryMapping should ignore zero-size sections

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
@@ -67,6 +67,8 @@ static bool VerifyMemoryMapping(MemoryMappingLayout* mapping) {
   InternalMmapVector<LoadedModule::AddressRange> segments;
   for (uptr i = 0; i < modules.size(); ++i) {
     for (auto& range : modules[i].ranges()) {
+      if (range.beg == range.end)
+        continue;
       segments.push_back(range);
     }
   }


### PR DESCRIPTION
Zero size sections cause VerifyMemoryMapping to falsely report overlapping mappings.

rdar://167467041