### PR TITLE
Add SuppressDeclAttributes printing policy

### DIFF
--- a/clang/include/clang/AST/PrettyPrinter.h
+++ b/clang/include/clang/AST/PrettyPrinter.h
@@ -82,7 +82,8 @@ struct PrintingPolicy {
         PrintAsCanonical(false), PrintInjectedClassNameWithArguments(true),
         UsePreferredNames(true), AlwaysIncludeTypeForTemplateArgument(false),
         CleanUglifiedParameters(false), EntireContentsOfLargeArray(true),
-        UseEnumerators(true), UseHLSLTypes(LO.HLSL) {}
+        UseEnumerators(true), UseHLSLTypes(LO.HLSL),
+        SuppressDeclAttributes(false) {}
 
   /// Adjust this printing policy for cases where it's known that we're
   /// printing C++ code (for instance, if AST dumping reaches a C++-only
@@ -357,6 +358,10 @@ struct PrintingPolicy {
   /// sugared types when possible.
   LLVM_PREFERRED_TYPE(bool)
   unsigned UseHLSLTypes : 1;
+
+  /// Whether to suppress attributes in decl printing.
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned SuppressDeclAttributes : 1;
 
   /// Callbacks to use to allow the behavior of printing to be customized.
   const PrintingCallbacks *Callbacks = nullptr;

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -257,7 +257,7 @@ static DeclPrinter::AttrPosAsWritten getPosAsWritten(const Attr *A,
 std::optional<std::string>
 DeclPrinter::prettyPrintAttributes(const Decl *D,
                                    AttrPosAsWritten Pos /*=Default*/) {
-  if (!D->hasAttrs())
+  if (Policy.SuppressDeclAttributes || !D->hasAttrs())
     return std::nullopt;
 
   std::string AttrStr;

--- a/clang/unittests/AST/DeclPrinterTest.cpp
+++ b/clang/unittests/AST/DeclPrinterTest.cpp
@@ -1572,3 +1572,19 @@ TEST(DeclPrinter, TestTemplateFinalWithPolishForDecl) {
       "template <typename T> class FinalTemplate final {}",
       [](PrintingPolicy &Policy) { Policy.PolishForDeclaration = true; }));
 }
+
+TEST(DeclPrinter, TestClassSuppressDeclAttributes) {
+  ASSERT_TRUE(PrintedDeclCXX11Matches(
+      "class alignas(32) [[deprecated]] A final {};",
+      cxxRecordDecl(hasName("A")).bind("id"), "class A {}",
+      [](PrintingPolicy &Policy) { Policy.SuppressDeclAttributes = true; }));
+}
+
+TEST(DeclPrinter, TestTemplateSuppressDeclAttributes) {
+  ASSERT_TRUE(PrintedDeclCXX11Matches(
+      "template<typename T>\n"
+      "class alignas(32) [[deprecated]] A final {};",
+      classTemplateDecl(hasName("A")).bind("id"),
+      "template <typename T> class A {}",
+      [](PrintingPolicy &Policy) { Policy.SuppressDeclAttributes = true; }));
+}


### PR DESCRIPTION
This policy causes DeclPrinter to skip attributes entirely when printing
attribute lists, for brevity.

Removing attributes from a printed Decl post-facto is very hard (tm),
especially in the presence of more complex declaration syntax, such as
template requires-expressions, alignas-expressions, default values, etc.