### PR TITLE
[lldb][Formatters] Remove broken/redundant lookup into anonymous child when extracting from compressed pairs

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/GenericList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericList.cpp
@@ -354,9 +354,8 @@ lldb::ChildCacheState LibCxxForwardListFrontEnd::Update() {
     return lldb::ChildCacheState::eRefetch;
 
   // Anonymous strucutre index is in base class at index 0.
-  auto [impl_sp, is_compressed_pair] =
-      GetValueOrOldCompressedPair(*list_base_sp, /*anon_struct_idx=*/0,
-                                  "__before_begin_", "__before_begin_");
+  auto [impl_sp, is_compressed_pair] = GetValueOrOldCompressedPair(
+      *list_base_sp, "__before_begin_", "__before_begin_");
   if (!impl_sp)
     return ChildCacheState::eRefetch;
 
@@ -383,8 +382,8 @@ llvm::Expected<uint32_t> LibCxxListFrontEnd::CalculateNumChildren() {
   if (!m_head || !m_tail || m_node_address == 0)
     return 0;
 
-  auto [size_node_sp, is_compressed_pair] = GetValueOrOldCompressedPair(
-      m_backend, /*anon_struct_idx=*/1, "__size_", "__size_alloc_");
+  auto [size_node_sp, is_compressed_pair] =
+      GetValueOrOldCompressedPair(m_backend, "__size_", "__size_alloc_");
   if (is_compressed_pair)
     size_node_sp = GetFirstValueOfLibCXXCompressedPair(*size_node_sp);
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -104,21 +104,12 @@ lldb_private::formatters::GetSecondValueOfLibCXXCompressedPair(
 
 std::pair<lldb::ValueObjectSP, bool>
 lldb_private::formatters::GetValueOrOldCompressedPair(
-    ValueObject &obj, size_t anon_struct_idx, llvm::StringRef child_name,
+    ValueObject &obj, llvm::StringRef child_name,
     llvm::StringRef compressed_pair_name) {
   auto is_old_compressed_pair = [](ValueObject &pair_obj) -> bool {
     return isStdTemplate(pair_obj.GetTypeName(), "__compressed_pair");
   };
 
-  // Try searching the child member in an anonymous structure first.
-  if (auto unwrapped = obj.GetChildAtIndex(anon_struct_idx)) {
-    ValueObjectSP node_sp(obj.GetChildMemberWithName(child_name));
-    if (node_sp)
-      return {node_sp, is_old_compressed_pair(*node_sp)};
-  }
-
-  // Older versions of libc++ don't wrap the children in anonymous structures.
-  // Try that instead.
   ValueObjectSP node_sp(obj.GetChildMemberWithName(child_name));
   if (node_sp)
     return {node_sp, is_old_compressed_pair(*node_sp)};
@@ -240,8 +231,8 @@ bool lldb_private::formatters::LibcxxUniquePointerSummaryProvider(
   if (!valobj_sp)
     return false;
 
-  auto [ptr_sp, is_compressed_pair] = GetValueOrOldCompressedPair(
-      *valobj_sp, /*anon_struct_idx=*/0, "__ptr_", "__ptr_");
+  auto [ptr_sp, is_compressed_pair] =
+      GetValueOrOldCompressedPair(*valobj_sp, "__ptr_", "__ptr_");
   if (!ptr_sp)
     return false;
 
@@ -415,8 +406,8 @@ lldb_private::formatters::LibcxxUniquePtrSyntheticFrontEnd::Update() {
   if (!valobj_sp)
     return lldb::ChildCacheState::eRefetch;
 
-  auto [ptr_sp, is_compressed_pair] = GetValueOrOldCompressedPair(
-      *valobj_sp, /*anon_struct_idx=*/0, "__ptr_", "__ptr_");
+  auto [ptr_sp, is_compressed_pair] =
+      GetValueOrOldCompressedPair(*valobj_sp, "__ptr_", "__ptr_");
   if (!ptr_sp)
     return lldb::ChildCacheState::eRefetch;
 
@@ -461,8 +452,8 @@ enum class StringLayout { CSD, DSC };
 }
 
 static ValueObjectSP ExtractLibCxxStringData(ValueObject &valobj) {
-  auto [valobj_r_sp, is_compressed_pair] = GetValueOrOldCompressedPair(
-      valobj, /*anon_struct_idx=*/0, "__rep_", "__r_");
+  auto [valobj_r_sp, is_compressed_pair] =
+      GetValueOrOldCompressedPair(valobj, "__rep_", "__r_");
   if (!valobj_r_sp)
     return nullptr;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.h
@@ -38,8 +38,7 @@ lldb::ValueObjectSP GetSecondValueOfLibCXXCompressedPair(ValueObject &pair);
 ///
 /// If no child was found returns a nullptr.
 std::pair<lldb::ValueObjectSP, bool>
-GetValueOrOldCompressedPair(ValueObject &obj, size_t anon_struct_idx,
-                            llvm::StringRef child_name,
+GetValueOrOldCompressedPair(ValueObject &obj, llvm::StringRef child_name,
                             llvm::StringRef compressed_pair_name);
 bool isStdTemplate(ConstString type_name, llvm::StringRef type);
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -274,8 +274,8 @@ llvm::Expected<uint32_t> lldb_private::formatters::
   if (m_tree == nullptr)
     return 0;
 
-  auto [size_sp, is_compressed_pair] = GetValueOrOldCompressedPair(
-      *m_tree, /*anon_struct_idx=*/2, "__size_", "__pair3_");
+  auto [size_sp, is_compressed_pair] =
+      GetValueOrOldCompressedPair(*m_tree, "__size_", "__pair3_");
   if (!size_sp)
     return llvm::createStringError("Unexpected std::map layout");
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -135,8 +135,8 @@ CompilerType lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
   if (!table_sp)
     return {};
 
-  auto [node_sp, is_compressed_pair] = GetValueOrOldCompressedPair(
-      *table_sp, /*anon_struct_idx=*/1, "__first_node_", "__p1_");
+  auto [node_sp, is_compressed_pair] =
+      GetValueOrOldCompressedPair(*table_sp, "__first_node_", "__p1_");
   if (is_compressed_pair)
     node_sp = GetFirstValueOfLibCXXCompressedPair(*node_sp);
 
@@ -218,8 +218,8 @@ lldb::ValueObjectSP lldb_private::formatters::
 llvm::Expected<size_t>
 lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
     CalculateNumChildrenImpl(ValueObject &table) {
-  auto [size_sp, is_compressed_pair] = GetValueOrOldCompressedPair(
-      table, /*anon_struct_idx=*/2, "__size_", "__p2_");
+  auto [size_sp, is_compressed_pair] =
+      GetValueOrOldCompressedPair(table, "__size_", "__p2_");
   if (!is_compressed_pair && size_sp)
     return size_sp->GetValueAsUnsigned(0);
 
@@ -237,8 +237,8 @@ lldb_private::formatters::LibcxxStdUnorderedMapSyntheticFrontEnd::
 }
 
 static ValueObjectSP GetTreePointer(ValueObject &table) {
-  auto [tree_sp, is_compressed_pair] = GetValueOrOldCompressedPair(
-      table, /*anon_struct_idx=*/1, "__first_node_", "__p1_");
+  auto [tree_sp, is_compressed_pair] =
+      GetValueOrOldCompressedPair(table, "__first_node_", "__p1_");
   if (is_compressed_pair)
     tree_sp = GetFirstValueOfLibCXXCompressedPair(*tree_sp);
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -126,8 +126,8 @@ lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::GetChildAtIndex(
 }
 
 static ValueObjectSP GetDataPointer(ValueObject &root) {
-  auto [cap_sp, is_compressed_pair] = GetValueOrOldCompressedPair(
-      root, /*anon_struct_idx=*/2, "__cap_", "__end_cap_");
+  auto [cap_sp, is_compressed_pair] =
+      GetValueOrOldCompressedPair(root, "__cap_", "__end_cap_");
   if (!cap_sp)
     return nullptr;
 


### PR DESCRIPTION
(brought to my attention in https://github.com/llvm/llvm-project/pull/155153#discussion_r2682666325)

This patch removes the `anon_struct_idx` of `GetValueOrOldCompressedPair`.

The latest `_LIBCPP_COMPRESSED_PAIR` wraps the members in an anonymous structure. Around the time of the original patch that introduced `GetValueOrOldCompressedPair` (https://github.com/llvm/llvm-project/pull/155153), `GetChildMemberWithName` wasn't capable of "seeing through" anonymous structures when searching for children. However, around the same time as https://github.com/llvm/llvm-project/pull/155153 landed, the `GetChildMemberWithName` behaviour was fixed (in https://github.com/llvm/llvm-project/pull/138487). So regardless of whether the the compressed pair is wrapped in an anonymous structure, simply calling `GetChildMemberWithName` is the right thing to do.

We weren't even using the result of `GetChildAtIndex`, so we were always calling `GetChildMemberWithName` with the root ValueObject anyways.

Our `libcxx-simulators` already test both compressed pair layouts, so no extra coverage is needed here.