### PR TITLE
[SPIRV] Extend and fix SPV_KHR_bit_instructions testing.

### DIFF
--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_bit_instructions/cl_khr_extended_bit_ops.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_bit_instructions/cl_khr_extended_bit_ops.ll
@@ -2745,6 +2745,23 @@ declare spir_func <16 x i8> @_Z11bit_reverseDv16_h(<16 x i8> noundef)
 
 attributes #2 = { convergent nounwind willreturn memory(none) }
 
+; CHECK-EXTENSION: %[[#]] = OpFunction %[[#]] None %[[#]]
+; CHECK-EXTENSION: %[[#reversebase:]] = OpFunctionParameter %[[#]]
+; CHECK-EXTENSION: %[[#]] = OpBitReverse %[[#]] %[[#reversebase]]
+; OpenCL equivalent.
+; kernel void testBitReverse_uchar16(uchar16 b, global uchar16 *res) {
+;   *res = bit_reverse(b);
+; }
+
+define dso_local spir_kernel void @testBitReverse_uchar16_intrinsic(<16 x i8> noundef %b, ptr addrspace(1) nocapture noundef writeonly align 16 initializes((0, 16)) %res) {
+entry:
+  %call = tail call spir_func <16 x i8> @llvm.bitreverse(<16 x i8> noundef %b) #2
+  store <16 x i8> %call, ptr addrspace(1) %res, align 16, !tbaa !22
+  ret void
+}
+
+declare spir_func <16 x i8> @llvm.bitreverse(<16 x i8> noundef)
+
 !llvm.module.flags = !{!0}
 !opencl.ocl.version = !{!1}
 !opencl.spir.version = !{!1}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_bit_instructions/cl_khr_extended_bit_ops_spv-friendly_only.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_bit_instructions/cl_khr_extended_bit_ops_spv-friendly_only.ll
@@ -1,12 +1,8 @@
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-opencl %s --spirv-ext=+SPV_KHR_bit_instructions -o - | FileCheck %s --check-prefix=CHECK-EXTENSION
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-NO-EXTENSION
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s --spirv-ext=+SPV_KHR_bit_instructions -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s --spirv-ext=+SPV_KHR_bit_instructions -o - | FileCheck %s --check-prefix=CHECK-EXTENSION
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64v1.2-unknown-unknown %s --spirv-ext=+SPV_KHR_bit_instructions -o - -filetype=obj | spirv-val --target-env opencl2.2 %}
 ;
 ; CHECK-EXTENSION: Capability BitInstructions
 ; CHECK-EXTENSION: Extension "SPV_KHR_bit_instructions"
-; CHECK-NO-EXTENSION-NOT: Capability BitInstructions
-; CHECK-NO-EXTENSION-NOT: Extension "SPV_KHR_bit_instructions"
-; CHECK-NO-EXTENSION: Capability Shader
 ;
 ; CHECK-EXTENSION: %[[#]] = OpFunction %[[#]] None %[[#]]
 ; CHECK-EXTENSION: %[[#reversebase:]] = OpFunctionParameter %[[#]]
@@ -15,34 +11,21 @@
 ; kernel void testBitReverse_SPIRVFriendly(long4 b, global long4 *res) {
 ;   *res = bit_reverse(b);
 ; }
-define spir_kernel void @testBitReverse_SPIRVFriendly_kernel(<4 x i64> %b, ptr addrspace(1) nocapture align 32 %res) #3 {
+define spir_kernel void @testBitReverse_SPIRVFriendly_kernel(<4 x i64> %b, ptr addrspace(1) %res) {
 entry:
   %call = call <4 x i64> @_Z18__spirv_BitReverseDv4_l(<4 x i64> %b)
-  store <4 x i64> %call, ptr addrspace(1) %res, align 32
+  store <4 x i64> %call, ptr addrspace(1) %res
   ret void
 }
 
 ; CHECK-EXTENSION: %[[#]] = OpFunction %[[#]] None %[[#]]
 ; CHECK-EXTENSION: %[[#reversebase:]] = OpFunctionParameter %[[#]]
 ; CHECK-EXTENSION: %[[#]] = OpBitReverse %[[#]] %[[#reversebase]]
-define void @testBitReverse_SPIRVFriendly(<4 x i64> %b, ptr addrspace(1) nocapture align 32 %res) #3 {
+define void @testBitReverse_SPIRVFriendly(<4 x i64> %b, ptr addrspace(1) %res) {
 entry:
   %call = call <4 x i64> @_Z18__spirv_BitReverseDv4_l(<4 x i64> %b)
-  store <4 x i64> %call, ptr addrspace(1) %res, align 32
+  store <4 x i64> %call, ptr addrspace(1) %res
   ret void
 }
 
-declare <4 x i64> @_Z18__spirv_BitReverseDv4_l(<4 x i64>) #4
-
-
-attributes #3 = { nounwind "hlsl.shader"="compute" }
-attributes #4 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
-
-!llvm.module.flags = !{!0}
-!opencl.ocl.version = !{!1}
-!opencl.spir.version = !{!1}
-!llvm.ident = !{!2}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{i32 2, i32 0}
-!2 = !{!"clang version 20.0.0git (https://github.com/llvm/llvm-project.git cc61409d353a40f62d3a137f3c7436aa00df779d)"}
+declare <4 x i64> @_Z18__spirv_BitReverseDv4_l(<4 x i64>)

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_bit_instructions/cl_khr_extended_bit_ops_spv-friendly_only.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_bit_instructions/cl_khr_extended_bit_ops_spv-friendly_only.ll
@@ -1,8 +1,12 @@
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s --spirv-ext=+SPV_KHR_bit_instructions -o - | FileCheck %s --check-prefix=CHECK-EXTENSION
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64v1.2-unknown-unknown %s --spirv-ext=+SPV_KHR_bit_instructions -o - -filetype=obj | spirv-val --target-env opencl2.2 %} 
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-opencl %s --spirv-ext=+SPV_KHR_bit_instructions -o - | FileCheck %s --check-prefix=CHECK-EXTENSION
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-NO-EXTENSION
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s --spirv-ext=+SPV_KHR_bit_instructions -o - -filetype=obj | spirv-val %}
 ;
 ; CHECK-EXTENSION: Capability BitInstructions
 ; CHECK-EXTENSION: Extension "SPV_KHR_bit_instructions"
+; CHECK-NO-EXTENSION-NOT: Capability BitInstructions
+; CHECK-NO-EXTENSION-NOT: Extension "SPV_KHR_bit_instructions"
+; CHECK-NO-EXTENSION: Capability Shader
 ;
 ; CHECK-EXTENSION: %[[#]] = OpFunction %[[#]] None %[[#]]
 ; CHECK-EXTENSION: %[[#reversebase:]] = OpFunctionParameter %[[#]]
@@ -11,11 +15,34 @@
 ; kernel void testBitReverse_SPIRVFriendly(long4 b, global long4 *res) {
 ;   *res = bit_reverse(b);
 ; }
-define spir_kernel void @testBitReverse_SPIRVFriendly(<4 x i64> %b, ptr addrspace(1) %res) {
+define spir_kernel void @testBitReverse_SPIRVFriendly_kernel(<4 x i64> %b, ptr addrspace(1) nocapture align 32 %res) #3 {
 entry:
-  %call = call <4 x i64> @llvm.bitreverse.v4i64(<4 x i64> %b)
-  store <4 x i64> %call, ptr addrspace(1) %res
+  %call = call <4 x i64> @_Z18__spirv_BitReverseDv4_l(<4 x i64> %b)
+  store <4 x i64> %call, ptr addrspace(1) %res, align 32
   ret void
 }
 
-declare <4 x i64> @llvm.bitreverse.v4i64(<4 x i64>)
+; CHECK-EXTENSION: %[[#]] = OpFunction %[[#]] None %[[#]]
+; CHECK-EXTENSION: %[[#reversebase:]] = OpFunctionParameter %[[#]]
+; CHECK-EXTENSION: %[[#]] = OpBitReverse %[[#]] %[[#reversebase]]
+define void @testBitReverse_SPIRVFriendly(<4 x i64> %b, ptr addrspace(1) nocapture align 32 %res) #3 {
+entry:
+  %call = call <4 x i64> @_Z18__spirv_BitReverseDv4_l(<4 x i64> %b)
+  store <4 x i64> %call, ptr addrspace(1) %res, align 32
+  ret void
+}
+
+declare <4 x i64> @_Z18__spirv_BitReverseDv4_l(<4 x i64>) #4
+
+
+attributes #3 = { nounwind "hlsl.shader"="compute" }
+attributes #4 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}
+!2 = !{!"clang version 20.0.0git (https://github.com/llvm/llvm-project.git cc61409d353a40f62d3a137f3c7436aa00df779d)"}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_bit_instructions/spirv-friendly_extended_bit_ops.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_KHR_bit_instructions/spirv-friendly_extended_bit_ops.ll
@@ -76,12 +76,12 @@ declare spir_func <8 x i8> @_Z24__spirv_BitFieldUExtractDv8_hjj(<8 x i8>, i32, i
 ; }
 define spir_kernel void @testBitReverse_SPIRVFriendly(<4 x i64> %b, ptr addrspace(1) nocapture align 32 %res) #3 {
 entry:
-  %call = call <4 x i64> @llvm.bitreverse.v4i64(<4 x i64> %b)
+  %call = call <4 x i64> @_Z18__spirv_BitReverseDv4_l(<4 x i64> %b)
   store <4 x i64> %call, ptr addrspace(1) %res, align 32
   ret void
 }
 
-declare <4 x i64> @llvm.bitreverse.v4i64(<4 x i64>) #4
+declare <4 x i64> @_Z18__spirv_BitReverseDv4_l(<4 x i64>) #4
 
 
 


### PR DESCRIPTION
On one hand, this patch adds a couple of new testcases related to SPV_KHR_bit_instructions. On the other hand, it fixes a couple of testcases that were using `llvm.bitreverse.*`, while they were supposed to use the SPIRV-friendly equivalent.