### PR TITLE
[DebugInfo] Set the DI flag for the simplified name of a template function/type (2/3).

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -714,7 +714,8 @@ private:
   };
 
   bool HasReconstitutableArgs(ArrayRef<TemplateArgument> Args) const;
-  std::string GetName(const Decl *, bool Qualified = false) const;
+  std::string GetName(const Decl *, bool Qualified = false,
+                      bool *NameIsSimplified = nullptr) const;
 
   /// Build up structure info for the byref.  See \a BuildByRefType.
   BlockByRefType EmitTypeForVarWithBlocksAttr(const VarDecl *VD,
@@ -837,7 +838,8 @@ private:
   /// Get function name for the given FunctionDecl. If the name is
   /// constructed on demand (e.g., C++ destructor) then the name is
   /// stored on the side.
-  StringRef getFunctionName(const FunctionDecl *FD);
+  StringRef getFunctionName(const FunctionDecl *FD,
+                            bool *NameIsSimplified = nullptr);
 
   /// Returns the unmangled name of an Objective-C method.
   /// This is the display name for the debugging info.
@@ -848,7 +850,8 @@ private:
   StringRef getSelectorName(Selector S);
 
   /// Get class name including template argument list.
-  StringRef getClassName(const RecordDecl *RD);
+  StringRef getClassName(const RecordDecl *RD,
+                         bool *NameIsSimplified = nullptr);
 
   /// Get the vtable name for the given class.
   StringRef getVTableName(const CXXRecordDecl *Decl);

--- a/clang/test/DebugInfo/CXX/simple-template-names.cpp
+++ b/clang/test/DebugInfo/CXX/simple-template-names.cpp
@@ -39,20 +39,20 @@ void f4() {
 void f() {
   // Basic examples of simplifiable/rebuildable names
   f1<>();
-  // CHECK: !DISubprogram(name: "_STN|f1|<>",
-  // SIMPLE: !DISubprogram(name: "f1",
+  // CHECK: !DISubprogram(name: "_STN|f1|<>", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
+  // SIMPLE: !DISubprogram(name: "f1", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
   // FULL: !DISubprogram(name: "f1<>",
   f1<int>();
-  // CHECK: !DISubprogram(name: "_STN|f1|<int>",
+  // CHECK: !DISubprogram(name: "_STN|f1|<int>", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
   f1<void()>();
-  // CHECK: !DISubprogram(name: "_STN|f1|<void ()>",
+  // CHECK: !DISubprogram(name: "_STN|f1|<void ()>", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
   f2<int, 42>();
-  // CHECK: !DISubprogram(name: "_STN|f2|<int, 42>",
+  // CHECK: !DISubprogram(name: "_STN|f2|<int, 42>", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
 
   // Check that even though the nested name can't be rebuilt, it'll carry its
   // full name and the outer name can be rebuilt from that.
   f1<t1<void() noexcept>>();
-  // CHECK: !DISubprogram(name: "_STN|f1|<t1<void () noexcept> >",
+  // CHECK: !DISubprogram(name: "_STN|f1|<t1<void () noexcept> >", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
 
   // Vector array types are encoded in DWARF but the decoding in llvm-dwarfdump
   // isn't implemented yet.
@@ -105,6 +105,7 @@ void f() {
   t2().operator t1<int>();
   // FIXME: This should be something like "operator t1<int><float>"
   // CHECK: !DISubprogram(name: "operator t1<float>",
+  // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "_STN|t1|<int>", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
 
   // Function pointer non-type-template parameters currently don't get any DWARF
   // value (GCC doesn't provide one either) and even if there was a value, if
@@ -113,25 +114,25 @@ void f() {
   // worry about seeing conversion operators as parameters to other templates.
 
   f3<t1>();
-  // CHECK: !DISubprogram(name: "_STN|f3|<t1>",
+  // CHECK: !DISubprogram(name: "_STN|f3|<t1>", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
 
   f1<_BitInt(3)>();
-  // CHECK: !DISubprogram(name: "_STN|f1|<_BitInt(3)>",
+  // CHECK: !DISubprogram(name: "_STN|f1|<_BitInt(3)>", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
 
   f1<const unsigned _BitInt(5)>();
-  // CHECK: !DISubprogram(name: "_STN|f1|<const unsigned _BitInt(5)>",
+  // CHECK: !DISubprogram(name: "_STN|f1|<const unsigned _BitInt(5)>", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
 
   f1<_BitInt(120)>();
-  // CHECK: !DISubprogram(name: "_STN|f1|<_BitInt(120)>",
+  // CHECK: !DISubprogram(name: "_STN|f1|<_BitInt(120)>", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
 
   f1<const unsigned _BitInt(120)>();
-  // CHECK: !DISubprogram(name: "_STN|f1|<const unsigned _BitInt(120)>",
+  // CHECK: !DISubprogram(name: "_STN|f1|<const unsigned _BitInt(120)>", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
 
   f2<_BitInt(2), 1>();
-  // CHECK: !DISubprogram(name: "_STN|f2|<_BitInt(2), (_BitInt(2))1>",
+  // CHECK: !DISubprogram(name: "_STN|f2|<_BitInt(2), (_BitInt(2))1>", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
 
   f2<_BitInt(64), 12>();
-  // CHECK: !DISubprogram(name: "_STN|f2|<_BitInt(64), (_BitInt(64))12>",
+  // CHECK: !DISubprogram(name: "_STN|f2|<_BitInt(64), (_BitInt(64))12>", {{.*}}flags:{{.*}}DIFlagNameIsSimplified,
 
   // FIXME: make block forms reconstitutable
   f2<_BitInt(65), 1>();


### PR DESCRIPTION
Set the `NameIsSimplified` flag for a template function/type that is treated as having simplified names.  Previous patch: #175130 .
Based on: [RFC](https://discourse.llvm.org/t/rfc-debuginfo-selectively-generate-template-parameters-in-the-skeleton-cu/89395).