### PR TITLE
[LLDB][Windows] Store PTY in `ProcessWindows`

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -214,6 +214,7 @@ Status ProcessWindows::DoLaunch(Module *exe_module,
   error = LaunchProcess(launch_info, delegate);
   if (error.Success())
     SetID(launch_info.GetProcessID());
+  m_pty = launch_info.GetPTYSP();
   return error;
 }
 
@@ -650,8 +651,10 @@ void ProcessWindows::OnExitProcess(uint32_t exit_code) {
   Log *log = GetLog(WindowsLog::Process);
   LLDB_LOG(log, "Process {0} exited with code {1}", GetID(), exit_code);
 
+  if (m_pty)
+    m_pty->Close();
+
   TargetSP target = CalculateTarget();
-  target->GetProcessLaunchInfo().GetPTY().Close();
   if (target) {
     ModuleSP executable_module = target->GetExecutableModule();
     ModuleList unloaded_modules;

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.h
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.h
@@ -117,6 +117,7 @@ private:
   };
   std::map<lldb::break_id_t, WatchpointInfo> m_watchpoints;
   std::vector<lldb::break_id_t> m_watchpoint_ids;
+  std::shared_ptr<PTY> m_pty;
 };
 } // namespace lldb_private
 


### PR DESCRIPTION
I noticed that LLDB takes longer to stop than it should. Running a tiny program like `int main() { return 0; }` in LLDB with `lldb test.exe -o r -o q` takes about five seconds.

This is caused by the `WaitForMultipleObjects` in [`ConnectionGenericFile::Read`](https://github.com/llvm/llvm-project/blob/25976e83606f1a7615e3725e6038bb53ee96c3d5/lldb/source/Host/windows/ConnectionGenericFileWindows.cpp#L191-L192) timing out (it has a timeout of 5s).

It times out, because we never close the PTY created in [`ProcessLaunchInfo::SetUpPtyRedirection`](https://github.com/llvm/llvm-project/blob/25976e83606f1a7615e3725e6038bb53ee96c3d5/lldb/source/Host/common/ProcessLaunchInfo.cpp#L213). When we call `target->GetProcessLaunchInfo().GetPTY().Close()` in `ProcessWindows::OnExitProcess`, we don't access the PTY we created when setting up the redirection - we're closing a default constructed one. This is because the target's `m_launch_info` isn't necessarily the `launch_info` we get in [`Target::FinalizeFileActions`](https://github.com/llvm/llvm-project/blob/4a8a0593bdecee49331cb5c31a6c9b18d87ea41c/lldb/source/Target/Target.cpp#L3850) when calling `SetUpPtyRedirection`. 

With this PR, we store the PTY that a process was launched with inside `ProcessWindows`, so we can later close it.

The wait of five seconds and a timed out `WaitForMultipleObjects` sounds similar to https://github.com/llvm/llvm-project/pull/159308, but it's a different call to `WaitForMultipleObjects` here. Still, I wonder if we could do something to detect this earlier. Maybe some warning message or debug-only assert if these waits time out?