### PR TITLE
[asan][AIX] Add vec_malloc and vec_calloc interceptors

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -791,13 +791,14 @@ struct Allocator {
     return new_ptr;
   }
 
-  void *Calloc(uptr nmemb, uptr size, BufferedStackTrace *stack, uptr align = 8) {
+  void* Calloc(uptr nmemb, uptr size, BufferedStackTrace* stack,
+               uptr align = 8) {
     if (UNLIKELY(CheckForCallocOverflow(size, nmemb))) {
       if (AllocatorMayReturnNull())
         return nullptr;
       ReportCallocOverflow(nmemb, size, stack);
     }
-    void *ptr = Allocate(nmemb * size, align, stack, FROM_MALLOC, false);
+    void* ptr = Allocate(nmemb * size, align, stack, FROM_MALLOC, false);
     // If the memory comes from the secondary allocator no need to clear it
     // as it comes directly from mmap.
     if (ptr && allocator.FromPrimary(ptr))

--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -1026,17 +1026,17 @@ void *asan_calloc(uptr nmemb, uptr size, BufferedStackTrace *stack) {
 }
 
 #if SANITIZER_AIX
-void *asan_vec_malloc(uptr size, BufferedStackTrace *stack) {
+void* asan_vec_malloc(uptr size, BufferedStackTrace* stack) {
   return SetErrnoOnNull(instance.Allocate(size, 16, stack, FROM_MALLOC, true));
 }
 
-void *asan_vec_calloc(uptr nmemb, uptr size, BufferedStackTrace *stack) {
+void* asan_vec_calloc(uptr nmemb, uptr size, BufferedStackTrace* stack) {
   if (UNLIKELY(CheckForCallocOverflow(size, nmemb))) {
     if (AllocatorMayReturnNull())
       return nullptr;
     ReportCallocOverflow(nmemb, size, stack);
   }
-  void *ptr = instance.Allocate(nmemb * size, 16, stack, FROM_MALLOC, false);
+  void* ptr = instance.Allocate(nmemb * size, 16, stack, FROM_MALLOC, false);
   // If the memory comes from the secondary allocator no need to clear it
   // as it comes directly from mmap.
   if (ptr && get_allocator().FromPrimary(ptr))

--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -1025,6 +1025,26 @@ void *asan_calloc(uptr nmemb, uptr size, BufferedStackTrace *stack) {
   return SetErrnoOnNull(instance.Calloc(nmemb, size, stack));
 }
 
+#if SANITIZER_AIX
+void *asan_vec_malloc(uptr size, BufferedStackTrace *stack) {
+  return SetErrnoOnNull(instance.Allocate(size, 16, stack, FROM_MALLOC, true));
+}
+
+void *asan_vec_calloc(uptr nmemb, uptr size, BufferedStackTrace *stack) {
+  if (UNLIKELY(CheckForCallocOverflow(size, nmemb))) {
+    if (AllocatorMayReturnNull())
+      return nullptr;
+    ReportCallocOverflow(nmemb, size, stack);
+  }
+  void *ptr = instance.Allocate(nmemb * size, 16, stack, FROM_MALLOC, false);
+  // If the memory comes from the secondary allocator no need to clear it
+  // as it comes directly from mmap.
+  if (ptr && get_allocator().FromPrimary(ptr))
+    REAL(memset)(ptr, 0, nmemb * size);
+  return SetErrnoOnNull(ptr);
+}
+#endif
+
 void *asan_reallocarray(void *p, uptr nmemb, uptr size,
                         BufferedStackTrace *stack) {
   if (UNLIKELY(CheckForCallocOverflow(size, nmemb))) {

--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -791,13 +791,13 @@ struct Allocator {
     return new_ptr;
   }
 
-  void *Calloc(uptr nmemb, uptr size, BufferedStackTrace *stack) {
+  void *Calloc(uptr nmemb, uptr size, BufferedStackTrace *stack, uptr align = 8) {
     if (UNLIKELY(CheckForCallocOverflow(size, nmemb))) {
       if (AllocatorMayReturnNull())
         return nullptr;
       ReportCallocOverflow(nmemb, size, stack);
     }
-    void *ptr = Allocate(nmemb * size, 8, stack, FROM_MALLOC, false);
+    void *ptr = Allocate(nmemb * size, align, stack, FROM_MALLOC, false);
     // If the memory comes from the secondary allocator no need to clear it
     // as it comes directly from mmap.
     if (ptr && allocator.FromPrimary(ptr))
@@ -1031,17 +1031,7 @@ void* asan_vec_malloc(uptr size, BufferedStackTrace* stack) {
 }
 
 void* asan_vec_calloc(uptr nmemb, uptr size, BufferedStackTrace* stack) {
-  if (UNLIKELY(CheckForCallocOverflow(size, nmemb))) {
-    if (AllocatorMayReturnNull())
-      return nullptr;
-    ReportCallocOverflow(nmemb, size, stack);
-  }
-  void* ptr = instance.Allocate(nmemb * size, 16, stack, FROM_MALLOC, false);
-  // If the memory comes from the secondary allocator no need to clear it
-  // as it comes directly from mmap.
-  if (ptr && get_allocator().FromPrimary(ptr))
-    REAL(memset)(ptr, 0, nmemb * size);
-  return SetErrnoOnNull(ptr);
+  return SetErrnoOnNull(instance.Calloc(nmemb, size, stack, 16));
 }
 #endif
 

--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -281,8 +281,8 @@ void asan_free(void *ptr, BufferedStackTrace *stack);
 void *asan_malloc(uptr size, BufferedStackTrace *stack);
 void *asan_calloc(uptr nmemb, uptr size, BufferedStackTrace *stack);
 #if SANITIZER_AIX
-void *asan_vec_malloc(uptr size, BufferedStackTrace *stack);
-void *asan_vec_calloc(uptr nmemb, uptr size, BufferedStackTrace *stack);
+void* asan_vec_malloc(uptr size, BufferedStackTrace* stack);
+void* asan_vec_calloc(uptr nmemb, uptr size, BufferedStackTrace* stack);
 #endif
 void *asan_realloc(void *p, uptr size, BufferedStackTrace *stack);
 void *asan_reallocarray(void *p, uptr nmemb, uptr size,

--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -280,6 +280,10 @@ void asan_free(void *ptr, BufferedStackTrace *stack);
 
 void *asan_malloc(uptr size, BufferedStackTrace *stack);
 void *asan_calloc(uptr nmemb, uptr size, BufferedStackTrace *stack);
+#if SANITIZER_AIX
+void *asan_vec_malloc(uptr size, BufferedStackTrace *stack);
+void *asan_vec_calloc(uptr nmemb, uptr size, BufferedStackTrace *stack);
+#endif
 void *asan_realloc(void *p, uptr size, BufferedStackTrace *stack);
 void *asan_reallocarray(void *p, uptr nmemb, uptr size,
                         BufferedStackTrace *stack);

--- a/compiler-rt/lib/asan/asan_malloc_linux.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_linux.cpp
@@ -61,6 +61,24 @@ INTERCEPTOR(void, cfree, void *ptr) {
 }
 #endif // SANITIZER_INTERCEPT_CFREE
 
+#  if SANITIZER_AIX
+INTERCEPTOR(void*, vec_malloc, uptr size) {
+  if (DlsymAlloc::Use())
+    return DlsymAlloc::Allocate(size);
+  AsanInitFromRtl();
+  GET_STACK_TRACE_MALLOC;
+  return asan_malloc(size, &stack);
+}
+
+INTERCEPTOR(void*, vec_calloc, uptr nmemb, uptr size) {
+  if (DlsymAlloc::Use())
+    return DlsymAlloc::Callocate(nmemb, size);
+  AsanInitFromRtl();
+  GET_STACK_TRACE_MALLOC;
+  return asan_calloc(nmemb, size, &stack);
+}
+#  endif
+
 INTERCEPTOR(void*, malloc, uptr size) {
   if (DlsymAlloc::Use())
     return DlsymAlloc::Allocate(size);

--- a/compiler-rt/lib/asan/asan_malloc_linux.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_linux.cpp
@@ -65,17 +65,17 @@ INTERCEPTOR(void, cfree, void *ptr) {
 INTERCEPTOR(void*, vec_malloc, uptr size) {
   if (DlsymAlloc::Use())
     return DlsymAlloc::Allocate(size);
-  AsanInitFromRtl();
   GET_STACK_TRACE_MALLOC;
-  return asan_malloc(size, &stack);
+  // Unlike malloc, vec_malloc must return memory aligned to 16 bytes.
+  return asan_vec_malloc(size, &stack);
 }
 
 INTERCEPTOR(void*, vec_calloc, uptr nmemb, uptr size) {
   if (DlsymAlloc::Use())
     return DlsymAlloc::Callocate(nmemb, size);
-  AsanInitFromRtl();
   GET_STACK_TRACE_MALLOC;
-  return asan_calloc(nmemb, size, &stack);
+  // Unlike calloc, vec_calloc must return memory aligned to 16 bytes.
+  return asan_vec_calloc(nmemb, size, &stack);
 }
 #  endif
 

--- a/compiler-rt/lib/asan/asan_malloc_linux.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_linux.cpp
@@ -79,7 +79,8 @@ INTERCEPTOR(void*, vec_calloc, uptr nmemb, uptr size) {
 }
 #  endif
 
-// TODO: Fix malloc/calloc interceptors to return 16-byte alignment with AIX on PASE.
+// TODO: Fix malloc/calloc interceptors to return 16-byte alignment with AIX on
+// PASE.
 INTERCEPTOR(void*, malloc, uptr size) {
   if (DlsymAlloc::Use())
     return DlsymAlloc::Allocate(size);
@@ -94,8 +95,8 @@ INTERCEPTOR(void*, calloc, uptr nmemb, uptr size) {
   return asan_calloc(nmemb, size, &stack);
 }
 
-// TODO: AIX needs a method to ensure 16-byte alignment if the incoming 
-// pointer was allocated with a 16-byte alignment requirement (or perhaps 
+// TODO: AIX needs a method to ensure 16-byte alignment if the incoming
+// pointer was allocated with a 16-byte alignment requirement (or perhaps
 // merely if it happens to have 16-byte alignment).
 INTERCEPTOR(void*, realloc, void *ptr, uptr size) {
   if (DlsymAlloc::Use() || DlsymAlloc::PointerIsMine(ptr))

--- a/compiler-rt/lib/asan/asan_malloc_linux.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_linux.cpp
@@ -62,23 +62,24 @@ INTERCEPTOR(void, cfree, void *ptr) {
 #endif // SANITIZER_INTERCEPT_CFREE
 
 #  if SANITIZER_AIX
+// Unlike malloc, vec_malloc must return memory aligned to 16 bytes.
 INTERCEPTOR(void*, vec_malloc, uptr size) {
   if (DlsymAlloc::Use())
-    return DlsymAlloc::Allocate(size);
+    return DlsymAlloc::Allocate(size, 16);
   GET_STACK_TRACE_MALLOC;
-  // Unlike malloc, vec_malloc must return memory aligned to 16 bytes.
   return asan_vec_malloc(size, &stack);
 }
 
+// Unlike calloc, vec_calloc must return memory aligned to 16 bytes.
 INTERCEPTOR(void*, vec_calloc, uptr nmemb, uptr size) {
   if (DlsymAlloc::Use())
-    return DlsymAlloc::Callocate(nmemb, size);
+    return DlsymAlloc::Callocate(nmemb, size, 16);
   GET_STACK_TRACE_MALLOC;
-  // Unlike calloc, vec_calloc must return memory aligned to 16 bytes.
   return asan_vec_calloc(nmemb, size, &stack);
 }
 #  endif
 
+// TODO: Fix malloc/calloc interceptors to return 16-byte alignment with AIX on PASE.
 INTERCEPTOR(void*, malloc, uptr size) {
   if (DlsymAlloc::Use())
     return DlsymAlloc::Allocate(size);
@@ -93,6 +94,9 @@ INTERCEPTOR(void*, calloc, uptr nmemb, uptr size) {
   return asan_calloc(nmemb, size, &stack);
 }
 
+// TODO: AIX needs a method to ensure 16-byte alignment if the incoming 
+// pointer was allocated with a 16-byte alignment requirement (or perhaps 
+// merely if it happens to have 16-byte alignment).
 INTERCEPTOR(void*, realloc, void *ptr, uptr size) {
   if (DlsymAlloc::Use() || DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Realloc(ptr, size);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator.cpp
@@ -109,14 +109,15 @@ void *InternalReallocArray(void *addr, uptr count, uptr size,
   return InternalRealloc(addr, count * size, cache);
 }
 
-void *InternalCalloc(uptr count, uptr size, InternalAllocatorCache *cache, uptr alignment) {
+void* InternalCalloc(uptr count, uptr size, InternalAllocatorCache* cache,
+                     uptr alignment) {
   if (UNLIKELY(CheckForCallocOverflow(count, size))) {
     Report("FATAL: %s: calloc parameters overflow: count * size (%zd * %zd) "
            "cannot be represented in type size_t\n", SanitizerToolName, count,
            size);
     Die();
   }
-  void *p = InternalAlloc(count * size, cache, alignment);
+  void* p = InternalAlloc(count * size, cache, alignment);
   if (LIKELY(p))
     internal_memset(p, 0, count * size);
   return p;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator.cpp
@@ -109,14 +109,14 @@ void *InternalReallocArray(void *addr, uptr count, uptr size,
   return InternalRealloc(addr, count * size, cache);
 }
 
-void *InternalCalloc(uptr count, uptr size, InternalAllocatorCache *cache) {
+void *InternalCalloc(uptr count, uptr size, InternalAllocatorCache *cache, uptr alignment) {
   if (UNLIKELY(CheckForCallocOverflow(count, size))) {
     Report("FATAL: %s: calloc parameters overflow: count * size (%zd * %zd) "
            "cannot be represented in type size_t\n", SanitizerToolName, count,
            size);
     Die();
   }
-  void *p = InternalAlloc(count * size, cache);
+  void *p = InternalAlloc(count * size, cache, alignment);
   if (LIKELY(p))
     internal_memset(p, 0, count * size);
   return p;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_dlsym.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_dlsym.h
@@ -40,8 +40,8 @@ struct DlSymAllocator {
     return ptr;
   }
 
-  static void *Callocate(usize nmemb, usize size) {
-    void *ptr = InternalCalloc(nmemb, size);
+  static void *Callocate(usize nmemb, usize size, uptr align = kWordSize) {
+    void *ptr = InternalCalloc(nmemb, size, nullptr, align);
     CHECK(internal_allocator()->FromPrimary(ptr));
     Details::OnAllocate(ptr, GetSize(ptr));
     return ptr;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_dlsym.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_dlsym.h
@@ -40,8 +40,8 @@ struct DlSymAllocator {
     return ptr;
   }
 
-  static void *Callocate(usize nmemb, usize size, uptr align = kWordSize) {
-    void *ptr = InternalCalloc(nmemb, size, nullptr, align);
+  static void* Callocate(usize nmemb, usize size, uptr align = kWordSize) {
+    void* ptr = InternalCalloc(nmemb, size, nullptr, align);
     CHECK(internal_allocator()->FromPrimary(ptr));
     Details::OnAllocate(ptr, GetSize(ptr));
     return ptr;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_internal.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_internal.h
@@ -45,8 +45,8 @@ void *InternalRealloc(void *p, uptr size,
                       InternalAllocatorCache *cache = nullptr);
 void *InternalReallocArray(void *p, uptr count, uptr size,
                            InternalAllocatorCache *cache = nullptr);
-void *InternalCalloc(uptr count, uptr size,
-                     InternalAllocatorCache *cache = nullptr,
+void* InternalCalloc(uptr count, uptr size,
+                     InternalAllocatorCache* cache = nullptr,
                      uptr alignment = 0);
 void InternalFree(void *p, InternalAllocatorCache *cache = nullptr);
 void InternalAllocatorLock();

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_internal.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_internal.h
@@ -46,7 +46,8 @@ void *InternalRealloc(void *p, uptr size,
 void *InternalReallocArray(void *p, uptr count, uptr size,
                            InternalAllocatorCache *cache = nullptr);
 void *InternalCalloc(uptr count, uptr size,
-                     InternalAllocatorCache *cache = nullptr);
+                     InternalAllocatorCache *cache = nullptr,
+                     uptr alignment = 0);
 void InternalFree(void *p, InternalAllocatorCache *cache = nullptr);
 void InternalAllocatorLock();
 void InternalAllocatorUnlock();

--- a/compiler-rt/test/asan/TestCases/AIX/vec_malloc_calloc.cpp
+++ b/compiler-rt/test/asan/TestCases/AIX/vec_malloc_calloc.cpp
@@ -8,18 +8,22 @@
 #include <string.h>
 
 int main(int argc, char **argv) {
-  if (argc != 2) return 1;
+  if (argc != 2)
+    return 1;
 
-  char *p; 
-  if (strcmp(argv[1], "vec_malloc") == 0) p = (char *)vec_malloc(10);
+  char *p;
+  if (strcmp(argv[1], "vec_malloc") == 0)
+    p = (char *)vec_malloc(10);
   // CHECK-MALLOC: {{READ of size 1 at 0x.* thread T0}}
   // CHECK-MALLOC: {{0x.* is located 0 bytes after 10-byte region}}
   // CHECK-MALLOC: {{0x.* in .vec_malloc}}
-  else if (strcmp(argv[1], "vec_calloc") == 0) p = (char *)vec_calloc(10, 1);
+  else if (strcmp(argv[1], "vec_calloc") == 0)
+    p = (char *)vec_calloc(10, 1);
   // CHECK-CALLOC: {{READ of size 1 at 0x.* thread T0}}
   // CHECK-CALLOC: {{0x.* is located 0 bytes after 10-byte region}}
   // CHECK-CALLOC: {{0x.* in .vec_calloc}}
-  else return 1;
+  else
+    return 1;
 
   char x = p[10];
   free(p);

--- a/compiler-rt/test/asan/TestCases/AIX/vec_malloc_calloc.cpp
+++ b/compiler-rt/test/asan/TestCases/AIX/vec_malloc_calloc.cpp
@@ -1,0 +1,28 @@
+// Verify vec_malloc and vec_calloc interceptors
+
+// RUN: %clangxx_asan -O0 %s -o %t
+// RUN: not %run %t vec_malloc 2>&1 | FileCheck %s --check-prefix=CHECK-MALLOC
+// RUN: not %run %t vec_calloc 2>&1 | FileCheck %s --check-prefix=CHECK-CALLOC
+
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+  if (argc != 2) return 1;
+
+  char *p; 
+  if (strcmp(argv[1], "vec_malloc") == 0) p = (char *)vec_malloc(10);
+  // CHECK-MALLOC: {{READ of size 1 at 0x.* thread T0}}
+  // CHECK-MALLOC: {{0x.* is located 0 bytes after 10-byte region}}
+  // CHECK-MALLOC: {{0x.* in .vec_malloc}}
+  else if (strcmp(argv[1], "vec_calloc") == 0) p = (char *)vec_calloc(10, 1);
+  // CHECK-CALLOC: {{READ of size 1 at 0x.* thread T0}}
+  // CHECK-CALLOC: {{0x.* is located 0 bytes after 10-byte region}}
+  // CHECK-CALLOC: {{0x.* in .vec_calloc}}
+  else return 1;
+
+  char x = p[10];
+  free(p);
+
+  return x;
+}


### PR DESCRIPTION
On AIX, when both the `__VEC__` and `_ALL_SOURCE` macros are defined (they are defined by default), the malloc and calloc system calls are mapped to vec_malloc and vec_calloc respectively, so we need the following vec_malloc and vec_calloc interceptors. 

Issue: #138916