### PR TITLE
[llvm-jitlink] Make the -show-addrs option work without -check.

### DIFF
--- a/llvm/test/ExecutionEngine/JITLink/AArch64/ELF_zero_sized_symbols_with_show_addrs.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/ELF_zero_sized_symbols_with_show_addrs.s
@@ -1,0 +1,16 @@
+# RUN: llvm-mc -triple=aarch64-unknown-linux-gnu \
+# RUN:   -position-independent -filetype=obj -o %t.o %s
+# RUN: llvm-jitlink -noexec -show-addrs %t.o | FileCheck %s
+
+# Check that show-addrs works with zero-sized symbols.
+
+# CHECK: main{{.*}}target addr =
+
+        .text
+        .globl  main
+        .p2align        2
+        .type   main,@function
+main:
+        mov     w0, wzr
+        ret
+        .size   main, 0

--- a/llvm/test/ExecutionEngine/JITLink/Generic/llvm-jitlink-option-show-addrs.test
+++ b/llvm/test/ExecutionEngine/JITLink/Generic/llvm-jitlink-option-show-addrs.test
@@ -1,0 +1,14 @@
+# RUN: llc -filetype=obj -o %t.o %S/Inputs/main-ret-0.ll
+# RUN: llvm-jitlink -noexec -show-addrs %t.o | FileCheck %s
+#
+# Check that the llvm-jitlink -show-addrs option reports an address for main.
+
+# Jitlink does not support ARM64 COFF files.
+# UNSUPPORTED: target=aarch64-{{.*}}-windows-{{.*}}
+
+# On MinGW targets, when compiling the main() function, it gets
+# an implicitly generated call to __main(), which is missing in
+# this context.
+# XFAIL: target={{.*}}-windows-gnu
+
+# CHECK: main{{.*}} target addr = 0x{{[[:xdigit:]]+}}, content:

--- a/llvm/tools/llvm-jitlink/llvm-jitlink-elf.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink-elf.cpp
@@ -176,6 +176,8 @@ Error registerELFGraphInfo(Session &S, LinkGraph &G) {
     }
 
     // Add symbol info for absolute symbols.
+    // MemoryRegionInfo doesn't support zero-sized symbols, so use a minimum of
+    // 1.
     for (auto *Sym : G.absolute_symbols())
       S.SymbolInfos[Sym->getName()] = {Sym->getSize(),
                                        Sym->getAddress().getValue()};


### PR DESCRIPTION
Ensures that the address scraping passes are added to the JIT linker pipeline if either of the -check or -show-addrs are passed. Prior to this commit we only considered -check, so passing -show-addrs on its own was printing an empty (unpopulated) symbol table.