### PR TITLE
[Support][NFC] Move JSON::dump out-of-line

### DIFF
--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -477,10 +477,7 @@ public:
 
   LLVM_ABI void print(llvm::raw_ostream &OS) const;
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  LLVM_DUMP_METHOD void dump() const {
-    print(llvm::dbgs());
-    llvm::dbgs() << '\n';
-  }
+  LLVM_DUMP_METHOD void dump() const;
 #endif // !NDEBUG || LLVM_ENABLE_DUMP
 
 private:

--- a/llvm/lib/Support/JSON.cpp
+++ b/llvm/lib/Support/JSON.cpp
@@ -175,6 +175,13 @@ void Value::destroy() {
 
 void Value::print(llvm::raw_ostream &OS) const { OS << *this; }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void Value::dump() const {
+  print(llvm::dbgs());
+  llvm::dbgs() << '\n';
+}
+#endif
+
 bool operator==(const Value &L, const Value &R) {
   if (L.kind() != R.kind())
     return false;


### PR DESCRIPTION
Prevents redundant compilation into all objects that include the header.