### PR TITLE
[libc++] [NFC] Rename transparency test header & reformat it

### DIFF
--- a/libcxx/test/std/containers/unord/unord.map/contains.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/contains.transparent.pass.cpp
@@ -18,7 +18,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
 #include <unordered_map>
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.map/count.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/count.transparent.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <unordered_map>
 
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.map/equal_range.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/equal_range.transparent.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <unordered_map>
 
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.map/find.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/find.transparent.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <unordered_map>
 
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.multimap/contains.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/contains.transparent.pass.cpp
@@ -18,7 +18,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
 #include <unordered_map>
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.multimap/count.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/count.transparent.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <unordered_map>
 
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.multimap/equal_range.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/equal_range.transparent.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <unordered_map>
 
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.multimap/find.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/find.transparent.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <unordered_map>
 
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.multiset/contains.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/contains.transparent.pass.cpp
@@ -18,7 +18,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
 #include <unordered_set>
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.multiset/count.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/count.transparent.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <unordered_set>
 
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.multiset/equal_range.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/equal_range.transparent.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <unordered_set>
 
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.multiset/find.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/find.transparent.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <unordered_set>
 
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.set/contains.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/contains.transparent.pass.cpp
@@ -18,7 +18,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
 #include <unordered_set>
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.set/count.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/count.transparent.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <unordered_set>
 
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.set/equal_range.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/equal_range.transparent.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <unordered_set>
 
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/std/containers/unord/unord.set/find.transparent.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/find.transparent.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <unordered_set>
 
-#include "test_transparent_unordered.h"
+#include "test_transparent_associative.h"
 
 int main(int, char**) {
   using key_type = StoredType<int>;

--- a/libcxx/test/support/test_transparent_associative.h
+++ b/libcxx/test/support/test_transparent_associative.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TEST_TRANSPARENT_UNORDERED_H
-#define TEST_TRANSPARENT_UNORDERED_H
+#ifndef TEST_TRANSPARENT_ASSOCIATIVE_H
+#define TEST_TRANSPARENT_ASSOCIATIVE_H
 
 #include "test_macros.h"
 #include "is_transparent.h"
@@ -46,7 +46,7 @@ struct transparent_equal_final final : std::equal_to<> {};
 
 template <typename T>
 struct SearchedType {
-  explicit SearchedType(T value, int *counter) : value_(value), conversions_(counter) { }
+  explicit SearchedType(T value, int* counter) : value_(value), conversions_(counter) {}
 
   // Whenever a conversion is performed, increment the counter to keep track
   // of conversions.
@@ -55,48 +55,40 @@ struct SearchedType {
     return StoredType<T>{value_};
   }
 
-  int get_value() const {
-    return value_;
-  }
+  T get_value() const { return value_; }
 
 private:
   T value_;
-  int *conversions_;
+  int* conversions_;
 };
 
 template <typename T>
 struct StoredType {
   StoredType() = default;
-  StoredType(T value) : value_(value) { }
+  StoredType(T value) : value_(value) {}
 
-  friend bool operator==(StoredType const& lhs, StoredType const& rhs) {
-    return lhs.value_ == rhs.value_;
-  }
+  friend bool operator==(StoredType const& lhs, StoredType const& rhs) { return lhs.value_ == rhs.value_; }
 
   // If we're being passed a SearchedType<T> object, avoid the conversion
   // to T. This allows testing that the transparent operations are correctly
   // forwarding the SearchedType all the way to this comparison by checking
   // that we didn't have a conversion when we search for a SearchedType<T>
   // in a container full of StoredType<T>.
-  friend bool operator==(StoredType const& lhs, SearchedType<T> const& rhs) {
-    return lhs.value_ == rhs.get_value();
-  }
+  friend bool operator==(StoredType const& lhs, SearchedType<T> const& rhs) { return lhs.value_ == rhs.get_value(); }
 
-  int get_value() const {
-    return value_;
-  }
+  T get_value() const { return value_; }
 
 private:
   T value_;
 };
 
-template<template<class...> class UnorderedSet, class Hash, class Equal>
+template <template <class...> class UnorderedSet, class Hash, class Equal>
 using unord_set_type = UnorderedSet<StoredType<int>, Hash, Equal>;
 
-template<template<class...> class UnorderedMap, class Hash, class Equal>
+template <template <class...> class UnorderedMap, class Hash, class Equal>
 using unord_map_type = UnorderedMap<StoredType<int>, int, Hash, Equal>;
 
-template<class Container>
+template <class Container>
 void test_transparent_find(Container c) {
   int conversions = 0;
   assert(c.find(SearchedType<int>(1, &conversions)) != c.end());
@@ -105,7 +97,7 @@ void test_transparent_find(Container c) {
   assert(conversions == 0);
 }
 
-template<class Container>
+template <class Container>
 void test_non_transparent_find(Container c) {
   int conversions = 0;
   assert(c.find(SearchedType<int>(1, &conversions)) != c.end());
@@ -116,7 +108,7 @@ void test_non_transparent_find(Container c) {
   assert(conversions == 3);
 }
 
-template<class Container>
+template <class Container>
 void test_transparent_count(Container c) {
   int conversions = 0;
   assert(c.count(SearchedType<int>(1, &conversions)) > 0);
@@ -125,7 +117,7 @@ void test_transparent_count(Container c) {
   assert(conversions == 0);
 }
 
-template<class Container>
+template <class Container>
 void test_non_transparent_count(Container c) {
   int conversions = 0;
   assert(c.count(SearchedType<int>(1, &conversions)) > 0);
@@ -136,7 +128,7 @@ void test_non_transparent_count(Container c) {
   assert(conversions == 3);
 }
 
-template<class Container>
+template <class Container>
 void test_transparent_contains(Container c) {
   int conversions = 0;
   assert(c.contains(SearchedType<int>(1, &conversions)));
@@ -145,7 +137,7 @@ void test_transparent_contains(Container c) {
   assert(conversions == 0);
 }
 
-template<class Container>
+template <class Container>
 void test_non_transparent_contains(Container c) {
   int conversions = 0;
   assert(c.contains(SearchedType<int>(1, &conversions)));
@@ -156,10 +148,10 @@ void test_non_transparent_contains(Container c) {
   assert(conversions == 3);
 }
 
-template<class Container>
+template <class Container>
 void test_transparent_equal_range(Container c) {
   int conversions = 0;
-  auto iters = c.equal_range(SearchedType<int>(1, &conversions));
+  auto iters      = c.equal_range(SearchedType<int>(1, &conversions));
   assert(std::distance(iters.first, iters.second) > 0);
   iters = c.equal_range(SearchedType<int>(2, &conversions));
   assert(std::distance(iters.first, iters.second) > 0);
@@ -168,10 +160,10 @@ void test_transparent_equal_range(Container c) {
   assert(conversions == 0);
 }
 
-template<class Container>
+template <class Container>
 void test_non_transparent_equal_range(Container c) {
   int conversions = 0;
-  auto iters = c.equal_range(SearchedType<int>(1, &conversions));
+  auto iters      = c.equal_range(SearchedType<int>(1, &conversions));
   assert(std::distance(iters.first, iters.second) > 0);
   assert(conversions == 1);
   iters = c.equal_range(SearchedType<int>(2, &conversions));
@@ -184,4 +176,4 @@ void test_non_transparent_equal_range(Container c) {
 
 #endif // TEST_STD_VER > 17
 
-#endif // TEST_TRANSPARENT_UNORDERED_H
+#endif // TEST_TRANSPARENT_ASSOCIATIVE_H


### PR DESCRIPTION
Rename `test_transparent_unordered.h` => `test_transparent_associative.h` & reformat it

PR #174680 depends on this refactoring in order to not create separate test header with duplicated code for ordered associative containers