### PR TITLE
ValueTracking: Account for undef in adjustKnownFPClassForSelectArm

### DIFF
--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -137,14 +137,19 @@ struct KnownFPClass {
     return isKnownNever(fcPositive) && isKnownNeverLogicalNegZero(Mode);
   }
 
-  KnownFPClass intersectWith(const KnownFPClass &RHS) {
+  KnownFPClass intersectWith(const KnownFPClass &RHS) const {
     return KnownFPClass(KnownFPClasses | RHS.KnownFPClasses,
                         SignBit == RHS.SignBit ? SignBit : std::nullopt);
   }
 
-  KnownFPClass unionWith(const KnownFPClass &RHS) {
-    // TODO: Handle sign bit?
-    return KnownFPClass(KnownFPClasses & RHS.KnownFPClasses);
+  KnownFPClass unionWith(const KnownFPClass &RHS) const {
+    std::optional<bool> MergedSignBit;
+    if (SignBit && !RHS.SignBit)
+      MergedSignBit = SignBit;
+    else if (!SignBit && RHS.SignBit)
+      MergedSignBit = RHS.SignBit;
+
+    return KnownFPClass(KnownFPClasses & RHS.KnownFPClasses, MergedSignBit);
   }
 
   KnownFPClass &operator|=(const KnownFPClass &RHS) {

--- a/llvm/include/llvm/Support/KnownFPClass.h
+++ b/llvm/include/llvm/Support/KnownFPClass.h
@@ -138,8 +138,13 @@ struct KnownFPClass {
   }
 
   KnownFPClass intersectWith(const KnownFPClass &RHS) {
-    return KnownFPClass(~(~KnownFPClasses & ~RHS.KnownFPClasses),
+    return KnownFPClass(KnownFPClasses | RHS.KnownFPClasses,
                         SignBit == RHS.SignBit ? SignBit : std::nullopt);
+  }
+
+  KnownFPClass unionWith(const KnownFPClass &RHS) {
+    // TODO: Handle sign bit?
+    return KnownFPClass(KnownFPClasses & RHS.KnownFPClasses);
   }
 
   KnownFPClass &operator|=(const KnownFPClass &RHS) {

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -4885,11 +4885,16 @@ void llvm::adjustKnownFPClassForSelectArm(KnownFPClass &Known, Value *Cond,
                                           Value *Arm, bool Invert,
                                           const SimplifyQuery &SQ,
                                           unsigned Depth) {
+
+  KnownFPClass KnownSrc;
   computeKnownFPClassFromCond(Arm, Cond,
-                              /*CondIsTrue=*/!Invert, SQ.CxtI, Known,
+                              /*CondIsTrue=*/!Invert, SQ.CxtI, KnownSrc,
                               Depth + 1);
-  // TODO: Do we need to check isGuaranteedNotToBeUndef, like the KnownBits
-  // case?
+  if (KnownSrc.isUnknown())
+    return;
+
+  if (isGuaranteedNotToBeUndef(Arm, SQ.AC, SQ.CxtI, SQ.DT, Depth + 1))
+    Known = KnownSrc;
 }
 
 void computeKnownFPClass(const Value *V, const APInt &DemandedElts,

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -4893,6 +4893,7 @@ void llvm::adjustKnownFPClassForSelectArm(KnownFPClass &Known, Value *Cond,
   if (KnownSrc.isUnknown())
     return;
 
+  KnownSrc |= Known;
   if (isGuaranteedNotToBeUndef(Arm, SQ.AC, SQ.CxtI, SQ.DT, Depth + 1))
     Known = KnownSrc;
 }

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -4890,10 +4890,10 @@ void llvm::adjustKnownFPClassForSelectArm(KnownFPClass &Known, Value *Cond,
   computeKnownFPClassFromCond(Arm, Cond,
                               /*CondIsTrue=*/!Invert, SQ.CxtI, KnownSrc,
                               Depth + 1);
+  KnownSrc = KnownSrc.unionWith(Known);
   if (KnownSrc.isUnknown())
     return;
 
-  KnownSrc |= Known;
   if (isGuaranteedNotToBeUndef(Arm, SQ.AC, SQ.CxtI, SQ.DT, Depth + 1))
     Known = KnownSrc;
 }

--- a/llvm/test/Transforms/Attributor/nofpclass-implied-by-fcmp.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-implied-by-fcmp.ll
@@ -10,9 +10,9 @@ declare void @llvm.assume(i1 noundef)
 ;---------------------------------------------------------------------
 
 ; can't be +inf
-define float @clamp_is_ogt_1_to_1(float %arg) {
-; CHECK-LABEL: define nofpclass(pinf) float @clamp_is_ogt_1_to_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2:[0-9]+]] {
+define float @clamp_is_ogt_1_to_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(pinf) float @clamp_is_ogt_1_to_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2:[0-9]+]] {
 ; CHECK-NEXT:    [[IS_OGT_1:%.*]] = fcmp ogt float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGT_1]], float 1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -22,9 +22,9 @@ define float @clamp_is_ogt_1_to_1(float %arg) {
   ret float %select
 }
 
-define float @clamp_is_ogt_1_to_1_commute(float %arg) {
-; CHECK-LABEL: define nofpclass(pinf) float @clamp_is_ogt_1_to_1_commute(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ogt_1_to_1_commute(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(pinf) float @clamp_is_ogt_1_to_1_commute(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ULE_1:%.*]] = fcmp ule float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ULE_1]], float [[ARG]], float 1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -35,9 +35,9 @@ define float @clamp_is_ogt_1_to_1_commute(float %arg) {
 }
 
 ; can't be +inf or nan
-define float @clamp_is_ugt_1_to_1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan pinf) float @clamp_is_ugt_1_to_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ugt_1_to_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan pinf) float @clamp_is_ugt_1_to_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UGT_1:%.*]] = fcmp ugt float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGT_1]], float 1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -48,9 +48,9 @@ define float @clamp_is_ugt_1_to_1(float %arg) {
 }
 
 ; can't be +inf or nan
-define float @clamp_is_ugt_1_to_1_commute(float %arg) {
-; CHECK-LABEL: define nofpclass(nan pinf) float @clamp_is_ugt_1_to_1_commute(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ugt_1_to_1_commute(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan pinf) float @clamp_is_ugt_1_to_1_commute(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OLE_1:%.*]] = fcmp ole float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OLE_1]], float [[ARG]], float 1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -61,9 +61,9 @@ define float @clamp_is_ugt_1_to_1_commute(float %arg) {
 }
 
 ; can't be +inf
-define float @clamp_is_oge_1_to_1(float %arg) {
-; CHECK-LABEL: define nofpclass(pinf) float @clamp_is_oge_1_to_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_oge_1_to_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(pinf) float @clamp_is_oge_1_to_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OGE_1:%.*]] = fcmp oge float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGE_1]], float 1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -74,7 +74,7 @@ define float @clamp_is_oge_1_to_1(float %arg) {
 }
 
 define float @clamp_is_oge_1_to_1_commute(float %arg) {
-; CHECK-LABEL: define nofpclass(pinf) float @clamp_is_oge_1_to_1_commute(
+; CHECK-LABEL: define float @clamp_is_oge_1_to_1_commute(
 ; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ULT_1:%.*]] = fcmp ult float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ULT_1]], float [[ARG]], float 1.000000e+00
@@ -86,9 +86,9 @@ define float @clamp_is_oge_1_to_1_commute(float %arg) {
 }
 
 ; can't be +inf or nan
-define float @clamp_is_uge_1_to_1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan pinf) float @clamp_is_uge_1_to_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_uge_1_to_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan pinf) float @clamp_is_uge_1_to_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UGT_1:%.*]] = fcmp uge float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGT_1]], float 1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -99,9 +99,9 @@ define float @clamp_is_uge_1_to_1(float %arg) {
 }
 
 ; can't be negative, zero, or denormal
-define float @clamp_is_olt_1_to_1(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf zero sub nnorm) float @clamp_is_olt_1_to_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_olt_1_to_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf zero sub nnorm) float @clamp_is_olt_1_to_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OLT_1:%.*]] = fcmp olt float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OLT_1]], float 1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -112,9 +112,9 @@ define float @clamp_is_olt_1_to_1(float %arg) {
 }
 
 ; can't be negative, zero, or denormal
-define float @clamp_is_olt_1_to_1_commute(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf zero sub nnorm) float @clamp_is_olt_1_to_1_commute(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_olt_1_to_1_commute(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf zero sub nnorm) float @clamp_is_olt_1_to_1_commute(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UGE_1:%.*]] = fcmp uge float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGE_1]], float [[ARG]], float 1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -125,9 +125,9 @@ define float @clamp_is_olt_1_to_1_commute(float %arg) {
 }
 
 ; can't be negative or zero, nan or denormal
-define float @clamp_is_ult_1_to_1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan ninf zero sub nnorm) float @clamp_is_ult_1_to_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ult_1_to_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan ninf zero sub nnorm) float @clamp_is_ult_1_to_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ULT_1:%.*]] = fcmp ult float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ULT_1]], float 1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -138,9 +138,9 @@ define float @clamp_is_ult_1_to_1(float %arg) {
 }
 
 ; can't be negative or zero, nan or denormal
-define float @clamp_is_ult_1_to_1_commute(float %arg) {
-; CHECK-LABEL: define nofpclass(nan ninf zero sub nnorm) float @clamp_is_ult_1_to_1_commute(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ult_1_to_1_commute(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan ninf zero sub nnorm) float @clamp_is_ult_1_to_1_commute(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OGE_1:%.*]] = fcmp oge float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGE_1]], float [[ARG]], float 1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -151,9 +151,9 @@ define float @clamp_is_ult_1_to_1_commute(float %arg) {
 }
 
 ; can't be negative, zero or denormal
-define float @clamp_is_ole_1_to_1(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf zero sub nnorm) float @clamp_is_ole_1_to_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ole_1_to_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf zero sub nnorm) float @clamp_is_ole_1_to_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OLE_1:%.*]] = fcmp ole float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OLE_1]], float 1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -164,9 +164,9 @@ define float @clamp_is_ole_1_to_1(float %arg) {
 }
 
 ; can't be negative or zero, nan or denormal
-define float @clamp_is_ule_1_to_1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan ninf zero sub nnorm) float @clamp_is_ule_1_to_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ule_1_to_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan ninf zero sub nnorm) float @clamp_is_ule_1_to_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ULE_1:%.*]] = fcmp ule float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ULE_1]], float 1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -177,9 +177,9 @@ define float @clamp_is_ule_1_to_1(float %arg) {
 }
 
 ; can't be negative or denormal
-define float @clamp_is_olt_1_to_0(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf nzero sub nnorm) float @clamp_is_olt_1_to_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_olt_1_to_0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero sub nnorm) float @clamp_is_olt_1_to_0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OLT_1:%.*]] = fcmp olt float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OLT_1]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -190,9 +190,9 @@ define float @clamp_is_olt_1_to_0(float %arg) {
 }
 
 ; can't be negative, nan or denormal
-define float @clamp_is_ult_1_to_0(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf nzero sub nnorm) float @clamp_is_ult_1_to_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ult_1_to_0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero sub nnorm) float @clamp_is_ult_1_to_0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ULT_1:%.*]] = fcmp olt float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ULT_1]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -203,9 +203,9 @@ define float @clamp_is_ult_1_to_0(float %arg) {
 }
 
 ; can't be negative or denormal
-define float @clamp_is_ole_1_to_0(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf nzero sub nnorm) float @clamp_is_ole_1_to_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ole_1_to_0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero sub nnorm) float @clamp_is_ole_1_to_0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OLE_1:%.*]] = fcmp ole float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OLE_1]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -216,9 +216,9 @@ define float @clamp_is_ole_1_to_0(float %arg) {
 }
 
 ; can't be negative or denormal
-define float @clamp_is_ole_1_to_0_commute(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf nzero sub nnorm) float @clamp_is_ole_1_to_0_commute(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ole_1_to_0_commute(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero sub nnorm) float @clamp_is_ole_1_to_0_commute(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UGT_1:%.*]] = fcmp ugt float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGT_1]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -229,9 +229,9 @@ define float @clamp_is_ole_1_to_0_commute(float %arg) {
 }
 
 ; can't be negative or denormal
-define float @clamp_is_ule_1_to_0(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf nzero sub nnorm) float @clamp_is_ule_1_to_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ule_1_to_0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero sub nnorm) float @clamp_is_ule_1_to_0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ULE_1:%.*]] = fcmp ole float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ULE_1]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -242,9 +242,9 @@ define float @clamp_is_ule_1_to_0(float %arg) {
 }
 
 ; can't be positive, zero or denormal
-define float @clamp_is_ogt_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define nofpclass(pinf zero sub pnorm) float @clamp_is_ogt_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ogt_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(pinf zero sub pnorm) float @clamp_is_ogt_neg1_to_neg1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OGT_NEG1:%.*]] = fcmp ogt float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGT_NEG1]], float -1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -255,9 +255,9 @@ define float @clamp_is_ogt_neg1_to_neg1(float %arg) {
 }
 
 ; can't be positive, zero, nan or denormal
-define float @clamp_is_ugt_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan pinf zero sub pnorm) float @clamp_is_ugt_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ugt_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan pinf zero sub pnorm) float @clamp_is_ugt_neg1_to_neg1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UGT_NEG1:%.*]] = fcmp ugt float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGT_NEG1]], float -1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -268,9 +268,9 @@ define float @clamp_is_ugt_neg1_to_neg1(float %arg) {
 }
 
 ; can't be positive or denormal
-define float @clamp_is_ogt_neg1_to_0(float %arg) {
-; CHECK-LABEL: define nofpclass(pinf nzero sub pnorm) float @clamp_is_ogt_neg1_to_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ogt_neg1_to_0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(pinf nzero sub pnorm) float @clamp_is_ogt_neg1_to_0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OGT_NEG1:%.*]] = fcmp ogt float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGT_NEG1]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -281,9 +281,9 @@ define float @clamp_is_ogt_neg1_to_0(float %arg) {
 }
 
 ; can't be positive, nan or denormal
-define float @clamp_is_ugt_neg1_to_0(float %arg) {
-; CHECK-LABEL: define nofpclass(nan pinf nzero sub pnorm) float @clamp_is_ugt_neg1_to_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ugt_neg1_to_0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan pinf nzero sub pnorm) float @clamp_is_ugt_neg1_to_0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UGT_NEG1:%.*]] = fcmp ugt float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGT_NEG1]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -294,9 +294,9 @@ define float @clamp_is_ugt_neg1_to_0(float %arg) {
 }
 
 ; can't be -inf
-define float @clamp_is_olt_neg1_to_neg1_commute(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf) float @clamp_is_olt_neg1_to_neg1_commute(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_olt_neg1_to_neg1_commute(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf) float @clamp_is_olt_neg1_to_neg1_commute(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UGE_NEG1:%.*]] = fcmp uge float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGE_NEG1]], float [[ARG]], float -1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -307,9 +307,9 @@ define float @clamp_is_olt_neg1_to_neg1_commute(float %arg) {
 }
 
 ; can't be -inf
-define float @clamp_is_olt_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf) float @clamp_is_olt_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_olt_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf) float @clamp_is_olt_neg1_to_neg1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OLT_NEG1:%.*]] = fcmp olt float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OLT_NEG1]], float -1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -320,9 +320,9 @@ define float @clamp_is_olt_neg1_to_neg1(float %arg) {
 }
 
 ; can't be -inf or nan
-define float @clamp_is_ult_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan ninf) float @clamp_is_ult_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ult_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan ninf) float @clamp_is_ult_neg1_to_neg1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ULT_NEG1:%.*]] = fcmp ult float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ULT_NEG1]], float -1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -333,9 +333,9 @@ define float @clamp_is_ult_neg1_to_neg1(float %arg) {
 }
 
 ; can't be -inf or nan
-define float @clamp_is_ult_neg1_to_neg1_commute(float %arg) {
-; CHECK-LABEL: define nofpclass(nan ninf) float @clamp_is_ult_neg1_to_neg1_commute(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ult_neg1_to_neg1_commute(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan ninf) float @clamp_is_ult_neg1_to_neg1_commute(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OGE_NEG1:%.*]] = fcmp oge float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGE_NEG1]], float [[ARG]], float -1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -350,9 +350,9 @@ define float @clamp_is_ult_neg1_to_neg1_commute(float %arg) {
 ;---------------------------------------------------------------------
 
 ; Must be 1, only posnormal
-define float @fcmp_oeq_1_else_1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf zero sub nnorm) float @fcmp_oeq_1_else_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @fcmp_oeq_1_else_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf zero sub nnorm) float @fcmp_oeq_1_else_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OEQ_1:%.*]] = fcmp oeq float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OEQ_1]], float [[ARG]], float 1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -363,9 +363,9 @@ define float @fcmp_oeq_1_else_1(float %arg) {
 }
 
 ; Don't know anything
-define float @fcmp_one_1_else_1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan) float @fcmp_one_1_else_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @fcmp_one_1_else_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan) float @fcmp_one_1_else_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ONE_1:%.*]] = fcmp one float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ONE_1]], float [[ARG]], float 1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -376,9 +376,9 @@ define float @fcmp_one_1_else_1(float %arg) {
 }
 
 ; must be 1 or nan
-define float @fcmp_one_1_1_else_arg(float %arg) {
-; CHECK-LABEL: define nofpclass(inf zero sub nnorm) float @fcmp_one_1_1_else_arg(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @fcmp_one_1_1_else_arg(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf zero sub nnorm) float @fcmp_one_1_1_else_arg(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ONE_1:%.*]] = fcmp one float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ONE_1]], float 1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -389,9 +389,9 @@ define float @fcmp_one_1_1_else_arg(float %arg) {
 }
 
 ; must be 1
-define float @fcmp_une_1_1_else_arg(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf zero sub nnorm) float @fcmp_une_1_1_else_arg(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @fcmp_une_1_1_else_arg(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf zero sub nnorm) float @fcmp_une_1_1_else_arg(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UNE_1:%.*]] = fcmp une float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UNE_1]], float 1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -402,9 +402,9 @@ define float @fcmp_une_1_1_else_arg(float %arg) {
 }
 
 ; Must be -1, only negnormal
-define float @fcmp_oeq_neg1_else_neg1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf zero sub pnorm) float @fcmp_oeq_neg1_else_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @fcmp_oeq_neg1_else_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf zero sub pnorm) float @fcmp_oeq_neg1_else_neg1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OEQ_NEG1:%.*]] = fcmp oeq float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OEQ_NEG1]], float [[ARG]], float -1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -415,9 +415,9 @@ define float @fcmp_oeq_neg1_else_neg1(float %arg) {
 }
 
 ; Don't know anything
-define float @fcmp_one_neg1_else_neg1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan) float @fcmp_one_neg1_else_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @fcmp_one_neg1_else_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan) float @fcmp_one_neg1_else_neg1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ONE_NEG1:%.*]] = fcmp one float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ONE_NEG1]], float [[ARG]], float -1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -427,9 +427,9 @@ define float @fcmp_one_neg1_else_neg1(float %arg) {
   ret float %select
 }
 
-define float @fcmp_oeq_1_else_0(float %arg) {
+define float @fcmp_oeq_1_else_0(float noundef %arg) {
 ; CHECK-LABEL: define noundef nofpclass(nan inf nzero sub nnorm) float @fcmp_oeq_1_else_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OEQ_1:%.*]] = fcmp oeq float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OEQ_1]], float 1.000000e+00, float 0.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -439,9 +439,9 @@ define float @fcmp_oeq_1_else_0(float %arg) {
   ret float %select
 }
 
-define float @fcmp_ueq_1_else_0(float %arg) {
+define float @fcmp_ueq_1_else_0(float noundef %arg) {
 ; CHECK-LABEL: define noundef nofpclass(nan inf nzero sub nnorm) float @fcmp_ueq_1_else_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UEQ_1:%.*]] = fcmp ueq float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UEQ_1]], float 1.000000e+00, float 0.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -451,9 +451,9 @@ define float @fcmp_ueq_1_else_0(float %arg) {
   ret float %select
 }
 
-define float @if_fcmp_oeq_1_0_else_arg(float %arg) {
-; CHECK-LABEL: define float @if_fcmp_oeq_1_0_else_arg(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @if_fcmp_oeq_1_0_else_arg(float noundef %arg) {
+; CHECK-LABEL: define noundef float @if_fcmp_oeq_1_0_else_arg(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OEQ_1:%.*]] = fcmp oeq float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OEQ_1]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -463,9 +463,9 @@ define float @if_fcmp_oeq_1_0_else_arg(float %arg) {
   ret float %select
 }
 
-define float @if_fcmp_oeq_0_1_else_arg(float %arg) {
-; CHECK-LABEL: define nofpclass(zero) float @if_fcmp_oeq_0_1_else_arg(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @if_fcmp_oeq_0_1_else_arg(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(zero) float @if_fcmp_oeq_0_1_else_arg(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OEQ_0:%.*]] = fcmp oeq float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OEQ_0]], float 1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -475,9 +475,9 @@ define float @if_fcmp_oeq_0_1_else_arg(float %arg) {
   ret float %select
 }
 
-define float @if_fcmp_one_0_arg_else_1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan zero) float @if_fcmp_one_0_arg_else_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @if_fcmp_one_0_arg_else_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan zero) float @if_fcmp_one_0_arg_else_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ONE_0:%.*]] = fcmp one float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ONE_0]], float [[ARG]], float 1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -487,9 +487,9 @@ define float @if_fcmp_one_0_arg_else_1(float %arg) {
   ret float %select
 }
 
-define float @if_fcmp_une_0_arg_else_1(float %arg) {
-; CHECK-LABEL: define nofpclass(zero) float @if_fcmp_une_0_arg_else_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @if_fcmp_une_0_arg_else_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(zero) float @if_fcmp_une_0_arg_else_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UNE_0:%.*]] = fcmp une float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UNE_0]], float [[ARG]], float 1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -499,9 +499,9 @@ define float @if_fcmp_une_0_arg_else_1(float %arg) {
   ret float %select
 }
 
-define float @if_fcmp_one_0_1_else_arg(float %arg) {
-; CHECK-LABEL: define nofpclass(inf sub nnorm) float @if_fcmp_one_0_1_else_arg(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @if_fcmp_one_0_1_else_arg(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf sub nnorm) float @if_fcmp_one_0_1_else_arg(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ONE_0:%.*]] = fcmp one float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ONE_0]], float 1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -511,9 +511,9 @@ define float @if_fcmp_one_0_1_else_arg(float %arg) {
   ret float %select
 }
 
-define float @if_fcmp_one_1_arg_else_0(float %arg) {
-; CHECK-LABEL: define nofpclass(nan) float @if_fcmp_one_1_arg_else_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @if_fcmp_one_1_arg_else_0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan) float @if_fcmp_one_1_arg_else_0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ONE_1:%.*]] = fcmp one float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ONE_1]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -523,10 +523,10 @@ define float @if_fcmp_one_1_arg_else_0(float %arg) {
   ret float %select
 }
 
-define float @fcmp_fabs_oeq_1_else_1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf zero sub) float @fcmp_fabs_oeq_1_else_1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4:[0-9]+]]
+define float @fcmp_fabs_oeq_1_else_1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf zero sub) float @fcmp_fabs_oeq_1_else_1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4:[0-9]+]]
 ; CHECK-NEXT:    [[FABS_IS_OEQ_1:%.*]] = fcmp oeq float [[FABS_ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_OEQ_1]], float [[ARG]], float 1.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -537,10 +537,10 @@ define float @fcmp_fabs_oeq_1_else_1(float %arg) {
   ret float %select
 }
 
-define float @fcmp_fabs_oeq_1_0_else_arg(float %arg) {
-; CHECK-LABEL: define float @fcmp_fabs_oeq_1_0_else_arg(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @fcmp_fabs_oeq_1_0_else_arg(float noundef %arg) {
+; CHECK-LABEL: define noundef float @fcmp_fabs_oeq_1_0_else_arg(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_OEQ_1:%.*]] = fcmp oeq float [[FABS_ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_OEQ_1]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -551,10 +551,10 @@ define float @fcmp_fabs_oeq_1_0_else_arg(float %arg) {
   ret float %select
 }
 
-define float @fcmp_fabs_ueq_1_0_else_arg(float %arg) {
-; CHECK-LABEL: define nofpclass(nan) float @fcmp_fabs_ueq_1_0_else_arg(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @fcmp_fabs_ueq_1_0_else_arg(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan) float @fcmp_fabs_ueq_1_0_else_arg(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_UEQ_1:%.*]] = fcmp ueq float [[FABS_ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_UEQ_1]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -565,10 +565,10 @@ define float @fcmp_fabs_ueq_1_0_else_arg(float %arg) {
   ret float %select
 }
 
-define float @fcmp_fabs_one_1_arg_else_0(float %arg) {
-; CHECK-LABEL: define nofpclass(nan) float @fcmp_fabs_one_1_arg_else_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @fcmp_fabs_one_1_arg_else_0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan) float @fcmp_fabs_one_1_arg_else_0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_ONE_1:%.*]] = fcmp one float [[FABS_ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_ONE_1]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -579,10 +579,10 @@ define float @fcmp_fabs_one_1_arg_else_0(float %arg) {
   ret float %select
 }
 
-define float @fcmp_fabs_une_1_arg_else_0(float %arg) {
-; CHECK-LABEL: define float @fcmp_fabs_une_1_arg_else_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @fcmp_fabs_une_1_arg_else_0(float noundef %arg) {
+; CHECK-LABEL: define noundef float @fcmp_fabs_une_1_arg_else_0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_UNE_1:%.*]] = fcmp une float [[FABS_ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_UNE_1]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -593,10 +593,10 @@ define float @fcmp_fabs_une_1_arg_else_0(float %arg) {
   ret float %select
 }
 
-define float @fcmp_fabs_one_1_0_else_arg(float %arg) {
-; CHECK-LABEL: define nofpclass(inf nzero sub) float @fcmp_fabs_one_1_0_else_arg(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @fcmp_fabs_one_1_0_else_arg(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf nzero sub) float @fcmp_fabs_one_1_0_else_arg(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_ONE_1:%.*]] = fcmp one float [[FABS_ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_ONE_1]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -607,10 +607,10 @@ define float @fcmp_fabs_one_1_0_else_arg(float %arg) {
   ret float %select
 }
 
-define float @fcmp_fabs_une_1_0_else_arg(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf nzero sub) float @fcmp_fabs_une_1_0_else_arg(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @fcmp_fabs_une_1_0_else_arg(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf nzero sub) float @fcmp_fabs_une_1_0_else_arg(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_UNE_1:%.*]] = fcmp une float [[FABS_ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_UNE_1]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -621,10 +621,10 @@ define float @fcmp_fabs_une_1_0_else_arg(float %arg) {
   ret float %select
 }
 
-define float @fcmp_fabs_one_1_neg2_else_arg(float %arg) {
-; CHECK-LABEL: define nofpclass(inf zero sub) float @fcmp_fabs_one_1_neg2_else_arg(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @fcmp_fabs_one_1_neg2_else_arg(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf zero sub) float @fcmp_fabs_one_1_neg2_else_arg(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_ONE_1:%.*]] = fcmp one float [[FABS_ARG]], 1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_ONE_1]], float -2.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -639,9 +639,9 @@ define float @fcmp_fabs_one_1_neg2_else_arg(float %arg) {
 ; compare to denormal
 ;---------------------------------------------------------------------
 
-define float @clamp_olt_largest_denormal_0.0(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) float @clamp_olt_largest_denormal_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_olt_largest_denormal_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero nsub nnorm) float @clamp_olt_largest_denormal_0.0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OLT_LARGEST_DENORMAL:%.*]] = fcmp olt float [[ARG]], 0x380FFFFFC0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OLT_LARGEST_DENORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -651,9 +651,9 @@ define float @clamp_olt_largest_denormal_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_ole_largest_denormal_0.0(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) float @clamp_ole_largest_denormal_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_ole_largest_denormal_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero nsub nnorm) float @clamp_ole_largest_denormal_0.0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OLE_LARGEST_DENORMAL:%.*]] = fcmp ole float [[ARG]], 0x380FFFFFC0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OLE_LARGEST_DENORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -663,9 +663,9 @@ define float @clamp_ole_largest_denormal_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_ult_largest_denormal_0.0(float %arg) {
-; CHECK-LABEL: define nofpclass(nan ninf nzero nsub nnorm) float @clamp_ult_largest_denormal_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_ult_largest_denormal_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan ninf nzero nsub nnorm) float @clamp_ult_largest_denormal_0.0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ULT_LARGEST_DENORMAL:%.*]] = fcmp ult float [[ARG]], 0x380FFFFFC0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ULT_LARGEST_DENORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -675,9 +675,9 @@ define float @clamp_ult_largest_denormal_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_ule_largest_denormal_0.0(float %arg) {
-; CHECK-LABEL: define nofpclass(nan ninf nzero nsub nnorm) float @clamp_ule_largest_denormal_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_ule_largest_denormal_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan ninf nzero nsub nnorm) float @clamp_ule_largest_denormal_0.0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_ULE_LARGEST_DENORMAL:%.*]] = fcmp ule float [[ARG]], 0x380FFFFFC0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ULE_LARGEST_DENORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -687,9 +687,9 @@ define float @clamp_ule_largest_denormal_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_ogt_largest_denormal_0.0(float %arg) {
-; CHECK-LABEL: define nofpclass(nan ninf nzero nsub nnorm) float @clamp_ogt_largest_denormal_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_ogt_largest_denormal_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan ninf nzero nsub nnorm) float @clamp_ogt_largest_denormal_0.0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OGT_LARGEST_DENORMAL:%.*]] = fcmp ogt float [[ARG]], 0x380FFFFFC0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGT_LARGEST_DENORMAL]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -699,9 +699,9 @@ define float @clamp_ogt_largest_denormal_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_oge_largest_denormal_0.0(float %arg) {
-; CHECK-LABEL: define nofpclass(nan ninf nzero nsub nnorm) float @clamp_oge_largest_denormal_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_oge_largest_denormal_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan ninf nzero nsub nnorm) float @clamp_oge_largest_denormal_0.0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OGE_LARGEST_DENORMAL:%.*]] = fcmp oge float [[ARG]], 0x380FFFFFC0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGE_LARGEST_DENORMAL]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -711,9 +711,9 @@ define float @clamp_oge_largest_denormal_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_ugt_largest_denormal_0.0(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) float @clamp_ugt_largest_denormal_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_ugt_largest_denormal_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero nsub nnorm) float @clamp_ugt_largest_denormal_0.0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UGT_LARGEST_DENORMAL:%.*]] = fcmp ugt float [[ARG]], 0x380FFFFFC0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGT_LARGEST_DENORMAL]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -723,9 +723,9 @@ define float @clamp_ugt_largest_denormal_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_uge_largest_denormal_0.0(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) float @clamp_uge_largest_denormal_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_uge_largest_denormal_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(ninf nzero nsub nnorm) float @clamp_uge_largest_denormal_0.0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UGE_LARGEST_DENORMAL:%.*]] = fcmp uge float [[ARG]], 0x380FFFFFC0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGE_LARGEST_DENORMAL]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -735,9 +735,9 @@ define float @clamp_uge_largest_denormal_0.0(float %arg) {
   ret float %select
 }
 
-define float @fcmp_oeq_largest_denormal_arg_else_0.0(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf nzero nsub norm) float @fcmp_oeq_largest_denormal_arg_else_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @fcmp_oeq_largest_denormal_arg_else_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf nzero nsub norm) float @fcmp_oeq_largest_denormal_arg_else_0.0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OEQ_LARGEST_DENORMAL:%.*]] = fcmp oeq float [[ARG]], 0x380FFFFFC0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OEQ_LARGEST_DENORMAL]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -747,10 +747,10 @@ define float @fcmp_oeq_largest_denormal_arg_else_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_olt_largest_denormal_0.0(float %arg) {
-; CHECK-LABEL: define nofpclass(nzero) float @clamp_fabs_olt_largest_denormal_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_olt_largest_denormal_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nzero) float @clamp_fabs_olt_largest_denormal_0.0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_FABS_OLT_LARGEST_DENORMAL:%.*]] = fcmp olt float [[FABS_ARG]], 0x380FFFFFC0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_FABS_OLT_LARGEST_DENORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -761,10 +761,10 @@ define float @clamp_fabs_olt_largest_denormal_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_ole_largest_denormal_0.0(float %arg) {
-; CHECK-LABEL: define nofpclass(nzero) float @clamp_fabs_ole_largest_denormal_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_ole_largest_denormal_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nzero) float @clamp_fabs_ole_largest_denormal_0.0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_FABS_OLE_LARGEST_DENORMAL:%.*]] = fcmp ole float [[FABS_ARG]], 0x380FFFFFC0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_FABS_OLE_LARGEST_DENORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -780,12 +780,12 @@ define float @clamp_fabs_ole_largest_denormal_0.0(float %arg) {
 ;---------------------------------------------------------------------
 
 ; can't be inf
-define float @clamp_fabs_value_ogt_1_to_1_copysign(float %arg) {
-; CHECK-LABEL: define nofpclass(inf) float @clamp_fabs_value_ogt_1_to_1_copysign(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_value_ogt_1_to_1_copysign(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf) float @clamp_fabs_value_ogt_1_to_1_copysign(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_OGT_1:%.*]] = fcmp ogt float [[FABS_ARG]], 1.000000e+00
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = call float @llvm.copysign.f32(float noundef 1.000000e+00, float [[ARG]]) #[[ATTR4]]
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = call noundef float @llvm.copysign.f32(float noundef 1.000000e+00, float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_OGT_1]], float [[COPYSIGN]], float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
@@ -797,12 +797,12 @@ define float @clamp_fabs_value_ogt_1_to_1_copysign(float %arg) {
 }
 
 ; can't be inf
-define float @clamp_fabs_value_oge_1_to_1_copysign(float %arg) {
-; CHECK-LABEL: define nofpclass(inf) float @clamp_fabs_value_oge_1_to_1_copysign(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_value_oge_1_to_1_copysign(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf) float @clamp_fabs_value_oge_1_to_1_copysign(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_OGE_1:%.*]] = fcmp oge float [[FABS_ARG]], 1.000000e+00
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = call float @llvm.copysign.f32(float noundef 1.000000e+00, float [[ARG]]) #[[ATTR4]]
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = call noundef float @llvm.copysign.f32(float noundef 1.000000e+00, float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_OGE_1]], float [[COPYSIGN]], float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
@@ -814,12 +814,12 @@ define float @clamp_fabs_value_oge_1_to_1_copysign(float %arg) {
 }
 
 ; can't be inf or nan
-define float @clamp_fabs_value_olt_1_to_1_copysign(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf) float @clamp_fabs_value_olt_1_to_1_copysign(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_value_olt_1_to_1_copysign(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf) float @clamp_fabs_value_olt_1_to_1_copysign(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_OLT_1:%.*]] = fcmp olt float [[FABS_ARG]], 1.000000e+00
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = call nofpclass(nan inf zero sub) float @llvm.copysign.f32(float noundef 1.000000e+00, float [[ARG]]) #[[ATTR4]]
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = call noundef nofpclass(nan inf zero sub) float @llvm.copysign.f32(float noundef 1.000000e+00, float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_OLT_1]], float [[ARG]], float [[COPYSIGN]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
@@ -831,12 +831,12 @@ define float @clamp_fabs_value_olt_1_to_1_copysign(float %arg) {
 }
 
 ; can't be inf or nan
-define float @clamp_fabs_value_ole_1_to_1_copysign(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf) float @clamp_fabs_value_ole_1_to_1_copysign(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_value_ole_1_to_1_copysign(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf) float @clamp_fabs_value_ole_1_to_1_copysign(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_OLE_1:%.*]] = fcmp ole float [[FABS_ARG]], 1.000000e+00
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = call nofpclass(nan inf zero sub) float @llvm.copysign.f32(float noundef 1.000000e+00, float [[ARG]]) #[[ATTR4]]
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = call noundef nofpclass(nan inf zero sub) float @llvm.copysign.f32(float noundef 1.000000e+00, float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_OLE_1]], float [[ARG]], float [[COPYSIGN]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
@@ -848,12 +848,12 @@ define float @clamp_fabs_value_ole_1_to_1_copysign(float %arg) {
 }
 
 ; can't be inf or nan
-define float @clamp_fabs_value_ugt_1_to_1_copysign(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf) float @clamp_fabs_value_ugt_1_to_1_copysign(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_value_ugt_1_to_1_copysign(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf) float @clamp_fabs_value_ugt_1_to_1_copysign(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_UGT_1:%.*]] = fcmp ugt float [[FABS_ARG]], 1.000000e+00
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = call float @llvm.copysign.f32(float noundef 1.000000e+00, float [[ARG]]) #[[ATTR4]]
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = call noundef float @llvm.copysign.f32(float noundef 1.000000e+00, float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_UGT_1]], float [[COPYSIGN]], float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
@@ -865,12 +865,12 @@ define float @clamp_fabs_value_ugt_1_to_1_copysign(float %arg) {
 }
 
 ; can't be inf or nan
-define float @clamp_fabs_value_uge_1_to_1_copysign(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf) float @clamp_fabs_value_uge_1_to_1_copysign(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_value_uge_1_to_1_copysign(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf) float @clamp_fabs_value_uge_1_to_1_copysign(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_UGE_1:%.*]] = fcmp ugt float [[FABS_ARG]], 1.000000e+00
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = call float @llvm.copysign.f32(float noundef 1.000000e+00, float [[ARG]]) #[[ATTR4]]
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = call noundef float @llvm.copysign.f32(float noundef 1.000000e+00, float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_UGE_1]], float [[COPYSIGN]], float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
@@ -882,12 +882,12 @@ define float @clamp_fabs_value_uge_1_to_1_copysign(float %arg) {
 }
 
 ; can't be inf
-define float @clamp_fabs_value_ult_1_to_1_copysign(float %arg) {
-; CHECK-LABEL: define nofpclass(inf) float @clamp_fabs_value_ult_1_to_1_copysign(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_value_ult_1_to_1_copysign(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf) float @clamp_fabs_value_ult_1_to_1_copysign(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_ULT_1:%.*]] = fcmp ult float [[FABS_ARG]], 1.000000e+00
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = call nofpclass(nan inf zero sub) float @llvm.copysign.f32(float noundef 1.000000e+00, float [[ARG]]) #[[ATTR4]]
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = call noundef nofpclass(nan inf zero sub) float @llvm.copysign.f32(float noundef 1.000000e+00, float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_ULT_1]], float [[ARG]], float [[COPYSIGN]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
@@ -899,12 +899,12 @@ define float @clamp_fabs_value_ult_1_to_1_copysign(float %arg) {
 }
 
 ; can't be inf
-define float @clamp_fabs_value_ule_1_to_1_copysign(float %arg) {
-; CHECK-LABEL: define nofpclass(inf) float @clamp_fabs_value_ule_1_to_1_copysign(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_value_ule_1_to_1_copysign(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf) float @clamp_fabs_value_ule_1_to_1_copysign(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_ULE_1:%.*]] = fcmp ule float [[FABS_ARG]], 1.000000e+00
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = call nofpclass(nan inf zero sub) float @llvm.copysign.f32(float noundef 1.000000e+00, float [[ARG]]) #[[ATTR4]]
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = call noundef nofpclass(nan inf zero sub) float @llvm.copysign.f32(float noundef 1.000000e+00, float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_ULE_1]], float [[ARG]], float [[COPYSIGN]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
@@ -920,9 +920,9 @@ define float @clamp_fabs_value_ule_1_to_1_copysign(float %arg) {
 ;---------------------------------------------------------------------
 
 ; Can't be +inf
-define float @clamp_is_ogt_largest_normal_to_largest_normal(float %arg) {
-; CHECK-LABEL: define nofpclass(pinf) float @clamp_is_ogt_largest_normal_to_largest_normal(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ogt_largest_normal_to_largest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(pinf) float @clamp_is_ogt_largest_normal_to_largest_normal(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OGT_LARGEST_NORMAL:%.*]] = fcmp ogt float [[ARG]], 0x47EFFFFFE0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGT_LARGEST_NORMAL]], float 0x47EFFFFFE0000000, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -933,9 +933,9 @@ define float @clamp_is_ogt_largest_normal_to_largest_normal(float %arg) {
 }
 
 ; Can't be +inf
-define float @clamp_is_oge_largest_normal_to_largest_normal(float %arg) {
-; CHECK-LABEL: define nofpclass(pinf) float @clamp_is_oge_largest_normal_to_largest_normal(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_oge_largest_normal_to_largest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(pinf) float @clamp_is_oge_largest_normal_to_largest_normal(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_OGE_LARGEST_NORMAL:%.*]] = fcmp oge float [[ARG]], 0x47EFFFFFE0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGE_LARGEST_NORMAL]], float 0x47EFFFFFE0000000, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -946,9 +946,9 @@ define float @clamp_is_oge_largest_normal_to_largest_normal(float %arg) {
 }
 
 ; Can't be +inf or nan
-define float @clamp_is_ugt_largest_normal_to_largest_normal(float %arg) {
-; CHECK-LABEL: define nofpclass(nan pinf) float @clamp_is_ugt_largest_normal_to_largest_normal(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_ugt_largest_normal_to_largest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan pinf) float @clamp_is_ugt_largest_normal_to_largest_normal(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UGT_LARGEST_NORMAL:%.*]] = fcmp ugt float [[ARG]], 0x47EFFFFFE0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGT_LARGEST_NORMAL]], float 0x47EFFFFFE0000000, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -959,9 +959,9 @@ define float @clamp_is_ugt_largest_normal_to_largest_normal(float %arg) {
 }
 
 ; Can't be +inf or nan
-define float @clamp_is_uge_largest_normal_to_largest_normal(float %arg) {
-; CHECK-LABEL: define nofpclass(nan pinf) float @clamp_is_uge_largest_normal_to_largest_normal(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_is_uge_largest_normal_to_largest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan pinf) float @clamp_is_uge_largest_normal_to_largest_normal(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    [[IS_UGE_LARGEST_NORMAL:%.*]] = fcmp uge float [[ARG]], 0x47EFFFFFE0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGE_LARGEST_NORMAL]], float 0x47EFFFFFE0000000, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -972,10 +972,10 @@ define float @clamp_is_uge_largest_normal_to_largest_normal(float %arg) {
 }
 
 ; Can't be +inf or -inf
-define float @clamp_fabs_is_ogt_largest_normal_to_largest_normal(float %arg) {
-; CHECK-LABEL: define nofpclass(inf) float @clamp_fabs_is_ogt_largest_normal_to_largest_normal(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_is_ogt_largest_normal_to_largest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf) float @clamp_fabs_is_ogt_largest_normal_to_largest_normal(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_OGT_LARGEST_NORMAL:%.*]] = fcmp ogt float [[FABS_ARG]], 0x47EFFFFFE0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGT_LARGEST_NORMAL]], float 0x47EFFFFFE0000000, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -987,10 +987,10 @@ define float @clamp_fabs_is_ogt_largest_normal_to_largest_normal(float %arg) {
 }
 
 ; Can't be +inf or -inf
-define float @clamp_fabs_is_oge_largest_normal_to_largest_normal(float %arg) {
-; CHECK-LABEL: define nofpclass(inf) float @clamp_fabs_is_oge_largest_normal_to_largest_normal(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_is_oge_largest_normal_to_largest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf) float @clamp_fabs_is_oge_largest_normal_to_largest_normal(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_OGE_LARGEST_NORMAL:%.*]] = fcmp oge float [[FABS_ARG]], 0x47EFFFFFE0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGE_LARGEST_NORMAL]], float 0x47EFFFFFE0000000, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1002,10 +1002,10 @@ define float @clamp_fabs_is_oge_largest_normal_to_largest_normal(float %arg) {
 }
 
 ; Can't be +inf or -inf or nan
-define float @clamp_fabs_is_ugt_largest_normal_to_largest_normal(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf) float @clamp_fabs_is_ugt_largest_normal_to_largest_normal(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_is_ugt_largest_normal_to_largest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf) float @clamp_fabs_is_ugt_largest_normal_to_largest_normal(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_UGT_LARGEST_NORMAL:%.*]] = fcmp ugt float [[FABS_ARG]], 0x47EFFFFFE0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGT_LARGEST_NORMAL]], float 0x47EFFFFFE0000000, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1017,10 +1017,10 @@ define float @clamp_fabs_is_ugt_largest_normal_to_largest_normal(float %arg) {
 }
 
 ; Can't be +inf or -inf or nan
-define float @clamp_fabs_is_uge_largest_normal_to_largest_normal(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf) float @clamp_fabs_is_uge_largest_normal_to_largest_normal(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_is_uge_largest_normal_to_largest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf) float @clamp_fabs_is_uge_largest_normal_to_largest_normal(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_UGT_LARGEST_NORMAL:%.*]] = fcmp uge float [[FABS_ARG]], 0x47EFFFFFE0000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UGT_LARGEST_NORMAL]], float 0x47EFFFFFE0000000, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1036,10 +1036,10 @@ define float @clamp_fabs_is_uge_largest_normal_to_largest_normal(float %arg) {
 ;---------------------------------------------------------------------
 
 ; can't be negative or positive subnormal
-define float @clamp_fabs_ogt_smallest_normal_to_zero(float %arg) {
-; CHECK-LABEL: define nofpclass(inf) float @clamp_fabs_ogt_smallest_normal_to_zero(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_ogt_smallest_normal_to_zero(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf) float @clamp_fabs_ogt_smallest_normal_to_zero(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_OGT_SMALLEST_NORMAL:%.*]] = fcmp ogt float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGT_SMALLEST_NORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1052,10 +1052,10 @@ define float @clamp_fabs_ogt_smallest_normal_to_zero(float %arg) {
 }
 
 ; can't be negative or positive subnormal
-define float @clamp_fabs_oge_smallest_normal_to_zero(float %arg) {
-; CHECK-LABEL: define nofpclass(inf norm) float @clamp_fabs_oge_smallest_normal_to_zero(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_oge_smallest_normal_to_zero(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf norm) float @clamp_fabs_oge_smallest_normal_to_zero(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_OGE_SMALLEST_NORMAL:%.*]] = fcmp oge float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OGE_SMALLEST_NORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1067,10 +1067,10 @@ define float @clamp_fabs_oge_smallest_normal_to_zero(float %arg) {
 }
 
 ; can't be negative or subnormal
-define float @clamp_fabs_olt_smallest_normal_to_zero(float %arg) {
-; CHECK-LABEL: define nofpclass(nzero sub) float @clamp_fabs_olt_smallest_normal_to_zero(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_olt_smallest_normal_to_zero(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nzero sub) float @clamp_fabs_olt_smallest_normal_to_zero(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_OLT_SMALLEST_NORMAL:%.*]] = fcmp olt float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OLT_SMALLEST_NORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1082,10 +1082,10 @@ define float @clamp_fabs_olt_smallest_normal_to_zero(float %arg) {
 }
 
 ; can't be negative or subnormal
-define float @clamp_fabs_ole_smallest_normal_to_zero(float %arg) {
-; CHECK-LABEL: define nofpclass(nzero sub) float @clamp_fabs_ole_smallest_normal_to_zero(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_ole_smallest_normal_to_zero(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nzero sub) float @clamp_fabs_ole_smallest_normal_to_zero(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_OLE_SMALLEST_NORMAL:%.*]] = fcmp ole float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OLE_SMALLEST_NORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1096,10 +1096,10 @@ define float @clamp_fabs_ole_smallest_normal_to_zero(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_is_is_olt_smallest_normal_to_0(float %arg) {
-; CHECK-LABEL: define nofpclass(nzero sub) float @clamp_fabs_is_is_olt_smallest_normal_to_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_is_is_olt_smallest_normal_to_0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nzero sub) float @clamp_fabs_is_is_olt_smallest_normal_to_0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_OLT_SMALLEST_NORMAL:%.*]] = fcmp olt float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OLT_SMALLEST_NORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1110,10 +1110,10 @@ define float @clamp_fabs_is_is_olt_smallest_normal_to_0(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_is_is_ole_smallest_normal_to_0(float %arg) {
-; CHECK-LABEL: define nofpclass(nzero sub) float @clamp_fabs_is_is_ole_smallest_normal_to_0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_is_is_ole_smallest_normal_to_0(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nzero sub) float @clamp_fabs_is_is_ole_smallest_normal_to_0(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_OLE_SMALLEST_NORMAL:%.*]] = fcmp ole float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OLE_SMALLEST_NORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1124,24 +1124,24 @@ define float @clamp_fabs_is_is_ole_smallest_normal_to_0(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_oeq_smallest_normal_to_zero(float %arg) {
-; CHECK-LABEL: define float @clamp_fabs_oeq_smallest_normal_to_zero(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_oeq_smallest_normal_to_zero(float noundef %arg) {
+; CHECK-LABEL: define noundef float @clamp_fabs_oeq_smallest_normal_to_zero(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_OEQ_SMALLEST_NORMAL:%.*]] = fcmp oeq float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_OEQ_SMALLEST_NORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
-  %fabs.arg = call float @llvm.fabs.f32(float %arg)
+  %fabs.arg = call float @llvm.fabs.f32(float noundef %arg)
   %is.oeq.smallest.normal = fcmp oeq float %fabs.arg, 0x3810000000000000
   %select = select i1 %is.oeq.smallest.normal, float 0.0, float %arg
   ret float %select
 }
 
-define float @clamp_fabs_one_smallest_normal_to_zero(float %arg) {
-; CHECK-LABEL: define nofpclass(inf nzero sub) float @clamp_fabs_one_smallest_normal_to_zero(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_one_smallest_normal_to_zero(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf nzero sub) float @clamp_fabs_one_smallest_normal_to_zero(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_ONE_SMALLEST_NORMAL:%.*]] = fcmp one float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ONE_SMALLEST_NORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1152,10 +1152,10 @@ define float @clamp_fabs_one_smallest_normal_to_zero(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_ueq_smallest_normal_to_zero(float %arg) {
-; CHECK-LABEL: define nofpclass(nan) float @clamp_fabs_ueq_smallest_normal_to_zero(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_ueq_smallest_normal_to_zero(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan) float @clamp_fabs_ueq_smallest_normal_to_zero(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_UEQ_SMALLEST_NORMAL:%.*]] = fcmp ueq float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UEQ_SMALLEST_NORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1166,10 +1166,10 @@ define float @clamp_fabs_ueq_smallest_normal_to_zero(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_une_smallest_normal_to_zero(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf nzero sub) float @clamp_fabs_une_smallest_normal_to_zero(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_une_smallest_normal_to_zero(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan inf nzero sub) float @clamp_fabs_une_smallest_normal_to_zero(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_UNE_SMALLEST_NORMAL:%.*]] = fcmp une float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_UNE_SMALLEST_NORMAL]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1184,9 +1184,9 @@ define float @clamp_fabs_une_smallest_normal_to_zero(float %arg) {
 ; compare fabs to negative normal
 ;---------------------------------------------------------------------
 
-define float @clamp_fabs_olt_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define float @clamp_fabs_olt_neg1_to_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_fabs_olt_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @clamp_fabs_olt_neg1_to_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fabs.arg = call float @llvm.fabs.f32(float %arg)
@@ -1195,9 +1195,9 @@ define float @clamp_fabs_olt_neg1_to_neg1(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_ole_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define float @clamp_fabs_ole_neg1_to_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_fabs_ole_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @clamp_fabs_ole_neg1_to_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fabs.arg = call float @llvm.fabs.f32(float %arg)
@@ -1206,10 +1206,10 @@ define float @clamp_fabs_ole_neg1_to_neg1(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_ult_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan) float @clamp_fabs_ult_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_ult_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan) float @clamp_fabs_ult_neg1_to_neg1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_ULT_NEG1:%.*]] = fcmp ult float [[FABS_ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_ULT_NEG1]], float -1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1220,10 +1220,10 @@ define float @clamp_fabs_ult_neg1_to_neg1(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_ule_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan) float @clamp_fabs_ule_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_ule_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan) float @clamp_fabs_ule_neg1_to_neg1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_ULE_NEG1:%.*]] = fcmp ule float [[FABS_ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_ULE_NEG1]], float -1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1234,10 +1234,10 @@ define float @clamp_fabs_ule_neg1_to_neg1(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_ogt_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define nofpclass(inf zero sub pnorm) float @clamp_fabs_ogt_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_ogt_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf zero sub pnorm) float @clamp_fabs_ogt_neg1_to_neg1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_OGT_NEG1:%.*]] = fcmp ogt float [[FABS_ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_OGT_NEG1]], float -1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1248,10 +1248,10 @@ define float @clamp_fabs_ogt_neg1_to_neg1(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_oge_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define nofpclass(inf zero sub pnorm) float @clamp_fabs_oge_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_oge_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf zero sub pnorm) float @clamp_fabs_oge_neg1_to_neg1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_OGE_NEG1:%.*]] = fcmp oge float [[FABS_ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_OGE_NEG1]], float -1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1262,9 +1262,9 @@ define float @clamp_fabs_oge_neg1_to_neg1(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_ugt_neg1_to_neg1(float %arg) {
+define float @clamp_fabs_ugt_neg1_to_neg1(float noundef %arg) {
 ; CHECK-LABEL: define noundef nofpclass(nan inf zero sub pnorm) float @clamp_fabs_ugt_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float -1.000000e+00
 ;
   %fabs.arg = call float @llvm.fabs.f32(float %arg)
@@ -1273,9 +1273,9 @@ define float @clamp_fabs_ugt_neg1_to_neg1(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_uge_neg1_to_neg1(float %arg) {
+define float @clamp_fabs_uge_neg1_to_neg1(float noundef %arg) {
 ; CHECK-LABEL: define noundef nofpclass(nan inf zero sub pnorm) float @clamp_fabs_uge_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float -1.000000e+00
 ;
   %fabs.arg = call float @llvm.fabs.f32(float %arg)
@@ -1284,9 +1284,9 @@ define float @clamp_fabs_uge_neg1_to_neg1(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_oeq_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define float @clamp_fabs_oeq_neg1_to_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_fabs_oeq_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @clamp_fabs_oeq_neg1_to_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fabs.arg = call float @llvm.fabs.f32(float %arg)
@@ -1295,10 +1295,10 @@ define float @clamp_fabs_oeq_neg1_to_neg1(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_ueq_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan) float @clamp_fabs_ueq_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_ueq_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan) float @clamp_fabs_ueq_neg1_to_neg1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_UEQ_NEG1:%.*]] = fcmp ueq float [[FABS_ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_UEQ_NEG1]], float -1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1309,10 +1309,10 @@ define float @clamp_fabs_ueq_neg1_to_neg1(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_one_neg1_to_neg1(float %arg) {
-; CHECK-LABEL: define nofpclass(inf zero sub pnorm) float @clamp_fabs_one_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @clamp_fabs_one_neg1_to_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(inf zero sub pnorm) float @clamp_fabs_one_neg1_to_neg1(
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FABS_IS_ONE_NEG1:%.*]] = fcmp one float [[FABS_ARG]], -1.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[FABS_IS_ONE_NEG1]], float -1.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -1323,9 +1323,9 @@ define float @clamp_fabs_one_neg1_to_neg1(float %arg) {
   ret float %select
 }
 
-define float @clamp_fabs_une_neg1_to_neg1(float %arg) {
+define float @clamp_fabs_une_neg1_to_neg1(float noundef %arg) {
 ; CHECK-LABEL: define noundef nofpclass(nan inf zero sub pnorm) float @clamp_fabs_une_neg1_to_neg1(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float -1.000000e+00
 ;
   %fabs.arg = call float @llvm.fabs.f32(float %arg)
@@ -1338,9 +1338,9 @@ define float @clamp_fabs_une_neg1_to_neg1(float %arg) {
 ; assume > < to normal
 ;---------------------------------------------------------------------
 
-define float @ret_assumed_ogt_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_ogt_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3:[0-9]+]] {
+define float @ret_assumed_ogt_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_ogt_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3:[0-9]+]] {
 ; CHECK-NEXT:    [[OGT_1:%.*]] = fcmp ogt float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OGT_1]]) #[[ATTR5:[0-9]+]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1350,9 +1350,9 @@ define float @ret_assumed_ogt_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_oge_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_oge_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_oge_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_oge_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[OGE_1:%.*]] = fcmp ogt float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OGE_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1362,9 +1362,9 @@ define float @ret_assumed_oge_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_olt_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_olt_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_olt_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_olt_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[OLT_1:%.*]] = fcmp olt float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OLT_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1374,9 +1374,9 @@ define float @ret_assumed_olt_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_ole_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_ole_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_ole_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_ole_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[OLE_1:%.*]] = fcmp ole float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OLE_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1386,9 +1386,9 @@ define float @ret_assumed_ole_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_ugt_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_ugt_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_ugt_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_ugt_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[UGT_1:%.*]] = fcmp ugt float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UGT_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1398,9 +1398,9 @@ define float @ret_assumed_ugt_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_uge_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_uge_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_uge_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_uge_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[UGE_1:%.*]] = fcmp uge float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UGE_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1410,9 +1410,9 @@ define float @ret_assumed_uge_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_ult_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_ult_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_ult_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_ult_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[ULT_1:%.*]] = fcmp ult float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[ULT_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1422,9 +1422,9 @@ define float @ret_assumed_ult_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_ule_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_ule_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_ule_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_ule_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[ULE_1:%.*]] = fcmp ule float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[ULE_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1434,10 +1434,10 @@ define float @ret_assumed_ule_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_ogt_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_ogt_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_ogt_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_ogt_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[OGT_1:%.*]] = fcmp ogt float [[ARG_FABS]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OGT_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1448,10 +1448,10 @@ define float @ret_assumed_fabs_ogt_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_oge_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_oge_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_oge_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_oge_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[OGE_1:%.*]] = fcmp oge float [[ARG_FABS]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OGE_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1462,10 +1462,10 @@ define float @ret_assumed_fabs_oge_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_olt_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_olt_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_olt_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_olt_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[OLT_1:%.*]] = fcmp olt float [[ARG_FABS]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OLT_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1476,10 +1476,10 @@ define float @ret_assumed_fabs_olt_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_ole_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_ole_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_ole_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_ole_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[OLE_1:%.*]] = fcmp olt float [[ARG_FABS]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OLE_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1490,10 +1490,10 @@ define float @ret_assumed_fabs_ole_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_ugt_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_ugt_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_ugt_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_ugt_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[UGT_1:%.*]] = fcmp ugt float [[ARG_FABS]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UGT_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1504,10 +1504,10 @@ define float @ret_assumed_fabs_ugt_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_uge_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_uge_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_uge_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_uge_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[UGE_1:%.*]] = fcmp ugt float [[ARG_FABS]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UGE_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1518,10 +1518,10 @@ define float @ret_assumed_fabs_uge_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_ult_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_ult_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_ult_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_ult_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[ULT_1:%.*]] = fcmp ult float [[ARG_FABS]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[ULT_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1532,10 +1532,10 @@ define float @ret_assumed_fabs_ult_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_ule_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_ule_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_ule_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_ule_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[ULE_1:%.*]] = fcmp ule float [[ARG_FABS]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[ULE_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1546,9 +1546,9 @@ define float @ret_assumed_fabs_ule_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_ogt_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_ogt_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_ogt_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_ogt_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[OGT_NEG1:%.*]] = fcmp ogt float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OGT_NEG1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1558,9 +1558,9 @@ define float @ret_assumed_ogt_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_oge_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_oge_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_oge_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_oge_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[OGE_NEG1:%.*]] = fcmp ogt float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OGE_NEG1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1570,9 +1570,9 @@ define float @ret_assumed_oge_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_olt_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_olt_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_olt_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_olt_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[OLT_NEG1:%.*]] = fcmp olt float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OLT_NEG1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1582,9 +1582,9 @@ define float @ret_assumed_olt_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_ole_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_ole_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_ole_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_ole_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[OLE_NEG1:%.*]] = fcmp ole float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OLE_NEG1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1594,9 +1594,9 @@ define float @ret_assumed_ole_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_ugt_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_ugt_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_ugt_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_ugt_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[UGT_NEG1:%.*]] = fcmp ugt float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UGT_NEG1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1606,9 +1606,9 @@ define float @ret_assumed_ugt_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_uge_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_uge_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_uge_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_uge_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[UGE_NEG1:%.*]] = fcmp uge float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UGE_NEG1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1618,9 +1618,9 @@ define float @ret_assumed_uge_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_ult_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_ult_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_ult_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_ult_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[ULT_NEG1:%.*]] = fcmp ult float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[ULT_NEG1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1630,9 +1630,9 @@ define float @ret_assumed_ult_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_ule_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_ule_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_ule_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_ule_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[ULE_NEG1:%.*]] = fcmp ule float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[ULE_NEG1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1642,9 +1642,9 @@ define float @ret_assumed_ule_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_oeq_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_oeq_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_oeq_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_oeq_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[OEQ_1:%.*]] = fcmp oeq float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OEQ_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1654,9 +1654,9 @@ define float @ret_assumed_oeq_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_ueq_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_ueq_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_ueq_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_ueq_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[UEQ_1:%.*]] = fcmp ueq float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UEQ_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1666,9 +1666,9 @@ define float @ret_assumed_ueq_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_one_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_one_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_one_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_one_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[ONE_1:%.*]] = fcmp one float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[ONE_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1678,9 +1678,9 @@ define float @ret_assumed_one_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_one_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_one_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_one_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_one_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[ONE_NEG1:%.*]] = fcmp one float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[ONE_NEG1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1690,9 +1690,9 @@ define float @ret_assumed_one_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_une_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_une_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_une_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_une_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[UNE_NEG1:%.*]] = fcmp une float [[ARG]], -1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UNE_NEG1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1702,9 +1702,9 @@ define float @ret_assumed_une_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_une_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_une_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_une_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_une_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[UNE_1:%.*]] = fcmp une float [[ARG]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UNE_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1714,10 +1714,10 @@ define float @ret_assumed_une_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_oeq_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_oeq_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_oeq_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_oeq_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[OEQ_1:%.*]] = fcmp oeq float [[ARG_FABS]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[OEQ_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1728,10 +1728,10 @@ define float @ret_assumed_fabs_oeq_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_ueq_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_ueq_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_ueq_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_ueq_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[UEQ_1:%.*]] = fcmp ueq float [[ARG_FABS]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UEQ_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1742,10 +1742,10 @@ define float @ret_assumed_fabs_ueq_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_one_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_one_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_one_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_one_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[ONE_1:%.*]] = fcmp one float [[ARG_FABS]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[ONE_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1756,10 +1756,10 @@ define float @ret_assumed_fabs_one_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_une_1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_une_1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_une_1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_une_1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[UNE_1:%.*]] = fcmp one float [[ARG_FABS]], 1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UNE_1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1770,9 +1770,9 @@ define float @ret_assumed_fabs_une_1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_oeq_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_oeq_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_fabs_oeq_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_oeq_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef false) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -1782,10 +1782,10 @@ define float @ret_assumed_fabs_oeq_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_ueq_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_ueq_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_ueq_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_ueq_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[UEQ_NEG1:%.*]] = fcmp ueq float [[ARG_FABS]], -1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UEQ_NEG1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1796,10 +1796,10 @@ define float @ret_assumed_fabs_ueq_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_one_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_one_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @ret_assumed_fabs_one_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_one_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[ARG_FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[ONE_NEG1:%.*]] = fcmp one float [[ARG_FABS]], -1.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[ONE_NEG1]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -1810,9 +1810,9 @@ define float @ret_assumed_fabs_one_neg1(float %arg) {
   ret float %arg
 }
 
-define float @ret_assumed_fabs_une_neg1(float %arg) {
-; CHECK-LABEL: define float @ret_assumed_fabs_une_neg1(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @ret_assumed_fabs_une_neg1(float noundef %arg) {
+; CHECK-LABEL: define noundef float @ret_assumed_fabs_une_neg1(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef true) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2255,9 +2255,9 @@ define float @ret_assumed_uge_known_negative(float %arg, float %unknown) {
 ; assume compare to smallest normal
 ;---------------------------------------------------------------------
 
-define float @assume_oeq_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_oeq_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_oeq_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_oeq_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[IS_OEQ_SMALLEST_NORMAL:%.*]] = fcmp oeq float [[ARG]], 0x3810000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[IS_OEQ_SMALLEST_NORMAL]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2267,9 +2267,9 @@ define float @assume_oeq_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @assume_one_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_one_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_one_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_one_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[IS_ONE_SMALLEST_NORMAL:%.*]] = fcmp one float [[ARG]], 0x3810000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[IS_ONE_SMALLEST_NORMAL]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2279,9 +2279,9 @@ define float @assume_one_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @assume_ueq_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_ueq_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_ueq_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_ueq_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[IS_UEQ_SMALLEST_NORMAL:%.*]] = fcmp ueq float [[ARG]], 0x3810000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[IS_UEQ_SMALLEST_NORMAL]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2291,9 +2291,9 @@ define float @assume_ueq_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @assume_une_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_une_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_une_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_une_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[IS_UNE_SMALLEST_NORMAL:%.*]] = fcmp une float [[ARG]], 0x3810000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[IS_UNE_SMALLEST_NORMAL]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2303,9 +2303,9 @@ define float @assume_une_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @assume_ord_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_ord_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_ord_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_ord_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[IS_ORD_SMALLEST_NORMAL:%.*]] = fcmp ord float [[ARG]], 0x3810000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[IS_ORD_SMALLEST_NORMAL]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2315,9 +2315,9 @@ define float @assume_ord_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @assume_uno_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_uno_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_uno_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_uno_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[IS_UNO_SMALLEST_NORMAL:%.*]] = fcmp uno float [[ARG]], 0x3810000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[IS_UNO_SMALLEST_NORMAL]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2327,10 +2327,10 @@ define float @assume_uno_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @assume_fabs_oeq_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_oeq_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @assume_fabs_oeq_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_oeq_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_OEQ_SMALLEST_NORMAL:%.*]] = fcmp oeq float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[IS_OEQ_SMALLEST_NORMAL]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2341,10 +2341,10 @@ define float @assume_fabs_oeq_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @assume_fabs_one_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_one_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @assume_fabs_one_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_one_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_ONE_SMALLEST_NORMAL:%.*]] = fcmp one float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[IS_ONE_SMALLEST_NORMAL]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2355,10 +2355,10 @@ define float @assume_fabs_one_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @assume_fabs_ueq_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_ueq_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @assume_fabs_ueq_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_ueq_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_UEQ_SMALLEST_NORMAL:%.*]] = fcmp ueq float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[IS_UEQ_SMALLEST_NORMAL]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2369,10 +2369,10 @@ define float @assume_fabs_ueq_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @assume_fabs_une_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_une_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @assume_fabs_une_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_une_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_UNE_SMALLEST_NORMAL:%.*]] = fcmp une float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[IS_UNE_SMALLEST_NORMAL]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2383,10 +2383,10 @@ define float @assume_fabs_une_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @assume_fabs_ord_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_ord_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @assume_fabs_ord_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_ord_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_ORD_SMALLEST_NORMAL:%.*]] = fcmp ord float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[IS_ORD_SMALLEST_NORMAL]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2397,10 +2397,10 @@ define float @assume_fabs_ord_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @assume_fabs_uno_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_uno_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @assume_fabs_uno_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_uno_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[FABS_ARG:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[IS_UNO_SMALLEST_NORMAL:%.*]] = fcmp uno float [[FABS_ARG]], 0x3810000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[IS_UNO_SMALLEST_NORMAL]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2427,9 +2427,9 @@ define float @assume_oeq_smallest_normal_known_pos(float nofpclass(ninf nsub nno
 ; compare to inf
 ;---------------------------------------------------------------------
 
-define float @assume_ole_pinf(float %arg) {
-; CHECK-LABEL: define float @assume_ole_pinf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_ole_pinf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_ole_pinf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[FCMP:%.*]] = fcmp ole float [[ARG]], 0x7FF0000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[FCMP]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2439,9 +2439,9 @@ define float @assume_ole_pinf(float %arg) {
   ret float %arg
 }
 
-define float @assume_ole_ninf(float %arg) {
-; CHECK-LABEL: define float @assume_ole_ninf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_ole_ninf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_ole_ninf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[FCMP:%.*]] = fcmp ole float [[ARG]], 0xFFF0000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[FCMP]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2451,9 +2451,9 @@ define float @assume_ole_ninf(float %arg) {
   ret float %arg
 }
 
-define float @assume_ugt_pinf(float %arg) {
-; CHECK-LABEL: define float @assume_ugt_pinf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_ugt_pinf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_ugt_pinf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[FCMP:%.*]] = fcmp ugt float [[ARG]], 0x7FF0000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[FCMP]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2463,9 +2463,9 @@ define float @assume_ugt_pinf(float %arg) {
   ret float %arg
 }
 
-define float @assume_ugt_ninf(float %arg) {
-; CHECK-LABEL: define float @assume_ugt_ninf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_ugt_ninf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_ugt_ninf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    [[FCMP:%.*]] = fcmp ugt float [[ARG]], 0xFFF0000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[FCMP]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2475,10 +2475,10 @@ define float @assume_ugt_ninf(float %arg) {
   ret float %arg
 }
 
-define float @assume_fabs_ole_pinf(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_ole_pinf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @assume_fabs_ole_pinf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_ole_pinf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FCMP:%.*]] = fcmp ole float [[FABS]], 0x7FF0000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[FCMP]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2489,9 +2489,9 @@ define float @assume_fabs_ole_pinf(float %arg) {
   ret float %arg
 }
 
-define float @assume_fabs_ole_ninf(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_ole_ninf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_fabs_ole_ninf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_ole_ninf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef false) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2501,10 +2501,10 @@ define float @assume_fabs_ole_ninf(float %arg) {
   ret float %arg
 }
 
-define float @assume_fabs_ugt_pinf(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_ugt_pinf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
-; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR4]]
+define float @assume_fabs_ugt_pinf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_ugt_pinf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
+; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float noundef [[ARG]]) #[[ATTR4]]
 ; CHECK-NEXT:    [[FCMP:%.*]] = fcmp ugt float [[FABS]], 0x7FF0000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[FCMP]]) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
@@ -2515,9 +2515,9 @@ define float @assume_fabs_ugt_pinf(float %arg) {
   ret float %arg
 }
 
-define float @assume_fabs_ugt_ninf(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_ugt_ninf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_fabs_ugt_ninf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_ugt_ninf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef true) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2531,9 +2531,9 @@ define float @assume_fabs_ugt_ninf(float %arg) {
 ; fcmp false
 ;---------------------------------------------------------------------
 
-define float @assume_fabs_false_pinf(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_false_pinf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_fabs_false_pinf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_false_pinf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef false) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2543,9 +2543,9 @@ define float @assume_fabs_false_pinf(float %arg) {
   ret float %arg
 }
 
-define float @assume_fabs_false_ninf(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_false_ninf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_fabs_false_ninf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_false_ninf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef false) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2555,9 +2555,9 @@ define float @assume_fabs_false_ninf(float %arg) {
   ret float %arg
 }
 
-define float @assume_false_pinf(float %arg) {
-; CHECK-LABEL: define float @assume_false_pinf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_false_pinf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_false_pinf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef false) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2566,9 +2566,9 @@ define float @assume_false_pinf(float %arg) {
   ret float %arg
 }
 
-define float @assume_false_ninf(float %arg) {
-; CHECK-LABEL: define float @assume_false_ninf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_false_ninf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_false_ninf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef false) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2577,9 +2577,9 @@ define float @assume_false_ninf(float %arg) {
   ret float %arg
 }
 
-define float @clamp_false_pinf_0.0(float %arg) {
-; CHECK-LABEL: define float @clamp_false_pinf_0.0(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_false_pinf_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef float @clamp_false_pinf_0.0(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fcmp = fcmp false float %arg, 0x7FF0000000000000
@@ -2587,9 +2587,9 @@ define float @clamp_false_pinf_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_false_ninf_0.0(float %arg) {
-; CHECK-LABEL: define float @clamp_false_ninf_0.0(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_false_ninf_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef float @clamp_false_ninf_0.0(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fcmp = fcmp false float %arg, 0xFFF0000000000000
@@ -2597,9 +2597,9 @@ define float @clamp_false_ninf_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_false_smallest_normal_0.0(float %arg) {
-; CHECK-LABEL: define float @clamp_false_smallest_normal_0.0(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_false_smallest_normal_0.0(float noundef %arg) {
+; CHECK-LABEL: define noundef float @clamp_false_smallest_normal_0.0(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fcmp = fcmp false float %arg, 0x3810000000000000
@@ -2607,9 +2607,9 @@ define float @clamp_false_smallest_normal_0.0(float %arg) {
   ret float %select
 }
 
-define float @assume_false_p0(float %arg) {
-; CHECK-LABEL: define float @assume_false_p0(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_false_p0(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_false_p0(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef false) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2618,9 +2618,9 @@ define float @assume_false_p0(float %arg) {
   ret float %arg
 }
 
-define float @assume_false_n0(float %arg) {
-; CHECK-LABEL: define float @assume_false_n0(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_false_n0(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_false_n0(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef false) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2629,9 +2629,9 @@ define float @assume_false_n0(float %arg) {
   ret float %arg
 }
 
-define float @assume_false_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_false_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_false_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_false_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef false) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2640,9 +2640,9 @@ define float @assume_false_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @clamp_false_nan(float %arg) {
-; CHECK-LABEL: define float @clamp_false_nan(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_false_nan(float noundef %arg) {
+; CHECK-LABEL: define noundef float @clamp_false_nan(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fcmp = fcmp false float %arg, 0x7FF8000000000000
@@ -2650,9 +2650,9 @@ define float @clamp_false_nan(float %arg) {
   ret float %select
 }
 
-define float @clamp_false_p0(float %arg) {
-; CHECK-LABEL: define float @clamp_false_p0(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_false_p0(float noundef %arg) {
+; CHECK-LABEL: define noundef float @clamp_false_p0(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fcmp = fcmp false float %arg, 0.0
@@ -2660,9 +2660,9 @@ define float @clamp_false_p0(float %arg) {
   ret float %select
 }
 
-define float @clamp_false_n0(float %arg) {
-; CHECK-LABEL: define float @clamp_false_n0(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_false_n0(float noundef %arg) {
+; CHECK-LABEL: define noundef float @clamp_false_n0(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fcmp = fcmp false float %arg, -0.0
@@ -2674,9 +2674,9 @@ define float @clamp_false_n0(float %arg) {
 ; fcmp true
 ;---------------------------------------------------------------------
 
-define float @assume_fabs_true_pinf(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_true_pinf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_fabs_true_pinf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_true_pinf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef true) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2686,9 +2686,9 @@ define float @assume_fabs_true_pinf(float %arg) {
   ret float %arg
 }
 
-define float @assume_fabs_true_ninf(float %arg) {
-; CHECK-LABEL: define float @assume_fabs_true_ninf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_fabs_true_ninf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_fabs_true_ninf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef true) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2698,9 +2698,9 @@ define float @assume_fabs_true_ninf(float %arg) {
   ret float %arg
 }
 
-define float @assume_true_pinf(float %arg) {
-; CHECK-LABEL: define float @assume_true_pinf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_true_pinf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_true_pinf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef true) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2709,9 +2709,9 @@ define float @assume_true_pinf(float %arg) {
   ret float %arg
 }
 
-define float @assume_true_ninf(float %arg) {
-; CHECK-LABEL: define float @assume_true_ninf(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_true_ninf(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_true_ninf(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef true) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2720,9 +2720,9 @@ define float @assume_true_ninf(float %arg) {
   ret float %arg
 }
 
-define float @assume_true_p0(float %arg) {
-; CHECK-LABEL: define float @assume_true_p0(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_true_p0(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_true_p0(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef true) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2731,9 +2731,9 @@ define float @assume_true_p0(float %arg) {
   ret float %arg
 }
 
-define float @assume_true_n0(float %arg) {
-; CHECK-LABEL: define float @assume_true_n0(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_true_n0(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_true_n0(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef true) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2742,9 +2742,9 @@ define float @assume_true_n0(float %arg) {
   ret float %arg
 }
 
-define float @assume_true_smallest_normal(float %arg) {
-; CHECK-LABEL: define float @assume_true_smallest_normal(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR3]] {
+define float @assume_true_smallest_normal(float noundef %arg) {
+; CHECK-LABEL: define noundef float @assume_true_smallest_normal(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR3]] {
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef true) #[[ATTR5]]
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
@@ -2753,9 +2753,9 @@ define float @assume_true_smallest_normal(float %arg) {
   ret float %arg
 }
 
-define float @clamp_true_pinf_0.0(float %arg) {
+define float @clamp_true_pinf_0.0(float noundef %arg) {
 ; CHECK-LABEL: define noundef nofpclass(nan inf nzero sub norm) float @clamp_true_pinf_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
   %fcmp = fcmp true float %arg, 0x7FF0000000000000
@@ -2763,9 +2763,9 @@ define float @clamp_true_pinf_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_true_ninf_0.0(float %arg) {
+define float @clamp_true_ninf_0.0(float noundef %arg) {
 ; CHECK-LABEL: define noundef nofpclass(nan inf nzero sub norm) float @clamp_true_ninf_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
   %fcmp = fcmp true float %arg, 0xFFF0000000000000
@@ -2773,9 +2773,9 @@ define float @clamp_true_ninf_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_true_smallest_normal_0.0(float %arg) {
+define float @clamp_true_smallest_normal_0.0(float noundef %arg) {
 ; CHECK-LABEL: define noundef nofpclass(nan inf nzero sub norm) float @clamp_true_smallest_normal_0.0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
   %fcmp = fcmp true float %arg, 0x3810000000000000
@@ -2783,9 +2783,9 @@ define float @clamp_true_smallest_normal_0.0(float %arg) {
   ret float %select
 }
 
-define float @clamp_true_nan(float %arg) {
-; CHECK-LABEL: define float @clamp_true_nan(
-; CHECK-SAME: float returned [[ARG:%.*]]) #[[ATTR2]] {
+define float @clamp_true_nan(float noundef %arg) {
+; CHECK-LABEL: define noundef float @clamp_true_nan(
+; CHECK-SAME: float noundef returned [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float [[ARG]]
 ;
   %fcmp = fcmp true float %arg, 0x7FF8000000000000
@@ -2793,9 +2793,9 @@ define float @clamp_true_nan(float %arg) {
   ret float %select
 }
 
-define float @clamp_true_p0(float %arg) {
+define float @clamp_true_p0(float noundef %arg) {
 ; CHECK-LABEL: define noundef nofpclass(nan inf nzero sub norm) float @clamp_true_p0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
   %fcmp = fcmp true float %arg, 0.0
@@ -2803,9 +2803,9 @@ define float @clamp_true_p0(float %arg) {
   ret float %select
 }
 
-define float @clamp_true_n0(float %arg) {
+define float @clamp_true_n0(float noundef %arg) {
 ; CHECK-LABEL: define noundef nofpclass(nan inf nzero sub norm) float @clamp_true_n0(
-; CHECK-SAME: float [[ARG:%.*]]) #[[ATTR2]] {
+; CHECK-SAME: float noundef [[ARG:%.*]]) #[[ATTR2]] {
 ; CHECK-NEXT:    ret float 0.000000e+00
 ;
   %fcmp = fcmp true float %arg, -0.0

--- a/llvm/test/Transforms/Attributor/nofpclass-select.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass-select.ll
@@ -64,9 +64,9 @@ define float @ret_select_nonan__noinf_nonan(i1 %cond, float nofpclass(nan) %arg0
 }
 
 ; Clamp nan to 0 pattern
-define float @ret_select_clamp_nan_to_zero_uno(float %arg) {
-; CHECK-LABEL: define nofpclass(nan) float @ret_select_clamp_nan_to_zero_uno
-; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
+define float @ret_select_clamp_nan_to_zero_uno(float noundef %arg) {
+; CHECK-LABEL: define noundef nofpclass(nan) float @ret_select_clamp_nan_to_zero_uno
+; CHECK-SAME: (float noundef [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[IS_NAN:%.*]] = fcmp uno float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_NAN]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
@@ -77,7 +77,7 @@ define float @ret_select_clamp_nan_to_zero_uno(float %arg) {
 }
 
 define float @ret_select_clamp_nan_to_zero_ord(float %arg) {
-; CHECK-LABEL: define nofpclass(nan) float @ret_select_clamp_nan_to_zero_ord
+; CHECK-LABEL: define float @ret_select_clamp_nan_to_zero_ord
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[NOT_NAN:%.*]] = fcmp ord float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[NOT_NAN]], float [[ARG]], float 0.000000e+00
@@ -89,7 +89,7 @@ define float @ret_select_clamp_nan_to_zero_ord(float %arg) {
 }
 
 define float @ret_select_clamp_onlynans(float %arg) {
-; CHECK-LABEL: define nofpclass(inf zero sub norm) float @ret_select_clamp_onlynans
+; CHECK-LABEL: define float @ret_select_clamp_onlynans
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[NOT_NAN:%.*]] = fcmp ord float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[NOT_NAN]], float 0x7FF8000000000000, float [[ARG]]
@@ -101,7 +101,7 @@ define float @ret_select_clamp_onlynans(float %arg) {
 }
 
 define float @clamp_nonfinite_to_normal_olt(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf) float @clamp_nonfinite_to_normal_olt
+; CHECK-LABEL: define float @clamp_nonfinite_to_normal_olt
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR2]]
 ; CHECK-NEXT:    [[IS_FINITE:%.*]] = fcmp olt float [[FABS]], 0x7FF0000000000000
@@ -115,7 +115,7 @@ define float @clamp_nonfinite_to_normal_olt(float %arg) {
 }
 
 define float @clamp_eq_inf_to_pnormal(float %arg) {
-; CHECK-LABEL: define nofpclass(inf) float @clamp_eq_inf_to_pnormal
+; CHECK-LABEL: define float @clamp_eq_inf_to_pnormal
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR2]]
 ; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[FABS]], 0x7FF0000000000000
@@ -129,7 +129,7 @@ define float @clamp_eq_inf_to_pnormal(float %arg) {
 }
 
 define float @clamp_eq_pinf_to_pnormal(float %arg) {
-; CHECK-LABEL: define nofpclass(pinf) float @clamp_eq_pinf_to_pnormal
+; CHECK-LABEL: define float @clamp_eq_pinf_to_pnormal
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[ARG]], 0x7FF0000000000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float 1.024000e+03, float [[ARG]]
@@ -141,7 +141,7 @@ define float @clamp_eq_pinf_to_pnormal(float %arg) {
 }
 
 define float @clamp_eq_ninf_to_negnormal(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf) float @clamp_eq_ninf_to_negnormal
+; CHECK-LABEL: define float @clamp_eq_ninf_to_negnormal
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[ARG]], 0xFFF0000000000000
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_INF]], float -1.024000e+03, float [[ARG]]
@@ -153,7 +153,7 @@ define float @clamp_eq_ninf_to_negnormal(float %arg) {
 }
 
 define float @clamp_eq_inf_to_nan(float %arg) {
-; CHECK-LABEL: define nofpclass(inf) float @clamp_eq_inf_to_nan
+; CHECK-LABEL: define float @clamp_eq_inf_to_nan
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR2]]
 ; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[FABS]], 0x7FF0000000000000
@@ -179,7 +179,7 @@ define float @ret_select_clamp_nan_to_zero_uno_returned_different_arg(float %arg
 }
 
 define float @isfinite_select_fabs_val_0(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf nzero nsub nnorm) float @isfinite_select_fabs_val_0
+; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) float @isfinite_select_fabs_val_0
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[FABS:%.*]] = call nofpclass(ninf nzero nsub nnorm) float @llvm.fabs.f32(float [[ARG]]) #[[ATTR2]]
 ; CHECK-NEXT:    [[IS_FINITE:%.*]] = fcmp olt float [[FABS]], 0x7FF0000000000000
@@ -193,7 +193,7 @@ define float @isfinite_select_fabs_val_0(float %arg) {
 }
 
 define float @isfinite_select_fabs_val_1(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf nzero nsub nnorm) float @isfinite_select_fabs_val_1
+; CHECK-LABEL: define nofpclass(ninf nzero nsub nnorm) float @isfinite_select_fabs_val_1
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[FABS:%.*]] = call nofpclass(ninf nzero nsub nnorm) float @llvm.fabs.f32(float [[ARG]]) #[[ATTR2]]
 ; CHECK-NEXT:    [[NOT_IS_FINITE:%.*]] = fcmp uge float [[FABS]], 0x3810000000000000
@@ -207,7 +207,7 @@ define float @isfinite_select_fabs_val_1(float %arg) {
 }
 
 define float @clamp_denormal_to_poszero(float %arg) {
-; CHECK-LABEL: define nofpclass(nzero sub) float @clamp_denormal_to_poszero
+; CHECK-LABEL: define float @clamp_denormal_to_poszero
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR2]]
 ; CHECK-NEXT:    [[IS_DENORM_OR_ZERO:%.*]] = fcmp olt float [[FABS]], 0x3810000000000000
@@ -221,7 +221,7 @@ define float @clamp_denormal_to_poszero(float %arg) {
 }
 
 define float @clamp_denormal_to_negzero(float %arg) {
-; CHECK-LABEL: define nofpclass(pzero sub) float @clamp_denormal_to_negzero
+; CHECK-LABEL: define float @clamp_denormal_to_negzero
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR2]]
 ; CHECK-NEXT:    [[IS_DENORM_OR_ZERO:%.*]] = fcmp olt float [[FABS]], 0x3810000000000000
@@ -235,7 +235,7 @@ define float @clamp_denormal_to_negzero(float %arg) {
 }
 
 define float @clamp_denormal_to_zero_copysign(float %arg) {
-; CHECK-LABEL: define nofpclass(sub) float @clamp_denormal_to_zero_copysign
+; CHECK-LABEL: define float @clamp_denormal_to_zero_copysign
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR2]]
 ; CHECK-NEXT:    [[IS_DENORM_OR_ZERO:%.*]] = fcmp olt float [[FABS]], 0x3810000000000000
@@ -251,7 +251,7 @@ define float @clamp_denormal_to_zero_copysign(float %arg) {
 }
 
 define float @clamp_only_denormal_or_zero(float %arg) {
-; CHECK-LABEL: define nofpclass(nan inf norm) float @clamp_only_denormal_or_zero
+; CHECK-LABEL: define float @clamp_only_denormal_or_zero
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR2]]
 ; CHECK-NEXT:    [[IS_DENORM_OR_ZERO:%.*]] = fcmp olt float [[FABS]], 0x3810000000000000
@@ -265,7 +265,7 @@ define float @clamp_only_denormal_or_zero(float %arg) {
 }
 
 define float @clamp_inf_to_fabs(float %arg) {
-; CHECK-LABEL: define nofpclass(ninf) float @clamp_inf_to_fabs
+; CHECK-LABEL: define float @clamp_inf_to_fabs
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ARG]]) #[[ATTR2]]
 ; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[FABS]], 0x7FF0000000000000
@@ -279,7 +279,7 @@ define float @clamp_inf_to_fabs(float %arg) {
 }
 
 define float @not_clamp_inf_to_fabs(float %arg) {
-; CHECK-LABEL: define nofpclass(nzero nsub nnorm) float @not_clamp_inf_to_fabs
+; CHECK-LABEL: define float @not_clamp_inf_to_fabs
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[FABS:%.*]] = call nofpclass(ninf nzero nsub nnorm) float @llvm.fabs.f32(float [[ARG]]) #[[ATTR2]]
 ; CHECK-NEXT:    [[IS_INF:%.*]] = fcmp oeq float [[FABS]], 0x7FF0000000000000
@@ -293,7 +293,7 @@ define float @not_clamp_inf_to_fabs(float %arg) {
 }
 
 define float @clamp_zero_to_inf(float %arg) {
-; CHECK-LABEL: define nofpclass(zero) float @clamp_zero_to_inf
+; CHECK-LABEL: define float @clamp_zero_to_inf
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[IS_ZERO:%.*]] = fcmp oeq float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ZERO]], float 0x7FF0000000000000, float [[ARG]]
@@ -305,7 +305,7 @@ define float @clamp_zero_to_inf(float %arg) {
 }
 
 define float @clamp_zero_to_only_inf(float %arg) {
-; CHECK-LABEL: define nofpclass(nan ninf sub norm) float @clamp_zero_to_only_inf
+; CHECK-LABEL: define float @clamp_zero_to_only_inf
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[IS_ZERO:%.*]] = fcmp oeq float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_ZERO]], float [[ARG]], float 0x7FF0000000000000
@@ -317,7 +317,7 @@ define float @clamp_zero_to_only_inf(float %arg) {
 }
 
 define float @clamp_is_class_subnormal_or_inf_to_nan(float %arg) {
-; CHECK-LABEL: define nofpclass(inf sub) float @clamp_is_class_subnormal_or_inf_to_nan
+; CHECK-LABEL: define float @clamp_is_class_subnormal_or_inf_to_nan
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[IS_SUBNORMAL_OR_INF:%.*]] = call i1 @llvm.is.fpclass.f32(float [[ARG]], i32 noundef 660) #[[ATTR2]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_SUBNORMAL_OR_INF]], float 0x7FF8000000000000, float [[ARG]]
@@ -329,7 +329,7 @@ define float @clamp_is_class_subnormal_or_inf_to_nan(float %arg) {
 }
 
 define float @clamp_is_class_subnormal_or_inf_to_nan_swap(float %arg) {
-; CHECK-LABEL: define nofpclass(inf sub) float @clamp_is_class_subnormal_or_inf_to_nan_swap
+; CHECK-LABEL: define float @clamp_is_class_subnormal_or_inf_to_nan_swap
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[NOT_IS_SUBNORMAL_OR_INF:%.*]] = call i1 @llvm.is.fpclass.f32(float [[ARG]], i32 noundef 363) #[[ATTR2]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[NOT_IS_SUBNORMAL_OR_INF]], float [[ARG]], float 0x7FF8000000000000
@@ -341,7 +341,7 @@ define float @clamp_is_class_subnormal_or_inf_to_nan_swap(float %arg) {
 }
 
 define float @ret_select_clamp_nan_to_zero_fpclass(float %arg) {
-; CHECK-LABEL: define nofpclass(nan) float @ret_select_clamp_nan_to_zero_fpclass
+; CHECK-LABEL: define float @ret_select_clamp_nan_to_zero_fpclass
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[IS_NAN:%.*]] = call i1 @llvm.is.fpclass.f32(float [[ARG]], i32 noundef 3) #[[ATTR2]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_NAN]], float 0.000000e+00, float [[ARG]]
@@ -353,7 +353,7 @@ define float @ret_select_clamp_nan_to_zero_fpclass(float %arg) {
 }
 
 define float @ret_select_clamp_snan_to_zero_fpclass(float %arg) {
-; CHECK-LABEL: define nofpclass(snan) float @ret_select_clamp_snan_to_zero_fpclass
+; CHECK-LABEL: define float @ret_select_clamp_snan_to_zero_fpclass
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[IS_NAN:%.*]] = call i1 @llvm.is.fpclass.f32(float [[ARG]], i32 noundef 1) #[[ATTR2]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_NAN]], float 0.000000e+00, float [[ARG]]
@@ -365,7 +365,7 @@ define float @ret_select_clamp_snan_to_zero_fpclass(float %arg) {
 }
 
 define float @ret_select_clamp_qnan_to_zero_fpclass(float %arg) {
-; CHECK-LABEL: define nofpclass(qnan) float @ret_select_clamp_qnan_to_zero_fpclass
+; CHECK-LABEL: define float @ret_select_clamp_qnan_to_zero_fpclass
 ; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR1]] {
 ; CHECK-NEXT:    [[IS_NAN:%.*]] = call i1 @llvm.is.fpclass.f32(float [[ARG]], i32 noundef 2) #[[ATTR2]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_NAN]], float 0.000000e+00, float [[ARG]]

--- a/llvm/test/Transforms/Attributor/nofpclass.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass.ll
@@ -3632,16 +3632,31 @@ define float @fadd_double_no_zero__output_only_is_dynamic(float noundef nofpclas
 ; Implies return must be 0
 define float @assume_select_condition_not_nan(float noundef %arg) {
 ; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(inaccessiblemem: write)
-; CHECK-LABEL: define noundef nofpclass(inf nzero sub norm) float @assume_select_condition_not_nan
+; CHECK-LABEL: define noundef nofpclass(nan inf nzero sub norm) float @assume_select_condition_not_nan
 ; CHECK-SAME: (float noundef [[ARG:%.*]]) #[[ATTR19:[0-9]+]] {
-; CHECK-NEXT:    [[UNO:%.*]] = fcmp ord float [[ARG]], 0.000000e+00
-; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UNO]]) #[[ATTR22]]
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[UNO]], float 0.000000e+00, float [[ARG]]
+; CHECK-NEXT:    [[ORD:%.*]] = fcmp ord float [[ARG]], 0.000000e+00
+; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[ORD]]) #[[ATTR22]]
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[ORD]], float 0.000000e+00, float [[ARG]]
 ; CHECK-NEXT:    ret float [[SELECT]]
 ;
-  %uno = fcmp ord float %arg, 0.0
+  %ord = fcmp ord float %arg, 0.0
+  call void @llvm.assume(i1 %ord)
+  %select = select i1 %ord, float 0.0, float %arg
+  ret float %select
+}
+
+define float @assume_select_condition_not_nan_commute(float noundef %arg) {
+; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(inaccessiblemem: write)
+; CHECK-LABEL: define noundef nofpclass(inf nzero sub norm) float @assume_select_condition_not_nan_commute
+; CHECK-SAME: (float noundef [[ARG:%.*]]) #[[ATTR19]] {
+; CHECK-NEXT:    [[UNO:%.*]] = fcmp uno float [[ARG]], 0.000000e+00
+; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UNO]]) #[[ATTR22]]
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[UNO]], float [[ARG]], float 0.000000e+00
+; CHECK-NEXT:    ret float [[SELECT]]
+;
+  %uno = fcmp uno float %arg, 0.0
   call void @llvm.assume(i1 %uno)
-  %select = select i1 %uno, float 0.0, float %arg
+  %select = select i1 %uno, float %arg, float 0.0
   ret float %select
 }
 

--- a/llvm/test/Transforms/Attributor/nofpclass.ll
+++ b/llvm/test/Transforms/Attributor/nofpclass.ll
@@ -3630,10 +3630,10 @@ define float @fadd_double_no_zero__output_only_is_dynamic(float noundef nofpclas
 }
 
 ; Implies return must be 0
-define float @assume_select_condition_not_nan(float %arg) {
+define float @assume_select_condition_not_nan(float noundef %arg) {
 ; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(inaccessiblemem: write)
-; CHECK-LABEL: define nofpclass(nan inf nzero sub norm) float @assume_select_condition_not_nan
-; CHECK-SAME: (float [[ARG:%.*]]) #[[ATTR19:[0-9]+]] {
+; CHECK-LABEL: define noundef nofpclass(inf nzero sub norm) float @assume_select_condition_not_nan
+; CHECK-SAME: (float noundef [[ARG:%.*]]) #[[ATTR19:[0-9]+]] {
 ; CHECK-NEXT:    [[UNO:%.*]] = fcmp ord float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[UNO]]) #[[ATTR22]]
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[UNO]], float 0.000000e+00, float [[ARG]]
@@ -3662,10 +3662,10 @@ define float @assume_load(ptr %ptr) {
 }
 
 ; FIXME: Why is this not working?
-define float @assume_returned_arg(float %arg) {
+define float @assume_returned_arg(float noundef %arg) {
 ; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(inaccessiblemem: write)
-; CHECK-LABEL: define float @assume_returned_arg
-; CHECK-SAME: (float returned [[ARG:%.*]]) #[[ATTR19]] {
+; CHECK-LABEL: define noundef float @assume_returned_arg
+; CHECK-SAME: (float noundef returned [[ARG:%.*]]) #[[ATTR19]] {
 ; CHECK-NEXT:    [[ORD:%.*]] = fcmp ord float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    call void @llvm.assume(i1 noundef [[ORD]]) #[[ATTR22]]
 ; CHECK-NEXT:    ret float [[ARG]]

--- a/llvm/test/Transforms/InstCombine/minmax-fp.ll
+++ b/llvm/test/Transforms/InstCombine/minmax-fp.ll
@@ -118,7 +118,7 @@ define float @fmin_fmin_zero_mismatch(float %x) {
 }
 
 ; max(max(x, -0.0), -0.0) --> max(x, -0.0)
-define float @fmax_fmax_zero_mismatch(float %x) {
+define float @fmax_fmax_zero_mismatch(float noundef %x) {
 ; CHECK-LABEL: @fmax_fmax_zero_mismatch(
 ; CHECK-NEXT:    [[CMP1:%.*]] = fcmp ogt float [[X:%.*]], 0.000000e+00
 ; CHECK-NEXT:    [[MAX1:%.*]] = select i1 [[CMP1]], float [[X]], float -0.000000e+00

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
@@ -1009,10 +1009,23 @@ define nofpclass(ninf nnorm nsub nzero) float @ret_nofpclass_negatives__select_c
 }
 
 ; Can fold to ret +0
-define nofpclass(nan ninf nnorm nsub nzero) float @ret_nofpclass_nan_negatives__select_clamp_pos_to_zero(float %x) {
+define nofpclass(nan ninf nnorm nsub nzero) float @ret_nofpclass_nan_negatives__select_clamp_pos_to_zero(float noundef %x) {
 ; CHECK-LABEL: define nofpclass(nan ninf nzero nsub nnorm) float @ret_nofpclass_nan_negatives__select_clamp_pos_to_zero
-; CHECK-SAME: (float [[X:%.*]]) {
+; CHECK-SAME: (float noundef [[X:%.*]]) {
 ; CHECK-NEXT:    ret float 0.000000e+00
+;
+  %is.gt.zero = fcmp ogt float %x, 0.0
+  %select = select i1 %is.gt.zero, float 0.0, float %x
+  ret float %select
+}
+
+; Cannot fold due to undef
+define nofpclass(nan ninf nnorm nsub nzero) float @ret_nofpclass_nan_negatives__select_clamp_pos_to_zero__maybe_undef(float %x) {
+; CHECK-LABEL: define nofpclass(nan ninf nzero nsub nnorm) float @ret_nofpclass_nan_negatives__select_clamp_pos_to_zero__maybe_undef
+; CHECK-SAME: (float [[X:%.*]]) {
+; CHECK-NEXT:    [[IS_GT_ZERO:%.*]] = fcmp ogt float [[X]], 0.000000e+00
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_GT_ZERO]], float 0.000000e+00, float [[X]]
+; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %is.gt.zero = fcmp ogt float %x, 0.0
   %select = select i1 %is.gt.zero, float 0.0, float %x
@@ -1517,9 +1530,9 @@ define nofpclass(zero) <3 x float> @partially_defined_0_splat_to_poison() {
 
 ; The select must be 0, so the exp should fold to 1. This requires
 ; analysis of the select condition.
-define nofpclass(nan) float @exp_select_must_be_0(float %arg, float nofpclass(inf sub norm) %zero.or.nan) {
+define nofpclass(nan) float @exp_select_must_be_0(float noundef %arg, float nofpclass(inf sub norm) %zero.or.nan) {
 ; CHECK-LABEL: define nofpclass(nan) float @exp_select_must_be_0
-; CHECK-SAME: (float [[ARG:%.*]], float nofpclass(inf sub norm) [[ZERO_OR_NAN:%.*]]) {
+; CHECK-SAME: (float noundef [[ARG:%.*]], float nofpclass(inf sub norm) [[ZERO_OR_NAN:%.*]]) {
 ; CHECK-NEXT:    ret float 1.000000e+00
 ;
   %not.zero = fcmp one float %arg, 0.0
@@ -1530,9 +1543,9 @@ define nofpclass(nan) float @exp_select_must_be_0(float %arg, float nofpclass(in
 
 ; The select must be 0, so the exp should fold to 1. This requires
 ; analysis of the select condition.
-define nofpclass(nan) float @exp_select_must_be_0_commute(float %arg, float nofpclass(inf sub norm) %zero.or.nan) {
+define nofpclass(nan) float @exp_select_must_be_0_commute(float noundef %arg, float nofpclass(inf sub norm) %zero.or.nan) {
 ; CHECK-LABEL: define nofpclass(nan) float @exp_select_must_be_0_commute
-; CHECK-SAME: (float [[ARG:%.*]], float nofpclass(inf sub norm) [[ZERO_OR_NAN:%.*]]) {
+; CHECK-SAME: (float noundef [[ARG:%.*]], float nofpclass(inf sub norm) [[ZERO_OR_NAN:%.*]]) {
 ; CHECK-NEXT:    ret float 1.000000e+00
 ;
   %is.zero = fcmp oeq float %arg, 0.0


### PR DESCRIPTION
This needs to consider undef like the KnownBits case does.