### PR TITLE
InstCombine: Improve SimplifyDemandedFPClass min/max handling

### DIFF
--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-maximum.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-maximum.ll
@@ -389,8 +389,7 @@ define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_0() {
 ; CHECK-LABEL: define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_0() {
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO:%.*]] = call float @returns_negative_or_zero()
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO1:%.*]] = call float @returns_positive_or_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.maximum.f32(float [[MUST_BE_POSITIVE_OR_ZERO]], float [[MUST_BE_POSITIVE_OR_ZERO1]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[MUST_BE_POSITIVE_OR_ZERO1]]
 ;
   %must.be.negative.or.zero = call float @returns_negative_or_zero()
   %must.be.positive.or.zero = call float @returns_positive_or_zero()
@@ -402,8 +401,7 @@ define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_1() {
 ; CHECK-LABEL: define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_1() {
 ; CHECK-NEXT:    [[MUST_BE_NEGATIVE_OR_ZERO:%.*]] = call float @returns_positive_or_zero()
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO:%.*]] = call float @returns_negative_or_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.maximum.f32(float [[MUST_BE_NEGATIVE_OR_ZERO]], float [[MUST_BE_POSITIVE_OR_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[MUST_BE_NEGATIVE_OR_ZERO]]
 ;
   %must.be.positive.or.zero = call float @returns_positive_or_zero()
   %must.be.negative.or.zero = call float @returns_negative_or_zero()
@@ -864,8 +862,7 @@ define nofpclass(snan) float @known_positive__maximum__only_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive__maximum__only_zero() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[KNOWN_POSITIVE]], float [[KNOWN_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE]]
 ;
   %known.positive = call float @returns_positive()
   %known.zero = call float @returns_zero()
@@ -877,8 +874,7 @@ define nofpclass(snan) float @only_zero__maximum__known_positive() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_zero__maximum__known_positive() {
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[KNOWN_ZERO]], float [[KNOWN_POSITIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE]]
 ;
   %known.zero = call float @returns_zero()
   %known.positive = call float @returns_positive()
@@ -916,8 +912,7 @@ define nofpclass(snan) float @known_positive_or_nan__maximum__only_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive_or_nan__maximum__only_zero() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE_OR_NAN:%.*]] = call float @returns_positive_or_nan()
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[KNOWN_POSITIVE_OR_NAN]], float [[KNOWN_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE_OR_NAN]]
 ;
   %known.positive.or.nan = call float @returns_positive_or_nan()
   %known.zero = call float @returns_zero()
@@ -929,8 +924,7 @@ define nofpclass(snan) float @only_zero__maximum__known_positive_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_zero__maximum__known_positive_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
 ; CHECK-NEXT:    [[KNOWN_POSITIVE_OR_NAN:%.*]] = call float @returns_positive_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[KNOWN_ZERO]], float [[KNOWN_POSITIVE_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE_OR_NAN]]
 ;
   %known.zero = call float @returns_zero()
   %known.positive.or.nan = call float @returns_positive_or_nan()
@@ -966,8 +960,7 @@ define nofpclass(snan) float @known_positive__maximum__only_pzero() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive__maximum__only_pzero() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[KNOWN_PZERO:%.*]] = call float @returns_pzero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[KNOWN_POSITIVE]], float 0.000000e+00)
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE]]
 ;
   %known.positive = call float @returns_positive()
   %known.pzero = call float @returns_pzero()
@@ -979,8 +972,7 @@ define nofpclass(snan) float @only_pzero__maximum__known_positive() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_pzero__maximum__known_positive() {
 ; CHECK-NEXT:    [[KNOWN_PZERO:%.*]] = call float @returns_pzero()
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[KNOWN_POSITIVE]], float 0.000000e+00)
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE]]
 ;
   %known.pzero = call float @returns_pzero()
   %known.positive = call float @returns_positive()
@@ -992,8 +984,7 @@ define nofpclass(snan) float @known_negative__maximum__only_zero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_negative__maximum__only_zero_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[KNOWN_ZERO_OR_NAN:%.*]] = call float @returns_zero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[KNOWN_NEGATIVE]], float [[KNOWN_ZERO_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_ZERO_OR_NAN]]
 ;
   %known.negative = call float @returns_negative()
   %known.zero.or.nan = call float @returns_zero_or_nan()
@@ -1005,8 +996,7 @@ define nofpclass(snan) float @only_zero_or_nan__maximum__known_negative() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_zero_or_nan__maximum__known_negative() {
 ; CHECK-NEXT:    [[KNOWN_ZERO_OR_NAN:%.*]] = call float @returns_zero_or_nan()
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[KNOWN_ZERO_OR_NAN]], float [[KNOWN_NEGATIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_ZERO_OR_NAN]]
 ;
   %known.zero.or.nan = call float @returns_zero_or_nan()
   %known.negative = call float @returns_negative()
@@ -1068,8 +1058,7 @@ define nofpclass(snan) float @known_negative__maximum__only_nzero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_negative__maximum__only_nzero_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[KNOWN_NZERO_OR_NAN:%.*]] = call float @returns_nzero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[KNOWN_NEGATIVE]], float [[KNOWN_NZERO_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_NZERO_OR_NAN]]
 ;
   %known.negative = call float @returns_negative()
   %known.nzero.or.nan = call float @returns_nzero_or_nan()
@@ -1081,8 +1070,7 @@ define nofpclass(snan) float @only_nzero_or_nan__maximum__known_negative() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_nzero_or_nan__maximum__known_negative() {
 ; CHECK-NEXT:    [[KNOWN_NZERO_OR_NAN:%.*]] = call float @returns_nzero_or_nan()
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximum.f32(float [[KNOWN_NZERO_OR_NAN]], float [[KNOWN_NEGATIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_NZERO_OR_NAN]]
 ;
   %known.nzero.or.nan = call float @returns_nzero_or_nan()
   %known.negative = call float @returns_negative()
@@ -1740,8 +1728,7 @@ define nofpclass(snan) float @select_is_positive_or_0__maximum__nnorm_0(float no
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[SELECT]], float [[NNORM]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %is.pos.or.zero = fcmp oge float %arg, 0.0
   %select = select i1 %is.pos.or.zero, float %arg, float 0.0
@@ -1756,8 +1743,7 @@ define nofpclass(snan) float @select_is_positive_or_0__maximum__nnorm_1(float no
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[NNORM]], float [[SELECT]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %nnorm = call float @returns_nnorm()
   %is.pos.or.zero = fcmp oge float %arg, 0.0
@@ -1804,8 +1790,7 @@ define nofpclass(snan) float @select_is_positive_or_0__maximum__negative(float n
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    [[NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[SELECT]], float [[NEGATIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %is.pos.or.zero = fcmp oge float %arg, 0.0
   %select = select i1 %is.pos.or.zero, float %arg, float 0.0
@@ -1820,8 +1805,7 @@ define nofpclass(snan) float @negative__maximum__select_is_positive_or_0(float n
 ; CHECK-NEXT:    [[NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[NEGATIVE]], float [[SELECT]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %negative = call float @returns_negative()
   %is.pos.or.zero = fcmp oge float %arg, 0.0
@@ -1890,8 +1874,7 @@ define nofpclass(snan) float @negative_or_zero__maximum__positive_or_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @negative_or_zero__maximum__positive_or_zero() {
 ; CHECK-NEXT:    [[NEG_NONZERO:%.*]] = call float @returns_negative_nonzero()
 ; CHECK-NEXT:    [[POSITIVE_OR_ZERO:%.*]] = call float @returns_positive_or_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[NEG_NONZERO]], float [[POSITIVE_OR_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[POSITIVE_OR_ZERO]]
 ;
   %neg.nonzero = call float @returns_negative_nonzero()
   %positive.or.zero = call float @returns_positive_or_zero()
@@ -1903,8 +1886,7 @@ define nofpclass(snan) float @positive_or_zero__maximum__negative_or_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @positive_or_zero__maximum__negative_or_zero() {
 ; CHECK-NEXT:    [[POSITIVE_OR_ZERO:%.*]] = call float @returns_positive_or_zero()
 ; CHECK-NEXT:    [[NEG_NONZERO:%.*]] = call float @returns_negative_nonzero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[POSITIVE_OR_ZERO]], float [[NEG_NONZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[POSITIVE_OR_ZERO]]
 ;
   %positive.or.zero = call float @returns_positive_or_zero()
   %neg.nonzero = call float @returns_negative_nonzero()
@@ -1990,8 +1972,7 @@ define nofpclass(snan) float @known_pnorm__maximum__known_psub() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_pnorm__maximum__known_psub() {
 ; CHECK-NEXT:    [[PNORM:%.*]] = call float @returns_pnorm()
 ; CHECK-NEXT:    [[PSUB:%.*]] = call float @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[PNORM]], float [[PSUB]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[PNORM]]
 ;
   %pnorm = call float @returns_pnorm()
   %psub = call float @returns_psub()
@@ -2003,8 +1984,7 @@ define nofpclass(snan) float @known_psub__maximum__known_pnorm() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_psub__maximum__known_pnorm() {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call float @returns_psub()
 ; CHECK-NEXT:    [[PNORM:%.*]] = call float @returns_pnorm()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[PSUB]], float [[PNORM]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[PNORM]]
 ;
   %psub = call float @returns_psub()
   %pnorm = call float @returns_pnorm()
@@ -2040,8 +2020,7 @@ define nofpclass(snan) float @known_nnorm__maximum__known_nsub() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_nnorm__maximum__known_nsub() {
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
 ; CHECK-NEXT:    [[NSUB:%.*]] = call float @returns_nsub()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[NNORM]], float [[NSUB]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NSUB]]
 ;
   %nnorm = call float @returns_nnorm()
   %nsub = call float @returns_nsub()
@@ -2053,8 +2032,7 @@ define nofpclass(snan) float @known_nsub__maximum__known_nnorm() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_nsub__maximum__known_nnorm() {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call float @returns_nsub()
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximum.f32(float [[NSUB]], float [[NNORM]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NSUB]]
 ;
   %nsub = call float @returns_nsub()
   %nnorm = call float @returns_nnorm()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-maximumnum.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-maximumnum.ll
@@ -390,8 +390,7 @@ define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_0() {
 ; CHECK-LABEL: define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_0() {
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO:%.*]] = call float @returns_negative_or_zero()
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO1:%.*]] = call float @returns_positive_or_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.maximumnum.f32(float [[MUST_BE_POSITIVE_OR_ZERO]], float [[MUST_BE_POSITIVE_OR_ZERO1]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[MUST_BE_POSITIVE_OR_ZERO1]]
 ;
   %must.be.negative.or.zero = call float @returns_negative_or_zero()
   %must.be.positive.or.zero = call float @returns_positive_or_zero()
@@ -403,8 +402,7 @@ define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_1() {
 ; CHECK-LABEL: define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_1() {
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO:%.*]] = call float @returns_negative_or_zero()
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO1:%.*]] = call float @returns_positive_or_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.maximumnum.f32(float [[MUST_BE_POSITIVE_OR_ZERO1]], float [[MUST_BE_POSITIVE_OR_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[MUST_BE_POSITIVE_OR_ZERO1]]
 ;
   %must.be.negative.or.zero = call float @returns_negative_or_zero()
   %must.be.positive.or.zero = call float @returns_positive_or_zero()
@@ -865,8 +863,7 @@ define nofpclass(snan) float @known_positive__maximumnum__only_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive__maximumnum__only_zero() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[KNOWN_POSITIVE]], float [[KNOWN_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE]]
 ;
   %known.positive = call float @returns_positive()
   %known.zero = call float @returns_zero()
@@ -878,8 +875,7 @@ define nofpclass(snan) float @only_zero__maximumnum__known_positive() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_zero__maximumnum__known_positive() {
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[KNOWN_ZERO]], float [[KNOWN_POSITIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE]]
 ;
   %known.zero = call float @returns_zero()
   %known.positive = call float @returns_positive()
@@ -891,8 +887,7 @@ define nofpclass(snan) float @known_positive__maximumnum__only_zero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive__maximumnum__only_zero_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[KNOWN_ZERO_OR_NAN:%.*]] = call float @returns_zero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[KNOWN_POSITIVE]], float [[KNOWN_ZERO_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE]]
 ;
   %known.positive = call float @returns_positive()
   %known.zero.or.nan = call float @returns_zero_or_nan()
@@ -904,8 +899,7 @@ define nofpclass(snan) float @only_zero_or_nan__maximumnum__known_positive() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_zero_or_nan__maximumnum__known_positive() {
 ; CHECK-NEXT:    [[KNOWN_ZERO_OR_NAN:%.*]] = call float @returns_zero_or_nan()
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[KNOWN_ZERO_OR_NAN]], float [[KNOWN_POSITIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE]]
 ;
   %known.zero.or.nan = call float @returns_zero_or_nan()
   %known.positive = call float @returns_positive()
@@ -967,8 +961,7 @@ define nofpclass(snan) float @known_positive__maximumnum__only_pzero() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive__maximumnum__only_pzero() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[KNOWN_PZERO:%.*]] = call float @returns_pzero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[KNOWN_POSITIVE]], float 0.000000e+00)
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE]]
 ;
   %known.positive = call float @returns_positive()
   %known.pzero = call float @returns_pzero()
@@ -980,8 +973,7 @@ define nofpclass(snan) float @only_pzero__maximumnum__known_positive() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_pzero__maximumnum__known_positive() {
 ; CHECK-NEXT:    [[KNOWN_PZERO:%.*]] = call float @returns_pzero()
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[KNOWN_POSITIVE]], float 0.000000e+00)
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE]]
 ;
   %known.pzero = call float @returns_pzero()
   %known.positive = call float @returns_positive()
@@ -1019,8 +1011,7 @@ define nofpclass(snan) float @known_negative_or_nan__maximumnum__only_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_negative_or_nan__maximumnum__only_zero() {
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE_OR_NAN:%.*]] = call float @returns_negative_or_nan()
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[KNOWN_NEGATIVE_OR_NAN]], float [[KNOWN_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_ZERO]]
 ;
   %known.negative.or.nan = call float @returns_negative_or_nan()
   %known.zero = call float @returns_zero()
@@ -1032,8 +1023,7 @@ define nofpclass(snan) float @only_zero__maximumnum__known_negative_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_zero__maximumnum__known_negative_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE_OR_NAN:%.*]] = call float @returns_negative_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[KNOWN_ZERO]], float [[KNOWN_NEGATIVE_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_ZERO]]
 ;
   %known.zero = call float @returns_zero()
   %known.negative.or.nan = call float @returns_negative_or_nan()
@@ -1201,8 +1191,7 @@ define nofpclass(snan) float @known_positive__maximumnum__only_pzero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive__maximumnum__only_pzero_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[KNOWN_PZERO_OR_NAN:%.*]] = call float @returns_pzero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[KNOWN_POSITIVE]], float [[KNOWN_PZERO_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_POSITIVE]]
 ;
   %known.positive = call float @returns_positive()
   %known.pzero.or.nan = call float @returns_pzero_or_nan()
@@ -1746,8 +1735,7 @@ define nofpclass(snan) float @select_is_positive_or_0__maximumnum__nnorm_0(float
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[SELECT]], float [[NNORM]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %is.pos.or.zero = fcmp oge float %arg, 0.0
   %select = select i1 %is.pos.or.zero, float %arg, float 0.0
@@ -1762,8 +1750,7 @@ define nofpclass(snan) float @select_is_positive_or_0__maximumnum__nnorm_1(float
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[NNORM]], float [[SELECT]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %nnorm = call float @returns_nnorm()
   %is.pos.or.zero = fcmp oge float %arg, 0.0
@@ -1778,8 +1765,7 @@ define nofpclass(snan) float @select_is_positive_or_0__maximumnum__nnorm_or_nan_
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    [[NNORM_OR_NAN:%.*]] = call float @returns_nnorm_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[SELECT]], float [[NNORM_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %is.pos.or.zero = fcmp oge float %arg, 0.0
   %select = select i1 %is.pos.or.zero, float %arg, float 0.0
@@ -1794,8 +1780,7 @@ define nofpclass(snan) float @select_is_positive_or_0__maximumnum__nnorm_or_nan_
 ; CHECK-NEXT:    [[NNORM_OR_NAN:%.*]] = call float @returns_nnorm_or_nan()
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.maximumnum.f32(float [[NNORM_OR_NAN]], float [[SELECT]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %nnorm.or.nan = call float @returns_nnorm_or_nan()
   %is.pos.or.zero = fcmp oge float %arg, 0.0
@@ -1810,8 +1795,7 @@ define nofpclass(snan) float @select_is_positive_or_0__maximumnum__negative(floa
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    [[NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[SELECT]], float [[NEGATIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %is.pos.or.zero = fcmp oge float %arg, 0.0
   %select = select i1 %is.pos.or.zero, float %arg, float 0.0
@@ -1826,8 +1810,7 @@ define nofpclass(snan) float @negative__maximumnum__select_is_positive_or_0(floa
 ; CHECK-NEXT:    [[NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[NEGATIVE]], float [[SELECT]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %negative = call float @returns_negative()
   %is.pos.or.zero = fcmp oge float %arg, 0.0
@@ -1896,8 +1879,7 @@ define nofpclass(snan) float @negative_or_zero__maximumnum__positive_or_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @negative_or_zero__maximumnum__positive_or_zero() {
 ; CHECK-NEXT:    [[NEG_NONZERO:%.*]] = call float @returns_negative_nonzero()
 ; CHECK-NEXT:    [[POSITIVE_OR_ZERO:%.*]] = call float @returns_positive_or_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[NEG_NONZERO]], float [[POSITIVE_OR_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[POSITIVE_OR_ZERO]]
 ;
   %neg.nonzero = call float @returns_negative_nonzero()
   %positive.or.zero = call float @returns_positive_or_zero()
@@ -1909,8 +1891,7 @@ define nofpclass(snan) float @positive_or_zero__maximumnum__negative_or_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @positive_or_zero__maximumnum__negative_or_zero() {
 ; CHECK-NEXT:    [[POSITIVE_OR_ZERO:%.*]] = call float @returns_positive_or_zero()
 ; CHECK-NEXT:    [[NEG_NONZERO:%.*]] = call float @returns_negative_nonzero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[POSITIVE_OR_ZERO]], float [[NEG_NONZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[POSITIVE_OR_ZERO]]
 ;
   %positive.or.zero = call float @returns_positive_or_zero()
   %neg.nonzero = call float @returns_negative_nonzero()
@@ -1996,8 +1977,7 @@ define nofpclass(snan) float @known_pnorm__maximumnum__known_psub() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_pnorm__maximumnum__known_psub() {
 ; CHECK-NEXT:    [[PNORM:%.*]] = call float @returns_pnorm()
 ; CHECK-NEXT:    [[PSUB:%.*]] = call float @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[PNORM]], float [[PSUB]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[PNORM]]
 ;
   %pnorm = call float @returns_pnorm()
   %psub = call float @returns_psub()
@@ -2009,8 +1989,7 @@ define nofpclass(snan) float @known_psub__maximumnum__known_pnorm() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_psub__maximumnum__known_pnorm() {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call float @returns_psub()
 ; CHECK-NEXT:    [[PNORM:%.*]] = call float @returns_pnorm()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[PSUB]], float [[PNORM]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[PNORM]]
 ;
   %psub = call float @returns_psub()
   %pnorm = call float @returns_pnorm()
@@ -2046,8 +2025,7 @@ define nofpclass(snan) float @known_nnorm__maximumnum__known_nsub() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_nnorm__maximumnum__known_nsub() {
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
 ; CHECK-NEXT:    [[NSUB:%.*]] = call float @returns_nsub()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[NNORM]], float [[NSUB]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NSUB]]
 ;
   %nnorm = call float @returns_nnorm()
   %nsub = call float @returns_nsub()
@@ -2059,8 +2037,7 @@ define nofpclass(snan) float @known_nsub__maximumnum__known_nnorm() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_nsub__maximumnum__known_nnorm() {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call float @returns_nsub()
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.maximumnum.f32(float [[NSUB]], float [[NNORM]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NSUB]]
 ;
   %nsub = call float @returns_nsub()
   %nnorm = call float @returns_nnorm()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-minimum.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-minimum.ll
@@ -390,8 +390,7 @@ define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_0() {
 ; CHECK-LABEL: define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_0() {
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO:%.*]] = call float @returns_negative_or_zero()
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO1:%.*]] = call float @returns_positive_or_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.minimum.f32(float [[MUST_BE_POSITIVE_OR_ZERO]], float [[MUST_BE_POSITIVE_OR_ZERO1]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[MUST_BE_POSITIVE_OR_ZERO]]
 ;
   %must.be.negative.or.zero = call float @returns_negative_or_zero()
   %must.be.positive.or.zero = call float @returns_positive_or_zero()
@@ -403,8 +402,7 @@ define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_1() {
 ; CHECK-LABEL: define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_1() {
 ; CHECK-NEXT:    [[MUST_BE_NEGATIVE_OR_ZERO:%.*]] = call float @returns_positive_or_zero()
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO:%.*]] = call float @returns_negative_or_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.minimum.f32(float [[MUST_BE_NEGATIVE_OR_ZERO]], float [[MUST_BE_POSITIVE_OR_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[MUST_BE_POSITIVE_OR_ZERO]]
 ;
   %must.be.positive.or.zero = call float @returns_positive_or_zero()
   %must.be.negative.or.zero = call float @returns_negative_or_zero()
@@ -865,8 +863,7 @@ define nofpclass(snan) float @known_positive__minimum__only_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive__minimum__only_zero() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[KNOWN_POSITIVE]], float [[KNOWN_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_ZERO]]
 ;
   %known.positive = call float @returns_positive()
   %known.zero = call float @returns_zero()
@@ -878,8 +875,7 @@ define nofpclass(snan) float @only_zero__minimum__known_positive() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_zero__minimum__known_positive() {
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[KNOWN_ZERO]], float [[KNOWN_POSITIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_ZERO]]
 ;
   %known.zero = call float @returns_zero()
   %known.positive = call float @returns_positive()
@@ -891,8 +887,7 @@ define nofpclass(snan) float @known_positive__minimum__only_zero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive__minimum__only_zero_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[KNOWN_ZERO_OR_NAN:%.*]] = call float @returns_zero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[KNOWN_POSITIVE]], float [[KNOWN_ZERO_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_ZERO_OR_NAN]]
 ;
   %known.positive = call float @returns_positive()
   %known.zero.or.nan = call float @returns_zero_or_nan()
@@ -904,8 +899,7 @@ define nofpclass(snan) float @only_zero_or_nan__minimum__known_positive() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_zero_or_nan__minimum__known_positive() {
 ; CHECK-NEXT:    [[KNOWN_ZERO_OR_NAN:%.*]] = call float @returns_zero_or_nan()
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[KNOWN_ZERO_OR_NAN]], float [[KNOWN_POSITIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_ZERO_OR_NAN]]
 ;
   %known.zero.or.nan = call float @returns_zero_or_nan()
   %known.positive = call float @returns_positive()
@@ -1017,8 +1011,7 @@ define nofpclass(snan) float @known_negative_or_nan__minimum__only_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_negative_or_nan__minimum__only_zero() {
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE_OR_NAN:%.*]] = call float @returns_negative_or_nan()
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[KNOWN_NEGATIVE_OR_NAN]], float [[KNOWN_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_NEGATIVE_OR_NAN]]
 ;
   %known.negative.or.nan = call float @returns_negative_or_nan()
   %known.zero = call float @returns_zero()
@@ -1030,8 +1023,7 @@ define nofpclass(snan) float @only_zero__minimum__known_negative_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_zero__minimum__known_negative_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE_OR_NAN:%.*]] = call float @returns_negative_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[KNOWN_ZERO]], float [[KNOWN_NEGATIVE_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_NEGATIVE_OR_NAN]]
 ;
   %known.zero = call float @returns_zero()
   %known.negative.or.nan = call float @returns_negative_or_nan()
@@ -1043,8 +1035,7 @@ define nofpclass(snan) float @known_negative__minimum__only_nzero() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_negative__minimum__only_nzero() {
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[KNOWN_NZERO:%.*]] = call float @returns_nzero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[KNOWN_NEGATIVE]], float -0.000000e+00)
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_NEGATIVE]]
 ;
   %known.negative = call float @returns_negative()
   %known.nzero = call float @returns_nzero()
@@ -1056,8 +1047,7 @@ define nofpclass(snan) float @only_nzero__minimum__known_negative() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_nzero__minimum__known_negative() {
 ; CHECK-NEXT:    [[KNOWN_NZERO:%.*]] = call float @returns_nzero()
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[KNOWN_NEGATIVE]], float -0.000000e+00)
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_NEGATIVE]]
 ;
   %known.nzero = call float @returns_nzero()
   %known.negative = call float @returns_negative()
@@ -1201,8 +1191,7 @@ define nofpclass(snan) float @known_positive__minimum__only_pzero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive__minimum__only_pzero_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[KNOWN_PZERO_OR_NAN:%.*]] = call float @returns_pzero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[KNOWN_POSITIVE]], float [[KNOWN_PZERO_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_PZERO_OR_NAN]]
 ;
   %known.positive = call float @returns_positive()
   %known.pzero.or.nan = call float @returns_pzero_or_nan()
@@ -1738,11 +1727,8 @@ define nofpclass(snan) float @not_nan__minimum_noundef_md__not_nan(float nofpcla
 define nofpclass(snan) float @select_is_positive_or_0__minimum__nnorm_0(float noundef %arg) {
 ; CHECK-LABEL: define nofpclass(snan) float @select_is_positive_or_0__minimum__nnorm_0(
 ; CHECK-SAME: float noundef [[ARG:%.*]]) {
-; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[SELECT]], float [[NNORM]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NNORM]]
 ;
   %is.pos.or.zero = fcmp oge float %arg, 0.0
   %select = select i1 %is.pos.or.zero, float %arg, float 0.0
@@ -1755,10 +1741,7 @@ define nofpclass(snan) float @select_is_positive_or_0__minimum__nnorm_1(float no
 ; CHECK-LABEL: define nofpclass(snan) float @select_is_positive_or_0__minimum__nnorm_1(
 ; CHECK-SAME: float noundef [[ARG:%.*]]) {
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
-; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[NNORM]], float [[SELECT]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NNORM]]
 ;
   %nnorm = call float @returns_nnorm()
   %is.pos.or.zero = fcmp oge float %arg, 0.0
@@ -1770,11 +1753,8 @@ define nofpclass(snan) float @select_is_positive_or_0__minimum__nnorm_1(float no
 define nofpclass(snan) float @select_is_positive_or_0__minimum__nnorm_or_nan_0(float noundef %arg) {
 ; CHECK-LABEL: define nofpclass(snan) float @select_is_positive_or_0__minimum__nnorm_or_nan_0(
 ; CHECK-SAME: float noundef [[ARG:%.*]]) {
-; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    [[NNORM_OR_NAN:%.*]] = call float @returns_nnorm_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[SELECT]], float [[NNORM_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NNORM_OR_NAN]]
 ;
   %is.pos.or.zero = fcmp oge float %arg, 0.0
   %select = select i1 %is.pos.or.zero, float %arg, float 0.0
@@ -1787,10 +1767,7 @@ define nofpclass(snan) float @select_is_positive_or_0__minimum__nnorm_or_nan_1(f
 ; CHECK-LABEL: define nofpclass(snan) float @select_is_positive_or_0__minimum__nnorm_or_nan_1(
 ; CHECK-SAME: float noundef [[ARG:%.*]]) {
 ; CHECK-NEXT:    [[NNORM_OR_NAN:%.*]] = call float @returns_nnorm_or_nan()
-; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimum.f32(float [[NNORM_OR_NAN]], float [[SELECT]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NNORM_OR_NAN]]
 ;
   %nnorm.or.nan = call float @returns_nnorm_or_nan()
   %is.pos.or.zero = fcmp oge float %arg, 0.0
@@ -1802,11 +1779,8 @@ define nofpclass(snan) float @select_is_positive_or_0__minimum__nnorm_or_nan_1(f
 define nofpclass(snan) float @select_is_positive_or_0__minimum__negative(float noundef %arg) {
 ; CHECK-LABEL: define nofpclass(snan) float @select_is_positive_or_0__minimum__negative(
 ; CHECK-SAME: float noundef [[ARG:%.*]]) {
-; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    [[NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[SELECT]], float [[NEGATIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NEGATIVE]]
 ;
   %is.pos.or.zero = fcmp oge float %arg, 0.0
   %select = select i1 %is.pos.or.zero, float %arg, float 0.0
@@ -1819,10 +1793,7 @@ define nofpclass(snan) float @negative__minimum__select_is_positive_or_0(float n
 ; CHECK-LABEL: define nofpclass(snan) float @negative__minimum__select_is_positive_or_0(
 ; CHECK-SAME: float noundef [[ARG:%.*]]) {
 ; CHECK-NEXT:    [[NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[NEGATIVE]], float [[SELECT]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NEGATIVE]]
 ;
   %negative = call float @returns_negative()
   %is.pos.or.zero = fcmp oge float %arg, 0.0
@@ -1891,8 +1862,7 @@ define nofpclass(snan) float @negative_or_zero__minimum__positive_or_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @negative_or_zero__minimum__positive_or_zero() {
 ; CHECK-NEXT:    [[NEG_NONZERO:%.*]] = call float @returns_negative_nonzero()
 ; CHECK-NEXT:    [[POSITIVE_OR_ZERO:%.*]] = call float @returns_positive_or_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[NEG_NONZERO]], float [[POSITIVE_OR_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NEG_NONZERO]]
 ;
   %neg.nonzero = call float @returns_negative_nonzero()
   %positive.or.zero = call float @returns_positive_or_zero()
@@ -1904,8 +1874,7 @@ define nofpclass(snan) float @positive_or_zero__minimum__negative_or_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @positive_or_zero__minimum__negative_or_zero() {
 ; CHECK-NEXT:    [[POSITIVE_OR_ZERO:%.*]] = call float @returns_positive_or_zero()
 ; CHECK-NEXT:    [[NEG_NONZERO:%.*]] = call float @returns_negative_nonzero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[POSITIVE_OR_ZERO]], float [[NEG_NONZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NEG_NONZERO]]
 ;
   %positive.or.zero = call float @returns_positive_or_zero()
   %neg.nonzero = call float @returns_negative_nonzero()
@@ -1991,8 +1960,7 @@ define nofpclass(snan) float @known_pnorm__minimum__known_psub() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_pnorm__minimum__known_psub() {
 ; CHECK-NEXT:    [[PNORM:%.*]] = call float @returns_pnorm()
 ; CHECK-NEXT:    [[PSUB:%.*]] = call float @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[PNORM]], float [[PSUB]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[PSUB]]
 ;
   %pnorm = call float @returns_pnorm()
   %psub = call float @returns_psub()
@@ -2004,8 +1972,7 @@ define nofpclass(snan) float @known_psub__minimum__known_pnorm() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_psub__minimum__known_pnorm() {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call float @returns_psub()
 ; CHECK-NEXT:    [[PNORM:%.*]] = call float @returns_pnorm()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[PSUB]], float [[PNORM]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[PSUB]]
 ;
   %psub = call float @returns_psub()
   %pnorm = call float @returns_pnorm()
@@ -2041,8 +2008,7 @@ define nofpclass(snan) float @known_nnorm__minimum__known_nsub() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_nnorm__minimum__known_nsub() {
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
 ; CHECK-NEXT:    [[NSUB:%.*]] = call float @returns_nsub()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[NNORM]], float [[NSUB]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NNORM]]
 ;
   %nnorm = call float @returns_nnorm()
   %nsub = call float @returns_nsub()
@@ -2054,8 +2020,7 @@ define nofpclass(snan) float @known_nsub__minimum__known_nnorm() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_nsub__minimum__known_nnorm() {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call float @returns_nsub()
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimum.f32(float [[NSUB]], float [[NNORM]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NNORM]]
 ;
   %nsub = call float @returns_nsub()
   %nnorm = call float @returns_nnorm()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-minimumnum.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-minimumnum.ll
@@ -388,8 +388,7 @@ define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_0() {
 ; CHECK-LABEL: define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_0() {
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO:%.*]] = call float @returns_negative_or_zero()
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO1:%.*]] = call float @returns_positive_or_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.minimumnum.f32(float [[MUST_BE_POSITIVE_OR_ZERO]], float [[MUST_BE_POSITIVE_OR_ZERO1]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[MUST_BE_POSITIVE_OR_ZERO]]
 ;
   %must.be.negative.or.zero = call float @returns_negative_or_zero()
   %must.be.positive.or.zero = call float @returns_positive_or_zero()
@@ -401,8 +400,7 @@ define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_1() {
 ; CHECK-LABEL: define nofpclass(snan) float @nsz_fold_negative_or_zero__positive_or_zero_1() {
 ; CHECK-NEXT:    [[MUST_BE_NEGATIVE_OR_ZERO:%.*]] = call float @returns_positive_or_zero()
 ; CHECK-NEXT:    [[MUST_BE_POSITIVE_OR_ZERO:%.*]] = call float @returns_negative_or_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan nsz float @llvm.minimumnum.f32(float [[MUST_BE_NEGATIVE_OR_ZERO]], float [[MUST_BE_POSITIVE_OR_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[MUST_BE_POSITIVE_OR_ZERO]]
 ;
   %must.be.positive.or.zero = call float @returns_positive_or_zero()
   %must.be.negative.or.zero = call float @returns_negative_or_zero()
@@ -863,8 +861,7 @@ define nofpclass(snan) float @known_positive__minimumnum__only_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive__minimumnum__only_zero() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[KNOWN_POSITIVE]], float [[KNOWN_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_ZERO]]
 ;
   %known.positive = call float @returns_positive()
   %known.zero = call float @returns_zero()
@@ -876,8 +873,7 @@ define nofpclass(snan) float @only_zero__minimumnum__known_positive() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_zero__minimumnum__known_positive() {
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
 ; CHECK-NEXT:    [[KNOWN_POSITIVE:%.*]] = call float @returns_positive()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[KNOWN_ZERO]], float [[KNOWN_POSITIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_ZERO]]
 ;
   %known.zero = call float @returns_zero()
   %known.positive = call float @returns_positive()
@@ -915,8 +911,7 @@ define nofpclass(snan) float @known_positive_or_nan__minimumnum__only_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_positive_or_nan__minimumnum__only_zero() {
 ; CHECK-NEXT:    [[KNOWN_POSITIVE_OR_NAN:%.*]] = call float @returns_positive_or_nan()
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[KNOWN_POSITIVE_OR_NAN]], float [[KNOWN_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_ZERO]]
 ;
   %known.positive.or.nan = call float @returns_positive_or_nan()
   %known.zero = call float @returns_zero()
@@ -928,8 +923,7 @@ define nofpclass(snan) float @only_zero__minimumnum__known_positive_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_zero__minimumnum__known_positive_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_ZERO:%.*]] = call float @returns_zero()
 ; CHECK-NEXT:    [[KNOWN_POSITIVE_OR_NAN:%.*]] = call float @returns_positive_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[KNOWN_ZERO]], float [[KNOWN_POSITIVE_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_ZERO]]
 ;
   %known.zero = call float @returns_zero()
   %known.positive.or.nan = call float @returns_positive_or_nan()
@@ -989,8 +983,7 @@ define nofpclass(snan) float @known_negative__minimumnum__only_zero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_negative__minimumnum__only_zero_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[KNOWN_ZERO_OR_NAN:%.*]] = call float @returns_zero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[KNOWN_NEGATIVE]], float [[KNOWN_ZERO_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_NEGATIVE]]
 ;
   %known.negative = call float @returns_negative()
   %known.zero.or.nan = call float @returns_zero_or_nan()
@@ -1002,8 +995,7 @@ define nofpclass(snan) float @only_zero_or_nan__minimumnum__known_negative() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_zero_or_nan__minimumnum__known_negative() {
 ; CHECK-NEXT:    [[KNOWN_ZERO_OR_NAN:%.*]] = call float @returns_zero_or_nan()
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[KNOWN_ZERO_OR_NAN]], float [[KNOWN_NEGATIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_NEGATIVE]]
 ;
   %known.zero.or.nan = call float @returns_zero_or_nan()
   %known.negative = call float @returns_negative()
@@ -1041,8 +1033,7 @@ define nofpclass(snan) float @known_negative__minimumnum__only_nzero() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_negative__minimumnum__only_nzero() {
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[KNOWN_NZERO:%.*]] = call float @returns_nzero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[KNOWN_NEGATIVE]], float -0.000000e+00)
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_NEGATIVE]]
 ;
   %known.negative = call float @returns_negative()
   %known.nzero = call float @returns_nzero()
@@ -1054,8 +1045,7 @@ define nofpclass(snan) float @only_nzero__minimumnum__known_negative() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_nzero__minimumnum__known_negative() {
 ; CHECK-NEXT:    [[KNOWN_NZERO:%.*]] = call float @returns_nzero()
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[KNOWN_NEGATIVE]], float -0.000000e+00)
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_NEGATIVE]]
 ;
   %known.nzero = call float @returns_nzero()
   %known.negative = call float @returns_negative()
@@ -1067,8 +1057,7 @@ define nofpclass(snan) float @known_negative__minimumnum__only_nzero_or_nan() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_negative__minimumnum__only_nzero_or_nan() {
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
 ; CHECK-NEXT:    [[KNOWN_NZERO_OR_NAN:%.*]] = call float @returns_nzero_or_nan()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[KNOWN_NEGATIVE]], float [[KNOWN_NZERO_OR_NAN]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_NEGATIVE]]
 ;
   %known.negative = call float @returns_negative()
   %known.nzero.or.nan = call float @returns_nzero_or_nan()
@@ -1080,8 +1069,7 @@ define nofpclass(snan) float @only_nzero_or_nan__minimumnum__known_negative() {
 ; CHECK-LABEL: define nofpclass(snan) float @only_nzero_or_nan__minimumnum__known_negative() {
 ; CHECK-NEXT:    [[KNOWN_NZERO_OR_NAN:%.*]] = call float @returns_nzero_or_nan()
 ; CHECK-NEXT:    [[KNOWN_NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.minimumnum.f32(float [[KNOWN_NZERO_OR_NAN]], float [[KNOWN_NEGATIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[KNOWN_NEGATIVE]]
 ;
   %known.nzero.or.nan = call float @returns_nzero_or_nan()
   %known.negative = call float @returns_negative()
@@ -1741,11 +1729,8 @@ define nofpclass(snan) float @not_nan__minimumnum_noundef_md__not_nan(float nofp
 define nofpclass(snan) float @select_is_positive_or_0__minimumnum__nnorm_0(float noundef %arg) {
 ; CHECK-LABEL: define nofpclass(snan) float @select_is_positive_or_0__minimumnum__nnorm_0(
 ; CHECK-SAME: float noundef [[ARG:%.*]]) {
-; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[SELECT]], float [[NNORM]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NNORM]]
 ;
   %is.pos.or.zero = fcmp oge float %arg, 0.0
   %select = select i1 %is.pos.or.zero, float %arg, float 0.0
@@ -1758,10 +1743,7 @@ define nofpclass(snan) float @select_is_positive_or_0__minimumnum__nnorm_1(float
 ; CHECK-LABEL: define nofpclass(snan) float @select_is_positive_or_0__minimumnum__nnorm_1(
 ; CHECK-SAME: float noundef [[ARG:%.*]]) {
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
-; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[NNORM]], float [[SELECT]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NNORM]]
 ;
   %nnorm = call float @returns_nnorm()
   %is.pos.or.zero = fcmp oge float %arg, 0.0
@@ -1805,11 +1787,8 @@ define nofpclass(snan) float @select_is_positive_or_0__minimumnum__nnorm_or_nan_
 define nofpclass(snan) float @select_is_positive_or_0__minimumnum__negative(float noundef %arg) {
 ; CHECK-LABEL: define nofpclass(snan) float @select_is_positive_or_0__minimumnum__negative(
 ; CHECK-SAME: float noundef [[ARG:%.*]]) {
-; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
 ; CHECK-NEXT:    [[NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[SELECT]], float [[NEGATIVE]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NEGATIVE]]
 ;
   %is.pos.or.zero = fcmp oge float %arg, 0.0
   %select = select i1 %is.pos.or.zero, float %arg, float 0.0
@@ -1822,10 +1801,7 @@ define nofpclass(snan) float @negative__minimumnum__select_is_positive_or_0(floa
 ; CHECK-LABEL: define nofpclass(snan) float @negative__minimumnum__select_is_positive_or_0(
 ; CHECK-SAME: float noundef [[ARG:%.*]]) {
 ; CHECK-NEXT:    [[NEGATIVE:%.*]] = call float @returns_negative()
-; CHECK-NEXT:    [[IS_POS_OR_ZERO:%.*]] = fcmp oge float [[ARG]], 0.000000e+00
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[IS_POS_OR_ZERO]], float [[ARG]], float 0.000000e+00
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[NEGATIVE]], float [[SELECT]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NEGATIVE]]
 ;
   %negative = call float @returns_negative()
   %is.pos.or.zero = fcmp oge float %arg, 0.0
@@ -1894,8 +1870,7 @@ define nofpclass(snan) float @negative_or_zero__minimumnum__positive_or_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @negative_or_zero__minimumnum__positive_or_zero() {
 ; CHECK-NEXT:    [[NEG_NONZERO:%.*]] = call float @returns_negative_nonzero()
 ; CHECK-NEXT:    [[POSITIVE_OR_ZERO:%.*]] = call float @returns_positive_or_zero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[NEG_NONZERO]], float [[POSITIVE_OR_ZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NEG_NONZERO]]
 ;
   %neg.nonzero = call float @returns_negative_nonzero()
   %positive.or.zero = call float @returns_positive_or_zero()
@@ -1907,8 +1882,7 @@ define nofpclass(snan) float @positive_or_zero__minimumnum__negative_or_zero() {
 ; CHECK-LABEL: define nofpclass(snan) float @positive_or_zero__minimumnum__negative_or_zero() {
 ; CHECK-NEXT:    [[POSITIVE_OR_ZERO:%.*]] = call float @returns_positive_or_zero()
 ; CHECK-NEXT:    [[NEG_NONZERO:%.*]] = call float @returns_negative_nonzero()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[POSITIVE_OR_ZERO]], float [[NEG_NONZERO]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NEG_NONZERO]]
 ;
   %positive.or.zero = call float @returns_positive_or_zero()
   %neg.nonzero = call float @returns_negative_nonzero()
@@ -1994,8 +1968,7 @@ define nofpclass(snan) float @known_pnorm__minimumnum__known_psub() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_pnorm__minimumnum__known_psub() {
 ; CHECK-NEXT:    [[PNORM:%.*]] = call float @returns_pnorm()
 ; CHECK-NEXT:    [[PSUB:%.*]] = call float @returns_psub()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[PNORM]], float [[PSUB]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[PSUB]]
 ;
   %pnorm = call float @returns_pnorm()
   %psub = call float @returns_psub()
@@ -2007,8 +1980,7 @@ define nofpclass(snan) float @known_psub__minimumnum__known_pnorm() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_psub__minimumnum__known_pnorm() {
 ; CHECK-NEXT:    [[PSUB:%.*]] = call float @returns_psub()
 ; CHECK-NEXT:    [[PNORM:%.*]] = call float @returns_pnorm()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[PSUB]], float [[PNORM]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[PSUB]]
 ;
   %psub = call float @returns_psub()
   %pnorm = call float @returns_pnorm()
@@ -2044,8 +2016,7 @@ define nofpclass(snan) float @known_nnorm__minimumnum__known_nsub() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_nnorm__minimumnum__known_nsub() {
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
 ; CHECK-NEXT:    [[NSUB:%.*]] = call float @returns_nsub()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[NNORM]], float [[NSUB]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NNORM]]
 ;
   %nnorm = call float @returns_nnorm()
   %nsub = call float @returns_nsub()
@@ -2057,8 +2028,7 @@ define nofpclass(snan) float @known_nsub__minimumnum__known_nnorm() {
 ; CHECK-LABEL: define nofpclass(snan) float @known_nsub__minimumnum__known_nnorm() {
 ; CHECK-NEXT:    [[NSUB:%.*]] = call float @returns_nsub()
 ; CHECK-NEXT:    [[NNORM:%.*]] = call float @returns_nnorm()
-; CHECK-NEXT:    [[RESULT:%.*]] = call nnan float @llvm.minimumnum.f32(float [[NSUB]], float [[NNORM]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[NNORM]]
 ;
   %nsub = call float @returns_nsub()
   %nnorm = call float @returns_nnorm()


### PR DESCRIPTION
Refine handling of minimum/maximum and minimumnum/maximumnum. The
previous folds to input were based on sign bit checks. This was too
conservative with 0s. This can now consider -0 as less than or equal
to +0 as appropriate, account for nsz. It additionally can handle
cases like one half is known positive normal and the other subnormal.