### PR TITLE
[lsan] Fix flaky test in swapcontext.cpp

### DIFF
--- a/compiler-rt/test/lsan/TestCases/swapcontext.cpp
+++ b/compiler-rt/test/lsan/TestCases/swapcontext.cpp
@@ -2,8 +2,15 @@
 // memory. Make sure we don't report these leaks.
 
 // RUN: %clangxx_lsan %s -o %t
+//
+// Heap-allocated
 // RUN: %env_lsan_opts= %run %t 2>&1
-// RUN: %env_lsan_opts= not %run %t foo 2>&1 | FileCheck %s
+//
+// The stack-allocated test case:
+//   %env_lsan_opts= not %run %t foo 2>&1 | FileCheck %s
+// is disabled because due to flakiness. LSan, by design, can have false
+// negatives, making it unreliable to check that the leak was found.
+//
 // Missing 'getcontext' and 'makecontext' on Android.
 // UNSUPPORTED: target={{(arm|aarch64|loongarch64|powerpc64).*}},android
 

--- a/compiler-rt/test/lsan/TestCases/swapcontext.cpp
+++ b/compiler-rt/test/lsan/TestCases/swapcontext.cpp
@@ -6,16 +6,15 @@
 // Heap-allocated
 // RUN: %env_lsan_opts= %run %t 2>&1
 //
-// The stack-allocated test case:
-//   %env_lsan_opts= not %run %t foo 2>&1 | FileCheck %s
-// is disabled because due to flakiness. LSan, by design, can have false
-// negatives, making it unreliable to check that the leak was found.
+// Stack-allocated
+// RUN: %env_lsan_opts= not %run %t foo 2>&1 | FileCheck %s
 //
 // Missing 'getcontext' and 'makecontext' on Android.
 // UNSUPPORTED: target={{(arm|aarch64|loongarch64|powerpc64).*}},android
 
 #include "sanitizer_common/sanitizer_ucontext.h"
 #include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 
 const int kStackSize = 1 << 20;
@@ -43,6 +42,10 @@ int main(int argc, char *argv[]) {
     perror("swapcontext");
     return 1;
   }
+
+  // If 'leaked' is inside 'stack_memory', LSan's pointer-tracing may consider
+  // 'leaked' to be reachable.
+  memset(stack_memory, 0, kStackSize + 1);
 
   delete[] heap_memory;
   return 0;


### PR DESCRIPTION
LSan, by design, can have false negatives, making it unreliable to check that the leak was found in the stack-allocated case:
```
==123685==Scanning STACK range 0x7ffe6e554ca0-0x7ffe6e557000.
==123685==0x7ffe6e554de0: found 0x51e0000009f0 pointing into chunk 0x51e000000000-0x51e000000c00 of size 3072.
==123685==0x7ffe6e554e30: found 0x51e000000c00 pointing into chunk 0x51e000000c00-0x51e000001668 of size 2664. <- this prevented the leak from being found
```

This has led to flakiness on the buildbots e.g., https://lab.llvm.org/buildbot/#/builders/66/builds/24669
```
# | /home/b/sanitizer-x86_64-linux/build/llvm-project/compiler-rt/test/lsan/TestCases/swapcontext.cpp:44:11: error: CHECK: expected string not found in input
# | // CHECK: SUMMARY: {{.*}}Sanitizer: 2664 byte(s) leaked in 1 allocation(s)
...
Failed Tests (2):
  LeakSanitizer-HWAddressSanitizer-x86_64 :: TestCases/swapcontext.cpp
  LeakSanitizer-Standalone-x86_64 :: TestCases/swapcontext.cpp
```

This patch fixes the issue by clearing the buffer, as suggested by Vitaly.