### PR TITLE
[clang][bytecode] Don't evaluate builtin_assume argument

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -5153,6 +5153,10 @@ bool Compiler<Emitter>::VisitBuiltinCallExpr(const CallExpr *E,
       return false;
 
   } break;
+  case Builtin::BI__assume:
+  case Builtin::BI__builtin_assume:
+    // Argument is not evaluated.
+    break;
   default:
     if (!Context::isUnevaluatedBuiltin(BuiltinID)) {
       // Put arguments on the stack.

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -248,12 +248,13 @@ static bool interp__builtin_is_constant_evaluated(InterpState &S, CodePtr OpPC,
   return true;
 }
 
-// __builtin_assume(int)
+// __builtin_assume
+// __assume (MS extension)
 static bool interp__builtin_assume(InterpState &S, CodePtr OpPC,
                                    const InterpFrame *Frame,
                                    const CallExpr *Call) {
+  // Nothing to be done here since the argument is NOT evaluated.
   assert(Call->getNumArgs() == 1);
-  discard(S.Stk, *S.getContext().classify(Call->getArg(0)));
   return true;
 }
 

--- a/clang/test/AST/ByteCode/builtins.cpp
+++ b/clang/test/AST/ByteCode/builtins.cpp
@@ -3,9 +3,6 @@
 // RUN: %clang_cc1 -verify=ref %s -Wno-constant-evaluated -fms-extensions
 // RUN: %clang_cc1 -verify=ref %s -Wno-constant-evaluated %s -fms-extensions -emit-llvm -o - | FileCheck %s
 
-// expected-no-diagnostics
-// ref-no-diagnostics
-
 using size_t = decltype(sizeof(int));
 
 namespace std {
@@ -31,6 +28,14 @@ constexpr bool assume() {
   return true;
 }
 static_assert(assume(), "");
+
+constexpr int assumeArgIsUnevaluated() {
+  int a = 0;
+  __builtin_assume(++a); // expected-warning {{assumption is ignored because it contains (potential) side-effects}} \
+                         // ref-warning {{assumption is ignored because it contains (potential) side-effects}}
+  return a;
+}
+static_assert(assumeArgIsUnevaluated() == 0, "");
 
 void test_builtin_os_log(void *buf, int i, const char *data) {
   constexpr int len = __builtin_os_log_format_buffer_size("%d %{public}s %{private}.16P", i, data, data);

--- a/clang/test/Parser/MicrosoftExtensions.c
+++ b/clang/test/Parser/MicrosoftExtensions.c
@@ -1,4 +1,6 @@
-// RUN: %clang_cc1 -triple i386-mingw32 -fsyntax-only -Wno-missing-declarations -verify -fms-extensions  %s
+// RUN: %clang_cc1 -triple i386-mingw32 -fsyntax-only -Wno-missing-declarations -verify -fms-extensions %s
+// RUN: %clang_cc1 -triple i386-mingw32 -fsyntax-only -Wno-missing-declarations -verify -fms-extensions %s -fexperimental-new-constant-interpreter
+
 __stdcall int func0(void);
 int __stdcall func(void);
 typedef int (__cdecl *tptr)(void);


### PR DESCRIPTION
This is what the current interpreter does.