### PR TITLE
[libc++] Fix use of static in constexpr

### DIFF
--- a/libcxx/include/__algorithm/equal.h
+++ b/libcxx/include/__algorithm/equal.h
@@ -247,7 +247,7 @@ equal(_InputIterator1 __first1,
       _InputIterator2 __first2,
       _InputIterator2 __last2,
       _BinaryPredicate __pred) {
-  static constexpr bool __both_random_access =
+  constexpr bool __both_random_access =
       __has_random_access_iterator_category<_InputIterator1>::value &&
       __has_random_access_iterator_category<_InputIterator2>::value;
   if constexpr (__both_random_access) {

--- a/libcxx/include/__algorithm/ranges_equal.h
+++ b/libcxx/include/__algorithm/ranges_equal.h
@@ -50,7 +50,7 @@ struct __equal {
       _Pred __pred   = {},
       _Proj1 __proj1 = {},
       _Proj2 __proj2 = {}) const {
-    static constexpr bool __both_sized = sized_sentinel_for<_Sent1, _Iter1> && sized_sentinel_for<_Sent2, _Iter2>;
+    constexpr bool __both_sized = sized_sentinel_for<_Sent1, _Iter1> && sized_sentinel_for<_Sent2, _Iter2>;
     if constexpr (__both_sized) {
       if (__last1 - __first1 != __last2 - __first2)
         return false;
@@ -71,7 +71,7 @@ struct __equal {
     requires indirectly_comparable<iterator_t<_Range1>, iterator_t<_Range2>, _Pred, _Proj1, _Proj2>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool operator()(
       _Range1&& __range1, _Range2&& __range2, _Pred __pred = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const {
-    static constexpr bool __both_sized = sized_range<_Range1> && sized_range<_Range2>;
+    constexpr bool __both_sized = sized_range<_Range1> && sized_range<_Range2>;
     if constexpr (__both_sized) {
       if (ranges::size(__range1) != ranges::size(__range2))
         return false;


### PR DESCRIPTION
static is not allowed inside constexpr functions in C++ versions below
23. This is causing a build error when compiled with GCC and warning
when compiled with Clang. This patch fixes this.

Fixes #196938.
