### PR TITLE
[clang-tidy] Speed up `readability-container-contains`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ContainerContainsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ContainerContainsCheck.cpp
@@ -14,6 +14,7 @@
 using namespace clang::ast_matchers;
 
 namespace clang::tidy::readability {
+
 void ContainerContainsCheck::registerMatchers(MatchFinder *Finder) {
   const auto Literal0 = integerLiteral(equals(0));
   const auto Literal1 = integerLiteral(equals(1));
@@ -47,66 +48,35 @@ void ContainerContainsCheck::registerMatchers(MatchFinder *Finder) {
   const auto StringNpos = anyOf(declRefExpr(to(varDecl(hasName("npos")))),
                                 memberExpr(member(hasName("npos"))));
 
-  // Find membership tests which use `count()`.
   Finder->addMatcher(
       traverse(TK_AsIs,
                implicitCastExpr(hasImplicitDestinationType(booleanType()),
                                 hasSourceExpression(CountCall))
                    .bind("positiveComparison")),
       this);
-  Finder->addMatcher(
-      binaryOperation(hasOperatorName("!="), hasOperands(CountCall, Literal0))
-          .bind("positiveComparison"),
-      this);
-  Finder->addMatcher(
-      binaryOperation(hasLHS(CountCall), hasOperatorName(">"), hasRHS(Literal0))
-          .bind("positiveComparison"),
-      this);
-  Finder->addMatcher(
-      binaryOperation(hasLHS(Literal0), hasOperatorName("<"), hasRHS(CountCall))
-          .bind("positiveComparison"),
-      this);
-  Finder->addMatcher(binaryOperation(hasLHS(CountCall), hasOperatorName(">="),
-                                     hasRHS(Literal1))
-                         .bind("positiveComparison"),
-                     this);
-  Finder->addMatcher(binaryOperation(hasLHS(Literal1), hasOperatorName("<="),
-                                     hasRHS(CountCall))
-                         .bind("positiveComparison"),
-                     this);
 
-  // Find inverted membership tests which use `count()`.
-  Finder->addMatcher(
-      binaryOperation(hasOperatorName("=="), hasOperands(CountCall, Literal0))
-          .bind("negativeComparison"),
-      this);
-  Finder->addMatcher(binaryOperation(hasLHS(CountCall), hasOperatorName("<="),
-                                     hasRHS(Literal0))
-                         .bind("negativeComparison"),
-                     this);
-  Finder->addMatcher(binaryOperation(hasLHS(Literal0), hasOperatorName(">="),
-                                     hasRHS(CountCall))
-                         .bind("negativeComparison"),
-                     this);
-  Finder->addMatcher(
-      binaryOperation(hasLHS(CountCall), hasOperatorName("<"), hasRHS(Literal1))
-          .bind("negativeComparison"),
-      this);
-  Finder->addMatcher(
-      binaryOperation(hasLHS(Literal1), hasOperatorName(">"), hasRHS(CountCall))
-          .bind("negativeComparison"),
-      this);
+  const auto PositiveComparison =
+      anyOf(allOf(hasOperatorName("!="), hasOperands(CountCall, Literal0)),
+            allOf(hasLHS(CountCall), hasOperatorName(">"), hasRHS(Literal0)),
+            allOf(hasLHS(Literal0), hasOperatorName("<"), hasRHS(CountCall)),
+            allOf(hasLHS(CountCall), hasOperatorName(">="), hasRHS(Literal1)),
+            allOf(hasLHS(Literal1), hasOperatorName("<="), hasRHS(CountCall)),
+            allOf(hasOperatorName("!="),
+                  hasOperands(FindCall, anyOf(EndCall, StringNpos))));
 
-  // Find membership tests based on `find() == end()` or `find() == npos`.
+  const auto NegativeComparison =
+      anyOf(allOf(hasOperatorName("=="), hasOperands(CountCall, Literal0)),
+            allOf(hasLHS(CountCall), hasOperatorName("<="), hasRHS(Literal0)),
+            allOf(hasLHS(Literal0), hasOperatorName(">="), hasRHS(CountCall)),
+            allOf(hasLHS(CountCall), hasOperatorName("<"), hasRHS(Literal1)),
+            allOf(hasLHS(Literal1), hasOperatorName(">"), hasRHS(CountCall)),
+            allOf(hasOperatorName("=="),
+                  hasOperands(FindCall, anyOf(EndCall, StringNpos))));
+
   Finder->addMatcher(
-      binaryOperation(hasOperatorName("!="),
-                      hasOperands(FindCall, anyOf(EndCall, StringNpos)))
-          .bind("positiveComparison"),
-      this);
-  Finder->addMatcher(
-      binaryOperation(hasOperatorName("=="),
-                      hasOperands(FindCall, anyOf(EndCall, StringNpos)))
-          .bind("negativeComparison"),
+      binaryOperation(
+          anyOf(allOf(PositiveComparison, expr().bind("positiveComparison")),
+                allOf(NegativeComparison, expr().bind("negativeComparison")))),
       this);
 }
 

--- a/clang-tools-extra/clang-tidy/readability/ContainerContainsCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/ContainerContainsCheck.h
@@ -29,7 +29,7 @@ public:
     return LO.CPlusPlus;
   }
   std::optional<TraversalKind> getCheckTraversalKind() const override {
-    return TK_AsIs;
+    return TK_IgnoreUnlessSpelledInSource;
   }
 };
 


### PR DESCRIPTION
This is currently one of our most expensive checks according to `--enable-check-profile`. I measured using [the usual setup](https://github.com/llvm/llvm-project/pull/174357#issue-3780188615):
```sh
hyperfine \
    --shell=none \
    --prepare='cmake --build build/release --target clang-tidy' \
    './build/release/bin/clang-tidy --checks=-*,readability-container-contains all_headers.cpp -header-filter=.* -system-headers -- -std=c++23 -fno-delayed-template-parsing'
```

First, the status quo:
```txt
  Time (mean ± σ):      5.243 s ±  0.158 s    [User: 4.964 s, System: 0.248 s]
  Range (min … max):    5.133 s …  5.612 s    10 runs
```
This PR improves that in two independent commits. The first commit changes the default traversal mode from `TK_AsIs` to `TK_IgnoreUnlessSpelledInSource`. Result:
```txt
  Time (mean ± σ):      4.554 s ±  0.100 s    [User: 4.273 s, System: 0.248 s]
  Range (min … max):    4.442 s …  4.785 s    10 runs
```

The second commit merges all 12 of the check's `BinaryOperation` matchers into one, because I found that each additional registered `BinaryOperation` matcher has pretty extreme overhead. Result:
```txt
  Time (mean ± σ):      3.480 s ±  0.121 s    [User: 3.264 s, System: 0.186 s]
  Range (min … max):    3.400 s …  3.798 s    10 runs
```