### PR TITLE
[profcheck] Remove ffs-i16.ll test from xfail.txt

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -242,7 +242,6 @@ Transforms/InstCombine/div-shift.ll
 Transforms/InstCombine/fabs.ll
 Transforms/InstCombine/fcmp-select.ll
 Transforms/InstCombine/ffs-1.ll
-Transforms/InstCombine/ffs-i16.ll
 Transforms/InstCombine/fmul-bool.ll
 Transforms/InstCombine/fmul.ll
 Transforms/InstCombine/fneg.ll


### PR DESCRIPTION
I checked this locally and this test no longer fails in the profcheck config.

Tracking issue: #147390