### PR TITLE
[clang-doc] Fix misnamed, mismatched, or incorrect tags

### DIFF
--- a/clang-tools-extra/clang-doc/JSONGenerator.cpp
+++ b/clang-tools-extra/clang-doc/JSONGenerator.cpp
@@ -650,9 +650,9 @@ serializeInfo(const RecordInfo &I, json::Object &Obj,
     }
 
     if (!PubFunctionsArrayRef.empty())
-      insertArray(Obj, PubFunctionsArray, "PublicFunctions");
+      insertArray(Obj, PubFunctionsArray, "PublicMethods");
     if (!ProtFunctionsArrayRef.empty())
-      insertArray(Obj, ProtFunctionsArray, "ProtectedFunctions");
+      insertArray(Obj, ProtFunctionsArray, "ProtectedMethods");
   }
 
   if (!I.Members.empty()) {

--- a/clang-tools-extra/clang-doc/assets/alias-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/alias-template.mustache
@@ -2,7 +2,7 @@
     {{#Template}}
     <pre><code class="language-cpp code-clang-doc">template &lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;</code></pre>
     {{/Template}}
-    <pre><code class="language-cpp code-clang-doc">{{#IsUsing}}using{{/IsUsing}}{{^IsUsing}}typedef{{/IsUsing}} {{Name}}{{#IsUsing}} ={{/Isusing}} {{#Underlying}}{{Name}}{{/Underlying}}</code></pre>
+    <pre><code class="language-cpp code-clang-doc">{{#IsUsing}}using{{/IsUsing}}{{^IsUsing}}typedef{{/IsUsing}} {{Name}}{{#IsUsing}} ={{/IsUsing}}{{#Underlying}} {{Name}}{{/Underlying}}</code></pre>
     {{#Description}}
     {{>Comments}}
     {{/Description}}

--- a/clang-tools-extra/clang-doc/assets/class-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/class-template.mustache
@@ -49,38 +49,38 @@
                         </details>
                     </li>
                     {{/HasProtectedMembers}}
-                    {{#HasPublicFunctions}}
+                    {{#HasPublicMethods}}
                     <li>
                         <details open>
                             <summary class="sidebar-section">
-                                <a class="sidebar-item" href="#PublicMethods">Public Method</a>
+                                <a class="sidebar-item" href="#PublicMethods">Public Methods</a>
                             </summary>
                             <ul>
-                                {{#PublicFunctions}}
+                                {{#PublicMethods}}
                                 <li class="sidebar-item-container">
                                     <a class="sidebar-item" href="#{{USR}}">{{Name}}</a>
                                 </li>
-                                {{/PublicFunctions}}
+                                {{/PublicMethods}}
                             </ul>
                         </details>
                     </li>
-                    {{/HasPublicFunctions}}
-                    {{#HasProtectedFunctions}}
+                    {{/HasPublicMethods}}
+                    {{#HasProtectedMethods}}
                     <li>
                         <details open>
                             <summary class="sidebar-section">
                                 <a class="sidebar-item" href="#ProtectedMethods">Protected Methods</a>
                             </summary>
                             <ul>
-                                {{#ProtectedFunctions}}
+                                {{#ProtectedMethods}}
                                 <li class="sidebar-item-container">
                                     <a class="sidebar-item" href="#{{USR}}">{{Name}}</a>
                                 </li>
-                                {{/ProtectedFunctions}}
+                                {{/ProtectedMethods}}
                             </ul>
                         </details>
                     </li>
-                    {{/HasProtectedFunctions}}
+                    {{/HasProtectedMethods}}
                     {{#HasEnums}}
                     <li>
                         <details open>
@@ -117,7 +117,7 @@
                     <li>
                         <details open>
                             <summary class="sidebar-section">
-                                <a class="sidebar-item" href="#Classes">Inner Classes</a>
+                                <a class="sidebar-item" href="#Records">Records</a>
                             </summary>
                             <ul>
                                 {{#Records}}
@@ -144,7 +144,7 @@
                             </ul>
                         </details>
                     </li>
-                    {{/HasRecords}}
+                    {{/HasFriends}}
                 </ul>
             </div>
             <div class="resizer" id="resizer"></div>
@@ -172,11 +172,6 @@
                         {{#PublicMembers}}
                         <div id="{{Name}}" class="delimiter-container">
                             <pre><code class="language-cpp code-clang-doc" >{{#IsStatic}}static {{/IsStatic}}{{Type}} {{Name}}</code></pre>
-                            {{#MemberComments}}
-                            <div>
-                                {{>Comments}}
-                            </div>
-                            {{/MemberComments}}
                         </div>
                         {{/PublicMembers}}
                     </div>
@@ -194,24 +189,24 @@
                     </div>
                 </section>
                 {{/HasProtectedMembers}}
-                {{#HasPublicFunctions}}
+                {{#HasPublicMethods}}
                 <section id="PublicMethods" class="section-container">
                     <h2>Public Methods</h2>
-                    {{#PublicFunctions}}
+                    {{#PublicMethods}}
                     {{>FunctionPartial}}
-                    {{/PublicFunctions}}
+                    {{/PublicMethods}}
                 </section>
-                {{/PublicFunctions}}
-                {{#HasProtectedFunctions}}
+                {{/HasPublicMethods}}
+                {{#HasProtectedMethods}}
                 <section id="ProtectedMethods" class="section-container">
                     <h2>Protected Methods</h2>
                     <div>
-                        {{#ProtectedFunctions}}
+                        {{#ProtectedMethods}}
                         {{>FunctionPartial}}
-                        {{/ProtectedFunctions}}
+                        {{/ProtectedMethods}}
                     </div>
                 </section>
-                {{/HasProtectedFunctions}}
+                {{/HasProtectedMethods}}
                 {{#HasEnums}}
                 <section id="Enums" class="section-container">
                     <h2>Enumerations</h2>
@@ -221,8 +216,8 @@
                 </section>
                 {{/HasEnums}}
                 {{#HasRecords}}
-                <section id="Classes" class="section-container">
-                    <h2>Inner Classes</h2>
+                <section id="Records" class="section-container">
+                    <h2>Records</h2>
                     <ul class="class-container">
                         {{#Records}}
                         <li id="{{USR}}" style="max-height: 40px;">
@@ -256,9 +251,6 @@
                         {{^IsClass}}
                         <pre><code class="language-cpp code-clang-doc">{{ReturnType.Name}} {{Name}}{{#Template}}{{#Specialization}}&lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;{{/Specialization}}{{/Template}} ({{#Params}}{{Type.QualName}} {{Name}}{{^End}}, {{/End}}{{/Params}})</code></pre>
                         {{/IsClass}}
-                        {{#.Description}}
-                        {{>Comments}}
-                        {{/.Description}}
                     </div>
                     {{/Friends}}
                 </section>

--- a/clang-tools-extra/clang-doc/assets/comment-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/comment-template.mustache
@@ -42,7 +42,7 @@
         <b>{{ParamName}}</b> {{#Explicit}}{{Direction}}{{/Explicit}} {{#Children}}{{TextComment}}{{/Children}}
     </div>
 </div>
-{{/#TParamComments}}
+{{/TParamComments}}
 {{/HasTParamComments}}
 {{#HasReturnComments}}
 <div class="nested-delimiter-container">
@@ -78,15 +78,3 @@
     {{/ThrowsComments}}
 </div>
 {{/HasThrowsComments}}
-{{#BlockCommandComment}}
-    <div class="block-command-comment__command">
-        <div class="block-command-command">
-            {{Command}}
-        </div>
-        <div>
-            {{#Children}}
-                {{>Comments}}
-            {{/Children}}
-        </div>
-    </div>
-{{/BlockCommandComment}}

--- a/clang-tools-extra/clang-doc/assets/enum-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/enum-template.mustache
@@ -15,9 +15,6 @@
             <tr>
                 <th>Name</th>
                 <th>Value</th>
-                {{#HasComment}}
-                <th>Comment</th>
-                {{/HasComment}}
             </tr>
             {{#Members}}
             <tr>
@@ -29,18 +26,15 @@
                 {{^Value}}
                 <td>{{ValueExpr}}</td>
                 {{/Value}}
-                {{#EnumValueComments}}
-                <td>{{>Comments}}</td>
-                {{/EnumValueComments}}
             </tr>
             {{/Members}}
         </tbody>
     </table>
-    {{#EnumComments}}
-    <div>
+    {{#Description}}
+    <div class="doc-card">
         {{>Comments}}
     </div>
-    {{/EnumComments}}
+    {{/Description}}
     {{#Location}}
     <p>Defined at line {{LineNumber}} of file {{^FileURL}}{{Filename}}{{/FileURL}}{{#FileURL}}<a href="{{FileURL}}">{{Filename}}</a>{{/FileURL}}</p>
     {{/Location}}

--- a/clang-tools-extra/clang-doc/assets/index-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/index-template.mustache
@@ -13,12 +13,12 @@
                     <li>
                         <details open>
                             <summary class="sidebar-section">
-                                <a class="sidebar-item" href="#Namespaces">Namespaces</a>
+                                <a class="sidebar-item" href="#Index">Index</a>
                             </summary>
                             <ul>
                                 {{#Index}}
                                 <li class="sidebar-item-container">
-                                    <a class="sidebar-item" href="#{{Name}}">{{Name}}</a>
+                                    <a class="sidebar-item" href="#{{USR}}">{{Name}}</a>
                                 </li>
                                 {{/Index}}
                             </ul>
@@ -33,7 +33,7 @@
                     {{#Index}}
                     <div>
                         <a href="{{#Path}}{{Path}}/{{/Path}}{{Name}}/index.html">
-                            <pre><code class="language-cpp code-clang-doc">namespace {{Name}}</code></pre>
+                            <pre><code id="{{USR}}" class="language-cpp code-clang-doc">namespace {{Name}}</code></pre>
                         </a>
                     </div>
                     {{/Index}}

--- a/clang-tools-extra/clang-doc/assets/namespace-template.mustache
+++ b/clang-tools-extra/clang-doc/assets/namespace-template.mustache
@@ -15,7 +15,7 @@
     <main>
         <div class="container">
             <div class="sidebar">
-                <h2>{{#RecordType}}{{RecordType}} {{/RecordType}}{{Name}}</h2>
+                <h2>{{Name}}</h2>
                 <ul>
                     {{#HasEnums}}
                     <li>
@@ -37,7 +37,7 @@
                     <li>
                         <details open>
                             <summary class="sidebar-section">
-                                <a class="sidebar-item" href="#Classes">Inner Classes</a>
+                                <a class="sidebar-item" href="#Records">Records</a>
                             </summary>
                             <ul>
                                 {{#Records}}
@@ -158,8 +158,8 @@
                 </section>
                 {{/HasEnums}}
                 {{#HasRecords}}
-                <section id="Classes" class="section-container">
-                    <h2>Inner Classes</h2>
+                <section id="Records" class="section-container">
+                    <h2>Records</h2>
                     <ul class="class-container">
                         {{#Records}}
                         <li id="{{USR}}" style="max-height: 40px;">
@@ -187,7 +187,7 @@
                 <section id="Concepts" class="section-container">
                     <h2>Concepts</h2>
                     {{#Concepts}}
-                    <div id="{{ID}}" class="delimiter-container">
+                    <div id="{{USR}}" class="delimiter-container">
                         <div>
                             <pre><code class="language-cpp code-clang-doc">{{#Template}}template &lt;{{#Parameters}}{{Param}}{{^End}}, {{/End}}{{/Parameters}}&gt;{{/Template}} {{Name}} {{ConstraintExpression}}</code></pre> 
                         </div>

--- a/clang-tools-extra/test/clang-doc/basic-project.mustache.test
+++ b/clang-tools-extra/test/clang-doc/basic-project.mustache.test
@@ -42,7 +42,7 @@ HTML-SHAPE:             <ul>
 HTML-SHAPE:                 <li>
 HTML-SHAPE:                     <details open>
 HTML-SHAPE:                         <summary class="sidebar-section">
-HTML-SHAPE:                             <a class="sidebar-item" href="#PublicMethods">Public Method</a>
+HTML-SHAPE:                             <a class="sidebar-item" href="#PublicMethods">Public Methods</a>
 HTML-SHAPE:                         </summary>
 HTML-SHAPE:                         <ul>
 HTML-SHAPE:                             <li class="sidebar-item-container">
@@ -167,7 +167,7 @@ HTML-CALC:                 </li>
 HTML-CALC:                 <li>
 HTML-CALC:                     <details open>
 HTML-CALC:                         <summary class="sidebar-section">
-HTML-CALC:                             <a class="sidebar-item" href="#PublicMethods">Public Method</a>
+HTML-CALC:                             <a class="sidebar-item" href="#PublicMethods">Public Methods</a>
 HTML-CALC:                         </summary>
 HTML-CALC:                         <ul>
 HTML-CALC:                             <li class="sidebar-item-container">
@@ -366,7 +366,7 @@ HTML-RECTANGLE:             <ul>
 HTML-RECTANGLE:                 <li>
 HTML-RECTANGLE:                     <details open>
 HTML-RECTANGLE:                         <summary class="sidebar-section">
-HTML-RECTANGLE:                             <a class="sidebar-item" href="#PublicMethods">Public Method</a>
+HTML-RECTANGLE:                             <a class="sidebar-item" href="#PublicMethods">Public Methods</a>
 HTML-RECTANGLE:                         </summary>
 HTML-RECTANGLE:                         <ul>
 HTML-RECTANGLE:                             <li class="sidebar-item-container">
@@ -480,7 +480,7 @@ HTML-CIRCLE:             <ul>
 HTML-CIRCLE:                 <li>
 HTML-CIRCLE:                     <details open>
 HTML-CIRCLE:                         <summary class="sidebar-section">
-HTML-CIRCLE:                             <a class="sidebar-item" href="#PublicMethods">Public Method</a>
+HTML-CIRCLE:                             <a class="sidebar-item" href="#PublicMethods">Public Methods</a>
 HTML-CIRCLE:                         </summary>
 HTML-CIRCLE:                         <ul>
 HTML-CIRCLE:                             <li class="sidebar-item-container">

--- a/clang-tools-extra/test/clang-doc/enum.cpp
+++ b/clang-tools-extra/test/clang-doc/enum.cpp
@@ -148,6 +148,11 @@ public:
 // HTML-ANIMAL-NEXT:                 </tr>
 // HTML-ANIMAL-NEXT:             </tbody>
 // HTML-ANIMAL-NEXT:         </table>
+// HTML-ANIMAL-NEXT:         <div class="doc-card">
+// HTML-ANIMAL-NEXT:             <div class="nested-delimiter-container">
+// HTML-ANIMAL-NEXT:                 <p> specify what animal the class is</p>
+// HTML-ANIMAL-NEXT:             </div>
+// HTML-ANIMAL-NEXT:         </div>
 // HTML-ANIMAL-NEXT:         <p>Defined at line 116 of file {{.*}}enum.cpp</p>
 // HTML-ANIMAL-NEXT:     </div>
 // HTML-ANIMAL-NEXT: </section>

--- a/clang-tools-extra/test/clang-doc/index.cpp
+++ b/clang-tools-extra/test/clang-doc/index.cpp
@@ -30,14 +30,14 @@ namespace inner {
 // CHECK-HTML-NEXT:                    <li>
 // CHECK-HTML-NEXT:                        <details open>
 // CHECK-HTML-NEXT:                            <summary class="sidebar-section">
-// CHECK-HTML-NEXT:                                <a class="sidebar-item" href="#Namespaces">Namespaces</a>
+// CHECK-HTML-NEXT:                                <a class="sidebar-item" href="#Index">Index</a>
 // CHECK-HTML-NEXT:                            </summary>
 // CHECK-HTML-NEXT:                            <ul>
 // CHECK-HTML-NEXT:                                <li class="sidebar-item-container">
-// CHECK-HTML-NEXT:                                    <a class="sidebar-item" href="#GlobalNamespace">GlobalNamespace</a>
+// CHECK-HTML-NEXT:                                    <a class="sidebar-item" href="#{{([0-9A-F]{40})}}">GlobalNamespace</a>
 // CHECK-HTML-NEXT:                                </li>
 // CHECK-HTML-NEXT:                                <li class="sidebar-item-container">
-// CHECK-HTML-NEXT:                                    <a class="sidebar-item" href="#inner">inner</a>
+// CHECK-HTML-NEXT:                                    <a class="sidebar-item" href="#{{([0-9A-F]{40})}}">inner</a>
 // CHECK-HTML-NEXT:                                </li>
 // CHECK-HTML-NEXT:                            </ul>
 // CHECK-HTML-NEXT:                        </details> 
@@ -50,12 +50,12 @@ namespace inner {
 // CHECK-HTML-NEXT:                    <h2>Index</h2>
 // CHECK-HTML-NEXT:                    <div>
 // CHECK-HTML-NEXT:                        <a href="GlobalNamespace/index.html">
-// CHECK-HTML-NEXT:                            <pre><code class="language-cpp code-clang-doc">namespace GlobalNamespace</code></pre>
+// CHECK-HTML-NEXT:                            <pre><code id="{{([0-9A-F]{40})}}" class="language-cpp code-clang-doc">namespace GlobalNamespace</code></pre>
 // CHECK-HTML-NEXT:                        </a>
 // CHECK-HTML-NEXT:                    </div>
 // CHECK-HTML-NEXT:                    <div>
 // CHECK-HTML-NEXT:                        <a href="inner/index.html">
-// CHECK-HTML-NEXT:                            <pre><code class="language-cpp code-clang-doc">namespace inner</code></pre>
+// CHECK-HTML-NEXT:                            <pre><code id="{{([0-9A-F]{40})}}" class="language-cpp code-clang-doc">namespace inner</code></pre>
 // CHECK-HTML-NEXT:                        </a>
 // CHECK-HTML-NEXT:                    </div>
 // CHECK-HTML-NEXT:                </section>

--- a/clang-tools-extra/test/clang-doc/json/class-template.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class-template.cpp
@@ -8,6 +8,13 @@ template<typename T> struct MyClass {
 };
 
 // CHECK:         "Name": "MyClass",
+// CHECK:         "PublicMembers": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "IsStatic": false,
+// CHECK-NEXT:        "Name": "MemberTemplate",
+// CHECK-NEXT:        "Type": "T"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
 // CHECK:         "Name": "method",
 // CHECK:         "Params": [
 // CHECK-NEXT:      {
@@ -24,10 +31,8 @@ template<typename T> struct MyClass {
 // CHECK-NEXT:      "IsBuiltIn": false,
 // CHECK-NEXT:      "IsTemplate": true,
 // CHECK-NEXT:      "Name": "T",
-// CHECK-NEXT:      "QualName": "T"
+// CHECK-NEXT:      "QualName": "T",
 // CHECK-NEXT:      "USR": "0000000000000000000000000000000000000000"
-// CHECK:           "Name": "MemberTemplate",
-// CHECK:           "Type": "T"
 // CHECK:         "Template": {
 // CHECK-NEXT:      "Parameters": [
 // CHECK-NEXT:        {

--- a/clang-tools-extra/test/clang-doc/json/class.cpp
+++ b/clang-tools-extra/test/clang-doc/json/class.cpp
@@ -170,10 +170,10 @@ private:
 // CHECK-NEXT:    "HasEnums": true,
 // CHECK-NEXT:    "HasFriends": true,
 // CHECK-NEXT:    "HasPrivateMembers": true,
-// CHECK-NEXT:    "HasProtectedFunctions": true,
 // CHECK-NEXT:    "HasProtectedMembers": true,
-// CHECK-NEXT:    "HasPublicFunctions": true,
+// CHECK-NEXT:    "HasProtectedMethods": true,
 // CHECK-NEXT:    "HasPublicMembers": true,
+// CHECK-NEXT:    "HasPublicMethods": true,
 // CHECK-NEXT:    "HasRecords": true,
 // CHECK-NEXT:    "HasTypedefs": true,
 // CHECK-NEXT:    "InfoType": "record",
@@ -195,7 +195,14 @@ private:
 // CHECK-NEXT:       "Type": "int"
 // CHECK-NEXT:     }
 // CHECK-NEXT:   ],
-// CHECK-NEXT:   "ProtectedFunctions": [
+// CHECK-NEXT:    "ProtectedMembers": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "IsStatic": false,
+// CHECK-NEXT:        "Name": "ProtectedField",
+// CHECK-NEXT:        "Type": "int"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ],
+// CHECK-NEXT:   "ProtectedMethods": [
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "InfoType": "function",
 // CHECK-NEXT:       "IsStatic": false,
@@ -214,14 +221,14 @@ private:
 // CHECK-NEXT:       "USR": "{{[0-9A-F]*}}"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ],
-// CHECK-NEXT:    "ProtectedMembers": [
+// CHECK:         "PublicMembers": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "IsStatic": false,
-// CHECK-NEXT:        "Name": "ProtectedField",
+// CHECK-NEXT:        "Name": "PublicField",
 // CHECK-NEXT:        "Type": "int"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ],
-// CHECK-NEXT:    "PublicFunctions": [
+// CHECK-NEXT:    "PublicMethods": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "InfoType": "function",
 // CHECK-NEXT:        "IsStatic": false,
@@ -259,14 +266,7 @@ private:
 // CHECK-NEXT:          "QualName": "const int &",
 // CHECK-NEXT:          "USR": "{{[0-9A-F]*}}"
 // CHECK-NEXT:        },
-// CHECK:         "PublicMembers": [
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "IsStatic": false,
-// CHECK-NEXT:        "Name": "PublicField",
-// CHECK-NEXT:        "Type": "int"
-// CHECK-NEXT:      }
-// CHECK-NEXT:    ],
-// CHECK-NEXT:    "Records": [
+// CHECK:         "Records": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "DocumentationFileName": "_ZTVN7MyClass11NestedClassE",
 // CHECK-NEXT:        "End": true,
@@ -303,7 +303,7 @@ private:
 // CHECK:         "USR": "{{[0-9A-F]*}}"
 // CHECK-NEXT:  }
 
-// HTML:              <a class="sidebar-item" href="#Classes">Inner Classes</a>
+// HTML:              <a class="sidebar-item" href="#Records">Records</a>
 // HTML-NEXT:     </summary>
 // HTML-NEXT:     <ul>
 // HTML-NEXT:         <li class="sidebar-item-container">
@@ -338,8 +338,8 @@ private:
 // HTML-NEXT:         </div>
 // HTML-NEXT:     </div>
 // HTML-NEXT: </section>
-// HTML:      <section id="Classes" class="section-container">
-// HTML-NEXT:     <h2>Inner Classes</h2>
+// HTML:      <section id="Records" class="section-container">
+// HTML-NEXT:     <h2>Records</h2>
 // HTML-NEXT:     <ul class="class-container">
 // HTML-NEXT:         <li id="{{([0-9A-F]{40})}}" style="max-height: 40px;">
 // HTML-NEXT:             <a href="MyClass/_ZTVN7MyClass11NestedClassE.html">
@@ -353,14 +353,8 @@ private:
 // HTML-NEXT:     <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // HTML-NEXT:         <pre><code class="language-cpp code-clang-doc">template &lt;typename T&gt;</code></pre>
 // HTML-NEXT:         <pre><code class="language-cpp code-clang-doc">void MyClass (int )</code></pre>
-// HTML-NEXT:         <div class="nested-delimiter-container">
-// HTML-NEXT:             <p> This is a function template friend.</p>
-// HTML-NEXT:         </div>
 // HTML-NEXT:     </div>
 // HTML-NEXT:     <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // HTML-NEXT:         <pre><code class="language-cpp code-clang-doc">class Foo</code></pre>
-// HTML-NEXT:         <div class="nested-delimiter-container">
-// HTML-NEXT:             <p> This is a struct friend.</p>
-// HTML-NEXT:         </div>
 // HTML-NEXT:     </div>
 // HTML-NEXT: </section>

--- a/clang-tools-extra/test/clang-doc/json/compound-constraints.cpp
+++ b/clang-tools-extra/test/clang-doc/json/compound-constraints.cpp
@@ -144,7 +144,7 @@ template<typename T> requires (Incrementable<T> && Decrementable<T>) || PreIncre
 // CHECK-HTML-NEXT: </ul>
 // CHECK-HTML:      <section id="Concepts" class="section-container">
 // CHECK-HTML-NEXT:     <h2>Concepts</h2>
-// CHECK-HTML-NEXT:     <div id="" class="delimiter-container">
+// CHECK-HTML-NEXT:     <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // CHECK-HTML-NEXT:         <div>
 // CHECK-HTML-NEXT:             <pre><code class="language-cpp code-clang-doc">template &lt;typename T&gt; Incrementable requires (T a) { a++; }</code></pre> 
 // CHECK-HTML-NEXT:         </div>
@@ -159,7 +159,7 @@ template<typename T> requires (Incrementable<T> && Decrementable<T>) || PreIncre
 // CHECK-HTML-NEXT:         </div> 
 // CHECK-HTML-NEXT:         <p>Defined at line [[@LINE-151]] of file {{.*}}compound-constraints.cpp</p>
 // CHECK-HTML-NEXT:     </div>
-// CHECK-HTML-NEXT:     <div id="" class="delimiter-container">
+// CHECK-HTML-NEXT:     <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // CHECK-HTML-NEXT:         <div>
 // CHECK-HTML-NEXT:             <pre><code class="language-cpp code-clang-doc">template &lt;typename T&gt; Decrementable requires (T a) { a--; }</code></pre> 
 // CHECK-HTML-NEXT:         </div>
@@ -174,7 +174,7 @@ template<typename T> requires (Incrementable<T> && Decrementable<T>) || PreIncre
 // CHECK-HTML-NEXT:         </div> 
 // CHECK-HTML-NEXT:         <p>Defined at line [[@LINE-159]] of file {{.*}}compound-constraints.cpp</p>
 // CHECK-HTML-NEXT:     </div>
-// CHECK-HTML-NEXT:     <div id="" class="delimiter-container">
+// CHECK-HTML-NEXT:     <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // CHECK-HTML-NEXT:         <div>
 // CHECK-HTML-NEXT:             <pre><code class="language-cpp code-clang-doc">template &lt;typename T&gt; PreIncrementable requires (T a) { ++a; }</code></pre> 
 // CHECK-HTML-NEXT:         </div>
@@ -189,7 +189,7 @@ template<typename T> requires (Incrementable<T> && Decrementable<T>) || PreIncre
 // CHECK-HTML-NEXT:         </div> 
 // CHECK-HTML-NEXT:         <p>Defined at line [[@LINE-167]] of file {{.*}}compound-constraints.cpp</p>
 // CHECK-HTML-NEXT:     </div>
-// CHECK-HTML-NEXT:     <div id="" class="delimiter-container">
+// CHECK-HTML-NEXT:     <div id="{{([0-9A-F]{40})}}" class="delimiter-container">
 // CHECK-HTML-NEXT:         <div>
 // CHECK-HTML-NEXT:             <pre><code class="language-cpp code-clang-doc">template &lt;typename T&gt; PreDecrementable requires (T a) { --a; }</code></pre> 
 // CHECK-HTML-NEXT:         </div>

--- a/clang-tools-extra/test/clang-doc/json/method-template.cpp
+++ b/clang-tools-extra/test/clang-doc/json/method-template.cpp
@@ -7,7 +7,7 @@ struct MyClass {
   }
 };
 
-// CHECK:           "PublicFunctions": [
+// CHECK:           "PublicMethods": [
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "InfoType": "function",
 // CHECK-NEXT:          "IsStatic": false,

--- a/clang-tools-extra/test/clang-doc/mustache-index.cpp
+++ b/clang-tools-extra/test/clang-doc/mustache-index.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: clang-doc --format=html --output=%t --executor=standalone %s 
+// RUN: clang-doc --format=html --doxygen --output=%t --executor=standalone %s 
 // RUN: FileCheck %s < %t/html/GlobalNamespace/index.html
 
 enum Color {
@@ -19,7 +19,7 @@ class Foo;
 // CHECK-NEXT:      </li>
 // CHECK-NEXT:  </ul>
 // CHECK:       <summary class="sidebar-section">
-// CHECK-NEXT:      <a class="sidebar-item" href="#Classes">Inner Classes</a>
+// CHECK-NEXT:      <a class="sidebar-item" href="#Records">Records</a>
 // CHECK-NEXT:  </summary>
 // CHECK-NEXT:  <ul>
 // CHECK-NEXT:      <li class="sidebar-item-container">
@@ -59,8 +59,8 @@ class Foo;
 // CHECK-NEXT:      </div>
 // CHECK-NEXT:  </section>
 
-// CHECK:       <section id="Classes" class="section-container">
-// CHECK-NEXT:      <h2>Inner Classes</h2>
+// CHECK:       <section id="Records" class="section-container">
+// CHECK-NEXT:      <h2>Records</h2>
 // CHECK-NEXT:      <ul class="class-container">
 // CHECK-NEXT:          <li id="{{[0-9A-F]*}}" style="max-height: 40px;">
 // CHECK-NEXT:              <a href="_ZTV3Foo.html">

--- a/clang-tools-extra/test/clang-doc/namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/namespace.cpp
@@ -67,7 +67,7 @@ class AnonClass {};
 // HTML-ANON-INDEX:     <a href="../GlobalNamespace/index.html"><div class="navbar-breadcrumb-item">Global Namespace</div></a>
 // HTML-ANON-INDEX: </div>
 // HTML-ANON-INDEX: <h2>@nonymous_namespace</h2>
-// HTML-ANON-INDEX:     <h2>Inner Classes</h2>
+// HTML-ANON-INDEX:     <h2>Records</h2>
 // HTML-ANON-INDEX:         <ul class="class-container">
 // HTML-ANON-INDEX:             <li id="{{([0-9A-F]{40})}}" style="max-height: 40px;">
 // HTML-ANON-INDEX:                 <a href="_ZTVN12_GLOBAL__N_19AnonClassE.html">
@@ -136,7 +136,7 @@ class ClassInNestedNamespace {};
 // HTML-NESTED-INDEX:     <a href="../index.html"><div class="navbar-breadcrumb-item">PrimaryNamespace</div></a>
 // HTML-NESTED-INDEX: </div>
 // HTML-NESTED-INDEX: <h2>NestedNamespace</h2>
-// HTML-NESTED-INDEX:     <h2>Inner Classes</h2>
+// HTML-NESTED-INDEX:     <h2>Records</h2>
 // HTML-NESTED-INDEX:     <ul class="class-container">
 // HTML-NESTED-INDEX:         <li id="{{([0-9A-F]{40})}}" style="max-height: 40px;">
 // HTML-NESTED-INDEX:             <a href="_ZTVN16PrimaryNamespace15NestedNamespace22ClassInNestedNamespaceE.html">
@@ -171,7 +171,7 @@ class ClassInNestedNamespace {};
 // HTML-PRIMARY-INDEX: <h2>PrimaryNamespace</h2>
 // HTML-PRIMARY-INDEX-NOT: <h2 id="Namespaces">Namespaces</h2>
 // HTML-PRIMARY-INDEX-NOT: <a href="NestedNamespace{{[\/]}}index.html">NestedNamespace</a>
-// HTML-PRIMARY-INDEX:      <h2>Inner Classes</h2>
+// HTML-PRIMARY-INDEX:      <h2>Records</h2>
 // HTML-PRIMARY-INDEX:          <ul class="class-container">
 // HTML-PRIMARY-INDEX:              <li id="{{([0-9A-F]{40})}}" style="max-height: 40px;">
 // HTML-PRIMARY-INDEX:                  <a href="_ZTVN16PrimaryNamespace23ClassInPrimaryNamespaceE.html">
@@ -223,7 +223,7 @@ class ClassInAnotherNamespace {};
 // HTML-ANOTHER-INDEX:     <a href="../GlobalNamespace/index.html"><div class="navbar-breadcrumb-item">Global Namespace</div></a>
 // HTML-ANOTHER-INDEX: </div>
 // HTML-ANOTHER-INDEX: <h2>AnotherNamespace</h2>
-// HTML-ANOTHER-INDEX:     <h2>Inner Classes</h2>
+// HTML-ANOTHER-INDEX:     <h2>Records</h2>
 // HTML-ANOTHER-INDEX:     <ul class="class-container">
 // HTML-ANOTHER-INDEX:         <li id="{{([0-9A-F]{40})}}" style="max-height: 40px;">
 // HTML-ANOTHER-INDEX:             <a href="_ZTVN16AnotherNamespace23ClassInAnotherNamespaceE.html">

--- a/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/JSONGeneratorTest.cpp
@@ -64,8 +64,8 @@ TEST_F(JSONGeneratorTest, emitRecordJSON) {
     {
       "Access": "public",
       "End": true,
-      "HasPublicFunctions": true,
       "HasPublicMembers": true,
+      "HasPublicMethods": true,
       "InfoType": "record",
       "IsParent": true,
       "IsTypedef": false,
@@ -73,7 +73,14 @@ TEST_F(JSONGeneratorTest, emitRecordJSON) {
       "MangledName": "",
       "Name": "F",
       "Path": "path/to/F",
-      "PublicFunctions": [
+      "PublicMembers": [
+        {
+          "IsStatic": false,
+          "Name": "N",
+          "Type": "int"
+        }
+      ],
+      "PublicMethods": [
         {
           "InfoType": "function",
           "IsStatic": false,
@@ -86,13 +93,6 @@ TEST_F(JSONGeneratorTest, emitRecordJSON) {
             "USR": "0000000000000000000000000000000000000000"
           },
           "USR": "0000000000000000000000000000000000000000"
-        }
-      ],
-      "PublicMembers": [
-        {
-          "IsStatic": false,
-          "Name": "N",
-          "Type": "int"
         }
       ],
       "TagType": "struct",
@@ -118,7 +118,7 @@ TEST_F(JSONGeneratorTest, emitRecordJSON) {
   "HasEnums": true,
   "HasParents": true,
   "HasProtectedMembers": true,
-  "HasPublicFunctions": true,
+  "HasPublicMethods": true,
   "HasRecords": true,
   "HasVirtualParents": true,
   "InfoType": "record",
@@ -148,7 +148,7 @@ TEST_F(JSONGeneratorTest, emitRecordJSON) {
       "Type": "int"
     }
   ],
-  "PublicFunctions": [
+  "PublicMethods": [
     {
       "InfoType": "function",
       "IsStatic": false,


### PR DESCRIPTION
This is mostly a chore patch that fixes misnamed, mismatched,
or non-existant tags. That includes renaming the function tags in the
class template to `Has*Methods` instead of `Has*Functions`. The "method"
style was already preferred in the template HTML.

Some extraneous tags were removed from the enum template. All templates should use
`Description` for rendering comments, but it was still using an old tag
name. Also, the JSON generator currently doesn't serialize individual
enum value comments, so that tag was removed. Same for public members.

`Description` is removed for friends due to the way Mustache handles missing
tags. If `Description` isn't present, it will use the parent's
description which is undesirable.