### PR TITLE
[libc][math] Refactor dfmal to Header Only.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -39,6 +39,7 @@
 #include "math/coshf16.h"
 #include "math/cospif.h"
 #include "math/cospif16.h"
+#include "math/dfmal.h"
 #include "math/dsqrtl.h"
 #include "math/erff.h"
 #include "math/exp.h"

--- a/libc/shared/math/dfmal.h
+++ b/libc/shared/math/dfmal.h
@@ -1,4 +1,4 @@
-//===-- Implementation of dfmal function ----------------------------------===//
+//===-- Shared dfmal function -----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,16 +6,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/dfmal.h"
-#include "src/__support/common.h"
-#include "src/__support/macros/config.h"
+#ifndef LLVM_LIBC_SHARED_MATH_DFMAL_H
+#define LLVM_LIBC_SHARED_MATH_DFMAL_H
+
+#include "shared/libc_common.h"
+
 #include "src/__support/math/dfmal.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(double, dfmal,
-                   (long double x, long double y, long double z)) {
-  return math::dfmal(x, y, z);
-}
+using math::dfmal;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_DFMAL_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1040,3 +1040,13 @@ add_header_library(
     libc.src.__support.math.sincos_eval
     libc.src.__support.macros.optimization
 )
+
+add_header_library(
+  dfmal
+  HDRS
+    dfmal.h
+  DEPENDS
+    libc.src.__support.FPUtil.fma
+    libc.src.__support.common
+    libc.src.__support.macros.config
+)

--- a/libc/src/__support/math/dfmal.h
+++ b/libc/src/__support/math/dfmal.h
@@ -1,4 +1,4 @@
-//===-- Implementation header for dfmal       -----------------------------===//
+//===-- Implementation header for dfmal -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/src/__support/math/dfmal.h
+++ b/libc/src/__support/math/dfmal.h
@@ -1,4 +1,4 @@
-//===-- Implementation of dfmal function ----------------------------------===//
+//===-- Implementation headre for dfmal       -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,16 +6,22 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/dfmal.h"
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_DFMAL_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_DFMAL_H
+
+#include "src/__support/FPUtil/FMA.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
-#include "src/__support/math/dfmal.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(double, dfmal,
-                   (long double x, long double y, long double z)) {
-  return math::dfmal(x, y, z);
+namespace math {
+
+LIBC_INLINE static double dfmal(long double x, long double y, long double z) {
+
+  return fputil::fma<double>(x, y, z);
 }
 
+} // namespace math
 } // namespace LIBC_NAMESPACE_DECL
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_DFMAL_H

--- a/libc/src/__support/math/dfmal.h
+++ b/libc/src/__support/math/dfmal.h
@@ -1,4 +1,4 @@
-//===-- Implementation headre for dfmal       -----------------------------===//
+//===-- Implementation header for dfmal       -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -14,14 +14,13 @@
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
-
 namespace math {
 
 LIBC_INLINE static double dfmal(long double x, long double y, long double z) {
-
   return fputil::fma<double>(x, y, z);
 }
 
 } // namespace math
 } // namespace LIBC_NAMESPACE_DECL
+
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_DFMAL_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -260,7 +260,7 @@ add_entrypoint_object(
   HDRS
     ../dfmal.h
   DEPENDS
-    libc.src.__support.FPUtil.fma
+    libc.src.__support.math.dfmal
 )
 
 add_entrypoint_object(

--- a/libc/src/math/generic/dfmal.cpp
+++ b/libc/src/math/generic/dfmal.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/dfmal.h"
-#include "src/__support/common.h"
-#include "src/__support/macros/config.h"
 #include "src/__support/math/dfmal.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -35,6 +35,7 @@ add_fp_unittest(
     libc.src.__support.math.coshf16
     libc.src.__support.math.cospif
     libc.src.__support.math.cospif16
+    libc.src.__support.math.dfmal
     libc.src.__support.math.dsqrtl
     libc.src.__support.math.exp10m1f
     libc.src.__support.math.exp10m1f16
@@ -62,5 +63,4 @@ add_fp_unittest(
     libc.src.__support.math.rsqrtf
     libc.src.__support.math.rsqrtf16
     libc.src.__support.math.sin
-    libc.src.__support.math.dfmal
 )

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -62,4 +62,5 @@ add_fp_unittest(
     libc.src.__support.math.rsqrtf
     libc.src.__support.math.rsqrtf16
     libc.src.__support.math.sin
+    libc.src.__support.math.dfmal
 )

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -111,8 +111,6 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
                LIBC_NAMESPACE::shared::ldexpf128(float128(8), 5));
   ASSERT_FP_EQ(float128(-1 * (8 << 5)),
                LIBC_NAMESPACE::shared::ldexpf128(float128(-8), 5));
-  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::dfmal(
-                           float128(0.0), float128(0.0), float128(0.0)));
 }
 
 #endif // LIBC_TYPES_HAS_FLOAT128

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -108,6 +108,8 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
                LIBC_NAMESPACE::shared::ldexpf128(float128(8), 5));
   ASSERT_FP_EQ(float128(-1 * (8 << 5)),
                LIBC_NAMESPACE::shared::ldexpf128(float128(-8), 5));
+  EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::dfmal(
+                           float128(0.0), float128(0.0), float128(0.0)));
 }
 
 #endif // LIBC_TYPES_HAS_FLOAT128

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -92,7 +92,10 @@ TEST(LlvmLibcSharedMathTest, AllDouble) {
   EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::expm1(0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::sin(0.0));
 }
-
+TEST(LlvmLibcSharedMathTest, AllLongDouble) {
+  EXPECT_FP_EQ(0x0p+0L,
+               LIBC_NAMESPACE::shared::dfmal(0x0.p+0L, 0x0.p+0L, 0x0.p+0L));
+}
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
 TEST(LlvmLibcSharedMathTest, AllFloat128) {

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3119,6 +3119,16 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_dfmal",
+    hdrs = ["src/__support/math/dfmal.h"],
+    deps = [
+        ":__support_common",
+        ":__support_fputil_fma",
+        ":__support_macros_config",
+    ],
+)
+
+libc_support_library(
     name = "__support_range_reduction_double",
     hdrs = [
         "src/__support/math/range_reduction_double_common.h",
@@ -3718,7 +3728,7 @@ libc_math_function(name = "ddivf128")
 libc_math_function(
     name = "dfmal",
     additional_deps = [
-        ":__support_fputil_fma",
+        ":__support_math_dfmal",
     ],
 )
 


### PR DESCRIPTION
builds correctly with both Clang and GCC 12.2.

Since `fma` is not `constexpr`, `dfmal` cannot be declared `constexpr` either.
Closes #175316.