### PR TITLE
[MachineInst] Increase LLVM_MI_FLAGS_BITS to 32 bits (NFCI)

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -136,7 +136,7 @@ private:
   MachineOperand *Operands = nullptr;   // Pointer to the first operand.
 
 #define LLVM_MI_NUMOPERANDS_BITS 24
-#define LLVM_MI_FLAGS_BITS 24
+#define LLVM_MI_FLAGS_BITS 32
 #define LLVM_MI_ASMPRINTERFLAGS_BITS 8
 
   /// Number of operands on instruction.
@@ -148,12 +148,19 @@ private:
   OperandCapacity CapOperands;          // Capacity of the Operands array.
 
   /// Various bits of additional information about the machine instruction.
-  uint32_t Flags : LLVM_MI_FLAGS_BITS;
+  uint32_t Flags;
 
   /// Various bits of information used by the AsmPrinter to emit helpful
   /// comments.  This is *not* semantic information.  Do not use this for
   /// anything other than to convey comment information to AsmPrinter.
-  uint32_t AsmPrinterFlags : LLVM_MI_ASMPRINTERFLAGS_BITS;
+  uint8_t AsmPrinterFlags;
+
+  /// Cached opcode from MCID.
+  uint16_t Opcode;
+
+  /// Unique instruction number. Used by DBG_INSTR_REFs to refer to the values
+  /// defined by this instruction.
+  unsigned DebugInstrNum;
 
   /// Internal implementation detail class that provides out-of-line storage for
   /// extra info used by the machine instruction when this info cannot be stored
@@ -317,13 +324,6 @@ private:
       Info;
 
   DebugLoc DbgLoc; // Source line information.
-
-  /// Unique instruction number. Used by DBG_INSTR_REFs to refer to the values
-  /// defined by this instruction.
-  unsigned DebugInstrNum;
-
-  /// Cached opcode from MCID.
-  uint16_t Opcode;
 
   // Intrusive list support
   friend struct ilist_traits<MachineInstr>;

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -100,7 +100,7 @@ void MachineInstr::addImplicitDefUseOperands(MachineFunction &MF) {
 MachineInstr::MachineInstr(MachineFunction &MF, const MCInstrDesc &TID,
                            DebugLoc DL, bool NoImp)
     : MCID(&TID), NumOperands(0), Flags(0), AsmPrinterFlags(0),
-      DbgLoc(std::move(DL)), DebugInstrNum(0), Opcode(TID.Opcode) {
+      Opcode(TID.Opcode), DebugInstrNum(0), DbgLoc(std::move(DL)) {
   assert(DbgLoc.hasTrivialDestructor() && "Expected trivial destructor");
 
   // Reserve space for the expected number of operands.
@@ -119,8 +119,8 @@ MachineInstr::MachineInstr(MachineFunction &MF, const MCInstrDesc &TID,
 /// uniqueness.
 MachineInstr::MachineInstr(MachineFunction &MF, const MachineInstr &MI)
     : MCID(&MI.getDesc()), NumOperands(0), Flags(0), AsmPrinterFlags(0),
-      Info(MI.Info), DbgLoc(MI.getDebugLoc()), DebugInstrNum(0),
-      Opcode(MI.getOpcode()) {
+      Opcode(MI.getOpcode()), DebugInstrNum(0), Info(MI.Info),
+      DbgLoc(MI.getDebugLoc()) {
   assert(DbgLoc.hasTrivialDestructor() && "Expected trivial destructor");
 
   CapOperands = OperandCapacity::get(MI.getNumOperands());


### PR DESCRIPTION
We have hit the limit of 24 bits for LLVM_MI_FLAGS_BITS in upstream. In our downstream target we are using additional bits, so we're hitting the "Flag is out of range" assertions in get/setFlag functions.

Increase LLVM_MI_FLAGS_BITS to 32 bits, and reorder the fields of MachineInstr to avoid extra padding and the subsequent increase in size. Since the alignment of the class is 8 and the last member was 16-bit before this change we can get more bits by moving things around. 