### PR TITLE
Nominations for code coverage maintainer in Clang

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -206,6 +206,9 @@ Code Coverage
 | Takumi Nakamura
 | geek4civic\@gmail.com (email), chapuni(GitHub), chapuni (Discord), chapuni (Discourse)
 
+| Alan Phipps
+| a-phipps\@ti.com (email), evodius96 (GitHub), evodius96 (Discourse)
+
 
 Tools
 -----

--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -201,6 +201,12 @@ Function Effect Analysis
 | aeternalmail\@gmail.com (email), Sirraide (GitHub), Ætérnal (Discord), Sirraide (Discourse)
 
 
+Code Coverage
+~~~~~~~~~~~~~
+| Takumi Nakamura
+| geek4civic\@gmail.com (email), chapuni(GitHub), chapuni (Discord), chapuni (Discourse)
+
+
 Tools
 -----
 These maintainers are responsible for user-facing tools under the Clang


### PR DESCRIPTION
Per discussion on [Discourse](https://discourse.llvm.org/t/rfc-integrating-singlebytecoverage-with-branch-coverage/82492/15), I am nominating @chapuni and @evodius96 as maintainers of code coverage in Clang.

Please accept this PR to signal your acceptance of the nomination, if you'd like.

Additionally, I took a shot at adding contact information for you, so please let me know if anything is wrong or missing.