### PR TITLE
[libc++] __key_equiv is sometimes 2x expensive

### DIFF
--- a/libcxx/include/__algorithm/ranges_unique.h
+++ b/libcxx/include/__algorithm/ranges_unique.h
@@ -47,7 +47,7 @@ struct __unique {
             indirect_equivalence_relation<projected<_Iter, _Proj>> _Comp = ranges::equal_to>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter>
   operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
-    auto __ret = std::__unchecked_unique<_RangeAlgPolicy>(
+    auto __ret = std::__unique_sorted_range<_RangeAlgPolicy>(
         std::move(__first), std::move(__last), std::__make_projected(__comp, __proj));
     return {std::move(__ret.first), std::move(__ret.second)};
   }
@@ -58,7 +58,7 @@ struct __unique {
     requires permutable<iterator_t<_Range>>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_subrange_t<_Range>
   operator()(_Range&& __range, _Comp __comp = {}, _Proj __proj = {}) const {
-    auto __ret = std::__unchecked_unique<_RangeAlgPolicy>(
+    auto __ret = std::__unique_sorted_range<_RangeAlgPolicy>(
         ranges::begin(__range), ranges::end(__range), std::__make_projected(__comp, __proj));
     return {std::move(__ret.first), std::move(__ret.second)};
   }

--- a/libcxx/include/__algorithm/ranges_unique.h
+++ b/libcxx/include/__algorithm/ranges_unique.h
@@ -47,8 +47,8 @@ struct __unique {
             indirect_equivalence_relation<projected<_Iter, _Proj>> _Comp = ranges::equal_to>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter>
   operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
-    auto __ret =
-        std::__unchecked_unique<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::__make_projected(__comp, __proj));
+    auto __ret = std::__unchecked_unique<_RangeAlgPolicy>(
+        std::move(__first), std::move(__last), std::__make_projected(__comp, __proj));
     return {std::move(__ret.first), std::move(__ret.second)};
   }
 

--- a/libcxx/include/__algorithm/ranges_unique.h
+++ b/libcxx/include/__algorithm/ranges_unique.h
@@ -48,7 +48,7 @@ struct __unique {
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr subrange<_Iter>
   operator()(_Iter __first, _Sent __last, _Comp __comp = {}, _Proj __proj = {}) const {
     auto __ret =
-        std::__unique<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::__make_projected(__comp, __proj));
+        std::__unchecked_unique<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::__make_projected(__comp, __proj));
     return {std::move(__ret.first), std::move(__ret.second)};
   }
 
@@ -58,7 +58,7 @@ struct __unique {
     requires permutable<iterator_t<_Range>>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr borrowed_subrange_t<_Range>
   operator()(_Range&& __range, _Comp __comp = {}, _Proj __proj = {}) const {
-    auto __ret = std::__unique<_RangeAlgPolicy>(
+    auto __ret = std::__unchecked_unique<_RangeAlgPolicy>(
         ranges::begin(__range), ranges::end(__range), std::__make_projected(__comp, __proj));
     return {std::move(__ret.first), std::move(__ret.second)};
   }

--- a/libcxx/include/__algorithm/unique.h
+++ b/libcxx/include/__algorithm/unique.h
@@ -29,9 +29,10 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // unique
 
+// For this unchecked algorithm, __pred does not need to be an equivalence relation.
 template <class _AlgPolicy, class _Iter, class _Sent, class _BinaryPredicate>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 std::pair<_Iter, _Iter>
-__unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
+__unchecked_unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
   __identity __proj;
   __first = std::__adjacent_find(__first, __last, __pred, __proj);
   if (__first != __last) {
@@ -50,7 +51,7 @@ __unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
 template <class _ForwardIterator, class _BinaryPredicate>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 unique(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred) {
-  return std::__unique<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __pred).first;
+  return std::__unchecked_unique<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __pred).first;
 }
 
 template <class _ForwardIterator>

--- a/libcxx/include/__algorithm/unique.h
+++ b/libcxx/include/__algorithm/unique.h
@@ -32,7 +32,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // For this unchecked algorithm, __pred does not need to be an equivalence relation.
 template <class _AlgPolicy, class _Iter, class _Sent, class _BinaryPredicate>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 std::pair<_Iter, _Iter>
-__unchecked_unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
+__unique_sorted_range(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
   __identity __proj;
   __first = std::__adjacent_find(__first, __last, __pred, __proj);
   if (__first != __last) {
@@ -51,7 +51,7 @@ __unchecked_unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
 template <class _ForwardIterator, class _BinaryPredicate>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _ForwardIterator
 unique(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred) {
-  return std::__unchecked_unique<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __pred).first;
+  return std::__unique_sorted_range<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __pred).first;
 }
 
 template <class _ForwardIterator>

--- a/libcxx/include/__cxx03/__algorithm/unique.h
+++ b/libcxx/include/__cxx03/__algorithm/unique.h
@@ -28,10 +28,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // unique
 
-// For this unchecked algorithm, __pred does not need to be an equivalence relation.
 template <class _AlgPolicy, class _Iter, class _Sent, class _BinaryPredicate>
 _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI std::pair<_Iter, _Iter>
-__unchecked_unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
+__unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
   __first = std::__adjacent_find(__first, __last, __pred);
   if (__first != __last) {
     // ...  a  a  ?  ...
@@ -49,7 +48,7 @@ __unchecked_unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
 template <class _ForwardIterator, class _BinaryPredicate>
 _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI _ForwardIterator
 unique(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred) {
-  return std::__unchecked_unique<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __pred).first;
+  return std::__unique<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __pred).first;
 }
 
 template <class _ForwardIterator>

--- a/libcxx/include/__cxx03/__algorithm/unique.h
+++ b/libcxx/include/__cxx03/__algorithm/unique.h
@@ -28,9 +28,10 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // unique
 
+// For this unchecked algorithm, __pred does not need to be an equivalence relation.
 template <class _AlgPolicy, class _Iter, class _Sent, class _BinaryPredicate>
 _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI std::pair<_Iter, _Iter>
-__unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
+__unchecked_unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
   __first = std::__adjacent_find(__first, __last, __pred);
   if (__first != __last) {
     // ...  a  a  ?  ...
@@ -48,7 +49,7 @@ __unique(_Iter __first, _Sent __last, _BinaryPredicate&& __pred) {
 template <class _ForwardIterator, class _BinaryPredicate>
 _LIBCPP_NODISCARD _LIBCPP_HIDE_FROM_ABI _ForwardIterator
 unique(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred) {
-  return std::__unique<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __pred).first;
+  return std::__unchecked_unique<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __pred).first;
 }
 
 template <class _ForwardIterator>

--- a/libcxx/include/__flat_map/flat_map.h
+++ b/libcxx/include/__flat_map/flat_map.h
@@ -944,8 +944,8 @@ private:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __sort_and_unique() {
     auto __zv = ranges::views::zip(__containers_.keys, __containers_.values);
     ranges::sort(__zv, __compare_, [](const auto& __p) -> decltype(auto) { return std::get<0>(__p); });
-    auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(
-        __zv.begin(), __zv.end(), __key_not_less(__compare_)).first;
+    auto __dup_start =
+        std::__unchecked_unique<_RangeAlgPolicy>(__zv.begin(), __zv.end(), __key_not_less(__compare_)).first;
     auto __dist      = ranges::distance(__zv.begin(), __dup_start);
     __containers_.keys.erase(__containers_.keys.begin() + __dist, __containers_.keys.end());
     __containers_.values.erase(__containers_.values.begin() + __dist, __containers_.values.end());
@@ -980,8 +980,8 @@ private:
       }
       ranges::inplace_merge(__zv.begin(), __zv.begin() + __append_start_offset, __end, __compare_key);
 
-      auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(
-          __zv.begin(), __zv.end(), __key_not_less(__compare_)).first;
+      auto __dup_start =
+          std::__unchecked_unique<_RangeAlgPolicy>(__zv.begin(), __zv.end(), __key_not_less(__compare_)).first;
       auto __dist      = ranges::distance(__zv.begin(), __dup_start);
       __containers_.keys.erase(__containers_.keys.begin() + __dist, __containers_.keys.end());
       __containers_.values.erase(__containers_.values.begin() + __dist, __containers_.values.end());

--- a/libcxx/include/__flat_map/flat_map.h
+++ b/libcxx/include/__flat_map/flat_map.h
@@ -10,6 +10,7 @@
 #ifndef _LIBCPP___FLAT_MAP_FLAT_MAP_H
 #define _LIBCPP___FLAT_MAP_FLAT_MAP_H
 
+#include <__algorithm/iterator_operations.h>
 #include <__algorithm/lexicographical_compare_three_way.h>
 #include <__algorithm/lower_bound.h>
 #include <__algorithm/min.h>

--- a/libcxx/include/__flat_map/flat_map.h
+++ b/libcxx/include/__flat_map/flat_map.h
@@ -944,7 +944,8 @@ private:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __sort_and_unique() {
     auto __zv = ranges::views::zip(__containers_.keys, __containers_.values);
     ranges::sort(__zv, __compare_, [](const auto& __p) -> decltype(auto) { return std::get<0>(__p); });
-    auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(__zv, __key_not_less(__compare_)).begin();
+    auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(
+        __zv.begin(), __zv.end(), __key_not_less(__compare_)).begin();
     auto __dist      = ranges::distance(__zv.begin(), __dup_start);
     __containers_.keys.erase(__containers_.keys.begin() + __dist, __containers_.keys.end());
     __containers_.values.erase(__containers_.values.begin() + __dist, __containers_.values.end());
@@ -979,7 +980,8 @@ private:
       }
       ranges::inplace_merge(__zv.begin(), __zv.begin() + __append_start_offset, __end, __compare_key);
 
-      auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(__zv, __key_not_less(__compare_)).begin();
+      auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(
+          __zv.begin(), __zv.end(), __key_not_less(__compare_)).begin();
       auto __dist      = ranges::distance(__zv.begin(), __dup_start);
       __containers_.keys.erase(__containers_.keys.begin() + __dist, __containers_.keys.end());
       __containers_.values.erase(__containers_.values.begin() + __dist, __containers_.values.end());

--- a/libcxx/include/__flat_map/flat_map.h
+++ b/libcxx/include/__flat_map/flat_map.h
@@ -946,7 +946,7 @@ private:
     auto __zv = ranges::views::zip(__containers_.keys, __containers_.values);
     ranges::sort(__zv, __compare_, [](const auto& __p) -> decltype(auto) { return std::get<0>(__p); });
     auto __dup_start =
-        std::__unchecked_unique<_RangeAlgPolicy>(__zv.begin(), __zv.end(), __key_not_less(__compare_)).first;
+        std::__unique_sorted_range<_RangeAlgPolicy>(__zv.begin(), __zv.end(), __key_not_less(__compare_)).first;
     auto __dist      = ranges::distance(__zv.begin(), __dup_start);
     __containers_.keys.erase(__containers_.keys.begin() + __dist, __containers_.keys.end());
     __containers_.values.erase(__containers_.values.begin() + __dist, __containers_.values.end());
@@ -982,7 +982,7 @@ private:
       ranges::inplace_merge(__zv.begin(), __zv.begin() + __append_start_offset, __end, __compare_key);
 
       auto __dup_start =
-          std::__unchecked_unique<_RangeAlgPolicy>(__zv.begin(), __zv.end(), __key_not_less(__compare_)).first;
+          std::__unique_sorted_range<_RangeAlgPolicy>(__zv.begin(), __zv.end(), __key_not_less(__compare_)).first;
       auto __dist      = ranges::distance(__zv.begin(), __dup_start);
       __containers_.keys.erase(__containers_.keys.begin() + __dist, __containers_.keys.end());
       __containers_.values.erase(__containers_.values.begin() + __dist, __containers_.values.end());

--- a/libcxx/include/__flat_map/flat_map.h
+++ b/libcxx/include/__flat_map/flat_map.h
@@ -945,7 +945,7 @@ private:
     auto __zv = ranges::views::zip(__containers_.keys, __containers_.values);
     ranges::sort(__zv, __compare_, [](const auto& __p) -> decltype(auto) { return std::get<0>(__p); });
     auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(
-        __zv.begin(), __zv.end(), __key_not_less(__compare_)).begin();
+        __zv.begin(), __zv.end(), __key_not_less(__compare_)).first;
     auto __dist      = ranges::distance(__zv.begin(), __dup_start);
     __containers_.keys.erase(__containers_.keys.begin() + __dist, __containers_.keys.end());
     __containers_.values.erase(__containers_.values.begin() + __dist, __containers_.values.end());
@@ -981,7 +981,7 @@ private:
       ranges::inplace_merge(__zv.begin(), __zv.begin() + __append_start_offset, __end, __compare_key);
 
       auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(
-          __zv.begin(), __zv.end(), __key_not_less(__compare_)).begin();
+          __zv.begin(), __zv.end(), __key_not_less(__compare_)).first;
       auto __dist      = ranges::distance(__zv.begin(), __dup_start);
       __containers_.keys.erase(__containers_.keys.begin() + __dist, __containers_.keys.end());
       __containers_.values.erase(__containers_.values.begin() + __dist, __containers_.values.end());

--- a/libcxx/include/__flat_set/flat_set.h
+++ b/libcxx/include/__flat_set/flat_set.h
@@ -688,7 +688,8 @@ private:
   // is no invariant state to preserve
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __sort_and_unique() {
     ranges::sort(__keys_, __compare_);
-    auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(__keys_, __key_not_less(__compare_)).begin();
+    auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(
+        __keys_.begin(), __keys_.end(), __key_not_less(__compare_)).begin();
     __keys_.erase(__dup_start, __keys_.end());
   }
 
@@ -706,7 +707,8 @@ private:
       }
       ranges::inplace_merge(__keys_.begin(), __keys_.begin() + __old_size, __keys_.end(), __compare_);
 
-      auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(__keys_, __key_not_less(__compare_)).begin();
+      auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(
+          __keys_.begin(), __keys_.end(), __key_not_less(__compare_)).begin();
       __keys_.erase(__dup_start, __keys_.end());
     }
     __on_failure.__complete();

--- a/libcxx/include/__flat_set/flat_set.h
+++ b/libcxx/include/__flat_set/flat_set.h
@@ -10,6 +10,7 @@
 #ifndef _LIBCPP___FLAT_SET_FLAT_SET_H
 #define _LIBCPP___FLAT_SET_FLAT_SET_H
 
+#include <__algorithm/iterator_operations.h>
 #include <__algorithm/lexicographical_compare_three_way.h>
 #include <__algorithm/lower_bound.h>
 #include <__algorithm/ranges_adjacent_find.h>

--- a/libcxx/include/__flat_set/flat_set.h
+++ b/libcxx/include/__flat_set/flat_set.h
@@ -689,7 +689,7 @@ private:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __sort_and_unique() {
     ranges::sort(__keys_, __compare_);
     auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(
-        __keys_.begin(), __keys_.end(), __key_not_less(__compare_)).begin();
+        __keys_.begin(), __keys_.end(), __key_not_less(__compare_)).first;
     __keys_.erase(__dup_start, __keys_.end());
   }
 
@@ -708,7 +708,7 @@ private:
       ranges::inplace_merge(__keys_.begin(), __keys_.begin() + __old_size, __keys_.end(), __compare_);
 
       auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(
-          __keys_.begin(), __keys_.end(), __key_not_less(__compare_)).begin();
+          __keys_.begin(), __keys_.end(), __key_not_less(__compare_)).first;
       __keys_.erase(__dup_start, __keys_.end());
     }
     __on_failure.__complete();

--- a/libcxx/include/__flat_set/flat_set.h
+++ b/libcxx/include/__flat_set/flat_set.h
@@ -688,8 +688,8 @@ private:
   // is no invariant state to preserve
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __sort_and_unique() {
     ranges::sort(__keys_, __compare_);
-    auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(
-        __keys_.begin(), __keys_.end(), __key_not_less(__compare_)).first;
+    auto __dup_start =
+        std::__unchecked_unique<_RangeAlgPolicy>(__keys_.begin(), __keys_.end(), __key_not_less(__compare_)).first;
     __keys_.erase(__dup_start, __keys_.end());
   }
 
@@ -707,8 +707,8 @@ private:
       }
       ranges::inplace_merge(__keys_.begin(), __keys_.begin() + __old_size, __keys_.end(), __compare_);
 
-      auto __dup_start = std::__unchecked_unique<_RangeAlgPolicy>(
-          __keys_.begin(), __keys_.end(), __key_not_less(__compare_)).first;
+      auto __dup_start =
+          std::__unchecked_unique<_RangeAlgPolicy>(__keys_.begin(), __keys_.end(), __key_not_less(__compare_)).first;
       __keys_.erase(__dup_start, __keys_.end());
     }
     __on_failure.__complete();

--- a/libcxx/include/__flat_set/flat_set.h
+++ b/libcxx/include/__flat_set/flat_set.h
@@ -690,7 +690,7 @@ private:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void __sort_and_unique() {
     ranges::sort(__keys_, __compare_);
     auto __dup_start =
-        std::__unchecked_unique<_RangeAlgPolicy>(__keys_.begin(), __keys_.end(), __key_not_less(__compare_)).first;
+        std::__unique_sorted_range<_RangeAlgPolicy>(__keys_.begin(), __keys_.end(), __key_not_less(__compare_)).first;
     __keys_.erase(__dup_start, __keys_.end());
   }
 
@@ -709,7 +709,7 @@ private:
       ranges::inplace_merge(__keys_.begin(), __keys_.begin() + __old_size, __keys_.end(), __compare_);
 
       auto __dup_start =
-          std::__unchecked_unique<_RangeAlgPolicy>(__keys_.begin(), __keys_.end(), __key_not_less(__compare_)).first;
+          std::__unique_sorted_range<_RangeAlgPolicy>(__keys_.begin(), __keys_.end(), __key_not_less(__compare_)).first;
       __keys_.erase(__dup_start, __keys_.end());
     }
     __on_failure.__complete();


### PR DESCRIPTION
Rename to __key_not_less. Rename and comment on __unique
to __unchecked_unique: ranges::unique has UB but internal
function helper __unchecked_unique does not have UB.

Fixes #175086

This patch reduces the number of comparisons used by that test program from 27 to only 18 so I think it is a large improvement.