### PR TITLE
[MSP430] Use `softPromoteHalfType`

### DIFF
--- a/llvm/lib/Target/MSP430/MSP430ISelLowering.h
+++ b/llvm/lib/Target/MSP430/MSP430ISelLowering.h
@@ -129,6 +129,8 @@ namespace llvm {
                                     SDValue &Offset,
                                     ISD::MemIndexedMode &AM,
                                     SelectionDAG &DAG) const override;
+
+    bool softPromoteHalfType() const override { return true; }
   };
 } // namespace llvm
 

--- a/llvm/test/CodeGen/Generic/half-op.ll
+++ b/llvm/test/CodeGen/Generic/half-op.ll
@@ -25,7 +25,7 @@
 ; RUN: %if mips-registered-target        %{ llc %s -o - -mtriple=mips64-unknown-linux-gnuabi64   | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
 ; RUN: %if mips-registered-target        %{ llc %s -o - -mtriple=mips64el-unknown-linux-gnuabi64 | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
 ; RUN: %if mips-registered-target        %{ llc %s -o - -mtriple=mipsel-unknown-linux-gnu        | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
-; RUN: %if msp430-registered-target      %{ llc %s -o - -mtriple=msp430-none-elf                 | FileCheck %s --check-prefixes=ALL,BAD-NEG-ABS,BAD-COPYSIGN,BAD-FMA %}
+; RUN: %if msp430-registered-target      %{ llc %s -o - -mtriple=msp430-none-elf                 | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
 ; RUN: %if nvptx-registered-target       %{ llc %s -o - -mtriple=nvptx64-nvidia-cuda             | FileCheck %s --check-prefixes=NOCRASH %}
 ; RUN: %if powerpc-registered-target     %{ llc %s -o - -mtriple=powerpc-unknown-linux-gnu       | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
 ; RUN: %if powerpc-registered-target     %{ llc %s -o - -mtriple=powerpc64-unknown-linux-gnu     | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}

--- a/llvm/test/CodeGen/MSP430/llvm.sincos.ll
+++ b/llvm/test/CodeGen/MSP430/llvm.sincos.ll
@@ -17,7 +17,7 @@ define { half, half } @test_sincos_f16(half %a) #0 {
 ; CHECK-NEXT:    mov r9, r13
 ; CHECK-NEXT:    call #cosf
 ; CHECK-NEXT:    call #__truncsfhf2
-; CHECK-NEXT:    mov r12, r14
+; CHECK-NEXT:    mov r12, r13
 ; CHECK-NEXT:    mov r8, r12
 ; CHECK-NEXT:    pop r10
 ; CHECK-NEXT:    pop r9
@@ -60,34 +60,33 @@ define { <2 x half>, <2 x half> } @test_sincos_v2f16(<2 x half> %a) #0 {
 ; CHECK-NEXT:    push r8
 ; CHECK-NEXT:    push r9
 ; CHECK-NEXT:    push r10
-; CHECK-NEXT:    mov r12, r7
-; CHECK-NEXT:    mov r13, r12
+; CHECK-NEXT:    mov r13, r7
 ; CHECK-NEXT:    call #__extendhfsf2
-; CHECK-NEXT:    mov r12, r10
-; CHECK-NEXT:    mov r13, r9
+; CHECK-NEXT:    mov r12, r9
+; CHECK-NEXT:    mov r13, r8
 ; CHECK-NEXT:    call #sinf
 ; CHECK-NEXT:    call #__truncsfhf2
-; CHECK-NEXT:    mov r12, r8
+; CHECK-NEXT:    mov r12, r10
 ; CHECK-NEXT:    mov r7, r12
 ; CHECK-NEXT:    call #__extendhfsf2
-; CHECK-NEXT:    mov r12, r6
-; CHECK-NEXT:    mov r13, r5
-; CHECK-NEXT:    call #cosf
-; CHECK-NEXT:    call #__truncsfhf2
 ; CHECK-NEXT:    mov r12, r7
-; CHECK-NEXT:    mov r6, r12
-; CHECK-NEXT:    mov r5, r13
+; CHECK-NEXT:    mov r13, r6
 ; CHECK-NEXT:    call #sinf
 ; CHECK-NEXT:    call #__truncsfhf2
-; CHECK-NEXT:    mov r12, r6
-; CHECK-NEXT:    mov r10, r12
-; CHECK-NEXT:    mov r9, r13
+; CHECK-NEXT:    mov r12, r5
+; CHECK-NEXT:    mov r9, r12
+; CHECK-NEXT:    mov r8, r13
+; CHECK-NEXT:    call #cosf
+; CHECK-NEXT:    call #__truncsfhf2
+; CHECK-NEXT:    mov r12, r9
+; CHECK-NEXT:    mov r7, r12
+; CHECK-NEXT:    mov r6, r13
 ; CHECK-NEXT:    call #cosf
 ; CHECK-NEXT:    call #__truncsfhf2
 ; CHECK-NEXT:    mov r12, r15
-; CHECK-NEXT:    mov r6, r12
-; CHECK-NEXT:    mov r8, r13
-; CHECK-NEXT:    mov r7, r14
+; CHECK-NEXT:    mov r10, r12
+; CHECK-NEXT:    mov r5, r13
+; CHECK-NEXT:    mov r9, r14
 ; CHECK-NEXT:    pop r10
 ; CHECK-NEXT:    pop r9
 ; CHECK-NEXT:    pop r8


### PR DESCRIPTION
Follow suite from other targets.

Fixes the MSP430 portion of https://github.com/llvm/llvm-project/issues/97975
Fixes the MSP430 portion of https://github.com/llvm/llvm-project/issues/97981