### PR TITLE
[libc++][istream] Removed `[[nodiscard]]` from `peek()`

### DIFF
--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -298,7 +298,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI basic_istream& ignore(streamsize __n, char_type __delim) {
     return ignore(__n, traits_type::to_int_type(__delim));
   }
-  [[__nodiscard__]] int_type peek();
+  int_type peek();
   basic_istream& read(char_type* __s, streamsize __n);
   streamsize readsome(char_type* __s, streamsize __n);
 

--- a/libcxx/test/libcxx/input.output/iostream.format/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/nodiscard.verify.cpp
@@ -29,9 +29,6 @@ void test() {
     stream.gcount();
 
     // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-    stream.peek();
-
-    // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
     stream.tellg();
   }
 


### PR DESCRIPTION
Calling `peek()` after constructing a stream is something one can use to make the stream ignore empty inputs:

```
#include <sstream>

int main() {
  std::istringstream s;
  s.peek();
  while (s && !s.eof()) {
    char c;
    s >> c;
    printf("not eof; read \'%c\' (%d)\n", c, c);
  }
}
```

as discussed in https://github.com/llvm/llvm-project/pull/173754#discussion_r2669631585 this patch removes the `[[nodiscard]]` annotation.