### PR TITLE
[NFC][PowerPC] add  test cases for milicode

### DIFF
--- a/llvm/test/CodeGen/PowerPC/milicode32.ll
+++ b/llvm/test/CodeGen/PowerPC/milicode32.ll
@@ -140,7 +140,6 @@ entry:
   call void @llvm.memmove.p0.p0.i32(ptr align 1 %dst, ptr align 1 %src, i32 %n, i1 false)
   ret ptr %dst
 }
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memmove.p0.p0.i32(ptr writeonly captures(none), ptr readonly captures(none), i32, i1 immarg)
 
 define ptr @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {

--- a/llvm/test/CodeGen/PowerPC/milicode32.ll
+++ b/llvm/test/CodeGen/PowerPC/milicode32.ll
@@ -104,6 +104,45 @@ entry:
 declare i32 @strlen(ptr noundef) nounwind
 attributes #0 = { strictfp }
 
+; Function Attrs: noinline nounwind optnone
+define ptr @test_memmove(ptr noundef %dst, ptr noundef %src, i32 noundef %n) nounwind {
+; CHECK-AIX-32-P9-LABEL: test_memmove:
+; CHECK-AIX-32-P9:       # %bb.0: # %entry
+; CHECK-AIX-32-P9-NEXT:    mflr r0
+; CHECK-AIX-32-P9-NEXT:    stwu r1, -64(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r0, 72(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r31, 60(r1) # 4-byte Folded Spill
+; CHECK-AIX-32-P9-NEXT:    mr r31, r3
+; CHECK-AIX-32-P9-NEXT:    bl .___memmove[PR]
+; CHECK-AIX-32-P9-NEXT:    nop
+; CHECK-AIX-32-P9-NEXT:    mr r3, r31
+; CHECK-AIX-32-P9-NEXT:    lwz r31, 60(r1) # 4-byte Folded Reload
+; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 64
+; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)
+; CHECK-AIX-32-P9-NEXT:    mtlr r0
+; CHECK-AIX-32-P9-NEXT:    blr
+;
+; CHECK-LINUX32-P9-LABEL: test_memmove:
+; CHECK-LINUX32-P9:       # %bb.0: # %entry
+; CHECK-LINUX32-P9-NEXT:    mflr r0
+; CHECK-LINUX32-P9-NEXT:    stwu r1, -16(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r30, 8(r1) # 4-byte Folded Spill
+; CHECK-LINUX32-P9-NEXT:    mr r30, r3
+; CHECK-LINUX32-P9-NEXT:    bl memmove
+; CHECK-LINUX32-P9-NEXT:    mr r3, r30
+; CHECK-LINUX32-P9-NEXT:    lwz r30, 8(r1) # 4-byte Folded Reload
+; CHECK-LINUX32-P9-NEXT:    lwz r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 16
+; CHECK-LINUX32-P9-NEXT:    mtlr r0
+; CHECK-LINUX32-P9-NEXT:    blr
+entry:
+  call void @llvm.memmove.p0.p0.i32(ptr align 1 %dst, ptr align 1 %src, i32 %n, i1 false)
+  ret ptr %dst
+}
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memmove.p0.p0.i32(ptr writeonly captures(none), ptr readonly captures(none), i32, i1 immarg)
+
 define ptr @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
 ; CHECK-AIX-32-P9-LABEL: strcpy_test:
 ; CHECK-AIX-32-P9:       # %bb.0: # %entry
@@ -163,47 +202,7 @@ entry:
 }
 
 declare ptr @stpcpy(ptr noundef, ptr noundef)
-; Function Attrs: noinline nounwind optnone
-define ptr @test_memmove(ptr noundef %dst, ptr noundef %src, i32 noundef %n) nounwind {
-; CHECK-AIX-32-P9-LABEL: test_memmove:
-; CHECK-AIX-32-P9:       # %bb.0: # %entry
-; CHECK-AIX-32-P9-NEXT:    mflr r0
-; CHECK-AIX-32-P9-NEXT:    stwu r1, -64(r1)
-; CHECK-AIX-32-P9-NEXT:    stw r0, 72(r1)
-; CHECK-AIX-32-P9-NEXT:    stw r31, 60(r1) # 4-byte Folded Spill
-; CHECK-AIX-32-P9-NEXT:    mr r31, r3
-; CHECK-AIX-32-P9-NEXT:    bl .___memmove[PR]
-; CHECK-AIX-32-P9-NEXT:    nop
-; CHECK-AIX-32-P9-NEXT:    mr r3, r31
-; CHECK-AIX-32-P9-NEXT:    lwz r31, 60(r1) # 4-byte Folded Reload
-; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 64
-; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)
-; CHECK-AIX-32-P9-NEXT:    mtlr r0
-; CHECK-AIX-32-P9-NEXT:    blr
-;
-; CHECK-LINUX32-P9-LABEL: test_memmove:
-; CHECK-LINUX32-P9:       # %bb.0: # %entry
-; CHECK-LINUX32-P9-NEXT:    mflr r0
-; CHECK-LINUX32-P9-NEXT:    stwu r1, -16(r1)
-; CHECK-LINUX32-P9-NEXT:    stw r0, 20(r1)
-; CHECK-LINUX32-P9-NEXT:    stw r30, 8(r1) # 4-byte Folded Spill
-; CHECK-LINUX32-P9-NEXT:    mr r30, r3
-; CHECK-LINUX32-P9-NEXT:    bl memmove
-; CHECK-LINUX32-P9-NEXT:    mr r3, r30
-; CHECK-LINUX32-P9-NEXT:    lwz r30, 8(r1) # 4-byte Folded Reload
-; CHECK-LINUX32-P9-NEXT:    lwz r0, 20(r1)
-; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 16
-; CHECK-LINUX32-P9-NEXT:    mtlr r0
-; CHECK-LINUX32-P9-NEXT:    blr
-entry:
-  call void @llvm.memmove.p0.p0.i32(ptr align 1 %dst, ptr align 1 %src, i32 %n, i1 false)
-  ret ptr %dst
-}
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.memmove.p0.p0.i32(ptr writeonly captures(none), ptr readonly captures(none), i32, i1 immarg)
-
-; Function Attrs: noinline nounwind optnone
 define ptr @test_memcpy(ptr noundef %dst, ptr noundef %src, i32 noundef %n) nounwind {
 ; CHECK-AIX-32-P9-LABEL: test_memcpy:
 ; CHECK-AIX-32-P9:       # %bb.0:
@@ -239,10 +238,8 @@ define ptr @test_memcpy(ptr noundef %dst, ptr noundef %src, i32 noundef %n) noun
   ret ptr %dst
 }
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memcpy.p0.p0.i32(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i32, i1 immarg)
 
-; Function Attrs: noinline nounwind optnone
 define ptr @test_memset(ptr noundef %dst, i32 noundef signext %value, i32 noundef %num) nounwind {
 ; CHECK-AIX-32-P9-LABEL: test_memset:
 ; CHECK-AIX-32-P9:       # %bb.0: # %entry
@@ -280,7 +277,6 @@ entry:
   ret ptr %dst
 }
 
-; Function Attrs: noinline nounwind optnone
 define ptr @test_strstr(ptr noundef %s1, ptr noundef %s2) nounwind {
 ; CHECK-AIX-32-P9-LABEL: test_strstr:
 ; CHECK-AIX-32-P9:       # %bb.0: # %entry
@@ -309,10 +305,8 @@ entry:
   ret ptr %call
 }
 
-; Function Attrs: nounwind
-declare ptr @strstr(ptr noundef, ptr noundef) #3
+declare ptr @strstr(ptr noundef, ptr noundef)
 
-; Function Attrs: noinline nounwind optnone
 define ptr @test_memccpy(ptr noalias noundef %dst, ptr noalias noundef %src, i32 noundef signext %c, i32 noundef %n) nounwind {
 ; CHECK-AIX-32-P9-LABEL: test_memccpy:
 ; CHECK-AIX-32-P9:       # %bb.0: # %entry
@@ -343,7 +337,6 @@ entry:
 
 declare ptr @memccpy(ptr noundef, ptr noundef, i32 noundef signext, i32 noundef)
 
-; Function Attrs: noinline nounwind optnone
 define signext i32 @test_strcmp(ptr noundef %s1, ptr noundef %s2) nounwind {
 ; CHECK-AIX-32-P9-LABEL: test_strcmp:
 ; CHECK-AIX-32-P9:       # %bb.0: # %entry
@@ -372,5 +365,4 @@ entry:
   ret i32 %call
 }
 
-; Function Attrs: nounwind
 declare signext i32 @strcmp(ptr noundef, ptr noundef)

--- a/llvm/test/CodeGen/PowerPC/milicode32.ll
+++ b/llvm/test/CodeGen/PowerPC/milicode32.ll
@@ -104,62 +104,6 @@ entry:
 declare i32 @strlen(ptr noundef) nounwind
 attributes #0 = { strictfp }
 
-define ptr @test_memmove(ptr noundef %destination, ptr noundef %source, i32 noundef %num) #0 {
-; CHECK-AIX-32-P9-LABEL: test_memmove:
-; CHECK-AIX-32-P9:       # %bb.0: # %entry
-; CHECK-AIX-32-P9-NEXT:    mflr r0
-; CHECK-AIX-32-P9-NEXT:    stwu r1, -80(r1)
-; CHECK-AIX-32-P9-NEXT:    stw r0, 88(r1)
-; CHECK-AIX-32-P9-NEXT:    stw r31, 76(r1) # 4-byte Folded Spill
-; CHECK-AIX-32-P9-NEXT:    mr r31, r3
-; CHECK-AIX-32-P9-NEXT:    stw r3, 72(r1)
-; CHECK-AIX-32-P9-NEXT:    stw r4, 68(r1)
-; CHECK-AIX-32-P9-NEXT:    stw r5, 64(r1)
-; CHECK-AIX-32-P9-NEXT:    bl .___memmove[PR]
-; CHECK-AIX-32-P9-NEXT:    nop
-; CHECK-AIX-32-P9-NEXT:    mr r3, r31
-; CHECK-AIX-32-P9-NEXT:    lwz r31, 76(r1) # 4-byte Folded Reload
-; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 80
-; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)
-; CHECK-AIX-32-P9-NEXT:    mtlr r0
-; CHECK-AIX-32-P9-NEXT:    blr
-;
-; CHECK-LINUX32-P9-LABEL: test_memmove:
-; CHECK-LINUX32-P9:       # %bb.0: # %entry
-; CHECK-LINUX32-P9-NEXT:    mflr r0
-; CHECK-LINUX32-P9-NEXT:    stwu r1, -32(r1)
-; CHECK-LINUX32-P9-NEXT:    stw r0, 36(r1)
-; CHECK-LINUX32-P9-NEXT:    .cfi_def_cfa_offset 32
-; CHECK-LINUX32-P9-NEXT:    .cfi_offset lr, 4
-; CHECK-LINUX32-P9-NEXT:    .cfi_offset r30, -8
-; CHECK-LINUX32-P9-NEXT:    stw r30, 24(r1) # 4-byte Folded Spill
-; CHECK-LINUX32-P9-NEXT:    mr r30, r3
-; CHECK-LINUX32-P9-NEXT:    stw r3, 20(r1)
-; CHECK-LINUX32-P9-NEXT:    stw r4, 16(r1)
-; CHECK-LINUX32-P9-NEXT:    stw r5, 12(r1)
-; CHECK-LINUX32-P9-NEXT:    bl memmove
-; CHECK-LINUX32-P9-NEXT:    mr r3, r30
-; CHECK-LINUX32-P9-NEXT:    lwz r30, 24(r1) # 4-byte Folded Reload
-; CHECK-LINUX32-P9-NEXT:    lwz r0, 36(r1)
-; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 32
-; CHECK-LINUX32-P9-NEXT:    mtlr r0
-; CHECK-LINUX32-P9-NEXT:    blr
-entry:
-  %destination.addr = alloca ptr, align 4
-  %source.addr = alloca ptr, align 4
-  %num.addr = alloca i32, align 4
-  store ptr %destination, ptr %destination.addr, align 4
-  store ptr %source, ptr %source.addr, align 4
-  store i32 %num, ptr %num.addr, align 4
-  %0 = load ptr, ptr %destination.addr, align 4
-  %1 = load ptr, ptr %source.addr, align 4
-  %2 = load i32, ptr %num.addr, align 4
-  call void @llvm.memmove.p0.p0.i32(ptr align 1 %0, ptr align 1 %1, i32 %2, i1 false)
-  ret ptr %0
-}
-
-declare void @llvm.memmove.p0.p0.i32(ptr writeonly captures(none), ptr readonly captures(none), i32, i1 immarg)
-
 define ptr @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
 ; CHECK-AIX-32-P9-LABEL: strcpy_test:
 ; CHECK-AIX-32-P9:       # %bb.0: # %entry
@@ -219,3 +163,214 @@ entry:
 }
 
 declare ptr @stpcpy(ptr noundef, ptr noundef)
+; Function Attrs: noinline nounwind optnone
+define ptr @test_memmove(ptr noundef %dst, ptr noundef %src, i32 noundef %n) nounwind {
+; CHECK-AIX-32-P9-LABEL: test_memmove:
+; CHECK-AIX-32-P9:       # %bb.0: # %entry
+; CHECK-AIX-32-P9-NEXT:    mflr r0
+; CHECK-AIX-32-P9-NEXT:    stwu r1, -64(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r0, 72(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r31, 60(r1) # 4-byte Folded Spill
+; CHECK-AIX-32-P9-NEXT:    mr r31, r3
+; CHECK-AIX-32-P9-NEXT:    bl .___memmove[PR]
+; CHECK-AIX-32-P9-NEXT:    nop
+; CHECK-AIX-32-P9-NEXT:    mr r3, r31
+; CHECK-AIX-32-P9-NEXT:    lwz r31, 60(r1) # 4-byte Folded Reload
+; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 64
+; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)
+; CHECK-AIX-32-P9-NEXT:    mtlr r0
+; CHECK-AIX-32-P9-NEXT:    blr
+;
+; CHECK-LINUX32-P9-LABEL: test_memmove:
+; CHECK-LINUX32-P9:       # %bb.0: # %entry
+; CHECK-LINUX32-P9-NEXT:    mflr r0
+; CHECK-LINUX32-P9-NEXT:    stwu r1, -16(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r30, 8(r1) # 4-byte Folded Spill
+; CHECK-LINUX32-P9-NEXT:    mr r30, r3
+; CHECK-LINUX32-P9-NEXT:    bl memmove
+; CHECK-LINUX32-P9-NEXT:    mr r3, r30
+; CHECK-LINUX32-P9-NEXT:    lwz r30, 8(r1) # 4-byte Folded Reload
+; CHECK-LINUX32-P9-NEXT:    lwz r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 16
+; CHECK-LINUX32-P9-NEXT:    mtlr r0
+; CHECK-LINUX32-P9-NEXT:    blr
+entry:
+  call void @llvm.memmove.p0.p0.i32(ptr align 1 %dst, ptr align 1 %src, i32 %n, i1 false)
+  ret ptr %dst
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memmove.p0.p0.i32(ptr writeonly captures(none), ptr readonly captures(none), i32, i1 immarg)
+
+; Function Attrs: noinline nounwind optnone
+define ptr @test_memcpy(ptr noundef %dst, ptr noundef %src, i32 noundef %n) nounwind {
+; CHECK-AIX-32-P9-LABEL: test_memcpy:
+; CHECK-AIX-32-P9:       # %bb.0:
+; CHECK-AIX-32-P9-NEXT:    mflr r0
+; CHECK-AIX-32-P9-NEXT:    stwu r1, -64(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r0, 72(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r31, 60(r1) # 4-byte Folded Spill
+; CHECK-AIX-32-P9-NEXT:    mr r31, r3
+; CHECK-AIX-32-P9-NEXT:    bl .___memmove[PR]
+; CHECK-AIX-32-P9-NEXT:    nop
+; CHECK-AIX-32-P9-NEXT:    mr r3, r31
+; CHECK-AIX-32-P9-NEXT:    lwz r31, 60(r1) # 4-byte Folded Reload
+; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 64
+; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)
+; CHECK-AIX-32-P9-NEXT:    mtlr r0
+; CHECK-AIX-32-P9-NEXT:    blr
+;
+; CHECK-LINUX32-P9-LABEL: test_memcpy:
+; CHECK-LINUX32-P9:       # %bb.0:
+; CHECK-LINUX32-P9-NEXT:    mflr r0
+; CHECK-LINUX32-P9-NEXT:    stwu r1, -16(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r30, 8(r1) # 4-byte Folded Spill
+; CHECK-LINUX32-P9-NEXT:    mr r30, r3
+; CHECK-LINUX32-P9-NEXT:    bl memcpy
+; CHECK-LINUX32-P9-NEXT:    mr r3, r30
+; CHECK-LINUX32-P9-NEXT:    lwz r30, 8(r1) # 4-byte Folded Reload
+; CHECK-LINUX32-P9-NEXT:    lwz r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 16
+; CHECK-LINUX32-P9-NEXT:    mtlr r0
+; CHECK-LINUX32-P9-NEXT:    blr
+  call void @llvm.memcpy.p0.p0.i32(ptr align 1 %dst, ptr align 1 %src, i32 %n, i1 false)
+  ret ptr %dst
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i32(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i32, i1 immarg)
+
+; Function Attrs: noinline nounwind optnone
+define ptr @test_memset(ptr noundef %dst, i32 noundef signext %value, i32 noundef %num) nounwind {
+; CHECK-AIX-32-P9-LABEL: test_memset:
+; CHECK-AIX-32-P9:       # %bb.0: # %entry
+; CHECK-AIX-32-P9-NEXT:    mflr r0
+; CHECK-AIX-32-P9-NEXT:    stwu r1, -64(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r0, 72(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r31, 60(r1) # 4-byte Folded Spill
+; CHECK-AIX-32-P9-NEXT:    mr r31, r3
+; CHECK-AIX-32-P9-NEXT:    bl .___memset[PR]
+; CHECK-AIX-32-P9-NEXT:    nop
+; CHECK-AIX-32-P9-NEXT:    mr r3, r31
+; CHECK-AIX-32-P9-NEXT:    lwz r31, 60(r1) # 4-byte Folded Reload
+; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 64
+; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)
+; CHECK-AIX-32-P9-NEXT:    mtlr r0
+; CHECK-AIX-32-P9-NEXT:    blr
+;
+; CHECK-LINUX32-P9-LABEL: test_memset:
+; CHECK-LINUX32-P9:       # %bb.0: # %entry
+; CHECK-LINUX32-P9-NEXT:    mflr r0
+; CHECK-LINUX32-P9-NEXT:    stwu r1, -16(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r30, 8(r1) # 4-byte Folded Spill
+; CHECK-LINUX32-P9-NEXT:    mr r30, r3
+; CHECK-LINUX32-P9-NEXT:    bl memset
+; CHECK-LINUX32-P9-NEXT:    mr r3, r30
+; CHECK-LINUX32-P9-NEXT:    lwz r30, 8(r1) # 4-byte Folded Reload
+; CHECK-LINUX32-P9-NEXT:    lwz r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 16
+; CHECK-LINUX32-P9-NEXT:    mtlr r0
+; CHECK-LINUX32-P9-NEXT:    blr
+entry:
+  %0 = trunc i32 %value to i8
+  call void @llvm.memset.p0.i32(ptr align 1 %dst, i8 %0, i32 %num, i1 false)
+  ret ptr %dst
+}
+
+; Function Attrs: noinline nounwind optnone
+define ptr @test_strstr(ptr noundef %s1, ptr noundef %s2) nounwind {
+; CHECK-AIX-32-P9-LABEL: test_strstr:
+; CHECK-AIX-32-P9:       # %bb.0: # %entry
+; CHECK-AIX-32-P9-NEXT:    mflr r0
+; CHECK-AIX-32-P9-NEXT:    stwu r1, -64(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r0, 72(r1)
+; CHECK-AIX-32-P9-NEXT:    bl .strstr[PR]
+; CHECK-AIX-32-P9-NEXT:    nop
+; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 64
+; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)
+; CHECK-AIX-32-P9-NEXT:    mtlr r0
+; CHECK-AIX-32-P9-NEXT:    blr
+;
+; CHECK-LINUX32-P9-LABEL: test_strstr:
+; CHECK-LINUX32-P9:       # %bb.0: # %entry
+; CHECK-LINUX32-P9-NEXT:    mflr r0
+; CHECK-LINUX32-P9-NEXT:    stwu r1, -16(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    bl strstr
+; CHECK-LINUX32-P9-NEXT:    lwz r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 16
+; CHECK-LINUX32-P9-NEXT:    mtlr r0
+; CHECK-LINUX32-P9-NEXT:    blr
+entry:
+  %call = call ptr @strstr(ptr noundef %s1, ptr noundef %s2)
+  ret ptr %call
+}
+
+; Function Attrs: nounwind
+declare ptr @strstr(ptr noundef, ptr noundef) #3
+
+; Function Attrs: noinline nounwind optnone
+define ptr @test_memccpy(ptr noalias noundef %dst, ptr noalias noundef %src, i32 noundef signext %c, i32 noundef %n) nounwind {
+; CHECK-AIX-32-P9-LABEL: test_memccpy:
+; CHECK-AIX-32-P9:       # %bb.0: # %entry
+; CHECK-AIX-32-P9-NEXT:    mflr r0
+; CHECK-AIX-32-P9-NEXT:    stwu r1, -64(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r0, 72(r1)
+; CHECK-AIX-32-P9-NEXT:    bl .memccpy[PR]
+; CHECK-AIX-32-P9-NEXT:    nop
+; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 64
+; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)
+; CHECK-AIX-32-P9-NEXT:    mtlr r0
+; CHECK-AIX-32-P9-NEXT:    blr
+;
+; CHECK-LINUX32-P9-LABEL: test_memccpy:
+; CHECK-LINUX32-P9:       # %bb.0: # %entry
+; CHECK-LINUX32-P9-NEXT:    mflr r0
+; CHECK-LINUX32-P9-NEXT:    stwu r1, -16(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    bl memccpy
+; CHECK-LINUX32-P9-NEXT:    lwz r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 16
+; CHECK-LINUX32-P9-NEXT:    mtlr r0
+; CHECK-LINUX32-P9-NEXT:    blr
+entry:
+  %call = call ptr @memccpy(ptr noundef %dst, ptr noundef %src, i32 noundef signext %c, i32 noundef %n)
+  ret ptr %call
+}
+
+declare ptr @memccpy(ptr noundef, ptr noundef, i32 noundef signext, i32 noundef)
+
+; Function Attrs: noinline nounwind optnone
+define signext i32 @test_strcmp(ptr noundef %s1, ptr noundef %s2) nounwind {
+; CHECK-AIX-32-P9-LABEL: test_strcmp:
+; CHECK-AIX-32-P9:       # %bb.0: # %entry
+; CHECK-AIX-32-P9-NEXT:    mflr r0
+; CHECK-AIX-32-P9-NEXT:    stwu r1, -64(r1)
+; CHECK-AIX-32-P9-NEXT:    stw r0, 72(r1)
+; CHECK-AIX-32-P9-NEXT:    bl .strcmp[PR]
+; CHECK-AIX-32-P9-NEXT:    nop
+; CHECK-AIX-32-P9-NEXT:    addi r1, r1, 64
+; CHECK-AIX-32-P9-NEXT:    lwz r0, 8(r1)
+; CHECK-AIX-32-P9-NEXT:    mtlr r0
+; CHECK-AIX-32-P9-NEXT:    blr
+;
+; CHECK-LINUX32-P9-LABEL: test_strcmp:
+; CHECK-LINUX32-P9:       # %bb.0: # %entry
+; CHECK-LINUX32-P9-NEXT:    mflr r0
+; CHECK-LINUX32-P9-NEXT:    stwu r1, -16(r1)
+; CHECK-LINUX32-P9-NEXT:    stw r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    bl strcmp
+; CHECK-LINUX32-P9-NEXT:    lwz r0, 20(r1)
+; CHECK-LINUX32-P9-NEXT:    addi r1, r1, 16
+; CHECK-LINUX32-P9-NEXT:    mtlr r0
+; CHECK-LINUX32-P9-NEXT:    blr
+entry:
+  %call = call signext i32 @strcmp(ptr noundef %s1, ptr noundef %s2)
+  ret i32 %call
+}
+
+; Function Attrs: nounwind
+declare signext i32 @strcmp(ptr noundef, ptr noundef)

--- a/llvm/test/CodeGen/PowerPC/milicode64.ll
+++ b/llvm/test/CodeGen/PowerPC/milicode64.ll
@@ -101,85 +101,6 @@ entry:
 
 declare i64 @strlen(ptr noundef) nounwind
 
-define ptr @test_memmove(ptr noundef %destination, ptr noundef %source, i64 noundef %num) #0 {
-; CHECK-LE-P9-LABEL: test_memmove:
-; CHECK-LE-P9:       # %bb.0: # %entry
-; CHECK-LE-P9-NEXT:    mflr r0
-; CHECK-LE-P9-NEXT:    .cfi_def_cfa_offset 80
-; CHECK-LE-P9-NEXT:    .cfi_offset lr, 16
-; CHECK-LE-P9-NEXT:    .cfi_offset r30, -16
-; CHECK-LE-P9-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
-; CHECK-LE-P9-NEXT:    stdu r1, -80(r1)
-; CHECK-LE-P9-NEXT:    std r0, 96(r1)
-; CHECK-LE-P9-NEXT:    mr r30, r3
-; CHECK-LE-P9-NEXT:    std r3, 56(r1)
-; CHECK-LE-P9-NEXT:    std r4, 48(r1)
-; CHECK-LE-P9-NEXT:    std r5, 40(r1)
-; CHECK-LE-P9-NEXT:    bl memmove
-; CHECK-LE-P9-NEXT:    nop
-; CHECK-LE-P9-NEXT:    mr r3, r30
-; CHECK-LE-P9-NEXT:    addi r1, r1, 80
-; CHECK-LE-P9-NEXT:    ld r0, 16(r1)
-; CHECK-LE-P9-NEXT:    ld r30, -16(r1) # 8-byte Folded Reload
-; CHECK-LE-P9-NEXT:    mtlr r0
-; CHECK-LE-P9-NEXT:    blr
-;
-; CHECK-BE-P9-LABEL: test_memmove:
-; CHECK-BE-P9:       # %bb.0: # %entry
-; CHECK-BE-P9-NEXT:    mflr r0
-; CHECK-BE-P9-NEXT:    stdu r1, -160(r1)
-; CHECK-BE-P9-NEXT:    std r0, 176(r1)
-; CHECK-BE-P9-NEXT:    .cfi_def_cfa_offset 160
-; CHECK-BE-P9-NEXT:    .cfi_offset lr, 16
-; CHECK-BE-P9-NEXT:    .cfi_offset r30, -16
-; CHECK-BE-P9-NEXT:    std r30, 144(r1) # 8-byte Folded Spill
-; CHECK-BE-P9-NEXT:    mr r30, r3
-; CHECK-BE-P9-NEXT:    std r3, 136(r1)
-; CHECK-BE-P9-NEXT:    std r4, 128(r1)
-; CHECK-BE-P9-NEXT:    std r5, 120(r1)
-; CHECK-BE-P9-NEXT:    bl memmove
-; CHECK-BE-P9-NEXT:    nop
-; CHECK-BE-P9-NEXT:    mr r3, r30
-; CHECK-BE-P9-NEXT:    ld r30, 144(r1) # 8-byte Folded Reload
-; CHECK-BE-P9-NEXT:    addi r1, r1, 160
-; CHECK-BE-P9-NEXT:    ld r0, 16(r1)
-; CHECK-BE-P9-NEXT:    mtlr r0
-; CHECK-BE-P9-NEXT:    blr
-;
-; CHECK-AIX-64-P9-LABEL: test_memmove:
-; CHECK-AIX-64-P9:       # %bb.0: # %entry
-; CHECK-AIX-64-P9-NEXT:    mflr r0
-; CHECK-AIX-64-P9-NEXT:    stdu r1, -144(r1)
-; CHECK-AIX-64-P9-NEXT:    std r0, 160(r1)
-; CHECK-AIX-64-P9-NEXT:    std r31, 136(r1) # 8-byte Folded Spill
-; CHECK-AIX-64-P9-NEXT:    mr r31, r3
-; CHECK-AIX-64-P9-NEXT:    std r3, 128(r1)
-; CHECK-AIX-64-P9-NEXT:    std r4, 120(r1)
-; CHECK-AIX-64-P9-NEXT:    std r5, 112(r1)
-; CHECK-AIX-64-P9-NEXT:    bl .___memmove64[PR]
-; CHECK-AIX-64-P9-NEXT:    nop
-; CHECK-AIX-64-P9-NEXT:    mr r3, r31
-; CHECK-AIX-64-P9-NEXT:    ld r31, 136(r1) # 8-byte Folded Reload
-; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 144
-; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)
-; CHECK-AIX-64-P9-NEXT:    mtlr r0
-; CHECK-AIX-64-P9-NEXT:    blr
-entry:
-  %destination.addr = alloca ptr, align 8
-  %source.addr = alloca ptr, align 8
-  %num.addr = alloca i64, align 8
-  store ptr %destination, ptr %destination.addr, align 8
-  store ptr %source, ptr %source.addr, align 8
-  store i64 %num, ptr %num.addr, align 8
-  %0 = load ptr, ptr %destination.addr, align 8
-  %1 = load ptr, ptr %source.addr, align 8
-  %2 = load i64, ptr %num.addr, align 8
-  call void @llvm.memmove.p0.p0.i64(ptr align 1 %0, ptr align 1 %1, i64 %2, i1 false)
-  ret ptr %0
-}
-
-declare void @llvm.memmove.p0.p0.i32(ptr writeonly captures(none), ptr readonly captures(none), i32, i1 immarg)
-
 define dso_local ptr @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
 ; CHECK-LE-P9-LABEL: strcpy_test:
 ; CHECK-LE-P9:       # %bb.0: # %entry
@@ -264,5 +185,308 @@ entry:
   ret ptr %call
 }
 
-
 declare ptr @stpcpy(ptr noundef, ptr noundef)
+
+; Function Attrs: noinline nounwind optnone
+define ptr @test_memcpy(ptr noundef %dst, ptr noundef %src, i64 noundef %n) nounwind {
+; CHECK-LE-P9-LABEL: test_memcpy:
+; CHECK-LE-P9:       # %bb.0:
+; CHECK-LE-P9-NEXT:    mflr r0
+; CHECK-LE-P9-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
+; CHECK-LE-P9-NEXT:    stdu r1, -48(r1)
+; CHECK-LE-P9-NEXT:    std r0, 64(r1)
+; CHECK-LE-P9-NEXT:    mr r30, r3
+; CHECK-LE-P9-NEXT:    bl memcpy
+; CHECK-LE-P9-NEXT:    nop
+; CHECK-LE-P9-NEXT:    mr r3, r30
+; CHECK-LE-P9-NEXT:    addi r1, r1, 48
+; CHECK-LE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-LE-P9-NEXT:    ld r30, -16(r1) # 8-byte Folded Reload
+; CHECK-LE-P9-NEXT:    mtlr r0
+; CHECK-LE-P9-NEXT:    blr
+;
+; CHECK-BE-P9-LABEL: test_memcpy:
+; CHECK-BE-P9:       # %bb.0:
+; CHECK-BE-P9-NEXT:    mflr r0
+; CHECK-BE-P9-NEXT:    stdu r1, -128(r1)
+; CHECK-BE-P9-NEXT:    std r0, 144(r1)
+; CHECK-BE-P9-NEXT:    std r30, 112(r1) # 8-byte Folded Spill
+; CHECK-BE-P9-NEXT:    mr r30, r3
+; CHECK-BE-P9-NEXT:    bl memcpy
+; CHECK-BE-P9-NEXT:    nop
+; CHECK-BE-P9-NEXT:    mr r3, r30
+; CHECK-BE-P9-NEXT:    ld r30, 112(r1) # 8-byte Folded Reload
+; CHECK-BE-P9-NEXT:    addi r1, r1, 128
+; CHECK-BE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-BE-P9-NEXT:    mtlr r0
+; CHECK-BE-P9-NEXT:    blr
+;
+; CHECK-AIX-64-P9-LABEL: test_memcpy:
+; CHECK-AIX-64-P9:       # %bb.0:
+; CHECK-AIX-64-P9-NEXT:    mflr r0
+; CHECK-AIX-64-P9-NEXT:    stdu r1, -128(r1)
+; CHECK-AIX-64-P9-NEXT:    std r0, 144(r1)
+; CHECK-AIX-64-P9-NEXT:    std r31, 120(r1) # 8-byte Folded Spill
+; CHECK-AIX-64-P9-NEXT:    mr r31, r3
+; CHECK-AIX-64-P9-NEXT:    bl .___memmove64[PR]
+; CHECK-AIX-64-P9-NEXT:    nop
+; CHECK-AIX-64-P9-NEXT:    mr r3, r31
+; CHECK-AIX-64-P9-NEXT:    ld r31, 120(r1) # 8-byte Folded Reload
+; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 128
+; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)
+; CHECK-AIX-64-P9-NEXT:    mtlr r0
+; CHECK-AIX-64-P9-NEXT:    blr
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 %n, i1 false)
+  ret ptr %dst
+}
+
+define ptr @test_memmove(ptr noundef %dst, ptr noundef %src, i64 noundef %n) nounwind {
+; CHECK-LE-P9-LABEL: test_memmove:
+; CHECK-LE-P9:       # %bb.0: # %entry
+; CHECK-LE-P9-NEXT:    mflr r0
+; CHECK-LE-P9-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
+; CHECK-LE-P9-NEXT:    stdu r1, -48(r1)
+; CHECK-LE-P9-NEXT:    std r0, 64(r1)
+; CHECK-LE-P9-NEXT:    mr r30, r3
+; CHECK-LE-P9-NEXT:    bl memmove
+; CHECK-LE-P9-NEXT:    nop
+; CHECK-LE-P9-NEXT:    mr r3, r30
+; CHECK-LE-P9-NEXT:    addi r1, r1, 48
+; CHECK-LE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-LE-P9-NEXT:    ld r30, -16(r1) # 8-byte Folded Reload
+; CHECK-LE-P9-NEXT:    mtlr r0
+; CHECK-LE-P9-NEXT:    blr
+;
+; CHECK-BE-P9-LABEL: test_memmove:
+; CHECK-BE-P9:       # %bb.0: # %entry
+; CHECK-BE-P9-NEXT:    mflr r0
+; CHECK-BE-P9-NEXT:    stdu r1, -128(r1)
+; CHECK-BE-P9-NEXT:    std r0, 144(r1)
+; CHECK-BE-P9-NEXT:    std r30, 112(r1) # 8-byte Folded Spill
+; CHECK-BE-P9-NEXT:    mr r30, r3
+; CHECK-BE-P9-NEXT:    bl memmove
+; CHECK-BE-P9-NEXT:    nop
+; CHECK-BE-P9-NEXT:    mr r3, r30
+; CHECK-BE-P9-NEXT:    ld r30, 112(r1) # 8-byte Folded Reload
+; CHECK-BE-P9-NEXT:    addi r1, r1, 128
+; CHECK-BE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-BE-P9-NEXT:    mtlr r0
+; CHECK-BE-P9-NEXT:    blr
+;
+; CHECK-AIX-64-P9-LABEL: test_memmove:
+; CHECK-AIX-64-P9:       # %bb.0: # %entry
+; CHECK-AIX-64-P9-NEXT:    mflr r0
+; CHECK-AIX-64-P9-NEXT:    stdu r1, -128(r1)
+; CHECK-AIX-64-P9-NEXT:    std r0, 144(r1)
+; CHECK-AIX-64-P9-NEXT:    std r31, 120(r1) # 8-byte Folded Spill
+; CHECK-AIX-64-P9-NEXT:    mr r31, r3
+; CHECK-AIX-64-P9-NEXT:    bl .___memmove64[PR]
+; CHECK-AIX-64-P9-NEXT:    nop
+; CHECK-AIX-64-P9-NEXT:    mr r3, r31
+; CHECK-AIX-64-P9-NEXT:    ld r31, 120(r1) # 8-byte Folded Reload
+; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 128
+; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)
+; CHECK-AIX-64-P9-NEXT:    mtlr r0
+; CHECK-AIX-64-P9-NEXT:    blr
+entry:
+  call void @llvm.memmove.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 %n, i1 false)
+  ret ptr %dst
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memmove.p0.p0.i64(ptr writeonly captures(none), ptr readonly captures(none), i64, i1 immarg)
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg)
+
+; Function Attrs: noinline nounwind optnone
+define ptr @test_memset(ptr noundef %dst, i32 noundef signext %value, i64 noundef %num) nounwind {
+; CHECK-LE-P9-LABEL: test_memset:
+; CHECK-LE-P9:       # %bb.0: # %entry
+; CHECK-LE-P9-NEXT:    mflr r0
+; CHECK-LE-P9-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
+; CHECK-LE-P9-NEXT:    stdu r1, -48(r1)
+; CHECK-LE-P9-NEXT:    clrldi r4, r4, 56
+; CHECK-LE-P9-NEXT:    std r0, 64(r1)
+; CHECK-LE-P9-NEXT:    mr r30, r3
+; CHECK-LE-P9-NEXT:    bl memset
+; CHECK-LE-P9-NEXT:    nop
+; CHECK-LE-P9-NEXT:    mr r3, r30
+; CHECK-LE-P9-NEXT:    addi r1, r1, 48
+; CHECK-LE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-LE-P9-NEXT:    ld r30, -16(r1) # 8-byte Folded Reload
+; CHECK-LE-P9-NEXT:    mtlr r0
+; CHECK-LE-P9-NEXT:    blr
+;
+; CHECK-BE-P9-LABEL: test_memset:
+; CHECK-BE-P9:       # %bb.0: # %entry
+; CHECK-BE-P9-NEXT:    mflr r0
+; CHECK-BE-P9-NEXT:    stdu r1, -128(r1)
+; CHECK-BE-P9-NEXT:    clrldi r4, r4, 56
+; CHECK-BE-P9-NEXT:    std r0, 144(r1)
+; CHECK-BE-P9-NEXT:    std r30, 112(r1) # 8-byte Folded Spill
+; CHECK-BE-P9-NEXT:    mr r30, r3
+; CHECK-BE-P9-NEXT:    bl memset
+; CHECK-BE-P9-NEXT:    nop
+; CHECK-BE-P9-NEXT:    mr r3, r30
+; CHECK-BE-P9-NEXT:    ld r30, 112(r1) # 8-byte Folded Reload
+; CHECK-BE-P9-NEXT:    addi r1, r1, 128
+; CHECK-BE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-BE-P9-NEXT:    mtlr r0
+; CHECK-BE-P9-NEXT:    blr
+;
+; CHECK-AIX-64-P9-LABEL: test_memset:
+; CHECK-AIX-64-P9:       # %bb.0: # %entry
+; CHECK-AIX-64-P9-NEXT:    mflr r0
+; CHECK-AIX-64-P9-NEXT:    stdu r1, -128(r1)
+; CHECK-AIX-64-P9-NEXT:    clrldi r4, r4, 56
+; CHECK-AIX-64-P9-NEXT:    std r0, 144(r1)
+; CHECK-AIX-64-P9-NEXT:    std r31, 120(r1) # 8-byte Folded Spill
+; CHECK-AIX-64-P9-NEXT:    mr r31, r3
+; CHECK-AIX-64-P9-NEXT:    bl .___memset64[PR]
+; CHECK-AIX-64-P9-NEXT:    nop
+; CHECK-AIX-64-P9-NEXT:    mr r3, r31
+; CHECK-AIX-64-P9-NEXT:    ld r31, 120(r1) # 8-byte Folded Reload
+; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 128
+; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)
+; CHECK-AIX-64-P9-NEXT:    mtlr r0
+; CHECK-AIX-64-P9-NEXT:    blr
+entry:
+  %0 = trunc i32 %value to i8
+  call void @llvm.memset.p0.i64(ptr align 1 %dst, i8 %0, i64 %num, i1 false)
+  ret ptr %dst
+}
+
+; Function Attrs: noinline nounwind optnone
+define ptr @test_strstr(ptr noundef %s1, ptr noundef %s2) nounwind {
+; CHECK-LE-P9-LABEL: test_strstr:
+; CHECK-LE-P9:       # %bb.0: # %entry
+; CHECK-LE-P9-NEXT:    mflr r0
+; CHECK-LE-P9-NEXT:    stdu r1, -32(r1)
+; CHECK-LE-P9-NEXT:    std r0, 48(r1)
+; CHECK-LE-P9-NEXT:    bl strstr
+; CHECK-LE-P9-NEXT:    nop
+; CHECK-LE-P9-NEXT:    addi r1, r1, 32
+; CHECK-LE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-LE-P9-NEXT:    mtlr r0
+; CHECK-LE-P9-NEXT:    blr
+;
+; CHECK-BE-P9-LABEL: test_strstr:
+; CHECK-BE-P9:       # %bb.0: # %entry
+; CHECK-BE-P9-NEXT:    mflr r0
+; CHECK-BE-P9-NEXT:    stdu r1, -112(r1)
+; CHECK-BE-P9-NEXT:    std r0, 128(r1)
+; CHECK-BE-P9-NEXT:    bl strstr
+; CHECK-BE-P9-NEXT:    nop
+; CHECK-BE-P9-NEXT:    addi r1, r1, 112
+; CHECK-BE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-BE-P9-NEXT:    mtlr r0
+; CHECK-BE-P9-NEXT:    blr
+;
+; CHECK-AIX-64-P9-LABEL: test_strstr:
+; CHECK-AIX-64-P9:       # %bb.0: # %entry
+; CHECK-AIX-64-P9-NEXT:    mflr r0
+; CHECK-AIX-64-P9-NEXT:    stdu r1, -112(r1)
+; CHECK-AIX-64-P9-NEXT:    std r0, 128(r1)
+; CHECK-AIX-64-P9-NEXT:    bl .strstr[PR]
+; CHECK-AIX-64-P9-NEXT:    nop
+; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 112
+; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)
+; CHECK-AIX-64-P9-NEXT:    mtlr r0
+; CHECK-AIX-64-P9-NEXT:    blr
+entry:
+  %call = call ptr @strstr(ptr noundef %s1, ptr noundef %s2)
+  ret ptr %call
+}
+
+; Function Attrs: nounwind
+declare ptr @strstr(ptr noundef, ptr noundef) #3
+
+; Function Attrs: noinline nounwind optnone
+define ptr @test_memccpy(ptr noalias noundef %dst, ptr noalias noundef %src, i32 noundef signext %c, i64 noundef %n) nounwind {
+; CHECK-LE-P9-LABEL: test_memccpy:
+; CHECK-LE-P9:       # %bb.0: # %entry
+; CHECK-LE-P9-NEXT:    mflr r0
+; CHECK-LE-P9-NEXT:    stdu r1, -32(r1)
+; CHECK-LE-P9-NEXT:    std r0, 48(r1)
+; CHECK-LE-P9-NEXT:    bl memccpy
+; CHECK-LE-P9-NEXT:    nop
+; CHECK-LE-P9-NEXT:    addi r1, r1, 32
+; CHECK-LE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-LE-P9-NEXT:    mtlr r0
+; CHECK-LE-P9-NEXT:    blr
+;
+; CHECK-BE-P9-LABEL: test_memccpy:
+; CHECK-BE-P9:       # %bb.0: # %entry
+; CHECK-BE-P9-NEXT:    mflr r0
+; CHECK-BE-P9-NEXT:    stdu r1, -112(r1)
+; CHECK-BE-P9-NEXT:    std r0, 128(r1)
+; CHECK-BE-P9-NEXT:    bl memccpy
+; CHECK-BE-P9-NEXT:    nop
+; CHECK-BE-P9-NEXT:    addi r1, r1, 112
+; CHECK-BE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-BE-P9-NEXT:    mtlr r0
+; CHECK-BE-P9-NEXT:    blr
+;
+; CHECK-AIX-64-P9-LABEL: test_memccpy:
+; CHECK-AIX-64-P9:       # %bb.0: # %entry
+; CHECK-AIX-64-P9-NEXT:    mflr r0
+; CHECK-AIX-64-P9-NEXT:    stdu r1, -112(r1)
+; CHECK-AIX-64-P9-NEXT:    std r0, 128(r1)
+; CHECK-AIX-64-P9-NEXT:    bl .memccpy[PR]
+; CHECK-AIX-64-P9-NEXT:    nop
+; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 112
+; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)
+; CHECK-AIX-64-P9-NEXT:    mtlr r0
+; CHECK-AIX-64-P9-NEXT:    blr
+entry:
+  %call = call ptr @memccpy(ptr noundef %dst, ptr noundef %src, i32 noundef signext %c, i64 noundef %n)
+  ret ptr %call
+}
+
+declare ptr @memccpy(ptr noundef, ptr noundef, i32 noundef signext, i64 noundef)
+
+; Function Attrs: noinline nounwind optnone
+define signext i32 @test_strcmp(ptr noundef %s1, ptr noundef %s2) nounwind {
+; CHECK-LE-P9-LABEL: test_strcmp:
+; CHECK-LE-P9:       # %bb.0: # %entry
+; CHECK-LE-P9-NEXT:    mflr r0
+; CHECK-LE-P9-NEXT:    stdu r1, -32(r1)
+; CHECK-LE-P9-NEXT:    std r0, 48(r1)
+; CHECK-LE-P9-NEXT:    bl strcmp
+; CHECK-LE-P9-NEXT:    nop
+; CHECK-LE-P9-NEXT:    addi r1, r1, 32
+; CHECK-LE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-LE-P9-NEXT:    mtlr r0
+; CHECK-LE-P9-NEXT:    blr
+;
+; CHECK-BE-P9-LABEL: test_strcmp:
+; CHECK-BE-P9:       # %bb.0: # %entry
+; CHECK-BE-P9-NEXT:    mflr r0
+; CHECK-BE-P9-NEXT:    stdu r1, -112(r1)
+; CHECK-BE-P9-NEXT:    std r0, 128(r1)
+; CHECK-BE-P9-NEXT:    bl strcmp
+; CHECK-BE-P9-NEXT:    nop
+; CHECK-BE-P9-NEXT:    addi r1, r1, 112
+; CHECK-BE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-BE-P9-NEXT:    mtlr r0
+; CHECK-BE-P9-NEXT:    blr
+;
+; CHECK-AIX-64-P9-LABEL: test_strcmp:
+; CHECK-AIX-64-P9:       # %bb.0: # %entry
+; CHECK-AIX-64-P9-NEXT:    mflr r0
+; CHECK-AIX-64-P9-NEXT:    stdu r1, -112(r1)
+; CHECK-AIX-64-P9-NEXT:    std r0, 128(r1)
+; CHECK-AIX-64-P9-NEXT:    bl .strcmp[PR]
+; CHECK-AIX-64-P9-NEXT:    nop
+; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 112
+; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)
+; CHECK-AIX-64-P9-NEXT:    mtlr r0
+; CHECK-AIX-64-P9-NEXT:    blr
+entry:
+  %call = call signext i32 @strcmp(ptr noundef %s1, ptr noundef %s2)
+  ret i32 %call
+}
+
+; Function Attrs: nounwind
+declare signext i32 @strcmp(ptr noundef, ptr noundef)

--- a/llvm/test/CodeGen/PowerPC/milicode64.ll
+++ b/llvm/test/CodeGen/PowerPC/milicode64.ll
@@ -101,6 +101,61 @@ entry:
 
 declare i64 @strlen(ptr noundef) nounwind
 
+define ptr @test_memmove(ptr noundef %dst, ptr noundef %src, i64 noundef %n) nounwind {
+; CHECK-LE-P9-LABEL: test_memmove:
+; CHECK-LE-P9:       # %bb.0: # %entry
+; CHECK-LE-P9-NEXT:    mflr r0
+; CHECK-LE-P9-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
+; CHECK-LE-P9-NEXT:    stdu r1, -48(r1)
+; CHECK-LE-P9-NEXT:    std r0, 64(r1)
+; CHECK-LE-P9-NEXT:    mr r30, r3
+; CHECK-LE-P9-NEXT:    bl memmove
+; CHECK-LE-P9-NEXT:    nop
+; CHECK-LE-P9-NEXT:    mr r3, r30
+; CHECK-LE-P9-NEXT:    addi r1, r1, 48
+; CHECK-LE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-LE-P9-NEXT:    ld r30, -16(r1) # 8-byte Folded Reload
+; CHECK-LE-P9-NEXT:    mtlr r0
+; CHECK-LE-P9-NEXT:    blr
+;
+; CHECK-BE-P9-LABEL: test_memmove:
+; CHECK-BE-P9:       # %bb.0: # %entry
+; CHECK-BE-P9-NEXT:    mflr r0
+; CHECK-BE-P9-NEXT:    stdu r1, -128(r1)
+; CHECK-BE-P9-NEXT:    std r0, 144(r1)
+; CHECK-BE-P9-NEXT:    std r30, 112(r1) # 8-byte Folded Spill
+; CHECK-BE-P9-NEXT:    mr r30, r3
+; CHECK-BE-P9-NEXT:    bl memmove
+; CHECK-BE-P9-NEXT:    nop
+; CHECK-BE-P9-NEXT:    mr r3, r30
+; CHECK-BE-P9-NEXT:    ld r30, 112(r1) # 8-byte Folded Reload
+; CHECK-BE-P9-NEXT:    addi r1, r1, 128
+; CHECK-BE-P9-NEXT:    ld r0, 16(r1)
+; CHECK-BE-P9-NEXT:    mtlr r0
+; CHECK-BE-P9-NEXT:    blr
+;
+; CHECK-AIX-64-P9-LABEL: test_memmove:
+; CHECK-AIX-64-P9:       # %bb.0: # %entry
+; CHECK-AIX-64-P9-NEXT:    mflr r0
+; CHECK-AIX-64-P9-NEXT:    stdu r1, -128(r1)
+; CHECK-AIX-64-P9-NEXT:    std r0, 144(r1)
+; CHECK-AIX-64-P9-NEXT:    std r31, 120(r1) # 8-byte Folded Spill
+; CHECK-AIX-64-P9-NEXT:    mr r31, r3
+; CHECK-AIX-64-P9-NEXT:    bl .___memmove64[PR]
+; CHECK-AIX-64-P9-NEXT:    nop
+; CHECK-AIX-64-P9-NEXT:    mr r3, r31
+; CHECK-AIX-64-P9-NEXT:    ld r31, 120(r1) # 8-byte Folded Reload
+; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 128
+; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)
+; CHECK-AIX-64-P9-NEXT:    mtlr r0
+; CHECK-AIX-64-P9-NEXT:    blr
+entry:
+  call void @llvm.memmove.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 %n, i1 false)
+  ret ptr %dst
+}
+
+declare void @llvm.memmove.p0.p0.i64(ptr writeonly captures(none), ptr readonly captures(none), i64, i1 immarg)
+
 define dso_local ptr @strcpy_test(ptr noundef %dest, ptr noundef %src) nounwind {
 ; CHECK-LE-P9-LABEL: strcpy_test:
 ; CHECK-LE-P9:       # %bb.0: # %entry
@@ -187,7 +242,6 @@ entry:
 
 declare ptr @stpcpy(ptr noundef, ptr noundef)
 
-; Function Attrs: noinline nounwind optnone
 define ptr @test_memcpy(ptr noundef %dst, ptr noundef %src, i64 noundef %n) nounwind {
 ; CHECK-LE-P9-LABEL: test_memcpy:
 ; CHECK-LE-P9:       # %bb.0:
@@ -240,66 +294,8 @@ define ptr @test_memcpy(ptr noundef %dst, ptr noundef %src, i64 noundef %n) noun
   ret ptr %dst
 }
 
-define ptr @test_memmove(ptr noundef %dst, ptr noundef %src, i64 noundef %n) nounwind {
-; CHECK-LE-P9-LABEL: test_memmove:
-; CHECK-LE-P9:       # %bb.0: # %entry
-; CHECK-LE-P9-NEXT:    mflr r0
-; CHECK-LE-P9-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
-; CHECK-LE-P9-NEXT:    stdu r1, -48(r1)
-; CHECK-LE-P9-NEXT:    std r0, 64(r1)
-; CHECK-LE-P9-NEXT:    mr r30, r3
-; CHECK-LE-P9-NEXT:    bl memmove
-; CHECK-LE-P9-NEXT:    nop
-; CHECK-LE-P9-NEXT:    mr r3, r30
-; CHECK-LE-P9-NEXT:    addi r1, r1, 48
-; CHECK-LE-P9-NEXT:    ld r0, 16(r1)
-; CHECK-LE-P9-NEXT:    ld r30, -16(r1) # 8-byte Folded Reload
-; CHECK-LE-P9-NEXT:    mtlr r0
-; CHECK-LE-P9-NEXT:    blr
-;
-; CHECK-BE-P9-LABEL: test_memmove:
-; CHECK-BE-P9:       # %bb.0: # %entry
-; CHECK-BE-P9-NEXT:    mflr r0
-; CHECK-BE-P9-NEXT:    stdu r1, -128(r1)
-; CHECK-BE-P9-NEXT:    std r0, 144(r1)
-; CHECK-BE-P9-NEXT:    std r30, 112(r1) # 8-byte Folded Spill
-; CHECK-BE-P9-NEXT:    mr r30, r3
-; CHECK-BE-P9-NEXT:    bl memmove
-; CHECK-BE-P9-NEXT:    nop
-; CHECK-BE-P9-NEXT:    mr r3, r30
-; CHECK-BE-P9-NEXT:    ld r30, 112(r1) # 8-byte Folded Reload
-; CHECK-BE-P9-NEXT:    addi r1, r1, 128
-; CHECK-BE-P9-NEXT:    ld r0, 16(r1)
-; CHECK-BE-P9-NEXT:    mtlr r0
-; CHECK-BE-P9-NEXT:    blr
-;
-; CHECK-AIX-64-P9-LABEL: test_memmove:
-; CHECK-AIX-64-P9:       # %bb.0: # %entry
-; CHECK-AIX-64-P9-NEXT:    mflr r0
-; CHECK-AIX-64-P9-NEXT:    stdu r1, -128(r1)
-; CHECK-AIX-64-P9-NEXT:    std r0, 144(r1)
-; CHECK-AIX-64-P9-NEXT:    std r31, 120(r1) # 8-byte Folded Spill
-; CHECK-AIX-64-P9-NEXT:    mr r31, r3
-; CHECK-AIX-64-P9-NEXT:    bl .___memmove64[PR]
-; CHECK-AIX-64-P9-NEXT:    nop
-; CHECK-AIX-64-P9-NEXT:    mr r3, r31
-; CHECK-AIX-64-P9-NEXT:    ld r31, 120(r1) # 8-byte Folded Reload
-; CHECK-AIX-64-P9-NEXT:    addi r1, r1, 128
-; CHECK-AIX-64-P9-NEXT:    ld r0, 16(r1)
-; CHECK-AIX-64-P9-NEXT:    mtlr r0
-; CHECK-AIX-64-P9-NEXT:    blr
-entry:
-  call void @llvm.memmove.p0.p0.i64(ptr align 1 %dst, ptr align 1 %src, i64 %n, i1 false)
-  ret ptr %dst
-}
-
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.memmove.p0.p0.i64(ptr writeonly captures(none), ptr readonly captures(none), i64, i1 immarg)
-
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg)
 
-; Function Attrs: noinline nounwind optnone
 define ptr @test_memset(ptr noundef %dst, i32 noundef signext %value, i64 noundef %num) nounwind {
 ; CHECK-LE-P9-LABEL: test_memset:
 ; CHECK-LE-P9:       # %bb.0: # %entry
@@ -357,7 +353,6 @@ entry:
   ret ptr %dst
 }
 
-; Function Attrs: noinline nounwind optnone
 define ptr @test_strstr(ptr noundef %s1, ptr noundef %s2) nounwind {
 ; CHECK-LE-P9-LABEL: test_strstr:
 ; CHECK-LE-P9:       # %bb.0: # %entry
@@ -399,10 +394,8 @@ entry:
   ret ptr %call
 }
 
-; Function Attrs: nounwind
 declare ptr @strstr(ptr noundef, ptr noundef) #3
 
-; Function Attrs: noinline nounwind optnone
 define ptr @test_memccpy(ptr noalias noundef %dst, ptr noalias noundef %src, i32 noundef signext %c, i64 noundef %n) nounwind {
 ; CHECK-LE-P9-LABEL: test_memccpy:
 ; CHECK-LE-P9:       # %bb.0: # %entry
@@ -446,7 +439,6 @@ entry:
 
 declare ptr @memccpy(ptr noundef, ptr noundef, i32 noundef signext, i64 noundef)
 
-; Function Attrs: noinline nounwind optnone
 define signext i32 @test_strcmp(ptr noundef %s1, ptr noundef %s2) nounwind {
 ; CHECK-LE-P9-LABEL: test_strcmp:
 ; CHECK-LE-P9:       # %bb.0: # %entry
@@ -488,5 +480,4 @@ entry:
   ret i32 %call
 }
 
-; Function Attrs: nounwind
 declare signext i32 @strcmp(ptr noundef, ptr noundef)


### PR DESCRIPTION
In this PR, we do the following:

1. Simplify the test case for the millicode function  `___memmove`.
2. Add test cases for the millicode functions `___memcpy` , `____memset`, `____memmove` which are supported in the patch  https://reviews.llvm.org/D143997.
3. Add pre-commit test cases for the functions `___strstr`, `___memccpy`, `___strcmp`