### PR TITLE
[clang] Restore diagnostic for certain jumps into VLA(ish) scopes.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -133,6 +133,8 @@ Miscellaneous Bug Fixes
 Miscellaneous Clang Crashes Fixed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Fixed a crash when attempting to jump over initialization of a variable with variably modified type. (#GH175540)
+
 OpenACC Specific Changes
 ------------------------
 

--- a/clang/lib/Sema/JumpDiagnostics.cpp
+++ b/clang/lib/Sema/JumpDiagnostics.cpp
@@ -179,8 +179,10 @@ static ScopePair GetDiagForGotoScopeDecl(Sema &S, const Decl *D) {
       }
     }
 
+    // An earlier diag::note_protected_by_vla is more severe, so don't overwrite
+    // it here.
     if (const Expr *Init = VD->getInit();
-        VD->hasLocalStorage() && Init && !Init->containsErrors()) {
+        !InDiag && VD->hasLocalStorage() && Init && !Init->containsErrors()) {
       // C++11 [stmt.dcl]p3:
       //   A program that jumps from a point where a variable with automatic
       //   storage duration is not in scope to a point where it is in scope

--- a/clang/test/Sema/scope-check.c
+++ b/clang/test/Sema/scope-check.c
@@ -256,3 +256,11 @@ void GH63682() {
     (void)({P:1;});  // expected-note {{jump enters a statement expression}}
   }
 }
+
+void gh175549(int b, void* c) {
+  __asm__ goto("" : : : : d); // expected-error {{cannot jump from this asm goto statement to one of its possible targets}}
+  int(*a)[b] = c; // expected-note {{jump bypasses initialization of variable length array}}
+d:  // expected-note {{possible target of asm goto statement}}
+  (void)a[0];
+}
+


### PR DESCRIPTION
Commit 543f112e148a enabled diagnostics for C++ compatibility for jumps over initialization of variables. However, inadvertently this may cause a prior diagnostic for jumps into scopes of variables with variably modified types to be replaced with the less severe C++ compatibility warning, resulting in impossible codegen.

This skips the check for the C++ compatibility warning if there is already another diagnostic planned for the scope.

Fixes #175540