### PR TITLE
[lldb] Make PlatformWasm a RemoteAwarePlatform

### DIFF
--- a/lldb/source/Plugins/Platform/WebAssembly/CMakeLists.txt
+++ b/lldb/source/Plugins/Platform/WebAssembly/CMakeLists.txt
@@ -8,6 +8,7 @@ lldb_tablegen(PlatformWasmPropertiesEnum.inc -gen-lldb-property-enum-defs
 
 add_lldb_library(lldbPluginPlatformWasm PLUGIN
   PlatformWasm.cpp
+  PlatformWasmRemoteGDBServer.cpp
 
   LINK_LIBS
     lldbCore

--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Plugins/Platform/WebAssembly/PlatformWasm.h"
+#include "Plugins/Platform/WebAssembly/PlatformWasmRemoteGDBServer.h"
 #include "Plugins/Process/wasm/ProcessWasm.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Host/FileSystem.h"
@@ -122,9 +123,24 @@ static auto get_arg_range(const Args &args) {
                           args.GetArgumentArrayRef().end());
 }
 
+lldb::ProcessSP PlatformWasm::Attach(ProcessAttachInfo &attach_info,
+                                     Debugger &debugger, Target *target,
+                                     Status &status) {
+  if (m_remote_platform_sp)
+    return m_remote_platform_sp->Attach(attach_info, debugger, target, status);
+
+  status = Status::FromErrorString(
+      "attaching is only supported when connected to a remote Wasm platform");
+  return nullptr;
+}
+
 lldb::ProcessSP PlatformWasm::DebugProcess(ProcessLaunchInfo &launch_info,
                                            Debugger &debugger, Target &target,
                                            Status &error) {
+  if (m_remote_platform_sp)
+    return m_remote_platform_sp->DebugProcess(launch_info, debugger, target,
+                                              error);
+
   Log *log = GetLog(LLDBLog::Platform);
 
   const PluginProperties &properties = GetGlobalProperties();
@@ -210,4 +226,15 @@ lldb::ProcessSP PlatformWasm::DebugProcess(ProcessLaunchInfo &launch_info,
         launch_info.GetPTY().ReleasePrimaryFileDescriptor());
 #endif
   return process_sp;
+}
+
+Status PlatformWasm::ConnectRemote(Args &args) {
+  if (IsHost())
+    return Status::FromErrorString(
+        "can't connect to the host platform, always connected");
+
+  if (!m_remote_platform_sp)
+    m_remote_platform_sp = PlatformSP(new PlatformWasmRemoteGDBServer());
+
+  return m_remote_platform_sp->ConnectRemote(args);
 }

--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.h
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.h
@@ -12,10 +12,11 @@
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Target/Platform.h"
+#include "lldb/Target/RemoteAwarePlatform.h"
 
 namespace lldb_private {
 
-class PlatformWasm : public Platform {
+class PlatformWasm : public RemoteAwarePlatform {
 public:
   static void Initialize();
   static void Terminate();
@@ -40,22 +41,9 @@ public:
                                Status &error) override;
 
   lldb::ProcessSP Attach(ProcessAttachInfo &attach_info, Debugger &debugger,
-                         Target *target, Status &status) override {
-    status = Status::FromErrorString("Not supported");
-    return nullptr;
-  }
+                         Target *target, Status &status) override;
 
-  uint32_t FindProcesses(const ProcessInstanceInfoMatch &match_info,
-                         ProcessInstanceInfoList &proc_infos) override {
-    return 0;
-  }
-
-  bool GetProcessInfo(lldb::pid_t pid,
-                      ProcessInstanceInfo &proc_info) override {
-    return false;
-  }
-
-  bool IsConnected() const override { return true; }
+  Status ConnectRemote(Args &args) override;
 
   void CalculateTrapHandlerSymbolNames() override {}
 
@@ -71,7 +59,7 @@ private:
   static lldb::PlatformSP CreateInstance(bool force, const ArchSpec *arch);
   static void DebuggerInitialize(Debugger &debugger);
 
-  PlatformWasm() : Platform(/*is_host=*/true) {}
+  PlatformWasm() : RemoteAwarePlatform(/*is_host=*/false) {}
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWasmRemoteGDBServer.cpp
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWasmRemoteGDBServer.cpp
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PlatformWasmRemoteGDBServer.h"
+
+using namespace lldb_private;
+
+PlatformWasmRemoteGDBServer::~PlatformWasmRemoteGDBServer() {}
+
+llvm::StringRef
+PlatformWasmRemoteGDBServer::GetDefaultProcessPluginName() const {
+  return "wasm";
+}

--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWasmRemoteGDBServer.h
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWasmRemoteGDBServer.h
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_PLATFORM_WASM_PLATFORMWASMREMOTEGDBSERVER_H
+#define LLDB_SOURCE_PLUGINS_PLATFORM_WASM_PLATFORMWASMREMOTEGDBSERVER_H
+
+#include "Plugins/Platform/gdb-server/PlatformRemoteGDBServer.h"
+
+namespace lldb_private {
+
+class PlatformWasmRemoteGDBServer
+    : public platform_gdb_server::PlatformRemoteGDBServer {
+public:
+  PlatformWasmRemoteGDBServer() = default;
+
+  ~PlatformWasmRemoteGDBServer() override;
+
+  virtual llvm::StringRef GetDefaultProcessPluginName() const override;
+
+private:
+  PlatformWasmRemoteGDBServer(const PlatformWasmRemoteGDBServer &) = delete;
+  const PlatformWasmRemoteGDBServer &
+  operator=(const PlatformWasmRemoteGDBServer &) = delete;
+};
+
+} // namespace lldb_private
+
+#endif // LLDB_SOURCE_PLUGINS_PLATFORM_WASM_PLATFORMWASMREMOTEGDBSERVER_H

--- a/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
+++ b/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.cpp
@@ -418,7 +418,7 @@ PlatformRemoteGDBServer::DebugProcess(ProcessLaunchInfo &launch_info,
       } else {
         // By default, we always use the GDB remote debugger plug-in.
         // Even when debugging locally, we are debugging remotely.
-        llvm::StringRef process_plugin = "gdb-remote";
+        llvm::StringRef process_plugin = GetDefaultProcessPluginName();
 
         // However, if a process plugin is specified by the attach info, we
         // should honor it.
@@ -514,7 +514,7 @@ lldb::ProcessSP PlatformRemoteGDBServer::Attach(
         if (target && error.Success()) {
           // By default, we always use the GDB remote debugger plug-in.
           // Even when debugging locally, we are debugging remotely.
-          llvm::StringRef process_plugin = "gdb-remote";
+          llvm::StringRef process_plugin = GetDefaultProcessPluginName();
 
           // However, if a process plugin is specified by the attach info, we
           // should honor it.
@@ -831,7 +831,8 @@ size_t PlatformRemoteGDBServer::ConnectToWaitingProcesses(Debugger &debugger,
   GetPendingGdbServerList(connection_urls);
 
   for (size_t i = 0; i < connection_urls.size(); ++i) {
-    ConnectProcess(connection_urls[i].c_str(), "gdb-remote", debugger, nullptr, error);
+    ConnectProcess(connection_urls[i].c_str(), GetDefaultProcessPluginName(),
+                   debugger, nullptr, error);
     if (error.Fail())
       return i; // We already connected to i process successfully
   }

--- a/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.h
+++ b/lldb/source/Plugins/Platform/gdb-server/PlatformRemoteGDBServer.h
@@ -180,6 +180,10 @@ protected:
   virtual std::string MakeUrl(const char *scheme, const char *hostname,
                               uint16_t port, const char *path);
 
+  virtual llvm::StringRef GetDefaultProcessPluginName() const {
+    return "gdb-remote";
+  }
+
 private:
   std::string MakeGdbServerUrl(const std::string &platform_scheme,
                                const std::string &platform_hostname,


### PR DESCRIPTION
This PR makes `PlatformWasm` a `RemoteAwarePlatform` that can connect to a remote GDB platform server. `PlatformWasmRemoteGDBServer` inherits from `PlatformRemoteGDBServer`, with the only difference that it picks the correct Process plugin when launching and attaching. The approach is identical to the one taken by `PlatformAndroid`. 

The context is that we're working on a platform based approach for discovering and attaching Wasm processes running under JSC with the [newly added debugging support](https://github.com/WebKit/WebKit/pull/51462). 