### PR TITLE
[mlir][interface] Add getNonSuccessorInputs API to RegionBranchOpInterface

### DIFF
--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
@@ -379,13 +379,12 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
     ::mlir::OperandRange getSuccessorOperands(
         ::mlir::RegionBranchPoint src, ::mlir::RegionSuccessor dest);
 
-    /// Return the non-forwarded values from the source branch point to the
-    /// destination region successor.
+    /// Return all successor inputs for the given region successor.
     ///
-    /// If the `RegionSuccessor` is a region, it will return non-forwarded
-    /// arguments, if it is a parent, it will return non-forwarded results.
+    /// If the "successor" is a region, it will return non-forwarded arguments,
+    /// if it is a "parent", it will return non-forwarded results.
     ::llvm::SmallVector<Value> getNonSuccessorInputs(
-        ::mlir::RegionSuccessor dest);
+        ::mlir::RegionSuccessor successor);
 
     /// Build a mapping from successor operands to successor input. Each
     /// successor operand could be forwarded to multiple successor inputs.

--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
@@ -379,6 +379,14 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
     ::mlir::OperandRange getSuccessorOperands(
         ::mlir::RegionBranchPoint src, ::mlir::RegionSuccessor dest);
 
+    /// Return the non-forwarded values from the source branch point to the
+    /// destination region successor.
+    ///
+    /// If the `RegionSuccessor` is a region, it will return non-forwarded
+    /// arguments, if it is a parent, it will return non-forwarded results.
+    ::llvm::SmallVector<Value> getRegionNonForwardedValues(
+        ::mlir::RegionBranchPoint src, ::mlir::RegionSuccessor dest);
+
     /// Build a mapping from successor operands to successor input. Each
     /// successor operand could be forwarded to multiple successor inputs.
     /// Operands that are not forwarded are not added to the map. Unless a

--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
@@ -384,8 +384,8 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
     ///
     /// If the `RegionSuccessor` is a region, it will return non-forwarded
     /// arguments, if it is a parent, it will return non-forwarded results.
-    ::llvm::SmallVector<Value> getRegionNonForwardedValues(
-        ::mlir::RegionBranchPoint src, ::mlir::RegionSuccessor dest);
+    ::llvm::SmallVector<Value> getNonSuccessorInputs(
+        ::mlir::RegionSuccessor dest);
 
     /// Build a mapping from successor operands to successor input. Each
     /// successor operand could be forwarded to multiple successor inputs.

--- a/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
@@ -617,10 +617,8 @@ void AbstractSparseBackwardDataFlowAnalysis::visitRegionSuccessors(
     auto ValueToArgument = [](Value value) {
       return cast<BlockArgument>(value);
     };
-    SmallVector<BlockArgument> noControlFlowArguments =
-        llvm::map_to_vector(branch.getRegionNonForwardedValues(
-                                RegionBranchPoint::parent(), successor),
-                            ValueToArgument);
+    SmallVector<BlockArgument> noControlFlowArguments = llvm::map_to_vector(
+        branch.getNonSuccessorInputs(successor), ValueToArgument);
     visitNonControlFlowArguments(successor, noControlFlowArguments);
   }
 

--- a/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
@@ -329,8 +329,9 @@ void AbstractSparseForwardDataFlowAnalysis::visitRegionSuccessors(
       }
     }
 
-    for (auto it : llvm::zip(*operands, lattices.drop_front(firstIndex)))
-      join(std::get<1>(it), *getLatticeElementFor(point, std::get<0>(it)));
+    for (auto [lattice, operand] :
+         llvm::zip(lattices.drop_front(firstIndex), *operands))
+      join(lattice, *getLatticeElementFor(point, operand));
   }
 }
 
@@ -606,7 +607,6 @@ void AbstractSparseBackwardDataFlowAnalysis::visitRegionSuccessors(
       unaccounted.reset(operand->getOperandNumber());
     }
   }
-
   Operation *op = branch.getOperation();
   SmallVector<RegionSuccessor> successors;
   SmallVector<Attribute> operands(op->getNumOperands(), nullptr);
@@ -614,17 +614,13 @@ void AbstractSparseBackwardDataFlowAnalysis::visitRegionSuccessors(
   for (RegionSuccessor &successor : successors) {
     if (successor.isParent())
       continue;
-    SmallVector<BlockArgument> noControlFlowArguments;
-    MutableArrayRef<BlockArgument> arguments =
-        successor.getSuccessor()->getArguments();
-    ValueRange inputs = branch.getSuccessorInputs(successor);
-    for (BlockArgument argument : arguments) {
-      // Visit blockArgument of RegionBranchOp which isn't "control
-      // flow block arguments". For example, the IV of a loop.
-      if (!llvm::is_contained(inputs, argument)) {
-        noControlFlowArguments.push_back(argument);
-      }
-    }
+    auto ValueToArgument = [](Value value) {
+      return cast<BlockArgument>(value);
+    };
+    SmallVector<BlockArgument> noControlFlowArguments =
+        llvm::map_to_vector(branch.getRegionNonForwardedValues(
+                                RegionBranchPoint::parent(), successor),
+                            ValueToArgument);
     visitNonControlFlowArguments(successor, noControlFlowArguments);
   }
 

--- a/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
@@ -614,11 +614,11 @@ void AbstractSparseBackwardDataFlowAnalysis::visitRegionSuccessors(
   for (RegionSuccessor &successor : successors) {
     if (successor.isParent())
       continue;
-    auto ValueToArgument = [](Value value) {
+    auto valueToArgument = [](Value value) {
       return cast<BlockArgument>(value);
     };
     SmallVector<BlockArgument> noControlFlowArguments = llvm::map_to_vector(
-        branch.getNonSuccessorInputs(successor), ValueToArgument);
+        branch.getNonSuccessorInputs(successor), valueToArgument);
     visitNonControlFlowArguments(successor, noControlFlowArguments);
   }
 

--- a/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
+++ b/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
@@ -443,14 +443,15 @@ RegionBranchOpInterface::getSuccessorOperands(RegionBranchPoint src,
 }
 
 SmallVector<Value>
-RegionBranchOpInterface::getNonSuccessorInputs(RegionSuccessor dest) {
+RegionBranchOpInterface::getNonSuccessorInputs(RegionSuccessor successor) {
   SmallVector<Value> results = llvm::to_vector(
-      dest.isParent() ? ValueRange(getOperation()->getResults())
-                      : ValueRange(dest.getSuccessor()->getArguments()));
-  ValueRange successorInputs = getSuccessorInputs(dest);
+      successor.isParent()
+          ? ValueRange(getOperation()->getResults())
+          : ValueRange(successor.getSuccessor()->getArguments()));
+  ValueRange successorInputs = getSuccessorInputs(successor);
   if (!successorInputs.empty()) {
     unsigned inputBegin =
-        dest.isParent()
+        successor.isParent()
             ? cast<OpResult>(successorInputs.front()).getResultNumber()
             : cast<BlockArgument>(successorInputs.front()).getArgNumber();
     results.erase(results.begin() + inputBegin,


### PR DESCRIPTION
Add getNonSuccessorInputs API to RegionBranchOpInterface.It is used to return the non-forwarded arguments or results.