### PR TITLE
[clang] Prevent sandbox violations in `CrossTranslationUnitContext`

### DIFF
--- a/clang/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/clang/lib/CrossTU/CrossTranslationUnit.cpp
@@ -623,7 +623,26 @@ CrossTranslationUnitContext::ASTLoader::loadFromSource(
   return CreateASTUnitFromCommandLine(
       CommandLineArgs.begin(), (CommandLineArgs.end()),
       CI.getPCHContainerOperations(), DiagOpts, Diags,
-      CI.getHeaderSearchOpts().ResourceDir);
+      CI.getHeaderSearchOpts().ResourceDir,
+      /*StorePreamblesInMemory=*/false,
+      /*PreambleStoragePath=*/StringRef(),
+      /*OnlyLocalDecls=*/false,
+      /*CaptureDiagnostics=*/CaptureDiagsKind::None,
+      /*RemappedFiles=*/{},
+      /*RemappedFilesKeepOriginalName=*/true,
+      /*PrecompilePreambleAfterNParses=*/0,
+      /*TUKind=*/TU_Complete,
+      /*CacheCodeCompletionResults=*/false,
+      /*IncludeBriefCommentsInCodeCompletion=*/false,
+      /*AllowPCHWithCompilerErrors=*/false,
+      /*SkipFunctionBodies=*/SkipFunctionBodiesScope::None,
+      /*SingleFileParse=*/false,
+      /*UserFilesAreVolatile=*/false,
+      /*ForSerialization=*/false,
+      /*RetainExcludedConditionalBlocks=*/false,
+      /*ModuleFormat=*/std::nullopt,
+      /*ErrAST=*/nullptr,
+      /*VFS=*/CI.getVirtualFileSystemPtr());
 }
 
 llvm::Expected<InvocationListTy>
@@ -710,7 +729,7 @@ llvm::Error CrossTranslationUnitContext::ASTLoader::lazyInitInvocationList() {
     return llvm::make_error<IndexError>(PreviousParsingResult);
 
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileContent =
-      llvm::MemoryBuffer::getFile(InvocationListFilePath);
+      CI.getVirtualFileSystem().getBufferForFile(InvocationListFilePath);
   if (!FileContent) {
     PreviousParsingResult = index_error_code::invocation_list_file_not_found;
     return llvm::make_error<IndexError>(PreviousParsingResult);

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -697,7 +697,7 @@ else()
   option(LLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
 endif()
 
-option(LLVM_ENABLE_IO_SANDBOX "Enable IO sandboxing in supported tools" ON) # TODO: Set to OFF before merging.
+option(LLVM_ENABLE_IO_SANDBOX "Enable IO sandboxing in supported tools" OFF)
 option(LLVM_ENABLE_EXPENSIVE_CHECKS "Enable expensive checks" OFF)
 
 set(LLVM_ABI_BREAKING_CHECKS "WITH_ASSERTS" CACHE STRING

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -697,7 +697,7 @@ else()
   option(LLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
 endif()
 
-option(LLVM_ENABLE_IO_SANDBOX "Enable IO sandboxing in supported tools" OFF)
+option(LLVM_ENABLE_IO_SANDBOX "Enable IO sandboxing in supported tools" ON) # TODO: Set to OFF before merging.
 option(LLVM_ENABLE_EXPENSIVE_CHECKS "Enable expensive checks" OFF)
 
 set(LLVM_ABI_BREAKING_CHECKS "WITH_ASSERTS" CACHE STRING


### PR DESCRIPTION
This uses the VFS to load a file instead of using `MemoryBuffer::getBufferForFile()` directly to avoid sandbox violation. Sandbox is then disabled for `CreateASTUnitFromCommandLine()` which invokes the driver which is not expected to be free of sandbox violations.