### PR TITLE
[flang] Visit "source" member in all AST nodes

### DIFF
--- a/flang/include/flang/Parser/parse-tree-visitor.h
+++ b/flang/include/flang/Parser/parse-tree-visitor.h
@@ -65,7 +65,6 @@ struct ParseTreeVisitorLookupScope {
       Walk(x.source, visitor);
     }
   }
-
   template <typename A, typename M>
   static void WalkSource(A &x, M &mutator) {
     if constexpr (HasSource<A>::value) {

--- a/flang/include/flang/Parser/parse-tree-visitor.h
+++ b/flang/include/flang/Parser/parse-tree-visitor.h
@@ -10,6 +10,7 @@
 #define FORTRAN_PARSER_PARSE_TREE_VISITOR_H_
 
 #include "parse-tree.h"
+#include "tools.h"
 #include "flang/Common/enum-set.h"
 #include "flang/Common/visit.h"
 #include <cstddef>
@@ -168,12 +169,18 @@ struct ParseTreeVisitorLookupScope {
   template <typename A, typename V>
   static std::enable_if_t<EmptyTrait<A>> Walk(const A &x, V &visitor) {
     if (visitor.Pre(x)) {
+      if constexpr (HasSource<A>::value) {
+        Walk(x.source, visitor);
+      }
       visitor.Post(x);
     }
   }
   template <typename A, typename M>
   static std::enable_if_t<EmptyTrait<A>> Walk(A &x, M &mutator) {
     if (mutator.Pre(x)) {
+      if constexpr (HasSource<A>::value) {
+        Walk(x.source, mutator);
+      }
       mutator.Post(x);
     }
   }
@@ -182,6 +189,9 @@ struct ParseTreeVisitorLookupScope {
   static std::enable_if_t<TupleTrait<A>> Walk(const A &x, V &visitor) {
     if (visitor.Pre(x)) {
       Walk(x.t, visitor);
+      if constexpr (HasSource<A>::value) {
+        Walk(x.source, visitor);
+      }
       visitor.Post(x);
     }
   }
@@ -189,6 +199,9 @@ struct ParseTreeVisitorLookupScope {
   static std::enable_if_t<TupleTrait<A>> Walk(A &x, M &mutator) {
     if (mutator.Pre(x)) {
       Walk(x.t, mutator);
+      if constexpr (HasSource<A>::value) {
+        Walk(x.source, mutator);
+      }
       mutator.Post(x);
     }
   }
@@ -197,6 +210,9 @@ struct ParseTreeVisitorLookupScope {
   static std::enable_if_t<UnionTrait<A>> Walk(const A &x, V &visitor) {
     if (visitor.Pre(x)) {
       Walk(x.u, visitor);
+      if constexpr (HasSource<A>::value) {
+        Walk(x.source, visitor);
+      }
       visitor.Post(x);
     }
   }
@@ -204,6 +220,9 @@ struct ParseTreeVisitorLookupScope {
   static std::enable_if_t<UnionTrait<A>> Walk(A &x, M &mutator) {
     if (mutator.Pre(x)) {
       Walk(x.u, mutator);
+      if constexpr (HasSource<A>::value) {
+        Walk(x.source, mutator);
+      }
       mutator.Post(x);
     }
   }
@@ -212,6 +231,9 @@ struct ParseTreeVisitorLookupScope {
   static std::enable_if_t<WrapperTrait<A>> Walk(const A &x, V &visitor) {
     if (visitor.Pre(x)) {
       Walk(x.v, visitor);
+      if constexpr (HasSource<A>::value) {
+        Walk(x.source, visitor);
+      }
       visitor.Post(x);
     }
   }
@@ -219,6 +241,9 @@ struct ParseTreeVisitorLookupScope {
   static std::enable_if_t<WrapperTrait<A>> Walk(A &x, M &mutator) {
     if (mutator.Pre(x)) {
       Walk(x.v, mutator);
+      if constexpr (HasSource<A>::value) {
+        Walk(x.source, mutator);
+      }
       mutator.Post(x);
     }
   }
@@ -227,6 +252,9 @@ struct ParseTreeVisitorLookupScope {
   static std::enable_if_t<ConstraintTrait<A>> Walk(const A &x, V &visitor) {
     if (visitor.Pre(x)) {
       Walk(x.thing, visitor);
+      if constexpr (HasSource<A>::value) {
+        Walk(x.source, visitor);
+      }
       visitor.Post(x);
     }
   }
@@ -234,6 +262,9 @@ struct ParseTreeVisitorLookupScope {
   static std::enable_if_t<ConstraintTrait<A>> Walk(A &x, M &mutator) {
     if (mutator.Pre(x)) {
       Walk(x.thing, mutator);
+      if constexpr (HasSource<A>::value) {
+        Walk(x.source, mutator);
+      }
       mutator.Post(x);
     }
   }

--- a/flang/include/flang/Parser/parse-tree-visitor.h
+++ b/flang/include/flang/Parser/parse-tree-visitor.h
@@ -59,16 +59,10 @@ struct ParseTreeVisitorLookupScope {
     }
   }
 
-  template <typename A, typename V>
-  static void WalkSource(const A &x, V &visitor) {
+  template <typename A, typename VM>
+  static void WalkSource(A &x, VM &visitorOrMutator) {
     if constexpr (HasSource<A>::value) {
-      Walk(x.source, visitor);
-    }
-  }
-  template <typename A, typename M>
-  static void WalkSource(A &x, M &mutator) {
-    if constexpr (HasSource<A>::value) {
-      Walk(x.source, mutator);
+      Walk(x.source, visitorOrMutator);
     }
   }
 

--- a/flang/include/flang/Parser/parse-tree-visitor.h
+++ b/flang/include/flang/Parser/parse-tree-visitor.h
@@ -59,6 +59,20 @@ struct ParseTreeVisitorLookupScope {
     }
   }
 
+  template <typename A, typename V>
+  static void WalkSource(const A &x, V &visitor) {
+    if constexpr (HasSource<A>::value) {
+      Walk(x.source, visitor);
+    }
+  }
+
+  template <typename A, typename M>
+  static void WalkSource(A &x, M &mutator) {
+    if constexpr (HasSource<A>::value) {
+      Walk(x.source, mutator);
+    }
+  }
+
   // Traversal of needed STL template classes (optional, list, tuple, variant)
   // For most lists, just traverse the elements; but when a list constitutes
   // a Block (i.e., std::list<ExecutionPartConstruct>), also invoke the
@@ -169,18 +183,14 @@ struct ParseTreeVisitorLookupScope {
   template <typename A, typename V>
   static std::enable_if_t<EmptyTrait<A>> Walk(const A &x, V &visitor) {
     if (visitor.Pre(x)) {
-      if constexpr (HasSource<A>::value) {
-        Walk(x.source, visitor);
-      }
+      WalkSource(x, visitor);
       visitor.Post(x);
     }
   }
   template <typename A, typename M>
   static std::enable_if_t<EmptyTrait<A>> Walk(A &x, M &mutator) {
     if (mutator.Pre(x)) {
-      if constexpr (HasSource<A>::value) {
-        Walk(x.source, mutator);
-      }
+      WalkSource(x, mutator);
       mutator.Post(x);
     }
   }
@@ -188,20 +198,16 @@ struct ParseTreeVisitorLookupScope {
   template <typename A, typename V>
   static std::enable_if_t<TupleTrait<A>> Walk(const A &x, V &visitor) {
     if (visitor.Pre(x)) {
+      WalkSource(x, visitor);
       Walk(x.t, visitor);
-      if constexpr (HasSource<A>::value) {
-        Walk(x.source, visitor);
-      }
       visitor.Post(x);
     }
   }
   template <typename A, typename M>
   static std::enable_if_t<TupleTrait<A>> Walk(A &x, M &mutator) {
     if (mutator.Pre(x)) {
+      WalkSource(x, mutator);
       Walk(x.t, mutator);
-      if constexpr (HasSource<A>::value) {
-        Walk(x.source, mutator);
-      }
       mutator.Post(x);
     }
   }
@@ -209,20 +215,16 @@ struct ParseTreeVisitorLookupScope {
   template <typename A, typename V>
   static std::enable_if_t<UnionTrait<A>> Walk(const A &x, V &visitor) {
     if (visitor.Pre(x)) {
+      WalkSource(x, visitor);
       Walk(x.u, visitor);
-      if constexpr (HasSource<A>::value) {
-        Walk(x.source, visitor);
-      }
       visitor.Post(x);
     }
   }
   template <typename A, typename M>
   static std::enable_if_t<UnionTrait<A>> Walk(A &x, M &mutator) {
     if (mutator.Pre(x)) {
+      WalkSource(x, mutator);
       Walk(x.u, mutator);
-      if constexpr (HasSource<A>::value) {
-        Walk(x.source, mutator);
-      }
       mutator.Post(x);
     }
   }
@@ -230,20 +232,16 @@ struct ParseTreeVisitorLookupScope {
   template <typename A, typename V>
   static std::enable_if_t<WrapperTrait<A>> Walk(const A &x, V &visitor) {
     if (visitor.Pre(x)) {
+      WalkSource(x, visitor);
       Walk(x.v, visitor);
-      if constexpr (HasSource<A>::value) {
-        Walk(x.source, visitor);
-      }
       visitor.Post(x);
     }
   }
   template <typename A, typename M>
   static std::enable_if_t<WrapperTrait<A>> Walk(A &x, M &mutator) {
     if (mutator.Pre(x)) {
+      WalkSource(x, mutator);
       Walk(x.v, mutator);
-      if constexpr (HasSource<A>::value) {
-        Walk(x.source, mutator);
-      }
       mutator.Post(x);
     }
   }
@@ -251,20 +249,16 @@ struct ParseTreeVisitorLookupScope {
   template <typename A, typename V>
   static std::enable_if_t<ConstraintTrait<A>> Walk(const A &x, V &visitor) {
     if (visitor.Pre(x)) {
+      WalkSource(x, visitor);
       Walk(x.thing, visitor);
-      if constexpr (HasSource<A>::value) {
-        Walk(x.source, visitor);
-      }
       visitor.Post(x);
     }
   }
   template <typename A, typename M>
   static std::enable_if_t<ConstraintTrait<A>> Walk(A &x, M &mutator) {
     if (mutator.Pre(x)) {
+      WalkSource(x, mutator);
       Walk(x.thing, mutator);
-      if constexpr (HasSource<A>::value) {
-        Walk(x.source, mutator);
-      }
       mutator.Post(x);
     }
   }


### PR DESCRIPTION
Some AST nodes had their "source" member visited by the parse tree visitor, while others, in particular those that were handled by the trait-based visitors, did not.

Make sure that we call the Walk function on the "source" member for all classes that have it.