### PR TITLE
[flang] Fix one legitimate warning found with -Werror

### DIFF
--- a/flang/include/flang/Semantics/dump-expr.h
+++ b/flang/include/flang/Semantics/dump-expr.h
@@ -203,7 +203,7 @@ private:
   }
   void Show(const evaluate::Relational<evaluate::SomeType> &x);
   template <typename T> void Show(const evaluate::Expr<T> &x) {
-    Indent("expr <" + std::string(TypeOf<T>::name) + ">");
+    Indent("expr <"s + std::string(TypeOf<T>::name) + ">"s);
     Show(x.u);
     Outdent();
   }


### PR DESCRIPTION
Fix two legitimate warnings found by build bots the last time that I tried to re-enable -Werror builds of flang-new by default, and turn it back on for another try.