### PR TITLE
[LLD][MachO][NFC] Rename Reloc to Relocation

### DIFF
--- a/lld/MachO/Arch/ARM64Common.cpp
+++ b/lld/MachO/Arch/ARM64Common.cpp
@@ -38,7 +38,7 @@ int64_t ARM64Common::getEmbeddedAddend(MemoryBufferRef mb, uint64_t offset,
   }
 }
 
-static void writeValue(uint8_t *loc, const Reloc &r, uint64_t value) {
+static void writeValue(uint8_t *loc, const Relocation &r, uint64_t value) {
   switch (r.length) {
   case 2:
     checkInt(loc, r, value, 32);
@@ -57,7 +57,7 @@ static void writeValue(uint8_t *loc, const Reloc &r, uint64_t value) {
 // instruction has opcode & register-operand bits set, with immediate
 // operands zeroed. We read it from text, OR-in the immediate
 // operands, then write-back the completed instruction.
-void ARM64Common::relocateOne(uint8_t *loc, const Reloc &r, uint64_t value,
+void ARM64Common::relocateOne(uint8_t *loc, const Relocation &r, uint64_t value,
                               uint64_t pc) const {
   auto loc32 = reinterpret_cast<uint32_t *>(loc);
   uint32_t base = ((r.length == 2) ? read32le(loc) : 0);
@@ -110,7 +110,7 @@ void ARM64Common::relaxGotLoad(uint8_t *loc, uint8_t type) const {
   write32le(loc, instruction);
 }
 
-void ARM64Common::handleDtraceReloc(const Symbol *sym, const Reloc &r,
+void ARM64Common::handleDtraceReloc(const Symbol *sym, const Relocation &r,
                                     uint8_t *loc) const {
   assert(r.type == ARM64_RELOC_BRANCH26);
 
@@ -138,8 +138,8 @@ static void reportUnalignedLdrStr(Twine loc, uint64_t va, int align,
         "-byte aligned");
 }
 
-void macho::reportUnalignedLdrStr(void *loc, const lld::macho::Reloc &r,
-                                  uint64_t va, int align) {
+void macho::reportUnalignedLdrStr(void *loc, const Relocation &r, uint64_t va,
+                                  int align) {
   uint64_t off = reinterpret_cast<const uint8_t *>(loc) - in.bufferStart;
   const InputSection *isec = offsetToInputSection(&off);
   std::string locStr = isec ? isec->getLocation(off) : "(invalid location)";

--- a/lld/MachO/Arch/ARM64Common.h
+++ b/lld/MachO/Arch/ARM64Common.h
@@ -23,13 +23,13 @@ struct ARM64Common : TargetInfo {
 
   int64_t getEmbeddedAddend(MemoryBufferRef, uint64_t offset,
                             const llvm::MachO::relocation_info) const override;
-  void relocateOne(uint8_t *loc, const Reloc &, uint64_t va,
+  void relocateOne(uint8_t *loc, const Relocation &, uint64_t va,
                    uint64_t pc) const override;
 
   void relaxGotLoad(uint8_t *loc, uint8_t type) const override;
   uint64_t getPageSize() const override { return 16 * 1024; }
 
-  void handleDtraceReloc(const Symbol *sym, const Reloc &r,
+  void handleDtraceReloc(const Symbol *sym, const Relocation &r,
                          uint8_t *loc) const override;
 };
 
@@ -42,7 +42,7 @@ inline uint64_t bitField(uint64_t value, int right, int width, int left) {
 // |           |                       imm26                       |
 // +-----------+---------------------------------------------------+
 
-inline void encodeBranch26(uint32_t *loc, const Reloc &r, uint32_t base,
+inline void encodeBranch26(uint32_t *loc, const Relocation &r, uint32_t base,
                            uint64_t va) {
   checkInt(loc, r, va, 28);
   // Since branch destinations are 4-byte aligned, the 2 least-
@@ -61,7 +61,7 @@ inline void encodeBranch26(uint32_t *loc, SymbolDiagnostic d, uint32_t base,
 // | |ilo|         |                immhi                |         |
 // +-+---+---------+-------------------------------------+---------+
 
-inline void encodePage21(uint32_t *loc, const Reloc &r, uint32_t base,
+inline void encodePage21(uint32_t *loc, const Relocation &r, uint32_t base,
                          uint64_t va) {
   checkInt(loc, r, va, 35);
   llvm::support::endian::write32le(loc, base | bitField(va, 12, 2, 29) |
@@ -75,7 +75,8 @@ inline void encodePage21(uint32_t *loc, SymbolDiagnostic d, uint32_t base,
                                             bitField(va, 14, 19, 5));
 }
 
-void reportUnalignedLdrStr(void *loc, const Reloc &, uint64_t va, int align);
+void reportUnalignedLdrStr(void *loc, const Relocation &, uint64_t va,
+                           int align);
 void reportUnalignedLdrStr(void *loc, SymbolDiagnostic, uint64_t va, int align);
 
 //                      21                   10

--- a/lld/MachO/Arch/X86_64.cpp
+++ b/lld/MachO/Arch/X86_64.cpp
@@ -28,7 +28,7 @@ struct X86_64 : TargetInfo {
 
   int64_t getEmbeddedAddend(MemoryBufferRef, uint64_t offset,
                             const relocation_info) const override;
-  void relocateOne(uint8_t *loc, const Reloc &, uint64_t va,
+  void relocateOne(uint8_t *loc, const Relocation &, uint64_t va,
                    uint64_t relocVA) const override;
 
   void writeStub(uint8_t *buf, const Symbol &,
@@ -44,7 +44,7 @@ struct X86_64 : TargetInfo {
   void relaxGotLoad(uint8_t *loc, uint8_t type) const override;
   uint64_t getPageSize() const override { return 4 * 1024; }
 
-  void handleDtraceReloc(const Symbol *sym, const Reloc &r,
+  void handleDtraceReloc(const Symbol *sym, const Relocation &r,
                          uint8_t *loc) const override;
 };
 } // namespace
@@ -102,7 +102,7 @@ int64_t X86_64::getEmbeddedAddend(MemoryBufferRef mb, uint64_t offset,
   return addend + pcrelOffset(rel.r_type);
 }
 
-void X86_64::relocateOne(uint8_t *loc, const Reloc &r, uint64_t value,
+void X86_64::relocateOne(uint8_t *loc, const Relocation &r, uint64_t value,
                          uint64_t relocVA) const {
   if (r.pcrel) {
     uint64_t pc = relocVA + (1ull << r.length) + pcrelOffset(r.type);
@@ -241,7 +241,7 @@ TargetInfo *macho::createX86_64TargetInfo() {
   return &t;
 }
 
-void X86_64::handleDtraceReloc(const Symbol *sym, const Reloc &r,
+void X86_64::handleDtraceReloc(const Symbol *sym, const Relocation &r,
                                uint8_t *loc) const {
   assert(r.type == X86_64_RELOC_BRANCH);
 

--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -85,7 +85,7 @@ struct BPOrdererMachO : lld::BPOrderer<BPOrdererMachO> {
 
 private:
   static uint64_t
-  getRelocHash(const macho::Reloc &reloc,
+  getRelocHash(const Relocation &reloc,
                const llvm::DenseMap<const void *, uint64_t> &sectionToIdx) {
     auto *isec = reloc.getReferentInputSection();
     std::optional<uint64_t> sectionIdx;

--- a/lld/MachO/ConcatOutputSection.cpp
+++ b/lld/MachO/ConcatOutputSection.cpp
@@ -148,7 +148,7 @@ bool TextOutputSection::needsThunks() const {
     parent->needsThunks = true;
   }
   for (ConcatInputSection *isec : inputs) {
-    for (Reloc &r : isec->relocs) {
+    for (Relocation &r : isec->relocs) {
       if (!target->hasAttr(r.type, RelocAttrBits::BRANCH))
         continue;
       auto *sym = cast<Symbol *>(r.referent);
@@ -333,12 +333,13 @@ void TextOutputSection::finalize() {
       branchTargetThresholdVA = estimateBranchTargetThresholdVA(callIdx);
     }
     // Process relocs by ascending address, i.e., ascending offset within isec
-    std::vector<Reloc> &relocs = isec->relocs;
+    std::vector<Relocation> &relocs = isec->relocs;
     // FIXME: This property does not hold for object files produced by ld64's
     // `-r` mode.
-    assert(is_sorted(relocs,
-                     [](Reloc &a, Reloc &b) { return a.offset > b.offset; }));
-    for (Reloc &r : reverse(relocs)) {
+    assert(is_sorted(relocs, [](Relocation &a, Relocation &b) {
+      return a.offset > b.offset;
+    }));
+    for (Relocation &r : reverse(relocs)) {
       ++relocCount;
       if (!target->hasAttr(r.type, RelocAttrBits::BRANCH))
         continue;

--- a/lld/MachO/EhFrame.cpp
+++ b/lld/MachO/EhFrame.cpp
@@ -109,16 +109,16 @@ template <bool Invert = false>
 static void createSubtraction(PointerUnion<Symbol *, InputSection *> a,
                               PointerUnion<Symbol *, InputSection *> b,
                               uint64_t off, uint8_t length,
-                              SmallVectorImpl<Reloc> *newRelocs) {
+                              SmallVectorImpl<Relocation> *newRelocs) {
   auto subtrahend = a;
   auto minuend = b;
   if (Invert)
     std::swap(subtrahend, minuend);
   assert(isa<Symbol *>(subtrahend));
-  Reloc subtrahendReloc(target->subtractorRelocType, /*pcrel=*/false, length,
-                        off, /*addend=*/0, subtrahend);
-  Reloc minuendReloc(target->unsignedRelocType, /*pcrel=*/false, length, off,
-                     (Invert ? 1 : -1) * off, minuend);
+  Relocation subtrahendReloc(target->subtractorRelocType, /*pcrel=*/false,
+                             length, off, /*addend=*/0, subtrahend);
+  Relocation minuendReloc(target->unsignedRelocType, /*pcrel=*/false, length,
+                          off, (Invert ? 1 : -1) * off, minuend);
   newRelocs->push_back(subtrahendReloc);
   newRelocs->push_back(minuendReloc);
 }

--- a/lld/MachO/EhFrame.h
+++ b/lld/MachO/EhFrame.h
@@ -108,7 +108,7 @@ private:
   InputSection *isec;
   // Insert new relocs here so that we don't invalidate iterators into the
   // existing relocs vector.
-  SmallVector<Reloc, 6> newRelocs;
+  SmallVector<Relocation, 6> newRelocs;
 };
 
 } // namespace lld::macho

--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -106,7 +106,7 @@ bool ICF::equalsConstant(const ConcatInputSection *ia,
     return false;
   if (ia->relocs.size() != ib->relocs.size())
     return false;
-  auto f = [](const Reloc &ra, const Reloc &rb) {
+  auto f = [](const Relocation &ra, const Relocation &rb) {
     if (ra.type != rb.type)
       return false;
     if (ra.pcrel != rb.pcrel)
@@ -213,7 +213,7 @@ bool ICF::equalsVariable(const ConcatInputSection *ia,
   if (verboseDiagnostics)
     ++equalsVariableCount;
   assert(ia->relocs.size() == ib->relocs.size());
-  auto f = [this](const Reloc &ra, const Reloc &rb) {
+  auto f = [this](const Relocation &ra, const Relocation &rb) {
     // We already filtered out mismatching values/addends in equalsConstant.
     if (ra.referent == rb.referent)
       return true;
@@ -390,7 +390,7 @@ void ICF::run() {
   for (icfPass = 0; icfPass < 2; ++icfPass) {
     parallelForEach(icfInputs, [&](ConcatInputSection *isec) {
       uint32_t hash = isec->icfEqClass[icfPass % 2];
-      for (const Reloc &r : isec->relocs) {
+      for (const Relocation &r : isec->relocs) {
         if (auto *sym = r.referent.dyn_cast<Symbol *>()) {
           if (auto *defined = dyn_cast<Defined>(sym)) {
             if (defined->isec()) {
@@ -520,7 +520,7 @@ void macho::markAddrSigSymbols() {
 
     const InputSection *isec = addrSigSection->subsections[0].isec;
 
-    for (const Reloc &r : isec->relocs) {
+    for (const Relocation &r : isec->relocs) {
       if (auto *sym = r.referent.dyn_cast<Symbol *>())
         markSymAsAddrSig(sym);
       else
@@ -609,7 +609,7 @@ void macho::foldIdenticalSections(bool onlyCfStrings) {
         // We have to do this copying serially as the BumpPtrAllocator is not
         // thread-safe. FIXME: Make a thread-safe allocator.
         MutableArrayRef<uint8_t> copy = isec->data.copy(bAlloc());
-        for (const Reloc &r : isec->relocs)
+        for (const Relocation &r : isec->relocs)
           target->relocateOne(copy.data() + r.offset, r, /*va=*/0,
                               /*relocVA=*/0);
         isec->data = copy;

--- a/lld/MachO/InputFiles.h
+++ b/lld/MachO/InputFiles.h
@@ -45,7 +45,7 @@ class ConcatInputSection;
 class Symbol;
 class Defined;
 class AliasSymbol;
-struct Reloc;
+struct Relocation;
 enum class RefState : uint8_t;
 
 // If --reproduce option is given, all input files are written

--- a/lld/MachO/InputSection.h
+++ b/lld/MachO/InputSection.h
@@ -56,7 +56,7 @@ public:
   // Format: Source.cpp:123 (/path/to/Source.cpp:123)
   std::string getSourceLocation(uint64_t off) const;
   // Return the relocation at \p off, if it exists. This does a linear search.
-  const Reloc *getRelocAt(uint32_t off) const;
+  const Relocation *getRelocAt(uint32_t off) const;
   // Whether the data at \p off in this InputSection is live.
   virtual bool isLive(uint64_t off) const = 0;
   virtual void markLive(uint64_t off) = 0;
@@ -88,7 +88,7 @@ public:
 
   OutputSection *parent = nullptr;
   ArrayRef<uint8_t> data;
-  std::vector<Reloc> relocs;
+  std::vector<Relocation> relocs;
   // The symbols that belong to this InputSection, sorted by value. With
   // .subsections_via_symbols, there is typically only one element here.
   llvm::TinyPtrVector<Defined *> symbols;

--- a/lld/MachO/MarkLive.cpp
+++ b/lld/MachO/MarkLive.cpp
@@ -154,7 +154,7 @@ void MarkLiveImpl<RecordWhyLive>::markTransitively() {
       assert(isec->live && "We mark as live when pushing onto the worklist!");
 
       // Mark all symbols listed in the relocation table for this section.
-      for (const Reloc &r : isec->relocs) {
+      for (const Relocation &r : isec->relocs) {
         if (auto *s = r.referent.dyn_cast<Symbol *>())
           addSym(s, entry);
         else
@@ -172,7 +172,7 @@ void MarkLiveImpl<RecordWhyLive>::markTransitively() {
       if (!(isec->getFlags() & S_ATTR_LIVE_SUPPORT) || isec->live)
         continue;
 
-      for (const Reloc &r : isec->relocs) {
+      for (const Relocation &r : isec->relocs) {
         if (auto *s = r.referent.dyn_cast<Symbol *>()) {
           if (s->isLive()) {
             InputSection *referentIsec = nullptr;

--- a/lld/MachO/Relocations.cpp
+++ b/lld/MachO/Relocations.cpp
@@ -18,10 +18,10 @@ using namespace llvm;
 using namespace lld;
 using namespace lld::macho;
 
-static_assert(sizeof(void *) != 8 || sizeof(Reloc) == 24,
+static_assert(sizeof(void *) != 8 || sizeof(Relocation) == 24,
               "Try to minimize Reloc's size; we create many instances");
 
-InputSection *Reloc::getReferentInputSection() const {
+InputSection *Relocation::getReferentInputSection() const {
   if (const auto *sym = referent.dyn_cast<Symbol *>()) {
     if (const auto *d = dyn_cast<Defined>(sym))
       return d->isec();
@@ -31,7 +31,7 @@ InputSection *Reloc::getReferentInputSection() const {
   }
 }
 
-StringRef Reloc::getReferentString() const {
+StringRef Relocation::getReferentString() const {
   if (auto *isec = dyn_cast<InputSection *>(referent)) {
     const auto *cisec = dyn_cast<CStringInputSection>(isec);
     assert(cisec && "referent must be a CStringInputSection");
@@ -57,7 +57,8 @@ StringRef Reloc::getReferentString() const {
 }
 
 bool macho::validateSymbolRelocation(const Symbol *sym,
-                                     const InputSection *isec, const Reloc &r) {
+                                     const InputSection *isec,
+                                     const Relocation &r) {
   const RelocAttrs &relocAttrs = target->getRelocAttrs(r.type);
   bool valid = true;
   auto message = [&](const Twine &diagnostic) {
@@ -117,7 +118,7 @@ InputSection *macho::offsetToInputSection(uint64_t *off) {
   return nullptr;
 }
 
-void macho::reportRangeError(void *loc, const Reloc &r, const Twine &v,
+void macho::reportRangeError(void *loc, const Relocation &r, const Twine &v,
                              uint8_t bits, int64_t min, uint64_t max) {
   std::string hint;
   uint64_t off = reinterpret_cast<const uint8_t *>(loc) - in.bufferStart;

--- a/lld/MachO/Relocations.h
+++ b/lld/MachO/Relocations.h
@@ -51,7 +51,7 @@ struct RelocAttrs {
   bool hasAttr(RelocAttrBits b) const { return (bits & b) == b; }
 };
 
-struct Reloc {
+struct Relocation {
   uint8_t type = llvm::MachO::GENERIC_RELOC_INVALID;
   bool pcrel = false;
   uint8_t length = 0;
@@ -63,10 +63,11 @@ struct Reloc {
   int64_t addend = 0;
   llvm::PointerUnion<Symbol *, InputSection *> referent = nullptr;
 
-  Reloc() = default;
+  Relocation() = default;
 
-  Reloc(uint8_t type, bool pcrel, uint8_t length, uint32_t offset,
-        int64_t addend, llvm::PointerUnion<Symbol *, InputSection *> referent)
+  Relocation(uint8_t type, bool pcrel, uint8_t length, uint32_t offset,
+             int64_t addend,
+             llvm::PointerUnion<Symbol *, InputSection *> referent)
       : type(type), pcrel(pcrel), length(length), offset(offset),
         addend(addend), referent(referent) {}
 
@@ -78,13 +79,13 @@ struct Reloc {
 };
 
 bool validateSymbolRelocation(const Symbol *, const InputSection *,
-                              const Reloc &);
+                              const Relocation &);
 
 /*
  * v: The value the relocation is attempting to encode
  * bits: The number of bits actually available to encode this relocation
  */
-void reportRangeError(void *loc, const Reloc &, const llvm::Twine &v,
+void reportRangeError(void *loc, const Relocation &, const llvm::Twine &v,
                       uint8_t bits, int64_t min, uint64_t max);
 
 struct SymbolDiagnostic {

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -2010,7 +2010,7 @@ uint64_t InitOffsetsSection::getSize() const {
 void InitOffsetsSection::writeTo(uint8_t *buf) const {
   // FIXME: Add function specified by -init when that argument is implemented.
   for (ConcatInputSection *isec : sections) {
-    for (const Reloc &rel : isec->relocs) {
+    for (const Relocation &rel : isec->relocs) {
       const Symbol *referent = cast<Symbol *>(rel.referent);
       assert(referent && "section relocation should have been rejected");
       uint64_t offset = referent->getVA() - in.header->addr;
@@ -2035,7 +2035,7 @@ void InitOffsetsSection::writeTo(uint8_t *buf) const {
 // not known at link time, stub-indirection has to be used.
 void InitOffsetsSection::setUp() {
   for (const ConcatInputSection *isec : sections) {
-    for (const Reloc &rel : isec->relocs) {
+    for (const Relocation &rel : isec->relocs) {
       RelocAttrs attrs = target->getRelocAttrs(rel.type);
       if (!attrs.hasAttr(RelocAttrBits::UNSIGNED))
         error(isec->getLocation(rel.offset) +
@@ -2076,7 +2076,7 @@ void ObjCMethListSection::setUp() {
 
     // Loop through all methods, and ensure a selref for each of them exists.
     while (methodNameOff < isec->data.size()) {
-      const Reloc *reloc = isec->getRelocAt(methodNameOff);
+      const Relocation *reloc = isec->getRelocAt(methodNameOff);
       assert(reloc && "Relocation expected at method list name slot");
 
       StringRef methname = reloc->getReferentString();
@@ -2177,7 +2177,7 @@ bool ObjCMethListSection::isMethodList(const ConcatInputSection *isec) {
 void ObjCMethListSection::writeRelativeOffsetForIsec(
     const ConcatInputSection *isec, uint8_t *buf, uint32_t &inSecOff,
     uint32_t &outSecOff, bool useSelRef) const {
-  const Reloc *reloc = isec->getRelocAt(inSecOff);
+  const Relocation *reloc = isec->getRelocAt(inSecOff);
   assert(reloc && "Relocation expected at __objc_methlist Offset");
 
   uint32_t symVA = 0;

--- a/lld/MachO/Target.h
+++ b/lld/MachO/Target.h
@@ -58,7 +58,7 @@ public:
   virtual int64_t
   getEmbeddedAddend(llvm::MemoryBufferRef, uint64_t offset,
                     const llvm::MachO::relocation_info) const = 0;
-  virtual void relocateOne(uint8_t *loc, const Reloc &, uint64_t va,
+  virtual void relocateOne(uint8_t *loc, const Relocation &, uint64_t va,
                            uint64_t relocVA) const = 0;
 
   // Write code for lazy binding. See the comments on StubsSection for more
@@ -119,7 +119,7 @@ public:
   // For now, handleDtraceReloc only implements -no_dtrace_dof, and ensures
   // that the linking would not fail even when there are user-provided dtrace
   // symbols. However, unlike ld64, lld currently does not emit __dof sections.
-  virtual void handleDtraceReloc(const Symbol *sym, const Reloc &r,
+  virtual void handleDtraceReloc(const Symbol *sym, const Relocation &r,
                                  uint8_t *loc) const {
     llvm_unreachable("Unsupported architecture for dtrace symbols");
   }

--- a/lld/MachO/UnwindInfoSection.cpp
+++ b/lld/MachO/UnwindInfoSection.cpp
@@ -232,7 +232,7 @@ void UnwindInfoSectionImpl::prepareRelocations(ConcatInputSection *isec) {
   // that are referenced from many places, at least some of them likely
   // live, it wouldn't reduce number of got entries.
   for (size_t i = 0; i < isec->relocs.size(); ++i) {
-    Reloc &r = isec->relocs[i];
+    Relocation &r = isec->relocs[i];
     assert(target->hasAttr(r.type, RelocAttrBits::UNSIGNED));
     // Since compact unwind sections aren't part of the inputSections vector,
     // they don't get canonicalized by scanRelocations(), so we have to do the
@@ -386,7 +386,7 @@ void UnwindInfoSectionImpl::relocateCompactUnwind(
     cu.functionLength =
         support::endian::read32le(buf + cuLayout.functionLengthOffset);
     cu.encoding = support::endian::read32le(buf + cuLayout.encodingOffset);
-    for (const Reloc &r : d->unwindEntry()->relocs) {
+    for (const Relocation &r : d->unwindEntry()->relocs) {
       if (r.offset == cuLayout.personalityOffset)
         cu.personality = cast<Symbol *>(r.referent);
       else if (r.offset == cuLayout.lsdaOffset)

--- a/lld/MachO/Writer.cpp
+++ b/lld/MachO/Writer.cpp
@@ -663,7 +663,7 @@ void Writer::treatSpecialUndefineds() {
 }
 
 static void prepareSymbolRelocation(Symbol *sym, const InputSection *isec,
-                                    const lld::macho::Reloc &r) {
+                                    const Relocation &r) {
   if (!sym->isLive()) {
     if (Defined *defined = dyn_cast<Defined>(sym)) {
       if (config->emitInitOffsets &&
@@ -707,7 +707,7 @@ void Writer::scanRelocations() {
       continue;
 
     for (auto it = isec->relocs.begin(); it != isec->relocs.end(); ++it) {
-      lld::macho::Reloc &r = *it;
+      Relocation &r = *it;
 
       // Canonicalize the referent so that later accesses in Writer won't
       // have to worry about it.


### PR DESCRIPTION
Due to heavy use of using namespace llvm, Reloc is often ambiguous with llvm::Reloc, the relocation model. Previously, this was sometimes disambiguated with macho::Reloc. This ambiguity is even more problematic when using pre-compiled headers, where it's no longer "obvious" whether it should be Reloc or macho::Reloc.

Therefore, rename Reloc to Relocation. This is also consistent with lld/ELF, where the type is also named Relocation.