### PR TITLE
[ReachingDefAnalysis] Simpilify `getGlobalReachingDefs`

### DIFF
--- a/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
+++ b/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
@@ -533,8 +533,9 @@ void ReachingDefInfo::getGlobalUses(MachineInstr *MI, Register Reg,
 
 void ReachingDefInfo::getGlobalReachingDefs(MachineInstr *MI, Register Reg,
                                             InstSet &Defs) const {
-  if (auto *Def = getUniqueReachingMIDef(MI, Reg)) {
-    Defs.insert(Def);
+  // If there's a local def before MI, return it.
+  if (MachineInstr *LocalDef = getReachingLocalMIDef(MI, Reg)) {
+    Defs.insert(LocalDef);
     return;
   }
 


### PR DESCRIPTION
This call to `getUniqueReachingMIDef` was an overkill. Replace it with simpler `getReachingLocalMIDef`.