### PR TITLE
[MLIR][NFC] Fix ambiguity between const char* and Twine

### DIFF
--- a/mlir/lib/Support/TypeID.cpp
+++ b/mlir/lib/Support/TypeID.cpp
@@ -49,7 +49,7 @@ struct ImplicitTypeIDRegistry {
                    "`MLIR_DEFINE_EXPLICIT_TYPE_ID` or "
                    "`MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID`.\n";
       }
-      llvm::report_fatal_error(errorStr);
+      llvm::report_fatal_error(llvm::StringRef(errorStr));
     }
 #endif
 


### PR DESCRIPTION
This only shows up once Twine gets included, e.g. through a pre-compiled header. Avoid this ambiguity with an explicit cast.