### PR TITLE
[MLIR][Python] Add `attr_name` for `FloatAttr`

### DIFF
--- a/mlir/include/mlir-c/BuiltinAttributes.h
+++ b/mlir/include/mlir-c/BuiltinAttributes.h
@@ -115,6 +115,8 @@ MLIR_CAPI_EXPORTED MlirTypeID mlirDictionaryAttrGetTypeID(void);
 /// Checks whether the given attribute is a floating point attribute.
 MLIR_CAPI_EXPORTED bool mlirAttributeIsAFloat(MlirAttribute attr);
 
+MLIR_CAPI_EXPORTED MlirStringRef mlirFloatAttrGetName(void);
+
 /// Creates a floating point attribute in the given context with the given
 /// double value and double-precision FP semantics.
 MLIR_CAPI_EXPORTED MlirAttribute mlirFloatAttrDoubleGet(MlirContext ctx,

--- a/mlir/include/mlir/Bindings/Python/IRAttributes.h
+++ b/mlir/include/mlir/Bindings/Python/IRAttributes.h
@@ -324,6 +324,7 @@ public:
   using PyConcreteAttribute::PyConcreteAttribute;
   static constexpr GetTypeIDFunctionTy getTypeIdFunction =
       mlirFloatAttrGetTypeID;
+  static inline const MlirStringRef name = mlirFloatAttrGetName();
 
   static void bindDerived(ClassTy &c);
 };

--- a/mlir/lib/CAPI/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/CAPI/IR/BuiltinAttributes.cpp
@@ -131,6 +131,8 @@ bool mlirAttributeIsAFloat(MlirAttribute attr) {
   return llvm::isa<FloatAttr>(unwrap(attr));
 }
 
+MlirStringRef mlirFloatAttrGetName(void) { return wrap(FloatAttr::name); }
+
 MlirAttribute mlirFloatAttrDoubleGet(MlirContext ctx, MlirType type,
                                      double value) {
   return wrap(FloatAttr::get(unwrap(type), value));

--- a/mlir/test/python/ir/attributes.py
+++ b/mlir/test/python/ir/attributes.py
@@ -747,3 +747,5 @@ def testAttrNames():
         print(DenseResourceElementsAttr.attr_name)
         # CHECK: builtin.string
         print(StringAttr.attr_name)
+        # CHECK: builtin.float
+        print(FloatAttr.attr_name)


### PR DESCRIPTION
After #174756 I found that attribute name for `FloatAttr` is missing. And this PR is to add it.

This is actually part of changes in #169045, but I think that we can make it a separate PR to make #169045 easier to review.