### PR TITLE
[clang-repl] Fix OrcRuntime lookup for Solaris and unit tests.

### DIFF
--- a/clang/tools/clang-repl/ClangRepl.cpp
+++ b/clang/tools/clang-repl/ClangRepl.cpp
@@ -288,6 +288,8 @@ int main(int argc, const char **argv) {
     return 0;
   }
 
+  ExitOnErr(sanitizeOopArguments(argv[0]));
+
   clang::IncrementalCompilerBuilder CB;
   CB.SetCompilerArgs(ClangArgv);
 
@@ -319,8 +321,6 @@ int main(int argc, const char **argv) {
 
     DeviceCI = ExitOnErr(CB.CreateCudaDevice());
   }
-
-  ExitOnErr(sanitizeOopArguments(argv[0]));
 
   // FIXME: Investigate if we could use runToolOnCodeWithArgs from tooling. It
   // can replace the boilerplate code for creation of the compiler instance.


### PR DESCRIPTION
The out-of-process execution in the interpreter depends on the orc runtime. It is generally easy to discover as it is in the clang runtime path. However, the clang runtime path is relative to clang's resource directory which is relative to the clang binary. That does not work well if clang is linked into a different binary which can be in a random place in the build directory structure.

This patch performs a conservative approach to detect the common directory structure and correctly infer the paths. That fixes the out-of-process execution unittests. The patch also contains a small adjustment for solaris.

Another take on trying to fix the issue uncovered by #175322.