### PR TITLE
[flang][OpenMP] Fix LINEAR clause validation and test expectations

### DIFF
--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -764,7 +764,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Linear &x) {
         context_.Say(clauseSource,
             "A modifier may not be specified in a LINEAR clause on the %s directive"_err_en_US,
             ContextDirectiveAsFortran());
-        return;
+        // Don't return early - continue to check other restrictions
       }
 
       auto &desc{OmpGetDescriptor<parser::OmpLinearModifier>()};

--- a/flang/test/Semantics/OpenMP/linear-clause01.f90
+++ b/flang/test/Semantics/OpenMP/linear-clause01.f90
@@ -7,11 +7,8 @@
 ! Case 1
 subroutine linear_clause_01(arg)
     integer, intent(in) :: arg(:)
-!    !ERROR: A modifier may not be specified in a LINEAR clause on the DO directive
-!    !ERROR: List item 'arg' in LINEAR clause must be a scalar variable
-! TODO: the following line currently breaks buildbots. Disabling it until the author
-! of the breaking change can fix it.
-!    !$omp do linear(uval(arg))
+    !ERROR: A modifier may not be specified in a LINEAR clause on the DO directive
+    !$omp do linear(uval(arg))
     do i = 1, 5
         print *, arg(i)
     end do

--- a/flang/test/Semantics/OpenMP/linear-clause01.f90
+++ b/flang/test/Semantics/OpenMP/linear-clause01.f90
@@ -8,6 +8,7 @@
 subroutine linear_clause_01(arg)
     integer, intent(in) :: arg(:)
     !ERROR: A modifier may not be specified in a LINEAR clause on the DO directive
+    !ERROR: List item 'arg' in LINEAR clause must be a scalar variable
     !$omp do linear(uval(arg))
     do i = 1, 5
         print *, arg(i)


### PR DESCRIPTION
Fixes #175688

After #175383 was merged, the test `Semantics/OpenMP/linear-clause01.f90` was failing because it had an early return that prevented multiple errors from being reported.

This PR fixes two issues:

1. **Removes the early return** after detecting a modifier error on DO/SIMD directives. Previously, when a modifier error was found, the function would return immediately without checking other restrictions like the scalar requirement. Now all applicable errors are reported.

2. **Updates test expectations** to expect both the modifier error AND the scalar error for Case 1, where `arg(:)` is an array used with `uval` modifier on a DO directive.

Thanks to @NimishMishra for catching this during review - arrays should always be rejected in LINEAR clauses (except for `declare simd` with `ref` modifier), regardless of whether there are other errors.