### PR TITLE
[RISCV][test] Fix `rda-stack.mir` test.

### DIFF
--- a/llvm/test/CodeGen/RISCV/rda-stack.mir
+++ b/llvm/test/CodeGen/RISCV/rda-stack.mir
@@ -113,15 +113,13 @@ body:             |
   ; CHECK-NEXT: %stack.0:{ }
   ; CHECK-NEXT: 2: SD $x10, %stack.0, 0 :: (store (s64))
   ; CHECK-EMPTY: 
-  ; CHECK-NEXT: $x0:{ }
-  ; CHECK-NEXT: $x0:{ }
-  ; CHECK-NEXT: 3: BEQ $x0, $x0, %bb.3
+  ; CHECK-NEXT: 3: PseudoBR %bb.3
   ; CHECK-EMPTY: 
-  ; CHECK-NEXT: $x10:{ 1 }
+  ; CHECK-NEXT: $x10:{ }
   ; CHECK-NEXT: 4: $x10 = ADDI $x10, 2
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: $x10:{ 4 }
-  ; CHECK-NEXT: %stack.0:{ 2 }
+  ; CHECK-NEXT: %stack.0:{ }
   ; CHECK-NEXT: 5: SD $x10, %stack.0, 0 :: (store (s64))
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %stack.0:{ 2 5 }
@@ -138,7 +136,7 @@ body:             |
     liveins: $x10
     $x10 = ADDI $x10, 1
     SD $x10, %stack.0, 0 :: (store (s64))
-    BEQ $x0, $x0, %bb.3
+    PseudoBR %bb.3
 
   bb.2:
     liveins: $x10


### PR DESCRIPTION
It was using `BEQ $x0, $x0, ...` which is treated as conditional branch. The intent of the test was to use unconditional branch. Replace it with `PseudoBR ...`.