### PR TITLE
[mlir][acc] Fix unused variable warning in non-asserts build

### DIFF
--- a/mlir/lib/Dialect/OpenACC/Transforms/OffloadLiveInValueCanonicalization.cpp
+++ b/mlir/lib/Dialect/OpenACC/Transforms/OffloadLiveInValueCanonicalization.cpp
@@ -285,7 +285,7 @@ public:
         // Canonicalization of values changes live-in set.
         // Rerun the algorithm until convergence.
         bool changes = false;
-        int iteration = 0;
+        [[maybe_unused]] int iteration = 0;
         do {
           LLVM_DEBUG(llvm::dbgs() << "\tIteration " << iteration++ << "\n");
           changes = canonicalizeLiveInValues(op->getRegion(0), accSupport);


### PR DESCRIPTION
f79f50cd547d0582af15aebd3a0413136b9311ae added a pass that has an iteration variable that is only used behind a LLVM_DEBUG macro which are no-op in release builds, thus leaving the variable unused.