### PR TITLE
[flang] Turn -Werror back off for Flang build

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -37,7 +37,7 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND NOT MSVC_IDE)
           `CMakeFiles'. Please delete them.")
 endif()
 
-option(FLANG_ENABLE_WERROR "Fail and stop building flang if a warning is triggered." ON)
+option(FLANG_ENABLE_WERROR "Fail and stop building flang if a warning is triggered." OFF)
 
 # Check for a standalone build and configure as appropriate from
 # there.

--- a/flang/include/flang/Semantics/expression.h
+++ b/flang/include/flang/Semantics/expression.h
@@ -429,7 +429,6 @@ private:
   bool inDataStmtConstant_{false};
   bool inStmtFunctionDefinition_{false};
   bool iterativelyAnalyzingSubexpressions_{false};
-  bool inDeadCode_{false};
   friend class ArgumentAnalyzer;
 };
 


### PR DESCRIPTION
Different build environments are picking up warnings that my testing didn't expose; turn -Werror back off.
(And also delete an unused data member that was triggering some MSVC warnings.)