### PR TITLE
GHA: Add the "Check LLVM ABI" flow to issue-write

### DIFF
--- a/.github/workflows/issue-write.yml
+++ b/.github/workflows/issue-write.yml
@@ -9,6 +9,7 @@ on:
       - "Code lint"
       - "CI Checks"
       - "Test Issue Write"
+      - "Check LLVM ABI annotations"
     types:
       - completed
 


### PR DESCRIPTION
This is needed to properly test that #172673 is working as expected.