### PR TITLE
[SPIR-V] Do not allow AS(2) to convert to generic

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -320,7 +320,7 @@ public:
 
   virtual bool isAddressSpaceSupersetOf(LangAS A, LangAS B) const override {
     // The generic space AS(4) is a superset of all the other address
-    // spaces used by the backend target.
+    // spaces used by the backend target except constant address space.
     return A == B || ((A == LangAS::Default ||
                        (isTargetAddressSpace(A) &&
                         toTargetAddressSpace(A) == /*Generic=*/4)) &&

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -325,7 +325,8 @@ public:
                        (isTargetAddressSpace(A) &&
                         toTargetAddressSpace(A) == /*Generic=*/4)) &&
                       isTargetAddressSpace(B) &&
-                      toTargetAddressSpace(B) <= /*Generic=*/4);
+                      (toTargetAddressSpace(B) <= /*Generic=*/4 &&
+                       toTargetAddressSpace(B) != /*Constant=*/2));
   }
 
   void getTargetDefines(const LangOptions &Opts,

--- a/clang/test/Sema/spirv-address-space.c
+++ b/clang/test/Sema/spirv-address-space.c
@@ -9,7 +9,7 @@
 #define _AS999 __attribute__((address_space(999)))
 
 void *p1(void _AS1 *p) { return p; } 
-void *p2(void _AS2 *p) { return p; } 
+void *p2(void _AS2 *p) { return p; } // expected-error {{returning '_AS2 void *' from a function with result type 'void *' changes address space of pointer}}
 void *p3(void _AS3 *p) { return p; }
 void *p4(void _AS4 *p) { return p; }
 void *p5(void _AS5 *p) { return p; } // expected-error {{returning '_AS5 void *' from a function with result type 'void *' changes address space of pointer}}
@@ -18,4 +18,3 @@ void *pc(void __attribute__((opencl_local)) *p) { return p; } // expected-error 
 void _AS1 *r0(void _AS1 *p) { return p; }
 void _AS1 *r1(void *p) { return p; } // expected-error {{returning 'void *' from a function with result type '_AS1 void *' changes address space of pointer}}
 void _AS1 *r2(void *p) { return (void _AS1 *)p; }
-


### PR DESCRIPTION
Summary:
The original logic permitted this, while it's not permitted by the
standard.
