### PR TITLE
[CMake][NFC] Don't use uninitialized LLVM_REQUIRES_*

### DIFF
--- a/clang/examples/LLVMPrintFunctionNames/CMakeLists.txt
+++ b/clang/examples/LLVMPrintFunctionNames/CMakeLists.txt
@@ -1,13 +1,5 @@
-# If we don't need RTTI or EH, there's no reason to export anything
-# from the plugin.
-if(NOT MSVC) # MSVC mangles symbols differently, and
-    # PrintLLVMFunctionNames.export contains C++ symbols.
-  if(NOT LLVM_REQUIRES_RTTI)
-    if(NOT LLVM_REQUIRES_EH)
-      set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/LLVMPrintFunctionNames.exports)
-    endif()
-  endif()
-endif()
+# There's no reason to export anything from the plugin.
+set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/LLVMPrintFunctionNames.exports)
 
 add_llvm_library(LLVMPrintFunctionNames MODULE LLVMPrintFunctionNames.cpp PLUGIN_TOOL clang)
 

--- a/clang/examples/PrintFunctionNames/CMakeLists.txt
+++ b/clang/examples/PrintFunctionNames/CMakeLists.txt
@@ -1,13 +1,5 @@
-# If we don't need RTTI or EH, there's no reason to export anything
-# from the plugin.
-if( NOT MSVC ) # MSVC mangles symbols differently, and
-               # PrintFunctionNames.export contains C++ symbols.
-  if( NOT LLVM_REQUIRES_RTTI )
-    if( NOT LLVM_REQUIRES_EH )
-      set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/PrintFunctionNames.exports)
-    endif()
-  endif()
-endif()
+# There's no reason to export anything from the plugin.
+set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/PrintFunctionNames.exports)
 
 add_llvm_library(PrintFunctionNames MODULE PrintFunctionNames.cpp PLUGIN_TOOL clang)
 

--- a/llvm/tools/bugpoint-passes/CMakeLists.txt
+++ b/llvm/tools/bugpoint-passes/CMakeLists.txt
@@ -2,13 +2,8 @@ if( NOT LLVM_BUILD_TOOLS )
   set(EXCLUDE_FROM_ALL ON)
 endif()
 
-# If we don't need RTTI or EH, there's no reason to export anything
-# from this plugin.
-if( NOT LLVM_REQUIRES_RTTI )
-  if( NOT LLVM_REQUIRES_EH )
-    set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/bugpoint.exports)
-  endif()
-endif()
+# There's no reason to export anything from the plugin.
+set(LLVM_EXPORTED_SYMBOL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/bugpoint.exports)
 
 if(WIN32 OR CYGWIN OR ZOS)
   set(LLVM_LINK_COMPONENTS Core Support)

--- a/offload/unittests/Conformance/lib/CMakeLists.txt
+++ b/offload/unittests/Conformance/lib/CMakeLists.txt
@@ -3,9 +3,5 @@ add_library(MathTest STATIC
 
 target_include_directories(MathTest PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include")
 
-if(NOT LLVM_REQUIRES_RTTI)
-  target_compile_options(MathTest PUBLIC -fno-rtti)
-endif()
-
 include(FindLibcCommonUtils)
 target_link_libraries(MathTest PUBLIC LLVMOffload LLVMSupport LLVMDemangle llvm-libc-common-utilities)

--- a/offload/unittests/Conformance/lib/CMakeLists.txt
+++ b/offload/unittests/Conformance/lib/CMakeLists.txt
@@ -3,5 +3,9 @@ add_library(MathTest STATIC
 
 target_include_directories(MathTest PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include")
 
+if(NOT LLVM_ENABLE_RTTI)
+  target_compile_options(MathTest PUBLIC -fno-rtti)
+endif()
+
 include(FindLibcCommonUtils)
 target_link_libraries(MathTest PUBLIC LLVMOffload LLVMSupport LLVMDemangle llvm-libc-common-utilities)


### PR DESCRIPTION
LLVM_REQUIRES_* are per-target flags that are never set globally. Yet, some files used these (undefined) flags for some logic. This patch emoves these dead checks/unconditionally executes the logic. Note that the referenced *.exports files are empty, so there is no need to make related logic conditional on MSVC.