### PR TITLE
[lit] Remove error message for %T

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1921,14 +1921,6 @@ def applySubstitutions(script, substitutions, conditions={}, recursion_limit=Non
             # seems reasonable.
             ln = _caching_re_compile(a).sub(str(b), escapePercents(ln))
 
-        # TODO(boomanaiden154): Remove when we branch LLVM 22 so people on the
-        # release branch will have sufficient time to migrate.
-        if bool(_caching_re_compile("%T").search(ln)):
-            raise ValueError(
-                "%T is no longer supported. Please create directories with names "
-                "based on %t."
-            )
-
         # Strip the trailing newline and any extra whitespace.
         return ln.strip()
 

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/capital-t-error-message.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/capital-t-error-message.txt
@@ -1,2 +1,0 @@
-# Check that we return a decent error message when someone uses %T
-# RUN: echo %T > %t

--- a/llvm/utils/lit/tests/shtest-shell.py
+++ b/llvm/utils/lit/tests/shtest-shell.py
@@ -12,10 +12,6 @@
 
 # CHECK: -- Testing:
 
-# CHECK: UNRESOLVED: shtest-shell :: capital-t-error-message.txt
-# CHECK: *** TEST 'shtest-shell :: capital-t-error-message.txt' FAILED ***
-# CHECK: ValueError: %T is no longer supported. Please create directories with names based on %t.
-
 # CHECK: FAIL: shtest-shell :: colon-error.txt
 # CHECK: *** TEST 'shtest-shell :: colon-error.txt' FAILED ***
 # CHECK: :
@@ -637,5 +633,5 @@
 #      CHECK: ***
 
 # CHECK: PASS: shtest-shell :: valid-shell.txt
-# CHECK: Unresolved Tests (2)
+# CHECK: Unresolved Tests (1)
 # CHECK: Failed Tests (37)


### PR DESCRIPTION
We left an error message for users of %T through the LLVM 22 branch point to hopefully make it easier for anyone migrating versions rather than having the checks silently fail with a %T ending up in the executed command. Now that 22 has branched, we can remove this check as we all downstream users should have seen the error by this point.