### PR TITLE
[clang][bytecode] Check for invalid function decls

### DIFF
--- a/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
+++ b/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
@@ -86,7 +86,8 @@ void ByteCodeEmitter::compileFunc(const FunctionDecl *FuncDecl,
 
   // Set the function's code.
   Func->setCode(FuncDecl, NextLocalOffset, std::move(Code), std::move(SrcMap),
-                std::move(Scopes), FuncDecl->hasBody());
+                std::move(Scopes), FuncDecl->hasBody(),
+                !FuncDecl->isInvalidDecl());
   Func->setIsFullyCompiled(true);
 }
 

--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -240,13 +240,14 @@ private:
   /// Sets the code of a function.
   void setCode(FunctionDeclTy Source, unsigned NewFrameSize,
                llvm::SmallVector<std::byte> &&NewCode, SourceMap &&NewSrcMap,
-               llvm::SmallVector<Scope, 2> &&NewScopes, bool NewHasBody) {
+               llvm::SmallVector<Scope, 2> &&NewScopes, bool NewHasBody,
+               bool NewIsValid) {
     this->Source = Source;
     FrameSize = NewFrameSize;
     Code = std::move(NewCode);
     SrcMap = std::move(NewSrcMap);
     Scopes = std::move(NewScopes);
-    IsValid = true;
+    IsValid = NewIsValid;
     HasBody = NewHasBody;
   }
 

--- a/clang/test/AST/ByteCode/invalid.cpp
+++ b/clang/test/AST/ByteCode/invalid.cpp
@@ -123,3 +123,12 @@ namespace InvalidIntPtrRecord {
   };
   Size_t foo() { return (Size_t)(&((struct S *)0)->a); }
 }
+
+namespace RetVoidInInvalidFunc {
+
+  constexpr bool foo() { return; } // both-error {{non-void constexpr function 'foo' should return a value}}
+  template <int N> struct X {
+    int v = N;
+  };
+  X<foo()> x; // both-error {{non-type template argument is not a constant expression}}
+}


### PR DESCRIPTION
If the function decl is invalid, the `interp::Function` shouldn't ever be valid.

Fixes https://github.com/llvm/llvm-project/issues/175280