### PR TITLE
[SPIRV] Deduce result type for `G_SEXT` and `G_ZEXT`

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPostLegalizer.cpp
@@ -202,6 +202,8 @@ static SPIRVType *deduceResultTypeFromOperands(MachineInstr *I,
   switch (I->getOpcode()) {
   case TargetOpcode::G_CONSTANT:
   case TargetOpcode::G_ANYEXT:
+  case TargetOpcode::G_SEXT:
+  case TargetOpcode::G_ZEXT:
     return deduceIntTypeFromResult(ResVReg, MIB, GR);
   case TargetOpcode::G_BUILD_VECTOR:
     return deduceTypeFromOperandRange(I, MIB, GR, 1, I->getNumOperands());

--- a/llvm/test/CodeGen/SPIRV/instructions/zext_sext_deduce_type.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/zext_sext_deduce_type.ll
@@ -1,0 +1,23 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: %[[#I8:]] = OpTypeInt 8
+; CHECK: %[[#I64:]] = OpTypeInt 64
+; CHECK: %[[#UINT32_MAX:]] = OpConstant %[[#I64]] 4294967295
+; CHECK: %[[#SHIFT:]] = OpConstant %[[#I64]] 2097152
+; CHECK-DAG: %[[#X:]] = OpFunctionParameter %[[#I8]]
+; CHECK: %[[#Y:]] = OpFunctionParameter %[[#I64]]
+; CHECK-DAG: %[[#SEXT:]] = OpSConvert %[[#I64]] %[[#X]]
+; CHECK: %[[#AND:]] = OpBitwiseAnd %[[#I64]] %[[#SEXT]] %[[#UINT32_MAX]]
+; CHECK: %[[#]] = OpShiftRightArithmetic %[[#I64]] %[[#SHIFT]] %[[#AND]]
+
+define i64 @foo(i8 %x, i64 %y) {
+  %2 = sext i8 %x to i32
+  %3 = zext i32 %2 to i64
+  %4 = ashr i64 2097152, %3
+
+  ret i64 %4
+}


### PR DESCRIPTION
During legalisation we can fold / combine `sext` followed by a widening via `zext`. Unfortunately, this yields a new result register with no SPIRV Type, which leads to incorrect behaviour during post legalisation when we end up deducing the  (narrower) type from the operand. This patch corrects the behaviour in that it ensures that we use the (widened) type of the result to yield the SPIRV Type for the register.