### PR TITLE
[Hexagon] Fix PIC crash when lowering HVX vector constants

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
@@ -910,8 +910,9 @@ HexagonTargetLowering::buildHvxVectorReg(ArrayRef<SDValue> Values,
                             (Constant**)Consts.end());
     Constant *CV = ConstantVector::get(Tmp);
     Align Alignment(HwLen);
-    SDValue CP =
-        LowerConstantPool(DAG.getConstantPool(CV, VecTy, Alignment), DAG);
+    SDValue CP = LowerConstantPool(
+        DAG.getConstantPool(CV, getPointerTy(DAG.getDataLayout()), Alignment),
+        DAG);
     return DAG.getLoad(VecTy, dl, DAG.getEntryNode(), CP,
                        MachinePointerInfo::getConstantPool(MF), Alignment);
   }
@@ -1623,8 +1624,9 @@ HexagonTargetLowering::compressHvxPred(SDValue VecQ, const SDLoc &dl,
   }
   Constant *CV = ConstantVector::get(Tmp);
   Align Alignment(HwLen);
-  SDValue CP =
-      LowerConstantPool(DAG.getConstantPool(CV, ByteTy, Alignment), DAG);
+  SDValue CP = LowerConstantPool(
+      DAG.getConstantPool(CV, getPointerTy(DAG.getDataLayout()), Alignment),
+      DAG);
   SDValue Bytes =
       DAG.getLoad(ByteTy, dl, DAG.getEntryNode(), CP,
                   MachinePointerInfo::getConstantPool(MF), Alignment);

--- a/llvm/test/CodeGen/Hexagon/hvx-constpool-vector-type.ll
+++ b/llvm/test/CodeGen/Hexagon/hvx-constpool-vector-type.ll
@@ -1,0 +1,14 @@
+; RUN: llc --mtriple=hexagon -mcpu=hexagonv79 -mattr=+hvxv79,+hvx-length128b -relocation-model=pic < %s -o /dev/null
+
+define void @store_const_vector(ptr %p) #0 {
+entry:
+  store <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7,
+                    i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15,
+                    i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23,
+                    i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>,
+        ptr %p, align 128
+  ret void
+}
+
+attributes #0 = { nounwind "target-cpu"="hexagonv79" "target-features"="+hvxv79,+hvx-length128b" }
+


### PR DESCRIPTION
Fix a PIC-only crash in Hexagon HVX lowering where we ended up treating a vector-typed constant-pool reference as an address (e.g. when forming PC-relative addresses), which triggers a type mismatch during lowering. Build the constant-pool reference with the target pointer type instead, then load the HVX vector from that address.