### PR TITLE
[libclc][cmake] Support custom GNU install dirs

### DIFF
--- a/libclc/libclc.pc.in
+++ b/libclc/libclc.pc.in
@@ -1,4 +1,4 @@
-libexecdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_DATADIR@/clc
+libexecdir=@CMAKE_INSTALL_FULL_DATADIR@/clc
 
 Name: libclc
 Description: Library requirements of the OpenCL C programming language


### PR DESCRIPTION
Custom GNU install dirs specified at configure time may be absolute paths, in which case appending to the install prefix is not correct. Instead we can use the already available CMAKE_INSTALL_FULL_* variables, which are correctly precomputed absolute paths.

This is helpful in Nixpkgs, where we specify an absolute CMAKE_INSTALL_DATADIR by default. Also, this may resolve the issue that prompted [https://reviews.llvm.org/D111111](https://web.archive.org/web/20241214215128/https://reviews.llvm.org/D111111)


This is a revival of [https://reviews.llvm.org/D118959](https://web.archive.org/web/20241214215128/https://reviews.llvm.org/D118959), which appears to still be an issue and has outlived the LLVM Phabricator. Maybe I'll even get a review this time around!