### PR TITLE
[lldb][NativePDB] NFC: Remove Clang-specific typedef handling

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
@@ -733,10 +733,12 @@ clang::VarDecl *PdbAstBuilder::GetOrCreateVariableDecl(PdbGlobalSymId var_id) {
   return CreateVariableDecl(PdbSymUid(var_id), sym, *context);
 }
 
-clang::TypedefNameDecl *
-PdbAstBuilder::GetOrCreateTypedefDecl(PdbGlobalSymId id) {
-  if (clang::Decl *decl = TryGetDecl(id))
-    return llvm::dyn_cast<clang::TypedefNameDecl>(decl);
+CompilerType PdbAstBuilder::GetOrCreateTypedefType(PdbGlobalSymId id) {
+  if (clang::Decl *decl = TryGetDecl(id)) {
+    if (auto *tnd = llvm::dyn_cast<clang::TypedefNameDecl>(decl))
+      return ToCompilerType(m_clang.getASTContext().getTypeDeclType(tnd));
+    return CompilerType();
+  }
 
   SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
       m_clang.GetSymbolFile()->GetBackingSymbolFile());
@@ -750,18 +752,17 @@ PdbAstBuilder::GetOrCreateTypedefDecl(PdbGlobalSymId id) {
   PdbTypeSymId real_type_id{udt.Type, false};
   clang::QualType qt = GetOrCreateClangType(real_type_id);
   if (qt.isNull() || !scope)
-    return nullptr;
+    return CompilerType();
 
   std::string uname = std::string(DropNameScope(udt.Name));
 
   CompilerType ct = ToCompilerType(qt).CreateTypedef(
       uname.c_str(), ToCompilerDeclContext(scope), 0);
-  clang::TypedefNameDecl *tnd = m_clang.GetAsTypedefDecl(ct);
   DeclStatus status;
   status.resolved = true;
   status.uid = toOpaqueUid(id);
-  m_decl_to_status.insert({tnd, status});
-  return tnd;
+  m_decl_to_status.insert({m_clang.GetAsTypedefDecl(ct), status});
+  return ct;
 }
 
 clang::QualType PdbAstBuilder::GetBasicType(lldb::BasicType type) {
@@ -1466,7 +1467,7 @@ CompilerDecl PdbAstBuilder::ToCompilerDecl(clang::Decl *decl) {
 }
 
 CompilerType PdbAstBuilder::ToCompilerType(clang::QualType qt) {
-  return {m_clang.weak_from_this(), qt.getAsOpaquePtr()};
+  return m_clang.GetType(qt);
 }
 
 clang::QualType PdbAstBuilder::FromCompilerType(CompilerType ct) {

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
@@ -71,7 +71,7 @@ public:
   clang::VarDecl *GetOrCreateVariableDecl(PdbCompilandSymId scope_id,
                                           PdbCompilandSymId var_id);
   clang::VarDecl *GetOrCreateVariableDecl(PdbGlobalSymId var_id);
-  clang::TypedefNameDecl *GetOrCreateTypedefDecl(PdbGlobalSymId id);
+  CompilerType GetOrCreateTypedefType(PdbGlobalSymId id);
   void ParseDeclsForContext(lldb_private::CompilerDeclContext context);
 
   clang::QualType GetBasicType(lldb::BasicType type);

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -2267,11 +2267,9 @@ TypeSP SymbolFileNativePDB::CreateTypedef(PdbGlobalSymId id) {
   if (!ts)
     return nullptr;
 
-  auto *typedef_decl = ts->GetNativePDBParser()->GetOrCreateTypedefDecl(id);
-
-  CompilerType ct = target_type->GetForwardCompilerType();
-  if (auto *clang = llvm::dyn_cast_or_null<TypeSystemClang>(ts.get()))
-    ct = clang->GetType(clang->getASTContext().getTypeDeclType(typedef_decl));
+  CompilerType ct = ts->GetNativePDBParser()->GetOrCreateTypedefType(id);
+  if (!ct)
+    ct = target_type->GetForwardCompilerType();
 
   Declaration decl;
   return MakeType(toOpaqueUid(id), ConstString(udt.Name),


### PR DESCRIPTION
Missed this one in https://github.com/llvm/llvm-project/pull/173111

Also tweaks `PdbAstBuilder::ToCompilerType` to make it more clear that the change is correct and take advantage of asserts in `TypeSystemClang`

This is part of the work to allow language-agnostic `PdbAstBuilder` (see RFC: https://discourse.llvm.org/t/rfc-lldb-make-pdbastbuilder-language-agnostic/89117)