### PR TITLE
[clang] [unittest] Fix linking against dylib

### DIFF
--- a/clang/unittests/Basic/CMakeLists.txt
+++ b/clang/unittests/Basic/CMakeLists.txt
@@ -16,8 +16,8 @@ add_distinct_clang_unittest(BasicTests
   clangBasic
   clangLex
   LINK_LIBS
-  LLVMTargetParser
   LLVMTestingSupport
   LLVM_COMPONENTS
   Support
+  TargetParser
   )


### PR DESCRIPTION
Fix a regression introduced in #174513 that would cause `BasicTests` to link directly to static `LLVMTargetParser` library instead of using the component linking, to respect dylib.