### PR TITLE
[SeparateConstOffsetFromGEP] Perform offset calculations on APInt

### DIFF
--- a/llvm/lib/Transforms/Scalar/SeparateConstOffsetFromGEP.cpp
+++ b/llvm/lib/Transforms/Scalar/SeparateConstOffsetFromGEP.cpp
@@ -216,7 +216,7 @@ public:
   /// Looks for a constant offset from the given GEP index without extracting
   /// it. It returns the numeric value of the extracted constant offset (0 if
   /// failed). The meaning of the arguments are the same as Extract.
-  static int64_t Find(Value *Idx, GetElementPtrInst *GEP);
+  static APInt Find(Value *Idx, GetElementPtrInst *GEP);
 
 private:
   ConstantOffsetExtractor(BasicBlock::iterator InsertionPt)
@@ -384,14 +384,14 @@ private:
   /// \p Variadic                  The variadic part of the original GEP.
   /// \p AccumulativeByteOffset    The constant offset.
   void lowerToSingleIndexGEPs(GetElementPtrInst *Variadic,
-                              int64_t AccumulativeByteOffset);
+                              const APInt &AccumulativeByteOffset);
 
   /// Finds the constant offset within each index and accumulates them. If
   /// LowerGEP is true, it finds in indices of both sequential and structure
   /// types, otherwise it only finds in sequential indices. The output
   /// NeedsExtraction indicates whether we successfully find a non-zero constant
   /// offset.
-  int64_t accumulateByteOffset(GetElementPtrInst *GEP, bool &NeedsExtraction);
+  APInt accumulateByteOffset(GetElementPtrInst *GEP, bool &NeedsExtraction);
 
   /// Canonicalize array indices to pointer-size integers. This helps to
   /// simplify the logic of splitting a GEP. For example, if a + b is a
@@ -874,12 +874,11 @@ Value *ConstantOffsetExtractor::Extract(Value *Idx, GetElementPtrInst *GEP,
   return IdxWithoutConstOffset;
 }
 
-int64_t ConstantOffsetExtractor::Find(Value *Idx, GetElementPtrInst *GEP) {
+APInt ConstantOffsetExtractor::Find(Value *Idx, GetElementPtrInst *GEP) {
   // If Idx is an index of an inbound GEP, Idx is guaranteed to be non-negative.
   return ConstantOffsetExtractor(GEP->getIterator())
       .find(Idx, /* SignExtended */ false, /* ZeroExtended */ false,
-            GEP->isInBounds())
-      .getSExtValue();
+            GEP->isInBounds());
 }
 
 bool SeparateConstOffsetFromGEP::canonicalizeArrayIndicesToIndexSize(
@@ -901,11 +900,11 @@ bool SeparateConstOffsetFromGEP::canonicalizeArrayIndicesToIndexSize(
   return Changed;
 }
 
-int64_t
-SeparateConstOffsetFromGEP::accumulateByteOffset(GetElementPtrInst *GEP,
-                                                 bool &NeedsExtraction) {
+APInt SeparateConstOffsetFromGEP::accumulateByteOffset(GetElementPtrInst *GEP,
+                                                       bool &NeedsExtraction) {
   NeedsExtraction = false;
-  int64_t AccumulativeByteOffset = 0;
+  unsigned IdxWidth = DL->getIndexTypeSizeInBits(GEP->getType());
+  APInt AccumulativeByteOffset(IdxWidth, 0);
   gep_type_iterator GTI = gep_type_begin(*GEP);
   for (unsigned I = 1, E = GEP->getNumOperands(); I != E; ++I, ++GTI) {
     if (GTI.isSequential()) {
@@ -914,15 +913,18 @@ SeparateConstOffsetFromGEP::accumulateByteOffset(GetElementPtrInst *GEP,
         continue;
 
       // Tries to extract a constant offset from this GEP index.
-      int64_t ConstantOffset =
-          ConstantOffsetExtractor::Find(GEP->getOperand(I), GEP);
+      APInt ConstantOffset =
+          ConstantOffsetExtractor::Find(GEP->getOperand(I), GEP)
+              .sextOrTrunc(IdxWidth);
       if (ConstantOffset != 0) {
         NeedsExtraction = true;
         // A GEP may have multiple indices.  We accumulate the extracted
         // constant offset to a byte offset, and later offset the remainder of
         // the original GEP with this byte offset.
         AccumulativeByteOffset +=
-            ConstantOffset * GTI.getSequentialElementStride(*DL);
+            ConstantOffset * APInt(IdxWidth,
+                                   GTI.getSequentialElementStride(*DL),
+                                   /*IsSigned=*/true, /*ImplicitTrunc=*/true);
       }
     } else if (LowerGEP) {
       StructType *StTy = GTI.getStructType();
@@ -931,7 +933,8 @@ SeparateConstOffsetFromGEP::accumulateByteOffset(GetElementPtrInst *GEP,
       if (Field != 0) {
         NeedsExtraction = true;
         AccumulativeByteOffset +=
-            DL->getStructLayout(StTy)->getElementOffset(Field);
+            APInt(IdxWidth, DL->getStructLayout(StTy)->getElementOffset(Field),
+                  /*IsSigned=*/true, /*ImplicitTrunc=*/true);
       }
     }
   }
@@ -939,7 +942,7 @@ SeparateConstOffsetFromGEP::accumulateByteOffset(GetElementPtrInst *GEP,
 }
 
 void SeparateConstOffsetFromGEP::lowerToSingleIndexGEPs(
-    GetElementPtrInst *Variadic, int64_t AccumulativeByteOffset) {
+    GetElementPtrInst *Variadic, const APInt &AccumulativeByteOffset) {
   IRBuilder<> Builder(Variadic);
   Type *PtrIndexTy = DL->getIndexType(Variadic->getType());
 
@@ -983,11 +986,7 @@ void SeparateConstOffsetFromGEP::lowerToSingleIndexGEPs(
 
   // Create a GEP with the constant offset index.
   if (AccumulativeByteOffset != 0) {
-    // TODO: GEP indices have sext-or-trunc semantics, so implicit truncation
-    // is fine here. However, we should really be doing this in APInt,
-    // otherwise there may be signed integer overflow.
-    Value *Offset = ConstantInt::getSigned(PtrIndexTy, AccumulativeByteOffset,
-                                           /*ImplicitTrunc=*/true);
+    Value *Offset = ConstantInt::get(PtrIndexTy, AccumulativeByteOffset);
     ResultPtr = Builder.CreatePtrAdd(ResultPtr, Offset, "uglygep");
   } else
     isSwapCandidate = false;
@@ -1011,14 +1010,14 @@ bool SeparateConstOffsetFromGEP::reorderGEP(GetElementPtrInst *GEP,
     return false;
 
   bool NestedNeedsExtraction;
-  int64_t NestedByteOffset =
-      accumulateByteOffset(PtrGEP, NestedNeedsExtraction);
+  APInt NestedByteOffset = accumulateByteOffset(PtrGEP, NestedNeedsExtraction);
   if (!NestedNeedsExtraction)
     return false;
 
   unsigned AddrSpace = PtrGEP->getPointerAddressSpace();
   if (!TTI.isLegalAddressingMode(GEP->getResultElementType(),
-                                 /*BaseGV=*/nullptr, NestedByteOffset,
+                                 /*BaseGV=*/nullptr,
+                                 NestedByteOffset.getSExtValue(),
                                  /*HasBaseReg=*/true, /*Scale=*/0, AddrSpace))
     return false;
 
@@ -1061,7 +1060,9 @@ bool SeparateConstOffsetFromGEP::splitGEP(GetElementPtrInst *GEP) {
       match(GEP->getPointerOperand(),
             m_PtrAdd(m_Value(NewBase), m_APInt(BaseOffset)));
 
-  const int64_t BaseByteOffset = ExtractBase ? BaseOffset->getSExtValue() : 0;
+  unsigned IdxWidth = DL->getIndexTypeSizeInBits(GEP->getType());
+  const APInt BaseByteOffset =
+      ExtractBase ? BaseOffset->sextOrTrunc(IdxWidth) : APInt(IdxWidth, 0);
 
   // The backend can already nicely handle the case where all indices are
   // constant.
@@ -1071,7 +1072,7 @@ bool SeparateConstOffsetFromGEP::splitGEP(GetElementPtrInst *GEP) {
   bool Changed = canonicalizeArrayIndicesToIndexSize(GEP);
 
   bool NeedsExtraction;
-  int64_t AccumulativeByteOffset =
+  APInt AccumulativeByteOffset =
       BaseByteOffset + accumulateByteOffset(GEP, NeedsExtraction);
 
   TargetTransformInfo &TTI = GetTTI(*GEP->getFunction());
@@ -1090,16 +1091,16 @@ bool SeparateConstOffsetFromGEP::splitGEP(GetElementPtrInst *GEP) {
   // case.
   if (!LowerGEP) {
     unsigned AddrSpace = GEP->getPointerAddressSpace();
-    if (!TTI.isLegalAddressingMode(GEP->getResultElementType(),
-                                   /*BaseGV=*/nullptr, AccumulativeByteOffset,
-                                   /*HasBaseReg=*/true, /*Scale=*/0,
-                                   AddrSpace)) {
+    if (!TTI.isLegalAddressingMode(
+            GEP->getResultElementType(),
+            /*BaseGV=*/nullptr, AccumulativeByteOffset.getSExtValue(),
+            /*HasBaseReg=*/true, /*Scale=*/0, AddrSpace)) {
       return Changed;
     }
   }
 
   // Track information for preserving GEP flags.
-  bool AllOffsetsNonNegative = AccumulativeByteOffset >= 0;
+  bool AllOffsetsNonNegative = AccumulativeByteOffset.isNonNegative();
   bool AllNUWPreserved = GEP->hasNoUnsignedWrap();
   bool NewGEPInBounds = GEP->isInBounds();
   bool NewGEPNUSW = GEP->hasNoUnsignedSignedWrap();
@@ -1144,7 +1145,7 @@ bool SeparateConstOffsetFromGEP::splitGEP(GetElementPtrInst *GEP) {
     AllNUWPreserved &= Base->hasNoUnsignedWrap();
     NewGEPInBounds &= Base->isInBounds();
     NewGEPNUSW &= Base->hasNoUnsignedSignedWrap();
-    AllOffsetsNonNegative &= BaseByteOffset >= 0;
+    AllOffsetsNonNegative &= BaseByteOffset.isNonNegative();
 
     GEP->setOperand(0, NewBase);
     RecursivelyDeleteTriviallyDeadInstructions(Base);
@@ -1229,7 +1230,7 @@ bool SeparateConstOffsetFromGEP::splitGEP(GetElementPtrInst *GEP) {
   Type *PtrIdxTy = DL->getIndexType(GEP->getType());
   IRBuilder<> Builder(GEP);
   NewGEP = cast<Instruction>(Builder.CreatePtrAdd(
-      NewGEP, ConstantInt::get(PtrIdxTy, AccumulativeByteOffset, true),
+      NewGEP, ConstantInt::get(PtrIdxTy, AccumulativeByteOffset),
       GEP->getName(), NewGEPFlags));
   NewGEP->copyMetadata(*GEP);
 

--- a/llvm/test/Transforms/SeparateConstOffsetFromGEP/negative-i32-offset.ll
+++ b/llvm/test/Transforms/SeparateConstOffsetFromGEP/negative-i32-offset.ll
@@ -21,8 +21,7 @@ define ptr @test_overflow(ptr %p, i32 %a) {
 ; CHECK-NEXT:    [[ADD22:%.*]] = add i32 [[A]], -2147483648
 ; CHECK-NEXT:    [[TMP1:%.*]] = shl i32 [[ADD22]], 2
 ; CHECK-NEXT:    [[UGLYGEP:%.*]] = getelementptr i8, ptr [[P]], i32 [[TMP1]]
-; CHECK-NEXT:    [[UGLYGEP3:%.*]] = getelementptr i8, ptr [[UGLYGEP]], i32 0
-; CHECK-NEXT:    ret ptr [[UGLYGEP3]]
+; CHECK-NEXT:    ret ptr [[UGLYGEP]]
 ;
   %add1 = add i32 %a, u0x80000000
   %add2 = add i32 %add1, u0x80000000
@@ -36,8 +35,7 @@ define ptr @test_xor_overflow(ptr %p, i32 range(i32 0, -2147483648) %a) {
 ; CHECK-NEXT:    [[XOR1:%.*]] = xor i32 [[A]], 2147483647
 ; CHECK-NEXT:    [[TMP1:%.*]] = shl i32 [[XOR1]], 2
 ; CHECK-NEXT:    [[UGLYGEP:%.*]] = getelementptr i8, ptr [[P]], i32 [[TMP1]]
-; CHECK-NEXT:    [[UGLYGEP2:%.*]] = getelementptr i8, ptr [[UGLYGEP]], i32 0
-; CHECK-NEXT:    ret ptr [[UGLYGEP2]]
+; CHECK-NEXT:    ret ptr [[UGLYGEP]]
 ;
   %xor = xor i32 %a, -1
   %arrayidx = getelementptr inbounds i32, ptr %p, i32 %xor


### PR DESCRIPTION
In general, GEP offset calculations are allowed to overflow (if no poison flags are set). Using int64_t for this purpose can result in C level signed integer overflow, which is UB. It also means that we incorrectly model whether some offsets are zero, and thus generate redundant zero-index GEPs.

Change the code to track offsets in APInts of the pointer index size, like we do in other places (like accumulateConstantOffset etc).