### PR TITLE
Fix gcc name shadow warning.

### DIFF
--- a/clang/unittests/Interpreter/OutOfProcessInterpreterTests.cpp
+++ b/clang/unittests/Interpreter/OutOfProcessInterpreterTests.cpp
@@ -113,7 +113,7 @@ protected:
 
 struct OutOfProcessInterpreterInfo {
   std::string OrcRuntimePath;
-  std::unique_ptr<Interpreter> Interpreter;
+  std::unique_ptr<Interpreter> Interp;
 };
 
 static OutOfProcessInterpreterInfo
@@ -180,7 +180,7 @@ TEST_F(OutOfProcessInterpreterTest, SanityWithRemoteExecution) {
 
   OutOfProcessInterpreterInfo Info =
       createInterpreterWithRemoteExecution(io_ctx);
-  Interpreter *Interp = Info.Interpreter.get();
+  Interpreter *Interp = Info.Interp.get();
   ASSERT_TRUE(Interp);
 
   using PTU = PartialTranslationUnit;
@@ -205,7 +205,7 @@ TEST_F(OutOfProcessInterpreterTest, FindRuntimeInterface) {
   ASSERT_TRUE(io_ctx->initializeTempFiles());
 
   OutOfProcessInterpreterInfo I = createInterpreterWithRemoteExecution(io_ctx);
-  ASSERT_TRUE(I.Interpreter);
+  ASSERT_TRUE(I.Interp);
 
   // FIXME: Not yet supported.
   // cantFail(I->Parse("int a = 1; a"));


### PR DESCRIPTION
Addresses comment in #175322