### PR TITLE
Remove CXXRecordDecl printer FIXME

### DIFF
--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -1100,8 +1100,6 @@ void DeclPrinter::VisitCXXRecordDecl(CXXRecordDecl *D) {
 
   Out << D->getKindName() << ' ';
 
-  // FIXME: Move before printing the decl kind to match the behavior of the
-  // attribute printing for variables and function where they are printed first.
   if (std::optional<std::string> Attrs =
           prettyPrintAttributes(D, AttrPosAsWritten::Left))
     Out << *Attrs << ' ';


### PR DESCRIPTION
It suggested it would be better to print attributes before the decl kind, to be consistent with value declarations.

But attributes are not accepted by the language before the decl kind:

    [[deprecated]] class A;
    __attribute__((deprecated)) class A;
    __declspec(deprecated) class A;

are all invalid or ignored. The only way to put an attribute before the decl kind is with something like:

    [[deprecated]] struct A {} a;

But that declares a variable, not a record tyoe, and will be correctly handled by the variable decl printer.