### PR TITLE
[llvm][docs] Release process improvements

### DIFF
--- a/llvm/docs/HowToReleaseLLVM.rst
+++ b/llvm/docs/HowToReleaseLLVM.rst
@@ -109,21 +109,19 @@ Branch the Git trunk using the following procedure:
 #. Verify the current git trunk is in decent shape by examining the status
    checks on the `most recent commits <https://github.com/llvm/llvm-project/commits/main>`_
 
-#. Bump the version in trunk to ``N.0.0git``, clear the release notes, and tag
-   the commit with ``llvmorg-N-init``.
-   If ``X`` is the version to be released, then ``N`` is ``X + 1``. ::
+#. Bump the version in trunk to ``N.0.0git`` and clear the release notes: ::
 
     $ llvm/utils/release/bump-version.py --git N.0.0
     $ llvm/utils/release/clear-release-notes.py
     $ git commit -am "Bump version to N.0.0git"
-    $ GPG_TTY=$(tty) git tag -sa llvmorg-N-init -m "llvmorg-N-init"
-
-#. Push changes to trunk: ::
-
     $ git push origin main
 
-#. Push tag to trunk: ::
+   If the push fails, rebase if necessary and try again.
 
+#. Tag the commit bumping the version on trunk with ``llvmorg-N-init``. If
+   ``X`` is the version to be released, then ``N`` is ``X + 1``. ::
+
+    $ GPG_TTY=$(tty) git tag -sa llvmorg-N-init -m "llvmorg-N-init"
     $ git push origin llvmorg-N-init
 
 #. Create the release branch from the last known good revision before the
@@ -146,6 +144,7 @@ Branch the Git trunk using the following procedure:
 #. And finally, create the release branch in ``llvm-test-suite`` repo: ::
 
     $ cd <llvm-test-suite>
+    $ git checkout main
     $ git pull
     $ git checkout -b release/X.x
     $ git push -u origin release/X.x

--- a/llvm/docs/HowToReleaseLLVM.rst
+++ b/llvm/docs/HowToReleaseLLVM.rst
@@ -106,32 +106,49 @@ Create Release Branch and Update LLVM Version
 
 Branch the Git trunk using the following procedure:
 
-#. Remind developers that the release branching is imminent and to refrain from
-   committing patches that might break the build, e.g., new features, large
-   patches for works in progress, an overhaul of the type system, an exciting
-   new TableGen feature, etc.
+#. Verify the current git trunk is in decent shape by examining the status
+   checks on the `most recent commits <https://github.com/llvm/llvm-project/commits/main>`_
 
-#. Verify that the current git trunk is in decent shape by
-   examining nightly tester and buildbot results.
-
-#. Bump the version in trunk to ``N.0.0git`` with the script in
-   ``llvm/utils/release/bump-version.py``, and tag the commit with ``llvmorg-N-init``.
+#. Bump the version in trunk to ``N.0.0git``, clear the release notes, and tag
+   the commit with ``llvmorg-N-init``.
    If ``X`` is the version to be released, then ``N`` is ``X + 1``. ::
 
-    $ git tag -sa llvmorg-N-init
+    $ llvm/utils/release/bump-version.py --git N.0.0
+    $ llvm/utils/release/clear-release-notes.py
+    $ git commit -am "Bump version to N.0.0git"
+    $ GPG_TTY=$(tty) git tag -sa llvmorg-N-init -m "llvmorg-N-init"
 
-#. Clear the release notes in trunk with the script in
-   ``llvm/utils/release/clear-release-notes.py``.
+#. Push changes to trunk: ::
 
-#. Create the release branch from the last known good revision from before the
-   version bump.  The branch's name is ``release/X.x`` where ``X`` is the major version
-   number and ``x`` is just the letter ``x``.
+    $ git push origin main
 
-#. On the newly-created release branch, immediately bump the version
-   to ``X.1.0git`` (where ``X`` is the major version of the branch.)
+#. Push tag to trunk: ::
 
-#. All tags and branches need to be created in both the ``llvm/llvm-project`` and
-   ``llvm/llvm-test-suite`` repos.
+    $ git push origin llvmorg-N-init
+
+#. Create the release branch from the last known good revision before the
+   version bump. The branch name is ``release/X.x`` where ``X`` is the major
+   version number and ``x`` is just the letter ``x``. Assuming the revision
+   before the version bump is ok, this would be: ::
+
+    $ git checkout -b release/X.x llvmorg-N-init^
+
+#. On the newly-created release branch, immediately bump the version to
+   ``X.1.0git`` (where ``X`` is the major version number): ::
+
+    $ llvm/utils/release/bump-version.py --git X.1.0
+    $ git commit -am "Bump version to X.1.0git"
+
+#. Push release branch: ::
+
+    $ git push -u origin release/X.x
+
+#. And finally, create the release branch in ``llvm-test-suite`` repo: ::
+
+    $ cd <llvm-test-suite>
+    $ git pull
+    $ git checkout -b release/X.x
+    $ git push -u origin release/X.x
 
 Tagging the LLVM Release Candidates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Some improvements from working through this getting LLVM 22 off the ground. Most of the changes are pretty straightforward, but one worth mentioning is the change to push the trunk version bump and tag before creating the release branch.

This avoids a scenario that was hit for 22 where the release/22.x branch was pushed first and more commits landed in trunk before the 23.0.0git version bump was rebased and committed. The commits landed on trunk during this brief window had the wrong version. This was resolved by cherry-picking the commits to the release branch.

It's not entirely clear how big of an issue this really is, but if we can avoid it and make the process less stressful in the process I think it makes sense to do so.