### PR TITLE
AMDGPU: Handle FP in integer in argument lowering

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -2309,7 +2309,7 @@ SDValue SITargetLowering::convertArgType(SelectionDAG &DAG, EVT VT, EVT MemVT,
   if (MemVT.isFloatingPoint()) {
     if (VT.isFloatingPoint()) {
       Val = getFPExtOrFPRound(DAG, Val, SL, VT);
-    }  else {
+    } else {
       assert(!MemVT.isVector());
       EVT IntVT = EVT::getIntegerVT(*DAG.getContext(), MemVT.getSizeInBits());
       SDValue Cast = DAG.getBitcast(IntVT, Val);

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -2307,9 +2307,9 @@ SDValue SITargetLowering::convertArgType(SelectionDAG &DAG, EVT VT, EVT MemVT,
   }
 
   if (MemVT.isFloatingPoint()) {
-    if (VT.isFloatingPoint())
+    if (VT.isFloatingPoint()) {
       Val = getFPExtOrFPRound(DAG, Val, SL, VT);
-    else {
+    }  else {
       assert(!MemVT.isVector());
       EVT IntVT = EVT::getIntegerVT(*DAG.getContext(), MemVT.getSizeInBits());
       SDValue Cast = DAG.getBitcast(IntVT, Val);

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -2306,9 +2306,16 @@ SDValue SITargetLowering::convertArgType(SelectionDAG &DAG, EVT VT, EVT MemVT,
     Val = DAG.getNode(Opc, SL, MemVT, Val, DAG.getValueType(VT));
   }
 
-  if (MemVT.isFloatingPoint())
-    Val = getFPExtOrFPRound(DAG, Val, SL, VT);
-  else if (Signed)
+  if (MemVT.isFloatingPoint()) {
+    if (VT.isFloatingPoint())
+      Val = getFPExtOrFPRound(DAG, Val, SL, VT);
+    else {
+      assert(!MemVT.isVector());
+      EVT IntVT = EVT::getIntegerVT(*DAG.getContext(), MemVT.getSizeInBits());
+      SDValue Cast = DAG.getBitcast(IntVT, Val);
+      Val = DAG.getAnyExtOrTrunc(Cast, SL, VT);
+    }
+  } else if (Signed)
     Val = DAG.getSExtOrTrunc(Val, SL, VT);
   else
     Val = DAG.getZExtOrTrunc(Val, SL, VT);


### PR DESCRIPTION
This avoids an assertion when softPromoteHalfType is
enabled.