### PR TITLE
 [Flang] Module name should not be the same as local name in the module.

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -2061,10 +2061,9 @@ void CheckHelper::CheckGeneric(
 void CheckHelper::CheckModule(const Symbol &symbol, const ModuleDetails &x) {
 
   for (const auto &pair : *symbol.scope()) {
-    const SourceName &memberName = pair.first;
     const Symbol &member = *pair.second;
 
-    if (const auto *obj = member.detailsIf<ObjectEntityDetails>()) {
+    if (member.detailsIf<ObjectEntityDetails>()) {
       if (symbol.name() == member.name()) {
         messages_.Say(member.name(),
             "Module name '%s' must not be the same as any local name in the module"_err_en_US,


### PR DESCRIPTION
Working on issue [175620](https://github.com/llvm/llvm-project/issues/175620) 

      The module name is global to the executable program, and must not be the same as the name of any other program unit, external procedure, or common block in the executable program, nor be the same as any local name in the module.
       Added CheckModule() helper method to take care of the above.