### PR TITLE
[flang] Fix SelectCaseOpConversion to convert block signatures

### DIFF
--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -3566,6 +3566,12 @@ struct SelectCaseOpConversion : public fir::FIROpConversion<fir::SelectCaseOp> {
       mlir::Block *dest = caseOp.getSuccessor(t);
       std::optional<mlir::ValueRange> destOps =
           caseOp.getSuccessorOperands(adaptor.getOperands(), t);
+      // Convert block signature if needed
+      if (destOps && !destOps->empty()) {
+        if (auto conversion = getTypeConverter()->convertBlockSignature(dest))
+          dest = rewriter.applySignatureConversion(dest, *conversion,
+                                                   getTypeConverter());
+      }
       std::optional<mlir::ValueRange> cmpOps =
           *caseOp.getCompareOperands(adaptor.getOperands(), t);
       mlir::Attribute attr = cases[t];

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -3567,11 +3567,10 @@ struct SelectCaseOpConversion : public fir::FIROpConversion<fir::SelectCaseOp> {
       std::optional<mlir::ValueRange> destOps =
           caseOp.getSuccessorOperands(adaptor.getOperands(), t);
       // Convert block signature if needed
-      if (destOps && !destOps->empty()) {
+      if (destOps && !destOps->empty())
         if (auto conversion = getTypeConverter()->convertBlockSignature(dest))
           dest = rewriter.applySignatureConversion(dest, *conversion,
                                                    getTypeConverter());
-      }
       std::optional<mlir::ValueRange> cmpOps =
           *caseOp.getCompareOperands(adaptor.getOperands(), t);
       mlir::Attribute attr = cases[t];

--- a/flang/test/Fir/convert-to-llvm.fir
+++ b/flang/test/Fir/convert-to-llvm.fir
@@ -2954,3 +2954,24 @@ func.func @select_with_cast(%arg1 : i8, %arg2 : i16, %arg3: i64, %arg4: index) -
 // CHECK:         ^bb5:
 // CHECK:           llvm.return
 // CHECK:         }
+
+// -----
+
+// Test `fir.select_case` with block arguments requiring type conversion.
+
+func.func @select_case_block_args(%arg0: !fir.ref<i32>, %arg1: !fir.ref<!fir.array<2xi32>>, %arg2: !fir.ref<!fir.array<2xi32>>) {
+  %0 = fir.load %arg0 : !fir.ref<i32>
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  fir.select_case %0 : i32 [#fir.point, %c1, ^bb1(%arg1 : !fir.ref<!fir.array<2xi32>>),
+                            #fir.point, %c2, ^bb1(%arg2 : !fir.ref<!fir.array<2xi32>>),
+                            unit, ^bb2]
+^bb1(%1: !fir.ref<!fir.array<2xi32>>):
+  cf.br ^bb2
+^bb2:
+  return
+}
+
+// CHECK-LABEL: llvm.func @select_case_block_args
+// CHECK: llvm.cond_br %{{.*}}, ^{{.*}}(%{{.*}} : !llvm.ptr), ^{{.*}}
+// CHECK: ^{{.*}}(%{{.*}}: !llvm.ptr):

--- a/flang/test/Integration/select-case-pointer-assign.f90
+++ b/flang/test/Integration/select-case-pointer-assign.f90
@@ -1,0 +1,18 @@
+! RUN: %flang_fc1 -emit-llvm %s -o -
+
+! Test that select case with pointer assignment compiles correctly.
+! This requires block signature conversion in SelectCaseOpConversion.
+subroutine test(l)
+  integer :: l
+  integer, pointer :: p(:)
+  integer, target :: a1(2), a2(2)
+
+  select case (l)
+    case (1)
+      p => a1
+    case (2)
+      p => a2
+  end select
+
+  p = 0
+end subroutine


### PR DESCRIPTION
When `fir.select_case` branches to blocks with arguments that have FIR types (e.g., `!fir.ref`), the block signature must be converted to LLVM types before creating the branch. Otherwise, the branch passes LLVM types (`!llvm.ptr`) but the block expects FIR types, causing a type mismatch error.

This adds block signature conversion similar to what `SelectOpConversionBase` already does for `fir.select` and `fir.select_rank`.