### PR TITLE
[lldb] Honor the process plugin name in the attach/launch info

### DIFF
--- a/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
+++ b/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
@@ -505,11 +505,18 @@ lldb::ProcessSP PlatformRemoteGDBServer::Attach(
           error.Clear();
 
         if (target && error.Success()) {
-          // The darwin always currently uses the GDB remote debugger plug-in
-          // so even when debugging locally we are debugging remotely!
+          // By default, we always use the GDB remote debugger plug-in.
+          // Even when debugging locally, we are debugging remotely.
+          llvm::StringRef process_plugin = "gdb-remote";
+
+          // However, if a process plugin is specified by the attach info, we
+          // should honor it.
+          if (!attach_info.GetProcessPluginName().empty())
+            process_plugin = attach_info.GetProcessPluginName();
+
           process_sp =
               target->CreateProcess(attach_info.GetListenerForProcess(debugger),
-                                    "gdb-remote", nullptr, true);
+                                    process_plugin, nullptr, true);
           if (process_sp) {
             error = process_sp->ConnectRemote(connect_url.c_str());
             if (error.Success()) {

--- a/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
+++ b/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
@@ -416,10 +416,17 @@ PlatformRemoteGDBServer::DebugProcess(ProcessLaunchInfo &launch_info,
         error = Status::FromErrorStringWithFormat(
             "unable to launch a GDB server on '%s'", GetHostname());
       } else {
-        // The darwin always currently uses the GDB remote debugger plug-in
-        // so even when debugging locally we are debugging remotely!
+        // By default, we always use the GDB remote debugger plug-in.
+        // Even when debugging locally, we are debugging remotely.
+        llvm::StringRef process_plugin = "gdb-remote";
+
+        // However, if a process plugin is specified by the attach info, we
+        // should honor it.
+        if (!launch_info.GetProcessPluginName().empty())
+          process_plugin = launch_info.GetProcessPluginName();
+
         process_sp = target.CreateProcess(launch_info.GetListener(),
-                                          "gdb-remote", nullptr, true);
+                                          process_plugin, nullptr, true);
 
         if (process_sp) {
           process_sp->HijackProcessEvents(launch_info.GetHijackListener());

--- a/lldb/test/API/functionalities/gdb_remote_client/TestPlatformAttach.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestPlatformAttach.py
@@ -49,10 +49,12 @@ class TestPlatformAttach(GDBRemoteTestBase):
 
         attach_info = lldb.SBAttachInfo()
         attach_info.SetExecutable("foo")
+        attach_info.SetProcessPluginName("wasm")
 
         target = lldb.SBTarget()
         process = platform.Attach(attach_info, self.dbg, target, error)
         self.assertSuccess(error)
         self.assertEqual(process.GetProcessID(), 95117)
+        self.assertEqual(process.GetPluginName(), "wasm")
 
         platform.DisconnectRemote()


### PR DESCRIPTION
When connected to a GDB remote platform, we always use "gdb-remote" as the process plugin when attaching. This means that the `--plugin` argument to `process attach` is effectively ignored. This patch makes it so that "gdb-remote" remains the default, while still honoring the process plugin name specified in the attach info. The same thing applies to launching a process.

rdar://167845923