### PR TITLE
[lldb-dap] Fix welcome message

### DIFF
--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -267,7 +267,7 @@ void BaseRequestHandler::PrintWelcomeMessage() const {
   llvm::raw_string_ostream OS(message);
 
 #ifdef LLDB_DAP_WELCOME_MESSAGE
-  dap.SendOutput(eOutputCategoryConsole, LLDB_DAP_WELCOME_MESSAGE);
+  dap.SendOutput(OutputType::Console, LLDB_DAP_WELCOME_MESSAGE);
 #endif
 
   // Trying to provide a brief but helpful welcome message for users to better


### PR DESCRIPTION
Fix the printing of the welcome message in lldb-dap. This is not the message introduced in PR 170795; it's the message printed by the LLDB_DAP_WELCOME_MESSAGE define.