### PR TITLE
[clang][bytecode] Fix assertion in Pointer::isInitialized() for GlobalInlineDescriptor

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -127,6 +127,8 @@ Bug Fixes to C++ Support
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Fixed assertion crash in bytecode interpreter when checking initialization of
+  constexpr pointer arrays with GlobalInlineDescriptor. (#GH175432)
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -454,6 +454,12 @@ bool Pointer::isInitialized() const {
     return GD.InitState == GlobalInitState::Initialized;
   }
 
+  // Safety check: if BS.Base == sizeof(GlobalInlineDescriptor) but we're not
+  // in the isRoot() case above, we still cannot call getInlineDesc().
+  // This can happen when Offset != BS.Base. Return true to avoid crash.
+  if (BS.Base == sizeof(GlobalInlineDescriptor))
+    return true;
+
   assert(BS.Pointee && "Cannot check if null pointer was initialized");
   const Descriptor *Desc = getFieldDesc();
   assert(Desc);

--- a/clang/test/AST/ByteCode/arrays.cpp
+++ b/clang/test/AST/ByteCode/arrays.cpp
@@ -835,3 +835,12 @@ namespace MultiDimConstructExpr {
   constexpr b d;
   static_assert(d.m[2][1].p == &d.m[2][1]);
 }
+
+// Test for issue #175432 - assertion crash with GlobalInlineDescriptor
+// Previously crashed with: Assertion `BS.Base != sizeof(GlobalInlineDescriptor)` failed
+namespace gh175432 {
+  constexpr const int *arr[][2] = {{nullptr, nullptr}};
+  static_assert(arr[0][0] == nullptr, "");
+  static_assert(arr[0][1] == nullptr, "");
+}
+

--- a/clang/test/AST/ByteCode/arrays.cpp
+++ b/clang/test/AST/ByteCode/arrays.cpp
@@ -838,8 +838,13 @@ namespace MultiDimConstructExpr {
 }
 
 namespace GH175432 {
-  constexpr const int *foo[][2] = {
-      {nullptr, int}, // both-error {{expected '(' for function-style cast or type construction}}
+  // Test that we don't crash when checking initialization of
+  // pointer arrays with invalid initializers
+  constexpr const int *foo[][2] = { // expected-error {{must be initialized by a constant expression}} \
+                                    // expected-note {{declared here}}
+      {nullptr, int}, // expected-error {{expected '(' for function-style cast or type construction}}
   };
-  static_assert(foo[0][0] == nullptr, ""); // both-error {{not an integral constant expression}}
+
+  static_assert(foo[0][0] == nullptr, ""); // expected-error {{not an integral constant expression}} \
+                                           // expected-note {{initializer of 'foo' is unknown}}
 }

--- a/clang/test/AST/ByteCode/arrays.cpp
+++ b/clang/test/AST/ByteCode/arrays.cpp
@@ -834,13 +834,12 @@ namespace MultiDimConstructExpr {
   };
   constexpr b d;
   static_assert(d.m[2][1].p == &d.m[2][1]);
+
 }
 
-// Test for issue #175432 - assertion crash with GlobalInlineDescriptor
-// Previously crashed with: Assertion `BS.Base != sizeof(GlobalInlineDescriptor)` failed
-namespace gh175432 {
-  constexpr const int *arr[][2] = {{nullptr, nullptr}};
-  static_assert(arr[0][0] == nullptr, "");
-  static_assert(arr[0][1] == nullptr, "");
+namespace GH175432 {
+  constexpr const int *foo[][2] = {
+      {nullptr, int}, // both-error {{expected '(' for function-style cast or type construction}}
+  };
+  static_assert(foo[0][0] == nullptr, ""); // both-error {{not an integral constant expression}}
 }
-


### PR DESCRIPTION
The existing check for BS.Base == sizeof(GlobalInlineDescriptor) required both isRoot() and Offset == BS.Base to be true. The pointer can have BS.Base == sizeof(GlobalInlineDescriptor) without satisfying isRoot() (which checks if Base equals getMetadataSize() or 0). This caused getFieldDesc() to be called, which then calls getInlineDesc(), triggering the assertion 'BS.Base != sizeof(GlobalInlineDescriptor)'. The fix removes the overly restrictive conditions and checks only for BS.Base == sizeof(GlobalInlineDescriptor) to determine if we should go to the GlobalInlineDescriptor's InitState.

Fixes #175432