### PR TITLE
[clangd] Support `=default` in DefineOutline to find insertion point

### DIFF
--- a/clang-tools-extra/clangd/unittests/tweaks/DefineOutlineTests.cpp
+++ b/clang-tools-extra/clangd/unittests/tweaks/DefineOutlineTests.cpp
@@ -950,6 +950,37 @@ inline void Foo::neighbor() {}
 )cpp",
           {}},
 
+      // Adjacent definition with `= default`
+      {
+          R"cpp(
+struct Foo {
+  void ignored1();
+  Foo();
+  void fun^c() {}
+  void ignored2();
+};
+)cpp",
+          R"cpp(
+#include "a.hpp"
+void Foo::ignored1() {}
+Foo::Foo() = default;
+void Foo::ignored2() {}
+)cpp",
+          R"cpp(
+struct Foo {
+  void ignored1();
+  Foo();
+  void func() ;
+  void ignored2();
+};
+)cpp",
+          R"cpp(
+#include "a.hpp"
+void Foo::ignored1() {}
+Foo::Foo() = default;void Foo::func() {}
+
+void Foo::ignored2() {}
+)cpp"},
   };
 
   for (const auto &Case : Cases) {


### PR DESCRIPTION
Since #128164 , the DefineOutline tweak is looking for a good insertion point by looking at where neighboring functions are defined. That heuristic didn't yet handle `= default`. This commit adds support for it.

**AI disclaimer**: I used AI (Cursor) to draft a first version of this code. I reviewed and adjusted it (rewrote roughly 50%) before submitting this PR.