### PR TITLE
Add filegroups for installed compiler-rt headers

### DIFF
--- a/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/compiler-rt/BUILD.bazel
@@ -114,6 +114,21 @@ cc_library(
     ],
 )
 
+filegroup(
+    name = "fuzzer_installed_hdrs",
+    srcs = glob(["include/fuzzer/*.h"]),
+)
+
+filegroup(
+    name = "profile_installed_hdrs",
+    srcs = glob(["include/profile/*.h"]),
+)
+
+filegroup(
+    name = "sanitizer_installed_hdrs",
+    srcs = glob(["include/sanitizer/*.h"]),
+)
+
 BUILTINS_CRTBEGIN_SRCS = ["lib/builtins/crtbegin.c"]
 
 filegroup(


### PR DESCRIPTION
These are installed along-side the builtin Clang headers. Adding these filegroups follows the filegroups in clang/BUILD.bazel and allows merging when both are needed.