### PR TITLE
[offload][lit] Enable llvm-omp-device-info.c on Intel GPUs

### DIFF
--- a/offload/test/tools/llvm-omp-device-info.c
+++ b/offload/test/tools/llvm-omp-device-info.c
@@ -1,5 +1,4 @@
 // RUN: %offload-device-info | %fcheck-generic
-// XFAIL: intelgpu
 //
 // Just check any device was found and something is printed
 //


### PR DESCRIPTION
It's XPASSing after https://github.com/llvm/llvm-project/pull/172946.

https://lab.llvm.org/staging/#/builders/225/builds/313