### PR TITLE
[CSKY] Use `softPromoteHalfType`

### DIFF
--- a/llvm/lib/Target/CSKY/CSKYISelLowering.h
+++ b/llvm/lib/Target/CSKY/CSKYISelLowering.h
@@ -159,6 +159,8 @@ private:
                               SDValue C) const override;
   bool isCheapToSpeculateCttz(Type *Ty) const override;
   bool isCheapToSpeculateCtlz(Type *Ty) const override;
+
+  bool softPromoteHalfType() const override { return true; }
 };
 
 } // namespace llvm

--- a/llvm/test/CodeGen/CSKY/fpu/fp16-promote.ll
+++ b/llvm/test/CodeGen/CSKY/fpu/fp16-promote.ll
@@ -181,16 +181,16 @@ define void @test_fadd(ptr %p, ptr %q) nounwind {
 ; CHECK-FPUV2-NEXT:    st16.w l1, (sp, 8) # 4-byte Folded Spill
 ; CHECK-FPUV2-NEXT:    st16.w l0, (sp, 4) # 4-byte Folded Spill
 ; CHECK-FPUV2-NEXT:    st32.w lr, (sp, 0) # 4-byte Folded Spill
-; CHECK-FPUV2-NEXT:    mov16 l0, a1
-; CHECK-FPUV2-NEXT:    mov16 l1, a0
-; CHECK-FPUV2-NEXT:    ld16.h a0, (a0, 0)
+; CHECK-FPUV2-NEXT:    mov16 l0, a0
+; CHECK-FPUV2-NEXT:    ld16.h l1, (a0, 0)
+; CHECK-FPUV2-NEXT:    ld16.h a0, (a1, 0)
 ; CHECK-FPUV2-NEXT:    jsri32 [.LCPI5_0]
 ; CHECK-FPUV2-NEXT:    fmovs vr8, vr0
-; CHECK-FPUV2-NEXT:    ld16.h a0, (l0, 0)
+; CHECK-FPUV2-NEXT:    mov16 a0, l1
 ; CHECK-FPUV2-NEXT:    jsri32 [.LCPI5_0]
-; CHECK-FPUV2-NEXT:    fadds vr0, vr8, vr0
+; CHECK-FPUV2-NEXT:    fadds vr0, vr0, vr8
 ; CHECK-FPUV2-NEXT:    jsri32 [.LCPI5_1]
-; CHECK-FPUV2-NEXT:    st16.h a0, (l1, 0)
+; CHECK-FPUV2-NEXT:    st16.h a0, (l0, 0)
 ; CHECK-FPUV2-NEXT:    ld32.w lr, (sp, 0) # 4-byte Folded Reload
 ; CHECK-FPUV2-NEXT:    ld16.w l0, (sp, 4) # 4-byte Folded Reload
 ; CHECK-FPUV2-NEXT:    ld16.w l1, (sp, 8) # 4-byte Folded Reload
@@ -212,16 +212,16 @@ define void @test_fadd(ptr %p, ptr %q) nounwind {
 ; CHECK-FPUV3-NEXT:    st16.w l1, (sp, 8) # 4-byte Folded Spill
 ; CHECK-FPUV3-NEXT:    st16.w l0, (sp, 4) # 4-byte Folded Spill
 ; CHECK-FPUV3-NEXT:    st32.w lr, (sp, 0) # 4-byte Folded Spill
-; CHECK-FPUV3-NEXT:    mov16 l0, a1
-; CHECK-FPUV3-NEXT:    mov16 l1, a0
-; CHECK-FPUV3-NEXT:    ld16.h a0, (a0, 0)
+; CHECK-FPUV3-NEXT:    mov16 l0, a0
+; CHECK-FPUV3-NEXT:    ld16.h l1, (a0, 0)
+; CHECK-FPUV3-NEXT:    ld16.h a0, (a1, 0)
 ; CHECK-FPUV3-NEXT:    jsri32 [.LCPI5_0]
 ; CHECK-FPUV3-NEXT:    fmov.32 vr8, vr0
-; CHECK-FPUV3-NEXT:    ld16.h a0, (l0, 0)
+; CHECK-FPUV3-NEXT:    mov16 a0, l1
 ; CHECK-FPUV3-NEXT:    jsri32 [.LCPI5_0]
-; CHECK-FPUV3-NEXT:    fadd.32 vr0, vr8, vr0
+; CHECK-FPUV3-NEXT:    fadd.32 vr0, vr0, vr8
 ; CHECK-FPUV3-NEXT:    jsri32 [.LCPI5_1]
-; CHECK-FPUV3-NEXT:    st16.h a0, (l1, 0)
+; CHECK-FPUV3-NEXT:    st16.h a0, (l0, 0)
 ; CHECK-FPUV3-NEXT:    ld32.w lr, (sp, 0) # 4-byte Folded Reload
 ; CHECK-FPUV3-NEXT:    ld16.w l0, (sp, 4) # 4-byte Folded Reload
 ; CHECK-FPUV3-NEXT:    ld16.w l1, (sp, 8) # 4-byte Folded Reload
@@ -250,16 +250,16 @@ define void @test_fmul(ptr %p, ptr %q) nounwind {
 ; CHECK-FPUV2-NEXT:    st16.w l1, (sp, 8) # 4-byte Folded Spill
 ; CHECK-FPUV2-NEXT:    st16.w l0, (sp, 4) # 4-byte Folded Spill
 ; CHECK-FPUV2-NEXT:    st32.w lr, (sp, 0) # 4-byte Folded Spill
-; CHECK-FPUV2-NEXT:    mov16 l0, a1
-; CHECK-FPUV2-NEXT:    mov16 l1, a0
-; CHECK-FPUV2-NEXT:    ld16.h a0, (a0, 0)
+; CHECK-FPUV2-NEXT:    mov16 l0, a0
+; CHECK-FPUV2-NEXT:    ld16.h l1, (a0, 0)
+; CHECK-FPUV2-NEXT:    ld16.h a0, (a1, 0)
 ; CHECK-FPUV2-NEXT:    jsri32 [.LCPI6_0]
 ; CHECK-FPUV2-NEXT:    fmovs vr8, vr0
-; CHECK-FPUV2-NEXT:    ld16.h a0, (l0, 0)
+; CHECK-FPUV2-NEXT:    mov16 a0, l1
 ; CHECK-FPUV2-NEXT:    jsri32 [.LCPI6_0]
-; CHECK-FPUV2-NEXT:    fmuls vr0, vr8, vr0
+; CHECK-FPUV2-NEXT:    fmuls vr0, vr0, vr8
 ; CHECK-FPUV2-NEXT:    jsri32 [.LCPI6_1]
-; CHECK-FPUV2-NEXT:    st16.h a0, (l1, 0)
+; CHECK-FPUV2-NEXT:    st16.h a0, (l0, 0)
 ; CHECK-FPUV2-NEXT:    ld32.w lr, (sp, 0) # 4-byte Folded Reload
 ; CHECK-FPUV2-NEXT:    ld16.w l0, (sp, 4) # 4-byte Folded Reload
 ; CHECK-FPUV2-NEXT:    ld16.w l1, (sp, 8) # 4-byte Folded Reload
@@ -281,16 +281,16 @@ define void @test_fmul(ptr %p, ptr %q) nounwind {
 ; CHECK-FPUV3-NEXT:    st16.w l1, (sp, 8) # 4-byte Folded Spill
 ; CHECK-FPUV3-NEXT:    st16.w l0, (sp, 4) # 4-byte Folded Spill
 ; CHECK-FPUV3-NEXT:    st32.w lr, (sp, 0) # 4-byte Folded Spill
-; CHECK-FPUV3-NEXT:    mov16 l0, a1
-; CHECK-FPUV3-NEXT:    mov16 l1, a0
-; CHECK-FPUV3-NEXT:    ld16.h a0, (a0, 0)
+; CHECK-FPUV3-NEXT:    mov16 l0, a0
+; CHECK-FPUV3-NEXT:    ld16.h l1, (a0, 0)
+; CHECK-FPUV3-NEXT:    ld16.h a0, (a1, 0)
 ; CHECK-FPUV3-NEXT:    jsri32 [.LCPI6_0]
 ; CHECK-FPUV3-NEXT:    fmov.32 vr8, vr0
-; CHECK-FPUV3-NEXT:    ld16.h a0, (l0, 0)
+; CHECK-FPUV3-NEXT:    mov16 a0, l1
 ; CHECK-FPUV3-NEXT:    jsri32 [.LCPI6_0]
-; CHECK-FPUV3-NEXT:    fmul.32 vr0, vr8, vr0
+; CHECK-FPUV3-NEXT:    fmul.32 vr0, vr0, vr8
 ; CHECK-FPUV3-NEXT:    jsri32 [.LCPI6_1]
-; CHECK-FPUV3-NEXT:    st16.h a0, (l1, 0)
+; CHECK-FPUV3-NEXT:    st16.h a0, (l0, 0)
 ; CHECK-FPUV3-NEXT:    ld32.w lr, (sp, 0) # 4-byte Folded Reload
 ; CHECK-FPUV3-NEXT:    ld16.w l0, (sp, 4) # 4-byte Folded Reload
 ; CHECK-FPUV3-NEXT:    ld16.w l1, (sp, 8) # 4-byte Folded Reload

--- a/llvm/test/CodeGen/Generic/half-op.ll
+++ b/llvm/test/CodeGen/Generic/half-op.ll
@@ -12,8 +12,8 @@
 ; RUN: %if arm-registered-target         %{ llc %s -o - -mtriple=thumbv7em-none-eabi             | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
 ; RUN: %if avr-registered-target         %{ llc %s -o - -mtriple=avr-none                        | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
 ; FIXME: BPF has a compiler error
-; RUN: %if csky-registered-target        %{ llc %s -o - -mtriple=csky-unknown-linux-gnuabiv2     | FileCheck %s --check-prefixes=ALL,BAD-NEG-ABS,BAD-COPYSIGN,BAD-FMA %}
-; RUN: %if csky-registered-target        %{ llc %s -o - -mtriple=csky-unknown-linux-gnuabiv2 -mcpu=ck860fv -mattr=+hard-float | FileCheck %s --check-prefixes=ALL,BAD-NEG-ABS,BAD-COPYSIGN,BAD-FMA %}
+; RUN: %if csky-registered-target        %{ llc %s -o - -mtriple=csky-unknown-linux-gnuabiv2     | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
+; RUN: %if csky-registered-target        %{ llc %s -o - -mtriple=csky-unknown-linux-gnuabiv2 -mcpu=ck860fv -mattr=+hard-float | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
 ; FIXME: directx has a compiler error
 ; RUN: %if hexagon-registered-target     %{ llc %s -o - -mtriple=hexagon-unknown-linux-musl      | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
 ; RUN: %if lanai-registered-target       %{ llc %s -o - -mtriple=lanai-unknown-unknown           | FileCheck %s --check-prefixes=ALL,BAD-NEG-ABS,BAD-COPYSIGN,BAD-FMA %}

--- a/llvm/test/CodeGen/Generic/half.ll
+++ b/llvm/test/CodeGen/Generic/half.ll
@@ -15,7 +15,7 @@
 ; RUN: %if avr-registered-target         %{ llc %s -o - -mtriple=avr-none                        | FileCheck %s --check-prefixes=ALL,CHECK %}
 ; RUN: %if bpf-registered-target         %{ llc %s -o - -mtriple=bpfel                           | FileCheck %s --check-prefixes=ALL,CHECK %}
 ; RUN: %if csky-registered-target        %{ llc %s -o - -mtriple=csky-unknown-linux-gnuabiv2     | FileCheck %s --check-prefixes=ALL,CHECK %}
-; RUN: %if csky-registered-target        %{ llc %s -o - -mtriple=csky-unknown-linux-gnuabiv2 -mcpu=ck860fv -mattr=+hard-float | FileCheck %s --check-prefixes=ALL,BAD %}
+; RUN: %if csky-registered-target        %{ llc %s -o - -mtriple=csky-unknown-linux-gnuabiv2 -mcpu=ck860fv -mattr=+hard-float | FileCheck %s --check-prefixes=ALL,CHECK %}
 ; RUN: %if directx-registered-target     %{ llc %s -o - -mtriple=dxil-pc-shadermodel6.3-library  | FileCheck %s --check-prefixes=NOCRASH %}
 ; RUN: %if hexagon-registered-target     %{ llc %s -o - -mtriple=hexagon-unknown-linux-musl      | FileCheck %s --check-prefixes=ALL,CHECK %}
 ; RUN: %if lanai-registered-target       %{ llc %s -o - -mtriple=lanai-unknown-unknown           | FileCheck %s --check-prefixes=ALL,CHECK %}


### PR DESCRIPTION
Follow suite from other targets.

Fixes the C-SKY portion of https://github.com/llvm/llvm-project/issues/97975
Fixes the C-SKY portion of https://github.com/llvm/llvm-project/issues/97981