### PR TITLE
[MLIR][NVVM][Tests] Re-enable matmul.py tests

### DIFF
--- a/mlir/test/Integration/GPU/CUDA/sm90/python/tools/nvgpucompiler.py
+++ b/mlir/test/Integration/GPU/CUDA/sm90/python/tools/nvgpucompiler.py
@@ -35,9 +35,11 @@ class NvgpuCompiler:
 
     def jit(self, module: ir.Module) -> execution_engine.ExecutionEngine:
         """Wraps the module in a JIT execution engine."""
-        return execution_engine.ExecutionEngine(
+        ee = execution_engine.ExecutionEngine(
             module, opt_level=self.opt_level, shared_libs=self.shared_libs
         )
+        ee.initialize()
+        return ee
 
     def compile_and_jit(self, module: ir.Module) -> execution_engine.ExecutionEngine:
         """Compiles and jits the module."""


### PR DESCRIPTION
This patch re-enables the matmul.py tests:
* Fix gpu.wait usages
* Fix gpu.launchOp usage
* Fix format-string for gpu.printf
* Fix verification failure by removing the block[0] append.
   This is now done by the python script's init.
* Fix the runtime error by adding the missing initialize() call during JIT.
* Add the missing waitGroup(0) for _ws implementation.
  This was mistakenly removed in PR #113713. Without this fix,
  I see timing issues and the _ws tests with stage>1 randomly show output mismatch.

With all these fixes, the test compiles and
executes successfully on an sm90a machine.
(locally verified for 1K iterations)