### PR TITLE
[flang][cuda] Remove extra managed spelling from bbc

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -9913,7 +9913,7 @@ void ResolveNamesVisitor::FinishSpecificationPart(
         SetBindNameOn(symbol);
       }
     }
-    // -gpu=mem:managed: implicitly treat allocatable arrays as managed.
+    // Implicitly treat allocatable arrays as managed when feature is enabled.
     // This is done after all explicit CUDA attributes have been processed.
     if (context().languageFeatures().IsEnabled(
             common::LanguageFeature::CudaManaged))

--- a/flang/test/Lower/CUDA/cuda-gpu-managed.cuf
+++ b/flang/test/Lower/CUDA/cuda-gpu-managed.cuf
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-hlfir -fcuda -gpu=mem:managed %s -o - | FileCheck %s
+! RUN: bbc -emit-hlfir -fcuda -gpu=managed %s -o - | FileCheck %s
 
 ! Test -gpu=managed flag: allocatable arrays without explicit CUDA attributes
 ! should be implicitly treated as managed.

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -638,11 +638,10 @@ int main(int argc, char **argv) {
         Fortran::common::LanguageFeature::CudaWarpMatchFunction, false);
   }
 
-  if (enableGPUMode == "managed" || enableGPUMode == "mem:managed") {
+  if (enableGPUMode == "managed")
     options.features.Enable(Fortran::common::LanguageFeature::CudaManaged);
-  } else if (enableGPUMode == "unified" || enableGPUMode == "mem:unified") {
+  else if (enableGPUMode == "unified")
     options.features.Enable(Fortran::common::LanguageFeature::CudaUnified);
-  }
 
   if (fixedForm) {
     options.isFixedForm = fixedForm;


### PR DESCRIPTION
`bbc` is just a testing tool so we don't need to support multiple option spelling. Keep it simple. 