### PR TITLE
[XCore] Use `softPromoteHalfType`

### DIFF
--- a/llvm/lib/Target/XCore/XCoreISelLowering.h
+++ b/llvm/lib/Target/XCore/XCoreISelLowering.h
@@ -72,6 +72,8 @@ namespace llvm {
       return XCore::R1;
     }
 
+    bool softPromoteHalfType() const override { return true; }
+
   private:
     const TargetMachine &TM;
     const XCoreSubtarget &Subtarget;

--- a/llvm/test/CodeGen/Generic/half-op.ll
+++ b/llvm/test/CodeGen/Generic/half-op.ll
@@ -41,7 +41,7 @@
 ; RUN: %if x86-registered-target         %{ llc %s -o - -mtriple=i686-unknown-linux-gnu          | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
 ; RUN: %if x86-registered-target         %{ llc %s -o - -mtriple=x86_64-pc-windows-msvc          | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
 ; RUN: %if x86-registered-target         %{ llc %s -o - -mtriple=x86_64-unknown-linux-gnu        | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
-; RUN: %if xcore-registered-target       %{ llc %s -o - -mtriple=xcore-unknown-unknown           | FileCheck %s --check-prefixes=ALL,BAD-NEG-ABS,BAD-COPYSIGN,BAD-FMA %}
+; RUN: %if xcore-registered-target       %{ llc %s -o - -mtriple=xcore-unknown-unknown           | FileCheck %s --check-prefixes=ALL,CHECK-NEG-ABS,CHECK-COPYSIGN,CHECK-FMA %}
 ; RUN: %if xtensa-registered-target      %{ llc %s -o - -mtriple=xtensa-none-elf                 | FileCheck %s --check-prefixes=ALL,BAD-NEG-ABS,BAD-COPYSIGN,CHECK-FMA %}
 
 ; Note that arm64ec labels are quoted, hence the `{{"?}}:`.

--- a/llvm/test/CodeGen/XCore/llvm.exp10.ll
+++ b/llvm/test/CodeGen/XCore/llvm.exp10.ll
@@ -11,10 +11,10 @@ define half @exp10_f16(half %x) #0 {
 
 ; CHECK-LABEL: exp10_v2f16:
 ; CHECK: bl __extendhfsf2
-; CHECK: bl __extendhfsf2
-; CHECK: bl exp10f
 ; CHECK: bl exp10f
 ; CHECK: bl __truncsfhf2
+; CHECK: bl __extendhfsf2
+; CHECK: bl exp10f
 ; CHECK: bl __truncsfhf2
 define <2 x half> @exp10_v2f16(<2 x half> %x) #0 {
   %r = call <2 x half> @llvm.exp10.v2f16(<2 x half> %x)

--- a/llvm/test/CodeGen/XCore/llvm.frexp.ll
+++ b/llvm/test/CodeGen/XCore/llvm.frexp.ll
@@ -4,8 +4,8 @@ define { half, i32 } @test_frexp_f16_i32(half %a) nounwind {
 ; CHECK-LABEL: test_frexp_f16_i32:
 ; CHECK: bl __extendhfsf2
 ; CHECK: bl frexpf
-; CHECK: ldw r{{[0-9]+}}, sp[1]
 ; CHECK: bl __truncsfhf2
+; CHECK: ldw r{{[0-9]+}}, sp[1]
 %result = call { half, i32 } @llvm.frexp.f16.i32(half %a)
   ret { half, i32 } %result
 }

--- a/llvm/test/CodeGen/XCore/llvm.sincos.ll
+++ b/llvm/test/CodeGen/XCore/llvm.sincos.ll
@@ -2,9 +2,9 @@
 
 ; CHECK-LABEL: test_sincos_f16:
 ; CHECK: bl __extendhfsf2
-; CHECK: bl cosf
 ; CHECK: bl sinf
 ; CHECK: bl __truncsfhf2
+; CHECK: bl cosf
 ; CHECK: bl __truncsfhf2
 define { half, half } @test_sincos_f16(half %a) nounwind {
   %result = call { half, half } @llvm.sincos.f16(half %a)
@@ -13,12 +13,14 @@ define { half, half } @test_sincos_f16(half %a) nounwind {
 
 ; CHECK-LABEL: test_sincos_v2f16:
 ; CHECK: bl __extendhfsf2
-; CHECK: bl __extendhfsf2
-; CHECK: bl cosf
-; CHECK: bl cosf
-; CHECK: bl sinf
 ; CHECK: bl sinf
 ; CHECK: bl __truncsfhf2
+; CHECK: bl __extendhfsf2
+; CHECK: bl sinf
+; CHECK: bl __truncsfhf2
+; CHECK: bl cosf
+; CHECK: bl __truncsfhf2
+; CHECK: bl cosf
 ; CHECK: bl __truncsfhf2
 define { <2 x half>, <2 x half> } @test_sincos_v2f16(<2 x half> %a) nounwind {
   %result = call { <2 x half>, <2 x half> } @llvm.sincos.v2f16(<2 x half> %a)


### PR DESCRIPTION
Follow suite from other targets.

Fixes the XCore portion of https://github.com/llvm/llvm-project/issues/97975
Fixes the XCore portion of https://github.com/llvm/llvm-project/issues/97981