### PR TITLE
[-Wunsafe-buffer-usage] Allow strerror for %s in printf-like calls

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -773,9 +773,7 @@ static bool isNullTermPointer(const Expr *Ptr, ASTContext &Ctx) {
   }
 
   // Functions known to return properly null terminated strings.
-  static const llvm::StringSet<> NullTermFunctions = {
-    "strerror"
-  };
+  static const llvm::StringSet<> NullTermFunctions = {"strerror"};
   if (auto *CE = dyn_cast<CallExpr>(Ptr->IgnoreParenImpCasts())) {
     const FunctionDecl *F = CE->getDirectCallee();
     if (F && F->getIdentifier() && NullTermFunctions.contains(F->getName()))

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -771,9 +771,14 @@ static bool isNullTermPointer(const Expr *Ptr, ASTContext &Ctx) {
       if (MD->getName() == "c_str" && RD->getName() == "basic_string")
         return true;
   }
+
+  // Functions known to return properly null terminated strings.
+  static const llvm::StringSet<> NullTermFunctions = {
+    "strerror"
+  };
   if (auto *CE = dyn_cast<CallExpr>(Ptr->IgnoreParenImpCasts())) {
     const FunctionDecl *F = CE->getDirectCallee();
-    if (F && F->getIdentifier() && F->getName() == "strerror")
+    if (F && F->getIdentifier() && NullTermFunctions.contains(F->getName()))
       return true;
   }
   return false;

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -771,6 +771,11 @@ static bool isNullTermPointer(const Expr *Ptr, ASTContext &Ctx) {
       if (MD->getName() == "c_str" && RD->getName() == "basic_string")
         return true;
   }
+  if (auto *CE = dyn_cast<CallExpr>(Ptr->IgnoreParenImpCasts())) {
+    const FunctionDecl *F = CE->getDirectCallee();
+    if (F && F->getName() == "strerror")
+      return true;
+  }
   return false;
 }
 

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -773,7 +773,7 @@ static bool isNullTermPointer(const Expr *Ptr, ASTContext &Ctx) {
   }
   if (auto *CE = dyn_cast<CallExpr>(Ptr->IgnoreParenImpCasts())) {
     const FunctionDecl *F = CE->getDirectCallee();
-    if (F && F->getName() == "strerror")
+    if (F && F->getIdentifier() && F->getName() == "strerror")
       return true;
   }
   return false;

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
@@ -298,6 +298,10 @@ void test_format_attr(char * Str, std::string StdStr) {
   myprintf("hello %s", Str);  // expected-warning{{function 'myprintf' is unsafe}} \
 			         expected-note{{string argument is not guaranteed to be null-terminated}}
 
+  extern int errno;
+  extern char *strerror(int errnum);
+  myprintf("errno: %s", strerror(errno));
+
   myprintf_2("hello", 0, Str);
   myprintf_2("hello %s", 0, StdStr.c_str());
   myprintf_2("hello %s", 0, Str);  // expected-warning{{function 'myprintf_2' is unsafe}} \


### PR DESCRIPTION
Passing strerror(errno) to printf of printf-like logging functions is a common pattern, and strerror() returns a null-terminated string.

Follow-up to #173096