### PR TITLE
[OpenCL] Add missing mipmap read_write image builtins to OpenCLBuiltins.td

### DIFF
--- a/clang/lib/Sema/OpenCLBuiltins.td
+++ b/clang/lib/Sema/OpenCLBuiltins.td
@@ -1528,7 +1528,7 @@ let Extension = FuncExtOpenCLCDeviceEnqueue in {
 // OpenCL Extension v2.0 s9.18 - Mipmaps
 let Extension = FuncExtKhrMipmapImage in {
   // Added to section 6.13.14.2.
-  foreach aQual = ["RO"] in {
+  foreach aQual = ["RO", "RW"] in {
     foreach imgTy = [Image2d] in {
       foreach name = ["read_imagef"] in {
         def : Builtin<name, [VectorType<Float, 4>, ImageType<imgTy, aQual>, Sampler, VectorType<Float, 2>, Float], Attr.Pure>;
@@ -1630,7 +1630,7 @@ let Extension = FuncExtKhrMipmapImage in {
 // Write functions are enabled using a separate extension.
 let Extension = FuncExtKhrMipmapImageWrites in {
   // Added to section 6.13.14.4.
-  foreach aQual = ["WO"] in {
+  foreach aQual = ["WO", "RW"] in {
     foreach imgTy = [Image2d] in {
       def : Builtin<"write_imagef", [Void, ImageType<imgTy, aQual>, VectorType<Int, 2>, Int, VectorType<Float, 4>]>;
       def : Builtin<"write_imagei", [Void, ImageType<imgTy, aQual>, VectorType<Int, 2>, Int, VectorType<Int, 4>]>;

--- a/clang/test/SemaOpenCL/fdeclare-opencl-builtins.cl
+++ b/clang/test/SemaOpenCL/fdeclare-opencl-builtins.cl
@@ -50,6 +50,7 @@ typedef char char2 __attribute__((ext_vector_type(2)));
 typedef char char4 __attribute__((ext_vector_type(4)));
 typedef uchar uchar4 __attribute__((ext_vector_type(4)));
 typedef uchar uchar16 __attribute__((ext_vector_type(16)));
+typedef float float2 __attribute__((ext_vector_type(2)));
 typedef float float4 __attribute__((ext_vector_type(4)));
 typedef float float16 __attribute__((ext_vector_type(16)));
 typedef half half4 __attribute__((ext_vector_type(4)));
@@ -302,6 +303,62 @@ kernel void basic_image_writeonly(write_only image1d_buffer_t image_write_only_i
 #if __OPENCL_C_VERSION__ <= CL_VERSION_1_2 && !defined(__OPENCL_CPP_VERSION__)
   // expected-error@-2{{no matching function for call to 'write_imagef'}}
 #endif
+}
+
+kernel void basic_image_readwrite_depth(read_write image2d_depth_t image_read_write_image2d_depth) {
+#if __OPENCL_C_VERSION__ < CL_VERSION_2_0 && !defined(__OPENCL_CPP_VERSION__)
+  // expected-error@-2{{access qualifier 'read_write' cannot be used for '__read_write image2d_depth_t' prior to OpenCL C version 2.0 or in version 3.0 and without __opencl_c_read_write_images feature}}
+#endif
+  int2 i2;
+  float f;
+  float2 f2;
+  sampler_t sampler;
+  float resf;
+
+  resf = read_imagef(image_read_write_image2d_depth, i2);
+  resf = read_imagef(image_read_write_image2d_depth, sampler, f2, f);
+  resf = read_imagef(image_read_write_image2d_depth, sampler, f2, f2, f2);
+}
+
+kernel void basic_image_readwrite_array_depth(read_write image2d_array_depth_t image_read_write_image2d_array_depth) {
+#if __OPENCL_C_VERSION__ < CL_VERSION_2_0 && !defined(__OPENCL_CPP_VERSION__)
+  // expected-error@-2{{access qualifier 'read_write' cannot be used for '__read_write image2d_array_depth_t' prior to OpenCL C version 2.0 or in version 3.0 and without __opencl_c_read_write_images feature}}
+#endif
+  int4 i4;
+  float f;
+  float2 f2;
+  float4 f4;
+  sampler_t sampler;
+  float resf;
+
+  resf = read_imagef(image_read_write_image2d_array_depth, i4);
+  resf = read_imagef(image_read_write_image2d_array_depth, sampler, f4, f);
+  resf = read_imagef(image_read_write_image2d_array_depth, sampler, f4, f2, f2);
+}
+
+kernel void basic_image_write_readwrite_depth(read_write image2d_depth_t image_read_write_image2d_depth) {
+#if __OPENCL_C_VERSION__ < CL_VERSION_2_0 && !defined(__OPENCL_CPP_VERSION__)
+  // expected-error@-2{{access qualifier 'read_write' cannot be used for '__read_write image2d_depth_t' prior to OpenCL C version 2.0 or in version 3.0 and without __opencl_c_read_write_images feature}}
+#endif
+  int i;
+  int2 i2;
+  float f;
+
+  write_imagef(image_read_write_image2d_depth, i2, f);
+  write_imagef(image_read_write_image2d_depth, i2, i, f);
+}
+
+kernel void basic_image_write_readwrite_array_depth(read_write image2d_array_depth_t image_read_write_image2d_array_depth) {
+#if __OPENCL_C_VERSION__ < CL_VERSION_2_0 && !defined(__OPENCL_CPP_VERSION__)
+  // expected-error@-2{{access qualifier 'read_write' cannot be used for '__read_write image2d_array_depth_t' prior to OpenCL C version 2.0 or in version 3.0 and without __opencl_c_read_write_images feature}}
+#endif
+  int i;
+  int4 i4;
+  float f;
+  float resf;
+
+  write_imagef(image_read_write_image2d_array_depth, i4, f);
+  write_imagef(image_read_write_image2d_array_depth, i4, i, f);
 }
 
 kernel void basic_subgroup(global uint *out) {


### PR DESCRIPTION
This issue was discovered while writing tests for #175120.