### PR TITLE
[AMDGPU][Scheduler] Fix use-after-poison by printing before deleting

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -2357,9 +2357,9 @@ void PreRARematStage::rollback(const RollbackInfo &Rollback,
   Register Reg = RematMI->getOperand(0).getReg();
   Register OriginalReg = Remat->DefMI->getOperand(0).getReg();
   Remat->UseMI->substituteRegister(Reg, OriginalReg, 0, *DAG.TRI);
-  DAG.deleteMI(Remat->UseRegion, RematMI);
   REMAT_DEBUG(dbgs() << '[' << Remat->UseRegion
                      << "] Deleting rematerialization " << *RematMI);
+  DAG.deleteMI(Remat->UseRegion, RematMI);
 
   // Regenerate the original register's interval as slot indices may have
   // changed slightly from before re-scheduling, and re-add it as a


### PR DESCRIPTION
A buildbot was failing with a use-after-poison (https://lab.llvm.org/buildbot/#/builders/24/builds/16530) after https://github.com/llvm/llvm-project/pull/175050:
```
==llc==1532559==ERROR: AddressSanitizer: use-after-poison on address 0xe26e74e12368 at pc 0xb36d41bd74dc bp 0xffffed72a450 sp 0xffffed72a448
READ of size 8 at 0xe26e74e12368 thread T0
    #0 0xb36d41bd74d8 in llvm::MachineInstr::print(llvm::raw_ostream&, bool, bool, bool, bool, llvm::TargetInstrInfo const*) const /home/b/sanitizer-aarch64-linux-bootstrap-asan/build/llvm-project/llvm/lib/CodeGen/MachineInstr.cpp:1796:35
    #1 0xb36d3e221b08 in operator<< /home/b/sanitizer-aarch64-linux-bootstrap-asan/build/llvm-project/llvm/include/llvm/CodeGen/MachineInstr.h:2150:6
    #2 0xb36d3e221b08 in llvm::PreRARematStage::rollback(llvm::PreRARematStage::RollbackInfo const&, llvm::BitVector&) const /home/b/sanitizer-aarch64-linux-bootstrap-asan/build/llvm-project/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp:2363:57
...
```

This is because it was printing an instruction that had already been deleted. This patch fixes this by reversing the order.