### PR TITLE
[ubsan][test] Skip Misc/Posix/static-link.cpp on Solaris

### DIFF
--- a/compiler-rt/test/ubsan/TestCases/Misc/Posix/static-link.cpp
+++ b/compiler-rt/test/ubsan/TestCases/Misc/Posix/static-link.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: i386-target-arch, internal_symbolizer
 
 // Does not link.
-// UNSUPPORTED: darwin
+// UNSUPPORTED: darwin,target={{.*solaris.*}}
 
 #include <signal.h>
 #include <stdio.h>


### PR DESCRIPTION
The `UBSan-Standalone-x86_64 :: TestCases/Misc/Posix/static-link.cpp` test currently `FAIL`s on Solaris/x86_64 with
```
ld: fatal: option '-z record' is incompatible with building a static executable
```
One cannot create static executables on Solaris since no `libc.a` is delivered, so this patch skips the test.

Tested on `x86_64-pc-solaris2.11`.