### PR TITLE
[libc][math] Refactor fsqrtf128 to Header Only.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -62,6 +62,7 @@
 #include "math/frexpf128.h"
 #include "math/frexpf16.h"
 #include "math/fsqrt.h"
+#include "math/fsqrtf128.h"
 #include "math/hypotf.h"
 #include "math/ilogbf16.h"
 #include "math/ldexpf.h"

--- a/libc/shared/math/fsqrtf128.h
+++ b/libc/shared/math/fsqrtf128.h
@@ -1,4 +1,4 @@
-//===-- Implementation of fsqrt128 function -------------------------------===//
+//===-- Shared fsqrtf128 function -------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,12 +6,23 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/fsqrtf128.h"
+#ifndef LLVM_LIBC_SHARED_MATH_FSQRTF128_H
+#define LLVM_LIBC_SHARED_MATH_FSQRTF128_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
 #include "src/__support/math/fsqrtf128.h"
+
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(float, fsqrtf128, (float128 x)) {
-  return math::fsqrtf128(x);
-}
+using math::fsqrtf128;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+       //
+#endif // LLVM_LIBC_SHARED_MATH_FSQRTF128_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1133,7 +1133,6 @@ add_header_library(
     libc.src.__support.math.range_reduction_double
     libc.src.__support.math.sincos_eval
     libc.src.__support.macros.optimization
-
 )
 
 add_header_library(

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -944,6 +944,15 @@ add_header_library(
 )
 
 add_header_library(
+  fsqrtf128
+  HDRS
+    fsqrtf128.h
+  DEPENDS
+    libc.src.__support.FPUtil.generic.sqrt
+    libc.src.__support.macros.properties.types
+)
+
+add_header_library(
   hypotf
   HDRS
     hypotf.h
@@ -1124,6 +1133,7 @@ add_header_library(
     libc.src.__support.math.range_reduction_double
     libc.src.__support.math.sincos_eval
     libc.src.__support.macros.optimization
+
 )
 
 add_header_library(

--- a/libc/src/__support/math/fsqrtf128.h
+++ b/libc/src/__support/math/fsqrtf128.h
@@ -1,0 +1,33 @@
+//===-- Implementation header for fsqrtf128 ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FSQRTF128_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_FSQRTF128_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "src/__support/FPUtil/generic/sqrt.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE static constexpr float fsqrtf128(float128 x) {
+  return fputil::sqrt<float>(x);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_FSQRTF128_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -5241,8 +5241,8 @@ add_entrypoint_object(
   HDRS
     ../fsqrtf128.h
   DEPENDS
-    libc.src.__support.macros.properties.types
-    libc.src.__support.FPUtil.generic.sqrt
+    libc.src.__support.math.fsqrtf128
+    libc.src.errno.errno
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -58,6 +58,7 @@ add_fp_unittest(
     libc.src.__support.math.frexpf128
     libc.src.__support.math.frexpf16
     libc.src.__support.math.fsqrt
+    libc.src.__support.math.fsqrtf128
     libc.src.__support.math.hypotf
     libc.src.__support.math.ilogbf16
     libc.src.__support.math.log

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -110,6 +110,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
 
   EXPECT_FP_EQ(float128(0x0p+0),
                LIBC_NAMESPACE::shared::atan2f128(float128(0.0), float128(0.0)));
+  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::fsqrtf128(float128(1.0f)));
   EXPECT_FP_EQ_ALL_ROUNDING(float128(0.75), LIBC_NAMESPACE::shared::frexpf128(
                                                 float128(24), &exponent));
   EXPECT_EQ(exponent, 5);

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2690,6 +2690,16 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_fsqrtf128",
+    hdrs = ["src/__support/math/fsqrtf128.h"],
+    deps = [
+        ":__support_common",
+        ":__support_fputil_sqrt",
+        ":__support_macros_config",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_exp10m1f",
     hdrs = ["src/__support/math/exp10m1f.h"],
     deps = [
@@ -4350,7 +4360,8 @@ libc_math_function(
 libc_math_function(
     name = "fsqrtf128",
     additional_deps = [
-        ":__support_fputil_sqrt",
+        ":__support_math_fsqrtf128",
+        ":errno",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2690,16 +2690,6 @@ libc_support_library(
 )
 
 libc_support_library(
-    name = "__support_math_fsqrtf128",
-    hdrs = ["src/__support/math/fsqrtf128.h"],
-    deps = [
-        ":__support_common",
-        ":__support_fputil_sqrt",
-        ":__support_macros_config",
-    ],
-)
-
-libc_support_library(
     name = "__support_math_exp10m1f",
     hdrs = ["src/__support/math/exp10m1f.h"],
     deps = [
@@ -2828,6 +2818,16 @@ libc_support_library(
     hdrs = ["src/__support/math/fsqrt.h"],
     deps = [
         ":__support_fputil_sqrt",
+    ],
+)
+
+libc_support_library(
+    name = "__support_math_fsqrtf128",
+    hdrs = ["src/__support/math/fsqrtf128.h"],
+    deps = [
+        ":__support_common",
+        ":__support_fputil_sqrt",
+        ":__support_macros_config",
     ],
 )
 


### PR DESCRIPTION
builds correctly with both Clang and GCC 12.2.

Closes #175333.