### PR TITLE
[lldb][TypeSystemClang] Simplify TypeSystemClang::IsEnumerationType implementation

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3310,11 +3310,7 @@ bool TypeSystemClang::IsEnumerationType(lldb::opaque_compiler_type_t type,
         GetCanonicalQualType(type)->getCanonicalTypeInternal());
 
     if (enum_type) {
-      IsIntegerType(enum_type->getDecl()
-                        ->getDefinitionOrSelf()
-                        ->getIntegerType()
-                        .getAsOpaquePtr(),
-                    is_signed);
+      is_signed = enum_type->isSignedIntegerOrEnumerationType();
       return true;
     }
   }

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -420,6 +420,64 @@ TEST_F(TestTypeSystemClang, TestEnumerationValueSign) {
   EXPECT_TRUE(enum_decl->getInitVal().isSigned());
 }
 
+TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
+  auto holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("enum_ast");
+  auto &ast = *holder->GetAST();
+
+  // Scoped signed enum
+  {
+    CompilerType enum_type = ast.CreateEnumerationType(
+        "scoped_signed_enum", ast.GetTranslationUnitDecl(),
+        OptionalClangModuleID(), Declaration(),
+        ast.GetBasicType(eBasicTypeLong), /*is_scoped=*/true);
+    ASSERT_TRUE(enum_type);
+
+    bool is_signed;
+    EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
+    EXPECT_TRUE(is_signed);
+  }
+
+  // Scoped unsigned enum
+  {
+    CompilerType enum_type = ast.CreateEnumerationType(
+        "scoped_unsigned_enum", ast.GetTranslationUnitDecl(),
+        OptionalClangModuleID(), Declaration(),
+        ast.GetBasicType(eBasicTypeUnsignedInt), /*is_scoped=*/true);
+    ASSERT_TRUE(enum_type);
+
+    bool is_signed;
+    EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
+    EXPECT_FALSE(is_signed);
+  }
+
+  // Unscoped signed enum
+  {
+    CompilerType enum_type = ast.CreateEnumerationType(
+        "unscoped_signed_enum", ast.GetTranslationUnitDecl(),
+        OptionalClangModuleID(), Declaration(),
+        ast.GetBasicType(eBasicTypeLong), /*is_scoped=*/false);
+    ASSERT_TRUE(enum_type);
+
+    bool is_signed;
+    EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
+    EXPECT_TRUE(is_signed);
+  }
+
+  // Unscoped unsigned enum
+  {
+    CompilerType enum_type = ast.CreateEnumerationType(
+        "unscoped_unsigned_enum", ast.GetTranslationUnitDecl(),
+        OptionalClangModuleID(), Declaration(),
+        ast.GetBasicType(eBasicTypeUnsignedInt), /*is_scoped=*/false);
+    ASSERT_TRUE(enum_type);
+
+    bool is_signed;
+    EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
+    EXPECT_FALSE(is_signed);
+  }
+}
+
 TEST_F(TestTypeSystemClang, TestOwningModule) {
   auto holder =
       std::make_unique<clang_utils::TypeSystemClangHolder>("module_ast");


### PR DESCRIPTION
We were calling into `IsIntegerType` to determine the signedness of the enum. Calling the relevant `clang::Type` API is simpler.

This shouldn't have any observable behaviour change.

We were lacking unit-test coverage for this. Added some tests that pass before and after this change.