### PR TITLE
[CIR] Attempt to fold casts and unary ops during codegen

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -552,8 +552,8 @@ public:
     }
 
     assert(castKind.has_value() && "Internal error: CastKind not set.");
-    return cir::CastOp::create(builder, src.getLoc(), fullDstTy, *castKind,
-                               src);
+    return builder.createOrFold<cir::CastOp>(src.getLoc(), fullDstTy, *castKind,
+                                             src);
   }
 
   mlir::Value
@@ -801,9 +801,9 @@ public:
 
   mlir::Value emitUnaryOp(const UnaryOperator *e, cir::UnaryOpKind kind,
                           mlir::Value input, bool nsw = false) {
-    return cir::UnaryOp::create(builder,
-                                cgf.getLoc(e->getSourceRange().getBegin()),
-                                input.getType(), kind, input, nsw);
+    return builder.createOrFold<cir::UnaryOp>(
+        cgf.getLoc(e->getSourceRange().getBegin()), input.getType(), kind,
+        input, nsw);
   }
 
   mlir::Value VisitUnaryNot(const UnaryOperator *e) {

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -66,6 +66,17 @@ struct RemoveRedundantBranches : public OpRewritePattern<BrOp> {
   }
 };
 
+struct RemoveUnusedConstants : public OpRewritePattern<ConstantOp> {
+  using OpRewritePattern<ConstantOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ConstantOp op,
+                                PatternRewriter &rewriter) const final {
+    if (op.use_empty())
+      op.erase();
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // CIRCanonicalizePass
 //===----------------------------------------------------------------------===//
@@ -88,7 +99,8 @@ struct CIRCanonicalizePass
 void populateCIRCanonicalizePatterns(RewritePatternSet &patterns) {
   // clang-format off
   patterns.add<
-    RemoveRedundantBranches
+    RemoveRedundantBranches,
+    RemoveUnusedConstants
   >(patterns.getContext());
   // clang-format on
 }
@@ -110,7 +122,7 @@ void CIRCanonicalizePass::runOnOperation() {
             ComplexCreateOp, ComplexImagOp, ComplexRealOp, VecCmpOp,
             VecCreateOp, VecExtractOp, VecShuffleOp, VecShuffleDynamicOp,
             VecTernaryOp, BitClrsbOp, BitClzOp, BitCtzOp, BitFfsOp, BitParityOp,
-            BitPopcountOp, BitReverseOp, ByteSwapOp, RotateOp>(op))
+            BitPopcountOp, BitReverseOp, ByteSwapOp, RotateOp, ConstantOp>(op))
       ops.push_back(op);
   });
 

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -66,17 +66,6 @@ struct RemoveRedundantBranches : public OpRewritePattern<BrOp> {
   }
 };
 
-struct RemoveUnusedConstants : public OpRewritePattern<ConstantOp> {
-  using OpRewritePattern<ConstantOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ConstantOp op,
-                                PatternRewriter &rewriter) const final {
-    if (op.use_empty())
-      op.erase();
-    return success();
-  }
-};
-
 //===----------------------------------------------------------------------===//
 // CIRCanonicalizePass
 //===----------------------------------------------------------------------===//
@@ -99,8 +88,7 @@ struct CIRCanonicalizePass
 void populateCIRCanonicalizePatterns(RewritePatternSet &patterns) {
   // clang-format off
   patterns.add<
-    RemoveRedundantBranches,
-    RemoveUnusedConstants
+    RemoveRedundantBranches
   >(patterns.getContext());
   // clang-format on
 }

--- a/clang/test/CIR/CodeGen/binassign.c
+++ b/clang/test/CIR/CodeGen/binassign.c
@@ -121,7 +121,6 @@ int ignore_result_assign() {
 // CIR:         %[[VAL_123:.*]] = cir.const #cir.int<123> : !s32i
 // CIR:         cir.store{{.*}} %[[VAL_123]], %[[I]] : !s32i, !cir.ptr<!s32i>
 // CIR:         cir.store{{.*}} %[[VAL_123]], %[[J]] : !s32i, !cir.ptr<!s32i>
-// CIR:         %[[VAL_0:.*]] = cir.const #cir.int<0> : !s32i
 // CIR:         %[[VAL_5:.*]] = cir.const #cir.int<5> : !s32i
 // CIR:         cir.store{{.*}} %[[VAL_5]], %[[I]] : !s32i, !cir.ptr<!s32i>
 // CIR:         %[[ARR_ELEM:.*]] = cir.get_element %[[ARR]][%[[VAL_5]] : !s32i] : !cir.ptr<!cir.array<!s32i x 10>> -> !cir.ptr<!s32i>

--- a/clang/test/CIR/CodeGen/fold-during-cg.c
+++ b/clang/test/CIR/CodeGen/fold-during-cg.c
@@ -1,0 +1,259 @@
+// RUN: %clang_cc1 -std=c23 -triple x86_64-unknown-linux-gnu -mmlir -mlir-print-ir-before=cir-canonicalize -Wno-unused-value -Wno-constant-conversion -Wno-literal-conversion -fclangir -emit-cir %s -o %t.cir 2> %t-before.cir
+// Note: The "before" check intentionally uses the same CIR check prefixes to
+//       verify that the IR is folded during code generation and not during
+//       canonicalization. In a few cases, it is necessary to match an unused
+//       duplicate constant that will be erased during canonicalization.
+// RUN: FileCheck --input-file=%t-before.cir %s -check-prefixes=CIR,CIR-DUP,ALL
+// RUN: FileCheck --input-file=%t.cir %s -check-prefixes=CIR,ALL
+// RUN: %clang_cc1 -std=c23 -triple x86_64-unknown-linux-gnu -Wno-unused-value -Wno-constant-conversion -Wno-literal-conversion -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefixes=LLVM_OGCG,ALL
+// RUN: %clang_cc1 -std=c23 -triple x86_64-unknown-linux-gnu -Wno-unused-value -Wno-constant-conversion -Wno-literal-conversion -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefixes=LLVM_OGCG,ALL
+
+void fold_int_not() {
+// ALL: fold_int_not
+  int n;
+  short s;
+  unsigned u;
+
+  n = ~0;
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<-1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 -1, ptr %{{.*}}
+
+  n = ~1;
+  // CIR: %[[MINUS_TWO:.*]] = cir.const #cir.int<-2> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_TWO]], %{{.*}}
+  // LLVM_OGCG: store i32 -2, ptr %{{.*}}
+
+  n = ~0xFFFFFFFE;
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+}
+
+void fold_int_plus() {
+// ALL: fold_int_plus
+  int n;
+  short s;
+  unsigned u;
+
+  n = +1;
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+
+  n = +2;
+  // CIR: %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[TWO]], %{{.*}}
+  // LLVM_OGCG: store i32 2, ptr %{{.*}}
+
+  n = +(-3);
+  // CIR: %[[MINUS_THREE:.*]] = cir.const #cir.int<-3> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_THREE]], %{{.*}}
+  // LLVM_OGCG: store i32 -3, ptr %{{.*}}
+
+  n = +(0x1FFFFFFFF);
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<-1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 -1, ptr %{{.*}}
+
+  s = +1;
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i16 1, ptr %{{.*}}
+
+  s = +2;
+  // CIR: %[[TWO:.*]] = cir.const #cir.int<2> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[TWO]], %{{.*}}
+  // LLVM_OGCG: store i16 2, ptr %{{.*}}
+
+  s = +(-3);
+  // CIR: %[[MINUS_THREE:.*]] = cir.const #cir.int<-3> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_THREE]], %{{.*}}
+  // LLVM_OGCG: store i16 -3, ptr %{{.*}}
+
+  s = +(0x1FFFF);
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<-1> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i16 -1, ptr %{{.*}}
+
+  u = +1;
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+
+  u = +2;
+  // CIR: %[[TWO:.*]] = cir.const #cir.int<2> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[TWO]], %{{.*}}
+  // LLVM_OGCG: store i32 2, ptr %{{.*}}
+
+  u = +(-3);
+  // CIR: %[[MINUS_THREE:.*]] = cir.const #cir.int<4294967293> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_THREE]], %{{.*}}
+  // LLVM_OGCG: store i32 -3, ptr %{{.*}}
+
+  u = +(0x1FFFFFFFF);
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<4294967295> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 -1, ptr %{{.*}}
+}
+
+void fold_int_minus() {
+// ALL: fold_int_minus
+  int n;
+  short s;
+  unsigned u;
+
+  n = -1;
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<-1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 -1, ptr %{{.*}}
+
+  n = -2;
+  // CIR: %[[MINUS_TWO:.*]] = cir.const #cir.int<-2> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_TWO]], %{{.*}}
+  // LLVM_OGCG: store i32 -2, ptr %{{.*}}
+
+  n = -(-3);
+  // CIR-DUP: %[[UNUSED_THREE:.*]] = cir.const #cir.int<3> : !s32i
+  // CIR: %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[THREE]], %{{.*}}
+  // LLVM_OGCG: store i32 3, ptr %{{.*}}
+
+  n = -(0x1FFFFFFFF);
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+
+  s = -1;
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<-1> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i16 -1, ptr %{{.*}}
+
+  s = -2;
+  // CIR: %[[MINUS_TWO:.*]] = cir.const #cir.int<-2> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_TWO]], %{{.*}}
+  // LLVM_OGCG: store i16 -2, ptr %{{.*}}
+
+  s = -(-3);
+  // CIR-DUP: %[[UNUSED_THREE:.*]] = cir.const #cir.int<3> : !s32i
+  // CIR: %[[THREE:.*]] = cir.const #cir.int<3> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[THREE]], %{{.*}}
+  // LLVM_OGCG: store i16 3, ptr %{{.*}}
+
+  s = -(0x1FFFF);
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !s16i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i16 1, ptr %{{.*}}
+
+  u = -1;
+  // CIR: %[[MINUS_ONE:.*]] = cir.const #cir.int<4294967295> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 -1, ptr %{{.*}}
+
+  u = -2;
+  // CIR: %[[MINUS_TWO:.*]] = cir.const #cir.int<4294967294> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_TWO]], %{{.*}}
+  // LLVM_OGCG: store i32 -2, ptr %{{.*}}
+
+  u = -(-3);
+  // CIR-DUP: %[[UNUSED_THREE:.*]] = cir.const #cir.int<3> : !s32i
+  // CIR: %[[THREE:.*]] = cir.const #cir.int<3> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[THREE]], %{{.*}}
+  // LLVM_OGCG: store i32 3, ptr %{{.*}}
+
+  u = -(0x1FFFFFFFF);
+  // CIR: %[[ONE:.*]] = cir.const #cir.int<1> : !u32i
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[ONE]], %{{.*}}
+  // LLVM_OGCG: store i32 1, ptr %{{.*}}
+}
+
+void fold_float_plus() {
+// ALL: fold_float_plus
+  float f;
+  double d;
+
+  f = +2.0f;
+  // CIR: %[[TWO:.*]] = cir.const #cir.fp<2.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[TWO]], %{{.*}}
+  // LLVM_OGCG: store float 2.000000e+00, ptr %{{.*}}
+
+  f = +(-3.0f);
+  // CIR: %[[MINUS_THREE:.*]] = cir.const #cir.fp<-3.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_THREE]], %{{.*}}
+  // LLVM_OGCG: store float -3.000000e+00, ptr %{{.*}}
+
+  d = +2.0;
+  // CIR: %[[TWO:.*]] = cir.const #cir.fp<2.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[TWO]], %{{.*}}
+  // LLVM_OGCG: store double 2.000000e+00, ptr %{{.*}}
+
+  d = +(-3.0);
+  // CIR: %[[MINUS_THREE:.*]] = cir.const #cir.fp<-3.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_THREE]], %{{.*}}
+  // LLVM_OGCG: store double -3.000000e+00, ptr %{{.*}}
+}
+
+void fold_float_minus() {
+// ALL: fold_float_minus
+  float f;
+  double d;
+
+  f = -2.0f;
+  // CIR: %[[MINUS_TWO:.*]] = cir.const #cir.fp<-2.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_TWO]], %{{.*}}
+  // LLVM_OGCG: store float -2.000000e+00, ptr %{{.*}}
+
+  f = -(-3.0f);
+  // CIR-DUP: %[[UNUSED_THREE:.*]] = cir.const #cir.fp<3.000000e+00> : !cir.float
+  // CIR: %[[THREE:.*]] = cir.const #cir.fp<3.000000e+00> : !cir.float
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[THREE]], %{{.*}}
+  // LLVM_OGCG: store float 3.000000e+00, ptr %{{.*}}
+
+  d = -2.0;
+  // CIR: %[[MINUS_TWO:.*]] = cir.const #cir.fp<-2.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[MINUS_TWO]], %{{.*}}
+  // LLVM_OGCG: store double -2.000000e+00, ptr %{{.*}}
+
+  d = -(-3.0);
+  // CIR-DUP: %[[UNUSED_THREE:.*]] = cir.const #cir.fp<3.000000e+00> : !cir.double
+  // CIR: %[[THREE:.*]] = cir.const #cir.fp<3.000000e+00> : !cir.double
+  // CIR-NOT: cir.unary
+  // CIR: cir.store{{.*}} %[[THREE]], %{{.*}}
+  // LLVM_OGCG: store double 3.000000e+00, ptr %{{.*}}
+}

--- a/clang/test/CIR/CodeGen/new.cpp
+++ b/clang/test/CIR/CodeGen/new.cpp
@@ -185,12 +185,8 @@ void t_new_constant_size() {
   auto p = new double[16];
 }
 
-// In this test, NUM_ELEMENTS isn't used because no cookie is needed and there
-//   are no constructor calls needed.
-
 // CHECK:   cir.func{{.*}} @_Z19t_new_constant_sizev()
 // CHECK:    %[[P_ADDR:.*]] = cir.alloca !cir.ptr<!cir.double>, !cir.ptr<!cir.ptr<!cir.double>>, ["p", init] {alignment = 8 : i64}
-// CHECK:    %[[#NUM_ELEMENTS:]] = cir.const #cir.int<16> : !u64i
 // CHECK:    %[[#ALLOCATION_SIZE:]] = cir.const #cir.int<128> : !u64i
 // CHECK:    %[[RAW_PTR:.*]] = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
 // CHECK:    %[[TYPED_PTR:.*]] = cir.cast bitcast %[[RAW_PTR]] : !cir.ptr<!void> -> !cir.ptr<!cir.double>
@@ -220,7 +216,6 @@ void t_constant_size_nontrivial() {
 // CHECK:  cir.func{{.*}} @_Z26t_constant_size_nontrivialv()
 // CHECK:    %[[P_ADDR:.*]] = cir.alloca !cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!rec_C>>, ["p", init] {alignment = 8 : i64}
 // CHECK:    %[[#NUM_ELEMENTS:]] = cir.const #cir.int<3> : !u64i
-// CHECK:    %[[#SIZE_WITHOUT_COOKIE:]] = cir.const #cir.int<3> : !u64i
 // CHECK:    %[[#ALLOCATION_SIZE:]] = cir.const #cir.int<11> : !u64i
 // CHECK:    %[[RAW_PTR:.*]] = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
 // CHECK:    %[[COOKIE_PTR_BASE:.*]] = cir.cast bitcast %[[RAW_PTR]] : !cir.ptr<!void> -> !cir.ptr<!cir.ptr<!u8i>>
@@ -258,13 +253,9 @@ void t_constant_size_nontrivial2() {
   auto p = new D[3];
 }
 
-// In this test SIZE_WITHOUT_COOKIE isn't used, but it would be if there were
-// an initializer.
-
 // CHECK:  cir.func{{.*}} @_Z27t_constant_size_nontrivial2v()
 // CHECK:    %[[P_ADDR:.*]] = cir.alloca !cir.ptr<!rec_D>, !cir.ptr<!cir.ptr<!rec_D>>, ["p", init] {alignment = 8 : i64}
 // CHECK:    %[[#NUM_ELEMENTS:]] = cir.const #cir.int<3> : !u64i
-// CHECK:    %[[#SIZE_WITHOUT_COOKIE:]] = cir.const #cir.int<12> : !u64i
 // CHECK:    %[[#ALLOCATION_SIZE:]] = cir.const #cir.int<20> : !u64i
 // CHECK:    %[[RAW_PTR:.*]] = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
 // CHECK:    %[[COOKIE_PTR_BASE:.*]] = cir.cast bitcast %[[RAW_PTR]] : !cir.ptr<!void> -> !cir.ptr<!cir.ptr<!u8i>>
@@ -297,7 +288,6 @@ void t_align16_nontrivial() {
 // CHECK:  cir.func{{.*}} @_Z20t_align16_nontrivialv()
 // CHECK:    %[[P_ADDR:.*]] = cir.alloca !cir.ptr<!rec_E>, !cir.ptr<!cir.ptr<!rec_E>>, ["p", init] {alignment = 8 : i64}
 // CHECK:    %[[#NUM_ELEMENTS:]] = cir.const #cir.int<2> : !u64i
-// CHECK:    %[[#SIZE_WITHOUT_COOKIE:]] = cir.const #cir.int<32> : !u64i
 // CHECK:    %[[#ALLOCATION_SIZE:]] = cir.const #cir.int<48> : !u64i
 // CHECK:    %[[RAW_PTR:.*]] = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
 // CHECK:    %[[COOKIE_PTR_BASE:.*]] = cir.cast bitcast %[[RAW_PTR]] : !cir.ptr<!void> -> !cir.ptr<!cir.ptr<!u8i>>
@@ -334,11 +324,8 @@ void t_new_multidim_constant_size() {
   auto p = new double[2][3][4];
 }
 
-// As above, NUM_ELEMENTS isn't used.
-
 // CHECK:   cir.func{{.*}} @_Z28t_new_multidim_constant_sizev()
 // CHECK:    %[[P_ADDR:.*]] = cir.alloca !cir.ptr<!cir.array<!cir.array<!cir.double x 4> x 3>>, !cir.ptr<!cir.ptr<!cir.array<!cir.array<!cir.double x 4> x 3>>>, ["p", init] {alignment = 8 : i64}
-// CHECK:    %[[#NUM_ELEMENTS:]] = cir.const #cir.int<24> : !u64i
 // CHECK:    %[[#ALLOCATION_SIZE:]] = cir.const #cir.int<192> : !u64i
 // CHECK:    %[[RAW_PTR:.*]] = cir.call @_Znam(%[[#ALLOCATION_SIZE]]) : (!u64i) -> !cir.ptr<!void>
 // CHECK:    %[[TYPED_PTR:.*]] = cir.cast bitcast %[[RAW_PTR]] : !cir.ptr<!void> -> !cir.ptr<!cir.array<!cir.array<!cir.double x 4> x 3>>

--- a/clang/test/CIR/CodeGen/placement-new.cpp
+++ b/clang/test/CIR/CodeGen/placement-new.cpp
@@ -20,7 +20,6 @@ void test_reserved_placement_new(void *p) {
 // CIR-SAME:                                   %[[ARG0:.*]]: !cir.ptr<!void>
 // CIR:           %[[P:.*]] = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["p", init]
 // CIR:           cir.store %[[ARG0]], %[[P]] : !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>
-// CIR:           %[[SIZE:.*]] = cir.const #cir.int<1> : !u64i
 // CIR:           %[[PTR:.*]] = cir.load{{.*}} %[[P]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
 // CIR:           %[[PTR_A:.*]] = cir.cast bitcast %[[PTR]] : !cir.ptr<!void> -> !cir.ptr<!rec_A>
 // CIR:           cir.call @_ZN1AC1Ev(%[[PTR_A]]) : (!cir.ptr<!rec_A>) -> ()

--- a/clang/test/CIR/CodeGen/statement-exprs.c
+++ b/clang/test/CIR/CodeGen/statement-exprs.c
@@ -13,7 +13,6 @@ int f19(void) {
 // CIR:   %[[RETVAL:.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
 // CIR:   %[[TMP:.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["tmp"]
 // CIR:   cir.scope {
-// CIR:     %[[C3:.+]] = cir.const #cir.int<3> : !s32i
 // CIR:     %[[C4:.+]] = cir.const #cir.int<4> : !s32i
 // CIR:     cir.store {{.*}} %[[C4]], %[[TMP]] : !s32i, !cir.ptr<!s32i>
 // CIR:   }

--- a/clang/test/CIR/CodeGenBuiltins/X86/avx512f-builtins.c
+++ b/clang/test/CIR/CodeGenBuiltins/X86/avx512f-builtins.c
@@ -845,9 +845,6 @@ __m128i test_mm512_extracti32x4_epi32(__m512i __A) {
   // CIR-LABEL: test_mm512_extracti32x4_epi32
   // CIR: [[POISON:%.*]] = cir.const #cir.poison : !cir.vector<16 x !s32i>
   // CIR: [[FULL_VEC:%.*]] = cir.vec.shuffle(%{{.*}}, [[POISON]] : !cir.vector<16 x !s32i>) [#cir.int<12> : !s32i, #cir.int<13> : !s32i, #cir.int<14> : !s32i, #cir.int<15> : !s32i] : !cir.vector<4 x !s32i>
-  // CIR: [[MASK_VEC:%.*]] = cir.cast bitcast {{.*}} : !u8i -> !cir.vector<8 x !cir.int<s, 1>>
-  // CIR: [[FULL_MASK_VEC:%.*]] = cir.vec.shuffle([[MASK_VEC]], [[MASK_VEC]] : !cir.vector<8 x !cir.int<s, 1>>) [#cir.int<0> : !s32i, #cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i] : !cir.vector<4 x !cir.int<s, 1>>
-  // CIR: cir.vec.ternary([[FULL_MASK_VEC]], [[FULL_VEC]], {{.*}}) : !cir.vector<4 x !cir.int<s, 1>>, !cir.vector<4 x !s32i>
 
   // LLVM-LABEL: test_mm512_extracti32x4_epi32
   // LLVM: shufflevector <16 x i32> %{{.*}}, <16 x i32> poison, <4 x i32> <i32 12, i32 13, i32 14, i32 15>
@@ -897,9 +894,6 @@ __m256i test_mm512_extracti64x4_epi64(__m512i __A) {
   // CIR-LABEL: test_mm512_extracti64x4_epi64
   // CIR: [[POISON:%.*]] = cir.const #cir.poison : !cir.vector<8 x !s64i>
   // CIR: [[FULL_VEC:%.*]] = cir.vec.shuffle(%{{.*}}, [[POISON]] : !cir.vector<8 x !s64i>) [#cir.int<4> : !s32i, #cir.int<5> : !s32i, #cir.int<6> : !s32i, #cir.int<7> : !s32i] : !cir.vector<4 x !s64i>
-  // CIR: [[MASK_VEC:%.*]] = cir.cast bitcast {{.*}} : !u8i -> !cir.vector<8 x !cir.int<s, 1>>
-  // CIR: [[FULL_MASK_VEC:%.*]] = cir.vec.shuffle([[MASK_VEC]], [[MASK_VEC]] : !cir.vector<8 x !cir.int<s, 1>>) [#cir.int<0> : !s32i, #cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i] : !cir.vector<4 x !cir.int<s, 1>>
-  // CIR: cir.vec.ternary([[FULL_MASK_VEC]], [[FULL_VEC]], {{.*}}) : !cir.vector<4 x !cir.int<s, 1>>, !cir.vector<4 x !s64i>
 
   // LLVM-LABEL: test_mm512_extracti64x4_epi64
   // LLVM: shufflevector <8 x i64> %{{.*}}, <8 x i64> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>


### PR DESCRIPTION
This change introduces basic folding of casts and unary ops as they are created this is needed in order to allow later codegen pieces, such as builtin handlers, to more easily identify and examine constant operands. For example, many X86 builtin functions use a default mask operand of -1, which was previously generated as a constant 1 and a unary minus.

In some cases, the folding process leaves behind unused constant operations, so I am also added a simple change to the canonicalize pass to remove unused constants. We had other places where unused constants were being generated already, and this change cleans those up too.