### PR TITLE
Revert "Silence -Wunused-parameter warnings in Unwind-wasm.c"

### DIFF
--- a/libunwind/src/Unwind-wasm.c
+++ b/libunwind/src/Unwind-wasm.c
@@ -102,7 +102,8 @@ _LIBUNWIND_EXPORT uintptr_t _Unwind_GetIP(struct _Unwind_Context *context) {
 }
 
 /// Not used in Wasm.
-_LIBUNWIND_EXPORT void _Unwind_SetIP(struct _Unwind_Context *, uintptr_t) {}
+_LIBUNWIND_EXPORT void _Unwind_SetIP(struct _Unwind_Context *context,
+                                     uintptr_t value) {}
 
 /// Called by personality handler to get LSDA for current frame.
 _LIBUNWIND_EXPORT uintptr_t
@@ -114,7 +115,8 @@ _Unwind_GetLanguageSpecificData(struct _Unwind_Context *context) {
 }
 
 /// Not used in Wasm.
-_LIBUNWIND_EXPORT uintptr_t _Unwind_GetRegionStart(struct _Unwind_Context *) {
+_LIBUNWIND_EXPORT uintptr_t
+_Unwind_GetRegionStart(struct _Unwind_Context *context) {
   return 0;
 }
 


### PR DESCRIPTION
Reverts llvm/llvm-project#125412

See the discussion in #125412 for why this is necessary.  The summary is that:

- Eliding arguments is the C23 extension, but libunwind builds its C files with `-std=c99`, so this change broke the build.
- `-Wno-unused-parameter` is part of the build for libunwind, so the codebase does allow them.