### PR TITLE
[SelectionDAG] Provide context for vector count / type mismatch

### DIFF
--- a/llvm/include/llvm/CodeGenTypes/MachineValueType.h
+++ b/llvm/include/llvm/CodeGenTypes/MachineValueType.h
@@ -64,6 +64,9 @@ namespace llvm {
     bool operator>=(const MVT& S) const { return SimpleTy >= S.SimpleTy; }
     bool operator<=(const MVT& S) const { return SimpleTy <= S.SimpleTy; }
 
+    /// Return the value type as a string, e.g. `i32`.
+    std::string getString() const;
+
     /// Support for debugging, callable in GDB: VT.dump()
     LLVM_ABI void dump() const;
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -95,6 +95,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/InstructionCost.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
@@ -330,6 +331,21 @@ static void diagnosePossiblyInvalidConstraint(LLVMContext &Ctx, const Value *V,
   return Ctx.emitError(I, ErrMsg);
 }
 
+/// Emit a fatal error if the broken dow registers don't match part type
+// or count.
+static void ensureMatchedVecRegParts(unsigned NumRegs, unsigned NumParts,
+                                     MVT RegisterVT, MVT PartVT) {
+  if (NumRegs != NumParts || RegisterVT != PartVT)
+    report_fatal_error(Twine("Part count doesn't match vector breakdown! ")
+                           .concat(Twine(NumRegs))
+                           .concat(" registers, ")
+                           .concat(Twine(NumParts))
+                           .concat(" parts, ")
+                           .concat(Twine(RegisterVT.getString()))
+                           .concat(" RegisterVT, ")
+                           .concat(Twine(PartVT.getString()))
+                           .concat(" PartVT"));
+}
 /// getCopyFromPartsVector - Create a value that contains the specified legal
 /// parts combined into the value they represent.  If the parts combine to a
 /// type larger than ValueVT then AssertOp can be used to specify whether the
@@ -364,9 +380,7 @@ static SDValue getCopyFromPartsVector(SelectionDAG &DAG, const SDLoc &DL,
                                      NumIntermediates, RegisterVT);
     }
 
-    assert(NumRegs == NumParts && "Part count doesn't match vector breakdown!");
-    NumParts = NumRegs; // Silence a compiler warning.
-    assert(RegisterVT == PartVT && "Part type doesn't match vector breakdown!");
+    ensureMatchedVecRegParts(NumRegs, NumParts, RegisterVT, PartVT);
     assert(RegisterVT.getSizeInBits() ==
            Parts[0].getSimpleValueType().getSizeInBits() &&
            "Part type sizes don't match!");
@@ -769,10 +783,7 @@ static void getCopyToPartsVector(SelectionDAG &DAG, const SDLoc &DL,
                                    NumIntermediates, RegisterVT);
   }
 
-  assert(NumRegs == NumParts && "Part count doesn't match vector breakdown!");
-  NumParts = NumRegs; // Silence a compiler warning.
-  assert(RegisterVT == PartVT && "Part type doesn't match vector breakdown!");
-
+  ensureMatchedVecRegParts(NumRegs, NumParts, RegisterVT, PartVT);
   assert(IntermediateVT.isScalableVector() == ValueVT.isScalableVector() &&
          "Mixing scalable and fixed vectors when copying in parts");
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -95,7 +95,6 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/InstructionCost.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
@@ -331,21 +330,17 @@ static void diagnosePossiblyInvalidConstraint(LLVMContext &Ctx, const Value *V,
   return Ctx.emitError(I, ErrMsg);
 }
 
-/// Emit a fatal error if the broken dow registers don't match part type
-// or count.
+/// Emit a fatal error if the broken down registers don't match part type
+/// or count.
 static void ensureMatchedVecRegParts(unsigned NumRegs, unsigned NumParts,
                                      MVT RegisterVT, MVT PartVT) {
   if (NumRegs != NumParts || RegisterVT != PartVT)
-    report_fatal_error(Twine("Part count doesn't match vector breakdown! ")
-                           .concat(Twine(NumRegs))
-                           .concat(" registers, ")
-                           .concat(Twine(NumParts))
-                           .concat(" parts, ")
-                           .concat(Twine(RegisterVT.getString()))
-                           .concat(" RegisterVT, ")
-                           .concat(Twine(PartVT.getString()))
-                           .concat(" PartVT"));
+    llvm::reportFatalInternalError(
+        Twine("Part count doesn't match vector breakdown! ") + Twine(NumRegs) +
+        " registers, " + Twine(NumParts) + " parts, " + RegisterVT.getString() +
+        " RegisterVT, " + PartVT.getString() + " PartVT");
 }
+
 /// getCopyFromPartsVector - Create a value that contains the specified legal
 /// parts combined into the value they represent.  If the parts combine to a
 /// type larger than ValueVT then AssertOp can be used to specify whether the

--- a/llvm/lib/CodeGen/ValueTypes.cpp
+++ b/llvm/lib/CodeGen/ValueTypes.cpp
@@ -333,6 +333,13 @@ const fltSemantics &EVT::getFltSemantics() const {
   return getScalarType().getSimpleVT().getFltSemantics();
 }
 
+std::string MVT::getString() const {
+  if (SimpleTy == INVALID_SIMPLE_VALUE_TYPE)
+    return "invalid";
+
+  return EVT(*this).getEVTString();
+}
+
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 void MVT::dump() const {
   print(dbgs());
@@ -340,9 +347,4 @@ void MVT::dump() const {
 }
 #endif
 
-void MVT::print(raw_ostream &OS) const {
-  if (SimpleTy == INVALID_SIMPLE_VALUE_TYPE)
-    OS << "invalid";
-  else
-    OS << EVT(*this).getEVTString();
-}
+void MVT::print(raw_ostream &OS) const { OS << getString(); }


### PR DESCRIPTION
This now gives better details about what the mismatch is in the error message:

    subprocess.CalledProcessError: Command '/usr/local/bin/llc -mtriple=amdgcn -mcpu=tahiti' returned non-zero exit status 134.
    LLVM ERROR: Part count doesn't match vector breakdown! 6 registers, 6 parts, i32 RegisterVT, f32 PartVT
    PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace and instructions to reproduce the bug.