### PR TITLE
[ORC] Handle unset FinalizeFuture in ELFDebugObjectPlugin::awaitTargetMem

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.cpp
@@ -75,7 +75,12 @@ public:
 
   void trackFinalizedAlloc(FinalizedAlloc FA) { Alloc = std::move(FA); }
 
-  Expected<ExecutorAddrRange> awaitTargetMem() { return FinalizeFuture.get(); }
+  Expected<ExecutorAddrRange> awaitTargetMem() {
+    if (!FinalizeFuture.valid()) {
+      return ExecutorAddrRange();
+    }
+    return FinalizeFuture.get();
+  }
 
   void reportTargetMem(ExecutorAddrRange TargetMem) {
     FinalizePromise.set_value(TargetMem);


### PR DESCRIPTION
When debug registration is skipped, DebugObj->collectTargetAlloc() is never called, leaving the FinalizeFuture unset. The next call to awaitTargetMem will fail with a

```
terminate called after throwing an instance of 'std::future_error'
  what():  std::future_error: No associated state
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace and instructions to reproduce the bug.

...
#13 0x0000ef6fd6ca2b50 void std::__future_base::_State_baseV2::_S_check<std::__future_base::_State_baseV2>(std::shared_ptr<std::__future_base::_State_baseV2> const&) /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/future:582:9
#14 0x0000ef6fd6ca6574 std::__basic_future<llvm::MSVCPExpected<llvm::orc::ExecutorAddrRange>>::_M_get_result() const /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/future:740:9
#15 0x0000ef6fd6ca628c std::future<llvm::MSVCPExpected<llvm::orc::ExecutorAddrRange>>::get() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/future:827:48
#16 0x0000ef6fd6cb4a40 llvm::orc::DebugObject::awaitTargetMem() /var/lib/postgresql/llvm-project/llvm/lib/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.cpp:78:72
#17 0x0000ef6fd6c9b3c8 llvm::orc::ELFDebugObjectPlugin::modifyPassConfig(llvm::orc::MaterializationResponsibility&, llvm::jitlink::LinkGraph&, llvm::jitlink::PassConfiguration&)::$_1::operator()(llvm::jitlink::LinkGraph&) const /var/lib/postgresql/llvm-project/llvm/lib/ExecutionEngine/Orc/Debugging/ELFDebugObjectPlugin.cpp:345:47
```

This patch modifies awaitTargetMem to return an empty address range if the FinalizeFuture is never initialised.