### PR TITLE
[AArch64][llvm] Add extra dependencies for recently added features

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -599,7 +599,7 @@ def FeatureMPAMv2: ExtensionWithMArch<"mpamv2", "MPAMv2", "FEAT_MPAMv2",
   "Enable Armv9.7-A MPAMv2 Lookaside Buffer Invalidate instructions">;
 
 def FeatureMTETC: ExtensionWithMArch<"mtetc", "MTETC", "FEAT_MTETC",
-  "Enable Virtual Memory Tagging Extension">;
+  "Enable Virtual Memory Tagging Extension", [FeatureMTE]>;
 
 def FeatureGCIE: ExtensionWithMArch<"gcie", "GCIE", "FEAT_GCIE",
   "Enable GICv5 (Generic Interrupt Controller) CPU Interface Extension">;
@@ -627,7 +627,7 @@ def FeatureF16F32MM : ExtensionWithMArch<"f16f32mm", "F16F32MM", "FEAT_F16F32MM"
 //===----------------------------------------------------------------------===//
 
 def FeatureMOPS_GO: ExtensionWithMArch<"mops-go", "MOPS_GO", "FEAT_MOPS_GO",
-  "Enable memset acceleration granule only">;
+  "Enable memset acceleration granule only", [FeatureMOPS, FeatureMTE]>;
 
 def FeatureBTIE: ExtensionWithMArch<"btie", "BTIE", "FEAT_BTIE",
   "Enable Enhanced Branch Target Identification extension">;

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2206,6 +2206,15 @@ AArch64ExtensionDependenciesBaseArchTestParams
         {AArch64::ARMV8A, {"nolse", "lse128"}, {"lse", "lse128"}, {}},
         {AArch64::ARMV8A, {"lse128", "nolse"}, {}, {"lse", "lse128"}},
 
+        // mtetc -> mte
+        {AArch64::ARMV9_7A, {"nomemtag", "mtetc"}, {"mte"}, {}},
+
+        // mops-go -> mops, mte
+        {AArch64::ARMV9_7A,
+         {"nomops", "nomemtag", "mops-go"},
+         {"mops", "mte"},
+         {}},
+
         // predres -> predres2
         {AArch64::ARMV8A,
          {"nopredres", "predres2"},


### PR DESCRIPTION
Add a couple of extra dependencies, for recently added features:
```
   FeatureMTETC   -> enable FeatureMTE (aka memtag)
   FeatureMOPS_GO -> enable FeatureMTE and FeatureMOPS
```