### PR TITLE
[llvm-exegesis] Fix intermittent failure in setReg_init_check.s

### DIFF
--- a/llvm/test/tools/llvm-exegesis/AArch64/setReg_init_check.s
+++ b/llvm/test/tools/llvm-exegesis/AArch64/setReg_init_check.s
@@ -105,8 +105,6 @@ RUN: FileCheck %s --check-prefix=WSEQPAIR-ASM < %t.s
 WSEQPAIR-ASM:         <foo>:
 WSEQPAIR-ASM:         mov     w{{[0-9]+}}, #0x0
 WSEQPAIR-ASM-NEXT:    mov     w{{[0-9]+}}, #0x0
-WSEQPAIR-ASM-NEXT:    mov     w{{[0-9]+}}, #0x0
-WSEQPAIR-ASM-NEXT:    mov     w{{[0-9]+}}, #0x0
 WSEQPAIR-ASM:         casp    w{{[0-9]+}}, w{{[0-9]+}}, w{{[0-9]+}}, w{{[0-9]+}}, [x{{[0-9]+}}]
 
 ## XSeqPair Register Class Initialization Testcase
@@ -115,8 +113,6 @@ RUN: llvm-objdump -d %d > %t.s
 RUN: FileCheck %s --check-prefix=XSEQPAIR-ASM < %t.s
 XSEQPAIR-ASM:         <foo>:
 XSEQPAIR-ASM:         mov     x{{[0-9]+}}, #0x{{[0-9]+}}
-XSEQPAIR-ASM-NEXT:    mov     x{{[0-9]+}}, #0x{{[0-9]+}}
-XSEQPAIR-ASM-NEXT:    mov     x{{[0-9]+}}, #0x{{[0-9]+}}
 XSEQPAIR-ASM-NEXT:    mov     x{{[0-9]+}}, #0x{{[0-9]+}}
 XSEQPAIR-ASM:         casp    x{{[0-9]+}}, x{{[0-9]+}}, x{{[0-9]+}}, x{{[0-9]+}}, [x{{[0-9]+}}]
 


### PR DESCRIPTION
Test is failing intermittently after #174944. The issue this time is the `WSeqPair`/`XSeqPair` tests fail if the same pair is used as there's fewer MOVs.

The test was expecting:
```
  0000000000000000 <foo>:
         0: f81e0ffb      str     x27, [sp, #-0x20]!
         4: a90163fa      stp     x26, x24, [sp, #0x10]
         8: d2800006      mov     x6, #0x0                // =0
         c: d2800007      mov     x7, #0x0                // =0
        10: d280001a      mov     x26, #0x0               // =0
        14: d280001b      mov     x27, #0x0               // =0
        18: d2800018      mov     x24, #0x0               // =0
        1c: 48267f1a      casp    x6, x7, x26, x27, [x24]
```
but this can occur:
```
  0000000000000000 <foo>:
         0: f81e0ffb      str     x27, [sp, #-0x20]!
         4: a90153f5      stp     x21, x20, [sp, #0x10]
         8: d2800014      mov     x20, #0x0               // =0
         c: d2800015      mov     x21, #0x0               // =0
        10: d280001b      mov     x27, #0x0               // =0
        14: 48347f74      casp    x20, x21, x20, x21, [x27]
```