### PR TITLE
Remove LLVM_ABI from symbolicate declaration in BacktraceTools.h

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/BacktraceTools.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/BacktraceTools.h
@@ -78,7 +78,7 @@ public:
 
   /// Given a backtrace, try to symbolicate any unsymbolicated lines using the
   /// symbol addresses in the dumped symbol table.
-  LLVM_ABI std::string symbolicate(StringRef Backtrace);
+  std::string symbolicate(StringRef Backtrace);
 
 private:
   DumpedSymbolTable(std::unique_ptr<MemoryBuffer> SymtabBuffer);


### PR DESCRIPTION
If I try and build llvm/clang using the following

```
cmake -S ./llvm/ -B build -G Ninja                `
        -DCMAKE_ASM_MASM_FLAGS="-m64"     `
        -DLLVM_ENABLE_PROJECTS="clang"              `
        -DLLVM_ENABLE_PLUGINS=On                    `
        -DLLVM_TARGETS_TO_BUILD="host"              `
        -DCMAKE_BUILD_TYPE=RelWithDebInfo           `
        -DCMAKE_CXX_COMPILER=clang-cl               `
        -DCMAKE_C_COMPILER=clang-cl                 `
        -DCMAKE_ASM_MASM_COMPILER=llvm-ml           `
        -DLLVM_BUILD_LLVM_DYLIB_VIS=On              `
        -DLLVM_LINK_LLVM_DYLIB=On                   `
        -DCLANG_ENABLE_STATIC_ANALYZER=OFF                  `
        -DCLANG_LINK_CLANG_DYLIB=On                                 
  cmake --build build --config RelWithDebInfo --parallel 4
```

Then I get the following error 

```
FAILED: [code=1] lib/ExecutionEngine/Orc/CMakeFiles/LLVMOrcJIT.dir/BacktraceTools.cpp.obj 
C:\PROGRA~1\LLVM\bin\clang-cl.exe  /nologo -TP -DLLVM_EXPORTS -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_HAS_EXCEPTIONS=0 -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -ID:\a\clad\clad\llvm-project\build\lib\ExecutionEngine\Orc -ID:\a\clad\clad\llvm-project\llvm\lib\ExecutionEngine\Orc -ID:\a\clad\clad\llvm-project\build\include -ID:\a\clad\clad\llvm-project\llvm\include /DWIN32 /D_WINDOWS   /Zc:inline /Zc:__cplusplus -gcodeview-ghash /Oi /bigobj /permissive- -Werror=unguarded-availability-new /W4  -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wno-pass-failed -Wmisleading-indentation -Wctad-maybe-unsupported /Gw /O2 /Ob1 /DNDEBUG -std:c++17 -MD -Zi /Zc:dllexportInlines- /EHs-c- /GR- /showIncludes /Folib\ExecutionEngine\Orc\CMakeFiles\LLVMOrcJIT.dir\BacktraceTools.cpp.obj /Fdlib\ExecutionEngine\Orc\CMakeFiles\LLVMOrcJIT.dir\LLVMOrcJIT.pdb -c -- D:\a\clad\clad\llvm-project\llvm\lib\ExecutionEngine\Orc\BacktraceTools.cpp
In file included from D:\a\clad\clad\llvm-project\llvm\lib\ExecutionEngine\Orc\BacktraceTools.cpp:9:
D:\a\clad\clad\llvm-project\llvm\include\llvm/ExecutionEngine/Orc/BacktraceTools.h(81,3): error: attribute 'dllexport' cannot be applied to member of 'dllexport' class
   81 |   LLVM_ABI std::string symbolicate(StringRef Backtrace);
      |   ^
D:\a\clad\clad\llvm-project\llvm\include\llvm/Support/Compiler.h(188,29): note: expanded from macro 'LLVM_ABI'
  188 | #define LLVM_ABI __declspec(dllexport)
      |                             ^
D:\a\clad\clad\llvm-project\llvm\include\llvm/ExecutionEngine/Orc/BacktraceTools.h(74,7): note: previous attribute is here
   74 | class LLVM_ABI DumpedSymbolTable {
      |       ^
D:\a\clad\clad\llvm-project\llvm\include\llvm/Support/Compiler.h(188,29): note: expanded from macro 'LLVM_ABI'
  188 | #define LLVM_ABI __declspec(dllexport)
      |                             ^
1 error generated.
[1862/4339] Building CXX object lib\ExecutionEngine\Orc\CMakeFiles\LLVMOrcJIT.dir\COFFVCRuntimeSuppo
```

This can be seen in the following workflow run here https://github.com/vgvassilev/clad/actions/runs/20958692652/job/60229731491?pr=1154#step:19:2313 which builds against llvms main, commit

```
commit c6013a196611f88672537961c8cc90237f353dad
Author: Abhinav Pradeep <abhinav.pradeep@oracle.com>
Date:   Tue Jan 13 23:30:10 2026 +1000
```

Looking at the build error symbolicate in `llvm/ExecutionEngine/Orc/BacktraceTools.h` was incorrectly annotated with LLVM_ABI in https://github.com/llvm/llvm-project/pull/175469. Therefore this PR removes this annotation. 