### PR TITLE
[clang][bytecode] Diagnose regular CK_LValueBitCast cast nodes

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -779,6 +779,9 @@ bool Compiler<Emitter>::VisitCastExpr(const CastExpr *CE) {
     // a diagnostic if appropriate.
     return this->delegate(SubExpr);
 
+  case CK_LValueBitCast:
+    return this->emitInvalidCast(CastKind::ReinterpretLike, /*Fatal=*/true, CE);
+
   default:
     return this->emitInvalid(CE);
   }

--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -33,6 +33,10 @@ constexpr int b = b; // both-error {{must be initialized by a constant expressio
                                                       // both-note {{declared here}}
 
 
+  void func();
+  constexpr int (&fp4)() = (int(&)())func; // both-error {{constant expression}} \
+                                           // both-note {{reinterpret_cast}}
+
 struct S {
   int m;
 };


### PR DESCRIPTION
We already do this similarly for CXXReinterpretCastExprs, except in that case we try harder to make things work.