### PR TITLE
[Delinearization] Extract outer array dimensions using global object size

### DIFF
--- a/llvm/test/Analysis/Delinearization/global_array_bounds.ll
+++ b/llvm/test/Analysis/Delinearization/global_array_bounds.ll
@@ -18,9 +18,9 @@ define void @test_2d_array(i64 %i, i64 %j, i64 %N, i64 %M) {
 ; CHECK-NEXT:  Inst: %val = load i32, ptr %gepij, align 4
 ; CHECK-NEXT:  AccessFunction: {{\{\{}}0,+,80}<%for.i>,+,4}<%for.j>
 ; CHECK-NEXT:  Base offset: @test_array_10x20
-; CHECK-NEXT:  ArrayDecl[UnknownSize][20] with elements of 4 bytes.
+; CHECK-NEXT:  ArrayDecl[10][20] with elements of 4 bytes.
 ; CHECK-NEXT:  ArrayRef[{0,+,1}<nuw><%for.i>][{0,+,1}<nuw><nsw><%for.j>]
-; CHECK-NEXT:  Delinearization validation: Failed
+; CHECK-NEXT:  Delinearization validation: Succeeded
 ;
 entry:
   br label %for.i

--- a/llvm/test/Analysis/Delinearization/validation_large_size.ll
+++ b/llvm/test/Analysis/Delinearization/validation_large_size.ll
@@ -26,7 +26,7 @@ define void @large_size_fixed(ptr %A) {
 ; CHECK-NEXT:  Base offset: %A
 ; CHECK-NEXT:  ArrayDecl[UnknownSize][256] with elements of 1 bytes.
 ; CHECK-NEXT:  ArrayRef[{0,+,1}<nuw><nsw><%for.i.header>][{0,+,1}<nuw><nsw><%for.j>]
-; CHECK-NEXT:  Delinearization validation: Failed
+; CHECK-NEXT:  Delinearization validation: Succeeded
 ;
 entry:
   br label %for.i.header
@@ -151,7 +151,7 @@ define void @elementsize_cause_ovfl(ptr %A) {
 ; CHECK-NEXT:  Base offset: %A
 ; CHECK-NEXT:  ArrayDecl[UnknownSize][256] with elements of 8 bytes.
 ; CHECK-NEXT:  ArrayRef[{0,+,1}<nuw><nsw><%for.i.header>][{0,+,1}<nuw><nsw><%for.j>]
-; CHECK-NEXT:  Delinearization validation: Failed
+; CHECK-NEXT:  Delinearization validation: Succeeded
 ;
 entry:
   br label %for.i.header


### PR DESCRIPTION
Use the size of a statically declared array to calculate the outer array
dimension. Obtaining this size and feeding that extra information into the
subscript recognition part helps to get more accurate results.