### PR TITLE
[LifetimeSafety] Add support for derived-to-base conversions

### DIFF
--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -219,6 +219,8 @@ void FactsGenerator::VisitImplicitCastExpr(const ImplicitCastExpr *ICE) {
   case CK_NoOp:
   case CK_ConstructorConversion:
   case CK_UserDefinedConversion:
+  case CK_UncheckedDerivedToBase:
+  case CK_DerivedToBase:
     flow(Dest, SrcList, /*Kill=*/true);
     return;
   case CK_FunctionToPointerDecay:


### PR DESCRIPTION
Add support for derived-to-base conversions in lifetime analysis.

Added handling for `CK_UncheckedDerivedToBase` and `CK_DerivedToBase` cast kinds in the `FactsGenerator::VisitImplicitCastExpr` method. These cast kinds are now treated similarly to other conversions by flowing origins from source to destination.

Added a unit test `DerivedToBaseThisArg` that verifies lifetime information is correctly propagated through derived-to-base conversions when using member functions inherited from a base class.