### PR TITLE
[llvm][RISCV] Suppress unused `IsMulH` warning.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -15351,6 +15351,7 @@ void RISCVTargetLowering::ReplaceNodeResults(SDNode *N,
     bool IsMulH = Opcode == RISCVISD::PMULHSU || Opcode == RISCVISD::PMULHR ||
                   Opcode == RISCVISD::PMULHRU || Opcode == RISCVISD::PMULHRSU;
     assert(VT == MVT::v2i16 || (!IsMulH && VT == MVT::v4i8));
+    (void)IsMulH;
     MVT NewVT = MVT::v4i16;
     if (VT == MVT::v4i8)
       NewVT = MVT::v8i8;

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -15348,10 +15348,10 @@ void RISCVTargetLowering::ReplaceNodeResults(SDNode *N,
     SDValue Op1 = N->getOperand(1);
     unsigned Opcode = N->getOpcode();
     // PMULH* variants don't support i8
-    bool IsMulH = Opcode == RISCVISD::PMULHSU || Opcode == RISCVISD::PMULHR ||
-                  Opcode == RISCVISD::PMULHRU || Opcode == RISCVISD::PMULHRSU;
+    [[maybe_unused]] bool IsMulH =
+        Opcode == RISCVISD::PMULHSU || Opcode == RISCVISD::PMULHR ||
+        Opcode == RISCVISD::PMULHRU || Opcode == RISCVISD::PMULHRSU;
     assert(VT == MVT::v2i16 || (!IsMulH && VT == MVT::v4i8));
-    (void)IsMulH;
     MVT NewVT = MVT::v4i16;
     if (VT == MVT::v4i8)
       NewVT = MVT::v8i8;


### PR DESCRIPTION
Introduced in commit d28daddd. `IsMulH` is only used in assert(), and triggers unused variable warnings in non-debug builds.