### PR TITLE
[Flang]Fix Free-Form Token Separation: Add error for identifiers without required separator

### DIFF
--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -205,8 +205,8 @@ TYPE_CONTEXT_PARSER("declaration type spec"_en_US,
 // Extensions: DOUBLE COMPLEX, BYTE
 TYPE_CONTEXT_PARSER("intrinsic type spec"_en_US,
     first(construct<IntrinsicTypeSpec>(integerTypeSpec),
-        construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Real>(
-            "REAL"_kw >> maybe(kindSelector))),
+        construct<IntrinsicTypeSpec>(
+            construct<IntrinsicTypeSpec::Real>("REAL"_kw >> maybe(kindSelector))),
         construct<IntrinsicTypeSpec>("DOUBLE PRECISION" >>
             construct<IntrinsicTypeSpec::DoublePrecision>()),
         construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Complex>(

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -205,8 +205,8 @@ TYPE_CONTEXT_PARSER("declaration type spec"_en_US,
 // Extensions: DOUBLE COMPLEX, BYTE
 TYPE_CONTEXT_PARSER("intrinsic type spec"_en_US,
     first(construct<IntrinsicTypeSpec>(integerTypeSpec),
-        construct<IntrinsicTypeSpec>(
-            construct<IntrinsicTypeSpec::Real>("REAL"_kw >> maybe(kindSelector))),
+        construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Real>(
+            "REAL"_kw >> maybe(kindSelector))),
         construct<IntrinsicTypeSpec>("DOUBLE PRECISION" >>
             construct<IntrinsicTypeSpec::DoublePrecision>()),
         construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Complex>(

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -205,8 +205,7 @@ TYPE_CONTEXT_PARSER("declaration type spec"_en_US,
 // Extensions: DOUBLE COMPLEX, BYTE
 TYPE_CONTEXT_PARSER("intrinsic type spec"_en_US,
     first(construct<IntrinsicTypeSpec>(integerTypeSpec),
-        construct<IntrinsicTypeSpec>(
-            construct<IntrinsicTypeSpec::Real>(
+        construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Real>(
                 "REAL"_kw >> maybe(kindSelector))),
         construct<IntrinsicTypeSpec>("DOUBLE PRECISION" >>
             construct<IntrinsicTypeSpec::DoublePrecision>()),

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -206,7 +206,7 @@ TYPE_CONTEXT_PARSER("declaration type spec"_en_US,
 TYPE_CONTEXT_PARSER("intrinsic type spec"_en_US,
     first(construct<IntrinsicTypeSpec>(integerTypeSpec),
         construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Real>(
-                "REAL"_kw >> maybe(kindSelector))),
+            "REAL"_kw >> maybe(kindSelector))),
         construct<IntrinsicTypeSpec>("DOUBLE PRECISION" >>
             construct<IntrinsicTypeSpec::DoublePrecision>()),
         construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Complex>(

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -206,7 +206,8 @@ TYPE_CONTEXT_PARSER("declaration type spec"_en_US,
 TYPE_CONTEXT_PARSER("intrinsic type spec"_en_US,
     first(construct<IntrinsicTypeSpec>(integerTypeSpec),
         construct<IntrinsicTypeSpec>(
-            construct<IntrinsicTypeSpec::Real>("REAL"_kw >> maybe(kindSelector))),
+            construct<IntrinsicTypeSpec::Real>(
+                "REAL"_kw >> maybe(kindSelector))),
         construct<IntrinsicTypeSpec>("DOUBLE PRECISION" >>
             construct<IntrinsicTypeSpec::DoublePrecision>()),
         construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Complex>(
@@ -221,8 +222,8 @@ TYPE_CONTEXT_PARSER("intrinsic type spec"_en_US,
             construct<IntrinsicTypeSpec>("DOUBLE COMPLEX"_sptok >>
                 construct<IntrinsicTypeSpec::DoubleComplex>())),
         extension<LanguageFeature::Byte>("nonstandard usage: BYTE"_port_en_US,
-            construct<IntrinsicTypeSpec>(construct<IntegerTypeSpec>(
-                "BYTE"_kw >> construct<std::optional<KindSelector>>(pure(1)))))))
+            construct<IntrinsicTypeSpec>(construct<IntegerTypeSpec>("BYTE"_kw >>
+                construct<std::optional<KindSelector>>(pure(1)))))))
 
 // Extension: Vector type
 // VECTOR(intrinsic-type-spec) | __VECTOR_PAIR | __VECTOR_QUAD

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -206,15 +206,15 @@ TYPE_CONTEXT_PARSER("declaration type spec"_en_US,
 TYPE_CONTEXT_PARSER("intrinsic type spec"_en_US,
     first(construct<IntrinsicTypeSpec>(integerTypeSpec),
         construct<IntrinsicTypeSpec>(
-            construct<IntrinsicTypeSpec::Real>("REAL" >> maybe(kindSelector))),
+            construct<IntrinsicTypeSpec::Real>("REAL"_kw >> maybe(kindSelector))),
         construct<IntrinsicTypeSpec>("DOUBLE PRECISION" >>
             construct<IntrinsicTypeSpec::DoublePrecision>()),
         construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Complex>(
-            "COMPLEX" >> maybe(kindSelector))),
+            "COMPLEX"_kw >> maybe(kindSelector))),
         construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Character>(
-            "CHARACTER" >> maybe(Parser<CharSelector>{}))),
+            "CHARACTER"_kw >> maybe(Parser<CharSelector>{}))),
         construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Logical>(
-            "LOGICAL" >> maybe(kindSelector))),
+            "LOGICAL"_kw >> maybe(kindSelector))),
         construct<IntrinsicTypeSpec>(unsignedTypeSpec),
         extension<LanguageFeature::DoubleComplex>(
             "nonstandard usage: DOUBLE COMPLEX"_port_en_US,
@@ -222,7 +222,7 @@ TYPE_CONTEXT_PARSER("intrinsic type spec"_en_US,
                 construct<IntrinsicTypeSpec::DoubleComplex>())),
         extension<LanguageFeature::Byte>("nonstandard usage: BYTE"_port_en_US,
             construct<IntrinsicTypeSpec>(construct<IntegerTypeSpec>(
-                "BYTE" >> construct<std::optional<KindSelector>>(pure(1)))))))
+                "BYTE"_kw >> construct<std::optional<KindSelector>>(pure(1)))))))
 
 // Extension: Vector type
 // VECTOR(intrinsic-type-spec) | __VECTOR_PAIR | __VECTOR_QUAD
@@ -241,13 +241,13 @@ TYPE_PARSER(construct<IntrinsicVectorTypeSpec>("VECTOR" >>
     parenthesized(construct<VectorElementType>(integerTypeSpec) ||
         construct<VectorElementType>(unsignedTypeSpec) ||
         construct<VectorElementType>(construct<IntrinsicTypeSpec::Real>(
-            "REAL" >> maybe(kindSelector))))))
+            "REAL"_kw >> maybe(kindSelector))))))
 
 // UNSIGNED type
-TYPE_PARSER(construct<UnsignedTypeSpec>("UNSIGNED" >> maybe(kindSelector)))
+TYPE_PARSER(construct<UnsignedTypeSpec>("UNSIGNED"_kw >> maybe(kindSelector)))
 
 // R705 integer-type-spec -> INTEGER [kind-selector]
-TYPE_PARSER(construct<IntegerTypeSpec>("INTEGER" >> maybe(kindSelector)))
+TYPE_PARSER(construct<IntegerTypeSpec>("INTEGER"_kw >> maybe(kindSelector)))
 
 // R706 kind-selector -> ( [KIND =] scalar-int-constant-expr )
 // Legacy extension: kind-selector -> * digit-string

--- a/flang/lib/Parser/token-parsers.h
+++ b/flang/lib/Parser/token-parsers.h
@@ -104,7 +104,7 @@ template <bool IsTypeKeyword = false> struct SpaceCheck {
         if constexpr (IsTypeKeyword) {
           if (!state.inFixedForm()) {
             state.Say(
-                "Unexpected syntax while parsing the statement-function statement"_err_en_US);
+                "A blank space or a separator (::) is required after the type keyword"_err_en_US);
           }
         } else {
           MissingSpace(state);

--- a/flang/test/Parser/type-keyword-space.f90
+++ b/flang/test/Parser/type-keyword-space.f90
@@ -1,30 +1,30 @@
 ! RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
 
-! CHECK: error: Unexpected syntax while parsing the statement-function statement
+! CHECK: error: A blank space or a separator (::) is required after the type keyword
 ! CHECK: reala
 program test_real
   reala(10)
 end program
 
-! CHECK: error: Unexpected syntax while parsing the statement-function statement
+! CHECK: error: A blank space or a separator (::) is required after the type keyword
 ! CHECK: integerb
 subroutine test_integer
   integerb(20)
 end subroutine
 
-! CHECK: error: Unexpected syntax while parsing the statement-function statement  
+! CHECK: error: A blank space or a separator (::) is required after the type keyword  
 ! CHECK: logicalflag
 subroutine test_logical
   logicalflag
 end subroutine
 
-! CHECK: error: Unexpected syntax while parsing the statement-function statement
+! CHECK: error: A blank space or a separator (::) is required after the type keyword
 ! CHECK: complexz
 subroutine test_complex
   complexz
 end subroutine
 
-! CHECK: error: Unexpected syntax while parsing the statement-function statement
+! CHECK: error: A blank space or a separator (::) is required after the type keyword
 ! CHECK: characterstr
 subroutine test_character
   characterstr

--- a/flang/test/Parser/type-keyword-space.f90
+++ b/flang/test/Parser/type-keyword-space.f90
@@ -1,0 +1,36 @@
+! RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
+
+! Test that a blank is required between type keywords and names in free-form
+! source per Fortran standard 6.3.2.2: "A blank shall be used to separate
+! names, constants, or labels from adjacent keywords, names, constants, or
+! labels."
+
+! CHECK: error: Unexpected syntax while parsing the statement-function statement
+! CHECK: reala
+program test_real
+  reala(10)
+end program
+
+! CHECK: error: Unexpected syntax while parsing the statement-function statement
+! CHECK: integerb
+subroutine test_integer
+  integerb(20)
+end subroutine
+
+! CHECK: error: Unexpected syntax while parsing the statement-function statement  
+! CHECK: logicalflag
+subroutine test_logical
+  logicalflag
+end subroutine
+
+! CHECK: error: Unexpected syntax while parsing the statement-function statement
+! CHECK: complexz
+subroutine test_complex
+  complexz
+end subroutine
+
+! CHECK: error: Unexpected syntax while parsing the statement-function statement
+! CHECK: characterstr
+subroutine test_character
+  characterstr
+end subroutine

--- a/flang/test/Parser/type-keyword-space.f90
+++ b/flang/test/Parser/type-keyword-space.f90
@@ -1,10 +1,5 @@
 ! RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
 
-! Test that a blank is required between type keywords and names in free-form
-! source per Fortran standard 6.3.2.2: "A blank shall be used to separate
-! names, constants, or labels from adjacent keywords, names, constants, or
-! labels."
-
 ! CHECK: error: Unexpected syntax while parsing the statement-function statement
 ! CHECK: reala
 program test_real

--- a/flang/test/Semantics/Inputs/modfile73-a.f90
+++ b/flang/test/Semantics/Inputs/modfile73-a.f90
@@ -1,7 +1,7 @@
 MODULE modfile73a
 PUBLIC re_alloc, defaults
-integersp
-integerselected_real_kind0
+integer sp
+integer selected_real_kind0
 integer:: i8b = selected_int_kind(8)
 interface
    subroutine alloc_error_report_interf(str,code)
@@ -13,12 +13,12 @@ procedure()alloc_error_report
 procedure()alloc_memory_event
   interface de_alloc
   end interface
-  charactercharacter, DEFAULT_ROUTINE
+  character character, DEFAULT_ROUTINE
   type allocDefaults
     logical copy
     logical shrink
     integer imin
-    characterroutine
+    character routine
   end type
   type(allocDefaults)DEFAULT
   integer IERR

--- a/flang/test/Semantics/Inputs/modfile73-b.f90
+++ b/flang/test/Semantics/Inputs/modfile73-b.f90
@@ -1,6 +1,6 @@
 module modfile73ba
   use modfile73a, only: re_alloc, de_alloc
-  charactermod_name
+  character mod_name
   type lData1D
      integer refCount
      character   id
@@ -42,7 +42,7 @@ end
 
 module modfile73bb
   use modfile73a, only: re_alloc, de_alloc
-  charactermod_name
+  character mod_name
   type lData1D
      integer refCount
      character   id


### PR DESCRIPTION
This patch updates Flang’s free-form parsing to correctly enforce token separation rules as specified in Section 6.3.2 [Fortran-doc](https://j3-fortran.org/doc/year/25/25-007r1.pdf). In free-form source, a blank is required to separate keywords from adjacent names/constants. The current behavior incorrectly permits constructs such as:
`real_a(10), integerb(b)`

With this change, Flang now emits a diagnostic to match the expected behavior.