### PR TITLE
[llvm-jitlink] Remove build_version directive.

### DIFF
--- a/llvm/test/ExecutionEngine/JITLink/AArch64/backtrace-symbolication.s
+++ b/llvm/test/ExecutionEngine/JITLink/AArch64/backtrace-symbolication.s
@@ -13,7 +13,6 @@
 
 # CHECK: this_should_crash {{.*}} ({{.*}}crash.o)
 
-	.build_version macos, 26, 0
 	.section	__TEXT,__text,regular,pure_instructions
 	.globl	_this_should_crash
 	.p2align	2


### PR DESCRIPTION
Fixes a warning on some bots.