### PR TITLE
[Support][Windows][DTLTO] Expand short 8.3 form system temp dirs

### DIFF
--- a/llvm/include/llvm/Support/Windows/WindowsSupport.h
+++ b/llvm/include/llvm/Support/Windows/WindowsSupport.h
@@ -249,6 +249,11 @@ LLVM_ABI std::error_code widenPath(const Twine &Path8,
 /// ensuring we're not retrieving a malicious injected module but a module
 /// loaded from the system path.
 LLVM_ABI HMODULE loadSystemModuleSecure(LPCWSTR lpModuleName);
+
+/// Convert a UTF-8 path to a long form UTF-8 path expanding any short 8.3 form
+/// components.
+LLVM_ABI std::error_code makeLongFormPath(const Twine &Path8,
+                                          llvm::SmallVectorImpl<char> &Result8);
 } // end namespace windows
 } // end namespace sys
 } // end namespace llvm.

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -60,13 +60,29 @@ static bool is_separator(const wchar_t value) {
   }
 }
 
+// Extended-length path prefix constants (UTF-8).
+static constexpr llvm::StringLiteral ExtendedPrefix8 = R"(\\?\)";
+static constexpr llvm::StringLiteral ExtendedUNCPrefix8 = R"(\\?\UNC\)";
+
+// Extended-length path prefix constants (UTF-16).
+static constexpr wchar_t ExtendedPrefix16[] = LR"(\\?\)";
+static constexpr wchar_t ExtendedUNCPathPrefix16[] = LR"(\\?\UNC\)";
+
+static constexpr DWORD ExtendedPrefix16Len =
+    static_cast<DWORD>(std::size(ExtendedPrefix16) - 1);
+static constexpr DWORD ExtendedUNCPathPrefix16Len =
+    static_cast<DWORD>(std::size(ExtendedUNCPathPrefix16) - 1);
+
 static void stripExtendedPrefix(wchar_t *&Data, DWORD &CountChars) {
-  if (CountChars >= 8 && ::memcmp(Data, L"\\\\?\\UNC\\", 16) == 0) {
+  if (CountChars >= ExtendedUNCPathPrefix16Len &&
+      ::wmemcmp(Data, ExtendedUNCPathPrefix16, ExtendedUNCPathPrefix16Len) ==
+          0) {
     // Convert \\?\UNC\foo\bar to \\foo\bar
     CountChars -= 6;
     Data += 6;
-    Data[0] = '\\';
-  } else if (CountChars >= 4 && ::memcmp(Data, L"\\\\?\\", 8) == 0) {
+    Data[0] = L'\\';
+  } else if (CountChars >= ExtendedPrefix16Len &&
+             ::wmemcmp(Data, ExtendedPrefix16, ExtendedPrefix16Len) == 0) {
     // Convert \\?\C:\foo to C:\foo
     CountChars -= 4;
     Data += 4;
@@ -108,10 +124,8 @@ std::error_code widenPath(const Twine &Path8, SmallVectorImpl<wchar_t> &Path16,
       return mapWindowsError(::GetLastError());
   }
 
-  const char *const LongPathPrefix = "\\\\?\\";
-
   if ((Path16.size() + CurPathLen) < MaxPathLen ||
-      Path8Str.starts_with(LongPathPrefix))
+      Path8Str.starts_with(ExtendedPrefix8))
     return std::error_code();
 
   if (!IsAbsolute) {
@@ -129,11 +143,12 @@ std::error_code widenPath(const Twine &Path8, SmallVectorImpl<wchar_t> &Path16,
   assert(!RootName.empty() &&
          "Root name cannot be empty for an absolute path!");
 
-  SmallString<2 * MAX_PATH> FullPath(LongPathPrefix);
+  SmallString<2 * MAX_PATH> FullPath;
   if (RootName[1] != ':') { // Check if UNC.
-    FullPath.append("UNC\\");
+    FullPath.append(ExtendedUNCPrefix8);
     FullPath.append(Path8Str.begin() + 2, Path8Str.end());
   } else {
+    FullPath.append(ExtendedPrefix8);
     FullPath.append(Path8Str);
   }
 
@@ -142,11 +157,9 @@ std::error_code widenPath(const Twine &Path8, SmallVectorImpl<wchar_t> &Path16,
 
 std::error_code makeLongFormPath(const Twine &Path8,
                                  llvm::SmallVectorImpl<char> &Result8) {
-  constexpr StringLiteral LongPathPrefix = R"(\\?\)";
-
   SmallString<128> PathStorage;
   StringRef PathStr = Path8.toStringRef(PathStorage);
-  bool HadPrefix = PathStr.starts_with(LongPathPrefix);
+  bool HadPrefix = PathStr.starts_with(ExtendedPrefix8);
 
   SmallVector<wchar_t, 128> Path16;
   if (std::error_code EC = widenPath(PathStr, Path16))
@@ -173,7 +186,9 @@ std::error_code makeLongFormPath(const Twine &Path8,
   // On success, GetLongPathNameW returns the number of characters not
   // including the null-terminator.
   Long16.truncate(Len);
-  // Strip \\?\ or \\?\UNC\ prefix if it wasn't part of the original path
+
+  // Strip \\?\ or \\?\UNC\ extended length prefix if it wasn't part of the
+  // original path.
   wchar_t *Data = Long16.data();
   if (!HadPrefix)
     stripExtendedPrefix(Data, Len);

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -60,6 +60,19 @@ static bool is_separator(const wchar_t value) {
   }
 }
 
+static void stripExtendedPrefix(wchar_t *&Data, DWORD &CountChars) {
+  if (CountChars >= 8 && ::memcmp(Data, L"\\\\?\\UNC\\", 16) == 0) {
+    // Convert \\?\UNC\foo\bar to \\foo\bar
+    CountChars -= 6;
+    Data += 6;
+    Data[0] = '\\';
+  } else if (CountChars >= 4 && ::memcmp(Data, L"\\\\?\\", 8) == 0) {
+    // Convert \\?\C:\foo to C:\foo
+    CountChars -= 4;
+    Data += 4;
+  }
+}
+
 namespace llvm {
 namespace sys {
 namespace windows {
@@ -125,6 +138,47 @@ std::error_code widenPath(const Twine &Path8, SmallVectorImpl<wchar_t> &Path16,
   }
 
   return UTF8ToUTF16(FullPath, Path16);
+}
+
+std::error_code makeLongFormPath(const Twine &Path8,
+                                 llvm::SmallVectorImpl<char> &Result8) {
+  constexpr StringLiteral LongPathPrefix = R"(\\?\)";
+
+  SmallString<128> PathStorage;
+  StringRef PathStr = Path8.toStringRef(PathStorage);
+  bool HadPrefix = PathStr.starts_with(LongPathPrefix);
+
+  SmallVector<wchar_t, 128> Path16;
+  if (std::error_code EC = widenPath(PathStr, Path16))
+    return EC;
+
+  // Start with a buffer equal to input.
+  llvm::SmallVector<wchar_t, 128> Long16;
+  DWORD Len = static_cast<DWORD>(Path16.size());
+
+  do {
+    Long16.resize_for_overwrite(Len);
+
+    Len = ::GetLongPathNameW(Path16.data(), Long16.data(), Len);
+
+    // A zero return value indicates a failure other than insufficient space.
+    if (Len == 0)
+      return mapWindowsError(::GetLastError());
+
+    // If there's insufficient space, the len returned is larger than the len
+    // given - in this case len includes the null-terminator. For equality, we
+    // retry defensively.
+  } while (Len >= Long16.size());
+
+  // On success, GetLongPathNameW returns the number of characters not
+  // including the null-terminator.
+  Long16.truncate(Len);
+  // Strip \\?\ or \\?\UNC\ prefix if it wasn't part of the original path
+  wchar_t *Data = Long16.data();
+  if (!HadPrefix)
+    stripExtendedPrefix(Data, Len);
+
+  return sys::windows::UTF16ToUTF8(Data, Len, Result8);
 }
 
 } // end namespace windows
@@ -405,16 +459,7 @@ static std::error_code realPathFromHandle(HANDLE H,
   // paths don't get canonicalized by file APIs.
   wchar_t *Data = Buffer.data();
   DWORD CountChars = Buffer.size();
-  if (CountChars >= 8 && ::memcmp(Data, L"\\\\?\\UNC\\", 16) == 0) {
-    // Convert \\?\UNC\foo\bar to \\foo\bar
-    CountChars -= 6;
-    Data += 6;
-    Data[0] = '\\';
-  } else if (CountChars >= 4 && ::memcmp(Data, L"\\\\?\\", 8) == 0) {
-    // Convert \\?\c:\foo to c:\foo
-    CountChars -= 4;
-    Data += 4;
-  }
+  stripExtendedPrefix(Data, CountChars);
 
   // Convert the result from UTF-16 to UTF-8.
   if (std::error_code EC = UTF16ToUTF8(Data, CountChars, RealPath))
@@ -1619,12 +1664,16 @@ void system_temp_directory(bool ErasedOnReboot, SmallVectorImpl<char> &Result) {
 
   // Check whether the temporary directory is specified by an environment var.
   // This matches GetTempPath logic to some degree. GetTempPath is not used
-  // directly as it cannot handle evn var longer than 130 chars on Windows 7
+  // directly as it cannot handle env var longer than 130 chars on Windows 7
   // (fixed on Windows 8).
   if (getTempDirEnvVar(Result)) {
     assert(!Result.empty() && "Unexpected empty path");
     native(Result); // Some Unix-like shells use Unix path separator in $TMP.
     fs::make_absolute(Result); // Make it absolute if not already.
+    // Expand to long-form. Best-effort; ignore failure.
+    SmallString<260> LongPath;
+    if (!llvm::sys::windows::makeLongFormPath(Result, LongPath))
+      Result.assign(LongPath.begin(), LongPath.end());
     return;
   }
 

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -32,6 +32,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Chrono.h"
 #include "llvm/Support/Windows/WindowsSupport.h"
+#include <fileapi.h>
 #include <windows.h>
 #include <winerror.h>
 #endif
@@ -651,12 +652,115 @@ TEST(SupportDeathTest, TempDirectoryOnWindows) {
   },
     "C:\\Temp");
 
-  // Test evn var / path with 260 chars.
+  // Test env var / path with 260 chars.
   SmallString<270> Expected{"C:\\Temp\\AB\\123456789"};
   while (Expected.size() < 260)
     Expected.append("\\DirNameWith19Charss");
   ASSERT_EQ(260U, Expected.size());
   EXPECT_TEMP_DIR(_putenv_s("TMP", Expected.c_str()), Expected.c_str());
+}
+
+/// Checks whether short 8.3 form names are enabled in the given UTF-8 path.
+/// This is the best way I have found of checking this. Note that short 8.3 form
+/// names can be enabled and disabled on a per-folder, per-volume, and
+/// per-system basis.
+static bool areShortNamesEnabled(llvm::StringRef Path8) {
+  // Create a directory under Path8 with a name long enough that Windows will
+  // provide a short 8.3 form name, if short 8.3 form names are enabled.
+  SmallString<256> Dir(Path8);
+  path::append(Dir, "verylongdir");
+  if (std::error_code EC = fs::create_directories(Dir))
+    return false;
+
+  // Check if the expected short 8.3 form name was created.
+  SmallString<256> Short(Path8);
+  path::append(Short, "verylo~1");
+  bool Result = fs::is_directory(Short);
+
+  fs::remove_directories(Dir);
+  return Result;
+}
+
+/// Returns the short 8.3 form path for the given UTF-8 path, or an empty string
+/// on failure. Uses Win32 GetShortPathNameW.
+static std::string getShortPathName(llvm::StringRef Path8) {
+  // Convert UTF-8 to UTF-16.
+  SmallVector<wchar_t, MAX_PATH> Path16;
+  if (std::error_code EC = sys::windows::widenPath(Path8, Path16))
+    return {};
+
+  // Get the required buffer size for the short 8.3 form path (includes null
+  // terminator).
+  DWORD Required = ::GetShortPathNameW(Path16.data(), nullptr, 0);
+  if (Required == 0)
+    return {};
+
+  SmallVector<wchar_t, MAX_PATH> ShortPath;
+  ShortPath.resize_for_overwrite(Required);
+
+  DWORD Written =
+      ::GetShortPathNameW(Path16.data(), ShortPath.data(), Required);
+  if (Written == 0 || Written >= Required)
+    return {};
+
+  ShortPath.truncate(Written);
+
+  SmallString<128> Utf8Result;
+  if (std::error_code EC = sys::windows::UTF16ToUTF8(
+          ShortPath.data(), ShortPath.size(), Utf8Result))
+    return {};
+
+  return std::string(Utf8Result);
+}
+
+/// Returns true if the two paths refer to the same file or directory by
+/// comparing their UniqueIDs.
+static bool sameEntity(llvm::StringRef P1, llvm::StringRef P2) {
+  fs::UniqueID ID1, ID2;
+  return !fs::getUniqueID(P1, ID1) && !fs::getUniqueID(P2, ID2) && ID1 == ID2;
+}
+
+TEST(SupportDeathTest, Short83FormTempDir) {
+  // Use subprocesses to avoid TMP environment variable pollution.
+
+  SmallString<128> TestDir;
+  ASSERT_NO_ERROR(
+      fs::createUniqueDirectory("short83form-temp-dir-test", TestDir));
+  if (!areShortNamesEnabled(TestDir))
+    GTEST_SKIP() << "Short 8.3 form names not enabled in: " << TestDir;
+
+  // Create a test directory longer than 8 characters for which a distinct
+  // short 8.3 form alias will be created on Windows (typically 123456~1).
+  constexpr StringRef DistinctAliasDir = "123456789"; // >8 chars
+
+  // Capture the short 8.3 form alias.
+  SmallString<256> DistinctAliasPath(TestDir);
+  path::append(DistinctAliasPath, DistinctAliasDir);
+  ASSERT_NO_ERROR(fs::create_directories(DistinctAliasPath));
+  std::string ShortPath = getShortPathName(DistinctAliasPath);
+  ASSERT_FALSE(ShortPath.empty())
+      << "Expected short 8.3 form path for test directory.";
+  ASSERT_NE(DistinctAliasPath, ShortPath)
+      << "Expected a distinct short 8.3 form path.";
+
+  // Case 1: short 8.3 form paths are expanded. Match only the stable tail of
+  // the path. The full path cannot be compared because createUniqueDirectory
+  // adds a unique prefix or suffix which won't match when run in a separate
+  // process.
+  EXPECT_TEMP_DIR(_putenv_s("TMP", ShortPath.c_str()),
+                  std::string(".*") + DistinctAliasDir.str());
+
+  // Create a non-existent path containing a short 8.3 form component.
+  SmallString<256> Unexpandable(ShortPath);
+  path::append(Unexpandable, "NoExists");
+  ASSERT_FALSE(fs::exists(Unexpandable));
+
+  // Case 2: Paths that cannot be expanded to long form (e.g. a non-existent
+  // path) do not result in an error. Match only the stable tail of the path as
+  // above.
+  EXPECT_TEMP_DIR(_putenv_s("TMP", Unexpandable.c_str()),
+                  std::string(".*") + sys::path::filename(ShortPath).str() +
+                      "\\NoExists");
 }
 #endif
 
@@ -2485,6 +2589,78 @@ TEST_F(FileSystemTest, widenPath) {
 #endif
 
 #ifdef _WIN32
+/// Removes the Windows extended path prefix (\\?\ or \\?\UNC\) from the given
+/// UTF-8 path, if present.
+static std::string stripPrefix(llvm::StringRef P) {
+  if (P.starts_with(R"(\\?\UNC\)"))
+    return "\\" + P.drop_front(7).str();
+  if (P.starts_with(R"(\\?\)"))
+    return P.drop_front(4).str();
+  return P.str();
+}
+
+TEST_F(FileSystemTest, makeLongFormPath) {
+  if (!areShortNamesEnabled(TestDirectory.str()))
+    GTEST_SKIP() << "Short 8.3 form names not enabled in: " << TestDirectory;
+
+  // Setup: A test directory longer than 8 characters for which a distinct
+  // short 8.3 form name will be created on Windows. Typically, 123456~1.
+  constexpr const char *OneDir = "\\123456789"; // >8 chars
+
+  // Setup: Create a path where even if all components were reduced to short 8.3
+  // form names, the total length would exceed MAX_PATH.
+  SmallString<MAX_PATH * 2> Deep(TestDirectory);
+  const size_t NLevels = (MAX_PATH / 8) + 1;
+  for (size_t I = 0; I < NLevels; ++I)
+    Deep.append(OneDir);
+
+  ASSERT_NO_ERROR(fs::create_directories(Deep));
+
+  // Setup: Create prefixed and non-prefixed short 8.3 form paths from the deep
+  // test path we just created.
+  std::string DeepShortWithPrefix = getShortPathName(Deep);
+  ASSERT_TRUE(StringRef(DeepShortWithPrefix).starts_with(R"(\\?\)"))
+      << "Expected prefixed short 8.3 form path, got: " << DeepShortWithPrefix;
+  std::string DeepShort = stripPrefix(DeepShortWithPrefix);
+
+  // Setup: Create a short 8.3 form path for the first-level directory.
+  SmallString<256> FirstLevel(TestDirectory);
+  FirstLevel.append(OneDir);
+  std::string Short = getShortPathName(FirstLevel);
+  ASSERT_FALSE(Short.empty())
+      << "Expected short 8.3 form path for test directory.";
+
+  // Case 1: Non-existent short 8.3 form path.
+  SmallString<128> NoExist("NotEre~1");
+  ASSERT_FALSE(fs::exists(NoExist));
+  SmallString<128> NoExistResult;
+  EXPECT_TRUE(windows::makeLongFormPath(NoExist, NoExistResult));
+  EXPECT_TRUE(NoExistResult.empty());
+
+  // Case 2: Valid short 8.3 form path.
+  SmallString<128> ShortResult;
+  ASSERT_FALSE(windows::makeLongFormPath(Short, ShortResult));
+  EXPECT_TRUE(sameEntity(Short, ShortResult));
+
+  // Case 3: Deep short 8.3 form path without \\?\ prefix.
+  SmallString<128> DeepResult;
+  ASSERT_FALSE(windows::makeLongFormPath(DeepShort, DeepResult));
+  EXPECT_TRUE(sameEntity(DeepShort, DeepResult));
+  EXPECT_FALSE(StringRef(DeepResult).starts_with(R"(\\?\)"))
+      << "Expected unprefixed result, got: " << DeepResult;
+
+  // Case 4: Deep short 8.3 form path with \\?\ prefix.
+  SmallString<128> DeepPrefixedResult;
+  ASSERT_FALSE(
+      windows::makeLongFormPath(DeepShortWithPrefix, DeepPrefixedResult));
+  EXPECT_TRUE(sameEntity(DeepShortWithPrefix, DeepPrefixedResult));
+  EXPECT_TRUE(StringRef(DeepPrefixedResult).starts_with(R"(\\?\)"))
+      << "Expected prefixed result, got: " << DeepPrefixedResult;
+
+  // Cleanup.
+  ASSERT_NO_ERROR(fs::remove_directories(TestDirectory.str()));
+}
+
 // Windows refuses lock request if file region is already locked by the same
 // process. POSIX system in this case updates the existing lock.
 TEST_F(FileSystemTest, FileLocker) {


### PR DESCRIPTION
On Windows, the system temporary directory is commonly derived from the `TMP` environment variable. For historical compatibility reasons, this variable is often set to a short 8.3 form path. This is especially common on systems where user names exceed eight characters; for example, a user name of `dunbobbin` may result in `C:\Users\DUNBOB~1\AppData\Local\Temp`.

Short 8.3 form paths are undesirable for distributed compilation scenarios, as they are a local mapping tied to a specific folder on a specific machine, and they can break or defeat sandboxing/path-based isolation used by distributed build systems. Such failures have been observed for DTLTO (https://llvm.org/docs/DTLTO.html), which is the primary motivation for this change. For example, on my machine, running:
```
clang.exe hello.c -flto=thin -fthinlto-distributor=fastbuild.exe -fuse-ld=lld -###
```
results in short 8.3 form paths being passed to LLD (output paraphrased):
```
ld.lld -o a.out -plugin-opt=thinlto \
  --thinlto-distributor=fastbuild.exe \
  --thinlto-remote-compiler=clang.exe \
  C:\Users\DUNBOB~1\AppData\Local\Temp\hello-380d65.o
```
For DTLTO, distribution-specific logic is kept out of LLVM where possible, but path normalization is required for ThinLTO ModuleIDs. The `TMP` environment variable is the main source of short 8.3 form paths, and normalizing here avoids intrusive changes elsewhere.

In addition to distribution, short 8.3 form paths are also confusing and inconvenient to work with; for example, tab completion in the Windows Command Prompt does not work reliably with short 8.3 form paths.

Note that, in practice, especially in automated and CI environments, users often have limited control over their environment variables. Normalizing the system temporary directory path to its long form therefore improves usability and robustness.

SIE internal tracker: TOOLCHAIN-19185