### PR TITLE
[OpenMP][Flang][MLIR] Introduce omp.declare_simd op and emit from Flang

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -3815,6 +3815,7 @@ static void
 genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
        semantics::SemanticsContext &semaCtx, lower::pft::Evaluation &eval,
        const parser::OpenMPDeclareSimdConstruct &declareSimdConstruct) {
+  mlir::Location loc = converter.getCurrentLocation();
   const parser::OmpDirectiveSpecification &beginSpec = declareSimdConstruct.v;
   List<Clause> clauses = makeClauses(beginSpec.Clauses(), semaCtx);
 
@@ -3823,19 +3824,9 @@ genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
   cp.processAligned(clauseOps);
   cp.processLinear(clauseOps);
   cp.processSimdlen(clauseOps);
-  cp.processTODO<clause::Uniform>(converter.getCurrentLocation(),
-                                  llvm::omp::Directive::OMPD_declare_simd);
+  cp.processTODO<clause::Uniform>(loc, llvm::omp::Directive::OMPD_declare_simd);
 
-  fir::FirOpBuilder &firOpBuilder = converter.getFirOpBuilder();
-  mlir::Location loc = converter.getCurrentLocation();
-  auto *ctx = firOpBuilder.getContext();
-  mlir::ArrayAttr alignments;
-  if (!clauseOps.alignments.empty())
-    alignments = mlir::ArrayAttr::get(ctx, clauseOps.alignments);
-  mlir::omp::DeclareSimdOp::create(firOpBuilder, loc, clauseOps.alignedVars,
-                                   alignments, clauseOps.linearVars,
-                                   clauseOps.linearStepVars,
-                                   clauseOps.linearVarTypes, clauseOps.simdlen);
+  mlir::omp::DeclareSimdOp::create(converter.getFirOpBuilder(), loc, clauseOps);
 }
 
 static void genOpenMPDeclareMapperImpl(

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -3824,6 +3824,8 @@ genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
   cp.processAligned(clauseOps);
   cp.processLinear(clauseOps);
   cp.processSimdlen(clauseOps);
+  cp.processTODO<clause::Uniform>(converter.getCurrentLocation(),
+                                  llvm::omp::Directive::OMPD_declare_simd);
 
   mlir::omp::DeclareSimdOp::create(converter.getFirOpBuilder(), loc, clauseOps);
 }

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -3815,8 +3815,17 @@ static void
 genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
        semantics::SemanticsContext &semaCtx, lower::pft::Evaluation &eval,
        const parser::OpenMPDeclareSimdConstruct &declareSimdConstruct) {
-  if (!semaCtx.langOptions().OpenMPSimd)
-    TODO(converter.getCurrentLocation(), "OpenMPDeclareSimdConstruct");
+  mlir::Location loc = converter.getCurrentLocation();
+  const parser::OmpDirectiveSpecification &beginSpec = declareSimdConstruct.v;
+  List<Clause> clauses = makeClauses(beginSpec.Clauses(), semaCtx);
+
+  mlir::omp::DeclareSimdOperands clauseOps;
+  ClauseProcessor cp(converter, semaCtx, clauses);
+  cp.processAligned(clauseOps);
+  cp.processLinear(clauseOps);
+  cp.processSimdlen(clauseOps);
+
+  mlir::omp::DeclareSimdOp::create(converter.getFirOpBuilder(), loc, clauseOps);
 }
 
 static void genOpenMPDeclareMapperImpl(

--- a/flang/test/Lower/OpenMP/Todo/declare-simd-uniform.f90
+++ b/flang/test/Lower/OpenMP/Todo/declare-simd-uniform.f90
@@ -1,0 +1,9 @@
+! RUN: %not_todo_cmd %flang_fc1 -emit-fir -fopenmp -o - %s 2>&1 | FileCheck %s
+
+! CHECK: not yet implemented: Unhandled clause UNIFORM in DECLARE SIMD construct
+subroutine declare_simd_uniform(x, y)
+    real(8), pointer, intent(inout) :: x(:)
+    real(8), pointer, intent(in)    :: y(:)
+    !$omp declare simd uniform(x, y)
+end subroutine declare_simd_uniform
+

--- a/flang/test/Lower/OpenMP/declare-simd.f90
+++ b/flang/test/Lower/OpenMP/declare-simd.f90
@@ -5,10 +5,14 @@
 
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=60 %s -o - | FileCheck %s
-! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=60 -cpp -DOMP_60 %s -o - | FileCheck %s --check-prefix=CHECK60
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=60 -cpp -DOMP_60 %s -o - | FileCheck %s
 
 subroutine declare_simd_no_clause()
-  !$omp declare simd
+#ifdef OMP_60
+!$omp declare_simd
+#else
+!$omp declare simd
+#endif
 end subroutine declare_simd_no_clause
 
 ! CHECK-LABEL: func.func @_QPdeclare_simd_no_clause()
@@ -16,7 +20,11 @@ end subroutine declare_simd_no_clause
 ! CHECK: return
 
 subroutine declare_simd_aligned(x, y, n, i)
-  !$omp declare simd aligned(x, y : 64)
+#ifdef OMP_60
+!$omp declare_simd aligned(x, y : 64)
+#else
+!$omp declare simd aligned(x, y : 64)
+#endif
   real(8), pointer, intent(inout) :: x(:)
   real(8), pointer, intent(in)    :: y(:)
   integer, intent(in) :: n, i
@@ -29,14 +37,16 @@ end subroutine declare_simd_aligned
 ! CHECK: %[[N_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK: %[[X_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
 ! CHECK: %[[Y_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK: omp.declare_simd
-! CHECK-SAME: aligned(%[[X_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64,
-! CHECK-SAME:         %[[Y_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64)
-! CHECK-NOT: {{[[:space:]]*(linear|simdlen)\(}}
+! CHECK: omp.declare_simd aligned(%[[X_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64,
+! CHECK-SAME:                    %[[Y_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64){{$}}
 ! CHECK: return
 
 subroutine declare_simd_linear(x, y, n, i)
-  !$omp declare simd linear(i)
+#ifdef OMP_60
+!$omp declare_simd linear(i)
+#else
+!$omp declare simd linear(i)
+#endif
   real(8), pointer, intent(inout) :: x(:)
   real(8), pointer, intent(in)    :: y(:)
   integer, intent(in) :: n, i
@@ -44,44 +54,38 @@ subroutine declare_simd_linear(x, y, n, i)
 end subroutine  declare_simd_linear
 
 ! CHECK-LABEL: func.func @_QPdeclare_simd_linear(
-! CHECK: %[[SCOPE_L:.*]] = fir.dummy_scope : !fir.dscope
-! CHECK: %[[I_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK: %[[N_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK: %[[X_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK: %[[Y_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK: %[[C1_L:.*]] = arith.constant 1 : i32
-! CHECK: omp.declare_simd
-! CHECK-NOT: {{[[:space:]]*(aligned|simdlen)\(}}
+! CHECK: %[[SCOPE:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK: %[[I:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[C1:.*]] = arith.constant 1 : i32
+! CHECK: omp.declare_simd linear(%[[I]]#0 = %[[C1]] : !fir.ref<i32>) {linear_var_types = [i32]}{{$}}
 ! CHECK: return
 
 subroutine declare_simd_simdlen(x, y, n, i)
-  !$omp declare simd simdlen(8)
-  real(8), pointer, intent(inout) :: x(:)
-  real(8), pointer, intent(in)    :: y(:)
-  integer, intent(in) :: n, i
-  if (i <= n) x(i) = x(i) + y(i)
+#ifdef OMP_60
+!$omp declare_simd simdlen(8)
+#else
+!$omp declare simd simdlen(8)
+#endif
 end subroutine declare_simd_simdlen
 
 ! CHECK-LABEL: func.func @_QPdeclare_simd_simdlen(
 ! CHECK: %[[SCOPE_S:.*]] = fir.dummy_scope : !fir.dscope
-! CHECK: %[[I_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK: %[[N_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK: %[[X_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK: %[[Y_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK: omp.declare_simd
-! CHECK-NOT: {{[[:space:]]*(aligned|linear)\(}}
-! CHECK-SAME: simdlen(8)
-! CHECK: return
+! CHECK: omp.declare_simd{{.*}}simdlen(8){{$}}
+! CHECK-NEXT: return
 
 subroutine declare_simd_combined(x, y, n, i)
-    !$omp declare simd aligned(x, y : 64) linear(i) simdlen(8)
-    real(8), pointer, intent(inout) :: x(:)
-    real(8), pointer, intent(in)    :: y(:)
-    integer, intent(in) :: n, i
+#ifdef OMP_60
+!$omp declare_simd aligned(x, y : 64) linear(i) simdlen(8)
+#else
+!$omp declare simd aligned(x, y : 64) linear(i) simdlen(8)
+#endif
+  real(8), pointer, intent(inout) :: x(:)
+  real(8), pointer, intent(in)    :: y(:)
+  integer, intent(in) :: n, i
 
-    if (i <= n) then
-        x(i) = x(i) + y(i)
-    end if
+  if (i <= n) then
+      x(i) = x(i) + y(i)
+  end if
 end subroutine declare_simd_combined
 
 ! CHECK-LABEL: func.func @_QPdeclare_simd_combined(
@@ -102,102 +106,3 @@ end subroutine declare_simd_combined
 ! CHECK-SAME: linear(%[[I_DECL]]#0 = %[[C1]] : !fir.ref<i32>)
 ! CHECK-SAME: simdlen(8)
 ! CHECK-SAME: {linear_var_types = [i32]}
-
-#ifdef OMP_60
-
-subroutine declare_simd_60_no_clause()
-  !$omp declare_simd
-end subroutine declare_simd_60_no_clause
-
-! CHECK60-LABEL: func.func @_QPdeclare_simd_60_no_clause() {
-! CHECK60: omp.declare_simd
-
-subroutine declare_simd_aligned_60(x, y, n, i)
-  !$omp declare_simd aligned(x, y : 64)
-  real(8), pointer, intent(inout) :: x(:)
-  real(8), pointer, intent(in)    :: y(:)
-  integer, intent(in) :: n, i
-  if (i <= n) x(i) = x(i) + y(i)
-end subroutine declare_simd_aligned_60
-
-! CHECK60-LABEL: func.func @_QPdeclare_simd_aligned_60(
-! CHECK60: %[[SCOPE_A:.*]] = fir.dummy_scope : !fir.dscope
-! CHECK60: %[[I_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK60: %[[N_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK60: %[[X_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK60: %[[Y_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK60: omp.declare_simd
-! CHECK60-SAME: aligned(%[[X_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64,
-! CHECK60-SAME:         %[[Y_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64)
-! CHECK60-NOT: {{[[:space:]]*(linear|simdlen)\(}}
-! CHECK60: return
-
-subroutine declare_simd_linear_60(x, y, n, i)
-  !$omp declare_simd linear(i)
-  real(8), pointer, intent(inout) :: x(:)
-  real(8), pointer, intent(in)    :: y(:)
-  integer, intent(in) :: n, i
-  if (i <= n) x(i) = x(i) + y(i)
-end subroutine  declare_simd_linear_60
-
-! CHECK60-LABEL: func.func @_QPdeclare_simd_linear_60(
-! CHECK60: %[[SCOPE_L:.*]] = fir.dummy_scope : !fir.dscope
-! CHECK60: %[[I_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK60: %[[N_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK60: %[[X_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK60: %[[Y_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK60: %[[C1_L:.*]] = arith.constant 1 : i32
-! CHECK60: omp.declare_simd
-! CHECK60-NOT: {{[[:space:]]*(aligned|simdlen)\(}}
-! CHECK60: return
-
-subroutine declare_simd_simdlen_60(x, y, n, i)
-  !$omp declare_simd simdlen(8)
-  real(8), pointer, intent(inout) :: x(:)
-  real(8), pointer, intent(in)    :: y(:)
-  integer, intent(in) :: n, i
-  if (i <= n) x(i) = x(i) + y(i)
-end subroutine declare_simd_simdlen_60
-
-! CHECK60-LABEL: func.func @_QPdeclare_simd_simdlen_60(
-! CHECK60: %[[SCOPE_S:.*]] = fir.dummy_scope : !fir.dscope
-! CHECK60: %[[I_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK60: %[[N_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK60: %[[X_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK60: %[[Y_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK60: omp.declare_simd
-! CHECK60-NOT: {{[[:space:]]*(aligned|linear)\(}}
-! CHECK60-SAME: simdlen(8)
-! CHECK60: return
-
-subroutine declare_simd_combined_60(x, y, n, i)
-    !$omp declare_simd aligned(x, y : 64) linear(i) simdlen(8)
-    real(8), pointer, intent(inout) :: x(:)
-    real(8), pointer, intent(in)    :: y(:)
-    integer, intent(in) :: n, i
-
-    if (i <= n) then
-        x(i) = x(i) + y(i)
-    end if
-end subroutine declare_simd_combined_60
-
-! CHECK60-LABEL: func.func @_QPdeclare_simd_combined_60(
-! CHECK60-SAME: %{{.*}}: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>{{.*}}fir.bindc_name = "x"
-! CHECK60-SAME: %{{.*}}: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>{{.*}}fir.bindc_name = "y"
-! CHECK60-SAME: %{{.*}}: !fir.ref<i32>{{.*}}fir.bindc_name = "n"
-! CHECK60-SAME: %{{.*}}: !fir.ref<i32>{{.*}}fir.bindc_name = "i"
-! CHECK60: %[[SCOPE:.*]] = fir.dummy_scope : !fir.dscope
-! CHECK60: %[[I_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK60: %[[N_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK60: %[[X_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 1 {{.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK60: %[[Y_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 2 {{.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK60: %[[C1:.*]] = arith.constant 1 : i32
-
-! CHECK60: omp.declare_simd
-! CHECK60-SAME: aligned(%[[X_DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64,
-! CHECK60-SAME:         %[[Y_DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64)
-! CHECK60-SAME: linear(%[[I_DECL]]#0 = %[[C1]] : !fir.ref<i32>)
-! CHECK60-SAME: simdlen(8)
-! CHECK60-SAME: {linear_var_types = [i32]}
-
-#endif !OMP_60

--- a/flang/test/Lower/OpenMP/declare-simd.f90
+++ b/flang/test/Lower/OpenMP/declare-simd.f90
@@ -1,0 +1,119 @@
+! This test checks the lowering of the OpenMP `declare simd` directive with
+! different clauses (e.g. aligned, linear, simdlen). It also verifies that
+! the `omp.declare_simd` operation is emitted after the function prologue,
+! since the directive requires access to function arguments.
+
+! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
+
+subroutine declare_simd_no_clause(x, y, n, i)
+  !$omp declare simd
+  real(8), pointer, intent(inout) :: x(:)
+  real(8), pointer, intent(in)    :: y(:)
+  integer, intent(in) :: n, i
+  if (i <= n) x(i) = x(i) + y(i)
+end subroutine declare_simd_no_clause
+
+! CHECK-LABEL: func.func @_QPdeclare_simd_no_clause(
+! CHECK: %[[SCOPE_NONE:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK: %[[I_NONE:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_NONE]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[N_NONE:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_NONE]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[X_NONE:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_NONE]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK: %[[Y_NONE:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_NONE]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK: omp.declare_simd
+! CHECK-NOT: aligned(
+! CHECK-NOT: linear(
+! CHECK-NOT: simdlen(
+! CHECK: return
+
+subroutine declare_simd_aligned(x, y, n, i)
+  !$omp declare simd aligned(x, y : 64)
+  real(8), pointer, intent(inout) :: x(:)
+  real(8), pointer, intent(in)    :: y(:)
+  integer, intent(in) :: n, i
+  if (i <= n) x(i) = x(i) + y(i)
+end subroutine declare_simd_aligned
+
+! CHECK-LABEL: func.func @_QPdeclare_simd_aligned(
+! CHECK: %[[SCOPE_A:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK: %[[I_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[N_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[X_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK: %[[Y_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK: omp.declare_simd
+! CHECK-SAME: aligned(%[[X_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64,
+! CHECK-SAME:         %[[Y_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64)
+! CHECK-NOT: linear(
+! CHECK-NOT: simdlen(
+! CHECK: return
+
+subroutine declare_simd_linear(x, y, n, i)
+  !$omp declare simd linear(i)
+  real(8), pointer, intent(inout) :: x(:)
+  real(8), pointer, intent(in)    :: y(:)
+  integer, intent(in) :: n, i
+  if (i <= n) x(i) = x(i) + y(i)
+end subroutine  declare_simd_linear
+
+! CHECK-LABEL: func.func @_QPdeclare_simd_linear(
+! CHECK: %[[SCOPE_L:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK: %[[I_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[N_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[X_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK: %[[Y_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK: %[[C1_L:.*]] = arith.constant 1 : i32
+! CHECK: omp.declare_simd
+! CHECK-NOT: aligned(
+! CHECK-SAME: linear(%[[I_L]]#0 = %[[C1_L]] : !fir.ref<i32>)
+! CHECK-SAME: {linear_var_types = [i32]}
+! CHECK-NOT: simdlen(
+! CHECK: return
+
+subroutine declare_simd_simdlen(x, y, n, i)
+  !$omp declare simd simdlen(8)
+  real(8), pointer, intent(inout) :: x(:)
+  real(8), pointer, intent(in)    :: y(:)
+  integer, intent(in) :: n, i
+  if (i <= n) x(i) = x(i) + y(i)
+end subroutine declare_simd_simdlen
+
+! CHECK-LABEL: func.func @_QPdeclare_simd_simdlen(
+! CHECK: %[[SCOPE_S:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK: %[[I_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[N_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[X_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK: %[[Y_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK: omp.declare_simd
+! CHECK-NOT: aligned(
+! CHECK-NOT: linear(
+! CHECK-SAME: simdlen(8)
+! CHECK: return
+
+subroutine declare_simd_combined(x, y, n, i)
+    !$omp declare simd aligned(x, y : 64) linear(i) simdlen(8)
+    real(8), pointer, intent(inout) :: x(:)
+    real(8), pointer, intent(in)    :: y(:)
+    integer, intent(in) :: n, i
+
+    if (i <= n) then
+        x(i) = x(i) + y(i)
+end if
+end subroutine declare_simd_combined
+
+! CHECK-LABEL: func.func @_QPdeclare_simd_combined(
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>{{.*}}fir.bindc_name = "x"
+! CHECK-SAME: %{{.*}}: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>{{.*}}fir.bindc_name = "y"
+! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}fir.bindc_name = "n"
+! CHECK-SAME: %{{.*}}: !fir.ref<i32>{{.*}}fir.bindc_name = "i"
+! CHECK: %[[SCOPE:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK: %[[I_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[N_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[X_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 1 {{.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK: %[[Y_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 2 {{.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK: %[[C1:.*]] = arith.constant 1 : i32
+
+! CHECK: omp.declare_simd
+! CHECK-SAME: aligned(%[[X_DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64,
+! CHECK-SAME:         %[[Y_DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64)
+! CHECK-SAME: linear(%[[I_DECL]]#0 = %[[C1]] : !fir.ref<i32>)
+! CHECK-SAME: simdlen(8)
+! CHECK-SAME: {linear_var_types = [i32]}

--- a/flang/test/Lower/OpenMP/declare-simd.f90
+++ b/flang/test/Lower/OpenMP/declare-simd.f90
@@ -1,28 +1,19 @@
-! This test checks the lowering of the OpenMP `declare simd` directive with
+! This test CHECKs the lowering of the OpenMP `declare simd` directive with
 ! different clauses (e.g. aligned, linear, simdlen). It also verifies that
 ! the `omp.declare_simd` operation is emitted after the function prologue,
 ! since the directive requires access to function arguments.
 
-! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=60 %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=60 -cpp -DOMP_60 %s -o - | FileCheck %s --check-prefix=CHECK60
 
-subroutine declare_simd_no_clause(x, y, n, i)
+subroutine declare_simd_no_clause()
   !$omp declare simd
-  real(8), pointer, intent(inout) :: x(:)
-  real(8), pointer, intent(in)    :: y(:)
-  integer, intent(in) :: n, i
-  if (i <= n) x(i) = x(i) + y(i)
 end subroutine declare_simd_no_clause
 
-! CHECK-LABEL: func.func @_QPdeclare_simd_no_clause(
-! CHECK: %[[SCOPE_NONE:.*]] = fir.dummy_scope : !fir.dscope
-! CHECK: %[[I_NONE:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_NONE]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK: %[[N_NONE:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_NONE]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK: %[[X_NONE:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_NONE]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
-! CHECK: %[[Y_NONE:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_NONE]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK-LABEL: func.func @_QPdeclare_simd_no_clause()
 ! CHECK: omp.declare_simd
-! CHECK-NOT: aligned(
-! CHECK-NOT: linear(
-! CHECK-NOT: simdlen(
+! CHECK-NOT: {{omp\.declare_simd[[:space:]]*(aligned|linear|simdlen)\(}}
 ! CHECK: return
 
 subroutine declare_simd_aligned(x, y, n, i)
@@ -42,8 +33,7 @@ end subroutine declare_simd_aligned
 ! CHECK: omp.declare_simd
 ! CHECK-SAME: aligned(%[[X_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64,
 ! CHECK-SAME:         %[[Y_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64)
-! CHECK-NOT: linear(
-! CHECK-NOT: simdlen(
+! CHECK-NOT: {{[[:space:]]*(linear|simdlen)\(}}
 ! CHECK: return
 
 subroutine declare_simd_linear(x, y, n, i)
@@ -62,10 +52,7 @@ end subroutine  declare_simd_linear
 ! CHECK: %[[Y_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
 ! CHECK: %[[C1_L:.*]] = arith.constant 1 : i32
 ! CHECK: omp.declare_simd
-! CHECK-NOT: aligned(
-! CHECK-SAME: linear(%[[I_L]]#0 = %[[C1_L]] : !fir.ref<i32>)
-! CHECK-SAME: {linear_var_types = [i32]}
-! CHECK-NOT: simdlen(
+! CHECK-NOT: {{[[:space:]]*(aligned|simdlen)\(}}
 ! CHECK: return
 
 subroutine declare_simd_simdlen(x, y, n, i)
@@ -83,8 +70,7 @@ end subroutine declare_simd_simdlen
 ! CHECK: %[[X_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
 ! CHECK: %[[Y_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
 ! CHECK: omp.declare_simd
-! CHECK-NOT: aligned(
-! CHECK-NOT: linear(
+! CHECK-NOT: {{[[:space:]]*(aligned|linear)\(}}
 ! CHECK-SAME: simdlen(8)
 ! CHECK: return
 
@@ -96,7 +82,7 @@ subroutine declare_simd_combined(x, y, n, i)
 
     if (i <= n) then
         x(i) = x(i) + y(i)
-end if
+    end if
 end subroutine declare_simd_combined
 
 ! CHECK-LABEL: func.func @_QPdeclare_simd_combined(
@@ -117,3 +103,102 @@ end subroutine declare_simd_combined
 ! CHECK-SAME: linear(%[[I_DECL]]#0 = %[[C1]] : !fir.ref<i32>)
 ! CHECK-SAME: simdlen(8)
 ! CHECK-SAME: {linear_var_types = [i32]}
+
+#ifdef OMP_60
+
+subroutine declare_simd_60_no_clause()
+  !$omp declare_simd
+end subroutine declare_simd_60_no_clause
+
+! CHECK60-LABEL: func.func @_QPdeclare_simd_60_no_clause() {
+! CHECK60: omp.declare_simd
+
+subroutine declare_simd_aligned_60(x, y, n, i)
+  !$omp declare_simd aligned(x, y : 64)
+  real(8), pointer, intent(inout) :: x(:)
+  real(8), pointer, intent(in)    :: y(:)
+  integer, intent(in) :: n, i
+  if (i <= n) x(i) = x(i) + y(i)
+end subroutine declare_simd_aligned_60
+
+! CHECK60-LABEL: func.func @_QPdeclare_simd_aligned_60(
+! CHECK60: %[[SCOPE_A:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK60: %[[I_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK60: %[[N_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK60: %[[X_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK60: %[[Y_A:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_A]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK60: omp.declare_simd
+! CHECK60-SAME: aligned(%[[X_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64,
+! CHECK60-SAME:         %[[Y_A]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64)
+! CHECK60-NOT: {{[[:space:]]*(linear|simdlen)\(}}
+! CHECK60: return
+
+subroutine declare_simd_linear_60(x, y, n, i)
+  !$omp declare_simd linear(i)
+  real(8), pointer, intent(inout) :: x(:)
+  real(8), pointer, intent(in)    :: y(:)
+  integer, intent(in) :: n, i
+  if (i <= n) x(i) = x(i) + y(i)
+end subroutine  declare_simd_linear_60
+
+! CHECK60-LABEL: func.func @_QPdeclare_simd_linear_60(
+! CHECK60: %[[SCOPE_L:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK60: %[[I_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK60: %[[N_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK60: %[[X_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK60: %[[Y_L:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_L]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK60: %[[C1_L:.*]] = arith.constant 1 : i32
+! CHECK60: omp.declare_simd
+! CHECK60-NOT: {{[[:space:]]*(aligned|simdlen)\(}}
+! CHECK60: return
+
+subroutine declare_simd_simdlen_60(x, y, n, i)
+  !$omp declare_simd simdlen(8)
+  real(8), pointer, intent(inout) :: x(:)
+  real(8), pointer, intent(in)    :: y(:)
+  integer, intent(in) :: n, i
+  if (i <= n) x(i) = x(i) + y(i)
+end subroutine declare_simd_simdlen_60
+
+! CHECK60-LABEL: func.func @_QPdeclare_simd_simdlen_60(
+! CHECK60: %[[SCOPE_S:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK60: %[[I_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK60: %[[N_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK60: %[[X_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 1 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK60: %[[Y_S:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE_S]] arg 2 {{.*pointer.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK60: omp.declare_simd
+! CHECK60-NOT: {{[[:space:]]*(aligned|linear)\(}}
+! CHECK60-SAME: simdlen(8)
+! CHECK60: return
+
+subroutine declare_simd_combined_60(x, y, n, i)
+    !$omp declare_simd aligned(x, y : 64) linear(i) simdlen(8)
+    real(8), pointer, intent(inout) :: x(:)
+    real(8), pointer, intent(in)    :: y(:)
+    integer, intent(in) :: n, i
+
+    if (i <= n) then
+        x(i) = x(i) + y(i)
+    end if
+end subroutine declare_simd_combined_60
+
+! CHECK60-LABEL: func.func @_QPdeclare_simd_combined_60(
+! CHECK60-SAME: %{{.*}}: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>{{.*}}fir.bindc_name = "x"
+! CHECK60-SAME: %{{.*}}: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>{{.*}}fir.bindc_name = "y"
+! CHECK60-SAME: %{{.*}}: !fir.ref<i32>{{.*}}fir.bindc_name = "n"
+! CHECK60-SAME: %{{.*}}: !fir.ref<i32>{{.*}}fir.bindc_name = "i"
+! CHECK60: %[[SCOPE:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK60: %[[I_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 4 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK60: %[[N_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 3 {{.*}} : (!fir.ref<i32>, !fir.dscope) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK60: %[[X_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 1 {{.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK60: %[[Y_DECL:.*]]:2 = hlfir.declare %{{.*}} dummy_scope %[[SCOPE]] arg 2 {{.*}} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>>)
+! CHECK60: %[[C1:.*]] = arith.constant 1 : i32
+
+! CHECK60: omp.declare_simd
+! CHECK60-SAME: aligned(%[[X_DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64,
+! CHECK60-SAME:         %[[Y_DECL]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf64>>>> -> 64 : i64)
+! CHECK60-SAME: linear(%[[I_DECL]]#0 = %[[C1]] : !fir.ref<i32>)
+! CHECK60-SAME: simdlen(8)
+! CHECK60-SAME: {linear_var_types = [i32]}
+
+#endif !OMP_60

--- a/flang/test/Lower/OpenMP/declare-simd.f90
+++ b/flang/test/Lower/OpenMP/declare-simd.f90
@@ -1,4 +1,4 @@
-! This test CHECKs the lowering of the OpenMP `declare simd` directive with
+! This test checks the lowering of the OpenMP `declare simd` directive with
 ! different clauses (e.g. aligned, linear, simdlen). It also verifies that
 ! the `omp.declare_simd` operation is emitted after the function prologue,
 ! since the directive requires access to function arguments.
@@ -12,8 +12,7 @@ subroutine declare_simd_no_clause()
 end subroutine declare_simd_no_clause
 
 ! CHECK-LABEL: func.func @_QPdeclare_simd_no_clause()
-! CHECK: omp.declare_simd
-! CHECK-NOT: {{omp\.declare_simd[[:space:]]*(aligned|linear|simdlen)\(}}
+! CHECK: omp.declare_simd{{$}}
 ! CHECK: return
 
 subroutine declare_simd_aligned(x, y, n, i)

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -2245,9 +2245,7 @@ def WorkdistributeOp : OpenMP_Op<"workdistribute"> {
 //===----------------------------------------------------------------------===//
 
 def DeclareSimdOp
-    : OpenMP_Op<"declare_simd",
-                traits = [AttrSizedOperandSegments,
-                          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>],
+    : OpenMP_Op<"declare_simd", traits = [AttrSizedOperandSegments],
                 clauses = [OpenMP_AlignedClause, OpenMP_LinearClause,
                            OpenMP_SimdlenClause]> {
   let summary = "declare simd directive";
@@ -2267,11 +2265,8 @@ def DeclareSimdOp
     ```
   }] # clausesDescription;
 
-  let arguments = clausesArgs;
-
-  let assemblyFormat =
-      clausesReqAssemblyFormat#" oilist("#clausesOptAssemblyFormat#") "#"attr-"
-                               "dict";
+  let builders = [OpBuilder<(
+      ins CArg<"const DeclareSimdOperands &">:$clauses)>];
 
   let hasVerifier = 1;
 }

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -2265,12 +2265,9 @@ def DeclareSimdOp
       ...
     }
     ```
-  }]#clausesDescription;
+  }] # clausesDescription;
 
   let arguments = clausesArgs;
-
-  let builders = [OpBuilder<(
-      ins CArg<"const DeclareSimdOperands &">:$clauses)>];
 
   let assemblyFormat =
       clausesReqAssemblyFormat#" oilist("#clausesOptAssemblyFormat#") "#"attr-"

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -2246,7 +2246,8 @@ def WorkdistributeOp : OpenMP_Op<"workdistribute"> {
 
 def DeclareSimdOp
     : OpenMP_Op<"declare_simd",
-                traits = [AttrSizedOperandSegments, IsolatedFromAbove],
+                traits = [AttrSizedOperandSegments,
+                          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>],
                 clauses = [OpenMP_AlignedClause, OpenMP_LinearClause,
                            OpenMP_SimdlenClause]> {
   let summary = "declare simd directive";

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOps.td
@@ -2240,4 +2240,42 @@ def WorkdistributeOp : OpenMP_Op<"workdistribute"> {
   let assemblyFormat = "$region attr-dict";
 }
 
+//===----------------------------------------------------------------------===//
+// declare simd Construct
+//===----------------------------------------------------------------------===//
+
+def DeclareSimdOp
+    : OpenMP_Op<"declare_simd",
+                traits = [AttrSizedOperandSegments, IsolatedFromAbove],
+                clauses = [OpenMP_AlignedClause, OpenMP_LinearClause,
+                           OpenMP_SimdlenClause]> {
+  let summary = "declare simd directive";
+  let description = [{
+    "omp.declare_simd" models the OpenMP `declare simd` directive.
+
+    This is a declarative operation (no region) intended to appear inside
+    a function body. It attaches clauses of declare simd to the enclosing
+    function.
+
+    Example:
+    ```mlir
+    func.func @add(%a: memref<16xi32>) {
+      omp.declare_simd simdlen(8) aligned(%a : memref<16xi32> -> 64 : i64)
+      ...
+    }
+    ```
+  }]#clausesDescription;
+
+  let arguments = clausesArgs;
+
+  let builders = [OpBuilder<(
+      ins CArg<"const DeclareSimdOperands &">:$clauses)>];
+
+  let assemblyFormat =
+      clausesReqAssemblyFormat#" oilist("#clausesOptAssemblyFormat#") "#"attr-"
+                               "dict";
+
+  let hasVerifier = 1;
+}
+
 #endif // OPENMP_OPS

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -4464,10 +4464,10 @@ LogicalResult WorkdistributeOp::verify() {
 
 LogicalResult DeclareSimdOp::verify() {
   // Must be nested inside a function-like op
-  auto func = (*this)->getParentOfType<mlir::FunctionOpInterface>();
+  auto func =
+      dyn_cast_if_present<mlir::FunctionOpInterface>((*this)->getParentOp());
   if (!func)
-    return emitOpError()
-           << "'omp.declare_simd' must be nested inside a function";
+    return emitOpError() << "must be nested inside a function";
 
   return verifyAlignedClause(*this, getAlignments(), getAlignedVars());
 }

--- a/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
+++ b/mlir/lib/Dialect/OpenMP/IR/OpenMPDialect.cpp
@@ -4462,15 +4462,6 @@ LogicalResult WorkdistributeOp::verify() {
 // Declare simd [7.7]
 //===----------------------------------------------------------------------===//
 
-void DeclareSimdOp::build(OpBuilder &odsBuilder, OperationState &odsState,
-                          const DeclareSimdOperands &clauses) {
-  MLIRContext *ctx = odsBuilder.getContext();
-  DeclareSimdOp::build(odsBuilder, odsState, clauses.alignedVars,
-                       makeArrayAttr(ctx, clauses.alignments),
-                       clauses.linearVars, clauses.linearStepVars,
-                       clauses.linearVarTypes, clauses.simdlen);
-}
-
 LogicalResult DeclareSimdOp::verify() {
   // Must be nested inside a function-like op
   auto func = (*this)->getParentOfType<mlir::FunctionOpInterface>();

--- a/mlir/test/Dialect/OpenMP/invalid.mlir
+++ b/mlir/test/Dialect/OpenMP/invalid.mlir
@@ -3141,5 +3141,5 @@ func.func @invalid_workdistribute() -> () {
 }
 
 // -----
-// expected-error @+1 {{'omp.declare_simd' must be nested inside a function}}
+// expected-error @+1 {{'omp.declare_simd' op must be nested inside a function}}
 omp.declare_simd

--- a/mlir/test/Dialect/OpenMP/invalid.mlir
+++ b/mlir/test/Dialect/OpenMP/invalid.mlir
@@ -3139,3 +3139,7 @@ func.func @invalid_workdistribute() -> () {
   }
   return
 }
+
+// -----
+// expected-error @+1 {{'omp.declare_simd' must be nested inside a function}}
+omp.declare_simd

--- a/mlir/test/Dialect/OpenMP/ops.mlir
+++ b/mlir/test/Dialect/OpenMP/ops.mlir
@@ -3369,25 +3369,23 @@ func.func @omp_target_map_clause_type_test(%arg0 : memref<?xi32>) -> () {
 }
 
 // CHECK-LABEL: func.func @omp_declare_simd
-func.func @omp_declare_simd(%a: f64, %b: f64) -> f64 {
+func.func @omp_declare_simd() -> () {
   // CHECK: omp.declare_simd
   omp.declare_simd
-  %0 = arith.addf %a, %b : f64
-  return %0 : f64
+  return
 }
 
 // CHECK-LABEL: func.func @omp_declare_simd_simdlen
-func.func @omp_declare_simd_simdlen(%a: f64, %b: f64) -> f64 {
+func.func @omp_declare_simd_simdlen() -> () {
   // CHECK: omp.declare_simd
   // CHECK-SAME: simdlen(8)
   omp.declare_simd simdlen(8)
-  %0 = arith.addf %a, %b : f64
-  return %0 : f64
+  return
 }
 
 // CHECK-LABEL: func.func @omp_declare_simd_aligned
 func.func @omp_declare_simd_aligned(%a: f64, %b: f64,
-                                         %p0: memref<i32>, %p1: memref<i32>) -> f64 {
+                                         %p0: memref<i32>, %p1: memref<i32>) -> () {
   // CHECK:      omp.declare_simd
   // CHECK-SAME: aligned(
   // CHECK-SAME: %{{.*}} : memref<i32> -> 32 : i64,
@@ -3395,33 +3393,30 @@ func.func @omp_declare_simd_aligned(%a: f64, %b: f64,
   omp.declare_simd aligned(%p0 : memref<i32> -> 32 : i64,
                            %p1 : memref<i32> -> 128 : i64)
 
-  %0 = arith.addf %a, %b : f64
-  return %0 : f64
+  return
 }
 
 // CHECK-LABEL: func.func @omp_declare_simd_aligned_list_generic
 func.func @omp_declare_simd_aligned_list_generic(%arg0: f64, %arg1: f64,
-                                                 %arg2: memref<i32>, %arg3: memref<i32>) -> f64 {
+                                                 %arg2: memref<i32>, %arg3: memref<i32>) -> () {
   // CHECK:      omp.declare_simd
   // CHECK-SAME: aligned(%{{.*}} : memref<i32> -> 32 : i64, %{{.*}} : memref<i32> -> 128 : i64)
   omp.declare_simd aligned(%arg2 : memref<i32> -> 32 : i64, %arg3 : memref<i32> -> 128 : i64)
-  %0 = arith.addf %arg0, %arg1 : f64
-  return %0 : f64
+  return
 }
 
 // CHECK-LABEL: func.func @omp_declare_simd_linear
-func.func @omp_declare_simd_linear(%a: f64, %b: f64, %iv: i32, %step: i32) -> f64 {
+func.func @omp_declare_simd_linear(%a: f64, %b: f64, %iv: i32, %step: i32) -> () {
   // CHECK: omp.declare_simd
   // CHECK-SAME: linear(%{{.*}} = %{{.*}} : i32)
   omp.declare_simd linear(%iv = %step : i32)
-  %0 = arith.addf %a, %b : f64
-  return %0 : f64
+  return
 }
 
 // CHECK-LABEL: func.func @omp_declare_simd_all_clauses
 func.func @omp_declare_simd_all_clauses(%a: f64, %b: f64,
                                         %p0: memref<i32>, %p1: memref<i32>,
-                                        %iv: i32, %step: i32) -> f64 {
+                                        %iv: i32, %step: i32) -> () {
   // CHECK:      omp.declare_simd
   // CHECK-SAME: aligned(
   // CHECK-SAME: %{{.*}} : memref<i32> -> 32 : i64,
@@ -3432,7 +3427,5 @@ func.func @omp_declare_simd_all_clauses(%a: f64, %b: f64,
     aligned(%p0 : memref<i32> -> 32 : i64,
             %p1 : memref<i32> -> 128 : i64)
     linear(%iv = %step : i32)
-
-  %0 = arith.addf %a, %b : f64
-  return %0 : f64
+  return
 }

--- a/mlir/test/Dialect/OpenMP/ops.mlir
+++ b/mlir/test/Dialect/OpenMP/ops.mlir
@@ -3367,3 +3367,72 @@ func.func @omp_target_map_clause_type_test(%arg0 : memref<?xi32>) -> () {
 
     return
 }
+
+// CHECK-LABEL: func.func @omp_declare_simd
+func.func @omp_declare_simd(%a: f64, %b: f64) -> f64 {
+  // CHECK: omp.declare_simd
+  omp.declare_simd
+  %0 = arith.addf %a, %b : f64
+  return %0 : f64
+}
+
+// CHECK-LABEL: func.func @omp_declare_simd_simdlen
+func.func @omp_declare_simd_simdlen(%a: f64, %b: f64) -> f64 {
+  // CHECK: omp.declare_simd
+  // CHECK-SAME: simdlen(8)
+  omp.declare_simd simdlen(8)
+  %0 = arith.addf %a, %b : f64
+  return %0 : f64
+}
+
+// CHECK-LABEL: func.func @omp_declare_simd_aligned
+func.func @omp_declare_simd_aligned(%a: f64, %b: f64,
+                                         %p0: memref<i32>, %p1: memref<i32>) -> f64 {
+  // CHECK:      omp.declare_simd
+  // CHECK-SAME: aligned(
+  // CHECK-SAME: %{{.*}} : memref<i32> -> 32 : i64,
+  // CHECK-SAME: %{{.*}} : memref<i32> -> 128 : i64)
+  omp.declare_simd aligned(%p0 : memref<i32> -> 32 : i64,
+                           %p1 : memref<i32> -> 128 : i64)
+
+  %0 = arith.addf %a, %b : f64
+  return %0 : f64
+}
+
+// CHECK-LABEL: func.func @omp_declare_simd_aligned_list_generic
+func.func @omp_declare_simd_aligned_list_generic(%arg0: f64, %arg1: f64,
+                                                 %arg2: memref<i32>, %arg3: memref<i32>) -> f64 {
+  // CHECK:      omp.declare_simd
+  // CHECK-SAME: aligned(%{{.*}} : memref<i32> -> 32 : i64, %{{.*}} : memref<i32> -> 128 : i64)
+  omp.declare_simd aligned(%arg2 : memref<i32> -> 32 : i64, %arg3 : memref<i32> -> 128 : i64)
+  %0 = arith.addf %arg0, %arg1 : f64
+  return %0 : f64
+}
+
+// CHECK-LABEL: func.func @omp_declare_simd_linear
+func.func @omp_declare_simd_linear(%a: f64, %b: f64, %iv: i32, %step: i32) -> f64 {
+  // CHECK: omp.declare_simd
+  // CHECK-SAME: linear(%{{.*}} = %{{.*}} : i32)
+  omp.declare_simd linear(%iv = %step : i32)
+  %0 = arith.addf %a, %b : f64
+  return %0 : f64
+}
+
+// CHECK-LABEL: func.func @omp_declare_simd_all_clauses
+func.func @omp_declare_simd_all_clauses(%a: f64, %b: f64,
+                                        %p0: memref<i32>, %p1: memref<i32>,
+                                        %iv: i32, %step: i32) -> f64 {
+  // CHECK:      omp.declare_simd
+  // CHECK-SAME: aligned(
+  // CHECK-SAME: %{{.*}} : memref<i32> -> 32 : i64,
+  // CHECK-SAME: %{{.*}} : memref<i32> -> 128 : i64)
+  // CHECK-SAME: linear(%{{.*}} = %{{.*}} : i32)
+  // CHECK-SAME: simdlen(8)
+  omp.declare_simd simdlen(8)
+    aligned(%p0 : memref<i32> -> 32 : i64,
+            %p1 : memref<i32> -> 128 : i64)
+    linear(%iv = %step : i32)
+
+  %0 = arith.addf %a, %b : f64
+  return %0 : f64
+}


### PR DESCRIPTION
Changes:
- Adds a new `omp.declare_simd` operation to the OpenMP MLIR dialect
- Lowers Fortran `!$omp declare simd` into `omp.declare_simd` inside the enclosing function body

mlir to LLVMIR translation and uniform clause will be added in follow-up PRs.