### PR TITLE
[SPIR-V] Fix store to first element array

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
@@ -370,6 +370,8 @@ class SPIRVLegalizePointerCast : public FunctionPass {
       storeToFirstValueAggregate(B, Src, Dst, D_VT, Alignment);
     else if (D_AT && S_VT && S_VT->getElementType() == D_AT->getElementType())
       storeArrayFromVector(B, Src, Dst, D_AT, Alignment);
+    else if (D_AT && D_AT->getElementType() == FromTy)
+      storeToFirstValueAggregate(B, Src, Dst, D_AT, Alignment);
     else
       llvm_unreachable("Unsupported ptrcast use in store. Please fix.");
 

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
@@ -357,21 +357,18 @@ class SPIRVLegalizePointerCast : public FunctionPass {
     Type *FromTy = Src->getType();
 
     auto *S_VT = dyn_cast<FixedVectorType>(FromTy);
-    auto *D_ST = dyn_cast<StructType>(ToTy);
     auto *D_VT = dyn_cast<FixedVectorType>(ToTy);
     auto *D_AT = dyn_cast<ArrayType>(ToTy);
 
     B.SetInsertPoint(BadStore);
-    if (D_ST && isTypeFirstElementAggregate(FromTy, D_ST))
-      storeToFirstValueAggregate(B, Src, Dst, D_ST, Alignment);
+    if (isTypeFirstElementAggregate(FromTy, ToTy))
+      storeToFirstValueAggregate(B, Src, Dst, ToTy, Alignment);
     else if (D_VT && S_VT)
       storeVectorFromVector(B, Src, Dst, Alignment);
     else if (D_VT && !S_VT && FromTy == D_VT->getElementType())
       storeToFirstValueAggregate(B, Src, Dst, D_VT, Alignment);
     else if (D_AT && S_VT && S_VT->getElementType() == D_AT->getElementType())
       storeArrayFromVector(B, Src, Dst, D_AT, Alignment);
-    else if (D_AT && D_AT->getElementType() == FromTy)
-      storeToFirstValueAggregate(B, Src, Dst, D_AT, Alignment);
     else
       llvm_unreachable("Unsupported ptrcast use in store. Please fix.");
 

--- a/llvm/test/CodeGen/SPIRV/pointers/store-to-array-first-element.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/store-to-array-first-element.ll
@@ -1,0 +1,20 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-pc-vulkan1.3-compute %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-pc-vulkan1.3-compute %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG: %[[#Int:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#IntPtr:]] = OpTypePointer Function %[[#Int]]
+; CHECK-DAG: %[[#Array:]] = OpTypeArray %[[#Int]] %[[#]]
+; CHECK-DAG: %[[#ArrayPtr:]] = OpTypePointer Function %[[#Array]]
+; CHECK-DAG: %[[#Const:]] = OpConstant %[[#Int]] 123
+; CHECK-DAG: %[[#Zero:]] = OpConstant %[[#Int]] 0
+
+; CHECK: %[[#Var:]] = OpVariable %[[#ArrayPtr]] Function
+; CHECK: %[[#GEP:]] = OpInBoundsAccessChain %[[#IntPtr]] %[[#Var]] %[[#Zero]]
+; CHECK: OpStore %[[#GEP]] %[[#Const]]
+
+define spir_func void @test_array_store() {
+entry:
+  %var = alloca [4 x i32]
+  store i32 123, ptr %var
+  ret void
+}


### PR DESCRIPTION
The IR can store to the first element of an array the same way it stores to the first element of a struct by specifying the base pointer. This commit fixes the pointercast legalization pass to support this.