### PR TITLE
[MLIR][Presburger] Fix full dimension check

### DIFF
--- a/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
@@ -2643,8 +2643,12 @@ bool IntegerRelation::isFullDim() {
   if (getNumEqualities() > 0)
     return false;
 
-  // The polytope is full-dimensional iff it is not flat along any of the
-  // inequality directions.
+  // The polytope is full-dimensional iff it is not flat along every
+  // inequality directions that involve at least one variable.
+  //
+  // To check this, we first remove inequalities involving no variables,
+  // which is done in the following function.
+  removeTrivialRedundancy();
   Simplex simplex(*this);
   return llvm::none_of(llvm::seq<int>(getNumInequalities()), [&](int i) {
     return simplex.isFlatAlong(getInequality(i));

--- a/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
@@ -740,3 +740,11 @@ TEST(IntegerRelationTest, simplify) {
   // It can be obtained from 2 times the first equality minus the second.
   EXPECT_TRUE(rel.getNumEqualities() == 2);
 }
+
+TEST(IntegerRelationTest, isFullDim) {
+  IntegerRelation rel = parseRelationFromSet("(x): (1 >= 0)", 1);
+  EXPECT_TRUE(rel.isFullDim());
+
+  rel = parseRelationFromSet("(x): (-1 >= 0)", 1);
+  EXPECT_FALSE(rel.isFullDim());
+}


### PR DESCRIPTION
Currently, the code mistakenly thinks `(x): (1 >= 0)` as non-full-dimensional.

The code determines full-dimensionality by testing whether an inequality is flat, i.e. takes the same value regardless of variable assignments. However, `1 >= 0` is obviously flat, and this case should be ignored since it didn't involve any variables.

To remove these inequalities, we can call `removeTrivialRedundancy`.