### PR TITLE
[flang] Changes to "unsafe Cray pointers" option

### DIFF
--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -207,7 +207,7 @@ void Flang::addCodegenOptions(const ArgList &Args,
                    options::OPT_fno_unsafe_cray_pointers, false)) {
     // TODO: currently passed as MLIR option
     CmdArgs.push_back("-mmlir");
-    CmdArgs.push_back("-funsafe-cray-pointers");
+    CmdArgs.push_back("-unsafe-cray-pointers");
   }
 
   Args.addOptInFlag(CmdArgs, options::OPT_fexperimental_loop_fusion,

--- a/flang/docs/Aliasing.md
+++ b/flang/docs/Aliasing.md
@@ -289,7 +289,7 @@ In order to disable optimizations that assume that there is no aliasing between
 Cray pointer targets and entities they alias with, add the TARGET attribute to
 variables aliasing with a Cray pointer (the `target` variable in this example).
 
-There is also a flag `-mmlir -funsafe-cray-pointers` which causes the compiler
+There is also a flag `-funsafe-cray-pointers` which causes the compiler
 to assume that cray pointers alias with all data whether or not it has the
 TARGET attribute.
 

--- a/flang/docs/Aliasing.md
+++ b/flang/docs/Aliasing.md
@@ -289,7 +289,7 @@ In order to disable optimizations that assume that there is no aliasing between
 Cray pointer targets and entities they alias with, add the TARGET attribute to
 variables aliasing with a Cray pointer (the `target` variable in this example).
 
-There is also a flag `-funsafe-cray-pointers` which causes the compiler
+There is also a flag, `-funsafe-cray-pointers`, which causes the compiler
 to assume that cray pointers alias with all data whether or not it has the
 TARGET attribute.
 

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -29,7 +29,7 @@ using namespace mlir;
 #define DEBUG_TYPE "fir-alias-analysis"
 
 llvm::cl::opt<bool> supportCrayPointers(
-    "funsafe-cray-pointers",
+    "unsafe-cray-pointers",
     llvm::cl::desc("Support Cray POINTERs that ALIAS with non-TARGET data"),
     llvm::cl::init(false));
 

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-cray-pointers.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-cray-pointers.fir
@@ -1,6 +1,6 @@
 // Check that cray pointers might alias with everything.
 
-// RUN: fir-opt %s -funsafe-cray-pointers -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-opt %s -unsafe-cray-pointers -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -mlir-disable-threading 2>&1 | FileCheck %s
 // RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -mlir-disable-threading 2>&1 | FileCheck --check-prefix=DEFAULT %s
 
 // Fortran source:

--- a/flang/test/Driver/unsafe-cray-pointers.f90
+++ b/flang/test/Driver/unsafe-cray-pointers.f90
@@ -1,5 +1,5 @@
 ! RUN: %flang -funsafe-cray-pointers -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-ON
 ! RUN: %flang -fno-unsafe-cray-pointers -### %s 2>&1 | FileCheck %s --check-prefix=CHECK-OFF
 
-! CHECK-ON: "-mmlir" "-funsafe-cray-pointers"
-! CHECK-OFF-NOT: "-mmlir" "-funsafe-cray-pointers"
+! CHECK-ON: "-mmlir" "-unsafe-cray-pointers"
+! CHECK-OFF-NOT: "-mmlir" "-unsafe-cray-pointers"

--- a/flang/test/Transforms/tbaa-cray-pointer.fir
+++ b/flang/test/Transforms/tbaa-cray-pointer.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt -funsafe-cray-pointers --fir-add-alias-tags %s | FileCheck %s
+// RUN: fir-opt -unsafe-cray-pointers --fir-add-alias-tags %s | FileCheck %s
 
 // Fortran source:
 // subroutine test()


### PR DESCRIPTION
Reserve "-funsafe-cray-pointers" (with "f") for the driver. In the fir-alias-analysis use "-unsafe-cray-pointers" (without "f").

This prevents conflicts with how certain kinds of tools use the "unsafe Cray pointers" options.