### PR TITLE
[libc++] Simplify __unwrap_iter a bit

### DIFF
--- a/libcxx/include/__algorithm/unwrap_iter.h
+++ b/libcxx/include/__algorithm/unwrap_iter.h
@@ -57,21 +57,19 @@ struct __unwrap_iter_impl<_Iter, true> {
   }
 };
 
-template <class _Iter,
-          class _Impl                                             = __unwrap_iter_impl<_Iter>,
-          __enable_if_t<is_copy_constructible<_Iter>::value, int> = 0>
+template <class _Iter, class _Impl = __unwrap_iter_impl<_Iter> >
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 decltype(_Impl::__unwrap(std::declval<_Iter>()))
 __unwrap_iter(_Iter __i) _NOEXCEPT {
-  return _Impl::__unwrap(__i);
-}
-
 // Allow input_iterators to be passed to __unwrap_iter (but not __rewrap_iter)
 #if _LIBCPP_STD_VER >= 20
-template <class _Iter, __enable_if_t<!is_copy_constructible<_Iter>::value, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI constexpr _Iter __unwrap_iter(_Iter __i) noexcept {
-  return __i;
-}
+  if constexpr (!is_copy_constructible_v<_Iter>) {
+    return __i;
+  } else
 #endif
+  {
+    return _Impl::__unwrap(__i);
+  }
+}
 
 template <class _OrigIter, class _Iter, class _Impl = __unwrap_iter_impl<_OrigIter> >
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _OrigIter __rewrap_iter(_OrigIter __orig_iter, _Iter __iter) _NOEXCEPT {


### PR DESCRIPTION
`__unwrap_iter` doesn't need to SFINAE away, so we can just check inside the function body whether an iterator is copy constructible. This reduces the overload set, improving compile times a bit.
