### PR TITLE
[mlir] Remove loop peeling explicit C'tor

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/SCF/Transforms/Passes.h
@@ -24,10 +24,6 @@ namespace mlir {
 /// vectorization.
 std::unique_ptr<Pass> createForLoopSpecializationPass();
 
-/// Creates a pass that peels for loops at their upper bounds for
-/// better vectorization.
-std::unique_ptr<Pass> createForLoopPeelingPass();
-
 /// Creates a pass that canonicalizes affine.min and affine.max operations
 /// inside of scf.for loops with known lower and upper bounds.
 std::unique_ptr<Pass> createSCFForLoopCanonicalizationPass();

--- a/mlir/include/mlir/Dialect/SCF/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/SCF/Transforms/Passes.td
@@ -23,7 +23,6 @@ def SCFForLoopCanonicalization
 
 def SCFForLoopPeeling : Pass<"scf-for-loop-peeling"> {
   let summary = "Peel `for` loops at their upper bounds.";
-  let constructor = "mlir::createForLoopPeelingPass()";
   let options = [
     Option<"peelFront", "peel-front", "bool",
            /*default=*/"false",

--- a/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp
@@ -337,6 +337,8 @@ struct ForLoopSpecialization
 };
 
 struct ForLoopPeeling : public impl::SCFForLoopPeelingBase<ForLoopPeeling> {
+  using impl::SCFForLoopPeelingBase<ForLoopPeeling>::SCFForLoopPeelingBase;
+
   void runOnOperation() override {
     auto *parentOp = getOperation();
     MLIRContext *ctx = parentOp->getContext();
@@ -359,8 +361,4 @@ std::unique_ptr<Pass> mlir::createParallelLoopSpecializationPass() {
 
 std::unique_ptr<Pass> mlir::createForLoopSpecializationPass() {
   return std::make_unique<ForLoopSpecialization>();
-}
-
-std::unique_ptr<Pass> mlir::createForLoopPeelingPass() {
-  return std::make_unique<ForLoopPeeling>();
 }


### PR DESCRIPTION
The SCF dialect loop peeling pass has an explicit C'tor. This creates an inconvenience to use non default pass options, since they can only be passed as a string after the pass creation. After removing the explicit C'tor, the code auto generation creates 2 C'tors, which one of them can directly receive pass options struct in case non default values are required.
The explicit C'tor does not match auto generated C'tor convention, so this change requires any uses of the pass in downstream projects to update to use the auto generated C'tor.