### PR TITLE
[Sema] Fix crash in asm goto with undeclared label

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -669,6 +669,7 @@ Miscellaneous Bug Fixes
 
 Miscellaneous Clang Crashes Fixed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- Fixed a crash when an ``asm goto`` statement referenced an undeclared label in the presence of a variable with ``__attribute__((cleanup))``. (#GH175314)
 
 OpenACC Specific Changes
 ------------------------

--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -455,6 +455,14 @@ bool Pointer::isInitialized() const {
   }
 
   assert(BS.Pointee && "Cannot check if null pointer was initialized");
+
+  // Handle the case where BS.Base == sizeof(GlobalInlineDescriptor) but
+  // the pointer is not a proper root. This can happen with invalid code.
+  // We cannot call getFieldDesc() or getInlineDesc() in this case as they
+  // would trigger assertions. Conservatively return false.
+  if (BS.Base == sizeof(GlobalInlineDescriptor))
+    return false;
+
   const Descriptor *Desc = getFieldDesc();
   assert(Desc);
   if (Desc->isPrimitiveArray())

--- a/clang/lib/Sema/JumpDiagnostics.cpp
+++ b/clang/lib/Sema/JumpDiagnostics.cpp
@@ -914,8 +914,11 @@ static void DiagnoseIndirectOrAsmJumpStmt(Sema &S, Stmt *Jump,
   bool IsAsmGoto = isa<GCCAsmStmt>(Jump);
   S.Diag(Jump->getBeginLoc(), diag::err_indirect_goto_in_protected_scope)
       << IsAsmGoto;
-  S.Diag(Target->getStmt()->getIdentLoc(), diag::note_indirect_goto_target)
-      << IsAsmGoto;
+  // Target->getStmt() can be null for undeclared labels.
+  SourceLocation TargetLoc = Target->getStmt()
+                                 ? Target->getStmt()->getIdentLoc()
+                                 : Target->getLocation();
+  S.Diag(TargetLoc, diag::note_indirect_goto_target) << IsAsmGoto;
   Diagnosed = true;
 }
 

--- a/clang/test/AST/ByteCode/arrays.cpp
+++ b/clang/test/AST/ByteCode/arrays.cpp
@@ -835,3 +835,15 @@ namespace MultiDimConstructExpr {
   constexpr b d;
   static_assert(d.m[2][1].p == &d.m[2][1]);
 }
+
+namespace GH175432 {
+  // Test that we don't crash when checking initialization of
+  // pointer arrays with invalid initializers
+  constexpr const int *foo[][2] = { // expected-error {{must be initialized by a constant expression}} \
+                                    // expected-note {{declared here}}
+      {nullptr, int}, // expected-error {{expected '(' for function-style cast or type construction}}
+  };
+
+  static_assert(foo[0][0] == nullptr, ""); // expected-error {{not an integral constant expression}} \
+                                           // expected-note {{initializer of 'foo' is unknown}}
+}

--- a/clang/test/Sema/asm-goto-undeclared-label-crash.c
+++ b/clang/test/Sema/asm-goto-undeclared-label-crash.c
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+// Test that we don't crash when an asm goto references an undeclared label
+// and there's a variable with __attribute__((cleanup)) in scope.
+// See: https://github.com/llvm/llvm-project/issues/175314
+
+void a(int *b) {
+  int __attribute__((cleanup(a))) c = 0; // expected-note {{jump exits scope of variable with __attribute__((cleanup))}}
+  __asm__ goto("" : : : : d); // expected-error {{use of undeclared label 'd'}} \
+                              // expected-error {{cannot jump from this asm goto statement to one of its possible targets}} \
+                              // expected-note {{possible target of asm goto statement}}
+}


### PR DESCRIPTION
When an asm goto statement references an undeclared label and there's a variable with __attribute__((cleanup)) in scope, clang would crash with a segmentation fault.

The issue was that DiagnoseIndirectOrAsmJumpStmt() called Target->getStmt()->getIdentLoc() without checking if getStmt() returns null. For undeclared labels, the LabelDecl exists but has no associated LabelStmt.

This patch adds a null check and falls back to Target->getLocation() when the statement is null.

Fixes #175314