### PR TITLE
[LLVM][Support] Minor code cleanup in `InterleavedRange`

### DIFF
--- a/llvm/include/llvm/Support/InterleavedRange.h
+++ b/llvm/include/llvm/Support/InterleavedRange.h
@@ -44,11 +44,9 @@ public:
 
   template <typename OStream>
   friend OStream &operator<<(OStream &OS, const InterleavedRange &Interleaved) {
-    if (!Interleaved.Prefix.empty())
-      OS << Interleaved.Prefix;
+    OS << Interleaved.Prefix;
     llvm::interleave(Interleaved.TheRange, OS, Interleaved.Separator);
-    if (!Interleaved.Suffix.empty())
-      OS << Interleaved.Suffix;
+    OS << Interleaved.Suffix;
     return OS;
   }
 
@@ -56,7 +54,6 @@ public:
     std::string Result;
     raw_string_ostream Stream(Result);
     Stream << *this;
-    Stream.flush();
     return Result;
   }
 


### PR DESCRIPTION
Remove redundant empty checks for prefix/suffix strings and flush() for raw_string_ostream.