### PR TITLE
[NFCI] Extract out the addVariableConstraints CGASM Function

### DIFF
--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -32,6 +32,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/PointerIntPair.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/ADT/iterator_range.h"
@@ -3311,6 +3312,16 @@ public:
 
   /// Assemble final IR asm string.
   std::string generateAsmString(const ASTContext &C) const;
+
+  using UnsupportedConstraintCallbackTy =
+      llvm::function_ref<void(const Stmt *, StringRef)>;
+  /// Look at AsmExpr and if it is a variable declared as using a particular
+  /// register add that as a constraint that will be used in this asm stmt.
+  std::string
+  addVariableConstraints(StringRef Constraint, const Expr &AsmExpr,
+                         const TargetInfo &Target, bool EarlyClobber,
+                         UnsupportedConstraintCallbackTy UnsupportedCB,
+                         std::string *GCCReg = nullptr) const;
 
   //===--- Output operands ---===//
 

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -450,6 +450,39 @@ AttributedStmt *AttributedStmt::CreateEmpty(const ASTContext &C,
   return new (Mem) AttributedStmt(EmptyShell(), NumAttrs);
 }
 
+std::string
+AsmStmt::addVariableConstraints(StringRef Constraint, const Expr &AsmExpr,
+                                const TargetInfo &Target, bool EarlyClobber,
+                                UnsupportedConstraintCallbackTy UnsupportedCB,
+                                std::string *GCCReg) const {
+  const DeclRefExpr *AsmDeclRef = dyn_cast<DeclRefExpr>(&AsmExpr);
+  if (!AsmDeclRef)
+    return Constraint.str();
+  const ValueDecl &Value = *AsmDeclRef->getDecl();
+  const VarDecl *Variable = dyn_cast<VarDecl>(&Value);
+  if (!Variable)
+    return Constraint.str();
+  if (Variable->getStorageClass() != SC_Register)
+    return Constraint.str();
+  AsmLabelAttr *Attr = Variable->getAttr<AsmLabelAttr>();
+  if (!Attr)
+    return Constraint.str();
+  StringRef Register = Attr->getLabel();
+  assert(Target.isValidGCCRegisterName(Register));
+  // We're using validateOutputConstraint here because we only care if
+  // this is a register constraint.
+  TargetInfo::ConstraintInfo Info(Constraint, "");
+  if (Target.validateOutputConstraint(Info) && !Info.allowsRegister()) {
+    UnsupportedCB(this, "__asm__");
+    return Constraint.str();
+  }
+  // Canonicalize the register here before returning it.
+  Register = Target.getNormalizedGCCRegisterName(Register);
+  if (GCCReg != nullptr)
+    *GCCReg = Register.str();
+  return (EarlyClobber ? "&{" : "{") + Register.str() + "}";
+}
+
 std::string AsmStmt::generateAsmString(const ASTContext &C) const {
   if (const auto *gccAsmStmt = dyn_cast<GCCAsmStmt>(this))
     return gccAsmStmt->generateAsmString(C);

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1761,6 +1761,12 @@ void CodeGenModule::ErrorUnsupported(const Stmt *S, const char *Type) {
       << Msg << S->getSourceRange();
 }
 
+void CodeGenModule::ErrorUnsupported(const Stmt *S, llvm::StringRef Type) {
+  getDiags().Report(Context.getFullLoc(S->getBeginLoc()),
+                    diag::err_codegen_unsupported)
+      << Type << S->getSourceRange();
+}
+
 /// ErrorUnsupported - Print out an error that codegen doesn't support the
 /// specified decl yet.
 void CodeGenModule::ErrorUnsupported(const Decl *D, const char *Type) {

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -1397,6 +1397,9 @@ public:
   /// Print out an error that codegen doesn't support the specified stmt yet.
   void ErrorUnsupported(const Stmt *S, const char *Type);
 
+  /// Print out an error that codegen doesn't support the specified stmt yet.
+  void ErrorUnsupported(const Stmt *S, llvm::StringRef Type);
+
   /// Print out an error that codegen doesn't support the specified decl yet.
   void ErrorUnsupported(const Decl *D, const char *Type);
 


### PR DESCRIPTION
This function is needed in identical form for CIR codegen, and pulling it out into AsmStmt is effectively trivial.  The only thing that actually needs the codegen in it is the ability to diagnose, so this patch adds that as a callback.  AsmStmt seems to be the most logical place for this to happen, as it does other similar things.  Howver, unlike the other similar things, th is is the same between MS and GCC, so it doesn't need separate implementations.