### PR TITLE
[CMake][NFC] Drop unnecessary GTest RTTI define

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -52,9 +52,6 @@ function(llvm_update_compile_flags name)
   # LLVM_REQUIRES_RTTI is an internal flag that individual
   # targets can use to force RTTI
   if(NOT (LLVM_REQUIRES_RTTI OR LLVM_ENABLE_RTTI))
-    # TODO: GTEST_HAS_RTTI should be determined automatically, evaluate whether
-    # the explicit definition is actually required.
-    list(APPEND LLVM_COMPILE_DEFINITIONS GTEST_HAS_RTTI=0)
     list(APPEND LLVM_COMPILE_CXXFLAGS ${LLVM_CXXFLAGS_RTTI_DISABLE})
   else()
     list(APPEND LLVM_COMPILE_CXXFLAGS ${LLVM_CXXFLAGS_RTTI_ENABLE})


### PR DESCRIPTION
gtest automatically determines GTEST_HAS_RTTI from pre-defined compiler macros, there is no need to explicitly define this and especially no need to define this for every single source file.