### PR TITLE
[lldb][TypeSystem] Call Type::isIntegralType from TypeSystemClang::IsIntegerType

### DIFF
--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -436,6 +436,7 @@ TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
     bool is_signed;
     EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
     EXPECT_TRUE(is_signed);
+    EXPECT_FALSE(enum_type.IsIntegerType(is_signed));
   }
 
   // Scoped unsigned enum
@@ -449,6 +450,7 @@ TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
     bool is_signed;
     EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
     EXPECT_FALSE(is_signed);
+    EXPECT_FALSE(enum_type.IsIntegerType(is_signed));
   }
 
   // Unscoped signed enum
@@ -462,6 +464,7 @@ TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
     bool is_signed;
     EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
     EXPECT_TRUE(is_signed);
+    EXPECT_FALSE(enum_type.IsIntegerType(is_signed));
   }
 
   // Unscoped unsigned enum
@@ -474,6 +477,45 @@ TEST_F(TestTypeSystemClang, TestIsEnumerationType) {
 
     bool is_signed;
     EXPECT_TRUE(enum_type.IsEnumerationType(is_signed));
+    EXPECT_FALSE(is_signed);
+    EXPECT_FALSE(enum_type.IsIntegerType(is_signed));
+  }
+}
+
+TEST_F(TestTypeSystemClang, TestIsIntegerType_BitInt) {
+  auto holder =
+      std::make_unique<clang_utils::TypeSystemClangHolder>("bitint_ast");
+  auto &ast = *holder->GetAST();
+
+  // Signed _BitInt
+  {
+    CompilerType bitint_type = ast.GetType(ast.getASTContext().getBitIntType(/*Unsigned=*/false, /*NumBits=*/37));
+    ASSERT_TRUE(bitint_type);
+
+    EXPECT_TRUE(bitint_type.IsInteger());
+    EXPECT_TRUE(bitint_type.IsSigned());
+
+    bool is_signed;
+    EXPECT_TRUE(bitint_type.IsIntegerType(is_signed));
+    EXPECT_TRUE(is_signed);
+
+    EXPECT_TRUE(bitint_type.IsIntegerOrEnumerationType(is_signed));
+    EXPECT_TRUE(is_signed);
+  }
+
+  // Unsigned _BitInt
+  {
+    CompilerType bitint_type = ast.GetType(ast.getASTContext().getBitIntType(/*Unsigned=*/true, /*NumBits=*/122));
+    ASSERT_TRUE(bitint_type);
+
+    EXPECT_TRUE(bitint_type.IsInteger());
+    EXPECT_FALSE(bitint_type.IsSigned());
+
+    bool is_signed;
+    EXPECT_TRUE(bitint_type.IsIntegerType(is_signed));
+    EXPECT_FALSE(is_signed);
+
+    EXPECT_TRUE(bitint_type.IsIntegerOrEnumerationType(is_signed));
     EXPECT_FALSE(is_signed);
   }
 }

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -489,7 +489,8 @@ TEST_F(TestTypeSystemClang, TestIsIntegerType_BitInt) {
 
   // Signed _BitInt
   {
-    CompilerType bitint_type = ast.GetType(ast.getASTContext().getBitIntType(/*Unsigned=*/false, /*NumBits=*/37));
+    CompilerType bitint_type = ast.GetType(
+        ast.getASTContext().getBitIntType(/*Unsigned=*/false, /*NumBits=*/37));
     ASSERT_TRUE(bitint_type);
 
     EXPECT_TRUE(bitint_type.IsInteger());
@@ -505,7 +506,8 @@ TEST_F(TestTypeSystemClang, TestIsIntegerType_BitInt) {
 
   // Unsigned _BitInt
   {
-    CompilerType bitint_type = ast.GetType(ast.getASTContext().getBitIntType(/*Unsigned=*/true, /*NumBits=*/122));
+    CompilerType bitint_type = ast.GetType(
+        ast.getASTContext().getBitIntType(/*Unsigned=*/true, /*NumBits=*/122));
     ASSERT_TRUE(bitint_type);
 
     EXPECT_TRUE(bitint_type.IsInteger());


### PR DESCRIPTION
Instead of re-implementing `Type::isIntegralType`, call it explicitly.

This means we get support for `BitIntType` out-of-the-box.

We don't use `IsIntegerType` here because we want to abide by the language-specific notions of an integer type (which differ between C++ and C).

The slight behaviour change here is that `IsIntegerType` will now treat complete enumerations as integers in C. This is correct according to the C standard.