### PR TITLE
[clang-tidy] Fix false positive from `readability-redundant-typename` on partially specialized variables

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/RedundantTypenameCheck.cpp
@@ -25,22 +25,25 @@ void RedundantTypenameCheck::registerMatchers(MatchFinder *Finder) {
   if (!getLangOpts().CPlusPlus20)
     return;
 
-  const auto InImplicitTypenameContext = anyOf(
-      hasParent(decl(anyOf(
-          typedefNameDecl(), templateTypeParmDecl(), nonTypeTemplateParmDecl(),
-          friendDecl(), fieldDecl(),
-          varDecl(hasDeclContext(anyOf(namespaceDecl(), translationUnitDecl())),
-                  unless(parmVarDecl())),
-          parmVarDecl(hasParent(expr(requiresExpr()))),
-          parmVarDecl(hasParent(typeLoc(hasParent(decl(
-              anyOf(cxxMethodDecl(), hasParent(friendDecl()),
+  const auto InImplicitTypenameContext =
+      anyOf(hasParent(decl(anyOf(
+                typedefNameDecl(), templateTypeParmDecl(),
+                nonTypeTemplateParmDecl(), friendDecl(), fieldDecl(),
+                parmVarDecl(hasParent(expr(requiresExpr()))),
+                parmVarDecl(hasParent(typeLoc(hasParent(decl(anyOf(
+                    cxxMethodDecl(), hasParent(friendDecl()),
                     functionDecl(has(nestedNameSpecifier())),
                     cxxDeductionGuideDecl(hasDeclContext(recordDecl())))))))),
-          // Match return types.
-          functionDecl(unless(cxxConversionDecl()))))),
-      hasParent(expr(anyOf(cxxNamedCastExpr(), cxxNewExpr()))));
+                // Match return types.
+                functionDecl(unless(cxxConversionDecl()))))),
+            hasParent(expr(anyOf(cxxNamedCastExpr(), cxxNewExpr()))));
   Finder->addMatcher(
       typeLoc(InImplicitTypenameContext).bind("dependentTypeLoc"), this);
+  Finder->addMatcher(
+      varDecl(hasDeclContext(anyOf(namespaceDecl(), translationUnitDecl())),
+              unless(parmVarDecl()),
+              hasTypeLoc(typeLoc().bind("dependentTypeLoc"))),
+      this);
 }
 
 void RedundantTypenameCheck::check(const MatchFinder::MatchResult &Result) {

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-typename.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-typename.cpp
@@ -157,6 +157,16 @@ typename T::R v = typename T::R();
 // CHECK-MESSAGES-20: :[[@LINE-1]]:1: warning: redundant 'typename' [readability-redundant-typename]
 // CHECK-FIXES-20: T::R v = typename T::R();
 
+template <typename T, typename>
+typename T::R PartiallySpecializedVariable = true;
+// CHECK-MESSAGES-20: :[[@LINE-1]]:1: warning: redundant 'typename' [readability-redundant-typename]
+// CHECK-FIXES-20: T::R PartiallySpecializedVariable = true;
+
+template <typename T>
+typename T::R PartiallySpecializedVariable<T, typename T::R> = false;
+// CHECK-MESSAGES-20: :[[@LINE-1]]:1: warning: redundant 'typename' [readability-redundant-typename]
+// CHECK-FIXES-20: T::R PartiallySpecializedVariable<T, typename T::R> = false;
+
 #endif // __cplusplus >= 201402L
 
 template <typename T>


### PR DESCRIPTION
Fixes #174827.