### PR TITLE
[Clang] Include clang standard lib header directory from Linux

### DIFF
--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -760,12 +760,10 @@ void Linux::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
   if (DriverArgs.hasArg(options::OPT_nostdlibinc))
     return;
 
-  // The LLVM-libc environment stores its C headers in the Clang include
+  // After the resource directory, we prioritize the standard clang include
   // directory.
-  if (getTriple().getEnvironment() == llvm::Triple::LLVM) {
-    if (std::optional<std::string> Path = getStdlibIncludePath())
-      addSystemInclude(DriverArgs, CC1Args, *Path);
-  }
+  if (std::optional<std::string> Path = getStdlibIncludePath())
+    addSystemInclude(DriverArgs, CC1Args, *Path);
 
   // LOCAL_INCLUDE_DIR
   addSystemInclude(DriverArgs, CC1Args, concat(SysRoot, "/usr/local/include"));

--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -760,6 +760,13 @@ void Linux::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
   if (DriverArgs.hasArg(options::OPT_nostdlibinc))
     return;
 
+  // The LLVM-libc environment stores its C headers in the Clang include
+  // directory.
+  if (getTriple().getEnvironment() == llvm::Triple::LLVM) {
+    if (std::optional<std::string> Path = getStdlibIncludePath())
+      addSystemInclude(DriverArgs, CC1Args, *Path);
+  }
+
   // LOCAL_INCLUDE_DIR
   addSystemInclude(DriverArgs, CC1Args, concat(SysRoot, "/usr/local/include"));
   // TOOL_INCLUDE_DIR

--- a/clang/test/Driver/linux-cross.cpp
+++ b/clang/test/Driver/linux-cross.cpp
@@ -32,6 +32,7 @@
 // DEBIAN_X86_64-SAME: {{^}} "-internal-isystem" "[[SYSROOT:[^"]+]]/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/x86_64-linux-gnu/c++/10"
 // DEBIAN_X86_64-SAME: {{^}} "-internal-isystem" "[[SYSROOT]]/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/backward"
 // DEBIAN_X86_64-SAME: {{^}} "-internal-isystem" "[[RESOURCE]]/include"
+// DEBIAN_X86_64-SAME: {{^}} "-internal-isystem" "[[BINROOT:[^"]+]]/usr/bin/../include/x86_64-unknown-linux-gnu"
 // DEBIAN_X86_64-SAME: {{^}} "-internal-isystem" "[[SYSROOT]]/usr/local/include"
 // DEBIAN_X86_64-SAME: {{^}} "-internal-isystem" "[[SYSROOT]]/usr/lib/gcc/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/include"
 /// We set explicit -ccc-install-dir ensure that Clang does not pick up extra
@@ -61,6 +62,7 @@
 // DEBIAN_X86_64_M32-SAME: {{^}} "-internal-isystem" "[[SYSROOT:[^"]+]]/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/x86_64-linux-gnu/c++/10/32"
 // DEBIAN_X86_64_M32-SAME: {{^}} "-internal-isystem" "[[SYSROOT:[^"]+]]/usr/lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/backward"
 // DEBIAN_X86_64_M32-SAME: {{^}} "-internal-isystem" "[[RESOURCE]]/include"
+// DEBIAN_X86_64-M32-SAME: {{^}} "-internal-isystem" "[[BINROOT:[^"]+]]/usr/bin/../include/x86_64-unknown-linux-gnu"
 // DEBIAN_X86_64_M32-SAME: {{^}} "-internal-isystem" "[[SYSROOT]]/usr/local/include"
 // DEBIAN_X86_64_M32-SAME: {{^}} "-internal-isystem" "[[SYSROOT:[^"]+]]/usr/lib/gcc/x86_64-linux-gnu/10/../../../../x86_64-linux-gnu/include"
 // DEBIAN_X86_64_M32:      "-internal-externc-isystem"
@@ -112,6 +114,7 @@
 // DEBIAN_I686_M64-SAME: {{^}} "-internal-isystem" "[[SYSROOT:[^"]+]]/usr/lib/gcc/i686-linux-gnu/10/../../../../include/i386-linux-gnu/c++/10/64"
 // DEBIAN_I686_M64-SAME: {{^}} "-internal-isystem" "[[SYSROOT:[^"]+]]/usr/lib/gcc/i686-linux-gnu/10/../../../../include/c++/10/backward"
 // DEBIAN_I686_M64-SAME: {{^}} "-internal-isystem" "[[RESOURCE]]/include"
+// DEBIAN_I686_M64-SAME: {{^}} "-internal-isystem" "[[BINROOT:[^"]+]]/usr/bin/../include/x86_64-unknown-linux-gnu"
 // DEBIAN_I686_M64-SAME: {{^}} "-internal-isystem" "[[SYSROOT]]/usr/local/include"
 // DEBIAN_I686_M64-SAME: {{^}} "-internal-isystem" "[[SYSROOT:[^"]+]]/usr/lib/gcc/i686-linux-gnu/10/../../../../i686-linux-gnu/include"
 // DEBIAN_I686_M64:      "-internal-externc-isystem"

--- a/clang/test/Driver/linux-header-search.cpp
+++ b/clang/test/Driver/linux-header-search.cpp
@@ -11,7 +11,7 @@
 // RUN:   | FileCheck --check-prefix=CHECK-BASIC-CLANG-SYSROOT-SLASH %s
 // CHECK-BASIC-CLANG-SYSROOT-SLASH: "-cc1"
 // CHECK-BASIC-CLANG-SYSROOT-SLASH-SAME: "-isysroot" "[[SYSROOT:[^"]+/]]"
-// CHECK-BASIC-CLANG-SYSROOT-SLASH-SAME: "-internal-isystem" "[[BINROOT:[^"]+]]/usr/bin/../include/x86_64-unknown-linux-gnu"
+// CHECK-BASIC-CLANG-SYSROOT-SLASH-SAME: "-internal-isystem" "[[BINROOT:[^"]+]]/usr/bin[[SEP:/|\\\\]]..[[SEP]]include[[SEP]]x86_64-unknown-linux-gnu"
 // CHECK-BASIC-CLANG-SYSROOT-SLASH-SAME: "-internal-isystem" "[[SYSROOT]]usr/local/include"
 //
 // Test a simulated installation of libc++ on Linux, both through sysroot and

--- a/clang/test/Driver/linux-header-search.cpp
+++ b/clang/test/Driver/linux-header-search.cpp
@@ -11,7 +11,7 @@
 // RUN:   | FileCheck --check-prefix=CHECK-BASIC-CLANG-SYSROOT-SLASH %s
 // CHECK-BASIC-CLANG-SYSROOT-SLASH: "-cc1"
 // CHECK-BASIC-CLANG-SYSROOT-SLASH-SAME: "-isysroot" "[[SYSROOT:[^"]+/]]"
-// CHECK-BASIC-CLANG-SYSROOT-SLASH-SAME: "-internal-isystem" "[[SYSROOT]]usr[[SEP:/|\\\\]]bin[[SEP]]..[[SEP]]include[[SEP]]x86_64-unknown-linux-gnu"
+// CHECK-BASIC-CLANG-SYSROOT-SLASH-SAME: "-internal-isystem" "[[BINROOT:[^"]+]]/usr/bin/../include/x86_64-unknown-linux-gnu"
 // CHECK-BASIC-CLANG-SYSROOT-SLASH-SAME: "-internal-isystem" "[[SYSROOT]]usr/local/include"
 //
 // Test a simulated installation of libc++ on Linux, both through sysroot and

--- a/clang/test/Driver/linux-header-search.cpp
+++ b/clang/test/Driver/linux-header-search.cpp
@@ -1,6 +1,19 @@
 // General tests that the header search paths detected by the driver and passed
 // to CC1 are sane.
 //
+// Test to see that the compiler include directory is present.
+// RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     --target=x86_64-unknown-linux-gnu \
+// RUN:     -stdlib=libc++ \
+// RUN:     -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin \
+// RUN:     -resource-dir=%S/Inputs/resource_dir \
+// RUN:     --sysroot=%S/Inputs/basic_linux_tree/ \
+// RUN:   | FileCheck --check-prefix=CHECK-BASIC-CLANG-SYSROOT-SLASH %s
+// CHECK-BASIC-CLANG-SYSROOT-SLASH: "-cc1"
+// CHECK-BASIC-CLANG-SYSROOT-SLASH-SAME: "-isysroot" "[[SYSROOT:[^"]+/]]"
+// CHECK-BASIC-CLANG-SYSROOT-SLASH-SAME: "-internal-isystem" "[[SYSROOT]]usr[[SEP:/|\\\\]]bin[[SEP]]..[[SEP]]include[[SEP]]x86_64-unknown-linux-gnu"
+// CHECK-BASIC-CLANG-SYSROOT-SLASH-SAME: "-internal-isystem" "[[SYSROOT]]usr/local/include"
+//
 // Test a simulated installation of libc++ on Linux, both through sysroot and
 // the installation path of Clang.
 // RUN: %clang -### %s -fsyntax-only 2>&1 \

--- a/clang/test/Driver/linux-llvm-toolchain.c
+++ b/clang/test/Driver/linux-llvm-toolchain.c
@@ -1,0 +1,3 @@
+// RUN:   %clang -### --target=x86_64-unknown-linux-llvm --sysroot=%S/Inputs/basic_llvm_linux_tree \
+// RUN:     -ccc-install-dir %S/Inputs/basic_llvm_linux_tree/bin %s 2>&1 | FileCheck %s --check-prefix=CHECK-HEADERS
+// CHECK-HEADERS: "-cc1"{{.*}}"-isysroot"{{.*}}"-internal-isystem" "{{.*}}include/x86_64-unknown-linux-llvm"

--- a/clang/test/Driver/linux-llvm-toolchain.c
+++ b/clang/test/Driver/linux-llvm-toolchain.c
@@ -1,3 +1,0 @@
-// RUN:   %clang -### --target=x86_64-unknown-linux-llvm --sysroot=%S/Inputs/basic_llvm_linux_tree \
-// RUN:     -ccc-install-dir %S/Inputs/basic_llvm_linux_tree/bin %s 2>&1 | FileCheck %s --check-prefix=CHECK-HEADERS
-// CHECK-HEADERS: "-cc1"{{.*}}"-isysroot"{{.*}}"-internal-isystem" "{{.*}}include/x86_64-unknown-linux-llvm"


### PR DESCRIPTION
Summary:
The LLVM-libc stores its headers in the target-specific include
directory. This PR makes the Linux toolchain include the standard lib
directory when used. This allows LLVM-libc to work and any other
standard language headers installed there. We search this first.
