### PR TITLE
[OpenMP] Allow libomp.so to link in Debug build with GCC 15 libstdc++

### DIFF
--- a/compiler-rt/test/ubsan/TestCases/Misc/Posix/static-link.cpp
+++ b/compiler-rt/test/ubsan/TestCases/Misc/Posix/static-link.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: i386-target-arch, internal_symbolizer
 
 // Does not link.
-// UNSUPPORTED: darwin
+// UNSUPPORTED: darwin,target={{.*solaris.*}}
 
 #include <signal.h>
 #include <stdio.h>

--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -48,6 +48,12 @@
 #define KMP_CANCEL_THREADS
 #define KMP_THREAD_ATTR
 
+// GCC 15 libstdc++ enables debug assertions in unoptimized builds.
+// Disable them to allow libomp.so to link without libstdc++.so.
+#if !__OPTIMIZE__
+#define GLIBCXX_NO_ASSERTIONS
+#endif
+
 // Android does not have pthread_cancel.  Undefine KMP_CANCEL_THREADS if being
 // built on Android
 #if defined(__ANDROID__)


### PR DESCRIPTION
As detailed in Issue #153569, a `Debug` build with the `GCC 15` `libstdc++` `FAIL`s to link `libomp.so`.

To avoid this, one needs to define `_GLIBCXX_NO_ASSERTIONS`.

Tested on `x86_64-pc-solaris2.11`.