### PR TITLE
[libclc][NFC] Remove unused builtins_opt_lib_tgt

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -435,8 +435,6 @@ function(add_libclc_builtin_set)
     endif()
   else()
     # Non-SPIR-V targets add an extra step to optimize the bytecode
-    set( builtins_opt_lib_tgt builtins.opt.${ARG_ARCH_SUFFIX} )
-
     set( obj_suffix ${ARG_ARCH_SUFFIX}.bc )
     set( libclc_builtins_lib ${LIBCLC_OUTPUT_LIBRARY_DIR}/${obj_suffix} )
 


### PR DESCRIPTION
It was left behind after f07988ff3ec8.