### PR TITLE
[NFC] Add tablegen_compile_commands.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ cscope.out
 autoconf/aclocal.m4
 autoconf/autom4te.cache
 /compile_commands.json
+/tablegen_compile_commands.yml
 # Visual Studio built-in CMake configuration
 /CMakeSettings.json
 # CLion project configuration


### PR DESCRIPTION
People may want to symlink the autogonerated
tablegen_compile_commands.yml into their source directories by analogy with compile_commands.json, and so this commit given them similar .gitignore treatment.