### PR TITLE
[RISCV] Add isCommutable=1 to some binary P extension instructions.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -380,19 +380,25 @@ class RVPBinaryScalar_rr<bits<3> f, bits<2> w, bits<3> funct3, string opcodestr>
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-class RVPBinary_rr<bits<4> f, bits<2> w, bits<3> funct3, string opcodestr>
+class RVPBinary_rr<bits<4> f, bits<2> w, bits<3> funct3, string opcodestr,
+                   bit Commutable = 0>
     : RVInstRBase<funct3, OPC_OP_32, (outs GPR:$rd),
                   (ins GPR:$rs1, GPR:$rs2), opcodestr, "$rd, $rs1, $rs2"> {
   let Inst{31} = 0b1;
   let Inst{30-27} = f;
   let Inst{26-25} = w;
+
+  let isCommutable = Commutable;
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-class RVPWideningBinary_rr<bits<4> f, bits<2> w, string opcodestr>
+class RVPWideningBinary_rr<bits<4> f, bits<2> w, string opcodestr,
+                           bit Commutable = 0>
     : RVPWideningBase<w, 0b1, (outs GPRPairRV32:$rd), (ins GPR:$rs1, GPR:$rs2),
                       opcodestr> {
   let Inst{30-27} = f;
+
+  let isCommutable = Commutable;
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
@@ -407,8 +413,11 @@ class RVPNarrowingBinary_rr<bits<3> f, bits<2> w, string opcodestr>
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-class RVPPairBinary_rr<bits<4> f, bits<2> w, string opcodestr>
-    : RVPPairBinaryBase_rr<f{3-1}, f{0}, w, 0b0, 0b0, opcodestr>;
+class RVPPairBinary_rr<bits<4> f, bits<2> w, string opcodestr,
+                       bit Commutable = 0>
+    : RVPPairBinaryBase_rr<f{3-1}, f{0}, w, 0b0, 0b0, opcodestr> {
+  let isCommutable = Commutable;
+}
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPPairBinaryShift_rr<bits<3> f, bits<2> w, string opcodestr>
@@ -419,8 +428,11 @@ class RVPPairBinaryPack_rr<bits<3> f, bits<2> w, string opcodestr>
     : RVPPairBinaryBase_rr<f, 0b0, w, 0b0, 0b1, opcodestr>;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-class RVPPairBinaryExchanged_rr<bits<4> f, bits<2> w, string opcodestr>
-    : RVPPairBinaryBase_rr<f{3-1}, f{0}, w, 0b1, 0b1, opcodestr>;
+class RVPPairBinaryExchanged_rr<bits<4> f, bits<2> w, string opcodestr,
+                                bit Commutable = 0>
+    : RVPPairBinaryBase_rr<f{3-1}, f{0}, w, 0b1, 0b1, opcodestr> {
+  let isCommutable = Commutable;
+}
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPTernary_rrr<bits<4> f, bits<2> w, bits<3> funct3, string opcodestr>
@@ -614,26 +626,26 @@ let Predicates = [HasStdExtP, IsRV64] in {
 } // Predicates = [HasStdExtP, IsRV64]
 
 let Predicates = [HasStdExtP] in {
-  def PADD_H   : RVPBinary_rr<0b0000, 0b00, 0b000, "padd.h">;
-  def PADD_B   : RVPBinary_rr<0b0000, 0b10, 0b000, "padd.b">;
+  def PADD_H   : RVPBinary_rr<0b0000, 0b00, 0b000, "padd.h", Commutable=1>;
+  def PADD_B   : RVPBinary_rr<0b0000, 0b10, 0b000, "padd.b", Commutable=1>;
 
-  def PSADD_H  : RVPBinary_rr<0b0010, 0b00, 0b000, "psadd.h">;
-  def PSADD_B  : RVPBinary_rr<0b0010, 0b10, 0b000, "psadd.b">;
+  def PSADD_H  : RVPBinary_rr<0b0010, 0b00, 0b000, "psadd.h", Commutable=1>;
+  def PSADD_B  : RVPBinary_rr<0b0010, 0b10, 0b000, "psadd.b", Commutable=1>;
 
-  def PAADD_H  : RVPBinary_rr<0b0011, 0b00, 0b000, "paadd.h">;
-  def PAADD_B  : RVPBinary_rr<0b0011, 0b10, 0b000, "paadd.b">;
+  def PAADD_H  : RVPBinary_rr<0b0011, 0b00, 0b000, "paadd.h", Commutable=1>;
+  def PAADD_B  : RVPBinary_rr<0b0011, 0b10, 0b000, "paadd.b", Commutable=1>;
 
-  def PSADDU_H : RVPBinary_rr<0b0110, 0b00, 0b000, "psaddu.h">;
-  def PSADDU_B : RVPBinary_rr<0b0110, 0b10, 0b000, "psaddu.b">;
+  def PSADDU_H : RVPBinary_rr<0b0110, 0b00, 0b000, "psaddu.h", Commutable=1>;
+  def PSADDU_B : RVPBinary_rr<0b0110, 0b10, 0b000, "psaddu.b", Commutable=1>;
 
-  def PAADDU_H : RVPBinary_rr<0b0111, 0b00, 0b000, "paaddu.h">;
-  def PAADDU_B : RVPBinary_rr<0b0111, 0b10, 0b000, "paaddu.b">;
+  def PAADDU_H : RVPBinary_rr<0b0111, 0b00, 0b000, "paaddu.h", Commutable=1>;
+  def PAADDU_B : RVPBinary_rr<0b0111, 0b10, 0b000, "paaddu.b", Commutable=1>;
 
   def PSUB_H   : RVPBinary_rr<0b1000, 0b00, 0b000, "psub.h">;
   def PSUB_B   : RVPBinary_rr<0b1000, 0b10, 0b000, "psub.b">;
 
-  def PABD_H   : RVPBinary_rr<0b1001, 0b00, 0b000, "pabd.h">;
-  def PABD_B   : RVPBinary_rr<0b1001, 0b10, 0b000, "pabd.b">;
+  def PABD_H   : RVPBinary_rr<0b1001, 0b00, 0b000, "pabd.h", Commutable=1>;
+  def PABD_B   : RVPBinary_rr<0b1001, 0b10, 0b000, "pabd.b", Commutable=1>;
 
   def PSSUB_H  : RVPBinary_rr<0b1010, 0b00, 0b000, "pssub.h">;
   def PSSUB_B  : RVPBinary_rr<0b1010, 0b10, 0b000, "pssub.b">;
@@ -641,8 +653,8 @@ let Predicates = [HasStdExtP] in {
   def PASUB_H  : RVPBinary_rr<0b1011, 0b00, 0b000, "pasub.h">;
   def PASUB_B  : RVPBinary_rr<0b1011, 0b10, 0b000, "pasub.b">;
 
-  def PABDU_H  : RVPBinary_rr<0b1101, 0b00, 0b000, "pabdu.h">;
-  def PABDU_B  : RVPBinary_rr<0b1101, 0b10, 0b000, "pabdu.b">;
+  def PABDU_H  : RVPBinary_rr<0b1101, 0b00, 0b000, "pabdu.h", Commutable=1>;
+  def PABDU_B  : RVPBinary_rr<0b1101, 0b10, 0b000, "pabdu.b", Commutable=1>;
 
   def PSSUBU_H : RVPBinary_rr<0b1110, 0b00, 0b000, "pssubu.h">;
   def PSSUBU_B : RVPBinary_rr<0b1110, 0b10, 0b000, "pssubu.b">;
@@ -651,13 +663,13 @@ let Predicates = [HasStdExtP] in {
   def PASUBU_B : RVPBinary_rr<0b1111, 0b10, 0b000, "pasubu.b">;
 } // Predicates = [HasStdExtP]
 let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
-  def SADD     : RVPBinary_rr<0b0010, 0b01, 0b000, "sadd">;
+  def SADD     : RVPBinary_rr<0b0010, 0b01, 0b000, "sadd", Commutable=1>;
 
-  def AADD     : RVPBinary_rr<0b0011, 0b01, 0b000, "aadd">;
+  def AADD     : RVPBinary_rr<0b0011, 0b01, 0b000, "aadd", Commutable=1>;
 
-  def SADDU    : RVPBinary_rr<0b0110, 0b01, 0b000, "saddu">;
+  def SADDU    : RVPBinary_rr<0b0110, 0b01, 0b000, "saddu", Commutable=1>;
 
-  def AADDU    : RVPBinary_rr<0b0111, 0b01, 0b000, "aaddu">;
+  def AADDU    : RVPBinary_rr<0b0111, 0b01, 0b000, "aaddu", Commutable=1>;
 
   def SSUB     : RVPBinary_rr<0b1010, 0b01, 0b000, "ssub">;
 
@@ -668,15 +680,15 @@ let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
   def ASUBU    : RVPBinary_rr<0b1111, 0b01, 0b000, "asubu">;
 } // Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only"
 let Predicates = [HasStdExtP, IsRV64] in {
-  def PADD_W   : RVPBinary_rr<0b0000, 0b01, 0b000, "padd.w">;
+  def PADD_W   : RVPBinary_rr<0b0000, 0b01, 0b000, "padd.w", Commutable=1>;
 
-  def PSADD_W  : RVPBinary_rr<0b0010, 0b01, 0b000, "psadd.w">;
+  def PSADD_W  : RVPBinary_rr<0b0010, 0b01, 0b000, "psadd.w", Commutable=1>;
 
-  def PAADD_W  : RVPBinary_rr<0b0011, 0b01, 0b000, "paadd.w">;
+  def PAADD_W  : RVPBinary_rr<0b0011, 0b01, 0b000, "paadd.w", Commutable=1>;
 
-  def PSADDU_W : RVPBinary_rr<0b0110, 0b01, 0b000, "psaddu.w">;
+  def PSADDU_W : RVPBinary_rr<0b0110, 0b01, 0b000, "psaddu.w", Commutable=1>;
 
-  def PAADDU_W : RVPBinary_rr<0b0111, 0b01, 0b000, "paaddu.w">;
+  def PAADDU_W : RVPBinary_rr<0b0111, 0b01, 0b000, "paaddu.w", Commutable=1>;
 
   def PSUB_W   : RVPBinary_rr<0b1000, 0b01, 0b000, "psub.w">;
 
@@ -950,8 +962,8 @@ let Predicates = [HasStdExtP] in {
   def PAAS_HX  : RVPBinary_rr<0b0011, 0b00, 0b110, "paas.hx">;
   def PASA_HX  : RVPBinary_rr<0b0011, 0b10, 0b110, "pasa.hx">;
 
-  def PMSEQ_H  : RVPBinary_rr<0b1000, 0b00, 0b110, "pmseq.h">;
-  def PMSEQ_B  : RVPBinary_rr<0b1000, 0b10, 0b110, "pmseq.b">;
+  def PMSEQ_H  : RVPBinary_rr<0b1000, 0b00, 0b110, "pmseq.h", Commutable=1>;
+  def PMSEQ_B  : RVPBinary_rr<0b1000, 0b10, 0b110, "pmseq.b", Commutable=1>;
 
   def PMSLT_H  : RVPBinary_rr<0b1010, 0b00, 0b110, "pmslt.h">;
   def PMSLT_B  : RVPBinary_rr<0b1010, 0b10, 0b110, "pmslt.b">;
@@ -959,20 +971,20 @@ let Predicates = [HasStdExtP] in {
   def PMSLTU_H : RVPBinary_rr<0b1011, 0b00, 0b110, "pmsltu.h">;
   def PMSLTU_B : RVPBinary_rr<0b1011, 0b10, 0b110, "pmsltu.b">;
 
-  def PMIN_H   : RVPBinary_rr<0b1100, 0b00, 0b110, "pmin.h">;
-  def PMIN_B   : RVPBinary_rr<0b1100, 0b10, 0b110, "pmin.b">;
+  def PMIN_H   : RVPBinary_rr<0b1100, 0b00, 0b110, "pmin.h", Commutable=1>;
+  def PMIN_B   : RVPBinary_rr<0b1100, 0b10, 0b110, "pmin.b", Commutable=1>;
 
-  def PMINU_H  : RVPBinary_rr<0b1101, 0b00, 0b110, "pminu.h">;
-  def PMINU_B  : RVPBinary_rr<0b1101, 0b10, 0b110, "pminu.b">;
+  def PMINU_H  : RVPBinary_rr<0b1101, 0b00, 0b110, "pminu.h", Commutable=1>;
+  def PMINU_B  : RVPBinary_rr<0b1101, 0b10, 0b110, "pminu.b", Commutable=1>;
 
-  def PMAX_H   : RVPBinary_rr<0b1110, 0b00, 0b110, "pmax.h">;
-  def PMAX_B   : RVPBinary_rr<0b1110, 0b10, 0b110, "pmax.b">;
+  def PMAX_H   : RVPBinary_rr<0b1110, 0b00, 0b110, "pmax.h", Commutable=1>;
+  def PMAX_B   : RVPBinary_rr<0b1110, 0b10, 0b110, "pmax.b", Commutable=1>;
 
-  def PMAXU_H  : RVPBinary_rr<0b1111, 0b00, 0b110, "pmaxu.h">;
-  def PMAXU_B  : RVPBinary_rr<0b1111, 0b10, 0b110, "pmaxu.b">;
+  def PMAXU_H  : RVPBinary_rr<0b1111, 0b00, 0b110, "pmaxu.h", Commutable=1>;
+  def PMAXU_B  : RVPBinary_rr<0b1111, 0b10, 0b110, "pmaxu.b", Commutable=1>;
 } // Predicates = [HasStdExtP]
 let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
-  def MSEQ  : RVPBinary_rr<0b1000, 0b01, 0b110, "mseq">;
+  def MSEQ  : RVPBinary_rr<0b1000, 0b01, 0b110, "mseq", Commutable=1>;
 
   def MSLT  : RVPBinary_rr<0b1010, 0b01, 0b110, "mslt">;
 
@@ -988,19 +1000,19 @@ let Predicates = [HasStdExtP, IsRV64] in {
   def PAAS_WX  : RVPBinary_rr<0b0011, 0b01, 0b110, "paas.wx">;
   def PASA_WX  : RVPBinary_rr<0b0011, 0b11, 0b110, "pasa.wx">;
 
-  def PMSEQ_W  : RVPBinary_rr<0b1000, 0b01, 0b110, "pmseq.w">;
+  def PMSEQ_W  : RVPBinary_rr<0b1000, 0b01, 0b110, "pmseq.w", Commutable=1>;
 
   def PMSLT_W  : RVPBinary_rr<0b1010, 0b01, 0b110, "pmslt.w">;
 
   def PMSLTU_W : RVPBinary_rr<0b1011, 0b01, 0b110, "pmsltu.w">;
 
-  def PMIN_W   : RVPBinary_rr<0b1100, 0b01, 0b110, "pmin.w">;
+  def PMIN_W   : RVPBinary_rr<0b1100, 0b01, 0b110, "pmin.w", Commutable=1>;
 
-  def PMINU_W  : RVPBinary_rr<0b1101, 0b01, 0b110, "pminu.w">;
+  def PMINU_W  : RVPBinary_rr<0b1101, 0b01, 0b110, "pminu.w", Commutable=1>;
 
-  def PMAX_W   : RVPBinary_rr<0b1110, 0b01, 0b110, "pmax.w">;
+  def PMAX_W   : RVPBinary_rr<0b1110, 0b01, 0b110, "pmax.w", Commutable=1>;
 
-  def PMAXU_W  : RVPBinary_rr<0b1111, 0b01, 0b110, "pmaxu.w">;
+  def PMAXU_W  : RVPBinary_rr<0b1111, 0b01, 0b110, "pmaxu.w", Commutable=1>;
 } // Predicates = [HasStdExtP, IsRV64]
 
 let Predicates = [HasStdExtP] in {
@@ -1166,9 +1178,9 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def WZIP8P       : RVPWideningShift_rr<0b111, 0b00, "wzip8p">;
   def WZIP16P      : RVPWideningShift_rr<0b111, 0b01, "wzip16p">;
 
-  def PWADD_H      : RVPWideningBinary_rr<0b0000, 0b00, "pwadd.h">;
-  def WADD         : RVPWideningBinary_rr<0b0000, 0b01, "wadd">;
-  def PWADD_B      : RVPWideningBinary_rr<0b0000, 0b10, "pwadd.b">;
+  def PWADD_H      : RVPWideningBinary_rr<0b0000, 0b00, "pwadd.h", Commutable=1>;
+  def WADD         : RVPWideningBinary_rr<0b0000, 0b01, "wadd", Commutable=1>;
+  def PWADD_B      : RVPWideningBinary_rr<0b0000, 0b10, "pwadd.b", Commutable=1>;
   def PM2WADD_H    : RVPWideningBinary_rr<0b0000, 0b11, "pm2wadd.h">;
 
   def PWADDA_H     : RVPWideningTernary_rrr<0b0001, 0b00, "pwadda.h">;
@@ -1176,9 +1188,9 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PWADDA_B     : RVPWideningTernary_rrr<0b0001, 0b10, "pwadda.b">;
   def PM2WADDA_H   : RVPWideningTernary_rrr<0b0001, 0b11, "pm2wadda.h">;
 
-  def PWADDU_H     : RVPWideningBinary_rr<0b0010, 0b00, "pwaddu.h">;
-  def WADDU        : RVPWideningBinary_rr<0b0010, 0b01, "waddu">;
-  def PWADDU_B     : RVPWideningBinary_rr<0b0010, 0b10, "pwaddu.b">;
+  def PWADDU_H     : RVPWideningBinary_rr<0b0010, 0b00, "pwaddu.h", Commutable=1>;
+  def WADDU        : RVPWideningBinary_rr<0b0010, 0b01, "waddu", Commutable=1>;
+  def PWADDU_B     : RVPWideningBinary_rr<0b0010, 0b10, "pwaddu.b", Commutable=1>;
   def PM2WADD_HX   : RVPWideningBinary_rr<0b0010, 0b11, "pm2wadd.hx">;
 
   def PWADDAU_H    : RVPWideningTernary_rrr<0b0011, 0b00, "pwaddau.h">;
@@ -1186,18 +1198,18 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PWADDAU_B    : RVPWideningTernary_rrr<0b0011, 0b10, "pwaddau.b">;
   def PM2WADDA_HX  : RVPWideningTernary_rrr<0b0011, 0b11, "pm2wadda.hx">;
 
-  def PWMUL_H      : RVPWideningBinary_rr<0b0100, 0b00, "pwmul.h">;
-  def WMUL         : RVPWideningBinary_rr<0b0100, 0b01, "wmul">;
-  def PWMUL_B      : RVPWideningBinary_rr<0b0100, 0b10, "pwmul.b">;
+  def PWMUL_H      : RVPWideningBinary_rr<0b0100, 0b00, "pwmul.h", Commutable=1>;
+  def WMUL         : RVPWideningBinary_rr<0b0100, 0b01, "wmul", Commutable=1>;
+  def PWMUL_B      : RVPWideningBinary_rr<0b0100, 0b10, "pwmul.b", Commutable=1>;
   def PM2WADDU_H   : RVPWideningBinary_rr<0b0100, 0b11, "pm2waddu.h">;
 
   def PWMACC_H     : RVPWideningTernary_rrr<0b0101, 0b00, "pwmacc.h">;
   def WMACC        : RVPWideningTernary_rrr<0b0101, 0b01, "wmacc">;
   def PM2WADDAU_H  : RVPWideningTernary_rrr<0b0101, 0b11, "pm2waddau.h">;
 
-  def PWMULU_H     : RVPWideningBinary_rr<0b0110, 0b00, "pwmulu.h">;
-  def WMULU        : RVPWideningBinary_rr<0b0110, 0b01, "wmulu">;
-  def PWMULU_B     : RVPWideningBinary_rr<0b0110, 0b10, "pwmulu.b">;
+  def PWMULU_H     : RVPWideningBinary_rr<0b0110, 0b00, "pwmulu.h", Commutable=1>;
+  def WMULU        : RVPWideningBinary_rr<0b0110, 0b01, "wmulu", Commutable=1>;
+  def PWMULU_B     : RVPWideningBinary_rr<0b0110, 0b10, "pwmulu.b", Commutable=1>;
 
   def PWMACCU_H    : RVPWideningTernary_rrr<0b0111, 0b00, "pwmaccu.h">;
   def WMACCU       : RVPWideningTernary_rrr<0b0111, 0b01, "wmaccu">;
@@ -1352,34 +1364,34 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PSRA_DWS     : RVPPairShift_rr<0b100, 0b01, "psra.dws", 0b1>;
   def PSRA_DBS     : RVPPairShift_rr<0b100, 0b10, "psra.dbs", 0b1>;
 
-  def PADD_DH      : RVPPairBinary_rr<0b0000, 0b00, "padd.dh">;
-  def PADD_DW      : RVPPairBinary_rr<0b0000, 0b01, "padd.dw">;
-  def PADD_DB      : RVPPairBinary_rr<0b0000, 0b10, "padd.db">;
-  def ADDD         : RVPPairBinary_rr<0b0000, 0b11, "addd">;
+  def PADD_DH      : RVPPairBinary_rr<0b0000, 0b00, "padd.dh", Commutable=1>;
+  def PADD_DW      : RVPPairBinary_rr<0b0000, 0b01, "padd.dw", Commutable=1>;
+  def PADD_DB      : RVPPairBinary_rr<0b0000, 0b10, "padd.db", Commutable=1>;
+  def ADDD         : RVPPairBinary_rr<0b0000, 0b11, "addd", Commutable=1>;
 
-  def PSADD_DH     : RVPPairBinary_rr<0b0010, 0b00, "psadd.dh">;
-  def PSADD_DW     : RVPPairBinary_rr<0b0010, 0b01, "psadd.dw">;
-  def PSADD_DB     : RVPPairBinary_rr<0b0010, 0b10, "psadd.db">;
+  def PSADD_DH     : RVPPairBinary_rr<0b0010, 0b00, "psadd.dh", Commutable=1>;
+  def PSADD_DW     : RVPPairBinary_rr<0b0010, 0b01, "psadd.dw", Commutable=1>;
+  def PSADD_DB     : RVPPairBinary_rr<0b0010, 0b10, "psadd.db", Commutable=1>;
 
-  def PAADD_DH     : RVPPairBinary_rr<0b0011, 0b00, "paadd.dh">;
-  def PAADD_DW     : RVPPairBinary_rr<0b0011, 0b01, "paadd.dw">;
-  def PAADD_DB     : RVPPairBinary_rr<0b0011, 0b10, "paadd.db">;
+  def PAADD_DH     : RVPPairBinary_rr<0b0011, 0b00, "paadd.dh", Commutable=1>;
+  def PAADD_DW     : RVPPairBinary_rr<0b0011, 0b01, "paadd.dw", Commutable=1>;
+  def PAADD_DB     : RVPPairBinary_rr<0b0011, 0b10, "paadd.db", Commutable=1>;
 
-  def PSADDU_DH    : RVPPairBinary_rr<0b0110, 0b00, "psaddu.dh">;
-  def PSADDU_DW    : RVPPairBinary_rr<0b0110, 0b01, "psaddu.dw">;
-  def PSADDU_DB    : RVPPairBinary_rr<0b0110, 0b10, "psaddu.db">;
+  def PSADDU_DH    : RVPPairBinary_rr<0b0110, 0b00, "psaddu.dh", Commutable=1>;
+  def PSADDU_DW    : RVPPairBinary_rr<0b0110, 0b01, "psaddu.dw", Commutable=1>;
+  def PSADDU_DB    : RVPPairBinary_rr<0b0110, 0b10, "psaddu.db", Commutable=1>;
 
-  def PAADDU_DH    : RVPPairBinary_rr<0b0111, 0b00, "paaddu.dh">;
-  def PAADDU_DW    : RVPPairBinary_rr<0b0111, 0b01, "paaddu.dw">;
-  def PAADDU_DB    : RVPPairBinary_rr<0b0111, 0b10, "paaddu.db">;
+  def PAADDU_DH    : RVPPairBinary_rr<0b0111, 0b00, "paaddu.dh", Commutable=1>;
+  def PAADDU_DW    : RVPPairBinary_rr<0b0111, 0b01, "paaddu.dw", Commutable=1>;
+  def PAADDU_DB    : RVPPairBinary_rr<0b0111, 0b10, "paaddu.db", Commutable=1>;
 
   def PSUB_DH      : RVPPairBinary_rr<0b1000, 0b00, "psub.dh">;
   def PSUB_DW      : RVPPairBinary_rr<0b1000, 0b01, "psub.dw">;
   def PSUB_DB      : RVPPairBinary_rr<0b1000, 0b10, "psub.db">;
   def SUBD         : RVPPairBinary_rr<0b1000, 0b11, "subd">;
 
-  def PABD_DH      : RVPPairBinary_rr<0b1001, 0b00, "pabd.dh">;
-  def PABD_DB      : RVPPairBinary_rr<0b1001, 0b10, "pabd.db">;
+  def PABD_DH      : RVPPairBinary_rr<0b1001, 0b00, "pabd.dh", Commutable=1>;
+  def PABD_DB      : RVPPairBinary_rr<0b1001, 0b10, "pabd.db", Commutable=1>;
 
   def PSSUB_DH     : RVPPairBinary_rr<0b1010, 0b00, "pssub.dh">;
   def PSSUB_DW     : RVPPairBinary_rr<0b1010, 0b01, "pssub.dw">;
@@ -1389,8 +1401,8 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PASUB_DW     : RVPPairBinary_rr<0b1011, 0b01, "pasub.dw">;
   def PASUB_DB     : RVPPairBinary_rr<0b1011, 0b10, "pasub.db">;
 
-  def PABDU_DH     : RVPPairBinary_rr<0b1101, 0b00, "pabdu.dh">;
-  def PABDU_DB     : RVPPairBinary_rr<0b1101, 0b10, "pabdu.db">;
+  def PABDU_DH     : RVPPairBinary_rr<0b1101, 0b00, "pabdu.dh", Commutable=1>;
+  def PABDU_DB     : RVPPairBinary_rr<0b1101, 0b10, "pabdu.db", Commutable=1>;
 
   def PSSUBU_DH    : RVPPairBinary_rr<0b1110, 0b00, "pssubu.dh">;
   def PSSUBU_DW    : RVPPairBinary_rr<0b1110, 0b01, "pssubu.dw">;
@@ -1427,9 +1439,9 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PAAX_DHX     : RVPPairBinaryExchanged_rr<0b0011, 0b00, "paax.dhx">;
   def PASA_DHX     : RVPPairBinaryExchanged_rr<0b0011, 0b10, "pasa.dhx">;
 
-  def PMSEQ_DH     : RVPPairBinaryExchanged_rr<0b1000, 0b00, "pmseq.dh">;
-  def PMSEQ_DW     : RVPPairBinaryExchanged_rr<0b1000, 0b01, "pmseq.dw">;
-  def PMSEQ_DB     : RVPPairBinaryExchanged_rr<0b1000, 0b10, "pmseq.db">;
+  def PMSEQ_DH     : RVPPairBinaryExchanged_rr<0b1000, 0b00, "pmseq.dh", Commutable=1>;
+  def PMSEQ_DW     : RVPPairBinaryExchanged_rr<0b1000, 0b01, "pmseq.dw", Commutable=1>;
+  def PMSEQ_DB     : RVPPairBinaryExchanged_rr<0b1000, 0b10, "pmseq.db", Commutable=1>;
 
   def PMSLT_DH     : RVPPairBinaryExchanged_rr<0b1010, 0b00, "pmslt.dh">;
   def PMSLT_DW     : RVPPairBinaryExchanged_rr<0b1010, 0b01, "pmslt.dw">;
@@ -1439,21 +1451,21 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PMSLTU_DW    : RVPPairBinaryExchanged_rr<0b1011, 0b01, "pmsltu.dw">;
   def PMSLTU_DB    : RVPPairBinaryExchanged_rr<0b1011, 0b10, "pmsltu.db">;
 
-  def PMIN_DH      : RVPPairBinaryExchanged_rr<0b1100, 0b00, "pmin.dh">;
-  def PMIN_DW      : RVPPairBinaryExchanged_rr<0b1100, 0b01, "pmin.dw">;
-  def PMIN_DB      : RVPPairBinaryExchanged_rr<0b1100, 0b10, "pmin.db">;
+  def PMIN_DH      : RVPPairBinaryExchanged_rr<0b1100, 0b00, "pmin.dh", Commutable=1>;
+  def PMIN_DW      : RVPPairBinaryExchanged_rr<0b1100, 0b01, "pmin.dw", Commutable=1>;
+  def PMIN_DB      : RVPPairBinaryExchanged_rr<0b1100, 0b10, "pmin.db", Commutable=1>;
 
-  def PMINU_DH     : RVPPairBinaryExchanged_rr<0b1101, 0b00, "pminu.dh">;
-  def PMINU_DW     : RVPPairBinaryExchanged_rr<0b1101, 0b01, "pminu.dw">;
-  def PMINU_DB     : RVPPairBinaryExchanged_rr<0b1101, 0b10, "pminu.db">;
+  def PMINU_DH     : RVPPairBinaryExchanged_rr<0b1101, 0b00, "pminu.dh", Commutable=1>;
+  def PMINU_DW     : RVPPairBinaryExchanged_rr<0b1101, 0b01, "pminu.dw", Commutable=1>;
+  def PMINU_DB     : RVPPairBinaryExchanged_rr<0b1101, 0b10, "pminu.db", Commutable=1>;
 
-  def PMAX_DH      : RVPPairBinaryExchanged_rr<0b1110, 0b00, "pmax.dh">;
-  def PMAX_DW      : RVPPairBinaryExchanged_rr<0b1110, 0b01, "pmax.dw">;
-  def PMAX_DB      : RVPPairBinaryExchanged_rr<0b1110, 0b10, "pmax.db">;
+  def PMAX_DH      : RVPPairBinaryExchanged_rr<0b1110, 0b00, "pmax.dh", Commutable=1>;
+  def PMAX_DW      : RVPPairBinaryExchanged_rr<0b1110, 0b01, "pmax.dw", Commutable=1>;
+  def PMAX_DB      : RVPPairBinaryExchanged_rr<0b1110, 0b10, "pmax.db", Commutable=1>;
 
-  def PMAXU_DH     : RVPPairBinaryExchanged_rr<0b1111, 0b00, "pmaxu.dh">;
-  def PMAXU_DW     : RVPPairBinaryExchanged_rr<0b1111, 0b01, "pmaxu.dw">;
-  def PMAXU_DB     : RVPPairBinaryExchanged_rr<0b1111, 0b10, "pmaxu.db">;
+  def PMAXU_DH     : RVPPairBinaryExchanged_rr<0b1111, 0b00, "pmaxu.dh", Commutable=1>;
+  def PMAXU_DW     : RVPPairBinaryExchanged_rr<0b1111, 0b01, "pmaxu.dw", Commutable=1>;
+  def PMAXU_DB     : RVPPairBinaryExchanged_rr<0b1111, 0b10, "pmaxu.db", Commutable=1>;
 } // Predicates = [HasStdExtP, IsRV32]
 
 


### PR DESCRIPTION
This allows MachineCSE to commute these instructions if it would allow CSE.