### PR TITLE
[lit] Avoid multiprocessing for -j1 runs

### DIFF
--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -140,7 +140,7 @@ if platform.system() == "Linux":
         )
         if result.returncode == 0:
             config.available_features.add("strace")
-    except OSError:
+    except FileNotFoundError:
         pass
 
 # Capture the system PATH _BEFORE_ we prepend fake-externals to PATH.

--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -132,19 +132,16 @@ if not llvm_config:
 # We need to actually try running strace, not just check if it exists,
 # because ptrace_scope and other security settings may prevent its use.
 if platform.system() == "Linux":
-    import shutil
-    if shutil.which("strace"):
-        try:
-            result = subprocess.run(
-                ["strace", "-o", "/dev/null", "true"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                timeout=5,
-            )
-            if result.returncode == 0:
-                config.available_features.add("strace")
-        except (subprocess.TimeoutExpired, OSError):
-            pass
+    try:
+        result = subprocess.run(
+            ["strace", "-o", "/dev/null", "true"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode == 0:
+            config.available_features.add("strace")
+    except OSError:
+        pass
 
 # Capture the system PATH _BEFORE_ we prepend fake-externals to PATH.
 # This allows tests that need external commands (e.g., strace) to bypass the

--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -129,10 +129,22 @@ if not llvm_config:
         config.available_features.add("system-aix")
 
 # Check for strace availability (Linux only)
+# We need to actually try running strace, not just check if it exists,
+# because ptrace_scope and other security settings may prevent its use.
 if platform.system() == "Linux":
     import shutil
     if shutil.which("strace"):
-        config.available_features.add("strace")
+        try:
+            result = subprocess.run(
+                ["strace", "-o", "/dev/null", "true"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                config.available_features.add("strace")
+        except (subprocess.TimeoutExpired, OSError):
+            pass
 
 # Capture the system PATH _BEFORE_ we prepend fake-externals to PATH.
 # This allows tests that need external commands (e.g., strace) to bypass the

--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -75,7 +75,6 @@ config.substitutions.append(
         ),
     )
 )
-config.substitutions.append(("%{lit-script}", os.path.join(lit_path, "lit.py")))
 config.substitutions.append(("%{python}", '"%s"' % (sys.executable)))
 
 # This diagnostic sometimes appears in windows when using bash as an external
@@ -134,6 +133,16 @@ if platform.system() == "Linux":
     import shutil
     if shutil.which("strace"):
         config.available_features.add("strace")
+
+# Capture system paths BEFORE we prepend fake-externals to PATH.
+# This allows tests that need external commands (e.g., strace) to bypass the
+# fake binaries by using %{system-env} and %{system-path}.
+import shutil
+_real_env = shutil.which("env")
+if _real_env:
+    config.substitutions.append(("%{system-env}", _real_env))
+    # Capture the current PATH before fake-externals are prepended
+    config.substitutions.append(("%{system-path}", config.environment.get("PATH", "")))
 
 # For each of lit's internal shell commands ('env', 'cd', 'diff', etc.), put
 # a fake command that always fails at the start of PATH.  This helps us check

--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -134,15 +134,10 @@ if platform.system() == "Linux":
     if shutil.which("strace"):
         config.available_features.add("strace")
 
-# Capture system paths BEFORE we prepend fake-externals to PATH.
+# Capture the system PATH _BEFORE_ we prepend fake-externals to PATH.
 # This allows tests that need external commands (e.g., strace) to bypass the
-# fake binaries by using %{system-env} and %{system-path}.
-import shutil
-_real_env = shutil.which("env")
-if _real_env:
-    config.substitutions.append(("%{system-env}", _real_env))
-    # Capture the current PATH before fake-externals are prepended
-    config.substitutions.append(("%{system-path}", config.environment.get("PATH", "")))
+# fake binaries by using: env PATH="%{system-path}" <command>
+config.substitutions.append(("%{system-path}", config.environment.get("PATH", "")))
 
 # For each of lit's internal shell commands ('env', 'cd', 'diff', etc.), put
 # a fake command that always fails at the start of PATH.  This helps us check

--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -128,6 +128,12 @@ if not llvm_config:
     if platform.system() == "AIX":
         config.available_features.add("system-aix")
 
+# Check for strace availability (Linux only)
+if platform.system() == "Linux":
+    import shutil
+    if shutil.which("strace"):
+        config.available_features.add("strace")
+
 # For each of lit's internal shell commands ('env', 'cd', 'diff', etc.), put
 # a fake command that always fails at the start of PATH.  This helps us check
 # that we always use lit's internal version rather than some external version

--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -75,6 +75,7 @@ config.substitutions.append(
         ),
     )
 )
+config.substitutions.append(("%{lit-script}", os.path.join(lit_path, "lit.py")))
 config.substitutions.append(("%{python}", '"%s"' % (sys.executable)))
 
 # This diagnostic sometimes appears in windows when using bash as an external

--- a/llvm/utils/lit/tests/single-process.py
+++ b/llvm/utils/lit/tests/single-process.py
@@ -16,9 +16,8 @@
 
 # RUN: export PATH="%{system-path}"
 #
-# RUN: strace -f -e trace=openat not %{lit} -j1 %{inputs}/shtest-format \
-# RUN:     > %t.j1.out 2>&1
-# RUN: FileCheck --check-prefix=CHECK-J1 %s < %t.j1.out
+# RUN: strace -f -e trace=openat not %{lit} -j1 %{inputs}/shtest-format 2>&1 \
+# RUN:   | FileCheck --check-prefix=CHECK-J1 %s
 #
 # CHECK-J1: 1 workers
 # CHECK-J1-NOT: /dev/shm/sem
@@ -28,9 +27,8 @@
 # POSIX semaphores. This validates that the CHECK-NOT pattern above is correct
 # and won't become stale if Python/glibc changes how semaphores are created.
 #
-# RUN: strace -f -e trace=openat not %{lit} -j2 %{inputs}/shtest-format \
-# RUN:     > %t.j2.out 2>&1
-# RUN: FileCheck --check-prefix=CHECK-J2 %s < %t.j2.out
+# RUN: strace -f -e trace=openat not %{lit} -j2 %{inputs}/shtest-format 2>&1 \
+# RUN:   | FileCheck --check-prefix=CHECK-J2 %s
 #
 # CHECK-J2: /dev/shm/sem
 # CHECK-J2: 2 workers

--- a/llvm/utils/lit/tests/single-process.py
+++ b/llvm/utils/lit/tests/single-process.py
@@ -14,7 +14,9 @@
 # These are the semaphores that fail in sandboxed environments, so verifying
 # they don't appear with -j1 confirms the fix works.
 
-# RUN: env PATH="%{system-path}" strace -f -e trace=openat %{lit} -j1 %{inputs}/shtest-format \
+# RUN: export PATH="%{system-path}"
+#
+# RUN: strace -f -e trace=openat %{lit} -j1 %{inputs}/shtest-format \
 # RUN:     > %t.j1.out 2>&1 || true
 # RUN: FileCheck --check-prefix=CHECK-J1 %s < %t.j1.out
 #
@@ -26,7 +28,7 @@
 # POSIX semaphores. This validates that the CHECK-NOT pattern above is correct
 # and won't become stale if Python/glibc changes how semaphores are created.
 #
-# RUN: env PATH="%{system-path}" strace -f -e trace=openat %{lit} -j2 %{inputs}/shtest-format \
+# RUN: strace -f -e trace=openat %{lit} -j2 %{inputs}/shtest-format \
 # RUN:     > %t.j2.out 2>&1 || true
 # RUN: FileCheck --check-prefix=CHECK-J2 %s < %t.j2.out
 #

--- a/llvm/utils/lit/tests/single-process.py
+++ b/llvm/utils/lit/tests/single-process.py
@@ -16,8 +16,8 @@
 
 # RUN: export PATH="%{system-path}"
 #
-# RUN: strace -f -e trace=openat %{lit} -j1 %{inputs}/shtest-format \
-# RUN:     > %t.j1.out 2>&1 || true
+# RUN: strace -f -e trace=openat not %{lit} -j1 %{inputs}/shtest-format \
+# RUN:     > %t.j1.out 2>&1
 # RUN: FileCheck --check-prefix=CHECK-J1 %s < %t.j1.out
 #
 # CHECK-J1: 1 workers
@@ -28,8 +28,8 @@
 # POSIX semaphores. This validates that the CHECK-NOT pattern above is correct
 # and won't become stale if Python/glibc changes how semaphores are created.
 #
-# RUN: strace -f -e trace=openat %{lit} -j2 %{inputs}/shtest-format \
-# RUN:     > %t.j2.out 2>&1 || true
+# RUN: strace -f -e trace=openat not %{lit} -j2 %{inputs}/shtest-format \
+# RUN:     > %t.j2.out 2>&1
 # RUN: FileCheck --check-prefix=CHECK-J2 %s < %t.j2.out
 #
 # CHECK-J2: /dev/shm/sem

--- a/llvm/utils/lit/tests/single-process.py
+++ b/llvm/utils/lit/tests/single-process.py
@@ -14,7 +14,7 @@
 # These are the semaphores that fail in sandboxed environments, so verifying
 # they don't appear with -j1 confirms the fix works.
 
-# RUN: %{system-env} PATH="%{system-path}" strace -f -e trace=openat %{lit} -j1 %{inputs}/shtest-format \
+# RUN: env PATH="%{system-path}" strace -f -e trace=openat %{lit} -j1 %{inputs}/shtest-format \
 # RUN:     > %t.j1.out 2>&1 || true
 # RUN: FileCheck --check-prefix=CHECK-J1 %s < %t.j1.out
 #
@@ -26,7 +26,7 @@
 # POSIX semaphores. This validates that the CHECK-NOT pattern above is correct
 # and won't become stale if Python/glibc changes how semaphores are created.
 #
-# RUN: %{system-env} PATH="%{system-path}" strace -f -e trace=openat %{lit} -j2 %{inputs}/shtest-format \
+# RUN: env PATH="%{system-path}" strace -f -e trace=openat %{lit} -j2 %{inputs}/shtest-format \
 # RUN:     > %t.j2.out 2>&1 || true
 # RUN: FileCheck --check-prefix=CHECK-J2 %s < %t.j2.out
 #

--- a/llvm/utils/lit/tests/single-process.py
+++ b/llvm/utils/lit/tests/single-process.py
@@ -14,7 +14,7 @@
 # These are the semaphores that fail in sandboxed environments, so verifying
 # they don't appear with -j1 confirms the fix works.
 
-# RUN: strace -f -e trace=openat %{python} %{lit-script} -j1 %{inputs}/shtest-format \
+# RUN: %{system-env} PATH="%{system-path}" strace -f -e trace=openat %{lit} -j1 %{inputs}/shtest-format \
 # RUN:     > %t.j1.out 2>&1 || true
 # RUN: FileCheck --check-prefix=CHECK-J1 %s < %t.j1.out
 #
@@ -26,7 +26,7 @@
 # POSIX semaphores. This validates that the CHECK-NOT pattern above is correct
 # and won't become stale if Python/glibc changes how semaphores are created.
 #
-# RUN: strace -f -e trace=openat %{python} %{lit-script} -j2 %{inputs}/shtest-format \
+# RUN: %{system-env} PATH="%{system-path}" strace -f -e trace=openat %{lit} -j2 %{inputs}/shtest-format \
 # RUN:     > %t.j2.out 2>&1 || true
 # RUN: FileCheck --check-prefix=CHECK-J2 %s < %t.j2.out
 #

--- a/llvm/utils/lit/tests/single-process.py
+++ b/llvm/utils/lit/tests/single-process.py
@@ -1,0 +1,42 @@
+# Test that -j1 runs in single-process mode (no multiprocessing).
+#
+# This ensures lit can run in sandboxed environments where multiprocessing
+# primitives (semaphores, process creation) are blocked.
+
+# REQUIRES: strace
+
+# Use strace to trace file operations. With -j1, lit should NOT create
+# POSIX semaphores in /dev/shm which are used by multiprocessing.Pool.
+#
+# Python's multiprocessing.BoundedSemaphore creates files like:
+#   openat(AT_FDCWD, "/dev/shm/sem.XXXXXX", O_RDWR|O_CREAT|O_EXCL|...)
+#
+# These are the semaphores that fail in sandboxed environments, so verifying
+# they don't appear with -j1 confirms the fix works.
+#
+# Note: We use /usr/bin/env explicitly because lit's test config puts
+# fake-externals (which use #!/usr/bin/env python) at the start of PATH.
+# We also call lit.py directly (../lit.py relative to tests/) to avoid
+# the %{lit} substitution which includes the problematic 'env' command.
+
+# RUN: strace -f -e trace=openat \
+# RUN:     /usr/bin/env -u FILECHECK_OPTS %{python} ../lit.py -j1 %{inputs}/shtest-format \
+# RUN:     > %t.j1.out 2>&1 || true
+# RUN: FileCheck --check-prefix=CHECK-J1 %s < %t.j1.out
+#
+# CHECK-J1: 1 workers
+# CHECK-J1-NOT: /dev/shm/sem
+# CHECK-J1: Total Discovered Tests:
+
+# With -j2 and multiple tests, lit MUST use multiprocessing.Pool which creates
+# POSIX semaphores. This validates that the CHECK-NOT pattern above is correct
+# and won't become stale if Python/glibc changes how semaphores are created.
+#
+# RUN: strace -f -e trace=openat \
+# RUN:     /usr/bin/env -u FILECHECK_OPTS %{python} ../lit.py -j2 %{inputs}/shtest-format \
+# RUN:     > %t.j2.out 2>&1 || true
+# RUN: FileCheck --check-prefix=CHECK-J2 %s < %t.j2.out
+#
+# CHECK-J2: /dev/shm/sem
+# CHECK-J2: 2 workers
+# CHECK-J2: Total Discovered Tests:

--- a/llvm/utils/lit/tests/single-process.py
+++ b/llvm/utils/lit/tests/single-process.py
@@ -13,14 +13,8 @@
 #
 # These are the semaphores that fail in sandboxed environments, so verifying
 # they don't appear with -j1 confirms the fix works.
-#
-# Note: We use /usr/bin/env explicitly because lit's test config puts
-# fake-externals (which use #!/usr/bin/env python) at the start of PATH.
-# We also call lit.py directly (../lit.py relative to tests/) to avoid
-# the %{lit} substitution which includes the problematic 'env' command.
 
-# RUN: strace -f -e trace=openat \
-# RUN:     /usr/bin/env -u FILECHECK_OPTS %{python} ../lit.py -j1 %{inputs}/shtest-format \
+# RUN: strace -f -e trace=openat %{python} %{lit-script} -j1 %{inputs}/shtest-format \
 # RUN:     > %t.j1.out 2>&1 || true
 # RUN: FileCheck --check-prefix=CHECK-J1 %s < %t.j1.out
 #
@@ -32,8 +26,7 @@
 # POSIX semaphores. This validates that the CHECK-NOT pattern above is correct
 # and won't become stale if Python/glibc changes how semaphores are created.
 #
-# RUN: strace -f -e trace=openat \
-# RUN:     /usr/bin/env -u FILECHECK_OPTS %{python} ../lit.py -j2 %{inputs}/shtest-format \
+# RUN: strace -f -e trace=openat %{python} %{lit-script} -j2 %{inputs}/shtest-format \
 # RUN:     > %t.j2.out 2>&1 || true
 # RUN: FileCheck --check-prefix=CHECK-J2 %s < %t.j2.out
 #


### PR DESCRIPTION
### Problem

When running `lit` with `-j1` in a sandboxed environment (e.g., [Cursor Sandbox Mode](https://cursor.com/blog/enterprise#sandbox-mode)), `lit` crashes with `PermissionError: [Errno 1] Operation not permitted` because it still attempts to create a `multiprocessing.Pool`, which requires POSIX semaphores (`/dev/shm/sem.*`) that are blocked by the sandbox.

**Reproducer:** Run any lit test suite with `-j1` in a [restricted sandbox](https://cursor.com/blog/enterprise#sandbox-mode):
`LIT_OPTS="-j1 -v" ninja check-lld`

**Error trace:** https://gist.github.com/alx32/0dc6abb45c40cf5753669e4c6cce929d

### Solution

When `workers == 1`, skip `multiprocessing.Pool` entirely and run tests sequentially in the main process. This avoids creating POSIX semaphores that fail in sandboxed environments.

To properly support `--max-time` in single-process mode (where we can't terminate workers mid-test), we temporarily set `maxIndividualTestTime` to the remaining time before the deadline. If a test times out due to hitting the deadline, it's marked as SKIPPED to match multiprocessing behavior.

### Testing

Added `single-process.py` test that uses strace to verify:
- With `-j1`: No `/dev/shm/sem.*` POSIX semaphores are created
- With `-j2`: Semaphores ARE created (validates the test won't XPASS)

### Historical Context

Lit previously had a "single process mode" that was:
- **Added** in Sept 2017 (42b6dcbcef4f) for debugging
- **Enhanced** in Feb 2019 (96adb78b120b) to auto-enable for `-j1`
- **Removed** in Oct 2019 (f3c329986cf4) as it "did not carry its weight"

The original motivation was performance/debugging. The new motivation is **compatibility with sandboxed execution environments** where multiprocessing primitives are unavailable.


[Assisted-by](https://t.ly/Dkjjk): Cursor IDE + claude-opus-4.5-high + gpt-5.2-xhigh