### PR TITLE
[AMDGPU] Support i8/i16 GEP indices when promoting allocas to vectors

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -556,7 +556,7 @@ computeGEPToVectorIndex(GetElementPtrInst *GEP, AllocaInst *Alloca,
   if (VarOffsets.size() > 1)
     return {};
 
-  // We support vector indices of the form ((A * stride) >> shift) + B.
+  // We support vector indices of the form ((VarIndex * stride) >> shift) + B.
   // IndexQuot represents B. Check that the constant offset is a multiple
   // of the vector element size.
   if (ConstOffset.srem(VecElemSize) != 0)
@@ -585,29 +585,29 @@ computeGEPToVectorIndex(GetElementPtrInst *GEP, AllocaInst *Alloca,
   if (!OffsetType)
     return {};
 
-  // The vector index for the variable part is: A * Scale / VecElemSize.
+  // The vector index for the variable part is: VarIndex * Scale / VecElemSize.
   if (Scale >= (uint64_t)VecElemSize) {
-    // Scale is a multiple of VecElemSize, so the index is just A * (Scale /
-    // VecElemSize).
     if (Scale % VecElemSize != 0)
       return {};
 
+    // Scale is a multiple of VecElemSize, so the index is just: VarIndex *
+    // (Scale / VecElemSize).
     uint64_t VarMul = Scale / VecElemSize;
     // Only the multiplier is needed.
     if (VarMul != 1)
       Result.VarMul = ConstantInt::get(Ctx, APInt(BW, VarMul));
   } else {
-    // VecElemSize is a multiple of Scale, so the index is A / (VecElemSize /
-    // Scale).
     if ((uint64_t)VecElemSize % Scale != 0)
       return {};
 
+    // VecElemSize is a multiple of Scale, so the index is just: VarIndex /
+    // (VecElemSize / Scale).
     uint64_t Divisor = VecElemSize / Scale;
     // The divisor must be a power of 2 so we can use a right shift.
     if (!isPowerOf2_64(Divisor))
       return {};
 
-    // A must be known to be divisible by that divisor.
+    // VarIndex must be known to be divisible by that divisor.
     KnownBits KB = computeKnownBits(VarOffset.first, DL);
     if (KB.countMinTrailingZeros() < Log2_64(Divisor))
       return {};

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-vector-gep.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-vector-gep.ll
@@ -250,6 +250,119 @@ bb2:
   store i32 0, ptr addrspace(5) %extractelement
   ret void
 }
+
+define amdgpu_ps void @scalar_alloca_vector_gep_i8_0_or_4(i1 %idx_sel) {
+; CHECK-LABEL: define amdgpu_ps void @scalar_alloca_vector_gep_i8_0_or_4(
+; CHECK-SAME: i1 [[IDX_SEL:%.*]]) {
+; CHECK-NEXT:    [[ALLOCA:%.*]] = freeze <3 x float> poison
+; CHECK-NEXT:    [[INDEX:%.*]] = select i1 [[IDX_SEL]], i32 0, i32 4
+; CHECK-NEXT:    [[TMP1:%.*]] = ashr exact i32 [[INDEX]], 2
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <3 x float> [[ALLOCA]], float 7.000000e+00, i32 [[TMP1]]
+; CHECK-NEXT:    ret void
+;
+  %alloca = alloca <3 x float>, align 16, addrspace(5)
+  %index = select i1 %idx_sel, i32 0, i32 4
+  %elt = getelementptr inbounds nuw i8, ptr addrspace(5) %alloca, i32 %index
+  store float 7.000000e+00, ptr addrspace(5) %elt, align 4
+  ret void
+}
+
+define amdgpu_ps void @scalar_alloca_vector_gep_i8_4_or_8(i1 %idx_sel) {
+; CHECK-LABEL: define amdgpu_ps void @scalar_alloca_vector_gep_i8_4_or_8(
+; CHECK-SAME: i1 [[IDX_SEL:%.*]]) {
+; CHECK-NEXT:    [[ALLOCA:%.*]] = freeze <3 x float> poison
+; CHECK-NEXT:    [[INDEX:%.*]] = select i1 [[IDX_SEL]], i32 4, i32 8
+; CHECK-NEXT:    [[TMP1:%.*]] = ashr exact i32 [[INDEX]], 2
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <3 x float> [[ALLOCA]], float 7.000000e+00, i32 [[TMP1]]
+; CHECK-NEXT:    ret void
+;
+  %alloca = alloca <3 x float>, align 16, addrspace(5)
+  %index = select i1 %idx_sel, i32 4, i32 8
+  %elt = getelementptr inbounds nuw i8, ptr addrspace(5) %alloca, i32 %index
+  store float 7.000000e+00, ptr addrspace(5) %elt, align 4
+  ret void
+}
+
+define amdgpu_ps void @scalar_alloca_nested_vector_gep_i8_4_or_5_no_promote(i1 %idx_sel) {
+; CHECK-LABEL: define amdgpu_ps void @scalar_alloca_nested_vector_gep_i8_4_or_5_no_promote(
+; CHECK-SAME: i1 [[IDX_SEL:%.*]]) {
+; CHECK-NEXT:    [[ALLOCA:%.*]] = alloca <3 x float>, align 16, addrspace(5)
+; CHECK-NEXT:    [[INDEX:%.*]] = select i1 [[IDX_SEL]], i32 4, i32 5
+; CHECK-NEXT:    [[ELT:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(5) [[ALLOCA]], i32 [[INDEX]]
+; CHECK-NEXT:    store float 7.000000e+00, ptr addrspace(5) [[ELT]], align 1
+; CHECK-NEXT:    ret void
+;
+  %alloca = alloca <3 x float>, align 16, addrspace(5)
+  %index = select i1 %idx_sel, i32 4, i32 5
+  %elt = getelementptr inbounds nuw i8, ptr addrspace(5) %alloca, i32 %index
+  store float 7.000000e+00, ptr addrspace(5) %elt, align 1
+  ret void
+}
+
+define amdgpu_ps void @scalar_alloca_vector_gep_i16_0_or_2(i1 %idx_sel) {
+; CHECK-LABEL: define amdgpu_ps void @scalar_alloca_vector_gep_i16_0_or_2(
+; CHECK-SAME: i1 [[IDX_SEL:%.*]]) {
+; CHECK-NEXT:    [[ALLOCA:%.*]] = freeze <3 x float> poison
+; CHECK-NEXT:    [[INDEX:%.*]] = select i1 [[IDX_SEL]], i32 0, i32 2
+; CHECK-NEXT:    [[TMP1:%.*]] = ashr exact i32 [[INDEX]], 1
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <3 x float> [[ALLOCA]], float 7.000000e+00, i32 [[TMP1]]
+; CHECK-NEXT:    ret void
+;
+  %alloca = alloca <3 x float>, align 16, addrspace(5)
+  %index = select i1 %idx_sel, i32 0, i32 2
+  %elt = getelementptr inbounds nuw i16, ptr addrspace(5) %alloca, i32 %index
+  store float 7.000000e+00, ptr addrspace(5) %elt, align 4
+  ret void
+}
+
+define amdgpu_ps void @scalar_alloca_vector_gep_i16_2_or_4(i1 %idx_sel) {
+; CHECK-LABEL: define amdgpu_ps void @scalar_alloca_vector_gep_i16_2_or_4(
+; CHECK-SAME: i1 [[IDX_SEL:%.*]]) {
+; CHECK-NEXT:    [[ALLOCA:%.*]] = freeze <3 x float> poison
+; CHECK-NEXT:    [[INDEX:%.*]] = select i1 [[IDX_SEL]], i32 2, i32 4
+; CHECK-NEXT:    [[TMP1:%.*]] = ashr exact i32 [[INDEX]], 1
+; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <3 x float> [[ALLOCA]], float 7.000000e+00, i32 [[TMP1]]
+; CHECK-NEXT:    ret void
+;
+  %alloca = alloca <3 x float>, align 16, addrspace(5)
+  %index = select i1 %idx_sel, i32 2, i32 4
+  %elt = getelementptr inbounds nuw i16, ptr addrspace(5) %alloca, i32 %index
+  store float 7.000000e+00, ptr addrspace(5) %elt, align 4
+  ret void
+}
+
+define amdgpu_ps void @scalar_alloca_vector_gep_i16_1_or_2_no_promote(i1 %idx_sel) {
+; CHECK-LABEL: define amdgpu_ps void @scalar_alloca_vector_gep_i16_1_or_2_no_promote(
+; CHECK-SAME: i1 [[IDX_SEL:%.*]]) {
+; CHECK-NEXT:    [[ALLOCA:%.*]] = alloca <3 x float>, align 16, addrspace(5)
+; CHECK-NEXT:    [[INDEX:%.*]] = select i1 [[IDX_SEL]], i32 1, i32 2
+; CHECK-NEXT:    [[ELT:%.*]] = getelementptr inbounds nuw i16, ptr addrspace(5) [[ALLOCA]], i32 [[INDEX]]
+; CHECK-NEXT:    store float 7.000000e+00, ptr addrspace(5) [[ELT]], align 1
+; CHECK-NEXT:    ret void
+;
+  %alloca = alloca <3 x float>, align 16, addrspace(5)
+  %index = select i1 %idx_sel, i32 1, i32 2
+  %elt = getelementptr inbounds nuw i16, ptr addrspace(5) %alloca, i32 %index
+  store float 7.000000e+00, ptr addrspace(5) %elt, align 1
+  ret void
+}
+
+define amdgpu_ps void @scalar_alloca_vector_gep_i8_odd(i1 %idx_sel) {
+; CHECK-LABEL: define amdgpu_ps void @scalar_alloca_vector_gep_i8_odd(
+; CHECK-SAME: i1 [[IDX_SEL:%.*]]) {
+; CHECK-NEXT:    [[ALLOCA:%.*]] = alloca <3 x i24>, align 1, addrspace(5)
+; CHECK-NEXT:    [[INDEX:%.*]] = select i1 [[IDX_SEL]], i32 0, i32 3
+; CHECK-NEXT:    [[ELT:%.*]] = getelementptr inbounds nuw i8, ptr addrspace(5) [[ALLOCA]], i32 [[INDEX]]
+; CHECK-NEXT:    store i8 7, ptr addrspace(5) [[ELT]], align 1
+; CHECK-NEXT:    ret void
+;
+  %alloca = alloca <3 x i24>, align 1, addrspace(5)
+  %index = select i1 %idx_sel, i32 0, i32 3
+  %elt = getelementptr inbounds nuw i8, ptr addrspace(5) %alloca, i32 %index
+  store i8 7, ptr addrspace(5) %elt, align 1
+  ret void
+}
+
 ;.
 ; CHECK: [[META0]] = !{}
 ; CHECK: [[RNG1]] = !{i32 0, i32 1025}


### PR DESCRIPTION
Allow promote alloca to vector to form a vector element index from i8/i16
GEPs when the dynamic offset is known to be element size aligned.

Example:
```llvm
%alloca = alloca <3 x float>, addrspace(5)
%idx = select i1 %idx_select, i32 0, i32 4
%p = getelementptr inbounds i8, ptr addrspace(5) %alloca, i32 %idx
```
Or:
```llvm
%alloca = alloca <3 x float>, addrspace(5)
%idx = select i1 %idx_select, i32 0, i32 2
%p = getelementptr inbounds i16, ptr addrspace(5) %alloca, i32 %idx
```