### PR TITLE
[flang-rt] Fix unused flag warning when compiling for the GPU

### DIFF
--- a/flang-rt/cmake/modules/HandleLibs.cmake
+++ b/flang-rt/cmake/modules/HandleLibs.cmake
@@ -43,8 +43,4 @@ elseif (FLANG_RT_LIBCXX_PROVIDER STREQUAL "llvm")
   if (CXX_SUPPORTS_NOSTDINCXX_FLAG)
     target_compile_options(flang-rt-libc-headers INTERFACE $<$<COMPILE_LANGUAGE:CXX,C>:-nostdinc++>)
   endif ()
-
-  if (FLANG_RT_HAS_STDLIB_FLAG)
-    target_compile_options(flang-rt-libc-headers INTERFACE $<$<COMPILE_LANGUAGE:CXX,C>:-stdlib=libc++>)
-  endif ()
 endif ()


### PR DESCRIPTION
Summary:
Because we link the `cxx` target directly we do not need to use this
flag, that's also why we pass `-nostdinc++` which makes this an unused
command line flag, hence the warning.
