### PR TITLE
[clangd] Add new highlighting modifier `CommandLineDefined`.

### DIFF
--- a/clang-tools-extra/clangd/CollectMacros.cpp
+++ b/clang-tools-extra/clangd/CollectMacros.cpp
@@ -11,6 +11,7 @@
 #include "Protocol.h"
 #include "SourceCode.h"
 #include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
 #include "clang/Tooling/Syntax/Tokens.h"
 #include "llvm/ADT/STLExtras.h"
 #include <cstddef>
@@ -40,10 +41,20 @@ void CollectMainFileMacros::add(const Token &MacroNameTok, const MacroInfo *MI,
   Out.Names.insert(Name);
   size_t Start = SM.getFileOffset(Loc);
   size_t End = SM.getFileOffset(MacroNameTok.getEndLoc());
+
+  bool IsCommandLineDefined = false;
+  if (MI) {
+    const auto DefLoc =/*  */ MI->getDefinitionLoc();
+    if (DefLoc.isValid())
+      IsCommandLineDefined = SM.isWrittenInCommandLineFile(DefLoc);
+  }
+
   if (auto SID = getSymbolID(Name, MI, SM))
-    Out.MacroRefs[SID].push_back({Start, End, IsDefinition, InIfCondition});
+    Out.MacroRefs[SID].push_back(
+        {Start, End, IsDefinition, InIfCondition, IsCommandLineDefined});
   else
-    Out.UnknownMacros.push_back({Start, End, IsDefinition, InIfCondition});
+    Out.UnknownMacros.push_back(
+        {Start, End, IsDefinition, InIfCondition, IsCommandLineDefined});
 }
 
 void CollectMainFileMacros::FileChanged(SourceLocation Loc, FileChangeReason,

--- a/clang-tools-extra/clangd/CollectMacros.cpp
+++ b/clang-tools-extra/clangd/CollectMacros.cpp
@@ -44,7 +44,7 @@ void CollectMainFileMacros::add(const Token &MacroNameTok, const MacroInfo *MI,
 
   bool IsCommandLineDefined = false;
   if (MI) {
-    const auto DefLoc =/*  */ MI->getDefinitionLoc();
+    const auto DefLoc = MI->getDefinitionLoc();
     if (DefLoc.isValid())
       IsCommandLineDefined = SM.isWrittenInCommandLineFile(DefLoc);
   }

--- a/clang-tools-extra/clangd/CollectMacros.h
+++ b/clang-tools-extra/clangd/CollectMacros.h
@@ -30,6 +30,9 @@ struct MacroOccurrence {
   bool IsDefinition;
   // True if the occurence is used in a conditional directive, e.g. #ifdef MACRO
   bool InConditionalDirective;
+  // True if the macro is defined via command line options (e.g. -D...)
+  // rather than in a source/header file.
+  bool IsCommandLineDefined;
 
   CharSourceRange toSourceRange(const SourceManager &SM) const;
   Range toRange(const SourceManager &SM) const;

--- a/clang-tools-extra/clangd/SemanticHighlighting.cpp
+++ b/clang-tools-extra/clangd/SemanticHighlighting.cpp
@@ -1190,6 +1190,8 @@ getSemanticHighlightings(ParsedAST &AST, bool IncludeInactiveRegionTokens) {
     auto &T = Builder.addToken(M.toRange(C.getSourceManager()),
                                HighlightingKind::Macro);
     T.addModifier(HighlightingModifier::GlobalScope);
+    if (M.IsCommandLineDefined)
+      T.addModifier(HighlightingModifier::CommandLineDefined);
     if (M.IsDefinition)
       T.addModifier(HighlightingModifier::Declaration);
   };
@@ -1319,6 +1321,7 @@ highlightingModifierFromString(llvm::StringRef Name) {
       {"ConstructorOrDestructor",
        HighlightingModifier::ConstructorOrDestructor},
       {"UserDefined", HighlightingModifier::UserDefined},
+      {"CommandLineDefined", HighlightingModifier::CommandLineDefined},
       {"FunctionScope", HighlightingModifier::FunctionScope},
       {"ClassScope", HighlightingModifier::ClassScope},
       {"FileScope", HighlightingModifier::FileScope},
@@ -1489,6 +1492,8 @@ llvm::StringRef toSemanticTokenModifier(HighlightingModifier Modifier) {
     return "constructorOrDestructor"; // nonstandard
   case HighlightingModifier::UserDefined:
     return "userDefined"; // nonstandard
+  case HighlightingModifier::CommandLineDefined:
+    return "commandLine"; // nonstandard
   case HighlightingModifier::FunctionScope:
     return "functionScope"; // nonstandard
   case HighlightingModifier::ClassScope:

--- a/clang-tools-extra/clangd/SemanticHighlighting.cpp
+++ b/clang-tools-extra/clangd/SemanticHighlighting.cpp
@@ -1493,7 +1493,7 @@ llvm::StringRef toSemanticTokenModifier(HighlightingModifier Modifier) {
   case HighlightingModifier::UserDefined:
     return "userDefined"; // nonstandard
   case HighlightingModifier::CommandLineDefined:
-    return "commandLine"; // nonstandard
+    return "commandLineDefined"; // nonstandard
   case HighlightingModifier::FunctionScope:
     return "functionScope"; // nonstandard
   case HighlightingModifier::ClassScope:

--- a/clang-tools-extra/clangd/SemanticHighlighting.h
+++ b/clang-tools-extra/clangd/SemanticHighlighting.h
@@ -80,6 +80,7 @@ enum class HighlightingModifier {
   UsedAsMutablePointer,
   ConstructorOrDestructor,
   UserDefined,
+  CommandLineDefined,
 
   FunctionScope,
   ClassScope,

--- a/clang-tools-extra/clangd/test/initialize-params.test
+++ b/clang-tools-extra/clangd/test/initialize-params.test
@@ -75,6 +75,7 @@
 # CHECK-NEXT:            "usedAsMutablePointer",
 # CHECK-NEXT:            "constructorOrDestructor",
 # CHECK-NEXT:            "userDefined",
+# CHECK-NEXT:            "commandLineDefined",
 # CHECK-NEXT:            "functionScope",
 # CHECK-NEXT:            "classScope",
 # CHECK-NEXT:            "fileScope",

--- a/clang-tools-extra/clangd/test/semantic-tokens.test
+++ b/clang-tools-extra/clangd/test/semantic-tokens.test
@@ -23,7 +23,7 @@
 # CHECK-NEXT:      4,
 # CHECK-NEXT:      1,
 # CHECK-NEXT:      0,
-# CHECK-NEXT:      131075
+# CHECK-NEXT:      262147
 # CHECK-NEXT:    ],
 # CHECK-NEXT:    "resultId": "1"
 # CHECK-NEXT:  }
@@ -49,7 +49,7 @@
 # CHECK-NEXT:          4,
 # CHECK-NEXT:          1,
 # CHECK-NEXT:          0,
-# CHECK-NEXT:          131075
+# CHECK-NEXT:          262147
 # CHECK-NEXT:        ],
 #                    Inserted at position 1
 # CHECK-NEXT:        "deleteCount": 0,
@@ -72,12 +72,12 @@
 # CHECK-NEXT:      4,
 # CHECK-NEXT:      1,
 # CHECK-NEXT:      0,
-# CHECK-NEXT:      131075,
+# CHECK-NEXT:      262147,
 # CHECK-NEXT:      1,
 # CHECK-NEXT:      4,
 # CHECK-NEXT:      1,
 # CHECK-NEXT:      0,
-# CHECK-NEXT:      131075
+# CHECK-NEXT:      262147
 # CHECK-NEXT:    ],
 # CHECK-NEXT:    "resultId": "3"
 # CHECK-NEXT:  }

--- a/clang-tools-extra/clangd/unittests/SemanticHighlightingTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SemanticHighlightingTests.cpp
@@ -1205,9 +1205,10 @@ TEST(SemanticHighlighting, CommandLineMacros) {
   checkHighlightings(R"cpp(
     int $Variable_def_globalScope[[x]] = $Macro_globalScope[[CMD_MACRO]];
   )cpp",
-                    /*AdditionalFiles=*/{}, 
-                    /*ModifierMask=*/~(1 << unsigned(HighlightingModifier::CommandLineDefined)),
-                    /*AdditionalArgs=*/{"-DCMD_MACRO=1"});
+                     /*AdditionalFiles=*/{},
+                     /*ModifierMask=*/
+                     ~(1 << unsigned(HighlightingModifier::CommandLineDefined)),
+                     /*AdditionalArgs=*/{"-DCMD_MACRO=1"});
 }
 
 // Ranges are highlighted as variables, unless highlighted as $Function etc.

--- a/clang-tools-extra/clangd/unittests/SemanticHighlightingTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SemanticHighlightingTests.cpp
@@ -1201,6 +1201,15 @@ TEST(SemanticHighlighting, ScopeModifiers) {
     checkHighlightings(Test, {}, ScopeModifierMask);
 }
 
+TEST(SemanticHighlighting, CommandLineMacros) {
+  checkHighlightings(R"cpp(
+    int $Variable_def_globalScope[[x]] = $Macro_globalScope[[CMD_MACRO]];
+  )cpp",
+                    /*AdditionalFiles=*/{}, 
+                    /*ModifierMask=*/~(1 << unsigned(HighlightingModifier::CommandLineDefined)),
+                    /*AdditionalArgs=*/{"-DCMD_MACRO=1"});
+}
+
 // Ranges are highlighted as variables, unless highlighted as $Function etc.
 std::vector<HighlightingToken> tokens(llvm::StringRef MarkedText) {
   Annotations A(MarkedText);

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -105,6 +105,11 @@ Diagnostics
 Semantic Highlighting
 ^^^^^^^^^^^^^^^^^^^^^
 
+- ``clangd`` now exposes a ``commandLineDefined`` semantic token modifier 
+  for macros that are defined via compiler command-line options 
+  (for example [-D] flags),  allowing clients to distinguish them 
+  from macros defined in source files or headers.
+
 Compile flags
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
### Feature

This PR added a new enum `HighlightingModifier::CommandLineDefined`.

### Reason

Macros can be either
- defined in header/source `#define`, or
- defined via command line `-Dxxx=yyy`

Before this PR, the macros above are all only labelled as `GlobalScope`.

After this PR, macros who were defined via `-Dxxx=yyy` have an additional label `CommandLineDefined` for users to distinguish them from *in-file-defined* ones.
