### PR TITLE
[flang][NFC] fix typo in mlirTypeToIntrinsicFortran

### DIFF
--- a/flang/include/flang/Optimizer/Support/Utils.h
+++ b/flang/include/flang/Optimizer/Support/Utils.h
@@ -85,7 +85,7 @@ inline std::string mlirTypeToIntrinsicFortran(fir::FirOpBuilder &builder,
       return "REAL(KIND="s + std::to_string(*kind) + ")";
   } else if (auto cplxTy = mlir::dyn_cast<mlir::ComplexType>(type)) {
     if (std::optional<int> kind = mlirFloatTypeToKind(cplxTy.getElementType()))
-      return "COMPLEX(KIND+"s + std::to_string(*kind) + ")";
+      return "COMPLEX(KIND="s + std::to_string(*kind) + ")";
   } else if (type.isUnsignedInteger()) {
     if (type.isInteger(8))
       return "UNSIGNED(KIND=1)";


### PR DESCRIPTION
Fix pretty printing of complex function types in the error messages when no runtime function is found to implement some intrinsic in lowering.