### PR TITLE
[lld-macho] Fix thunk insertion for multiple .text sections scenario

### DIFF
--- a/lld/MachO/ConcatOutputSection.cpp
+++ b/lld/MachO/ConcatOutputSection.cpp
@@ -141,7 +141,7 @@ uint64_t TextOutputSection::estimateFurthestBranchTargetEndVA() const {
   ArrayRef<OutputSection *> fromThis =
       sections.drop_until([this](const OutputSection *s) { return s == this; });
   assert(!fromThis.empty() && "section not found in parent segment");
-  ArrayRef<OutputSection *> subsequentSections = fromThis.drop_front(1);
+  ArrayRef<OutputSection *> subsequentSections = fromThis.drop_front();
 
   // Walk sections after this one, simulating layout (alignment + size).
   // Track the end VA of the furthest branch target section.

--- a/lld/MachO/ConcatOutputSection.cpp
+++ b/lld/MachO/ConcatOutputSection.cpp
@@ -115,7 +115,6 @@ void ConcatOutputSection::addInput(ConcatInputSection *input) {
 
 DenseMap<Symbol *, ThunkInfo> lld::macho::thunkMap;
 
-
 // Returns true if `osec` can be the target of a BRANCH relocation.
 // Branch targets include code sections and stub sections for dynamic calls.
 static bool isBranchTargetSection(const OutputSection *osec) {
@@ -136,10 +135,11 @@ uint64_t TextOutputSection::estimateFurthestBranchTargetEndVA() const {
   uint64_t curVA = estimateEndVA(addr);
   uint64_t furthestTargetEndVA = isBranchTargetSection(this) ? curVA : addr;
 
-  // Find this section in the segment's section list and get subsequent sections.
+  // Find this section in the segment's section list and get subsequent
+  // sections.
   ArrayRef<OutputSection *> sections = parent->getSections();
-  ArrayRef<OutputSection *> fromThis = sections.drop_until(
-      [this](const OutputSection *s) { return s == this; });
+  ArrayRef<OutputSection *> fromThis =
+      sections.drop_until([this](const OutputSection *s) { return s == this; });
   assert(!fromThis.empty() && "section not found in parent segment");
   ArrayRef<OutputSection *> subsequentSections = fromThis.drop_front(1);
 

--- a/lld/MachO/ConcatOutputSection.h
+++ b/lld/MachO/ConcatOutputSection.h
@@ -80,6 +80,17 @@ public:
   }
 
 private:
+  // Estimate the end VA of this section if it were to start at `startVA`.
+  uint64_t estimateEndVA(uint64_t startVA) const;
+
+  // Compute the end VA of the furthest section in this segment that can be
+  // the target of a branch relocation.
+  uint64_t estimateFurthestBranchTargetEndVA() const;
+
+  // Pre-populate thunkMap with call site counts for
+  // estimateBranchTargetThresholdVA().
+  void recordCallSites() const;
+
   uint64_t estimateBranchTargetThresholdVA(size_t callIdx) const;
 
   std::vector<ConcatInputSection *> thunks;

--- a/lld/test/MachO/arm64-thunks-crosssection.s
+++ b/lld/test/MachO/arm64-thunks-crosssection.s
@@ -1,0 +1,96 @@
+# REQUIRES: aarch64
+
+## This test verifies that thunks are created for branches between multiple
+## code sections in the same segment when the combined span exceeds the
+## branch range, even if each individual section is within range.
+##
+## The bug occurs when:
+## (1) Section __text is within branch range (e.g., 64 MB < 128 MB)
+## (2) Section __text_second is also within range (e.g., 64 MB < 128 MB)
+## (3) Combined span exceeds branch range (128+ MB total)
+## (4) Calls from early in __text to __text_second need thunks
+##
+## Without the fix, needsThunks() only considered individual section sizes,
+## not the total span, causing BRANCH26 out of range errors.
+
+# RUN: rm -rf %t; mkdir %t
+# RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %s -o %t/input.o
+# RUN: %lld -arch arm64 -lSystem -o %t/out %t/input.o
+# RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t/out | FileCheck %s
+
+# CHECK: Disassembly of section __TEXT,__text:
+
+## _early_func is at the start of __text, it calls _far_func which is in
+## __text_second section. This branch crosses sections and needs a thunk
+## because the total span exceeds branch range.
+# CHECK-LABEL: <_early_func>:
+# CHECK:         bl {{.*}} <_far_func.thunk.0>
+# CHECK:         bl {{.*}} <_helper>
+# CHECK:         ret
+
+# CHECK-LABEL: <_helper>:
+# CHECK:         ret
+
+## After padding, there's another function that also needs a thunk
+
+## Verify thunk is created - it appears before _mid_func in output
+# CHECK-LABEL: <_far_func.thunk.0>:
+# CHECK:         adrp x16
+# CHECK:         add  x16, x16
+# CHECK:         br   x16
+
+# CHECK-LABEL: <_mid_func>:
+# CHECK:         bl {{.*}} <_far_func.thunk.0>
+# CHECK:         ret
+
+# CHECK: Disassembly of section __TEXT,__text_second:
+
+# CHECK-LABEL: <_far_func>:
+# CHECK:         ret
+
+
+.text
+.globl _main
+.p2align 2
+_main:
+  bl _early_func
+  ret
+
+.globl _early_func
+.p2align 2
+_early_func:
+  ## This call to _far_func crosses sections and exceeds branch range
+  bl _far_func
+  bl _helper
+  ret
+
+.globl _helper
+.p2align 2
+_helper:
+  ret
+
+## Pad __text section to ~64 MB
+## 0x4000000 = 64 Mi = half the branch range
+.space 0x4000000-0x20
+
+.globl _mid_func
+.p2align 2
+_mid_func:
+  bl _far_func
+  ret
+
+## More padding to push __text to ~128 MB
+.space 0x4000000-0x10
+
+## This is a second code section in __TEXT segment
+.section __TEXT,__text_second,regular,pure_instructions
+
+.globl _far_func
+.p2align 2
+_far_func:
+  ret
+
+## Add padding in second section to ensure total span exceeds branch range
+.space 0x100000
+
+.subsections_via_symbols


### PR DESCRIPTION
#### Context
This change is to support [MachO basic block hot-cold splitting](https://discourse.llvm.org/t/rfc-support-fsplit-machine-functions-on-macho-arm64/89739) - though it's presented below outside of this context. 

#### Summary

Fix a MachO specific bug where thunks were not being created for branches between multiple code sections in the same segment when the combined span exceeds the branch range, even though each individual section is within range.

#### Problem

When determining whether thunk insertion is needed, `TextOutputSection::needsThunks()` was only considering the size of the current section being finalized. This caused incorrect behavior when we have two text sections that individually don't need thunks, but when considered together - they do need thunks
Without this fix, the linker would emit `BRANCH26 out of range` errors or produce incorrect binaries.

#### Solution

Modified `needsThunks()` to compute the end VA of the furthest branch target section in the segment, rather than just the current section's end (i.e. considering all `TEXT` sections). 
We also refactor `needsThunks()` into smaller helpers.

The `branchTargetThresholdVA >= addr` change ensures the threshold is valid for the current section before using it to skip thunk creation.

#### Test
Added `arm64-thunks-crosssection.s` which creates two code sections (`__text` and `__text_second`) with a combined span exceeding the 128 MB ARM64 branch range, and verifies that thunks are correctly generated for cross-section calls.


[Assisted-by](https://t.ly/Dkjjk): Cursor IDE + claude-opus-4.5-high + gpt-5.2-xhigh