### PR TITLE
[SampleProfile] Fix pseudo-probe-coro-debug-fix.ll to only x86 targets

### DIFF
--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-coro-debug-fix.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-coro-debug-fix.ll
@@ -1,3 +1,4 @@
+; REQUIRES: x86-registered-target
 ; RUN: opt < %s -passes='pseudo-probe,cgscc(coro-split),coro-cleanup,always-inline' -mtriple=x86_64 -pass-remarks=inline -S -o %t.ll
 ; RUN: llc -mtriple=x86_64 -stop-after=pseudo-probe-inserter < %t.ll --filetype=asm -o - | FileCheck -check-prefix=MIR %s
 


### PR DESCRIPTION
Test case in https://github.com/llvm/llvm-project/pull/173834 is failing on non-x86 targets. Adding `REQUIRES: x86-registered-target` to fix the failures.