### PR TITLE
ids-check: Disable workflow on push

### DIFF
--- a/.github/workflows/ids-check.yml
+++ b/.github/workflows/ids-check.yml
@@ -1,10 +1,6 @@
 name: "Check LLVM ABI annotations"
 on:
   pull_request:
-  push:
-    branches:
-      - 'main'
-      - 'release/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
The workflow is only meant to run on PRs.