### PR TITLE
[X86][SDAG] Fix shamt for vXi8 shift expansion

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -31301,14 +31301,14 @@ static SDValue LowerShift(SDValue Op, const X86Subtarget &Subtarget,
     Amt = DAG.getBitcast(VT, Amt);
 
     if (Opc == ISD::SHL || Opc == ISD::SRL) {
-      if (MinLZ < 2) {
+      if (MinLZ < 1) {
         // r = VSELECT(r, shift(r, 4), a);
         SDValue M = DAG.getNode(Opc, dl, VT, R, DAG.getConstant(4, dl, VT));
         R = SignBitSelect(VT, Amt, M, R);
         // a += a
         Amt = DAG.getNode(ISD::ADD, dl, VT, Amt, Amt);
       }
-      if (MinLZ < 1) {
+      if (MinLZ < 2) {
         // r = VSELECT(r, shift(r, 2), a);
         SDValue M = DAG.getNode(Opc, dl, VT, R, DAG.getConstant(2, dl, VT));
         R = SignBitSelect(VT, Amt, M, R);
@@ -31335,7 +31335,7 @@ static SDValue LowerShift(SDValue Op, const X86Subtarget &Subtarget,
       RHi = DAG.getBitcast(ExtVT, RHi);
 
       SDValue MLo, MHi;
-      if (MinLZ < 2) {
+      if (MinLZ < 1) {
         // r = VSELECT(r, shift(r, 4), a);
         MLo = getTargetVShiftByConstNode(X86OpcI, dl, ExtVT, RLo, 4, DAG);
         MHi = getTargetVShiftByConstNode(X86OpcI, dl, ExtVT, RHi, 4, DAG);
@@ -31345,7 +31345,7 @@ static SDValue LowerShift(SDValue Op, const X86Subtarget &Subtarget,
         ALo = DAG.getNode(ISD::ADD, dl, ExtVT, ALo, ALo);
         AHi = DAG.getNode(ISD::ADD, dl, ExtVT, AHi, AHi);
       }
-      if (MinLZ < 1) {
+      if (MinLZ < 2) {
         // r = VSELECT(r, shift(r, 2), a);
         MLo = getTargetVShiftByConstNode(X86OpcI, dl, ExtVT, RLo, 2, DAG);
         MHi = getTargetVShiftByConstNode(X86OpcI, dl, ExtVT, RHi, 2, DAG);

--- a/llvm/test/CodeGen/X86/pr162812.ll
+++ b/llvm/test/CodeGen/X86/pr162812.ll
@@ -241,8 +241,8 @@ define <32 x i8> @shl2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE2-NEXT:    pcmpgtb %xmm2, %xmm6
 ; SSE2-NEXT:    movdqa %xmm6, %xmm7
 ; SSE2-NEXT:    pandn %xmm0, %xmm7
-; SSE2-NEXT:    psllw $4, %xmm0
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [240,240,240,240,240,240,240,240,240,240,240,240,240,240,240,240]
+; SSE2-NEXT:    psllw $2, %xmm0
+; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [252,252,252,252,252,252,252,252,252,252,252,252,252,252,252,252]
 ; SSE2-NEXT:    pand %xmm8, %xmm0
 ; SSE2-NEXT:    pand %xmm6, %xmm0
 ; SSE2-NEXT:    por %xmm7, %xmm0
@@ -259,7 +259,7 @@ define <32 x i8> @shl2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE2-NEXT:    pcmpgtb %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm5
 ; SSE2-NEXT:    pandn %xmm1, %xmm5
-; SSE2-NEXT:    psllw $4, %xmm1
+; SSE2-NEXT:    psllw $2, %xmm1
 ; SSE2-NEXT:    pand %xmm8, %xmm1
 ; SSE2-NEXT:    pand %xmm2, %xmm1
 ; SSE2-NEXT:    por %xmm5, %xmm1
@@ -282,8 +282,8 @@ define <32 x i8> @shl2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE42-NEXT:    pand %xmm3, %xmm6
 ; SSE42-NEXT:    paddb %xmm6, %xmm6
 ; SSE42-NEXT:    movdqa %xmm0, %xmm7
-; SSE42-NEXT:    psllw $4, %xmm7
-; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [240,240,240,240,240,240,240,240,240,240,240,240,240,240,240,240]
+; SSE42-NEXT:    psllw $2, %xmm7
+; SSE42-NEXT:    movdqa {{.*#+}} xmm8 = [252,252,252,252,252,252,252,252,252,252,252,252,252,252,252,252]
 ; SSE42-NEXT:    pand %xmm8, %xmm7
 ; SSE42-NEXT:    movdqa %xmm5, %xmm0
 ; SSE42-NEXT:    pblendvb %xmm0, %xmm7, %xmm2
@@ -293,7 +293,7 @@ define <32 x i8> @shl2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE42-NEXT:    pblendvb %xmm0, %xmm5, %xmm2
 ; SSE42-NEXT:    pand %xmm4, %xmm3
 ; SSE42-NEXT:    movdqa %xmm1, %xmm5
-; SSE42-NEXT:    psllw $4, %xmm5
+; SSE42-NEXT:    psllw $2, %xmm5
 ; SSE42-NEXT:    pand %xmm8, %xmm5
 ; SSE42-NEXT:    movdqa %xmm4, %xmm0
 ; SSE42-NEXT:    pblendvb %xmm0, %xmm5, %xmm1
@@ -307,7 +307,7 @@ define <32 x i8> @shl2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ;
 ; AVX2-LABEL: shl2_v32i8:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpsllw $4, %ymm0, %ymm2
+; AVX2-NEXT:    vpsllw $2, %ymm0, %ymm2
 ; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm2, %ymm2
 ; AVX2-NEXT:    vpblendvb %ymm1, %ymm2, %ymm0, %ymm0
 ; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
@@ -318,7 +318,7 @@ define <32 x i8> @shl2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ;
 ; AVX512-LABEL: shl2_v32i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpsllw $4, %ymm0, %ymm2
+; AVX512-NEXT:    vpsllw $2, %ymm0, %ymm2
 ; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm2, %ymm2
 ; AVX512-NEXT:    vpblendvb %ymm1, %ymm2, %ymm0, %ymm0
 ; AVX512-NEXT:    vpaddb %ymm0, %ymm0, %ymm2
@@ -341,8 +341,8 @@ define <32 x i8> @lshr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE2-NEXT:    pcmpgtb %xmm2, %xmm6
 ; SSE2-NEXT:    movdqa %xmm6, %xmm7
 ; SSE2-NEXT:    pandn %xmm0, %xmm7
-; SSE2-NEXT:    psrlw $4, %xmm0
-; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; SSE2-NEXT:    psrlw $2, %xmm0
+; SSE2-NEXT:    movdqa {{.*#+}} xmm8 = [63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63]
 ; SSE2-NEXT:    pand %xmm8, %xmm0
 ; SSE2-NEXT:    pand %xmm6, %xmm0
 ; SSE2-NEXT:    por %xmm7, %xmm0
@@ -361,7 +361,7 @@ define <32 x i8> @lshr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE2-NEXT:    pcmpgtb %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm5
 ; SSE2-NEXT:    pandn %xmm1, %xmm5
-; SSE2-NEXT:    psrlw $4, %xmm1
+; SSE2-NEXT:    psrlw $2, %xmm1
 ; SSE2-NEXT:    pand %xmm8, %xmm1
 ; SSE2-NEXT:    pand %xmm2, %xmm1
 ; SSE2-NEXT:    por %xmm5, %xmm1
@@ -380,8 +380,8 @@ define <32 x i8> @lshr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE42-NEXT:    movdqa %xmm2, %xmm4
 ; SSE42-NEXT:    movdqa %xmm0, %xmm2
 ; SSE42-NEXT:    movdqa %xmm0, %xmm5
-; SSE42-NEXT:    psrlw $4, %xmm5
-; SSE42-NEXT:    movdqa {{.*#+}} xmm6 = [15,15,15,15,15,15,15,15,15,15,15,15,15,15,15,15]
+; SSE42-NEXT:    psrlw $2, %xmm5
+; SSE42-NEXT:    movdqa {{.*#+}} xmm6 = [63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63]
 ; SSE42-NEXT:    pand %xmm6, %xmm5
 ; SSE42-NEXT:    movdqa %xmm4, %xmm0
 ; SSE42-NEXT:    pblendvb %xmm0, %xmm5, %xmm2
@@ -395,7 +395,7 @@ define <32 x i8> @lshr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE42-NEXT:    movdqa %xmm4, %xmm0
 ; SSE42-NEXT:    pblendvb %xmm0, %xmm7, %xmm2
 ; SSE42-NEXT:    movdqa %xmm1, %xmm4
-; SSE42-NEXT:    psrlw $4, %xmm4
+; SSE42-NEXT:    psrlw $2, %xmm4
 ; SSE42-NEXT:    pand %xmm6, %xmm4
 ; SSE42-NEXT:    movdqa %xmm3, %xmm0
 ; SSE42-NEXT:    pblendvb %xmm0, %xmm4, %xmm1
@@ -411,7 +411,7 @@ define <32 x i8> @lshr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ;
 ; AVX2-LABEL: lshr2_v32i8:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    vpsrlw $4, %ymm0, %ymm2
+; AVX2-NEXT:    vpsrlw $2, %ymm0, %ymm2
 ; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm2, %ymm2
 ; AVX2-NEXT:    vpblendvb %ymm1, %ymm2, %ymm0, %ymm0
 ; AVX2-NEXT:    vpsrlw $1, %ymm0, %ymm2
@@ -423,7 +423,7 @@ define <32 x i8> @lshr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ;
 ; AVX512-LABEL: lshr2_v32i8:
 ; AVX512:       # %bb.0:
-; AVX512-NEXT:    vpsrlw $4, %ymm0, %ymm2
+; AVX512-NEXT:    vpsrlw $2, %ymm0, %ymm2
 ; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm2, %ymm2
 ; AVX512-NEXT:    vpblendvb %ymm1, %ymm2, %ymm0, %ymm0
 ; AVX512-NEXT:    vpsrlw $1, %ymm0, %ymm2
@@ -449,7 +449,7 @@ define <32 x i8> @ashr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE2-NEXT:    pcmpgtw %xmm7, %xmm8
 ; SSE2-NEXT:    movdqa %xmm8, %xmm9
 ; SSE2-NEXT:    pandn %xmm6, %xmm9
-; SSE2-NEXT:    psraw $4, %xmm6
+; SSE2-NEXT:    psraw $2, %xmm6
 ; SSE2-NEXT:    pand %xmm8, %xmm6
 ; SSE2-NEXT:    por %xmm9, %xmm6
 ; SSE2-NEXT:    paddw %xmm7, %xmm7
@@ -467,7 +467,7 @@ define <32 x i8> @ashr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE2-NEXT:    pcmpgtw %xmm2, %xmm7
 ; SSE2-NEXT:    movdqa %xmm7, %xmm8
 ; SSE2-NEXT:    pandn %xmm0, %xmm8
-; SSE2-NEXT:    psraw $4, %xmm0
+; SSE2-NEXT:    psraw $2, %xmm0
 ; SSE2-NEXT:    pand %xmm7, %xmm0
 ; SSE2-NEXT:    por %xmm8, %xmm0
 ; SSE2-NEXT:    paddw %xmm2, %xmm2
@@ -487,7 +487,7 @@ define <32 x i8> @ashr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE2-NEXT:    pcmpgtw %xmm5, %xmm6
 ; SSE2-NEXT:    movdqa %xmm6, %xmm7
 ; SSE2-NEXT:    pandn %xmm2, %xmm7
-; SSE2-NEXT:    psraw $4, %xmm2
+; SSE2-NEXT:    psraw $2, %xmm2
 ; SSE2-NEXT:    pand %xmm6, %xmm2
 ; SSE2-NEXT:    por %xmm7, %xmm2
 ; SSE2-NEXT:    paddw %xmm5, %xmm5
@@ -505,7 +505,7 @@ define <32 x i8> @ashr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE2-NEXT:    pcmpgtw %xmm3, %xmm5
 ; SSE2-NEXT:    movdqa %xmm5, %xmm6
 ; SSE2-NEXT:    pandn %xmm1, %xmm6
-; SSE2-NEXT:    psraw $4, %xmm1
+; SSE2-NEXT:    psraw $2, %xmm1
 ; SSE2-NEXT:    pand %xmm5, %xmm1
 ; SSE2-NEXT:    por %xmm6, %xmm1
 ; SSE2-NEXT:    paddw %xmm3, %xmm3
@@ -527,7 +527,7 @@ define <32 x i8> @ashr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE42-NEXT:    punpckhbw {{.*#+}} xmm0 = xmm0[8],xmm2[8],xmm0[9],xmm2[9],xmm0[10],xmm2[10],xmm0[11],xmm2[11],xmm0[12],xmm2[12],xmm0[13],xmm2[13],xmm0[14],xmm2[14],xmm0[15],xmm2[15]
 ; SSE42-NEXT:    punpckhbw {{.*#+}} xmm6 = xmm6[8],xmm4[8],xmm6[9],xmm4[9],xmm6[10],xmm4[10],xmm6[11],xmm4[11],xmm6[12],xmm4[12],xmm6[13],xmm4[13],xmm6[14],xmm4[14],xmm6[15],xmm4[15]
 ; SSE42-NEXT:    movdqa %xmm6, %xmm7
-; SSE42-NEXT:    psraw $4, %xmm7
+; SSE42-NEXT:    psraw $2, %xmm7
 ; SSE42-NEXT:    pblendvb %xmm0, %xmm7, %xmm6
 ; SSE42-NEXT:    movdqa %xmm6, %xmm7
 ; SSE42-NEXT:    psraw $1, %xmm7
@@ -537,7 +537,7 @@ define <32 x i8> @ashr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE42-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0],xmm2[0],xmm0[1],xmm2[1],xmm0[2],xmm2[2],xmm0[3],xmm2[3],xmm0[4],xmm2[4],xmm0[5],xmm2[5],xmm0[6],xmm2[6],xmm0[7],xmm2[7]
 ; SSE42-NEXT:    punpcklbw {{.*#+}} xmm2 = xmm2[0],xmm4[0],xmm2[1],xmm4[1],xmm2[2],xmm4[2],xmm2[3],xmm4[3],xmm2[4],xmm4[4],xmm2[5],xmm4[5],xmm2[6],xmm4[6],xmm2[7],xmm4[7]
 ; SSE42-NEXT:    movdqa %xmm2, %xmm4
-; SSE42-NEXT:    psraw $4, %xmm4
+; SSE42-NEXT:    psraw $2, %xmm4
 ; SSE42-NEXT:    pblendvb %xmm0, %xmm4, %xmm2
 ; SSE42-NEXT:    movdqa %xmm2, %xmm4
 ; SSE42-NEXT:    psraw $1, %xmm4
@@ -549,7 +549,7 @@ define <32 x i8> @ashr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE42-NEXT:    punpckhbw {{.*#+}} xmm0 = xmm0[8],xmm3[8],xmm0[9],xmm3[9],xmm0[10],xmm3[10],xmm0[11],xmm3[11],xmm0[12],xmm3[12],xmm0[13],xmm3[13],xmm0[14],xmm3[14],xmm0[15],xmm3[15]
 ; SSE42-NEXT:    punpckhbw {{.*#+}} xmm4 = xmm4[8],xmm1[8],xmm4[9],xmm1[9],xmm4[10],xmm1[10],xmm4[11],xmm1[11],xmm4[12],xmm1[12],xmm4[13],xmm1[13],xmm4[14],xmm1[14],xmm4[15],xmm1[15]
 ; SSE42-NEXT:    movdqa %xmm4, %xmm5
-; SSE42-NEXT:    psraw $4, %xmm5
+; SSE42-NEXT:    psraw $2, %xmm5
 ; SSE42-NEXT:    pblendvb %xmm0, %xmm5, %xmm4
 ; SSE42-NEXT:    movdqa %xmm4, %xmm5
 ; SSE42-NEXT:    psraw $1, %xmm5
@@ -559,7 +559,7 @@ define <32 x i8> @ashr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; SSE42-NEXT:    punpcklbw {{.*#+}} xmm0 = xmm0[0],xmm3[0],xmm0[1],xmm3[1],xmm0[2],xmm3[2],xmm0[3],xmm3[3],xmm0[4],xmm3[4],xmm0[5],xmm3[5],xmm0[6],xmm3[6],xmm0[7],xmm3[7]
 ; SSE42-NEXT:    punpcklbw {{.*#+}} xmm1 = xmm1[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7]
 ; SSE42-NEXT:    movdqa %xmm1, %xmm3
-; SSE42-NEXT:    psraw $4, %xmm3
+; SSE42-NEXT:    psraw $2, %xmm3
 ; SSE42-NEXT:    pblendvb %xmm0, %xmm3, %xmm1
 ; SSE42-NEXT:    movdqa %xmm1, %xmm3
 ; SSE42-NEXT:    psraw $1, %xmm3
@@ -575,7 +575,7 @@ define <32 x i8> @ashr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
 ; AVX2-NEXT:    vpunpckhbw {{.*#+}} ymm2 = ymm1[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15,24,24,25,25,26,26,27,27,28,28,29,29,30,30,31,31]
 ; AVX2-NEXT:    vpunpckhbw {{.*#+}} ymm3 = ymm0[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15,24,24,25,25,26,26,27,27,28,28,29,29,30,30,31,31]
-; AVX2-NEXT:    vpsraw $4, %ymm3, %ymm4
+; AVX2-NEXT:    vpsraw $2, %ymm3, %ymm4
 ; AVX2-NEXT:    vpblendvb %ymm2, %ymm4, %ymm3, %ymm3
 ; AVX2-NEXT:    vpsraw $1, %ymm3, %ymm4
 ; AVX2-NEXT:    vpaddw %ymm2, %ymm2, %ymm2
@@ -583,7 +583,7 @@ define <32 x i8> @ashr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; AVX2-NEXT:    vpsrlw $8, %ymm2, %ymm2
 ; AVX2-NEXT:    vpunpcklbw {{.*#+}} ymm1 = ymm1[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,16,16,17,17,18,18,19,19,20,20,21,21,22,22,23,23]
 ; AVX2-NEXT:    vpunpcklbw {{.*#+}} ymm0 = ymm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,16,16,17,17,18,18,19,19,20,20,21,21,22,22,23,23]
-; AVX2-NEXT:    vpsraw $4, %ymm0, %ymm3
+; AVX2-NEXT:    vpsraw $2, %ymm0, %ymm3
 ; AVX2-NEXT:    vpblendvb %ymm1, %ymm3, %ymm0, %ymm0
 ; AVX2-NEXT:    vpsraw $1, %ymm0, %ymm3
 ; AVX2-NEXT:    vpaddw %ymm1, %ymm1, %ymm1
@@ -597,7 +597,7 @@ define <32 x i8> @ashr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; AVX512-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to8}, %ymm1, %ymm1
 ; AVX512-NEXT:    vpunpckhbw {{.*#+}} ymm2 = ymm1[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15,24,24,25,25,26,26,27,27,28,28,29,29,30,30,31,31]
 ; AVX512-NEXT:    vpunpckhbw {{.*#+}} ymm3 = ymm0[8,8,9,9,10,10,11,11,12,12,13,13,14,14,15,15,24,24,25,25,26,26,27,27,28,28,29,29,30,30,31,31]
-; AVX512-NEXT:    vpsraw $4, %ymm3, %ymm4
+; AVX512-NEXT:    vpsraw $2, %ymm3, %ymm4
 ; AVX512-NEXT:    vpblendvb %ymm2, %ymm4, %ymm3, %ymm3
 ; AVX512-NEXT:    vpsraw $1, %ymm3, %ymm4
 ; AVX512-NEXT:    vpaddw %ymm2, %ymm2, %ymm2
@@ -605,7 +605,7 @@ define <32 x i8> @ashr2_v32i8(<32 x i8> %a, <32 x i8> %mask) {
 ; AVX512-NEXT:    vpsrlw $8, %ymm2, %ymm2
 ; AVX512-NEXT:    vpunpcklbw {{.*#+}} ymm1 = ymm1[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,16,16,17,17,18,18,19,19,20,20,21,21,22,22,23,23]
 ; AVX512-NEXT:    vpunpcklbw {{.*#+}} ymm0 = ymm0[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,16,16,17,17,18,18,19,19,20,20,21,21,22,22,23,23]
-; AVX512-NEXT:    vpsraw $4, %ymm0, %ymm3
+; AVX512-NEXT:    vpsraw $2, %ymm0, %ymm3
 ; AVX512-NEXT:    vpblendvb %ymm1, %ymm3, %ymm0, %ymm0
 ; AVX512-NEXT:    vpsraw $1, %ymm0, %ymm3
 ; AVX512-NEXT:    vpaddw %ymm1, %ymm1, %ymm1


### PR DESCRIPTION
The bailing-out logic for 3-stage shifts acts as follows:
```
if (MinLZ < 2) {
  conditionally shift by 4
}
if (MinLZ < 1) {
  conditionally shift by 2
}
conditionally shift by 1
```
When `MinLZ = 1`, only the shift by 4 and by 1 paths are executed. It is weird.

Closes https://github.com/llvm/llvm-project/issues/175303. The original reproducer is equivalent to the existing func `@shl2_v32i8`, so no new tests need to be added.

