### PR TITLE
[PowerPC] Fix instruction sizes / branch relaxation

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -27,6 +27,7 @@
 #include "PPCTargetMachine.h"
 #include "TargetInfo/PowerPCTargetInfo.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringExtras.h"
@@ -923,6 +924,32 @@ void PPCAsmPrinter::emitInstruction(const MachineInstr *MI) {
       return PPC::S_AIX_TLSML;
     return PPC::S_None;
   };
+
+#ifndef NDEBUG
+  // Instruction sizes must be correct for PPCBranchSelector to pick the
+  // right branch kind. Verify that the reported sizes and the actually
+  // emitted sizes match.
+  unsigned ExpectedSize = Subtarget->getInstrInfo()->getInstSizeInBytes(*MI);
+  MCFragment *OldFragment = OutStreamer->getCurrentFragment();
+  size_t OldFragSize = OldFragment->getFixedSize();
+  scope_exit VerifyInstSize([&]() {
+    if (!OutStreamer->isObj())
+      return; // Can only verify size when streaming to object.
+    MCFragment *NewFragment = OutStreamer->getCurrentFragment();
+    if (NewFragment != OldFragment)
+      return; // Don't try to handle fragment splitting cases.
+    unsigned ActualSize = NewFragment->getFixedSize() - OldFragSize;
+    // For now, allow over-estimates here. Some pseudos expand to a variable
+    // number of instructions, and for correctness using the upper bound size
+    // is fine.
+    if (ActualSize > ExpectedSize) {
+      dbgs() << "Size mismatch for: " << *MI << "\n";
+      dbgs() << "Expected size: " << ExpectedSize << "\n";
+      dbgs() << "Actual size: " << ActualSize << "\n";
+      abort();
+    }
+  });
+#endif
 
   // Lower multi-instruction pseudo operations.
   switch (MI->getOpcode()) {

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -939,10 +939,9 @@ void PPCAsmPrinter::emitInstruction(const MachineInstr *MI) {
     if (NewFragment != OldFragment)
       return; // Don't try to handle fragment splitting cases.
     unsigned ActualSize = NewFragment->getFixedSize() - OldFragSize;
-    // For now, allow over-estimates here. Some pseudos expand to a variable
-    // number of instructions, and for correctness using the upper bound size
-    // is fine.
-    if (ActualSize > ExpectedSize) {
+    // FIXME: InstrInfo currently over-estimates the size of STACKMAP.
+    if (ActualSize != ExpectedSize &&
+        MI->getOpcode() != TargetOpcode::STACKMAP) {
       dbgs() << "Size mismatch for: " << *MI << "\n";
       dbgs() << "Expected size: " << ExpectedSize << "\n";
       dbgs() << "Actual size: " << ActualSize << "\n";

--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -1514,18 +1514,12 @@ class GETtlsADDRPseudo <string asmstr> : PPCEmitTimePseudo<(outs g8rc:$rD), (ins
                                              asmstr,
                                              [(set i64:$rD,
                                                (PPCgetTlsAddr i64:$reg, tglobaltlsaddr:$sym))]>,
-                                      isPPC64 {
-  // May be either 4 or 8 bytes, specify upper bound.
-  let Size = 8;
-}
+                                      isPPC64;
 class GETtlsldADDRPseudo <string asmstr> : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc:$reg, tlsgd:$sym),
                                              asmstr,
                                              [(set i64:$rD,
                                                (PPCgetTlsldAddr i64:$reg, tglobaltlsaddr:$sym))]>,
-                                      isPPC64 {
-  // May be either 4 or 8 bytes, specify upper bound.
-  let Size = 8;
-}
+                                      isPPC64;
 
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1 in {
 // LR8 is a true define, while the rest of the Defs are clobbers. X3 is

--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -1524,14 +1524,16 @@ class GETtlsldADDRPseudo <string asmstr> : PPCEmitTimePseudo<(outs g8rc:$rD), (i
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1 in {
 // LR8 is a true define, while the rest of the Defs are clobbers. X3 is
 // explicitly defined when this op is created, so not mentioned here.
-let Defs = [X0,X4,X5,X6,X7,X8,X9,X10,X11,X12,LR8,CTR8,CR0,CR1,CR5,CR6,CR7] in
+// This is lowered to BL8_NOP_TLS by the assembly printer, so the size must be
+// correct because the branch select pass is relying on it.
+let Defs = [X0,X4,X5,X6,X7,X8,X9,X10,X11,X12,LR8,CTR8,CR0,CR1,CR5,CR6,CR7], Size = 8 in
 def GETtlsADDR : GETtlsADDRPseudo <"#GETtlsADDR">;
 let Defs = [X0,X2,X4,X5,X6,X7,X8,X9,X10,X11,X12,LR8,CTR8,CR0,CR1,CR5,CR6,CR7] in
 def GETtlsADDRPCREL : GETtlsADDRPseudo <"#GETtlsADDRPCREL">;
 
 // LR8 is a true define, while the rest of the Defs are clobbers. X3 is
 // explicitly defined when this op is created, so not mentioned here.
-let Defs = [X0,X4,X5,X6,X7,X8,X9,X10,X11,X12,LR8,CTR8,CR0,CR1,CR5,CR6,CR7] in
+let Defs = [X0,X4,X5,X6,X7,X8,X9,X10,X11,X12,LR8,CTR8,CR0,CR1,CR5,CR6,CR7], Size = 8 in
 def GETtlsldADDR : GETtlsldADDRPseudo <"#GETtlsldADDR">;
 let Defs = [X0,X2,X4,X5,X6,X7,X8,X9,X10,X11,X12,LR8,CTR8,CR0,CR1,CR5,CR6,CR7] in
 def GETtlsldADDRPCREL : GETtlsldADDRPseudo <"#GETtlsldADDRPCREL">;

--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -1514,21 +1514,25 @@ class GETtlsADDRPseudo <string asmstr> : PPCEmitTimePseudo<(outs g8rc:$rD), (ins
                                              asmstr,
                                              [(set i64:$rD,
                                                (PPCgetTlsAddr i64:$reg, tglobaltlsaddr:$sym))]>,
-                                      isPPC64;
+                                      isPPC64 {
+  // May be either 4 or 8 bytes, specify upper bound.
+  let Size = 8;
+}
 class GETtlsldADDRPseudo <string asmstr> : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc:$reg, tlsgd:$sym),
                                              asmstr,
                                              [(set i64:$rD,
                                                (PPCgetTlsldAddr i64:$reg, tglobaltlsaddr:$sym))]>,
-                                      isPPC64;
+                                      isPPC64 {
+  // May be either 4 or 8 bytes, specify upper bound.
+  let Size = 8;
+}
 
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1 in {
 // LR8 is a true define, while the rest of the Defs are clobbers. X3 is
 // explicitly defined when this op is created, so not mentioned here.
-// This is lowered to BL8_NOP_TLS by the assembly printer, so the size must be
-// correct because the branch select pass is relying on it.
-let Defs = [X0,X4,X5,X6,X7,X8,X9,X10,X11,X12,LR8,CTR8,CR0,CR1,CR5,CR6,CR7], Size = 8 in
+let Defs = [X0,X4,X5,X6,X7,X8,X9,X10,X11,X12,LR8,CTR8,CR0,CR1,CR5,CR6,CR7] in
 def GETtlsADDR : GETtlsADDRPseudo <"#GETtlsADDR">;
-let Defs = [X0,X2,X4,X5,X6,X7,X8,X9,X10,X11,X12,LR8,CTR8,CR0,CR1,CR5,CR6,CR7], Size = 8 in
+let Defs = [X0,X2,X4,X5,X6,X7,X8,X9,X10,X11,X12,LR8,CTR8,CR0,CR1,CR5,CR6,CR7] in
 def GETtlsADDRPCREL : GETtlsADDRPseudo <"#GETtlsADDRPCREL">;
 
 // LR8 is a true define, while the rest of the Defs are clobbers. X3 is

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -3017,10 +3017,7 @@ unsigned PPCInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   }
   case TargetOpcode::PATCHPOINT: {
     PatchPointOpers Opers(&MI);
-    // The call sequence is up to 44 bytes large.
-    // TODO: Per LangRef the client must ensure that the number of bytes is
-    // large enough, but many tests use patchpoint with 40 bytes.
-    return std::max(Opers.getNumPatchBytes(), 44u);
+    return Opers.getNumPatchBytes();
   }
   case TargetOpcode::PATCHABLE_FUNCTION_ENTER: {
     const MachineFunction *MF = MI.getParent()->getParent();

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -3028,14 +3028,6 @@ unsigned PPCInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
         .getAsInteger(10, Num);
     return Num * 4;
   }
-  case PPC::GETtlsADDR:
-  case PPC::GETtlsADDRPCREL:
-  case PPC::GETtlsldADDR:
-  case PPC::GETtlsldADDRPCREL:
-    if (MI.getOperand(2).getTargetFlags() == PPCII::MO_GOT_TLSGD_PCREL_FLAG ||
-        MI.getOperand(2).getTargetFlags() == PPCII::MO_GOT_TLSLD_PCREL_FLAG)
-      return 4;
-    return 8;
   default:
     return get(Opcode).getSize();
   }

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -2528,7 +2528,9 @@ def EnforceIEIO : XForm_24_eieio<31, 854, (outs), (ins),
                                  "eieio", IIC_LdStLoad, []>;
 
 def PseudoEIEIO : PPCEmitTimePseudo<(outs), (ins), "#PPCEIEIO",
-                  [(int_ppc_eieio)]>;
+                  [(int_ppc_eieio)]> {
+  let Size = 12;
+}
 
 def : Pat<(int_ppc_sync),   (SYNC 0)>, Requires<[HasSYNC]>;
 def : Pat<(int_ppc_iospace_sync),   (SYNC 0)>, Requires<[HasSYNC]>;
@@ -3487,14 +3489,18 @@ def : Pat<(add i32:$in, (PPChi tblockaddress:$g, 0)),
 
 // Support for thread-local storage.
 def PPC32GOT: PPCEmitTimePseudo<(outs gprc:$rD), (ins), "#PPC32GOT",
-                [(set i32:$rD, (PPCppc32GOT))]>;
+                [(set i32:$rD, (PPCppc32GOT))]> {
+  let Size = 8;
+}
 
 // Get the _GLOBAL_OFFSET_TABLE_ in PIC mode.
 // This uses two output registers, the first as the real output, the second as a
 // temporary register, used internally in code generation. A "bl" also clobbers LR.
 let Defs = [LR] in
 def PPC32PICGOT: PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins), "#PPC32PICGOT",
-                []>;
+                []> {
+  let Size = 20;
+}
 
 def LDgotTprelL32: PPCEmitTimePseudo<(outs gprc_nor0:$rD), (ins s16imm:$disp, gprc_nor0:$reg),
                            "#LDgotTprelL32",
@@ -3620,7 +3626,9 @@ def ADDItocL : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, tocentry3
 
 // Get Global (GOT) Base Register offset, from the word immediately preceding
 // the function label.
-def UpdateGBR : PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins gprc:$rI), "#UpdateGBR", []>;
+def UpdateGBR : PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins gprc:$rI), "#UpdateGBR", []> {
+  let Size = 8;
+}
 
 // Pseudo-instruction marked for deletion. When deleting the instruction would
 // cause iterator invalidation in MIR transformation passes, this pseudo can be


### PR DESCRIPTION
For PowerPC, having accurate (or at least not too small) instruction sizes is critical, because the PPCBranchSelector pass relies on them. Underestimating the size of an instruction can result in the wrong branch kind being chosen, which will result in an MC error.

This patch introduces validation that the instruction size reported by TII matches the actually emitted instruction size, and fixes various cases where this was not the case.

Fixes https://github.com/llvm/llvm-project/issues/175190.