### PR TITLE
[NFC][LLVM] Minor namespace cleanup in llvm-dis.cpp

### DIFF
--- a/llvm/tools/llvm-dis/llvm-dis.cpp
+++ b/llvm/tools/llvm-dis/llvm-dis.cpp
@@ -91,8 +91,6 @@ static cl::opt<bool> PrintThinLTOIndexOnly(
     cl::desc("Only read thinlto index and print the index as LLVM assembly."),
     cl::init(false), cl::Hidden, cl::cat(DisCategory));
 
-namespace {
-
 static void printDebugLoc(const DebugLoc &DL, formatted_raw_ostream &OS) {
   OS << DL.getLine() << ":" << DL.getCol();
   if (DILocation *IDL = DL.getInlinedAt()) {
@@ -100,6 +98,8 @@ static void printDebugLoc(const DebugLoc &DL, formatted_raw_ostream &OS) {
     printDebugLoc(IDL, OS);
   }
 }
+
+namespace {
 class CommentWriter : public AssemblyAnnotationWriter {
 private:
   bool canSafelyAccessUses(const Value &V) {
@@ -117,6 +117,7 @@ public:
     OS << "; [#uses=" << F->getNumUses() << ']';  // Output # uses
     OS << '\n';
   }
+
   void printInfoComment(const Value &V, formatted_raw_ostream &OS) override {
     if (!canSafelyAccessUses(V))
       return;
@@ -165,7 +166,7 @@ struct LLVMDisDiagnosticHandler : public DiagnosticHandler {
     return true;
   }
 };
-} // end anon namespace
+} // namespace
 
 static ExitOnError ExitOnErr;
 


### PR DESCRIPTION
Move static function `printDebugLoc` out of anonymous namespace.