### PR TITLE
[libc++] Disallow static variables in constexpr functions pre-C++23

### DIFF
--- a/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
+++ b/libcxx/test/tools/clang_tidy_checks/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SOURCES
     proper_version_checks.cpp
     robust_against_adl.cpp
     robust_against_operator_ampersand.cpp
+    static_in_constexpr.cpp
     uglify_attributes.cpp
 
     libcpp_module.cpp

--- a/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
@@ -17,6 +17,7 @@
 #include "proper_version_checks.hpp"
 #include "robust_against_adl.hpp"
 #include "robust_against_operator_ampersand.hpp"
+#include "static_in_constexpr.hpp"
 #include "uglify_attributes.hpp"
 
 namespace {
@@ -32,6 +33,7 @@ public:
     check_factories.registerCheck<libcpp::robust_against_adl_check>("libcpp-robust-against-adl");
     check_factories.registerCheck<libcpp::robust_against_operator_ampersand>(
         "libcpp-robust-against-operator-ampersand");
+    check_factories.registerCheck<libcpp::static_in_constexpr>("libcpp-static-in-constexpr");
     check_factories.registerCheck<libcpp::uglify_attributes>("libcpp-uglify-attributes");
   }
 };

--- a/libcxx/test/tools/clang_tidy_checks/static-in-constexpr.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/static-in-constexpr.cpp
@@ -1,0 +1,40 @@
+// RUN: %{clang-tidy} %s -checks='-*,libcpp-static-in-constexpr' -- | FileCheck %s
+
+void normal_func() {
+  static int x = 0;
+  thread_local int y = 0;
+}
+
+constexpr void constexpr_func() {
+  static constexpr int x = 0;
+  // CHECK: :[[@LINE-1]]:24: warning: variable of static or thread storage duration inside constexpr function [libcpp-static-in-constexpr]
+  
+  thread_local int y = 0;
+  // CHECK: :[[@LINE-1]]:20: warning: variable of static or thread storage duration inside constexpr function [libcpp-static-in-constexpr]
+}
+
+consteval void consteval_func() {
+  static constexpr int x = 0;
+  // CHECK: :[[@LINE-1]]:24: warning: variable of static or thread storage duration inside constexpr function [libcpp-static-in-constexpr]
+}
+
+constexpr void constexpr_with_lambda() {
+  auto l = []() {
+    static constexpr int x = 0;
+    // CHECK: :[[@LINE-1]]:26: warning: variable of static or thread storage duration inside constexpr function [libcpp-static-in-constexpr]
+  };
+}
+
+constexpr void constexpr_with_constexpr_lambda() {
+  auto l = []() constexpr {
+    static constexpr int x = 0;
+    // CHECK: :[[@LINE-1]]:26: warning: variable of static or thread storage duration inside constexpr function [libcpp-static-in-constexpr]
+  };
+}
+
+struct S {
+    static constexpr void static_member_func() {
+        static constexpr int x = 0;
+        // CHECK: :[[@LINE-1]]:30: warning: variable of static or thread storage duration inside constexpr function [libcpp-static-in-constexpr]
+    }
+};

--- a/libcxx/test/tools/clang_tidy_checks/static-in-constexpr.sh.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/static-in-constexpr.sh.cpp
@@ -1,4 +1,7 @@
-// RUN: %{clang-tidy} %s -checks='-*,libcpp-static-in-constexpr' -- | FileCheck %s
+// RUN: %{clang-tidy} %s --config-file=%{libcxx-dir}/.clang-tidy \
+// RUN:                  --load=%{test-tools-dir}/clang_tidy_checks/libcxx-tidy.plugin \
+// RUN:                  -checks='-*,libcpp-static-in-constexpr' -- \
+// RUN:                  %{flags} %{compile_flags} -Wno-unused-variable | FileCheck %s
 
 void normal_func() {
   static int x = 0;
@@ -8,9 +11,6 @@ void normal_func() {
 constexpr void constexpr_func() {
   static constexpr int x = 0;
   // CHECK: :[[@LINE-1]]:24: warning: variable of static or thread storage duration inside constexpr function [libcpp-static-in-constexpr]
-  
-  thread_local int y = 0;
-  // CHECK: :[[@LINE-1]]:20: warning: variable of static or thread storage duration inside constexpr function [libcpp-static-in-constexpr]
 }
 
 consteval void consteval_func() {

--- a/libcxx/test/tools/clang_tidy_checks/static_in_constexpr.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/static_in_constexpr.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "static_in_constexpr.hpp"
+#include "clang/AST/Decl.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace libcpp {
+
+void static_in_constexpr::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(varDecl(isStaticLocal()).bind("var"), this);
+}
+
+void static_in_constexpr::check(const MatchFinder::MatchResult &Result) {
+  const auto *Var = Result.Nodes.getNodeAs<clang::VarDecl>("var");
+  if (!Var)
+      return;
+
+  const clang::DeclContext *DC = Var->getDeclContext();
+
+  while (DC && !DC->isFunctionOrMethod())
+    DC = DC->getParent();
+
+  const auto *FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(DC);
+  if (!FD)
+    return;
+
+  if (FD->isConstexpr()) {
+    diag(Var->getLocation(),
+         "variable of static or thread storage duration inside constexpr "
+         "function");
+  }
+}
+
+} // namespace libcpp

--- a/libcxx/test/tools/clang_tidy_checks/static_in_constexpr.hpp
+++ b/libcxx/test/tools/clang_tidy_checks/static_in_constexpr.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LIBCXX_TEST_TOOLS_CLANG_TIDY_CHECKS_STATIC_IN_CONSTEXPR_HPP
+#define LIBCXX_TEST_TOOLS_CLANG_TIDY_CHECKS_STATIC_IN_CONSTEXPR_HPP
+
+#include "clang-tidy/ClangTidyCheck.h"
+
+namespace libcpp {
+
+class static_in_constexpr : public clang::tidy::ClangTidyCheck {
+public:
+  static_in_constexpr(llvm::StringRef name, clang::tidy::ClangTidyContext* context)
+      : clang::tidy::ClangTidyCheck(name, context) {}
+  void registerMatchers(clang::ast_matchers::MatchFinder* finder) override;
+  void check(const clang::ast_matchers::MatchFinder::MatchResult& result) override;
+};
+
+} // namespace libcpp
+
+#endif // LIBCXX_TEST_TOOLS_CLANG_TIDY_CHECKS_STATIC_IN_CONSTEXPR_HPP

--- a/libcxx/test/tools/clang_tidy_checks/static_in_constexpr.hpp
+++ b/libcxx/test/tools/clang_tidy_checks/static_in_constexpr.hpp
@@ -19,6 +19,8 @@ public:
       : clang::tidy::ClangTidyCheck(name, context) {}
   void registerMatchers(clang::ast_matchers::MatchFinder* finder) override;
   void check(const clang::ast_matchers::MatchFinder::MatchResult& result) override;
+
+  bool isLanguageVersionSupported(const clang::LangOptions& lang_opts) const override { return !lang_opts.CPlusPlus23; }
 };
 
 } // namespace libcpp


### PR DESCRIPTION
Static variables in constexpr functions are currently an error in GCC pre-C++23. Add a clang tidy check to catch such cases to prevent these cases slipping through in libc++ code.
