### PR TITLE
[Darwin] [compiler-rt] [Test-only] Normalize DYLD_LIBRARY_PATH to workaround LD bug

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -90,6 +90,12 @@ def push_dynamic_library_lookup_path(config, new_path):
     new_ld_library_path = os.path.pathsep.join(
         (new_path, config.environment.get(dynamic_library_lookup_var, ""))
     )
+
+    if platform.system() == "Darwin":
+        # Workaround an issue in LD which does not use the correct libLTO
+        # if the DYLD_LIBRARY_PATH is not normalized.
+        new_ld_library_path = os.path.normpath(new_ld_library_path)
+
     config.environment[dynamic_library_lookup_var] = new_ld_library_path
 
     if platform.system() == "FreeBSD":


### PR DESCRIPTION
There is an issue in certain versions of LD which causes the wrong libLTO to be used if the DYLD_LIBRARY_PATH is not normalized.

Will fix these failures:
```
AddressSanitizer-x86_64-darwin.TestCases/Darwin.odr-lto.cpp
AddressSanitizer-x86_64h-darwin.TestCases/Darwin.odr-lto.cpp
```

https://green.lab.llvm.org/job/llvm.org/job/clang-stage1-cmake-RA-incremental/13428/

rdar://168024431