### PR TITLE
[Metadata][profcheck] Handle identical MDNodes in getMergedProfMetadata

### DIFF
--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -1248,12 +1248,6 @@ MDNode *MDNode::getMergedProfMetadata(MDNode *A, MDNode *B,
     return A ? A : B;
   }
 
-  if (A == B && !ProfcheckDisableMetadataFixes) {
-    // For calls, we want to sum the weights even if identical.
-    if (!isa<CallInst>(AInstr))
-      return A;
-  }
-
   assert(AInstr->getMetadata(LLVMContext::MD_prof) == A &&
          "Caller should guarantee");
   assert(BInstr->getMetadata(LLVMContext::MD_prof) == B &&
@@ -1266,6 +1260,9 @@ MDNode *MDNode::getMergedProfMetadata(MDNode *A, MDNode *B,
   if (ACall && BCall && ACall->getCalledFunction() &&
       BCall->getCalledFunction())
     return mergeDirectCallProfMetadata(A, B, AInstr, BInstr);
+
+  if (A == B && !ProfcheckDisableMetadataFixes)
+    return A;
 
   // The rest of the cases are not implemented but could be added
   // when there are use cases.

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -5463,6 +5463,56 @@ TEST_F(MDTupleAllocationTest, Tracking2) {
   EXPECT_EQ(A->getOperand(2), Value2);
 }
 
+TEST_F(MDNodeTest, MergedProfMetadata) {
+  // Check that identical profile metadata is merged correctly.
+  Metadata *Ops[] = {
+      ConstantAsMetadata::get(ConstantInt::get(Context, APInt(32, 1))),
+      ConstantAsMetadata::get(ConstantInt::get(Context, APInt(32, 10))),
+      ConstantAsMetadata::get(ConstantInt::get(Context, APInt(32, 20)))};
+  MDNode *Prof = MDNode::get(Context, Ops);
+
+  // Create instructions to pass to getMergedProfMetadata.
+  // It requires the instructions to be of a supported type (e.g., SelectInst).
+  Value *C = ConstantInt::get(Context, APInt(1, 1));
+  Value *V1 = ConstantInt::get(Context, APInt(32, 1));
+  Value *V2 = ConstantInt::get(Context, APInt(32, 2));
+  std::unique_ptr<SelectInst> SI1(SelectInst::Create(C, V1, V2));
+  std::unique_ptr<SelectInst> SI2(SelectInst::Create(C, V1, V2));
+
+  SI1->setMetadata(LLVMContext::MD_prof, Prof);
+  SI2->setMetadata(LLVMContext::MD_prof, Prof);
+
+  MDNode *Merged =
+      MDNode::getMergedProfMetadata(Prof, Prof, SI1.get(), SI2.get());
+  EXPECT_EQ(Merged, Prof);
+}
+
+TEST_F(MDNodeTest, MergedProfMetadata_CallInst) {
+  // Check that identical profile metadata on CallInsts is SUMMED, not preserved.
+  Metadata *Ops[] = {
+      MDString::get(Context, "branch_weights"),
+      ConstantAsMetadata::get(ConstantInt::get(Context, APInt(32, 10)))};
+  MDNode *Prof = MDNode::get(Context, Ops);
+
+  // Create two CallInsts.
+  FunctionType *FTy = FunctionType::get(Type::getVoidTy(Context), false);
+  std::unique_ptr<CallInst> CI1(CallInst::Create(FTy, getFunction("f"), ArrayRef<Value *>()));
+  std::unique_ptr<CallInst> CI2(CallInst::Create(FTy, getFunction("f"), ArrayRef<Value *>()));
+
+  CI1->setMetadata(LLVMContext::MD_prof, Prof);
+  CI2->setMetadata(LLVMContext::MD_prof, Prof);
+
+  MDNode *Merged =
+      MDNode::getMergedProfMetadata(Prof, Prof, CI1.get(), CI2.get());
+
+  // Expect merged node to be different (summed weights).
+  EXPECT_NE(Merged, Prof);
+  // Verify value is 20.
+  ASSERT_EQ(Merged->getNumOperands(), 2u);
+  ConstantInt *W = mdconst::extract<ConstantInt>(Merged->getOperand(1));
+  EXPECT_EQ(W->getZExtValue(), 20u);
+}
+
 #if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG) && !defined(GTEST_HAS_SEH)
 typedef MetadataTest MDTupleAllocationDeathTest;
 TEST_F(MDTupleAllocationDeathTest, ResizeRejected) {

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -5488,7 +5488,8 @@ TEST_F(MDNodeTest, MergedProfMetadata) {
 }
 
 TEST_F(MDNodeTest, MergedProfMetadata_CallInst) {
-  // Check that identical profile metadata on CallInsts is SUMMED, not preserved.
+  // Check that identical profile metadata on CallInsts is SUMMED, not
+  // preserved.
   Metadata *Ops[] = {
       MDString::get(Context, "branch_weights"),
       ConstantAsMetadata::get(ConstantInt::get(Context, APInt(32, 10)))};
@@ -5496,8 +5497,10 @@ TEST_F(MDNodeTest, MergedProfMetadata_CallInst) {
 
   // Create two CallInsts.
   FunctionType *FTy = FunctionType::get(Type::getVoidTy(Context), false);
-  std::unique_ptr<CallInst> CI1(CallInst::Create(FTy, getFunction("f"), ArrayRef<Value *>()));
-  std::unique_ptr<CallInst> CI2(CallInst::Create(FTy, getFunction("f"), ArrayRef<Value *>()));
+  std::unique_ptr<CallInst> CI1(
+      CallInst::Create(FTy, getFunction("f"), ArrayRef<Value *>()));
+  std::unique_ptr<CallInst> CI2(
+      CallInst::Create(FTy, getFunction("f"), ArrayRef<Value *>()));
 
   CI1->setMetadata(LLVMContext::MD_prof, Prof);
   CI2->setMetadata(LLVMContext::MD_prof, Prof);

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -5487,32 +5487,6 @@ TEST_F(MDNodeTest, MergedProfMetadata) {
   EXPECT_EQ(Merged, Prof);
 }
 
-TEST_F(MDNodeTest, MergedProfMetadata_CallInst) {
-  // Check that identical profile metadata on CallInsts is SUMMED, not preserved.
-  Metadata *Ops[] = {
-      MDString::get(Context, "branch_weights"),
-      ConstantAsMetadata::get(ConstantInt::get(Context, APInt(32, 10)))};
-  MDNode *Prof = MDNode::get(Context, Ops);
-
-  // Create two CallInsts.
-  FunctionType *FTy = FunctionType::get(Type::getVoidTy(Context), false);
-  std::unique_ptr<CallInst> CI1(CallInst::Create(FTy, getFunction("f"), ArrayRef<Value *>()));
-  std::unique_ptr<CallInst> CI2(CallInst::Create(FTy, getFunction("f"), ArrayRef<Value *>()));
-
-  CI1->setMetadata(LLVMContext::MD_prof, Prof);
-  CI2->setMetadata(LLVMContext::MD_prof, Prof);
-
-  MDNode *Merged =
-      MDNode::getMergedProfMetadata(Prof, Prof, CI1.get(), CI2.get());
-
-  // Expect merged node to be different (summed weights).
-  EXPECT_NE(Merged, Prof);
-  // Verify value is 20.
-  ASSERT_EQ(Merged->getNumOperands(), 2u);
-  ConstantInt *W = mdconst::extract<ConstantInt>(Merged->getOperand(1));
-  EXPECT_EQ(W->getZExtValue(), 20u);
-}
-
 #if defined(GTEST_HAS_DEATH_TEST) && !defined(NDEBUG) && !defined(GTEST_HAS_SEH)
 typedef MetadataTest MDTupleAllocationDeathTest;
 TEST_F(MDTupleAllocationDeathTest, ResizeRejected) {

--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -505,9 +505,6 @@ Transforms/PreISelIntrinsicLowering/AArch64/expand-exp.ll
 Transforms/PreISelIntrinsicLowering/AArch64/expand-log.ll
 Transforms/PreISelIntrinsicLowering/PowerPC/memset-pattern.ll
 Transforms/PreISelIntrinsicLowering/RISCV/memset-pattern.ll
-Transforms/PreISelIntrinsicLowering/X86/memcpy-inline-non-constant-len.ll
-Transforms/PreISelIntrinsicLowering/X86/memset-inline-non-constant-len.ll
-Transforms/PreISelIntrinsicLowering/X86/memset-pattern.ll
 Transforms/ScalarizeMaskedMemIntrin/AArch64/expand-masked-load.ll
 Transforms/ScalarizeMaskedMemIntrin/AArch64/expand-masked-store.ll
 Transforms/ScalarizeMaskedMemIntrin/AArch64/streaming-compatible-expand-masked-gather-scatter.ll

--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -505,8 +505,9 @@ Transforms/PreISelIntrinsicLowering/AArch64/expand-exp.ll
 Transforms/PreISelIntrinsicLowering/AArch64/expand-log.ll
 Transforms/PreISelIntrinsicLowering/PowerPC/memset-pattern.ll
 Transforms/PreISelIntrinsicLowering/RISCV/memset-pattern.ll
-Transforms/SampleProfile/pseudo-probe-profile-mismatch-thinlto.ll
-Transforms/SampleProfile/remarks-hotness.ll
+Transforms/PreISelIntrinsicLowering/X86/memcpy-inline-non-constant-len.ll
+Transforms/PreISelIntrinsicLowering/X86/memset-inline-non-constant-len.ll
+Transforms/PreISelIntrinsicLowering/X86/memset-pattern.ll
 Transforms/ScalarizeMaskedMemIntrin/AArch64/expand-masked-load.ll
 Transforms/ScalarizeMaskedMemIntrin/AArch64/expand-masked-store.ll
 Transforms/ScalarizeMaskedMemIntrin/AArch64/streaming-compatible-expand-masked-gather-scatter.ll


### PR DESCRIPTION
This fixes a bug where !prof metadata was dropped from SelectInsts when GVN simplified/merged them.
Guarded by -profcheck-disable-metadata-fixes. Exposed by the tests in
Transforms/SampleProfile.