### PR TITLE
[DTLTO] Add DTLTO-specific LTO input handling time-trace scopes

### DIFF
--- a/lld/test/ELF/dtlto/timetrace.test
+++ b/lld/test/ELF/dtlto/timetrace.test
@@ -34,7 +34,7 @@ CHECK:      "name": "Add input for DTLTO"
 CHECK:      "name": "Add input for DTLTO"
 CHECK:      "name": "Remove temporary inputs for DTLTO"
 CHECK:      "name": "Save input archive member for DTLTO"
-CHECK-SAME:   "detail": "t1.a(t1.bc at [[#ARCHIVE_OFFSET:]]).1.[[PID:[a-fA-F0-9]+]].o"
+CHECK-SAME:   "detail": "t1.a(t1.bc at [[#ARCHIVE_OFFSET:]]).1.[[PID:[A-F0-9]+]].o"
 CHECK:      "name": "Total Add input for DTLTO"
 CHECK-SAME:   "count": 2,
 CHECK:      "name": "Total Remove temporary inputs for DTLTO"

--- a/lld/test/ELF/dtlto/timetrace.test
+++ b/lld/test/ELF/dtlto/timetrace.test
@@ -1,0 +1,65 @@
+REQUIRES: x86
+
+## Test that DTLTO-specific LTO input file handling time-trace output is
+## produced as expected.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+RUN: sed 's/@t1/@t2/g' t1.ll > t2.ll
+
+## Generate ThinLTO bitcode files.
+RUN: opt -thinlto-bc t1.ll -o t1.bc
+RUN: opt -thinlto-bc t2.ll -o t2.bc
+
+## Create archives.
+RUN: llvm-ar rcs t1.a t1.bc
+RUN: llvm-ar rcsT t2.thin.a t2.bc
+
+## Generate object files for mock.py to return.
+RUN: llc t1.ll --filetype=obj -o t1.o
+RUN: llc t2.ll --filetype=obj -o t2.o
+
+## Link and generate a time-trace.
+## Note: mock.py doesn't compile; it copies the specified object files to the
+## outputs in job order.
+RUN: ld.lld --whole-archive t1.a t2.thin.a -o my.elf \
+RUN:   --thinlto-distributor=%python \
+RUN:   --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py \
+RUN:   --thinlto-distributor-arg=t1.o --thinlto-distributor-arg=t2.o \
+RUN:   --time-trace-granularity=0 --time-trace=%t.json
+RUN: %python filter_order_and_pprint.py %t.json | FileCheck %s
+
+## Check that DTLTO add input file events are recorded.
+CHECK:      "name": "Add input for DTLTO"
+CHECK:      "name": "Add input for DTLTO"
+CHECK:      "name": "Remove temporary inputs for DTLTO"
+CHECK:      "name": "Save input archive member for DTLTO"
+CHECK-SAME:   "detail": "t1.a(t1.bc at [[#ARCHIVE_OFFSET:]]).1.[[PID:[a-fA-F0-9]+]].o"
+CHECK:      "name": "Total Add input for DTLTO"
+CHECK-SAME:   "count": 2,
+CHECK:      "name": "Total Remove temporary inputs for DTLTO"
+CHECK-SAME:   "count": 1,
+CHECK:      "name": "Total Save input archive member for DTLTO"
+CHECK-SAME:   "count": 1,
+
+#--- t1.ll
+target triple = "x86_64-unknown-linux-gnu"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+
+define void @t1() {
+  ret void
+}
+
+#--- filter_order_and_pprint.py
+import json, sys
+
+data = json.load(open(sys.argv[1], "r", encoding="utf-8"))
+
+# Get DTLTO events.
+events = [e for e in data["traceEvents"] if "DTLTO" in e["name"]]
+events.sort(key=lambda e: (e["name"], str(e.get("args", {}).get("detail", ""))))
+
+# Print an event per line. Ensure 'name' is the first key.
+for ev in events:
+    name = ev.pop("name")
+    print(json.dumps({"name": name, **ev}))

--- a/llvm/include/llvm/DTLTO/DTLTO.h
+++ b/llvm/include/llvm/DTLTO/DTLTO.h
@@ -29,6 +29,9 @@ private:
   // Removes temporary files.
   LLVM_ABI void removeTempFiles();
 
+  // Internal bookeeping.
+  bool RemoveTempFiles = true;
+
   // Determines if a file at the given path is a thin archive file.
   Expected<bool> isThinArchive(const StringRef ArchivePath);
 

--- a/llvm/include/llvm/DTLTO/DTLTO.h
+++ b/llvm/include/llvm/DTLTO/DTLTO.h
@@ -19,7 +19,7 @@ class DTLTO : public LTO {
 public:
   // Inherit contructors from LTO base class.
   using LTO::LTO;
-  ~DTLTO() { removeTempFiles(); }
+  ~DTLTO() {}
 
 private:
   // Bump allocator for a purpose of saving updated module IDs.
@@ -28,9 +28,6 @@ private:
 
   // Removes temporary files.
   LLVM_ABI void removeTempFiles();
-
-  // Internal bookeeping.
-  bool RemoveTempFiles = true;
 
   // Determines if a file at the given path is a thin archive file.
   Expected<bool> isThinArchive(const StringRef ArchivePath);

--- a/llvm/include/llvm/DTLTO/DTLTO.h
+++ b/llvm/include/llvm/DTLTO/DTLTO.h
@@ -37,7 +37,6 @@ private:
   BumpPtrAllocator PtrAlloc;
   StringSaver Saver{PtrAlloc};
 
-
   // Determines if a file at the given path is a thin archive file.
   Expected<bool> isThinArchive(const StringRef ArchivePath);
 
@@ -53,7 +52,6 @@ private:
 
   // A cache to avoid repeatedly reading the same archive file.
   StringMap<bool> ArchiveFiles;
-
 };
 
 } // namespace lto

--- a/llvm/include/llvm/DTLTO/DTLTO.h
+++ b/llvm/include/llvm/DTLTO/DTLTO.h
@@ -16,18 +16,27 @@ namespace llvm {
 namespace lto {
 
 class DTLTO : public LTO {
+  using Base = LTO;
+
 public:
-  // Inherit contructors from LTO base class.
-  using LTO::LTO;
-  ~DTLTO() {}
+  // Inherit constructors.
+  using Base::Base;
+  ~DTLTO() override = default;
+
+  // Add an input file and prepare it for distribution.
+  LLVM_ABI Expected<std::shared_ptr<InputFile>>
+  addInput(std::unique_ptr<InputFile> InputPtr) override;
+
+protected:
+  LLVM_ABI llvm::Error handleArchiveInputs() override;
+
+  LLVM_ABI void cleanup() override;
 
 private:
   // Bump allocator for a purpose of saving updated module IDs.
   BumpPtrAllocator PtrAlloc;
   StringSaver Saver{PtrAlloc};
 
-  // Removes temporary files.
-  LLVM_ABI void removeTempFiles();
 
   // Determines if a file at the given path is a thin archive file.
   Expected<bool> isThinArchive(const StringRef ArchivePath);
@@ -45,19 +54,8 @@ private:
   // A cache to avoid repeatedly reading the same archive file.
   StringMap<bool> ArchiveFiles;
 
-public:
-  // Adds the input file to the LTO object's list of input files.
-  // For archive members, generates a new module ID which is a path to a real
-  // file on a filesystem.
-  LLVM_ABI virtual Expected<std::shared_ptr<lto::InputFile>>
-  addInput(std::unique_ptr<lto::InputFile> InputPtr) override;
-
-  // Entry point for DTLTO archives support.
-  LLVM_ABI virtual llvm::Error handleArchiveInputs() override;
-
-  // Remove the temporary DTLTO input files.
-  LLVM_ABI virtual void cleanup() override;
 };
+
 } // namespace lto
 } // namespace llvm
 

--- a/llvm/include/llvm/DTLTO/DTLTO.h
+++ b/llvm/include/llvm/DTLTO/DTLTO.h
@@ -54,6 +54,9 @@ public:
 
   // Entry point for DTLTO archives support.
   LLVM_ABI virtual llvm::Error handleArchiveInputs() override;
+
+  // Remove the temporary DTLTO input files.
+  LLVM_ABI virtual void cleanup() override;
 };
 } // namespace lto
 } // namespace llvm

--- a/llvm/include/llvm/LTO/LTO.h
+++ b/llvm/include/llvm/LTO/LTO.h
@@ -443,6 +443,13 @@ public:
   LLVM_ABI static SmallVector<const char *>
   getRuntimeLibcallSymbols(const Triple &TT);
 
+protected:
+  // Finalise inputs before run().
+  virtual Error handleArchiveInputs() { return Error::success(); }
+
+  // Clean up after run().
+  virtual void cleanup() {}
+
 private:
   Config Conf;
 
@@ -620,10 +627,6 @@ public:
   addInput(std::unique_ptr<lto::InputFile> InputPtr) {
     return std::shared_ptr<lto::InputFile>(InputPtr.release());
   }
-
-  virtual llvm::Error handleArchiveInputs() { return llvm::Error::success(); }
-
-  virtual void cleanup() {}
 };
 
 /// The resolution for a symbol. The linker must provide a SymbolResolution for

--- a/llvm/include/llvm/LTO/LTO.h
+++ b/llvm/include/llvm/LTO/LTO.h
@@ -444,10 +444,10 @@ public:
   getRuntimeLibcallSymbols(const Triple &TT);
 
 protected:
-  // Finalise inputs before run().
+  // Called at the start of run().
   virtual Error handleArchiveInputs() { return Error::success(); }
 
-  // Clean up after run().
+  // Called before returning from run().
   virtual void cleanup() {}
 
 private:

--- a/llvm/include/llvm/LTO/LTO.h
+++ b/llvm/include/llvm/LTO/LTO.h
@@ -622,6 +622,8 @@ public:
   }
 
   virtual llvm::Error handleArchiveInputs() { return llvm::Error::success(); }
+
+  virtual void cleanup() {}
 };
 
 /// The resolution for a symbol. The linker must provide a SymbolResolution for

--- a/llvm/lib/DTLTO/DTLTO.cpp
+++ b/llvm/lib/DTLTO/DTLTO.cpp
@@ -216,4 +216,7 @@ llvm::Error lto::DTLTO::handleArchiveInputs() {
 }
 
 // Cleanup after LTO is complete.
-void lto::DTLTO::cleanup() { removeTempFiles(); }
+void lto::DTLTO::cleanup() {
+  removeTempFiles();
+  LTO::cleanup();
+}

--- a/llvm/lib/DTLTO/DTLTO.cpp
+++ b/llvm/lib/DTLTO/DTLTO.cpp
@@ -215,4 +215,3 @@ void lto::DTLTO::cleanup() {
   }
   Base::cleanup();
 }
-

--- a/llvm/lib/DTLTO/DTLTO.cpp
+++ b/llvm/lib/DTLTO/DTLTO.cpp
@@ -120,9 +120,6 @@ Expected<bool> lto::DTLTO::isThinArchive(const StringRef ArchivePath) {
 // Removes any temporary regular archive member files that were created during
 // processing.
 void lto::DTLTO::removeTempFiles() {
-  if (!RemoveTempFiles)
-    return;
-
   TimeTraceScope TimeScope("Remove temporary inputs for DTLTO");
   for (auto &Input : InputFiles) {
     if (Input->isMemberOfArchive())

--- a/llvm/lib/DTLTO/DTLTO.cpp
+++ b/llvm/lib/DTLTO/DTLTO.cpp
@@ -120,6 +120,9 @@ Expected<bool> lto::DTLTO::isThinArchive(const StringRef ArchivePath) {
 // Removes any temporary regular archive member files that were created during
 // processing.
 void lto::DTLTO::removeTempFiles() {
+  if (!RemoveTempFiles)
+    return;
+
   TimeTraceScope TimeScope("Remove temporary inputs for DTLTO");
   for (auto &Input : InputFiles) {
     if (Input->isMemberOfArchive())

--- a/llvm/lib/DTLTO/DTLTO.cpp
+++ b/llvm/lib/DTLTO/DTLTO.cpp
@@ -215,5 +215,5 @@ llvm::Error lto::DTLTO::handleArchiveInputs() {
   return Error::success();
 }
 
-// Cleanup temporary files after LTO is complete.
+// Cleanup after LTO is complete.
 void lto::DTLTO::cleanup() { removeTempFiles(); }

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -1215,7 +1215,6 @@ Error LTO::checkPartiallySplit() {
 }
 
 Error LTO::run(AddStreamFn AddStream, FileCache Cache) {
-
   llvm::scope_exit CleanUp([this]() { cleanup(); });
 
   if (Error EC = handleArchiveInputs())

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -1215,6 +1215,9 @@ Error LTO::checkPartiallySplit() {
 }
 
 Error LTO::run(AddStreamFn AddStream, FileCache Cache) {
+
+  llvm::scope_exit CleanUp([this]() { cleanup(); });
+
   if (Error EC = handleArchiveInputs())
     return EC;
 
@@ -1271,8 +1274,6 @@ Error LTO::run(AddStreamFn AddStream, FileCache Cache) {
 
   if (StatsFile)
     PrintStatisticsJSON(StatsFile->os());
-
-  cleanup();
 
   return Result;
 }

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -1272,6 +1272,8 @@ Error LTO::run(AddStreamFn AddStream, FileCache Cache) {
   if (StatsFile)
     PrintStatisticsJSON(StatsFile->os());
 
+  cleanup();
+
   return Result;
 }
 


### PR DESCRIPTION
Add time-trace scopes to the DTLTO-specific input-handling code to improve observability and debugging.

These scopes are tested via LLD, as the primary purpose of this code is to support member files of non-thin archives as DTLTO inputs. `llvm-lto2` does not currently support archives. Adding archive support to `llvm-lto2` solely for testing these scopes does not appear to be worthwhile.

As part of this change, the deletion of temporary DTLTO input files has been moved. Cleanup now occurs after LTO has completed, rather than during destruction of the LTO object ~~, although the destructor still performs cleanup in case LTO terminates early due to an error~~ _(Note that in the final revision of this PR a `scope_exit` construct in `LTO::run` is used to ensure cleanup, so the call in the destructor was not required)_. By the time the LTO object is destroyed, time traces have already been finalized, so no additional trace data can be recorded.

Recording time-trace data for temporary file deletion is important, as this has been a source of performance issues in the past and an area where we expect to make further performance improvements if supported by the data.

SIE internal tracker: TOOLCHAIN-21021

Rendered time trace output from the included LLD Lit test:

<img width="515" height="104" alt="image" src="https://github.com/user-attachments/assets/a69d84f8-69df-46d4-9e2a-0fb04ae09edd" />

<img width="1902" height="216" alt="image" src="https://github.com/user-attachments/assets/0001ecbe-9dbf-4a98-a9b5-69fc8a600bb3" />