### PR TITLE
[libcxx] Add missing member `cend()` to `MinSequenceContainer`

### DIFF
--- a/libcxx/test/support/MinSequenceContainer.h
+++ b/libcxx/test/support/MinSequenceContainer.h
@@ -54,6 +54,7 @@ struct MinSequenceContainer {
   TEST_CONSTEXPR_CXX20 const_iterator cbegin() const { return const_iterator(data_.data()); }
   TEST_CONSTEXPR_CXX20 iterator end() { return begin() + size(); }
   TEST_CONSTEXPR_CXX20 const_iterator end() const { return begin() + size(); }
+  TEST_CONSTEXPR_CXX20 const_iterator cend() const { return begin() + size(); }
   TEST_CONSTEXPR_CXX20 size_type size() const { return static_cast<size_type>(data_.size()); }
   TEST_CONSTEXPR_CXX20 bool empty() const { return data_.empty(); }
 

--- a/libcxx/test/support/MinSequenceContainer.h
+++ b/libcxx/test/support/MinSequenceContainer.h
@@ -54,7 +54,7 @@ struct MinSequenceContainer {
   TEST_CONSTEXPR_CXX20 const_iterator cbegin() const { return const_iterator(data_.data()); }
   TEST_CONSTEXPR_CXX20 iterator end() { return begin() + size(); }
   TEST_CONSTEXPR_CXX20 const_iterator end() const { return begin() + size(); }
-  TEST_CONSTEXPR_CXX20 const_iterator cend() const { return begin() + size(); }
+  TEST_CONSTEXPR_CXX20 const_iterator cend() const { return end(); }
   TEST_CONSTEXPR_CXX20 size_type size() const { return static_cast<size_type>(data_.size()); }
   TEST_CONSTEXPR_CXX20 bool empty() const { return data_.empty(); }
 


### PR DESCRIPTION
The `MinSequenceContainer` (used in tests for `<flat_map>` and `<flat_set>`) currently provides `begin()`, `end()`, `cbegin()` but no `cend()`.
[[container.reqmts]](https://eel.is/c++draft/container.reqmts#36) lists member function `cend` as one of container requirements, together with `begin()` and others.
