### PR TITLE
[VPlan] Give VPInstruction::ExplicitVectorLength name. NFC

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -3202,7 +3202,7 @@ void VPlanTransforms::addExplicitVectorLength(
                                "safe_avl");
   }
   auto *VPEVL = Builder.createNaryOp(VPInstruction::ExplicitVectorLength, AVL,
-                                     DebugLoc::getUnknown());
+                                     DebugLoc::getUnknown(), "evl");
 
   auto *CanonicalIVIncrement =
       cast<VPInstruction>(CanonicalIVPHI->getBackedgeValue());


### PR DESCRIPTION
This makes it a tad easier to read VPlan dumps, e.g.

    WIDEN vp.store vp<%7>, ir<%val>, vp<%5>
    ->
    WIDEN vp.store vp<%7>, ir<%val>, vp<%evl>
