### PR TITLE
[llvm] Fix comment references deprecated make_scope_exit

### DIFF
--- a/llvm/lib/Support/ThreadPool.cpp
+++ b/llvm/lib/Support/ThreadPool.cpp
@@ -187,7 +187,7 @@ void StdThreadPool::processTasksWithJobserver() {
       report_fatal_error("Timed out waiting for jobserver token.");
     }
 
-    // `make_scope_exit` guarantees the job slot is released, even if the
+    // `llvm::scope_exit` guarantees the job slot is released, even if the
     // task throws or we exit early. This prevents deadlocking the build.
     llvm::scope_exit SlotReleaser(
         [&] { TheJobserver->release(std::move(Slot)); });


### PR DESCRIPTION
After #173131 and #174030, make_scope_exit is no longer used in
ThreadPool. Fix comment that references old APIs and references the new
API instead.
