### PR TITLE
[LLDB] Mention MSVC STL formatters in release notes

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -297,6 +297,7 @@ Changes to LLDB
   LLDB's build configuration is included in the command's output. This includes
   all the supported targets, along with the presence of (or lack of) optional
   features like XML parsing.
+* LLDB now includes formatters for many types from the MSVC STL.
 
 Changes to BOLT
 ---------------------------------


### PR DESCRIPTION
We already had a few MSVC STL formatters at the last release, but we postponed the release note entry until they support PDB. The formatters now support PDB.

There are still some left (see https://github.com/llvm/llvm-project/issues/24834#issuecomment-3049291996), but the most common types are formatted.