### PR TITLE
[X86][NewPM] Port x86-argument-stack-slot

### DIFF
--- a/llvm/lib/Target/X86/X86.h
+++ b/llvm/lib/Target/X86/X86.h
@@ -339,12 +339,20 @@ FunctionPass *createX86LoadValueInjectionLoadHardeningPass();
 FunctionPass *createX86LoadValueInjectionRetHardeningPass();
 FunctionPass *createX86SpeculativeLoadHardeningPass();
 FunctionPass *createX86SpeculativeExecutionSideEffectSuppression();
-FunctionPass *createX86ArgumentStackSlotPass();
+
+class X86ArgumentStackSlotPass
+    : public PassInfoMixin<X86ArgumentStackSlotPass> {
+public:
+  PreservedAnalyses run(MachineFunction &MF,
+                        MachineFunctionAnalysisManager &MFAM);
+};
+
+FunctionPass *createX86ArgumentStackSlotLegacyPass();
 
 void initializeCompressEVEXLegacyPass(PassRegistry &);
 void initializeX86FixupBWInstLegacyPass(PassRegistry &);
 void initializeFixupLEAsLegacyPass(PassRegistry &);
-void initializeX86ArgumentStackSlotPassPass(PassRegistry &);
+void initializeX86ArgumentStackSlotLegacyPass(PassRegistry &);
 void initializeX86AsmPrinterPass(PassRegistry &);
 void initializeX86FixupInstTuningLegacyPass(PassRegistry &);
 void initializeX86FixupVectorConstantsLegacyPass(PassRegistry &);

--- a/llvm/lib/Target/X86/X86ArgumentStackSlotRebase.cpp
+++ b/llvm/lib/Target/X86/X86ArgumentStackSlotRebase.cpp
@@ -30,16 +30,16 @@
 
 using namespace llvm;
 
-#define DEBUG_TYPE "x86argumentstackrebase"
+#define DEBUG_TYPE "x86-argument-stack-slot"
 
 namespace {
 
-class X86ArgumentStackSlotPass : public MachineFunctionPass {
+class X86ArgumentStackSlotLegacy : public MachineFunctionPass {
 
 public:
   static char ID; // Pass identification, replacement for typeid
 
-  explicit X86ArgumentStackSlotPass() : MachineFunctionPass(ID) {}
+  explicit X86ArgumentStackSlotLegacy() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &MF) override;
 
@@ -51,13 +51,13 @@ public:
 
 } // end anonymous namespace
 
-char X86ArgumentStackSlotPass::ID = 0;
+char X86ArgumentStackSlotLegacy::ID = 0;
 
-INITIALIZE_PASS(X86ArgumentStackSlotPass, DEBUG_TYPE, "Argument Stack Rebase",
+INITIALIZE_PASS(X86ArgumentStackSlotLegacy, DEBUG_TYPE, "Argument Stack Rebase",
                 false, false)
 
-FunctionPass *llvm::createX86ArgumentStackSlotPass() {
-  return new X86ArgumentStackSlotPass();
+FunctionPass *llvm::createX86ArgumentStackSlotLegacyPass() {
+  return new X86ArgumentStackSlotLegacy();
 }
 
 static Register getArgBaseReg(MachineFunction &MF) {
@@ -97,7 +97,7 @@ static Register getArgBaseReg(MachineFunction &MF) {
     return NoReg;
 }
 
-bool X86ArgumentStackSlotPass::runOnMachineFunction(MachineFunction &MF) {
+static bool argumentStackSlotRebase(MachineFunction &MF) {
   const Function &F = MF.getFunction();
   MachineFrameInfo &MFI = MF.getFrameInfo();
   const X86Subtarget &STI = MF.getSubtarget<X86Subtarget>();
@@ -190,4 +190,16 @@ bool X86ArgumentStackSlotPass::runOnMachineFunction(MachineFunction &MF) {
   }
 
   return Changed;
+}
+
+bool X86ArgumentStackSlotLegacy::runOnMachineFunction(MachineFunction &MF) {
+  return argumentStackSlotRebase(MF);
+}
+
+PreservedAnalyses
+X86ArgumentStackSlotPass::run(MachineFunction &MF,
+                              MachineFunctionAnalysisManager &MFAM) {
+  return argumentStackSlotRebase(MF) ? getMachineFunctionPassPreservedAnalyses()
+                                           .preserveSet<CFGAnalyses>()
+                                     : PreservedAnalyses::all();
 }

--- a/llvm/lib/Target/X86/X86PassRegistry.def
+++ b/llvm/lib/Target/X86/X86PassRegistry.def
@@ -29,6 +29,7 @@ DUMMY_FUNCTION_PASS("x86-winehstate", WinEHStatePass())
 #ifndef MACHINE_FUNCTION_PASS
 #define MACHINE_FUNCTION_PASS(NAME, CREATE_PASS)
 #endif
+MACHINE_FUNCTION_PASS("x86-argument-stack-slot", X86ArgumentStackSlotPass())
 MACHINE_FUNCTION_PASS("x86-avoid-sfb", X86AvoidStoreForwardingBlocksPass())
 MACHINE_FUNCTION_PASS("x86-avoid-trailing-call", X86AvoidTrailingCallPass())
 MACHINE_FUNCTION_PASS("x86-cf-opt", X86CallFrameOptimizationPass())
@@ -64,5 +65,4 @@ DUMMY_MACHINE_FUNCTION_PASS("x86-slh", X86SpeculativeLoadHardeningPass())
 DUMMY_MACHINE_FUNCTION_PASS("tile-pre-config", X86PreTileConfig())
 DUMMY_MACHINE_FUNCTION_PASS("tileconfig", X86TileConfig())
 DUMMY_MACHINE_FUNCTION_PASS("x86-wineh-unwindv2", X86WinEHUnwindV2())
-DUMMY_MACHINE_FUNCTION_PASS("x86argumentstackrebase", X86ArgumentStackSlotPass())
 #undef DUMMY_MACHINE_FUNCTION_PASS

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -100,7 +100,7 @@ extern "C" LLVM_C_ABI void LLVMInitializeX86Target() {
   initializePseudoProbeInserterPass(PR);
   initializeX86ReturnThunksPass(PR);
   initializeX86DAGToDAGISelLegacyPass(PR);
-  initializeX86ArgumentStackSlotPassPass(PR);
+  initializeX86ArgumentStackSlotLegacyPass(PR);
   initializeX86AsmPrinterPass(PR);
   initializeX86FixupInstTuningLegacyPass(PR);
   initializeX86FixupVectorConstantsLegacyPass(PR);
@@ -462,7 +462,7 @@ bool X86PassConfig::addInstSelector() {
     addPass(createCleanupLocalDynamicTLSPass());
 
   addPass(createX86GlobalBaseRegPass());
-  addPass(createX86ArgumentStackSlotPass());
+  addPass(createX86ArgumentStackSlotLegacyPass());
   return false;
 }
 


### PR DESCRIPTION
Standard porting. Refactor runOnMachineFunction to a static function, and then wrap it in the legacy/new PMs. Rename the pass to be consistent with other backend passes.