### PR TITLE
[lldb][windows] add STDIN and STDOUT forwarding support

### DIFF
--- a/lldb/include/lldb/Host/windows/ProcessLauncherWindows.h
+++ b/lldb/include/lldb/Host/windows/ProcessLauncherWindows.h
@@ -11,7 +11,7 @@
 
 #include "lldb/Host/ProcessLauncher.h"
 #include "lldb/Host/windows/windows.h"
-#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/Error.h"
 
 namespace lldb_private {
 
@@ -37,6 +37,13 @@ public:
   ///     failure.
   static llvm::ErrorOr<ProcThreadAttributeList>
   Create(STARTUPINFOEXW &startupinfoex);
+
+  /// Setup the PseudoConsole handle in the underlying
+  /// LPPROC_THREAD_ATTRIBUTE_LIST.
+  ///
+  /// \param hPC
+  ///     The handle to the PseudoConsole.
+  llvm::Error SetupPseudoConsole(HPCON hPC);
 
   ~ProcThreadAttributeList() {
     if (lpAttributeList) {

--- a/lldb/include/lldb/Host/windows/PseudoConsole.h
+++ b/lldb/include/lldb/Host/windows/PseudoConsole.h
@@ -61,6 +61,16 @@ public:
   ///     invalid.
   HANDLE GetSTDINHandle() const { return m_conpty_input; };
 
+  /// Drains initialization sequences from the ConPTY output pipe.
+  ///
+  /// When a process first attaches to a ConPTY, Windows emits VT100/ANSI escape
+  /// sequences (ESC[2J for clear screen, ESC[H for cursor home and more) as
+  /// part of the PseudoConsole initialization. To prevent these sequences from
+  /// appearing in the debugger output (and flushing lldb's shell for instance)
+  /// we launch a short-lived dummy process that triggers the initialization,
+  /// then drain all output before launching the actual debuggee.
+  llvm::Error DrainInitSequences();
+
 protected:
   HANDLE m_conpty_handle = ((HANDLE)(long long)-1);
   HANDLE m_conpty_output = ((HANDLE)(long long)-1);

--- a/lldb/source/Host/windows/ProcessLauncherWindows.cpp
+++ b/lldb/source/Host/windows/ProcessLauncherWindows.cpp
@@ -106,6 +106,15 @@ ProcThreadAttributeList::Create(STARTUPINFOEXW &startupinfoex) {
   return ProcThreadAttributeList(startupinfoex.lpAttributeList);
 }
 
+llvm::Error ProcThreadAttributeList::SetupPseudoConsole(HPCON hPC) {
+  BOOL ok = UpdateProcThreadAttribute(lpAttributeList, 0,
+                                      PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, hPC,
+                                      sizeof(hPC), NULL, NULL);
+  if (!ok)
+    return llvm::errorCodeToError(llvm::mapWindowsError(GetLastError()));
+  return llvm::Error::success();
+}
+
 HostProcess
 ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
                                       Status &error) {
@@ -136,15 +145,15 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
     error = attributelist_or_err.getError();
     return HostProcess();
   }
+  ProcThreadAttributeList attributelist = std::move(*attributelist_or_err);
+
   llvm::scope_exit delete_attributelist(
       [&] { DeleteProcThreadAttributeList(startupinfoex.lpAttributeList); });
 
   std::vector<HANDLE> inherited_handles;
   if (use_pty) {
-    if (!UpdateProcThreadAttribute(startupinfoex.lpAttributeList, 0,
-                                   PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE, hPC,
-                                   sizeof(hPC), NULL, NULL)) {
-      error = Status(::GetLastError(), eErrorTypeWin32);
+    if (auto err = attributelist.SetupPseudoConsole(hPC)) {
+      error = Status::FromError(std::move(err));
       return HostProcess();
     }
   } else {

--- a/lldb/source/Host/windows/ProcessLauncherWindows.cpp
+++ b/lldb/source/Host/windows/ProcessLauncherWindows.cpp
@@ -116,9 +116,8 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
   startupinfoex.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
 
   HPCON hPC = launch_info.GetPTY().GetPseudoTerminalHandle();
-  bool use_pty = hPC != INVALID_HANDLE_VALUE &&
-                 launch_info.GetNumFileActions() == 0 &&
-                 launch_info.GetFlags().Test(lldb::eLaunchFlagLaunchInTTY);
+  bool use_pty =
+      hPC != INVALID_HANDLE_VALUE && launch_info.GetNumFileActions() == 0;
 
   HANDLE stdin_handle = GetStdioHandle(launch_info, STDIN_FILENO);
   HANDLE stdout_handle = GetStdioHandle(launch_info, STDOUT_FILENO);
@@ -199,7 +198,7 @@ ProcessLauncherWindows::LaunchProcess(const ProcessLaunchInfo &launch_info,
 
   BOOL result = ::CreateProcessW(
       wexecutable.c_str(), pwcommandLine, NULL, NULL,
-      /*bInheritHandles=*/!inherited_handles.empty(), flags, environment.data(),
+      /*bInheritHandles=*/TRUE, flags, environment.data(),
       wworkingDirectory.size() == 0 ? NULL : wworkingDirectory.c_str(),
       reinterpret_cast<STARTUPINFOW *>(&startupinfoex), &pi);
 

--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -146,9 +146,12 @@ llvm::Error PseudoConsole::DrainInitSequences() {
   auto attributelist_or_err = ProcThreadAttributeList::Create(startupinfoex);
   if (!attributelist_or_err)
     return llvm::errorCodeToError(attributelist_or_err.getError());
+  ProcThreadAttributeList attributelist = std::move(*attributelist_or_err);
+  if (auto error = attributelist.SetupPseudoConsole(m_conpty_handle))
+    return error;
 
   PROCESS_INFORMATION pi = {};
-  wchar_t cmdline[] = L"echo foo";
+  wchar_t cmdline[] = L"cmd.exe /c 'echo foo && exit'";
 
   if (!CreateProcessW(/*lpApplicationName=*/NULL, cmdline,
                       /*lpProcessAttributes=*/NULL, /*lpThreadAttributes=*/NULL,

--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -121,7 +121,8 @@ llvm::Error PseudoConsole::OpenPseudoConsole() {
 
   if (auto error = DrainInitSequences()) {
     Log *log = GetLog(LLDBLog::Host);
-    LLDB_LOG(log, "error: {0}", error);
+    LLDB_LOG_ERROR(log, std::move(error),
+                   "failed to finalize ConPTY's setup: {0}");
   }
 
   return llvm::Error::success();

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -1024,6 +1024,10 @@ public:
 
     DWORD consoleMode;
     bool isConsole = GetConsoleMode(hStdin, &consoleMode) != 0;
+    // With ENABLE_LINE_INPUT, ReadFile returns only when a carriage return is
+    // read. This will block lldb in ReadFile until the user hits enter. Save
+    // the previous console mode to restore it later and remove
+    // ENABLE_LINE_INPUT.
     DWORD oldConsoleMode = consoleMode;
     SetConsoleMode(hStdin,
                    consoleMode & ~ENABLE_LINE_INPUT & ~ENABLE_ECHO_INPUT);

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -1047,7 +1047,9 @@ public:
         if (isConsole) {
           auto hasInputOrErr = ConsoleHasTextInput(hStdin);
           if (!hasInputOrErr) {
-            llvm::consumeError(hasInputOrErr.takeError());
+            Log *log = GetLog(WindowsLog::Process);
+            LLDB_LOG_ERROR(log, hasInputOrErr.takeError(),
+                           "failed to process debuggee's IO: {0}");
             goto exit_loop;
           }
 

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -1007,6 +1007,8 @@ public:
             if (!PeekConsoleInput(hStdin, &inputRecord, 1, &numRead))
               goto exit_loop;
 
+            // If the pipe is empty, go back to waiting on
+            // WaitForMultipleObjects rather than ReadFile.
             if (numRead == 0)
               goto read_loop;
 
@@ -1051,7 +1053,7 @@ public:
     }
 
   exit_loop:;
-  SetIsRunning(false);
+    SetIsRunning(false);
   }
 
   void Cancel() override {

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -959,7 +959,7 @@ public:
         m_process(process),
         m_read_file(GetInputFD(), File::eOpenOptionReadOnly, false),
         m_write_file(conpty_input) {
-    m_pipe.CreateNew();
+    m_interrupt_event = INVALID_HANDLE_VALUE;
   }
 
   ~IOHandlerProcessSTDIOWindows() override = default;
@@ -970,9 +970,36 @@ public:
     m_is_running = running;
   }
 
+  /// Peek the console for input. If it has any, drain the pipe until text input
+  /// is found or the pipe is empty.
+  ///
+  /// \param[in, out] hStdin
+  ///     The handle to the standard input's pipe.
+  ///
+  /// \return
+  ///     true if the pipe has text input.
+  llvm::Expected<bool> ConsoleHasTextInput(HANDLE hStdin) {
+    while (true) {
+      INPUT_RECORD inputRecord;
+      DWORD numRead = 0;
+      if (!PeekConsoleInput(hStdin, &inputRecord, 1, &numRead))
+        return llvm::createStringError("Failed to peek standard input.");
+
+      if (numRead == 0)
+        return false;
+
+      if (inputRecord.EventType == KEY_EVENT &&
+          inputRecord.Event.KeyEvent.bKeyDown &&
+          inputRecord.Event.KeyEvent.uChar.AsciiChar != 0)
+        return true;
+
+      if (!ReadConsoleInput(hStdin, &inputRecord, 1, &numRead))
+        return llvm::createStringError("Failed to read standard input.");
+    }
+  }
+
   void Run() override {
-    if (!m_read_file.IsValid() || m_write_file == INVALID_HANDLE_VALUE ||
-        !m_pipe.CanRead() || !m_pipe.CanWrite()) {
+    if (!m_read_file.IsValid() || m_write_file == INVALID_HANDLE_VALUE) {
       SetIsDone(true);
       return;
     }
@@ -980,15 +1007,13 @@ public:
     SetIsDone(false);
     SetIsRunning(true);
 
-    HANDLE hStdin = (HANDLE)_get_osfhandle(m_read_file.GetDescriptor());
-    HANDLE hInterrupt = (HANDLE)_get_osfhandle(m_pipe.GetReadFileDescriptor());
-    HANDLE waitHandles[2] = {hStdin, hInterrupt};
+    HANDLE hStdin = m_read_file.GetWaitableHandle();
+    HANDLE waitHandles[2] = {hStdin, m_interrupt_event};
 
     DWORD consoleMode;
     bool isConsole = GetConsoleMode(hStdin, &consoleMode) != 0;
 
     while (true) {
-    read_loop:;
       {
         std::lock_guard<std::mutex> guard(m_mutex);
         if (GetIsDone())
@@ -1001,27 +1026,13 @@ public:
         goto exit_loop;
       case WAIT_OBJECT_0: {
         if (isConsole) {
-          while (true) {
-            INPUT_RECORD inputRecord;
-            DWORD numRead = 0;
-            if (!PeekConsoleInput(hStdin, &inputRecord, 1, &numRead))
-              goto exit_loop;
+          auto hasInputOrErr = ConsoleHasTextInput(hStdin);
+          if (hasInputOrErr.takeError())
+            goto exit_loop;
 
-            // If the pipe is empty, go back to waiting on
-            // WaitForMultipleObjects rather than ReadFile.
-            if (numRead == 0)
-              goto read_loop;
-
-            // We only care about text input. Consume all non text input events
-            // before letting ReadFile handle text input.
-            if (inputRecord.EventType == KEY_EVENT &&
-                inputRecord.Event.KeyEvent.bKeyDown &&
-                inputRecord.Event.KeyEvent.uChar.AsciiChar != 0)
-              break;
-
-            if (!ReadConsoleInput(hStdin, &inputRecord, 1, &numRead))
-              goto exit_loop;
-          }
+          // If no text input is ready, go back to waiting.
+          if (!*hasInputOrErr)
+            continue;
         }
 
         char ch = 0;
@@ -1035,14 +1046,10 @@ public:
         break;
       }
       case WAIT_OBJECT_0 + 1: {
-        char ch = 0;
-        DWORD read = 0;
-        if (!ReadFile(hInterrupt, &ch, 1, &read, nullptr) || read != 1)
+        ControlOp op = m_pending_op.exchange(eControlOpNone);
+        if (op == eControlOpQuit)
           goto exit_loop;
-
-        if (ch == eControlOpQuit)
-          goto exit_loop;
-        if (ch == eControlOpInterrupt &&
+        if (op == eControlOpInterrupt &&
             StateIsRunningState(m_process->GetState()))
           m_process->SendAsyncInterrupt();
         break;
@@ -1060,18 +1067,16 @@ public:
     std::lock_guard<std::mutex> guard(m_mutex);
     SetIsDone(true);
     if (m_is_running) {
-      char ch = eControlOpQuit;
-      if (llvm::Error err = m_pipe.Write(&ch, 1).takeError()) {
-        LLDB_LOG_ERROR(GetLog(LLDBLog::Process), std::move(err),
-                       "Pipe write failed: {0}");
-      }
+      m_pending_op.store(eControlOpQuit);
+      ::SetEvent(m_interrupt_event);
     }
   }
 
   bool Interrupt() override {
     if (m_active) {
-      char ch = eControlOpInterrupt;
-      return !errorToBool(m_pipe.Write(&ch, 1).takeError());
+      m_pending_op.store(eControlOpInterrupt);
+      ::SetEvent(m_interrupt_event);
+      return true;
     }
     if (StateIsRunningState(m_process->GetState())) {
       m_process->SendAsyncInterrupt();
@@ -1083,19 +1088,21 @@ public:
   void GotEOF() override {}
 
 private:
-  Process *m_process;
-  NativeFile m_read_file; // Read from this file (usually actual STDIN for LLDB
-  HANDLE m_write_file =
-      INVALID_HANDLE_VALUE; // Write to this file (usually the primary pty for
-                            // getting io to debuggee)
-  Pipe m_pipe;
-  std::mutex m_mutex;
-  bool m_is_running = false;
-
   enum ControlOp : char {
     eControlOpQuit = 'q',
     eControlOpInterrupt = 'i',
+    eControlOpNone = 0,
   };
+
+  Process *m_process;
+  /// Read from this file (usually actual STDIN for LLDB)
+  NativeFile m_read_file;
+  /// Write to this file (usually the primary pty for getting io to debuggee)
+  HANDLE m_write_file = INVALID_HANDLE_VALUE;
+  HANDLE m_interrupt_event = INVALID_HANDLE_VALUE;
+  std::atomic<ControlOp> m_pending_op{eControlOpNone};
+  std::mutex m_mutex;
+  bool m_is_running = false;
 };
 
 void ProcessWindows::SetPseudoConsoleHandle(

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -1007,7 +1007,8 @@ public:
                 numRead == 0)
               goto exit_loop;
 
-            // We only care about text input. Consume all non text input events before letting ReadFile handle text input.
+            // We only care about text input. Consume all non text input events
+            // before letting ReadFile handle text input.
             if (inputRecord.EventType == KEY_EVENT &&
                 inputRecord.Event.KeyEvent.bKeyDown &&
                 inputRecord.Event.KeyEvent.uChar.AsciiChar != 0)

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -1003,8 +1003,7 @@ public:
           while (true) {
             INPUT_RECORD inputRecord;
             DWORD numRead = 0;
-            if (!PeekConsoleInput(hStdin, &inputRecord, 1, &numRead) ||
-                numRead == 0)
+            if (!PeekConsoleInput(hStdin, &inputRecord, 1, &numRead))
               goto exit_loop;
 
             // We only care about text input. Consume all non text input events

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -958,9 +958,7 @@ public:
                   IOHandler::Type::ProcessIO),
         m_process(process),
         m_read_file(GetInputFD(), File::eOpenOptionReadOnly, false),
-        m_write_file(conpty_input) {
-    m_interrupt_event = INVALID_HANDLE_VALUE;
-  }
+        m_write_file(conpty_input), m_interrupt_event(INVALID_HANDLE_VALUE) {}
 
   ~IOHandlerProcessSTDIOWindows() override = default;
 
@@ -973,12 +971,12 @@ public:
   /// Peek the console for input. If it has any, drain the pipe until text input
   /// is found or the pipe is empty.
   ///
-  /// \param[in, out] hStdin
+  /// \param hStdin
   ///     The handle to the standard input's pipe.
   ///
   /// \return
   ///     true if the pipe has text input.
-  llvm::Expected<bool> ConsoleHasTextInput(HANDLE hStdin) {
+  llvm::Expected<bool> ConsoleHasTextInput(const HANDLE hStdin) {
     while (true) {
       INPUT_RECORD inputRecord;
       DWORD numRead = 0;

--- a/lldb/test/Shell/Settings/TestFrameFormatColor.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatColor.test
@@ -9,4 +9,4 @@ c
 q
 
 # Check the ASCII escape code
-# CHECK: 
+# CHECK: {{\[[0-9;]+m}}

--- a/lldb/test/Shell/Settings/TestFrameFormatNoColor.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatNoColor.test
@@ -9,4 +9,4 @@ c
 q
 
 # Check the ASCII escape code
-# CHECK-NOT: 
+# CHECK-NOT: {{\[[0-9;]+m}}


### PR DESCRIPTION
This patch enables standard input and standard output forwarding in lldb.

A debuggee using `std::cin` will currently hang because lldb does not forward stdin to it. Similarly, the output of a debuggee printing with `std::cout` will not appear either. This patch fixes both of those things using the ConPTY which was implemented in https://github.com/llvm/llvm-project/pull/168729.

This patch also fixes an infinite wait in `IOHandlerProcessSTDIOWindows`.

There were 2 issues:
1. `WaitForMultipleObjects` returns when a non text input is received. `ReadFile` however, does not, causing an infinite wait. This patch ensures that, if `hstdin` is a console handle, we don't try to call `ReadFile` on non text input (key up events for instance).
2. `IOHandlerProcessSTDIOWindows::Cancel()` writes to `m_pipe` but that does not cause `WaitForMultipleObjects` to return because it's waiting on the wrong handle.

Fixes:
1. `m_read_pipe` is consumed until a text character is reached (if any).
2. `IOHandlerProcessSTDIOWindows` does not use a pipe for inter thread communication anymore, but rather an overlapped event with an `std::atomic` representing the state.

I was not able to write a test for this. I have tried writing a shell test with `echo` piping commands to `lldb`, and also a custom Python script which sends the commands to `lldb` over stdin, but none of them work.

Related issues:
- fixes https://github.com/llvm/llvm-project/issues/175652

rdar://168587474