### PR TITLE
[AMDGPU] Fix AMDGPULowerKernelAttributes not invalidating analysis

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
@@ -438,11 +438,6 @@ AMDGPULowerKernelAttributesPass::run(Function &F, FunctionAnalysisManager &AM) {
     }
   }
 
-  PreservedAnalyses PA = PreservedAnalyses::all();
-  if (Changed) {
-    // The call graph is unchanged after this pass.
-    PA = PreservedAnalyses::none();
-    PA.preserveSet<CFGAnalyses>();
-  }
-  return PA;
+  return !Changed ? PreservedAnalyses::all()
+                  : PreservedAnalyses::none().preserveSet<CFGAnalyses>();
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
@@ -430,12 +430,13 @@ AMDGPULowerKernelAttributesPass::run(Function &F, FunctionAnalysisManager &AM) {
   if (!BasePtr) // ImplicitArgPtr/DispatchPtr not used.
     return PreservedAnalyses::all();
 
+  bool Changed = false;
   for (Instruction &I : instructions(F)) {
     if (CallInst *CI = dyn_cast<CallInst>(&I)) {
       if (CI->getCalledFunction() == BasePtr)
-        processUse(CI, IsV5OrAbove);
+        Changed |= processUse(CI, IsV5OrAbove);
     }
   }
 
-  return PreservedAnalyses::all();
+  return !Changed ? PreservedAnalyses::all() : PreservedAnalyses::none();
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelAttributes.cpp
@@ -15,7 +15,6 @@
 #include "AMDGPU.h"
 #include "Utils/AMDGPUBaseInfo.h"
 #include "llvm/Analysis/ConstantFolding.h"
-#include "llvm/Analysis/LazyCallGraph.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/CodeGen/Passes.h"
 #include "llvm/IR/Constants.h"
@@ -443,9 +442,7 @@ AMDGPULowerKernelAttributesPass::run(Function &F, FunctionAnalysisManager &AM) {
   if (Changed) {
     // The call graph is unchanged after this pass.
     PA = PreservedAnalyses::none();
-    PA.preserveSet<AllAnalysesOn<LazyCallGraph::SCC>>();
-    PA.preserve<LazyCallGraphAnalysis>();
-    PA.preserve<FunctionAnalysisManagerModuleProxy>();
+    PA.preserveSet<CFGAnalyses>();
   }
   return PA;
 }


### PR DESCRIPTION
Summary:
The new PM wasn't using the changed result which triggered failures after https://github.com/llvm/llvm-project/pull/174112
