### PR TITLE
[NFC] Suppress cppcheck false-positives in llvm/include/llvm/Support/MathExtras.h

### DIFF
--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -138,6 +138,7 @@ template <typename T> constexpr T reverseBits(T Val) {
   std::memcpy(in, &Val, sizeof(Val));
   for (unsigned i = 0; i < sizeof(Val); ++i)
     out[(sizeof(Val) - i) - 1] = BitReverseTable256[in[i]];
+  // cppcheck-suppress uninitvar symbolName=out
   std::memcpy(&Val, out, sizeof(Val));
   return Val;
 }
@@ -608,6 +609,7 @@ template <typename T>
 std::enable_if_t<std::is_unsigned_v<T>, T>
 SaturatingAdd(T X, T Y, bool *ResultOverflowed = nullptr) {
   bool Dummy;
+  // cppcheck-suppress legacyUninitvar symbolName=Overflowed
   bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
   // Hacker's Delight, p. 29
   T Z = X + Y;
@@ -637,6 +639,7 @@ template <typename T>
 std::enable_if_t<std::is_unsigned_v<T>, T>
 SaturatingMultiply(T X, T Y, bool *ResultOverflowed = nullptr) {
   bool Dummy;
+  // cppcheck-suppress legacyUninitvar symbolName=Overflowed
   bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
 
   // Hacker's Delight, p. 30 has a different algorithm, but we don't use that
@@ -683,6 +686,7 @@ template <typename T>
 std::enable_if_t<std::is_unsigned_v<T>, T>
 SaturatingMultiplyAdd(T X, T Y, T A, bool *ResultOverflowed = nullptr) {
   bool Dummy;
+  // cppcheck-suppress legacyUninitvar symbolName=Overflowed
   bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
 
   T Product = SaturatingMultiply(X, Y, &Overflowed);


### PR DESCRIPTION
Suppress these false-positive in llvm/include/llvm/Support/MathExtras.h

```
 Error: CPPCHECK_WARNING (CWE-457): [#def64]
 llvm-project-21.1.8.src/llvm/include/llvm/Support/MathExtras.h:146: warning[uninitvar]: Uninitialized variable: out
 #  144|     for (unsigned i = 0; i < sizeof(Val); ++i)
 #  145|       out[(sizeof(Val) - i) - 1] = BitReverseTable256[in[i]];
 #  146|->   std::memcpy(&Val, out, sizeof(Val));
 #  147|     return Val;
 #  148|   }

 Error: CPPCHECK_WARNING (CWE-457): [#def65]
 llvm-project-21.1.8.src/llvm/include/llvm/Support/MathExtras.h:620: error[legacyUninitvar]: Uninitialized variable: Dummy
 #  618|   SaturatingAdd(T X, T Y, bool *ResultOverflowed = nullptr) {
 #  619|     bool Dummy;
 #  620|->   bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
 #  621|     // Hacker's Delight, p. 29
 #  622|     T Z = X + Y;

 Error: CPPCHECK_WARNING (CWE-457): [#def66]
 llvm-project-21.1.8.src/llvm/include/llvm/Support/MathExtras.h:649: error[legacyUninitvar]: Uninitialized variable: Dummy
 #  647|   SaturatingMultiply(T X, T Y, bool *ResultOverflowed = nullptr) {
 #  648|     bool Dummy;
 #  649|->   bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
 #  650|
 #  651|     // Hacker's Delight, p. 30 has a different algorithm, but we don't use that

 Error: CPPCHECK_WARNING (CWE-457): [#def67]
 llvm-project-21.1.8.src/llvm/include/llvm/Support/MathExtras.h:695: error[legacyUninitvar]: Uninitialized variable: Dummy
 #  693|   SaturatingMultiplyAdd(T X, T Y, T A, bool *ResultOverflowed = nullptr) {
 #  694|     bool Dummy;
 #  695|->   bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
 #  696|
 #  697|     T Product = SaturatingMultiply(X, Y, &Overflowed);
```

```
 Error: CPPCHECK_WARNING (CWE-457): [#def65]
 llvm-project-21.1.8.src/llvm/include/llvm/Support/MathExtras.h:620: error[legacyUninitvar]: Uninitialized variable: Dummy
 #  618|   SaturatingAdd(T X, T Y, bool *ResultOverflowed = nullptr) {
 #  619|     bool Dummy;
 #  620|->   bool &Overflowed = ResultOverflowed ? *ResultOverflowed : Dummy;
 #  621|     // Hacker's Delight, p. 29
 #  622|     T Z = X + Y;
```

The report was done by OpenScanHub and can be seen here:

https://svashisht.fedorapeople.org/openscanhub/mass-scans/f44-08-Jan-2026/llvm-21.1.8-1.fc44/scan-results.html#def64
