### PR TITLE
[PatternMatch] Implement match_fn using bind_back (NFC)

### DIFF
--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -50,17 +50,11 @@ template <typename Val, typename Pattern> bool match(Val *V, const Pattern &P) {
   return P.match(V);
 }
 
-template <typename Val, typename Pattern> struct MatchFunctor {
-  const Pattern &P;
-  MatchFunctor(const Pattern &P) : P(P) {}
-  bool operator()(Val *V) const { return P.match(V); }
-};
-
 /// A match functor that can be used as a UnaryPredicate in functional
 /// algorithms like all_of.
 template <typename Val = const Value, typename Pattern>
-MatchFunctor<Val, Pattern> match_fn(const Pattern &P) {
-  return P;
+auto match_fn(const Pattern &P) {
+  return bind_back<match<Val, Pattern>>(P);
 }
 
 template <typename Pattern> bool match(ArrayRef<int> Mask, const Pattern &P) {

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -53,8 +53,8 @@ template <typename Val, typename Pattern> bool match(Val *V, const Pattern &P) {
 /// A match functor that can be used as a UnaryPredicate in functional
 /// algorithms like all_of.
 template <typename Val = const Value, typename Pattern>
-constexpr auto match_fn(const Pattern &P) {
-  return bind_back<match<Val, Pattern>>(P);
+auto match_fn(const Pattern &P) {
+  return bind_back(match<Val, Pattern>, P);
 }
 
 template <typename Pattern> bool match(ArrayRef<int> Mask, const Pattern &P) {

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -53,7 +53,7 @@ template <typename Val, typename Pattern> bool match(Val *V, const Pattern &P) {
 /// A match functor that can be used as a UnaryPredicate in functional
 /// algorithms like all_of.
 template <typename Val = const Value, typename Pattern>
-auto match_fn(const Pattern &P) {
+constexpr auto match_fn(const Pattern &P) {
   return bind_back<match<Val, Pattern>>(P);
 }
 

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -54,7 +54,7 @@ template <typename Val, typename Pattern> bool match(Val *V, const Pattern &P) {
 /// algorithms like all_of.
 template <typename Val = const Value, typename Pattern>
 auto match_fn(const Pattern &P) {
-  return bind_back(match<Val, Pattern>, P);
+  return bind_back<match<Val, Pattern>>(P);
 }
 
 template <typename Pattern> bool match(ArrayRef<int> Mask, const Pattern &P) {

--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -26,7 +26,7 @@ template <typename Val, typename Pattern> bool match(Val *V, const Pattern &P) {
 /// A match functor that can be used as a UnaryPredicate in functional
 /// algorithms like all_of.
 template <typename Val, typename Pattern> auto match_fn(const Pattern &P) {
-  return bind_back(match<Val, Pattern>, P);
+  return bind_back<match<Val, Pattern>>(P);
 }
 
 template <typename Pattern> bool match(VPUser *U, const Pattern &P) {
@@ -36,7 +36,7 @@ template <typename Pattern> bool match(VPUser *U, const Pattern &P) {
 
 /// Match functor for VPUser.
 template <typename Pattern> auto match_fn(const Pattern &P) {
-  return bind_back(match<Pattern>, P);
+  return bind_back<match<Pattern>>(P);
 }
 
 template <typename Pattern> bool match(VPSingleDefRecipe *R, const Pattern &P) {

--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -23,26 +23,25 @@ template <typename Val, typename Pattern> bool match(Val *V, const Pattern &P) {
   return P.match(V);
 }
 
+/// A match functor that can be used as a UnaryPredicate in functional
+/// algorithms like all_of.
+template <typename Val, typename Pattern>
+constexpr auto match_fn(const Pattern &P) {
+  return bind_back<match<Val, Pattern>>(P);
+}
+
 template <typename Pattern> bool match(VPUser *U, const Pattern &P) {
   auto *R = dyn_cast<VPRecipeBase>(U);
   return R && match(R, P);
 }
 
-template <typename Pattern> bool match(VPSingleDefRecipe *R, const Pattern &P) {
-  return P.match(static_cast<const VPRecipeBase *>(R));
+/// Match functor for VPUser.
+template <typename Pattern> constexpr auto match_fn(const Pattern &P) {
+  return bind_back<match<Pattern>>(P);
 }
 
-template <typename Val, typename Pattern> struct VPMatchFunctor {
-  const Pattern &P;
-  VPMatchFunctor(const Pattern &P) : P(P) {}
-  bool operator()(Val *V) const { return match(V, P); }
-};
-
-/// A match functor that can be used as a UnaryPredicate in functional
-/// algorithms like all_of.
-template <typename Val = VPUser, typename Pattern>
-VPMatchFunctor<Val, Pattern> match_fn(const Pattern &P) {
-  return P;
+template <typename Pattern> bool match(VPSingleDefRecipe *R, const Pattern &P) {
+  return P.match(static_cast<const VPRecipeBase *>(R));
 }
 
 template <typename Class> struct class_match {

--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -25,9 +25,8 @@ template <typename Val, typename Pattern> bool match(Val *V, const Pattern &P) {
 
 /// A match functor that can be used as a UnaryPredicate in functional
 /// algorithms like all_of.
-template <typename Val, typename Pattern>
-constexpr auto match_fn(const Pattern &P) {
-  return bind_back<match<Val, Pattern>>(P);
+template <typename Val, typename Pattern> auto match_fn(const Pattern &P) {
+  return bind_back(match<Val, Pattern>, P);
 }
 
 template <typename Pattern> bool match(VPUser *U, const Pattern &P) {
@@ -36,8 +35,8 @@ template <typename Pattern> bool match(VPUser *U, const Pattern &P) {
 }
 
 /// Match functor for VPUser.
-template <typename Pattern> constexpr auto match_fn(const Pattern &P) {
-  return bind_back<match<Pattern>>(P);
+template <typename Pattern> auto match_fn(const Pattern &P) {
+  return bind_back(match<Pattern>, P);
 }
 
 template <typename Pattern> bool match(VPSingleDefRecipe *R, const Pattern &P) {


### PR DESCRIPTION
Use llvm::bind_back landed in d2a521750 ([ADT] Introduce bind_{front,back}, [not_]equal_to, #175056) to simplify implementations of match_fn in PatternMatch and VPlanPatternMatch.