### PR TITLE
[PPC] Disable some ORC-powerpc64le-linux tests.

### DIFF
--- a/compiler-rt/test/orc/TestCases/Linux/ppc64/ehframe-default.cpp
+++ b/compiler-rt/test/orc/TestCases/Linux/ppc64/ehframe-default.cpp
@@ -1,6 +1,9 @@
 // RUN: %clangxx -fexceptions -fPIC -c -o %t %s
 // RUN: %llvm_jitlink %t
 
+// REQUIRES: disabled
+//// https://github.com/llvm/llvm-project/issues/175094
+
 extern "C" void llvm_jitlink_setTestResultOverride(long Value);
 
 int main(int argc, char *argv[]) {

--- a/compiler-rt/test/orc/TestCases/Linux/ppc64/lljit-ehframe.cpp
+++ b/compiler-rt/test/orc/TestCases/Linux/ppc64/lljit-ehframe.cpp
@@ -1,6 +1,9 @@
 // RUN: %clangxx -fPIC -emit-llvm -c -o %t %s
 // RUN: %lli_orc_jitlink -relocation-model=pic %t | FileCheck %s
 
+// REQUIRES: disabled
+//// https://github.com/llvm/llvm-project/issues/175094
+
 // CHECK: catch
 
 #include <stdio.h>

--- a/compiler-rt/test/orc/TestCases/Linux/ppc64/lljit-initialize-deinitialize.ll
+++ b/compiler-rt/test/orc/TestCases/Linux/ppc64/lljit-initialize-deinitialize.ll
@@ -1,5 +1,8 @@
 ; RUN: %lli_orc_jitlink %s | FileCheck %s
 
+; REQUIRES: disabled
+;; https://github.com/llvm/llvm-project/issues/175094
+
 ; CHECK: constructor
 ; CHECK-NEXT: main
 ; CHECK-NEXT: destructor

--- a/compiler-rt/test/orc/TestCases/Linux/ppc64/priority-static-initializer.S
+++ b/compiler-rt/test/orc/TestCases/Linux/ppc64/priority-static-initializer.S
@@ -4,6 +4,9 @@
 // RUN: %clang -c -o %t %s
 // RUN: %llvm_jitlink %t | FileCheck %s
 
+// REQUIRES: disabled
+//// https://github.com/llvm/llvm-project/issues/175094
+
 // CHECK: constructor 100
 // CHECK-NEXT: constructor 200
 // CHECK-NEXT: constructor 65535

--- a/compiler-rt/test/orc/TestCases/Linux/ppc64/trivial-cxa-atexit.S
+++ b/compiler-rt/test/orc/TestCases/Linux/ppc64/trivial-cxa-atexit.S
@@ -1,5 +1,8 @@
 // Test that the runtime correctly interposes ___cxa_atexit.
-//
+
+// REQUIRES: disabled
+//// https://github.com/llvm/llvm-project/issues/175094
+
 // RUN: %clang -c -o %t %s
 // RUN: %llvm_jitlink %t
 	.text

--- a/compiler-rt/test/orc/TestCases/Linux/ppc64/trivial-static-initializer.S
+++ b/compiler-rt/test/orc/TestCases/Linux/ppc64/trivial-static-initializer.S
@@ -6,6 +6,10 @@
 //
 // RUN: %clang -c -o %t %s
 // RUN: %llvm_jitlink %t
+
+// REQUIRES: disabled
+//// https://github.com/llvm/llvm-project/issues/175094
+
 	.text
 	.abiversion 2
 	.file	"init.c"

--- a/compiler-rt/test/orc/TestCases/Linux/ppc64/trivial-tls-pwr10.test
+++ b/compiler-rt/test/orc/TestCases/Linux/ppc64/trivial-tls-pwr10.test
@@ -2,6 +2,9 @@
 // RUN: %clangxx -fPIC -c -o %t/main.o %S/Inputs/trivial-tls-main.cpp
 // RUN: %clangxx -fPIC -c -o %t/pwr10.o %S/Inputs/trivial-tls-pwr10.cpp
 // RUN: %llvm_jitlink %t/main.o %t/pwr10.o
+// REQUIRES: disabled
+//// https://github.com/llvm/llvm-project/issues/175094
+
 // FIXME: We separate pwr10 code from main object file due to currrent
 // implementation only supports one PLT stub for the same symbol.
 // For example, `bl __tls_get_addr` in one object file has only one PLT stub,

--- a/compiler-rt/test/orc/TestCases/Linux/ppc64/trivial-tls.S
+++ b/compiler-rt/test/orc/TestCases/Linux/ppc64/trivial-tls.S
@@ -1,6 +1,9 @@
 // RUN: %clang -c -o %t %s
 // RUN: %llvm_jitlink %t
-//
+
+// REQUIRES: disabled
+//// https://github.com/llvm/llvm-project/issues/175094
+
 // Test that basic ELF TLS work by adding together TLSs with values
 // 0, 1, and -1, and returning the result (0 for success). This setup
 // tests both zero-initialized (.tbss) and non-zero-initialized


### PR DESCRIPTION
Tests fail to link when using LLVM C++ library. Disabling the tests until they can be investigated and the underlying cause identified and fixed.