### PR TITLE
[X86][GISEL] Enable Combines for constants and undef

### DIFF
--- a/llvm/lib/Target/X86/X86Combine.td
+++ b/llvm/lib/Target/X86/X86Combine.td
@@ -13,7 +13,7 @@ include "llvm/Target/GlobalISel/Combine.td"
 // combines. We will introduce more combines gradually.
 
 def all_x86combines : GICombineGroup<[identity_combines, reassocs, 
-    simplify_add_to_sub]>;
+    const_combines, undef_combines, trivial_combines, simplify_add_to_sub]>;
 
 def X86PreLegalizerCombiner : GICombiner<"X86PreLegalizerCombinerImpl", [all_x86combines]> {
     let CombineAllMethodName = "tryCombineAllImpl";

--- a/llvm/test/CodeGen/X86/GlobalISel/add-ext.ll
+++ b/llvm/test/CodeGen/X86/GlobalISel/add-ext.ll
@@ -92,7 +92,7 @@ define ptr @gep16(i32 %i, ptr %x) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addl $-5, %edi
 ; CHECK-NEXT:    movslq %edi, %rax
-; CHECK-NEXT:    imulq $2, %rax, %rax
+; CHECK-NEXT:    addq %rax, %rax
 ; CHECK-NEXT:    addq %rsi, %rax
 ; CHECK-NEXT:    retq
 
@@ -107,7 +107,7 @@ define ptr @gep32(i32 %i, ptr %x) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addl $5, %edi
 ; CHECK-NEXT:    movslq %edi, %rax
-; CHECK-NEXT:    imulq $4, %rax, %rax
+; CHECK-NEXT:    shlq $2, %rax
 ; CHECK-NEXT:    addq %rsi, %rax
 ; CHECK-NEXT:    retq
 
@@ -122,7 +122,7 @@ define ptr @gep64(i32 %i, ptr %x) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addl $-5, %edi
 ; CHECK-NEXT:    movslq %edi, %rax
-; CHECK-NEXT:    imulq $8, %rax, %rax
+; CHECK-NEXT:    shlq $3, %rax
 ; CHECK-NEXT:    addq %rsi, %rax
 ; CHECK-NEXT:    retq
 
@@ -139,7 +139,7 @@ define ptr @gep128(i32 %i, ptr %x) {
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    addl $5, %edi
 ; CHECK-NEXT:    movslq %edi, %rax
-; CHECK-NEXT:    imulq $16, %rax, %rax
+; CHECK-NEXT:    shlq $4, %rax
 ; CHECK-NEXT:    addq %rsi, %rax
 ; CHECK-NEXT:    retq
 
@@ -159,18 +159,20 @@ define void @PR20134(ptr %a, i32 %i) {
 ; CHECK-NEXT:    # kill: def $esi killed $esi def $rsi
 ; CHECK-NEXT:    leal 1(%rsi), %eax
 ; CHECK-NEXT:    cltq
-; CHECK-NEXT:    imulq $4, %rax, %rax
+; CHECK-NEXT:    shlq $2, %rax
 ; CHECK-NEXT:    addq %rdi, %rax
 ; CHECK-NEXT:    leal 2(%rsi), %ecx
-; CHECK-NEXT:    movslq %ecx, %rcx
-; CHECK-NEXT:    imulq $4, %rcx, %rcx
-; CHECK-NEXT:    addq %rdi, %rcx
-; CHECK-NEXT:    movl (%rcx), %ecx
-; CHECK-NEXT:    addl (%rax), %ecx
+; CHECK-NEXT:    movslq %ecx, %rdx
+; CHECK-NEXT:    movb $2, %cl
+; CHECK-NEXT:    shlq %cl, %rdx
+; CHECK-NEXT:    leaq (%rdi,%rdx), %rcx
+; CHECK-NEXT:    movl (%rcx), %edx
+; CHECK-NEXT:    addl (%rax), %edx
 ; CHECK-NEXT:    movslq %esi, %rax
-; CHECK-NEXT:    imulq $4, %rax, %rax
+; CHECK-NEXT:    movb $2, %cl
+; CHECK-NEXT:    shlq %cl, %rax
 ; CHECK-NEXT:    addq %rdi, %rax
-; CHECK-NEXT:    movl %ecx, (%rax)
+; CHECK-NEXT:    movl %edx, (%rax)
 ; CHECK-NEXT:    retq
 
   %add1 = add nsw i32 %i, 1
@@ -197,18 +199,20 @@ define void @PR20134_zext(ptr %a, i32 %i) {
 ; CHECK-NEXT:    # kill: def $esi killed $esi def $rsi
 ; CHECK-NEXT:    leal 1(%rsi), %eax
 ; CHECK-NEXT:    movl %eax, %eax
-; CHECK-NEXT:    imulq $4, %rax, %rax
+; CHECK-NEXT:    shlq $2, %rax
 ; CHECK-NEXT:    addq %rdi, %rax
 ; CHECK-NEXT:    leal 2(%rsi), %ecx
-; CHECK-NEXT:    movl %ecx, %ecx
-; CHECK-NEXT:    imulq $4, %rcx, %rcx
-; CHECK-NEXT:    addq %rdi, %rcx
-; CHECK-NEXT:    movl (%rcx), %ecx
-; CHECK-NEXT:    addl (%rax), %ecx
+; CHECK-NEXT:    movl %ecx, %edx
+; CHECK-NEXT:    movb $2, %cl
+; CHECK-NEXT:    shlq %cl, %rdx
+; CHECK-NEXT:    leaq (%rdi,%rdx), %rcx
+; CHECK-NEXT:    movl (%rcx), %edx
+; CHECK-NEXT:    addl (%rax), %edx
 ; CHECK-NEXT:    movl %esi, %eax
-; CHECK-NEXT:    imulq $4, %rax, %rax
+; CHECK-NEXT:    movb $2, %cl
+; CHECK-NEXT:    shlq %cl, %rax
 ; CHECK-NEXT:    addq %rdi, %rax
-; CHECK-NEXT:    movl %ecx, (%rax)
+; CHECK-NEXT:    movl %edx, (%rax)
 ; CHECK-NEXT:    retq
 
   %add1 = add nuw i32 %i, 1

--- a/llvm/test/CodeGen/X86/GlobalISel/pr49087.ll
+++ b/llvm/test/CodeGen/X86/GlobalISel/pr49087.ll
@@ -14,7 +14,7 @@ define i32 @test_01(ptr %p, i64 %len, i32 %x) {
 ; CHECK-NEXT:    jne .LBB0_4
 ; CHECK-NEXT:  # %bb.2: # %backedge
 ; CHECK-NEXT:    # in Loop: Header=BB0_1 Depth=1
-; CHECK-NEXT:    imulq $4, %rsi, %rcx
+; CHECK-NEXT:    leaq (,%rsi,4), %rcx
 ; CHECK-NEXT:    addq %rdi, %rcx
 ; CHECK-NEXT:    cmpl %edx, (%rcx)
 ; CHECK-NEXT:    sete %cl

--- a/llvm/test/CodeGen/X86/GlobalISel/ptr-add.ll
+++ b/llvm/test/CodeGen/X86/GlobalISel/ptr-add.ll
@@ -8,8 +8,8 @@ define ptr @test_gep_i8(ptr%arr, i8 %ind) {
 ; X64_GISEL-NEXT:    # kill: def $esi killed $esi def $rsi
 ; X64_GISEL-NEXT:    shlq $56, %rsi
 ; X64_GISEL-NEXT:    sarq $56, %rsi
-; X64_GISEL-NEXT:    imulq $4, %rsi, %rax
-; X64_GISEL-NEXT:    addq %rdi, %rax
+; X64_GISEL-NEXT:    shlq $2, %rsi
+; X64_GISEL-NEXT:    leaq (%rdi,%rsi), %rax
 ; X64_GISEL-NEXT:    retq
 ;
 ; X64-LABEL: test_gep_i8:
@@ -43,8 +43,8 @@ define ptr @test_gep_i16(ptr%arr, i16 %ind) {
 ; X64_GISEL-NEXT:    # kill: def $esi killed $esi def $rsi
 ; X64_GISEL-NEXT:    shlq $48, %rsi
 ; X64_GISEL-NEXT:    sarq $48, %rsi
-; X64_GISEL-NEXT:    imulq $4, %rsi, %rax
-; X64_GISEL-NEXT:    addq %rdi, %rax
+; X64_GISEL-NEXT:    shlq $2, %rsi
+; X64_GISEL-NEXT:    leaq (%rdi,%rsi), %rax
 ; X64_GISEL-NEXT:    retq
 ;
 ; X64-LABEL: test_gep_i16:
@@ -76,7 +76,7 @@ define ptr @test_gep_i32(ptr%arr, i32 %ind) {
 ; X64_GISEL-LABEL: test_gep_i32:
 ; X64_GISEL:       # %bb.0:
 ; X64_GISEL-NEXT:    movslq %esi, %rax
-; X64_GISEL-NEXT:    imulq $4, %rax, %rax
+; X64_GISEL-NEXT:    shlq $2, %rax
 ; X64_GISEL-NEXT:    addq %rdi, %rax
 ; X64_GISEL-NEXT:    retq
 ;
@@ -107,8 +107,8 @@ define ptr @test_gep_i32_const(ptr%arr) {
 define ptr @test_gep_i64(ptr%arr, i64 %ind) {
 ; X64_GISEL-LABEL: test_gep_i64:
 ; X64_GISEL:       # %bb.0:
-; X64_GISEL-NEXT:    imulq $4, %rsi, %rax
-; X64_GISEL-NEXT:    addq %rdi, %rax
+; X64_GISEL-NEXT:    shlq $2, %rsi
+; X64_GISEL-NEXT:    leaq (%rdi,%rsi), %rax
 ; X64_GISEL-NEXT:    retq
 ;
 ; X64-LABEL: test_gep_i64:

--- a/llvm/test/CodeGen/X86/GlobalISel/undef.ll
+++ b/llvm/test/CodeGen/X86/GlobalISel/undef.ll
@@ -11,9 +11,6 @@ define i8 @test() {
 define i8 @add_undef_i8(i8 %a) {
 ; ALL-LABEL: add_undef_i8:
 ; ALL:       # %bb.0:
-; ALL-NEXT:    movl %edi, %eax
-; ALL-NEXT:    addb %al, %al
-; ALL-NEXT:    # kill: def $al killed $al killed $eax
 ; ALL-NEXT:    retq
   %r = add i8 %a, undef
   ret i8 %r
@@ -22,9 +19,6 @@ define i8 @add_undef_i8(i8 %a) {
 define i16 @add_undef_i16(i16 %a) {
 ; ALL-LABEL: add_undef_i16:
 ; ALL:       # %bb.0:
-; ALL-NEXT:    movl %edi, %eax
-; ALL-NEXT:    addw %ax, %ax
-; ALL-NEXT:    # kill: def $ax killed $ax killed $eax
 ; ALL-NEXT:    retq
   %r = add i16 %a, undef
   ret i16 %r
@@ -33,7 +27,6 @@ define i16 @add_undef_i16(i16 %a) {
 define i16 @add_undef_i16_commute(i16 %a) {
 ; ALL-LABEL: add_undef_i16_commute:
 ; ALL:       # %bb.0:
-; ALL-NEXT:    addw %di, %ax
 ; ALL-NEXT:    retq
   %r = add i16 undef, %a
   ret i16 %r
@@ -42,8 +35,6 @@ define i16 @add_undef_i16_commute(i16 %a) {
 define i32 @add_undef_i32(i32 %a) {
 ; ALL-LABEL: add_undef_i32:
 ; ALL:       # %bb.0:
-; ALL-NEXT:    movl %edi, %eax
-; ALL-NEXT:    addl %eax, %eax
 ; ALL-NEXT:    retq
   %r = add i32 %a, undef
   ret i32 %r


### PR DESCRIPTION
This patch supports combines for constants and undef. Primary motive is to fold muls and remove undef chains from final outputs.