### PR TITLE
[ORC] Fixed incorrect additional header dirs

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/Shared/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/CMakeLists.txt
@@ -6,8 +6,9 @@ add_llvm_component_library(LLVMOrcShared
   OrcRTBridge.cpp
   SimpleRemoteEPCUtils.cpp
   SymbolStringPool.cpp
+
   ADDITIONAL_HEADER_DIRS
-  ${LLVM_MAIN_INCLUDE_DIR}/llvm/ExecutionEngine/Orc
+  ${LLVM_MAIN_INCLUDE_DIR}/llvm/ExecutionEngine/Orc/Shared
 
   DEPENDS
   intrinsics_gen

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/CMakeLists.txt
@@ -30,7 +30,7 @@ add_llvm_component_library(LLVMOrcTargetProcess
   UnwindInfoManager.cpp
 
   ADDITIONAL_HEADER_DIRS
-  ${LLVM_MAIN_INCLUDE_DIR}/llvm/ExecutionEngine/Orc
+  ${LLVM_MAIN_INCLUDE_DIR}/llvm/ExecutionEngine/Orc/TargetProcess
 
   LINK_LIBS
   ${LLVM_PTHREAD_LIB}


### PR DESCRIPTION
The CMake ADDITIONAL_HEADER_DIRS directive for two Orc libraries, specifically Shared and TargetProcess, used incorrect values that pointed to its parent library include directory instead of its own. This is now fixed.