### PR TITLE
[IR][InstCombine] Fix O(n^2) complexity in SliceUpIllegalIntegerPHI

### DIFF
--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -334,6 +334,17 @@ public:
         .getNonConst();
   }
 
+  /// Returns true if there is a valid insertion point for non-PHI instructions
+  /// in this block. Returns false for blocks that can only contain PHI nodes,
+  /// such as blocks with a catchswitch terminator.
+  ///
+  /// This is an O(1) check, unlike getFirstInsertionPt() which must scan
+  /// through all PHI nodes.
+  inline bool hasInsertionPt() const {
+    const Instruction *Term = getTerminator();
+    return Term && Term->getOpcode() != Instruction::CatchSwitch;
+  }
+
   /// Returns an iterator to the first instruction in this block that is
   /// not a PHINode, a debug intrinsic, a static alloca or any pseudo operation.
   LLVM_ABI const_iterator getFirstNonPHIOrDbgOrAlloca() const;

--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -340,7 +340,7 @@ public:
   ///
   /// This is an O(1) check, unlike getFirstInsertionPt() which must scan
   /// through all PHI nodes.
-  inline bool hasInsertionPt() const {
+  bool hasInsertionPt() const {
     const Instruction *Term = getTerminator();
     return Term && Term->getOpcode() != Instruction::CatchSwitch;
   }

--- a/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombinePHI.cpp
@@ -272,7 +272,7 @@ bool InstCombinerImpl::foldIntegerTypedPHI(PHINode &PN) {
         if (Inst->isTerminator())
           return true;
         auto *BB = Inst->getParent();
-        if (isa<PHINode>(Inst) && BB->getFirstInsertionPt() == BB->end())
+        if (isa<PHINode>(Inst) && !BB->hasInsertionPt())
           return true;
         return false;
       }))
@@ -1133,7 +1133,7 @@ Instruction *InstCombinerImpl::SliceUpIllegalIntegerPHI(PHINode &FirstPhi) {
     // extract the value within that BB because we cannot insert any non-PHI
     // instructions in the BB.
     for (auto *Pred : PN->blocks())
-      if (Pred->getFirstInsertionPt() == Pred->end())
+      if (!Pred->hasInsertionPt())
         return nullptr;
 
     for (User *U : PN->users()) {
@@ -1451,8 +1451,7 @@ Instruction *InstCombinerImpl::visitPHINode(PHINode &PN) {
 
   // If the incoming values are pointer casts of the same original value,
   // replace the phi with a single cast iff we can insert a non-PHI instruction.
-  if (PN.getType()->isPointerTy() &&
-      PN.getParent()->getFirstInsertionPt() != PN.getParent()->end()) {
+  if (PN.getType()->isPointerTy() && PN.getParent()->hasInsertionPt()) {
     Value *IV0 = PN.getIncomingValue(0);
     Value *IV0Stripped = IV0->stripPointerCasts();
     // Set to keep track of values known to be equal to IV0Stripped after

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -1381,8 +1381,7 @@ private:
     // If this is a PHI node before a catchswitch, we cannot insert any non-PHI
     // instructions in this BB, which may be required during rewriting. Bail out
     // on these cases.
-    if (isa<PHINode>(I) &&
-        I.getParent()->getFirstInsertionPt() == I.getParent()->end())
+    if (isa<PHINode>(I) && !I.getParent()->hasInsertionPt())
       return PI.setAborted(&I);
 
     // TODO: We could use simplifyInstruction here to fold PHINodes and


### PR DESCRIPTION
Add a hasInsertionPt() helper, which is equivalent to getFirstInsertionPt() != end(), but performs the check in O(1) instead of O(n). In particular, this avoids quadratic complexity inside SliceUpIllegalIntegerPHI().

Fixes #175465.
Should fix https://github.com/rust-lang/rust/issues/129713.