### PR TITLE
[flang] Handle useless NAMELIST in interface block

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -9872,6 +9872,9 @@ void ResolveNamesVisitor::FinishSpecificationPart(
   misparsedStmtFuncFound_ = false;
   funcResultStack().CompleteFunctionResultType();
   CheckImports();
+  if (inInterfaceBlock()) {
+    FinishNamelists(); // NAMELIST is useless in an interface, but allowed
+  }
   for (auto &pair : currScope()) {
     auto &symbol{*pair.second};
     if (inInterfaceBlock()) {

--- a/flang/test/Semantics/bug175207.f90
+++ b/flang/test/Semantics/bug175207.f90
@@ -1,0 +1,10 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1
+interface
+  subroutine sub(x)
+    real x
+    namelist /useless/x ! ok, but don't crash
+    !ERROR: 'sub' is not a variable
+    namelist /bad/sub
+  end
+end interface
+end


### PR DESCRIPTION
NAMELIST has no useful purpose in an interface block, but it's allowed.  Fix a crash due to our deferred handling of NAMELIST groups in the execution part (which doesn't exist in an interface block).

Fixes https://github.com/llvm/llvm-project/issues/175207.