### PR TITLE
[TableGen] Remove deprecated !getop and !setop

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -85,6 +85,9 @@ Changes to building LLVM
 Changes to TableGen
 -------------------
 
+* The `!getop` and `!setop` bang operators have been removed in favor of
+  `!getdagop` and `!setdagop`.
+
 Changes to Interprocedural Optimizations
 ----------------------------------------
 

--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -1654,10 +1654,6 @@ operator produces a boolean result, the result value will be 1 for true or 0
 for false. When an operator tests a boolean argument, it interprets 0 as false
 and non-0 as true.
 
-.. warning::
-  The ``!getop`` and ``!setop`` bang operators are deprecated in favor of
-  ``!getdagop`` and ``!setdagop``.
-
 ``!add(``\ *a*\ ``,`` *b*\ ``, ...)``
     This operator adds *a*, *b*, etc., and produces the sum.
 

--- a/llvm/lib/TableGen/TGLexer.cpp
+++ b/llvm/lib/TableGen/TGLexer.cpp
@@ -682,10 +682,8 @@ tgtok::TokKind TGLexer::LexExclaim() {
           .Case("instances", tgtok::XInstances)
           .Case("substr", tgtok::XSubstr)
           .Case("find", tgtok::XFind)
-          .Cases({"setdagop", "setop"},
-                 tgtok::XSetDagOp) // !setop is deprecated.
-          .Cases({"getdagop", "getop"},
-                 tgtok::XGetDagOp) // !getop is deprecated.
+          .Case("setdagop", tgtok::XSetDagOp)
+          .Case("getdagop", tgtok::XGetDagOp)
           .Case("setdagopname", tgtok::XSetDagOpName)
           .Case("getdagopname", tgtok::XGetDagOpName)
           .Case("getdagarg", tgtok::XGetDagArg)

--- a/llvm/test/TableGen/getsetdagop.td
+++ b/llvm/test/TableGen/getsetdagop.td
@@ -10,9 +10,6 @@
 // RUN: not llvm-tblgen -DERROR9 %s 2>&1 | FileCheck --check-prefix=ERROR9 %s
 // RUN: not llvm-tblgen -DERROR10 %s 2>&1 | FileCheck --check-prefix=ERROR10 %s
 
-// !setop and !getop are deprecated in favor of !setdagop and !getdagop.
-// Two tests retain the old names just to be sure they are still supported.
-
 class Base;
 class OtherBase;
 
@@ -31,13 +28,13 @@ def test {
   dag named = (foo:$root 1, 2:$a, $b);
 
   // CHECK: dag replaceWithBar = (bar 1, 2:$a, ?:$b);
-  dag replaceWithBar = !setop(orig, bar);
+  dag replaceWithBar = !setdagop(orig, bar);
 
   // CHECK: dag replaceWithBaz = (qux 1, 2:$a, ?:$b);
   dag replaceWithBaz = !setdagop(orig, qux);
 
   // CHECK: Base getopWithCast = foo;
-  Base getopWithCast = !getop<Base>(orig);
+  Base getopWithCast = !getdagop<Base>(orig);
 
   // CHECK: dag getopToSetop = (foo "hello", ?:$world);
   dag getopToSetop = !setdagop(another, !getdagop(orig));


### PR DESCRIPTION
They have been deprecated for more than five years in favor of !getdagop
and !setdagop. See https://reviews.llvm.org/D89814.
