### PR TITLE
[SPIR-V] Fix Linkage capability with pushconstant

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPushConstantAccess.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPushConstantAccess.cpp
@@ -44,6 +44,7 @@ static bool replacePushConstantAccesses(Module &M, SPIRVGlobalRegistry *GR) {
                            /* initializer= */ nullptr, GV.getName(),
                            /* InsertBefore= */ &GV, GV.getThreadLocalMode(),
                            GV.getAddressSpace(), GV.isExternallyInitialized());
+    NewGV->setVisibility(GV.getVisibility());
 
     for (User *U : make_early_inc_range(GV.users())) {
       Instruction *I = cast<Instruction>(U);

--- a/llvm/test/CodeGen/SPIRV/vk-pushconstant-access.ll
+++ b/llvm/test/CodeGen/SPIRV/vk-pushconstant-access.ll
@@ -2,6 +2,8 @@
 
 %struct.S = type <{ float }>
 
+; CHECK-NOT: OpCapability Linkage
+
 ; CHECK-DAG: %[[#F32:]] = OpTypeFloat 32
 ; CHECK-DAG: %[[#UINT:]] = OpTypeInt 32 0
 ; CHECK-DAG: %[[#S_S:]] = OpTypeStruct %[[#F32]]

--- a/llvm/test/CodeGen/SPIRV/vk-pushconstant-layout.ll
+++ b/llvm/test/CodeGen/SPIRV/vk-pushconstant-layout.ll
@@ -5,6 +5,8 @@
 %struct.T = type { [3 x <2 x float>] }
 %struct.S = type <{ float, <3 x float>, %struct.T }>
 
+; CHECK-NOT: OpCapability Linkage
+
 ; CHECK-DAG: %[[#PTR_PCS:]] = OpTypePointer PushConstant %[[#S_S:]]
 
 ; CHECK-DAG: %[[#F32:]] = OpTypeFloat 32


### PR DESCRIPTION
When the SPIR-V backend handles a push constant, a new global with a target-specific is generated. This global should have the same visibility as the source, but turns out it was not the case: linkage was still external, but visibility went from hidden to visible.

This causes the later passes to generate a Linkage decoration, adding the Linkage capability, which is not compatible with Vulkan. Fixing this.