### PR TITLE
[SDAG] Add freeze when simplifying select with undef arms

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -10820,9 +10820,9 @@ SDValue SelectionDAG::simplifySelect(SDValue Cond, SDValue T, SDValue F) {
   if (Cond.isUndef())
     return isConstantValueOfAnyType(T) ? T : F;
   if (T.isUndef())
-    return F;
+    return isGuaranteedNotToBePoison(F) ? F : getFreeze(F);
   if (F.isUndef())
-    return T;
+    return isGuaranteedNotToBePoison(T) ? T : getFreeze(T);
 
   // select true, T, F --> T
   // select false, T, F --> F

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -10815,14 +10815,14 @@ SDValue SelectionDAG::getSetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr,
 
 SDValue SelectionDAG::simplifySelect(SDValue Cond, SDValue T, SDValue F) {
   // select undef, T, F --> T (if T is a constant), otherwise F
-  // select, ?, undef, F --> freeze(F)
-  // select, ?, T, undef --> freeze(T)
+  // select, ?, undef, F --> F
+  // select, ?, T, undef --> T
   if (Cond.isUndef())
     return isConstantValueOfAnyType(T) ? T : F;
   if (T.isUndef())
-    return getFreeze(F);
+    return isGuaranteedNotToBePoison(F) ? F : getFreeze(F);
   if (F.isUndef())
-    return getFreeze(T);
+    return isGuaranteedNotToBePoison(T) ? T : getFreeze(T);
 
   // select true, T, F --> T
   // select false, T, F --> F

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -10815,14 +10815,14 @@ SDValue SelectionDAG::getSetFPEnv(SDValue Chain, const SDLoc &dl, SDValue Ptr,
 
 SDValue SelectionDAG::simplifySelect(SDValue Cond, SDValue T, SDValue F) {
   // select undef, T, F --> T (if T is a constant), otherwise F
-  // select, ?, undef, F --> F
-  // select, ?, T, undef --> T
+  // select, ?, undef, F --> freeze(F)
+  // select, ?, T, undef --> freeze(T)
   if (Cond.isUndef())
     return isConstantValueOfAnyType(T) ? T : F;
   if (T.isUndef())
-    return isGuaranteedNotToBePoison(F) ? F : getFreeze(F);
+    return getFreeze(F);
   if (F.isUndef())
-    return isGuaranteedNotToBePoison(T) ? T : getFreeze(T);
+    return getFreeze(T);
 
   // select true, T, F --> T
   // select false, T, F --> F

--- a/llvm/test/CodeGen/PowerPC/widen-vec-correctly-be.ll
+++ b/llvm/test/CodeGen/PowerPC/widen-vec-correctly-be.ll
@@ -8,18 +8,19 @@
 define void @test() local_unnamed_addr #0 align 2 {
 ; CHECK-BE-LABEL: test:
 ; CHECK-BE:       # %bb.0: # %bb
-; CHECK-BE-NEXT:    lhz r3, 0(r3)
+; CHECK-BE-NEXT:    lwz r3, 0(r3)
 ; CHECK-BE-NEXT:    vspltisw v2, -16
 ; CHECK-BE-NEXT:    addi r3, r3, 1
-; CHECK-BE-NEXT:    xxlxor vs1, vs1, vs1
-; CHECK-BE-NEXT:    vsrw v2, v2, v2
+; CHECK-BE-NEXT:    xxlxor vs0, vs0, vs0
 ; CHECK-BE-NEXT:    sldi r3, r3, 48
 ; CHECK-BE-NEXT:    std r3, -32(r1)
 ; CHECK-BE-NEXT:    std r3, -24(r1)
 ; CHECK-BE-NEXT:    addi r3, r1, -32
-; CHECK-BE-NEXT:    lxvw4x vs0, 0, r3
+; CHECK-BE-NEXT:    lxvw4x v3, 0, r3
 ; CHECK-BE-NEXT:    addi r3, r1, -16
-; CHECK-BE-NEXT:    xxsel vs0, vs0, vs1, v2
+; CHECK-BE-NEXT:    vmrghh v3, v3, v2
+; CHECK-BE-NEXT:    vsrw v2, v2, v2
+; CHECK-BE-NEXT:    xxsel vs0, v3, vs0, v2
 ; CHECK-BE-NEXT:    stxvw4x vs0, 0, r3
 ; CHECK-BE-NEXT:    lwz r3, -16(r1)
 ; CHECK-BE-NEXT:    stw r3, 0(r3)
@@ -30,14 +31,17 @@ define void @test() local_unnamed_addr #0 align 2 {
 ;
 ; CHECK-P9-BE-LABEL: test:
 ; CHECK-P9-BE:       # %bb.0: # %bb
-; CHECK-P9-BE-NEXT:    lhz r3, 0(r3)
-; CHECK-P9-BE-NEXT:    vspltisw v2, -16
-; CHECK-P9-BE-NEXT:    xxlxor vs0, vs0, vs0
+; CHECK-P9-BE-NEXT:    lwz r3, 0(r3)
+; CHECK-P9-BE-NEXT:    vspltisw v3, -16
+; CHECK-P9-BE-NEXT:    xxlxor vs2, vs2, vs2
 ; CHECK-P9-BE-NEXT:    addi r3, r3, 1
-; CHECK-P9-BE-NEXT:    vsrw v2, v2, v2
-; CHECK-P9-BE-NEXT:    sldi r3, r3, 48
-; CHECK-P9-BE-NEXT:    mtfprd f1, r3
-; CHECK-P9-BE-NEXT:    xxsel v2, vs1, vs0, v2
+; CHECK-P9-BE-NEXT:    vsrw v3, v3, v3
+; CHECK-P9-BE-NEXT:    mtfprwz f0, r3
+; CHECK-P9-BE-NEXT:    addis r3, r2, .LCPI0_0@toc@ha
+; CHECK-P9-BE-NEXT:    addi r3, r3, .LCPI0_0@toc@l
+; CHECK-P9-BE-NEXT:    lxv vs1, 0(r3)
+; CHECK-P9-BE-NEXT:    xxperm v2, vs0, vs1
+; CHECK-P9-BE-NEXT:    xxsel v2, v2, vs2, v3
 ; CHECK-P9-BE-NEXT:    xxsldwi vs0, v2, v2, 3
 ; CHECK-P9-BE-NEXT:    stfiwx f0, 0, r3
 ; CHECK-P9-BE-NEXT:    .p2align 4

--- a/llvm/test/CodeGen/X86/fshl.ll
+++ b/llvm/test/CodeGen/X86/fshl.ll
@@ -571,16 +571,16 @@ define i64 @const_shift_i64(i64 %x, i64 %y) nounwind {
 ; X86-SLOW-LABEL: const_shift_i64:
 ; X86-SLOW:       # %bb.0:
 ; X86-SLOW-NEXT:    pushl %esi
+; X86-SLOW-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-SLOW-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; X86-SLOW-NEXT:    movl {{[0-9]+}}(%esp), %edx
-; X86-SLOW-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SLOW-NEXT:    movl %ecx, %esi
 ; X86-SLOW-NEXT:    shrl $25, %esi
-; X86-SLOW-NEXT:    movl %ecx, %eax
-; X86-SLOW-NEXT:    shll $7, %eax
-; X86-SLOW-NEXT:    orl %esi, %eax
-; X86-SLOW-NEXT:    shrl $25, %ecx
 ; X86-SLOW-NEXT:    shll $7, %edx
-; X86-SLOW-NEXT:    orl %ecx, %edx
+; X86-SLOW-NEXT:    orl %esi, %edx
+; X86-SLOW-NEXT:    shll $7, %ecx
+; X86-SLOW-NEXT:    shrl $25, %eax
+; X86-SLOW-NEXT:    orl %ecx, %eax
 ; X86-SLOW-NEXT:    popl %esi
 ; X86-SLOW-NEXT:    retl
 ;

--- a/llvm/test/CodeGen/X86/funnel-shift.ll
+++ b/llvm/test/CodeGen/X86/funnel-shift.ll
@@ -262,9 +262,9 @@ define i32 @fshl_i32_const_overshift(i32 %x, i32 %y) nounwind {
 define i64 @fshl_i64_const_overshift(i64 %x, i64 %y) nounwind {
 ; X86-SSE2-LABEL: fshl_i64_const_overshift:
 ; X86-SSE2:       # %bb.0:
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; X86-SSE2-NEXT:    shldl $9, %ecx, %edx
 ; X86-SSE2-NEXT:    shrdl $23, %ecx, %eax
 ; X86-SSE2-NEXT:    retl
@@ -1004,9 +1004,9 @@ define i32 @fshr_i32_const_overshift(i32 %x, i32 %y) nounwind {
 define i64 @fshr_i64_const_overshift(i64 %x, i64 %y) nounwind {
 ; X86-SSE2-LABEL: fshr_i64_const_overshift:
 ; X86-SSE2:       # %bb.0:
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edx
-; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-SSE2-NEXT:    shrdl $9, %ecx, %eax
 ; X86-SSE2-NEXT:    shldl $23, %ecx, %edx
 ; X86-SSE2-NEXT:    retl

--- a/llvm/test/CodeGen/X86/select.ll
+++ b/llvm/test/CodeGen/X86/select.ll
@@ -2198,3 +2198,67 @@ define i32 @select_uaddo_common_op1(i32 %a, i32 %b, i32 %c, i1 %cond) {
   %sel = select i1 %cond, i32 %ab0, i32 %cb0
   ret i32 %sel
 }
+
+define i56 @select_undef_rhs(i64 %x, i1 %cmp) {
+; GENERIC-LABEL: select_undef_rhs:
+; GENERIC:       ## %bb.0:
+; GENERIC-NEXT:    movq %rdi, %rax
+; GENERIC-NEXT:    retq
+;
+; ATOM-LABEL: select_undef_rhs:
+; ATOM:       ## %bb.0:
+; ATOM-NEXT:    movq %rdi, %rax
+; ATOM-NEXT:    nop
+; ATOM-NEXT:    nop
+; ATOM-NEXT:    nop
+; ATOM-NEXT:    nop
+; ATOM-NEXT:    nop
+; ATOM-NEXT:    nop
+; ATOM-NEXT:    retq
+;
+; ATHLON-LABEL: select_undef_rhs:
+; ATHLON:       ## %bb.0:
+; ATHLON-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; ATHLON-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; ATHLON-NEXT:    retl
+;
+; MCU-LABEL: select_undef_rhs:
+; MCU:       # %bb.0:
+; MCU-NEXT:    retl
+  %trunc = trunc nuw i64 %x to i48
+  %sel = select i1 %cmp, i48 %trunc, i48 undef
+  %zext = zext i48 %sel to i56
+  ret i56 %zext
+}
+
+define i56 @select_undef_lhs(i64 %x, i1 %cmp) {
+; GENERIC-LABEL: select_undef_lhs:
+; GENERIC:       ## %bb.0:
+; GENERIC-NEXT:    movq %rdi, %rax
+; GENERIC-NEXT:    retq
+;
+; ATOM-LABEL: select_undef_lhs:
+; ATOM:       ## %bb.0:
+; ATOM-NEXT:    movq %rdi, %rax
+; ATOM-NEXT:    nop
+; ATOM-NEXT:    nop
+; ATOM-NEXT:    nop
+; ATOM-NEXT:    nop
+; ATOM-NEXT:    nop
+; ATOM-NEXT:    nop
+; ATOM-NEXT:    retq
+;
+; ATHLON-LABEL: select_undef_lhs:
+; ATHLON:       ## %bb.0:
+; ATHLON-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; ATHLON-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; ATHLON-NEXT:    retl
+;
+; MCU-LABEL: select_undef_lhs:
+; MCU:       # %bb.0:
+; MCU-NEXT:    retl
+  %trunc = trunc nuw i64 %x to i48
+  %sel = select i1 %cmp, i48 undef, i48 %trunc
+  %zext = zext i48 %sel to i56
+  ret i56 %zext
+}

--- a/llvm/test/CodeGen/X86/select.ll
+++ b/llvm/test/CodeGen/X86/select.ll
@@ -2202,14 +2202,14 @@ define i32 @select_uaddo_common_op1(i32 %a, i32 %b, i32 %c, i1 %cond) {
 define i56 @select_undef_rhs(i64 %x, i1 %cmp) {
 ; GENERIC-LABEL: select_undef_rhs:
 ; GENERIC:       ## %bb.0:
-; GENERIC-NEXT:    movq %rdi, %rax
+; GENERIC-NEXT:    movabsq $281474976710655, %rax ## imm = 0xFFFFFFFFFFFF
+; GENERIC-NEXT:    andq %rdi, %rax
 ; GENERIC-NEXT:    retq
 ;
 ; ATOM-LABEL: select_undef_rhs:
 ; ATOM:       ## %bb.0:
-; ATOM-NEXT:    movq %rdi, %rax
-; ATOM-NEXT:    nop
-; ATOM-NEXT:    nop
+; ATOM-NEXT:    movabsq $281474976710655, %rax ## imm = 0xFFFFFFFFFFFF
+; ATOM-NEXT:    andq %rdi, %rax
 ; ATOM-NEXT:    nop
 ; ATOM-NEXT:    nop
 ; ATOM-NEXT:    nop
@@ -2219,11 +2219,13 @@ define i56 @select_undef_rhs(i64 %x, i1 %cmp) {
 ; ATHLON-LABEL: select_undef_rhs:
 ; ATHLON:       ## %bb.0:
 ; ATHLON-NEXT:    movl {{[0-9]+}}(%esp), %eax
-; ATHLON-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; ATHLON-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; ATHLON-NEXT:    movzwl %cx, %edx
 ; ATHLON-NEXT:    retl
 ;
 ; MCU-LABEL: select_undef_rhs:
 ; MCU:       # %bb.0:
+; MCU-NEXT:    movzwl %dx, %edx
 ; MCU-NEXT:    retl
   %trunc = trunc nuw i64 %x to i48
   %sel = select i1 %cmp, i48 %trunc, i48 undef
@@ -2234,14 +2236,14 @@ define i56 @select_undef_rhs(i64 %x, i1 %cmp) {
 define i56 @select_undef_lhs(i64 %x, i1 %cmp) {
 ; GENERIC-LABEL: select_undef_lhs:
 ; GENERIC:       ## %bb.0:
-; GENERIC-NEXT:    movq %rdi, %rax
+; GENERIC-NEXT:    movabsq $281474976710655, %rax ## imm = 0xFFFFFFFFFFFF
+; GENERIC-NEXT:    andq %rdi, %rax
 ; GENERIC-NEXT:    retq
 ;
 ; ATOM-LABEL: select_undef_lhs:
 ; ATOM:       ## %bb.0:
-; ATOM-NEXT:    movq %rdi, %rax
-; ATOM-NEXT:    nop
-; ATOM-NEXT:    nop
+; ATOM-NEXT:    movabsq $281474976710655, %rax ## imm = 0xFFFFFFFFFFFF
+; ATOM-NEXT:    andq %rdi, %rax
 ; ATOM-NEXT:    nop
 ; ATOM-NEXT:    nop
 ; ATOM-NEXT:    nop
@@ -2251,11 +2253,13 @@ define i56 @select_undef_lhs(i64 %x, i1 %cmp) {
 ; ATHLON-LABEL: select_undef_lhs:
 ; ATHLON:       ## %bb.0:
 ; ATHLON-NEXT:    movl {{[0-9]+}}(%esp), %eax
-; ATHLON-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; ATHLON-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; ATHLON-NEXT:    movzwl %cx, %edx
 ; ATHLON-NEXT:    retl
 ;
 ; MCU-LABEL: select_undef_lhs:
 ; MCU:       # %bb.0:
+; MCU-NEXT:    movzwl %dx, %edx
 ; MCU-NEXT:    retl
   %trunc = trunc nuw i64 %x to i48
   %sel = select i1 %cmp, i48 undef, i48 %trunc


### PR DESCRIPTION
Consider the following pattern:
```
%trunc = trunc nuw i64 %x to i48
%sel = select i1 %cmp, i48 %trunc, i48 undef
```
We cannot simplify `%sel` to `%trunc` as `%trunc` may be poison, which cannot be refined into undef.

This patch checks whether the replacement may be poison. If so, it will insert a freeze.
We may need SDAG's version of `impliesPoison` if it causes significant regressions.
Compile-time impact: https://llvm-compile-time-tracker.com/compare.php?from=ded109c0cff41714ebf9bd60b073aaab07fa4ca8&to=103e605ce6b33bc9145526faf805ee38b972c215&stat=instructions%3Au

Closes https://github.com/llvm/llvm-project/issues/175018.
