### PR TITLE
[SPIR-V] Permit implicit conversion to generic AS

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -319,7 +319,7 @@ public:
   }
 
   virtual bool isAddressSpaceSupersetOf(LangAS A, LangAS B) const override {
-    // The geneirc space AS(4) is a superset of all the other address
+    // The generic space AS(4) is a superset of all the other address
     // spaces used by the backend target.
     return A == B || ((A == LangAS::Default ||
                        (isTargetAddressSpace(A) &&

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -14,6 +14,7 @@
 #define LLVM_CLANG_LIB_BASIC_TARGETS_SPIR_H
 
 #include "Targets.h"
+#include "clang/Basic/AddressSpaces.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/TargetOptions.h"
 #include "llvm/Support/Compiler.h"
@@ -315,6 +316,16 @@ public:
 
   bool hasFeature(StringRef Feature) const override {
     return Feature == "spirv";
+  }
+
+  virtual bool isAddressSpaceSupersetOf(LangAS A, LangAS B) const override {
+    // The geneirc space AS(4) is a superset of all the other address
+    // spaces used by the backend target.
+    return A == B || ((A == LangAS::Default ||
+                       (isTargetAddressSpace(A) &&
+                        toTargetAddressSpace(A) == /*Generic=*/4)) &&
+                      isTargetAddressSpace(B) &&
+                      toTargetAddressSpace(B) <= /*Generic=*/4);
   }
 
   void getTargetDefines(const LangOptions &Opts,

--- a/clang/test/Sema/spirv-address-space.c
+++ b/clang/test/Sema/spirv-address-space.c
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 %s -triple spirv64 -fsyntax-only -verify
+
+#define _AS0 __attribute__((address_space(0)))
+#define _AS1 __attribute__((address_space(1)))
+#define _AS2 __attribute__((address_space(2)))
+#define _AS3 __attribute__((address_space(3)))
+#define _AS4 __attribute__((address_space(4)))
+#define _AS5 __attribute__((address_space(5)))
+#define _AS999 __attribute__((address_space(999)))
+
+void *p1(void _AS1 *p) { return p; } 
+void *p2(void _AS2 *p) { return p; } 
+void *p3(void _AS3 *p) { return p; }
+void *p4(void _AS4 *p) { return p; }
+void *p5(void _AS5 *p) { return p; } // expected-error {{returning '_AS5 void *' from a function with result type 'void *' changes address space of pointer}}
+void *pi(void _AS999 *p) { return p; } // expected-error {{returning '_AS999 void *' from a function with result type 'void *' changes address space of pointer}}
+void *pc(void __attribute__((opencl_local)) *p) { return p; } // expected-error {{returning '__local void *' from a function with result type 'void *' changes address space of pointer}}
+void _AS1 *r0(void _AS1 *p) { return p; }
+void _AS1 *r1(void *p) { return p; } // expected-error {{returning 'void *' from a function with result type '_AS1 void *' changes address space of pointer}}
+void _AS1 *r2(void *p) { return (void _AS1 *)p; }
+


### PR DESCRIPTION
Summary:
We rely on this in most places we work with address spaces. This allows
target address spaces to implicity convert to generic ones.

I actually have no clue if this is valid or correct with SPIR-V, hoping
someone with more target / backend knowledge can chime in.
