### PR TITLE
[mlir] Use bind_front in RemarkEngine. NFC.

### DIFF
--- a/mlir/lib/IR/Remarks.cpp
+++ b/mlir/lib/IR/Remarks.cpp
@@ -259,11 +259,9 @@ llvm::LogicalResult RemarkEngine::initialize(
     std::unique_ptr<MLIRRemarkStreamerBase> streamer,
     std::unique_ptr<RemarkEmittingPolicyBase> remarkEmittingPolicy,
     std::string *errMsg) {
-
   remarkStreamer = std::move(streamer);
 
-  auto reportFunc =
-      std::bind(&RemarkEngine::reportImpl, this, std::placeholders::_1);
+  auto reportFunc = llvm::bind_front<&RemarkEngine::reportImpl>(this);
   remarkEmittingPolicy->initialize(ReportFn(std::move(reportFunc)));
 
   this->remarkEmittingPolicy = std::move(remarkEmittingPolicy);


### PR DESCRIPTION
Switch from C++11 `std::bind` to C++26 `bind_front` backported in https://github.com/llvm/llvm-project/pull/175056.

The former is an old design that predates lambdas and uses explicit placeholders. `bind_front` should produce a much smaller object (we only need one pointer).