### PR TITLE
[AArch64] Improve ISel for interleave2 of unpacked types

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -248,6 +248,23 @@ static inline bool isPackedVectorType(EVT VT, SelectionDAG &DAG) {
          VT.getSizeInBits().getKnownMinValue() == AArch64::SVEBitsPerBlock;
 }
 
+static inline bool isPackedPredicateType(EVT VT, SelectionDAG &DAG) {
+  assert(VT.isVector() && DAG.getTargetLoweringInfo().isTypeLegal(VT) &&
+         "Expected legal type!");
+  return VT == MVT::nxv16i1;
+}
+
+/// Returns true if VT's elements aren't placed back to back in its associated
+/// register class.
+///
+/// For example, nxv8i1 or nxv2f32 are unpacked types.
+static inline bool isUnpackedType(EVT VT, SelectionDAG &DAG) {
+  bool Res = !isPackedVectorType(VT, DAG) && !isPackedPredicateType(VT, DAG);
+  assert((!Res || VT.isScalableVector()) &&
+         "Unexpected fixed-size unpacked type.");
+  return Res;
+}
+
 // Returns true for ####_MERGE_PASSTHRU opcodes, whose operands have a leading
 // predicate and end with a passthru value matching the result type.
 static bool isMergePassthruOpcode(unsigned Opc) {
@@ -21132,6 +21149,22 @@ static SDValue performConcatVectorsCombine(SDNode *N,
   SDValue N0 = N->getOperand(0), N1 = N->getOperand(1);
   unsigned N0Opc = N0->getOpcode(), N1Opc = N1->getOpcode();
 
+  // For unpacked types:
+  // concat(zip1(a, b), zip2(a, b)) => trn1(a, b)
+  if (DCI.isAfterLegalizeDAG() && isUnpackedType(N0.getValueType(), DAG) &&
+      N->getNumOperands() == 2 && N0Opc == AArch64ISD::ZIP1 &&
+      N1Opc == AArch64ISD::ZIP2 && N0.getOperand(0) == N1.getOperand(0) &&
+      N0.getOperand(1) == N1.getOperand(1)) {
+    // If the type is unpacked, then each element is separated by a gap at least
+    // as big as the element size. It is therefore safe to re-interpret the
+    // inputs with double the elements and ignore odd elements (hence TRN1).
+    SDValue Op0MoreElems =
+        DAG.getNode(AArch64ISD::REINTERPRET_CAST, DL, VT, N0.getOperand(0));
+    SDValue Op1MoreElems =
+        DAG.getNode(AArch64ISD::REINTERPRET_CAST, DL, VT, N0.getOperand(1));
+    return DAG.getNode(AArch64ISD::TRN1, DL, VT, Op0MoreElems, Op1MoreElems);
+  }
+
   if (VT.isScalableVector())
     return SDValue();
 
@@ -31398,8 +31431,10 @@ SDValue AArch64TargetLowering::LowerVECTOR_INTERLEAVE(SDValue Op,
   }
 
   // Are multi-register zip instructions available?
+  // If so, use them for packed types. Interleaves of unpacked types can be
+  // selected using trn1.
   if (Subtarget->hasSME2() && Subtarget->isStreaming() &&
-      OpVT.isScalableVector() && OpVT.getVectorElementType() != MVT::i1) {
+      OpVT.isScalableVector() && isPackedVectorType(OpVT, DAG)) {
     Intrinsic::ID IntID;
     switch (Op->getNumOperands()) {
     default:

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -254,10 +254,13 @@ static inline bool isPackedPredicateType(EVT VT, SelectionDAG &DAG) {
   return VT == MVT::nxv16i1;
 }
 
-/// Returns true if VT's elements aren't placed back to back in its associated
-/// register class.
+/// Returns true if the conceptual representation for \p VT does not map
+/// directly to its physical register representation, meaning there are gaps
+/// between elements in the register. In practice, the vector elements will be
+/// strided by a power of two and placed starting from lane 0. For example,
+/// nxv8i1 or nxv2f32 are unpacked types.
 ///
-/// For example, nxv8i1 or nxv2f32 are unpacked types.
+///\pre VT is a legal type.
 static inline bool isUnpackedType(EVT VT, SelectionDAG &DAG) {
   bool Res = !isPackedVectorType(VT, DAG) && !isPackedPredicateType(VT, DAG);
   assert((!Res || VT.isScalableVector()) &&

--- a/llvm/test/CodeGen/AArch64/complex-deinterleaving-f16-add-scalable.ll
+++ b/llvm/test/CodeGen/AArch64/complex-deinterleaving-f16-add-scalable.ll
@@ -18,9 +18,7 @@ define <vscale x 4 x half> @complex_add_v4f16(<vscale x 4 x half> %a, <vscale x 
 ; CHECK-NEXT:    uunpklo z1.d, z1.s
 ; CHECK-NEXT:    fsubr z0.h, p0/m, z0.h, z1.h
 ; CHECK-NEXT:    fadd z2.h, p0/m, z2.h, z3.h
-; CHECK-NEXT:    zip2 z1.d, z0.d, z2.d
-; CHECK-NEXT:    zip1 z0.d, z0.d, z2.d
-; CHECK-NEXT:    uzp1 z0.s, z0.s, z1.s
+; CHECK-NEXT:    trn1 z0.s, z0.s, z2.s
 ; CHECK-NEXT:    ret
 entry:
   %a.deinterleaved = tail call { <vscale x 2 x half>, <vscale x 2 x half> } @llvm.vector.deinterleave2.nxv4f16(<vscale x 4 x half> %a)

--- a/llvm/test/CodeGen/AArch64/complex-deinterleaving-f16-mul-scalable.ll
+++ b/llvm/test/CodeGen/AArch64/complex-deinterleaving-f16-mul-scalable.ll
@@ -21,9 +21,7 @@ define <vscale x 4 x half> @complex_mul_v4f16(<vscale x 4 x half> %a, <vscale x 
 ; CHECK-NEXT:    fmul z3.h, p0/m, z3.h, z2.h
 ; CHECK-NEXT:    fmad z2.h, p0/m, z1.h, z4.h
 ; CHECK-NEXT:    fnmsb z0.h, p0/m, z1.h, z3.h
-; CHECK-NEXT:    zip2 z1.d, z0.d, z2.d
-; CHECK-NEXT:    zip1 z0.d, z0.d, z2.d
-; CHECK-NEXT:    uzp1 z0.s, z0.s, z1.s
+; CHECK-NEXT:    trn1 z0.s, z0.s, z2.s
 ; CHECK-NEXT:    ret
 entry:
   %a.deinterleaved = tail call { <vscale x 2 x half>, <vscale x 2 x half> } @llvm.vector.deinterleave2.nxv4f16(<vscale x 4 x half> %a)

--- a/llvm/test/CodeGen/AArch64/scalable_masked_deinterleaved_loads.ll
+++ b/llvm/test/CodeGen/AArch64/scalable_masked_deinterleaved_loads.ll
@@ -219,9 +219,7 @@ define { <vscale x 16 x i8>, <vscale x 16 x i8> } @foo_ld2_nxv16i8_bad_mask3(<vs
 define { <vscale x 8 x i8>, <vscale x 8 x i8> } @foo_ld2_nxv8i8(<vscale x 8 x i1> %mask, ptr %p) {
 ; CHECK-LABEL: foo_ld2_nxv8i8:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    zip2 p1.h, p0.h, p0.h
-; CHECK-NEXT:    zip1 p0.h, p0.h, p0.h
-; CHECK-NEXT:    uzp1 p0.b, p0.b, p1.b
+; CHECK-NEXT:    trn1 p0.b, p0.b, p0.b
 ; CHECK-NEXT:    ld1b { z0.b }, p0/z, [x0]
 ; CHECK-NEXT:    uunpkhi z1.h, z0.b
 ; CHECK-NEXT:    uunpklo z2.h, z0.b
@@ -270,9 +268,7 @@ define { <vscale x 8 x i16>, <vscale x 8 x i16> } @foo_deinterleave2_not_load(<v
 define { <vscale x 4 x i16>, <vscale x 4 x i16> } @foo_ld2_nxv8i8_exti16(<vscale x 4 x i1> %mask, ptr %p) {
 ; CHECK-LABEL: foo_ld2_nxv8i8_exti16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    zip2 p1.s, p0.s, p0.s
-; CHECK-NEXT:    zip1 p0.s, p0.s, p0.s
-; CHECK-NEXT:    uzp1 p0.h, p0.h, p1.h
+; CHECK-NEXT:    trn1 p0.h, p0.h, p0.h
 ; CHECK-NEXT:    ld1b { z0.h }, p0/z, [x0]
 ; CHECK-NEXT:    uunpkhi z1.s, z0.h
 ; CHECK-NEXT:    uunpklo z2.s, z0.h

--- a/llvm/test/CodeGen/AArch64/scalable_masked_interleaved_stores.ll
+++ b/llvm/test/CodeGen/AArch64/scalable_masked_interleaved_stores.ll
@@ -257,10 +257,8 @@ define void @foo_st2_nxv8i8(<vscale x 8 x i1> %mask, <vscale x 8 x i8> %val1, <v
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    zip2 z2.h, z0.h, z1.h
 ; CHECK-NEXT:    zip1 z0.h, z0.h, z1.h
-; CHECK-NEXT:    zip2 p1.h, p0.h, p0.h
-; CHECK-NEXT:    zip1 p0.h, p0.h, p0.h
+; CHECK-NEXT:    trn1 p0.b, p0.b, p0.b
 ; CHECK-NEXT:    uzp1 z0.b, z0.b, z2.b
-; CHECK-NEXT:    uzp1 p0.b, p0.b, p1.b
 ; CHECK-NEXT:    st1b { z0.b }, p0, [x0]
 ; CHECK-NEXT:    ret
   %interleaved.mask = call <vscale x 16 x i1> @llvm.vector.interleave2.nxv16i1(<vscale x 8 x i1> %mask, <vscale x 8 x i1> %mask)
@@ -274,10 +272,8 @@ define void @foo_st2_nxv8i8_trunc(<vscale x 4 x i1> %mask, <vscale x 4 x i16> %v
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    zip2 z2.s, z0.s, z1.s
 ; CHECK-NEXT:    zip1 z0.s, z0.s, z1.s
-; CHECK-NEXT:    zip2 p1.s, p0.s, p0.s
-; CHECK-NEXT:    zip1 p0.s, p0.s, p0.s
+; CHECK-NEXT:    trn1 p0.h, p0.h, p0.h
 ; CHECK-NEXT:    uzp1 z0.h, z0.h, z2.h
-; CHECK-NEXT:    uzp1 p0.h, p0.h, p1.h
 ; CHECK-NEXT:    st1b { z0.h }, p0, [x0]
 ; CHECK-NEXT:    ret
   %interleaved.mask = call <vscale x 8 x i1> @llvm.vector.interleave2.nxv8i1(<vscale x 4 x i1> %mask, <vscale x 4 x i1> %mask)

--- a/llvm/test/CodeGen/AArch64/sve-vector-interleave.ll
+++ b/llvm/test/CodeGen/AArch64/sve-vector-interleave.ll
@@ -7,35 +7,19 @@
 target triple = "aarch64-unknown-linux-gnu"
 
 define <vscale x 4 x half> @interleave2_nxv4f16(<vscale x 2 x half> %vec0, <vscale x 2 x half> %vec1) {
-; SVE-LABEL: interleave2_nxv4f16:
-; SVE:       // %bb.0:
-; SVE-NEXT:    zip2 z2.d, z0.d, z1.d
-; SVE-NEXT:    zip1 z0.d, z0.d, z1.d
-; SVE-NEXT:    uzp1 z0.s, z0.s, z2.s
-; SVE-NEXT:    ret
-;
-; SME2-LABEL: interleave2_nxv4f16:
-; SME2:       // %bb.0:
-; SME2-NEXT:    zip { z0.d, z1.d }, z0.d, z1.d
-; SME2-NEXT:    uzp1 z0.s, z0.s, z1.s
-; SME2-NEXT:    ret
+; CHECK-LABEL: interleave2_nxv4f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    trn1 z0.s, z0.s, z1.s
+; CHECK-NEXT:    ret
   %retval = call <vscale x 4 x half> @llvm.vector.interleave2.nxv4f16(<vscale x 2 x half> %vec0, <vscale x 2 x half> %vec1)
   ret <vscale x 4 x half> %retval
 }
 
 define <vscale x 8 x half> @interleave2_nxv8f16(<vscale x 4 x half> %vec0, <vscale x 4 x half> %vec1) {
-; SVE-LABEL: interleave2_nxv8f16:
-; SVE:       // %bb.0:
-; SVE-NEXT:    zip2 z2.s, z0.s, z1.s
-; SVE-NEXT:    zip1 z0.s, z0.s, z1.s
-; SVE-NEXT:    uzp1 z0.h, z0.h, z2.h
-; SVE-NEXT:    ret
-;
-; SME2-LABEL: interleave2_nxv8f16:
-; SME2:       // %bb.0:
-; SME2-NEXT:    zip { z0.s, z1.s }, z0.s, z1.s
-; SME2-NEXT:    uzp1 z0.h, z0.h, z1.h
-; SME2-NEXT:    ret
+; CHECK-LABEL: interleave2_nxv8f16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    trn1 z0.h, z0.h, z1.h
+; CHECK-NEXT:    ret
   %retval = call <vscale x 8 x half> @llvm.vector.interleave2.nxv8f16(<vscale x 4 x half> %vec0, <vscale x 4 x half> %vec1)
   ret <vscale x 8 x half> %retval
 }
@@ -57,18 +41,10 @@ define <vscale x 16 x half> @interleave2_nxv16f16(<vscale x 8 x half> %vec0, <vs
 }
 
 define <vscale x 4 x float> @interleave2_nxv4f32(<vscale x 2 x float> %vec0, <vscale x 2 x float> %vec1) {
-; SVE-LABEL: interleave2_nxv4f32:
-; SVE:       // %bb.0:
-; SVE-NEXT:    zip2 z2.d, z0.d, z1.d
-; SVE-NEXT:    zip1 z0.d, z0.d, z1.d
-; SVE-NEXT:    uzp1 z0.s, z0.s, z2.s
-; SVE-NEXT:    ret
-;
-; SME2-LABEL: interleave2_nxv4f32:
-; SME2:       // %bb.0:
-; SME2-NEXT:    zip { z0.d, z1.d }, z0.d, z1.d
-; SME2-NEXT:    uzp1 z0.s, z0.s, z1.s
-; SME2-NEXT:    ret
+; CHECK-LABEL: interleave2_nxv4f32:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    trn1 z0.s, z0.s, z1.s
+; CHECK-NEXT:    ret
   %retval = call <vscale x 4 x float> @llvm.vector.interleave2.nxv4f32(<vscale x 2 x float> %vec0, <vscale x 2 x float> %vec1)
   ret <vscale x 4 x float> %retval
 }
@@ -106,35 +82,19 @@ define <vscale x 4 x double> @interleave2_nxv4f64(<vscale x 2 x double> %vec0, <
 }
 
 define <vscale x 4 x bfloat> @interleave2_nxv4bf16(<vscale x 2 x bfloat> %vec0, <vscale x 2 x bfloat> %vec1) {
-; SVE-LABEL: interleave2_nxv4bf16:
-; SVE:       // %bb.0:
-; SVE-NEXT:    zip2 z2.d, z0.d, z1.d
-; SVE-NEXT:    zip1 z0.d, z0.d, z1.d
-; SVE-NEXT:    uzp1 z0.s, z0.s, z2.s
-; SVE-NEXT:    ret
-;
-; SME2-LABEL: interleave2_nxv4bf16:
-; SME2:       // %bb.0:
-; SME2-NEXT:    zip { z0.d, z1.d }, z0.d, z1.d
-; SME2-NEXT:    uzp1 z0.s, z0.s, z1.s
-; SME2-NEXT:    ret
+; CHECK-LABEL: interleave2_nxv4bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    trn1 z0.s, z0.s, z1.s
+; CHECK-NEXT:    ret
   %retval = call <vscale x 4 x bfloat> @llvm.vector.interleave2.nxv4bf16(<vscale x 2 x bfloat> %vec0, <vscale x 2 x bfloat> %vec1)
   ret <vscale x 4 x bfloat> %retval
 }
 
 define <vscale x 8 x bfloat> @interleave2_nxv8bf16(<vscale x 4 x bfloat> %vec0, <vscale x 4 x bfloat> %vec1) {
-; SVE-LABEL: interleave2_nxv8bf16:
-; SVE:       // %bb.0:
-; SVE-NEXT:    zip2 z2.s, z0.s, z1.s
-; SVE-NEXT:    zip1 z0.s, z0.s, z1.s
-; SVE-NEXT:    uzp1 z0.h, z0.h, z2.h
-; SVE-NEXT:    ret
-;
-; SME2-LABEL: interleave2_nxv8bf16:
-; SME2:       // %bb.0:
-; SME2-NEXT:    zip { z0.s, z1.s }, z0.s, z1.s
-; SME2-NEXT:    uzp1 z0.h, z0.h, z1.h
-; SME2-NEXT:    ret
+; CHECK-LABEL: interleave2_nxv8bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    trn1 z0.h, z0.h, z1.h
+; CHECK-NEXT:    ret
   %retval = call <vscale x 8 x bfloat> @llvm.vector.interleave2.nxv8bf16(<vscale x 4 x bfloat> %vec0, <vscale x 4 x bfloat> %vec1)
   ret <vscale x 8 x bfloat> %retval
 }
@@ -721,9 +681,7 @@ define <vscale x 32 x i1> @interleave2_nxv32i1(<vscale x 16 x i1> %vec0, <vscale
 define <vscale x 16 x i1> @interleave2_nxv16i1(<vscale x 8 x i1> %vec0, <vscale x 8 x i1> %vec1) {
 ; CHECK-LABEL: interleave2_nxv16i1:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    zip2 p2.h, p0.h, p1.h
-; CHECK-NEXT:    zip1 p0.h, p0.h, p1.h
-; CHECK-NEXT:    uzp1 p0.b, p0.b, p2.b
+; CHECK-NEXT:    trn1 p0.b, p0.b, p1.b
 ; CHECK-NEXT:    ret
   %retval = call <vscale x 16 x i1> @llvm.vector.interleave2.nxv16i1(<vscale x 8 x i1> %vec0, <vscale x 8 x i1> %vec1)
   ret <vscale x 16 x i1> %retval
@@ -732,9 +690,7 @@ define <vscale x 16 x i1> @interleave2_nxv16i1(<vscale x 8 x i1> %vec0, <vscale 
 define <vscale x 8 x i1> @interleave2_nxv8i1(<vscale x 4 x i1> %vec0, <vscale x 4 x i1> %vec1) {
 ; CHECK-LABEL: interleave2_nxv8i1:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    zip2 p2.s, p0.s, p1.s
-; CHECK-NEXT:    zip1 p0.s, p0.s, p1.s
-; CHECK-NEXT:    uzp1 p0.h, p0.h, p2.h
+; CHECK-NEXT:    trn1 p0.h, p0.h, p1.h
 ; CHECK-NEXT:    ret
   %retval = call <vscale x 8 x i1> @llvm.vector.interleave2.nxv8i1(<vscale x 4 x i1> %vec0, <vscale x 4 x i1> %vec1)
   ret <vscale x 8 x i1> %retval
@@ -743,12 +699,19 @@ define <vscale x 8 x i1> @interleave2_nxv8i1(<vscale x 4 x i1> %vec0, <vscale x 
 define <vscale x 4 x i1> @interleave2_nxv4i1(<vscale x 2 x i1> %vec0, <vscale x 2 x i1> %vec1) {
 ; CHECK-LABEL: interleave2_nxv4i1:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    zip2 p2.d, p0.d, p1.d
-; CHECK-NEXT:    zip1 p0.d, p0.d, p1.d
-; CHECK-NEXT:    uzp1 p0.s, p0.s, p2.s
+; CHECK-NEXT:    trn1 p0.s, p0.s, p1.s
 ; CHECK-NEXT:    ret
   %retval = call <vscale x 4 x i1> @llvm.vector.interleave2.nxv4i1(<vscale x 2 x i1> %vec0, <vscale x 2 x i1> %vec1)
   ret <vscale x 4 x i1> %retval
+}
+
+define <vscale x 2 x i1> @interleave2_nxv2i1(<vscale x 1 x i1> %vec0, <vscale x 1 x i1> %vec1) {
+; CHECK-LABEL: interleave2_nxv2i1:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    trn1 p0.d, p0.d, p1.d
+; CHECK-NEXT:    ret
+  %retval = call <vscale x 2 x i1> @llvm.vector.interleave2.nxv4i1(<vscale x 1 x i1> %vec0, <vscale x 1 x i1> %vec1)
+  ret <vscale x 2 x i1> %retval
 }
 
 ; Split illegal type size


### PR DESCRIPTION
This applies to predicate types and scalable FP/BFP vectors.