### PR TITLE
[clang][bytecode] Fix CK_ToVoid casts for Complex values

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -1381,6 +1381,10 @@ bool Compiler<Emitter>::VisitComplexBinOp(const BinaryOperator *E) {
     } else {
       if (!this->emitPop(ResultElemT, E))
         return false;
+      // Remove the Complex temporary pointer we created ourselves at the
+      // beginning of this function.
+      if (!Initializing)
+        return this->emitPopPtr(E);
     }
   }
   return true;

--- a/clang/test/AST/ByteCode/complex.cpp
+++ b/clang/test/AST/ByteCode/complex.cpp
@@ -434,5 +434,9 @@ namespace Discard {
   }
   static_assert(test3() == 10, ""); // both-error {{not an integral constant expression}}
 
+  constexpr void V() {
+    (void)(1 + 2i);
+  }
+  static_assert((V(), true));
 
 }


### PR DESCRIPTION
We need to remove the pointer to the local variable we've created specifically for this complex binary operator.

Fixes https://github.com/llvm/llvm-project/issues/175670