### PR TITLE
[llvm][formatters] Add LLDB formatter for llvm::PointerUnion

### DIFF
--- a/cross-project-tests/debuginfo-tests/llvm-prettyprinters/lldb/CMakeLists.txt
+++ b/cross-project-tests/debuginfo-tests/llvm-prettyprinters/lldb/CMakeLists.txt
@@ -11,8 +11,10 @@ endmacro()
 
 add_lldb_test(check-lldb-llvm-support-arrayref arrayref.cpp)
 add_lldb_test(check-lldb-llvm-support-pointer-int-pair pointer-int-pair.cpp)
+add_lldb_test(check-lldb-llvm-support-pointer-union pointer-union.cpp)
 
 set(LLDB_FORMATTER_TESTS
     check-lldb-llvm-support-arrayref
     check-lldb-llvm-support-pointer-int-pair
+    check-lldb-llvm-support-pointer-union
     PARENT_SCOPE)

--- a/cross-project-tests/debuginfo-tests/llvm-prettyprinters/lldb/pointer-union.cpp
+++ b/cross-project-tests/debuginfo-tests/llvm-prettyprinters/lldb/pointer-union.cpp
@@ -1,0 +1,28 @@
+#include <cstdio>
+
+#include "llvm/ADT/PointerUnion.h"
+
+int main() {
+  int a = 5;
+  float f = 4.0;
+  struct alignas(8) Z {};
+  Z z;
+
+  struct Derived : public Z {};
+  Derived derived;
+
+  llvm::PointerUnion<Z *, float *> z_float(&f);
+  llvm::PointerUnion<Z *, float *> raw_z_float(nullptr);
+
+  llvm::PointerUnion<long long *, int *, float *> long_int_float(&a);
+  llvm::PointerUnion<Z *> z_only(&z);
+
+  llvm::PointerIntPair<llvm::PointerUnion<Z *, float *>, 1> union_int_pair(
+      z_float, 1);
+
+  puts("Break here");
+
+  z_float = &derived;
+
+  puts("Break here");
+}

--- a/cross-project-tests/debuginfo-tests/llvm-prettyprinters/lldb/pointer-union.test
+++ b/cross-project-tests/debuginfo-tests/llvm-prettyprinters/lldb/pointer-union.test
@@ -1,0 +1,86 @@
+# REQUIRES: lldb-formatters-compatibility
+#
+# RUN: split-file %s %t
+# RUN: lldb -x \
+# RUN:   -o 'command script import %llvm_src_root/utils/lldbDataFormatters.py' \
+# RUN:   -s %t/commands.input %llvm_tools_dir/check-lldb-llvm-support-pointer-union \
+# RUN:   -o quit \
+# RUN:   | FileCheck %t/checks
+
+#--- commands.input
+break set -p "Break here"
+run
+
+p &f
+p &a
+p &z
+p &derived
+v -T z_float
+v -T raw_z_float
+v -T long_int_float
+v -T z_only
+v -T union_int_pair
+p z_float.Pointer
+p union_int_pair.Pointer
+p union_int_pair.Pointer.Pointer
+
+continue
+
+v -T z_float
+
+#--- checks
+# CHECK:      (lldb) p &f
+# CHECK-NEXT: (float *) [[PTR_F:0x[0-9a-zA-Z]+]]
+
+# CHECK:      (lldb) p &a
+# CHECK-NEXT: (int *) [[PTR_A:0x[0-9a-zA-Z]+]]
+
+# CHECK:      (lldb) p &z
+# CHECK-NEXT: (Z *) [[PTR_Z:0x[0-9a-zA-Z]+]]
+
+# CHECK:      (lldb) p &derived
+# CHECK-NEXT: (Derived *) [[PTR_DERIVED:0x[0-9a-zA-Z]+]]
+
+# CHECK:      (lldb) v -T z_float
+# CHECK-NEXT: (llvm::PointerUnion<Z *, float *>) z_float = {
+# CHECK-NEXT:   (float *) Pointer = [[PTR_F]]
+# CHECK-NEXT: }
+
+# CHECK:      (lldb) v -T raw_z_float
+# CHECK-NEXT: (llvm::PointerUnion<Z *, float *>) raw_z_float = {
+# CHECK-NEXT:   (Z *) Pointer = nullptr
+# CHECK-NEXT: }
+
+# CHECK:      (lldb) v -T long_int_float
+# CHECK-NEXT: (llvm::PointerUnion<long long *, int *, float *>) long_int_float = {
+# CHECK-NEXT:   (int *) Pointer = [[PTR_A]]
+# CHECK-NEXT: }
+
+# CHECK:      (lldb) v -T z_only
+# CHECK-NEXT: (llvm::PointerUnion<Z *>) z_only = {
+# CHECK-NEXT:   (Z *) Pointer = [[PTR_Z]]
+# CHECK-NEXT: }
+
+# CHECK:      (lldb) v -T union_int_pair
+# CHECK-NEXT: (llvm::PointerIntPair<llvm::PointerUnion<Z *, float *>, 1>) union_int_pair = {
+# CHECK-NEXT:   (llvm::PointerUnion<Z *, float *>) Pointer = {
+# CHECK-NEXT:     (float *) Pointer = [[PTR_F]]
+# CHECK-NEXT:   }
+# CHECK-NEXT:   (unsigned int) Int = 1
+# CHECK-NEXT: }
+
+# CHECK:      (lldb) p z_float.Pointer
+# CHECK-NEXT: (float *) [[PTR_F]]
+
+# CHECK:      (lldb) p union_int_pair.Pointer
+# CHECK-NEXT: (llvm::PointerUnion<Z *, float *>) {
+# CHECK-NEXT:   Pointer = [[PTR_F]]
+# CHECK-NEXT: }
+
+# CHECK:      (lldb) p union_int_pair.Pointer.Pointer
+# CHECK-NEXT: (float *) [[PTR_F]]
+
+# CHECK:      (lldb) v -T z_float
+# CHECK-NEXT: (llvm::PointerUnion<Z *, float *>) z_float = {
+# CHECK-NEXT:   (Z *) Pointer = [[PTR_DERIVED]]
+# CHECK-NEXT: }

--- a/llvm/utils/lldbDataFormatters.py
+++ b/llvm/utils/lldbDataFormatters.py
@@ -369,7 +369,10 @@ class PointerUnionSynthProvider:
         data = lldb.SBData()
         data.SetDataFromUInt64Array([pointer.GetValueAsUnsigned()])
 
-        self.pointer_valobj = self.valobj.CreateValueFromData("Pointer", data, active_type)
+        self.pointer_valobj = self.valobj.CreateValueFromData(
+            "Pointer", data, active_type
+        )
+
 
 def DenseMapSummary(valobj: lldb.SBValue, _) -> str:
     raw_value = valobj.GetNonSyntheticValue()

--- a/llvm/utils/lldbDataFormatters.py
+++ b/llvm/utils/lldbDataFormatters.py
@@ -63,6 +63,11 @@ def __lldb_init_module(debugger, internal_dict):
         '-x "^llvm::PointerIntPair<.+>$"'
     )
     debugger.HandleCommand(
+        "type synthetic add -w llvm "
+        f"-l {__name__}.PointerUnionSynthProvider "
+        '-x "^llvm::PointerUnion<.+>$"'
+    )
+    debugger.HandleCommand(
         "type summary add -w llvm "
         f"-e -F {__name__}.DenseMapSummary "
         '-x "^llvm::DenseMap<.+>$"'
@@ -318,6 +323,53 @@ class PointerIntPairSynthProvider:
             int_shift.GetValueAsUnsigned(), int_mask.GetValueAsUnsigned(), int_ty
         )
 
+
+class PointerUnionSynthProvider:
+    def __init__(self, valobj, internal_dict):
+        self.valobj = valobj
+        self.update()
+
+    def num_children(self):
+        return 1
+
+    def get_child_index(self, name):
+        if name == "Pointer":
+            return 0
+        return None
+
+    def get_child_at_index(self, index):
+        if index != 0:
+            return None
+
+        return self.pointer_valobj
+
+    def update(self):
+        pointer_int_pair: SBValue = self.valobj.GetChildMemberWithName(
+            "Val"
+        ).GetSyntheticValue()
+
+        if not pointer_int_pair:
+            return
+
+        pointer: SBValue = pointer_int_pair.GetChildAtIndex(0)
+        if not pointer:
+            return
+
+        active_tag: SBValue = pointer_int_pair.GetChildAtIndex(1)
+        if not active_tag:
+            return
+
+        # Index into the parameter pack of llvm::PointerUnion to find the active type.
+        active_type: SBType = self.valobj.GetType().GetTemplateArgumentType(
+            active_tag.GetValueAsUnsigned()
+        )
+        if not active_type:
+            return
+
+        data = lldb.SBData()
+        data.SetDataFromUInt64Array([pointer.GetValueAsUnsigned()])
+
+        self.pointer_valobj = self.valobj.CreateValueFromData("Pointer", data, active_type)
 
 def DenseMapSummary(valobj: lldb.SBValue, _) -> str:
     raw_value = valobj.GetNonSyntheticValue()


### PR DESCRIPTION
We make use of the fact that the `PointerUnion` element is a `PointerIntPair`, for which we have a synthetic provider already. We get the `Int` portion of the pair (which is the index into the template parameter pack of the union) to get the active type and the `Pointer` portion of the pair to get the actual pointer value.

Before:
```
(lldb) (lldb) v -T z_float
(llvm::PointerUnion<Z *, float *>) z_float = {
  (llvm::pointer_union_detail::PointerUnionMembers<llvm::PointerUnion<Z *, float *>, llvm::PointerIntPair<void *, 1, int, llvm::pointer_union_detail::PointerUnionUIntTraits<Z *, float *> >, 0, Z *, float *>) llvm::pointer_union_detail::PointerUnionMembers<llvm::PointerUnion<Z *, float *>, llvm::PointerIntPair<void *, 1, int, llvm::pointer_union_detail::PointerUnionUIntTraits<Z *, float *>, llvm::PointerIntPairInfo<void *, 1, llvm::pointer_union_detail::PointerUnionUIntTraits<Z *, float *> > >, 0, Z *, float *> = {
    (llvm::pointer_union_detail::PointerUnionMembers<llvm::PointerUnion<Z *, float *>, llvm::PointerIntPair<void *, 1, int, llvm::pointer_union_detail::PointerUnionUIntTraits<Z *, float *> >, 1, float *>) llvm::pointer_union_detail::PointerUnionMembers<llvm::PointerUnion<Z *, float *>, llvm::PointerIntPair<void *, 1, int, llvm::pointer_union_detail::PointerUnionUIntTraits<Z *, float *>, llvm::PointerIntPairInfo<void *, 1, llvm::pointer_union_detail::PointerUnionUIntTraits<Z *, float *> > >, 1, float *> = {
      (llvm::pointer_union_detail::PointerUnionMembers<llvm::PointerUnion<Z *, float *>, llvm::PointerIntPair<void *, 1, int, llvm::pointer_union_detail::PointerUnionUIntTraits<Z *, float *> >, 2>) llvm::pointer_union_detail::PointerUnionMembers<llvm::PointerUnion<Z *, float *>, llvm::PointerIntPair<void *, 1, int, llvm::pointer_union_detail::PointerUnionUIntTraits<Z *, float *>, llvm::PointerIntPairInfo<void *, 1, llvm::pointer_union_detail::PointerUnionUIntTraits<Z *, float *> > >, 2> = {
        (llvm::PointerIntPair<void *, 1, int, llvm::pointer_union_detail::PointerUnionUIntTraits<Z *, float *> >) Val = {...}
      }
    }
  }
}
```

After:
```
(llvm::PointerUnion<Z *, float *>) z_float = {
  (float *) Pointer = 0x000000016fdfebb0
}
```