### PR TITLE
[flang][OpenMP] Fix crash when arrays used in LINEAR clause

### DIFF
--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -810,8 +810,8 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Linear &x) {
   for (auto &[symbol, source] : symbols) {
     // Check that the list item is a scalar variable (rank 0)
     // For declare simd with REF modifier, arrays are allowed
-    bool isArrayAllowed = dir == llvm::omp::Directive::OMPD_declare_simd &&
-        linearMod && linearMod->v == parser::OmpLinearModifier::Value::Ref;
+    bool isArrayAllowed{dir == llvm::omp::Directive::OMPD_declare_simd &&
+        linearMod && linearMod->v == parser::OmpLinearModifier::Value::Ref};
     if (symbol->Rank() != 0 && !isArrayAllowed) {
       context_.Say(source,
           "List item '%s' in LINEAR clause must be a scalar variable"_err_en_US,

--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -811,8 +811,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Linear &x) {
     // Check that the list item is a scalar variable (rank 0)
     // For declare simd with REF modifier, arrays are allowed
     bool isArrayAllowed = dir == llvm::omp::Directive::OMPD_declare_simd &&
-                          linearMod &&
-                          linearMod->v == parser::OmpLinearModifier::Value::Ref;
+        linearMod && linearMod->v == parser::OmpLinearModifier::Value::Ref;
     if (symbol->Rank() != 0 && !isArrayAllowed) {
       context_.Say(source,
           "List item '%s' in LINEAR clause must be a scalar variable"_err_en_US,

--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -808,6 +808,16 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Linear &x) {
 
   // OpenMP 5.2: Linear clause Restrictions
   for (auto &[symbol, source] : symbols) {
+    // Check that the list item is a scalar variable (rank 0)
+    // For declare simd with REF modifier, arrays are allowed
+    bool isArrayAllowed = dir == llvm::omp::Directive::OMPD_declare_simd &&
+                          linearMod &&
+                          linearMod->v == parser::OmpLinearModifier::Value::Ref;
+    if (symbol->Rank() != 0 && !isArrayAllowed) {
+      context_.Say(source,
+          "List item '%s' in LINEAR clause must be a scalar variable"_err_en_US,
+          symbol->name());
+    }
     if (!linearMod) {
       // Already checked this with the modifier present.
       CheckIntegerNoRef(symbol, source);

--- a/flang/test/Semantics/OpenMP/cray-pointer-usage.f90
+++ b/flang/test/Semantics/OpenMP/cray-pointer-usage.f90
@@ -5,6 +5,7 @@ subroutine test_cray_pointer_usage
   real(8) :: var(*), pointee(2)
   pointer(ivar, var)
   ! ERROR: Cray Pointee 'var' may not appear in LINEAR clause
+  ! ERROR: List item 'var' in LINEAR clause must be a scalar variable
   ! ERROR: The list item 'var' specified without the REF 'linear-modifier' must be of INTEGER type
   ! ERROR: The list item `var` must be a dummy argument
   !$omp declare simd linear(var)

--- a/flang/test/Semantics/OpenMP/linear-clause01.f90
+++ b/flang/test/Semantics/OpenMP/linear-clause01.f90
@@ -8,6 +8,7 @@
 subroutine linear_clause_01(arg)
     integer, intent(in) :: arg(:)
     !ERROR: A modifier may not be specified in a LINEAR clause on the DO directive
+    !ERROR: List item 'arg' in LINEAR clause must be a scalar variable
     !$omp do linear(uval(arg))
     do i = 1, 5
         print *, arg(i)
@@ -17,6 +18,7 @@ end subroutine linear_clause_01
 ! Case 2
 subroutine linear_clause_02(arg_01, arg_02)
     !ERROR: The list item 'arg_01' specified without the REF 'linear-modifier' must be of INTEGER type
+    !ERROR: List item 'arg_01' in LINEAR clause must be a scalar variable
     !$omp declare simd linear(val(arg_01))
     real, intent(in) :: arg_01(:)
 

--- a/flang/test/Semantics/OpenMP/linear-iter.f90
+++ b/flang/test/Semantics/OpenMP/linear-iter.f90
@@ -32,6 +32,7 @@ SUBROUTINE LINEAR_BAD(N)
   !$omp target
   !$omp teams
   !ERROR: Variable 'j' not allowed in LINEAR clause, only loop iterator can be specified in LINEAR clause of a construct combined with DISTRIBUTE
+  !ERROR: List item 'b' in LINEAR clause must be a scalar variable
   !ERROR: Variable 'b' not allowed in LINEAR clause, only loop iterator can be specified in LINEAR clause of a construct combined with DISTRIBUTE
   !$omp distribute parallel do simd linear(j) linear(b)
   do i = 1, N
@@ -44,6 +45,7 @@ SUBROUTINE LINEAR_BAD(N)
   !$omp target
   !$omp teams
   !ERROR: Variable 'j' not allowed in LINEAR clause, only loop iterator can be specified in LINEAR clause of a construct combined with DISTRIBUTE
+  !ERROR: List item 'b' in LINEAR clause must be a scalar variable
   !ERROR: Variable 'b' not allowed in LINEAR clause, only loop iterator can be specified in LINEAR clause of a construct combined with DISTRIBUTE
   !$omp distribute parallel do simd linear(j, b)
   do i = 1, N

--- a/flang/test/Semantics/OpenMP/linear-iter.f90
+++ b/flang/test/Semantics/OpenMP/linear-iter.f90
@@ -32,8 +32,8 @@ SUBROUTINE LINEAR_BAD(N)
   !$omp target
   !$omp teams
   !ERROR: Variable 'j' not allowed in LINEAR clause, only loop iterator can be specified in LINEAR clause of a construct combined with DISTRIBUTE
-  !ERROR: List item 'b' in LINEAR clause must be a scalar variable
   !ERROR: Variable 'b' not allowed in LINEAR clause, only loop iterator can be specified in LINEAR clause of a construct combined with DISTRIBUTE
+  !ERROR: List item 'b' in LINEAR clause must be a scalar variable
   !$omp distribute parallel do simd linear(j) linear(b)
   do i = 1, N
      a = 3.14

--- a/flang/test/Semantics/OpenMP/linear-iter.f90
+++ b/flang/test/Semantics/OpenMP/linear-iter.f90
@@ -45,8 +45,8 @@ SUBROUTINE LINEAR_BAD(N)
   !$omp target
   !$omp teams
   !ERROR: Variable 'j' not allowed in LINEAR clause, only loop iterator can be specified in LINEAR clause of a construct combined with DISTRIBUTE
-  !ERROR: List item 'b' in LINEAR clause must be a scalar variable
   !ERROR: Variable 'b' not allowed in LINEAR clause, only loop iterator can be specified in LINEAR clause of a construct combined with DISTRIBUTE
+  !ERROR: List item 'b' in LINEAR clause must be a scalar variable
   !$omp distribute parallel do simd linear(j, b)
   do i = 1, N
      a = 3.14

--- a/flang/test/Semantics/OpenMP/simd-linear-array.f90
+++ b/flang/test/Semantics/OpenMP/simd-linear-array.f90
@@ -1,0 +1,71 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags
+! OpenMP Version 5.2
+! Test that arrays in LINEAR clause are rejected on SIMD directive
+! This test addresses issue #171007 - crash with array in LINEAR clause
+
+subroutine test_1d_array_in_linear()
+  implicit none
+  integer :: j, arr(2)
+  
+  !ERROR: List item 'arr' in LINEAR clause must be a scalar variable
+  !$omp simd linear(arr)
+  do j=1,10
+  end do
+end subroutine
+
+subroutine test_multidim_array()
+  implicit none
+  integer :: j, matrix(3,3)
+  
+  !ERROR: List item 'matrix' in LINEAR clause must be a scalar variable
+  !$omp simd linear(matrix)
+  do j=1,10
+  end do
+end subroutine
+
+subroutine test_assumed_shape_array(arr)
+  implicit none
+  integer :: j
+  integer, intent(in) :: arr(:)
+  
+  !ERROR: List item 'arr' in LINEAR clause must be a scalar variable
+  !$omp simd linear(arr)
+  do j=1,10
+  end do
+end subroutine
+
+subroutine test_multiple_vars_with_array()
+  implicit none
+  integer :: j, scalar1, arr(5), scalar2
+  
+  !ERROR: List item 'arr' in LINEAR clause must be a scalar variable
+  !$omp simd linear(scalar1, arr, scalar2)
+  do j=1,10
+    scalar1 = j
+    scalar2 = j
+  end do
+end subroutine
+
+! Valid case - scalar should work fine
+subroutine test_scalar_valid()
+  implicit none
+  integer :: j, scalar
+  
+  !$omp simd linear(scalar)
+  do j=1,10
+    scalar = j
+  end do
+end subroutine
+
+! Valid case - multiple scalars should work
+subroutine test_multiple_scalars_valid()
+  implicit none
+  integer :: j, scalar1, scalar2, scalar3
+  
+  !$omp simd linear(scalar1, scalar2, scalar3)
+  do j=1,10
+    scalar1 = j
+    scalar2 = j
+    scalar3 = j
+  end do
+end subroutine

--- a/flang/test/Semantics/OpenMP/simd-linear-array.f90
+++ b/flang/test/Semantics/OpenMP/simd-linear-array.f90
@@ -69,3 +69,12 @@ subroutine test_multiple_scalars_valid()
     scalar3 = j
   end do
 end subroutine
+
+! Valid case - declare simd with REF modifier allows arrays
+subroutine test_declare_simd_ref_array_valid(arr)
+  implicit none
+  integer, intent(in) :: arr(:)
+  
+  !$omp declare simd linear(ref(arr))
+  ! No error expected - REF modifier allows assumed-shape arrays
+end subroutine


### PR DESCRIPTION
Closes #171007

Found this crash while testing OpenMP code - turns out putting an array in a LINEAR clause on SIMD directives causes the compiler to blow up with "unknown LLVM dialect type" and hit an UNREACHABLE.

The issue is that LINEAR clauses only accept scalar variables (rank 0), but we weren't checking for that early enough. The invalid array type would slip through semantic analysis and then crash during MLIR to LLVM IR translation when it tried to convert the type.

**What changed:**
- Added a rank check in the LINEAR clause validation to catch arrays up front
- Made an exception for `declare simd` with the REF modifier since that's actually allowed per spec
- Added tests covering different array types (1D, multi-dim, assumed-shape)
- Updated existing tests that now catch the new error

**Before:**
```fortran
!$omp simd linear(arr)  ! arr is an array
```
→ Compiler crashes

**After:**
```fortran
!$omp simd linear(arr)  ! arr is an array
```
→ `error: List item 'arr' in LINEAR clause must be a scalar variable`

<img width="700" height="102" alt="image" src="https://github.com/user-attachments/assets/3726207a-cc6d-4cc6-889c-053814df008f" />

Tested with the original reproducer and it now fails cleanly with a proper error message instead of crashing.