### PR TITLE
[LLDB][NativePDB] Introduce PdbAstBuilderClang

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/CMakeLists.txt
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/CMakeLists.txt
@@ -2,7 +2,7 @@ add_lldb_library(lldbPluginSymbolFileNativePDB
   CodeViewRegisterMapping.cpp
   CompileUnitIndex.cpp
   DWARFLocationExpression.cpp
-  PdbAstBuilder.cpp
+  PdbAstBuilderClang.cpp
   PdbFPOProgramToDWARFExpression.cpp
   PdbIndex.cpp
   PdbSymUid.cpp

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
@@ -44,8 +44,8 @@ public:
 
   virtual void ParseDeclsForContext(CompilerDeclContext context) = 0;
 
-  virtual CompilerDeclContext
-  FindNamespaceDecl(CompilerDeclContext parent_ctx, llvm::StringRef name) = 0;
+  virtual CompilerDeclContext FindNamespaceDecl(CompilerDeclContext parent_ctx,
+                                                llvm::StringRef name) = 0;
 
   virtual void Dump(Stream &stream, llvm::StringRef filter,
                     bool show_color) = 0;

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
@@ -16,7 +16,6 @@
 #include "llvm/ADT/StringRef.h"
 
 #include "PdbSymUid.h"
-#include <optional>
 
 namespace lldb_private {
 class Stream;
@@ -27,7 +26,7 @@ class PdbAstBuilder {
 public:
   virtual ~PdbAstBuilder() = default;
 
-  virtual std::optional<CompilerDecl> GetOrCreateDeclForUid(PdbSymUid uid) = 0;
+  virtual CompilerDecl GetOrCreateDeclForUid(PdbSymUid uid) = 0;
   virtual CompilerDeclContext GetOrCreateDeclContextForUid(PdbSymUid uid) = 0;
   virtual CompilerDeclContext GetParentDeclContext(PdbSymUid uid) = 0;
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.h
@@ -9,170 +9,46 @@
 #ifndef LLDB_SOURCE_PLUGINS_SYMBOLFILE_NATIVEPDB_PDBASTBUILDER_H
 #define LLDB_SOURCE_PLUGINS_SYMBOLFILE_NATIVEPDB_PDBASTBUILDER_H
 
-#include "llvm/ADT/DenseMap.h"
+#include "lldb/Symbol/CompilerDecl.h"
+#include "lldb/Symbol/CompilerDeclContext.h"
+#include "lldb/Symbol/CompilerType.h"
+#include "lldb/lldb-types.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Threading.h"
 
-#include "Plugins/ExpressionParser/Clang/ClangASTImporter.h"
-
-#include "PdbIndex.h"
 #include "PdbSymUid.h"
 #include <optional>
 
-namespace clang {
-class TagDecl;
-class DeclContext;
-class Decl;
-class QualType;
-class FunctionDecl;
-class NamespaceDecl;
-} // namespace clang
-
-namespace llvm {
-namespace codeview {
-class ProcSym;
-}
-} // namespace llvm
-
 namespace lldb_private {
-class ClangASTImporter;
-class ObjectFile;
+class Stream;
 
 namespace npdb {
-class PdbIndex;
-struct VariableInfo;
-
-struct DeclStatus {
-  DeclStatus() = default;
-  DeclStatus(lldb::user_id_t uid, bool resolved)
-      : uid(uid), resolved(resolved) {}
-  lldb::user_id_t uid = 0;
-  bool resolved = false;
-};
 
 class PdbAstBuilder {
 public:
-  // Constructors and Destructors
-  PdbAstBuilder(TypeSystemClang &clang);
+  virtual ~PdbAstBuilder() = default;
 
-  lldb_private::CompilerDeclContext GetTranslationUnitDecl();
+  virtual std::optional<CompilerDecl> GetOrCreateDeclForUid(PdbSymUid uid) = 0;
+  virtual CompilerDeclContext GetOrCreateDeclContextForUid(PdbSymUid uid) = 0;
+  virtual CompilerDeclContext GetParentDeclContext(PdbSymUid uid) = 0;
 
-  std::optional<lldb_private::CompilerDecl>
-  GetOrCreateDeclForUid(PdbSymUid uid);
-  lldb_private::CompilerDeclContext GetOrCreateDeclContextForUid(PdbSymUid uid);
-  clang::DeclContext *GetOrCreateClangDeclContextForUid(PdbSymUid uid);
-  lldb_private::CompilerDeclContext GetParentDeclContext(PdbSymUid uid);
-  clang::DeclContext *GetParentClangDeclContext(PdbSymUid uid);
+  virtual void EnsureFunction(PdbCompilandSymId func_id) = 0;
+  virtual void EnsureInlinedFunction(PdbCompilandSymId inlinesite_id) = 0;
+  virtual void EnsureBlock(PdbCompilandSymId block_id) = 0;
+  virtual void EnsureVariable(PdbCompilandSymId scope_id,
+                              PdbCompilandSymId var_id) = 0;
+  virtual void EnsureVariable(PdbGlobalSymId var_id) = 0;
 
-  void EnsureFunction(PdbCompilandSymId func_id);
-  void EnsureInlinedFunction(PdbCompilandSymId inlinesite_id);
-  void EnsureBlock(PdbCompilandSymId block_id);
-  void EnsureVariable(PdbCompilandSymId scope_id, PdbCompilandSymId var_id);
-  void EnsureVariable(PdbGlobalSymId var_id);
-  CompilerType GetOrCreateTypedefType(PdbGlobalSymId id);
-  void ParseDeclsForContext(lldb_private::CompilerDeclContext context);
+  virtual CompilerType GetOrCreateType(PdbTypeSymId type) = 0;
+  virtual CompilerType GetOrCreateTypedefType(PdbGlobalSymId id) = 0;
+  virtual bool CompleteType(CompilerType ct) = 0;
 
-  clang::QualType GetBasicType(lldb::BasicType type);
-  clang::QualType GetOrCreateClangType(PdbTypeSymId type);
-  CompilerType GetOrCreateType(PdbTypeSymId type);
+  virtual void ParseDeclsForContext(CompilerDeclContext context) = 0;
 
-  bool CompleteTagDecl(clang::TagDecl &tag);
-  bool CompleteType(CompilerType ct);
+  virtual CompilerDeclContext
+  FindNamespaceDecl(CompilerDeclContext parent_ctx, llvm::StringRef name) = 0;
 
-  CompilerDecl ToCompilerDecl(clang::Decl *decl);
-  CompilerType ToCompilerType(clang::QualType qt);
-  CompilerDeclContext ToCompilerDeclContext(clang::DeclContext *context);
-  clang::QualType FromCompilerType(CompilerType ct);
-  clang::Decl *FromCompilerDecl(CompilerDecl decl);
-  clang::DeclContext *FromCompilerDeclContext(CompilerDeclContext context);
-
-  TypeSystemClang &clang() { return m_clang; }
-  ClangASTImporter &GetClangASTImporter() { return m_importer; }
-
-  void Dump(Stream &stream, llvm::StringRef filter, bool show_color);
-
-  lldb_private::CompilerDeclContext
-  FindNamespaceDecl(lldb_private::CompilerDeclContext parent_ctx,
-                    llvm::StringRef name);
-
-private:
-  clang::Decl *TryGetDecl(PdbSymUid uid) const;
-
-  clang::FunctionDecl *GetOrCreateFunctionDecl(PdbCompilandSymId func_id);
-  clang::FunctionDecl *
-  GetOrCreateInlinedFunctionDecl(PdbCompilandSymId inlinesite_id);
-  clang::BlockDecl *GetOrCreateBlockDecl(PdbCompilandSymId block_id);
-  clang::VarDecl *GetOrCreateVariableDecl(PdbCompilandSymId scope_id,
-                                          PdbCompilandSymId var_id);
-  clang::VarDecl *GetOrCreateVariableDecl(PdbGlobalSymId var_id);
-
-  using TypeIndex = llvm::codeview::TypeIndex;
-
-  clang::QualType
-  CreatePointerType(const llvm::codeview::PointerRecord &pointer);
-  clang::QualType
-  CreateModifierType(const llvm::codeview::ModifierRecord &modifier);
-  clang::QualType CreateArrayType(const llvm::codeview::ArrayRecord &array);
-  clang::QualType CreateRecordType(PdbTypeSymId id,
-                                   const llvm::codeview::TagRecord &record);
-  clang::QualType CreateEnumType(PdbTypeSymId id,
-                                 const llvm::codeview::EnumRecord &record);
-  clang::QualType
-  CreateFunctionType(TypeIndex args_type_idx, TypeIndex return_type_idx,
-                     llvm::codeview::CallingConvention calling_convention);
-  clang::QualType CreateType(PdbTypeSymId type);
-
-  void CreateFunctionParameters(PdbCompilandSymId func_id,
-                                clang::FunctionDecl &function_decl,
-                                uint32_t param_count);
-  clang::Decl *GetOrCreateSymbolForId(PdbCompilandSymId id);
-  clang::VarDecl *CreateVariableDecl(PdbSymUid uid,
-                                     llvm::codeview::CVSymbol sym,
-                                     clang::DeclContext &scope);
-  clang::NamespaceDecl *GetOrCreateNamespaceDecl(const char *name,
-                                                 clang::DeclContext &context);
-  clang::FunctionDecl *CreateFunctionDeclFromId(PdbTypeSymId func_tid,
-                                                PdbCompilandSymId func_sid);
-  clang::FunctionDecl *
-  CreateFunctionDecl(PdbCompilandSymId func_id, llvm::StringRef func_name,
-                     TypeIndex func_ti, CompilerType func_ct,
-                     uint32_t param_count, clang::StorageClass func_storage,
-                     bool is_inline, clang::DeclContext *parent);
-  void ParseNamespace(clang::DeclContext &parent);
-  void ParseAllTypes();
-  void ParseAllFunctionsAndNonLocalVars();
-  void ParseDeclsForSimpleContext(clang::DeclContext &context);
-  void ParseBlockChildren(PdbCompilandSymId block_id);
-
-  std::pair<clang::DeclContext *, std::string>
-  CreateDeclInfoForType(const llvm::codeview::TagRecord &record, TypeIndex ti);
-  std::pair<clang::DeclContext *, std::string>
-  CreateDeclInfoForUndecoratedName(llvm::StringRef uname);
-  clang::QualType CreateSimpleType(TypeIndex ti);
-
-  TypeSystemClang &m_clang;
-
-  ClangASTImporter m_importer;
-  llvm::once_flag m_parse_functions_and_non_local_vars;
-  llvm::once_flag m_parse_all_types;
-  llvm::DenseMap<clang::Decl *, DeclStatus> m_decl_to_status;
-  llvm::DenseMap<lldb::user_id_t, clang::Decl *> m_uid_to_decl;
-  llvm::DenseMap<lldb::user_id_t, clang::QualType> m_uid_to_type;
-
-  // From class/struct's opaque_compiler_type_t to a set containing the pairs of
-  // method's name and CompilerType.
-  llvm::DenseMap<lldb::opaque_compiler_type_t,
-                 llvm::SmallSet<std::pair<llvm::StringRef, CompilerType>, 8>>
-      m_cxx_record_map;
-
-  using NamespaceSet = llvm::DenseSet<clang::NamespaceDecl *>;
-
-  // These namespaces are fully parsed
-  NamespaceSet m_parsed_namespaces;
-
-  // We know about these namespaces, but they might not be completely parsed yet
-  NamespaceSet m_known_namespaces;
-  llvm::DenseMap<clang::DeclContext *, NamespaceSet> m_parent_to_namespaces;
+  virtual void Dump(Stream &stream, llvm::StringRef filter,
+                    bool show_color) = 0;
 };
 
 } // namespace npdb

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.cpp
@@ -277,8 +277,7 @@ clang::Decl *PdbAstBuilderClang::GetOrCreateSymbolForId(PdbCompilandSymId id) {
   }
 }
 
-std::optional<CompilerDecl>
-PdbAstBuilderClang::GetOrCreateDeclForUid(PdbSymUid uid) {
+CompilerDecl PdbAstBuilderClang::GetOrCreateDeclForUid(PdbSymUid uid) {
   if (clang::Decl *result = TryGetDecl(uid))
     return ToCompilerDecl(result);
 
@@ -290,19 +289,19 @@ PdbAstBuilderClang::GetOrCreateDeclForUid(PdbSymUid uid) {
   case PdbSymUidKind::Type: {
     clang::QualType qt = GetOrCreateClangType(uid.asTypeSym());
     if (qt.isNull())
-      return std::nullopt;
+      return CompilerDecl();
     if (auto *tag = qt->getAsTagDecl()) {
       result = tag;
       break;
     }
-    return std::nullopt;
+    return CompilerDecl();
   }
   default:
-    return std::nullopt;
+    return CompilerDecl();
   }
 
   if (!result)
-    return std::nullopt;
+    return CompilerDecl();
   m_uid_to_decl[toOpaqueUid(uid)] = result;
   return ToCompilerDecl(result);
 }
@@ -313,10 +312,7 @@ PdbAstBuilderClang::GetOrCreateClangDeclContextForUid(PdbSymUid uid) {
     if (uid.asCompilandSym().offset == 0)
       return FromCompilerDeclContext(GetTranslationUnitDecl());
   }
-  auto option = GetOrCreateDeclForUid(uid);
-  if (!option)
-    return nullptr;
-  clang::Decl *decl = FromCompilerDecl(*option);
+  clang::Decl *decl = FromCompilerDecl(GetOrCreateDeclForUid(uid));
   if (!decl)
     return nullptr;
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.cpp
@@ -1,4 +1,4 @@
-#include "PdbAstBuilder.h"
+#include "PdbAstBuilderClang.h"
 
 #include "llvm/DebugInfo/CodeView/CVTypeVisitor.h"
 #include "llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h"
@@ -161,14 +161,14 @@ static bool IsAnonymousNamespaceName(llvm::StringRef name) {
   return name == "`anonymous namespace'" || name == "`anonymous-namespace'";
 }
 
-PdbAstBuilder::PdbAstBuilder(TypeSystemClang &clang) : m_clang(clang) {}
+PdbAstBuilderClang::PdbAstBuilderClang(TypeSystemClang &clang) : m_clang(clang) {}
 
-lldb_private::CompilerDeclContext PdbAstBuilder::GetTranslationUnitDecl() {
+lldb_private::CompilerDeclContext PdbAstBuilderClang::GetTranslationUnitDecl() {
   return ToCompilerDeclContext(m_clang.GetTranslationUnitDecl());
 }
 
 std::pair<clang::DeclContext *, std::string>
-PdbAstBuilder::CreateDeclInfoForType(const TagRecord &record, TypeIndex ti) {
+PdbAstBuilderClang::CreateDeclInfoForType(const TagRecord &record, TypeIndex ti) {
   SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
       m_clang.GetSymbolFile()->GetBackingSymbolFile());
   // FIXME: Move this to GetDeclContextContainingUID.
@@ -240,7 +240,7 @@ static bool isLocalVariableType(SymbolKind K) {
   return false;
 }
 
-clang::Decl *PdbAstBuilder::GetOrCreateSymbolForId(PdbCompilandSymId id) {
+clang::Decl *PdbAstBuilderClang::GetOrCreateSymbolForId(PdbCompilandSymId id) {
   SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
       m_clang.GetSymbolFile()->GetBackingSymbolFile());
   PdbIndex &index = pdb->GetIndex();
@@ -276,7 +276,7 @@ clang::Decl *PdbAstBuilder::GetOrCreateSymbolForId(PdbCompilandSymId id) {
 }
 
 std::optional<CompilerDecl>
-PdbAstBuilder::GetOrCreateDeclForUid(PdbSymUid uid) {
+PdbAstBuilderClang::GetOrCreateDeclForUid(PdbSymUid uid) {
   if (clang::Decl *result = TryGetDecl(uid))
     return ToCompilerDecl(result);
 
@@ -306,7 +306,7 @@ PdbAstBuilder::GetOrCreateDeclForUid(PdbSymUid uid) {
 }
 
 clang::DeclContext *
-PdbAstBuilder::GetOrCreateClangDeclContextForUid(PdbSymUid uid) {
+PdbAstBuilderClang::GetOrCreateClangDeclContextForUid(PdbSymUid uid) {
   if (uid.kind() == PdbSymUidKind::CompilandSym) {
     if (uid.asCompilandSym().offset == 0)
       return FromCompilerDeclContext(GetTranslationUnitDecl());
@@ -321,12 +321,12 @@ PdbAstBuilder::GetOrCreateClangDeclContextForUid(PdbSymUid uid) {
   return clang::Decl::castToDeclContext(decl);
 }
 
-CompilerDeclContext PdbAstBuilder::GetOrCreateDeclContextForUid(PdbSymUid uid) {
+CompilerDeclContext PdbAstBuilderClang::GetOrCreateDeclContextForUid(PdbSymUid uid) {
   return ToCompilerDeclContext(GetOrCreateClangDeclContextForUid(uid));
 }
 
 std::pair<clang::DeclContext *, std::string>
-PdbAstBuilder::CreateDeclInfoForUndecoratedName(llvm::StringRef name) {
+PdbAstBuilderClang::CreateDeclInfoForUndecoratedName(llvm::StringRef name) {
   SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
       m_clang.GetSymbolFile()->GetBackingSymbolFile());
   PdbIndex &index = pdb->GetIndex();
@@ -362,7 +362,7 @@ PdbAstBuilder::CreateDeclInfoForUndecoratedName(llvm::StringRef name) {
   return {context, std::string(uname)};
 }
 
-clang::DeclContext *PdbAstBuilder::GetParentClangDeclContext(PdbSymUid uid) {
+clang::DeclContext *PdbAstBuilderClang::GetParentClangDeclContext(PdbSymUid uid) {
   // We must do this *without* calling GetOrCreate on the current uid, as
   // that would be an infinite recursion.
   SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
@@ -425,11 +425,11 @@ clang::DeclContext *PdbAstBuilder::GetParentClangDeclContext(PdbSymUid uid) {
   return FromCompilerDeclContext(GetTranslationUnitDecl());
 }
 
-CompilerDeclContext PdbAstBuilder::GetParentDeclContext(PdbSymUid uid) {
+CompilerDeclContext PdbAstBuilderClang::GetParentDeclContext(PdbSymUid uid) {
   return ToCompilerDeclContext(GetParentClangDeclContext(uid));
 }
 
-bool PdbAstBuilder::CompleteType(CompilerType ct) {
+bool PdbAstBuilderClang::CompleteType(CompilerType ct) {
   if (GetClangASTImporter().CanImport(ct))
     return GetClangASTImporter().CompleteType(ct);
 
@@ -447,7 +447,7 @@ bool PdbAstBuilder::CompleteType(CompilerType ct) {
   return CompleteTagDecl(*tag);
 }
 
-bool PdbAstBuilder::CompleteTagDecl(clang::TagDecl &tag) {
+bool PdbAstBuilderClang::CompleteTagDecl(clang::TagDecl &tag) {
   // If this is not in our map, it's an error.
   auto status_iter = m_decl_to_status.find(&tag);
   lldbassert(status_iter != m_decl_to_status.end());
@@ -507,7 +507,7 @@ bool PdbAstBuilder::CompleteTagDecl(clang::TagDecl &tag) {
   return true;
 }
 
-clang::QualType PdbAstBuilder::CreateSimpleType(TypeIndex ti) {
+clang::QualType PdbAstBuilderClang::CreateSimpleType(TypeIndex ti) {
   if (ti == TypeIndex::NullptrT())
     return GetBasicType(lldb::eBasicTypeNullPtr);
 
@@ -528,7 +528,7 @@ clang::QualType PdbAstBuilder::CreateSimpleType(TypeIndex ti) {
   return GetBasicType(bt);
 }
 
-clang::QualType PdbAstBuilder::CreatePointerType(const PointerRecord &pointer) {
+clang::QualType PdbAstBuilderClang::CreatePointerType(const PointerRecord &pointer) {
   clang::QualType pointee_type = GetOrCreateClangType(pointer.ReferentType);
 
   // This can happen for pointers to LF_VTSHAPE records, which we shouldn't
@@ -601,7 +601,7 @@ clang::QualType PdbAstBuilder::CreatePointerType(const PointerRecord &pointer) {
 }
 
 clang::QualType
-PdbAstBuilder::CreateModifierType(const ModifierRecord &modifier) {
+PdbAstBuilderClang::CreateModifierType(const ModifierRecord &modifier) {
   clang::QualType unmodified_type = GetOrCreateClangType(modifier.ModifiedType);
   if (unmodified_type.isNull())
     return {};
@@ -614,7 +614,7 @@ PdbAstBuilder::CreateModifierType(const ModifierRecord &modifier) {
   return unmodified_type;
 }
 
-clang::QualType PdbAstBuilder::CreateRecordType(PdbTypeSymId id,
+clang::QualType PdbAstBuilderClang::CreateRecordType(PdbTypeSymId id,
                                                 const TagRecord &record) {
   clang::DeclContext *context = nullptr;
   std::string uname;
@@ -649,7 +649,7 @@ clang::QualType PdbAstBuilder::CreateRecordType(PdbTypeSymId id,
   return result;
 }
 
-clang::Decl *PdbAstBuilder::TryGetDecl(PdbSymUid uid) const {
+clang::Decl *PdbAstBuilderClang::TryGetDecl(PdbSymUid uid) const {
   auto iter = m_uid_to_decl.find(toOpaqueUid(uid));
   if (iter != m_uid_to_decl.end())
     return iter->second;
@@ -657,7 +657,7 @@ clang::Decl *PdbAstBuilder::TryGetDecl(PdbSymUid uid) const {
 }
 
 clang::NamespaceDecl *
-PdbAstBuilder::GetOrCreateNamespaceDecl(const char *name,
+PdbAstBuilderClang::GetOrCreateNamespaceDecl(const char *name,
                                         clang::DeclContext &context) {
   clang::NamespaceDecl *ns = m_clang.GetUniqueNamespaceDeclaration(
       IsAnonymousNamespaceName(name) ? nullptr : name, &context,
@@ -668,7 +668,7 @@ PdbAstBuilder::GetOrCreateNamespaceDecl(const char *name,
 }
 
 clang::BlockDecl *
-PdbAstBuilder::GetOrCreateBlockDecl(PdbCompilandSymId block_id) {
+PdbAstBuilderClang::GetOrCreateBlockDecl(PdbCompilandSymId block_id) {
   if (clang::Decl *decl = TryGetDecl(block_id))
     return llvm::dyn_cast<clang::BlockDecl>(decl);
 
@@ -686,7 +686,7 @@ PdbAstBuilder::GetOrCreateBlockDecl(PdbCompilandSymId block_id) {
   return block_decl;
 }
 
-clang::VarDecl *PdbAstBuilder::CreateVariableDecl(PdbSymUid uid, CVSymbol sym,
+clang::VarDecl *PdbAstBuilderClang::CreateVariableDecl(PdbSymUid uid, CVSymbol sym,
                                                   clang::DeclContext &scope) {
   VariableInfo var_info = GetVariableNameInfo(sym);
   clang::QualType qt = GetOrCreateClangType(var_info.type);
@@ -705,7 +705,7 @@ clang::VarDecl *PdbAstBuilder::CreateVariableDecl(PdbSymUid uid, CVSymbol sym,
 }
 
 clang::VarDecl *
-PdbAstBuilder::GetOrCreateVariableDecl(PdbCompilandSymId scope_id,
+PdbAstBuilderClang::GetOrCreateVariableDecl(PdbCompilandSymId scope_id,
                                        PdbCompilandSymId var_id) {
   if (clang::Decl *decl = TryGetDecl(var_id))
     return llvm::dyn_cast<clang::VarDecl>(decl);
@@ -721,7 +721,7 @@ PdbAstBuilder::GetOrCreateVariableDecl(PdbCompilandSymId scope_id,
   return CreateVariableDecl(PdbSymUid(var_id), sym, *scope);
 }
 
-clang::VarDecl *PdbAstBuilder::GetOrCreateVariableDecl(PdbGlobalSymId var_id) {
+clang::VarDecl *PdbAstBuilderClang::GetOrCreateVariableDecl(PdbGlobalSymId var_id) {
   if (clang::Decl *decl = TryGetDecl(var_id))
     return llvm::dyn_cast<clang::VarDecl>(decl);
 
@@ -733,7 +733,7 @@ clang::VarDecl *PdbAstBuilder::GetOrCreateVariableDecl(PdbGlobalSymId var_id) {
   return CreateVariableDecl(PdbSymUid(var_id), sym, *context);
 }
 
-CompilerType PdbAstBuilder::GetOrCreateTypedefType(PdbGlobalSymId id) {
+CompilerType PdbAstBuilderClang::GetOrCreateTypedefType(PdbGlobalSymId id) {
   if (clang::Decl *decl = TryGetDecl(id)) {
     if (auto *tnd = llvm::dyn_cast<clang::TypedefNameDecl>(decl))
       return ToCompilerType(m_clang.getASTContext().getTypeDeclType(tnd));
@@ -765,12 +765,12 @@ CompilerType PdbAstBuilder::GetOrCreateTypedefType(PdbGlobalSymId id) {
   return ct;
 }
 
-clang::QualType PdbAstBuilder::GetBasicType(lldb::BasicType type) {
+clang::QualType PdbAstBuilderClang::GetBasicType(lldb::BasicType type) {
   CompilerType ct = m_clang.GetBasicType(type);
   return clang::QualType::getFromOpaquePtr(ct.GetOpaqueQualType());
 }
 
-clang::QualType PdbAstBuilder::CreateType(PdbTypeSymId type) {
+clang::QualType PdbAstBuilderClang::CreateType(PdbTypeSymId type) {
   if (type.index.isSimple())
     return CreateSimpleType(type.index);
 
@@ -824,7 +824,7 @@ clang::QualType PdbAstBuilder::CreateType(PdbTypeSymId type) {
   return {};
 }
 
-clang::QualType PdbAstBuilder::GetOrCreateClangType(PdbTypeSymId type) {
+clang::QualType PdbAstBuilderClang::GetOrCreateClangType(PdbTypeSymId type) {
   if (type.index.isNoneType())
     return {};
 
@@ -867,7 +867,7 @@ clang::QualType PdbAstBuilder::GetOrCreateClangType(PdbTypeSymId type) {
   return qt;
 }
 
-CompilerType PdbAstBuilder::GetOrCreateType(PdbTypeSymId type) {
+CompilerType PdbAstBuilderClang::GetOrCreateType(PdbTypeSymId type) {
   clang::QualType qt = GetOrCreateClangType(type);
   if (qt.isNull())
     return {};
@@ -875,7 +875,7 @@ CompilerType PdbAstBuilder::GetOrCreateType(PdbTypeSymId type) {
 }
 
 clang::FunctionDecl *
-PdbAstBuilder::CreateFunctionDecl(PdbCompilandSymId func_id,
+PdbAstBuilderClang::CreateFunctionDecl(PdbCompilandSymId func_id,
                                   llvm::StringRef func_name, TypeIndex func_ti,
                                   CompilerType func_ct, uint32_t param_count,
                                   clang::StorageClass func_storage,
@@ -950,7 +950,7 @@ PdbAstBuilder::CreateFunctionDecl(PdbCompilandSymId func_id,
 }
 
 clang::FunctionDecl *
-PdbAstBuilder::GetOrCreateInlinedFunctionDecl(PdbCompilandSymId inlinesite_id) {
+PdbAstBuilderClang::GetOrCreateInlinedFunctionDecl(PdbCompilandSymId inlinesite_id) {
   SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
       m_clang.GetSymbolFile()->GetBackingSymbolFile());
   PdbIndex &index = pdb->GetIndex();
@@ -989,7 +989,7 @@ PdbAstBuilder::GetOrCreateInlinedFunctionDecl(PdbCompilandSymId inlinesite_id) {
 }
 
 clang::FunctionDecl *
-PdbAstBuilder::CreateFunctionDeclFromId(PdbTypeSymId func_tid,
+PdbAstBuilderClang::CreateFunctionDeclFromId(PdbTypeSymId func_tid,
                                         PdbCompilandSymId func_sid) {
   lldbassert(func_tid.is_ipi);
   SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
@@ -1041,7 +1041,7 @@ PdbAstBuilder::CreateFunctionDeclFromId(PdbTypeSymId func_tid,
 }
 
 clang::FunctionDecl *
-PdbAstBuilder::GetOrCreateFunctionDecl(PdbCompilandSymId func_id) {
+PdbAstBuilderClang::GetOrCreateFunctionDecl(PdbCompilandSymId func_id) {
   if (clang::Decl *decl = TryGetDecl(func_id))
     return llvm::dyn_cast<clang::FunctionDecl>(decl);
 
@@ -1095,28 +1095,28 @@ PdbAstBuilder::GetOrCreateFunctionDecl(PdbCompilandSymId func_id) {
   return function_decl;
 }
 
-void PdbAstBuilder::EnsureFunction(PdbCompilandSymId func_id) {
+void PdbAstBuilderClang::EnsureFunction(PdbCompilandSymId func_id) {
   GetOrCreateFunctionDecl(func_id);
 }
 
-void PdbAstBuilder::EnsureInlinedFunction(PdbCompilandSymId inlinesite_id) {
+void PdbAstBuilderClang::EnsureInlinedFunction(PdbCompilandSymId inlinesite_id) {
   GetOrCreateInlinedFunctionDecl(inlinesite_id);
 }
 
-void PdbAstBuilder::EnsureBlock(PdbCompilandSymId block_id) {
+void PdbAstBuilderClang::EnsureBlock(PdbCompilandSymId block_id) {
   GetOrCreateBlockDecl(block_id);
 }
 
-void PdbAstBuilder::EnsureVariable(PdbCompilandSymId scope_id,
+void PdbAstBuilderClang::EnsureVariable(PdbCompilandSymId scope_id,
                                    PdbCompilandSymId var_id) {
   GetOrCreateVariableDecl(scope_id, var_id);
 }
 
-void PdbAstBuilder::EnsureVariable(PdbGlobalSymId var_id) {
+void PdbAstBuilderClang::EnsureVariable(PdbGlobalSymId var_id) {
   GetOrCreateVariableDecl(var_id);
 }
 
-void PdbAstBuilder::CreateFunctionParameters(PdbCompilandSymId func_id,
+void PdbAstBuilderClang::CreateFunctionParameters(PdbCompilandSymId func_id,
                                              clang::FunctionDecl &function_decl,
                                              uint32_t param_count) {
   SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
@@ -1191,7 +1191,7 @@ void PdbAstBuilder::CreateFunctionParameters(PdbCompilandSymId func_id,
     function_decl.setParams(params);
 }
 
-clang::QualType PdbAstBuilder::CreateEnumType(PdbTypeSymId id,
+clang::QualType PdbAstBuilderClang::CreateEnumType(PdbTypeSymId id,
                                               const EnumRecord &er) {
   clang::DeclContext *decl_context = nullptr;
   std::string uname;
@@ -1214,7 +1214,7 @@ clang::QualType PdbAstBuilder::CreateEnumType(PdbTypeSymId id,
   return clang::QualType::getFromOpaquePtr(enum_ct.GetOpaqueQualType());
 }
 
-clang::QualType PdbAstBuilder::CreateArrayType(const ArrayRecord &ar) {
+clang::QualType PdbAstBuilderClang::CreateArrayType(const ArrayRecord &ar) {
   clang::QualType element_type = GetOrCreateClangType(ar.ElementType);
   TypeSystemClang::RequireCompleteType(ToCompilerType(element_type));
 
@@ -1231,7 +1231,7 @@ clang::QualType PdbAstBuilder::CreateArrayType(const ArrayRecord &ar) {
   return clang::QualType::getFromOpaquePtr(array_ct.GetOpaqueQualType());
 }
 
-clang::QualType PdbAstBuilder::CreateFunctionType(
+clang::QualType PdbAstBuilderClang::CreateFunctionType(
     TypeIndex args_type_idx, TypeIndex return_type_idx,
     llvm::codeview::CallingConvention calling_convention) {
   SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
@@ -1287,7 +1287,7 @@ static bool isBlockDecl(clang::DeclContext &context) {
   return llvm::isa<clang::BlockDecl>(&context);
 }
 
-void PdbAstBuilder::ParseNamespace(clang::DeclContext &context) {
+void PdbAstBuilderClang::ParseNamespace(clang::DeclContext &context) {
   clang::NamespaceDecl *ns = llvm::dyn_cast<clang::NamespaceDecl>(&context);
   if (m_parsed_namespaces.contains(ns))
     return;
@@ -1326,7 +1326,7 @@ void PdbAstBuilder::ParseNamespace(clang::DeclContext &context) {
   m_parsed_namespaces.insert(ns);
 }
 
-void PdbAstBuilder::ParseAllTypes() {
+void PdbAstBuilderClang::ParseAllTypes() {
   llvm::call_once(m_parse_all_types, [this]() {
     SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
         m_clang.GetSymbolFile()->GetBackingSymbolFile());
@@ -1344,7 +1344,7 @@ void PdbAstBuilder::ParseAllTypes() {
   });
 }
 
-void PdbAstBuilder::ParseAllFunctionsAndNonLocalVars() {
+void PdbAstBuilderClang::ParseAllFunctionsAndNonLocalVars() {
   llvm::call_once(m_parse_functions_and_non_local_vars, [this]() {
     SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
         m_clang.GetSymbolFile()->GetBackingSymbolFile());
@@ -1405,7 +1405,7 @@ static CVSymbolArray skipFunctionParameters(clang::Decl &decl,
   return result;
 }
 
-void PdbAstBuilder::ParseBlockChildren(PdbCompilandSymId block_id) {
+void PdbAstBuilderClang::ParseBlockChildren(PdbCompilandSymId block_id) {
   SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
       m_clang.GetSymbolFile()->GetBackingSymbolFile());
   PdbIndex &index = pdb->GetIndex();
@@ -1436,7 +1436,7 @@ void PdbAstBuilder::ParseBlockChildren(PdbCompilandSymId block_id) {
   }
 }
 
-void PdbAstBuilder::ParseDeclsForSimpleContext(clang::DeclContext &context) {
+void PdbAstBuilderClang::ParseDeclsForSimpleContext(clang::DeclContext &context) {
 
   clang::Decl *decl = clang::Decl::castFromDeclContext(&context);
   lldbassert(decl);
@@ -1455,7 +1455,7 @@ void PdbAstBuilder::ParseDeclsForSimpleContext(clang::DeclContext &context) {
   }
 }
 
-void PdbAstBuilder::ParseDeclsForContext(CompilerDeclContext context) {
+void PdbAstBuilderClang::ParseDeclsForContext(CompilerDeclContext context) {
   clang::DeclContext *dc = FromCompilerDeclContext(context);
   if (!dc)
     return;
@@ -1483,39 +1483,39 @@ void PdbAstBuilder::ParseDeclsForContext(CompilerDeclContext context) {
   }
 }
 
-CompilerDecl PdbAstBuilder::ToCompilerDecl(clang::Decl *decl) {
+CompilerDecl PdbAstBuilderClang::ToCompilerDecl(clang::Decl *decl) {
   return m_clang.GetCompilerDecl(decl);
 }
 
-CompilerType PdbAstBuilder::ToCompilerType(clang::QualType qt) {
+CompilerType PdbAstBuilderClang::ToCompilerType(clang::QualType qt) {
   return m_clang.GetType(qt);
 }
 
-clang::QualType PdbAstBuilder::FromCompilerType(CompilerType ct) {
+clang::QualType PdbAstBuilderClang::FromCompilerType(CompilerType ct) {
   return ClangUtil::GetQualType(ct);
 }
 
 CompilerDeclContext
-PdbAstBuilder::ToCompilerDeclContext(clang::DeclContext *context) {
+PdbAstBuilderClang::ToCompilerDeclContext(clang::DeclContext *context) {
   return m_clang.CreateDeclContext(context);
 }
 
-clang::Decl * PdbAstBuilder::FromCompilerDecl(CompilerDecl decl) {
+clang::Decl * PdbAstBuilderClang::FromCompilerDecl(CompilerDecl decl) {
   return ClangUtil::GetDecl(decl);
 }
 
 clang::DeclContext *
-PdbAstBuilder::FromCompilerDeclContext(CompilerDeclContext context) {
+PdbAstBuilderClang::FromCompilerDeclContext(CompilerDeclContext context) {
   return static_cast<clang::DeclContext *>(context.GetOpaqueDeclContext());
 }
 
-void PdbAstBuilder::Dump(Stream &stream, llvm::StringRef filter,
+void PdbAstBuilderClang::Dump(Stream &stream, llvm::StringRef filter,
                          bool show_color) {
   m_clang.Dump(stream.AsRawOstream(), filter, show_color);
 }
 
 CompilerDeclContext
-PdbAstBuilder::FindNamespaceDecl(CompilerDeclContext parent_ctx,
+PdbAstBuilderClang::FindNamespaceDecl(CompilerDeclContext parent_ctx,
                                  llvm::StringRef name) {
   clang::DeclContext *parent = FromCompilerDeclContext(parent_ctx);
   NamespaceSet *set;

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.h
@@ -54,7 +54,7 @@ class PdbAstBuilderClang : public PdbAstBuilder {
 public:
   PdbAstBuilderClang(TypeSystemClang &clang);
 
-  std::optional<CompilerDecl> GetOrCreateDeclForUid(PdbSymUid uid) override;
+  CompilerDecl GetOrCreateDeclForUid(PdbSymUid uid) override;
   CompilerDeclContext GetOrCreateDeclContextForUid(PdbSymUid uid) override;
   CompilerDeclContext GetParentDeclContext(PdbSymUid uid) override;
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.h
@@ -1,0 +1,182 @@
+//===-- PdbAstBuilderClang.h ------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_SYMBOLFILE_NATIVEPDB_PDBASTBUILDERCLANG_H
+#define LLDB_SOURCE_PLUGINS_SYMBOLFILE_NATIVEPDB_PDBASTBUILDERCLANG_H
+
+#include "PdbAstBuilder.h"
+
+#include "Plugins/ExpressionParser/Clang/ClangASTImporter.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/DebugInfo/CodeView/CVRecord.h"
+#include "llvm/Support/Threading.h"
+
+namespace clang {
+class TagDecl;
+class DeclContext;
+class Decl;
+class QualType;
+class FunctionDecl;
+class NamespaceDecl;
+class BlockDecl;
+class VarDecl;
+} // namespace clang
+
+namespace llvm {
+namespace codeview {
+class PointerRecord;
+class ModifierRecord;
+class ArrayRecord;
+class TagRecord;
+class EnumRecord;
+enum class CallingConvention : uint8_t;
+} // namespace codeview
+} // namespace llvm
+
+namespace lldb_private {
+namespace npdb {
+
+struct DeclStatus {
+  DeclStatus() = default;
+  DeclStatus(lldb::user_id_t uid, bool resolved)
+      : uid(uid), resolved(resolved) {}
+  lldb::user_id_t uid = 0;
+  bool resolved = false;
+};
+
+class PdbAstBuilderClang : public PdbAstBuilder {
+public:
+  PdbAstBuilderClang(TypeSystemClang &clang);
+
+  std::optional<CompilerDecl> GetOrCreateDeclForUid(PdbSymUid uid) override;
+  CompilerDeclContext GetOrCreateDeclContextForUid(PdbSymUid uid) override;
+  CompilerDeclContext GetParentDeclContext(PdbSymUid uid) override;
+
+  void EnsureFunction(PdbCompilandSymId func_id) override;
+  void EnsureInlinedFunction(PdbCompilandSymId inlinesite_id) override;
+  void EnsureBlock(PdbCompilandSymId block_id) override;
+  void EnsureVariable(PdbCompilandSymId scope_id,
+                      PdbCompilandSymId var_id) override;
+  void EnsureVariable(PdbGlobalSymId var_id) override;
+
+  CompilerType GetOrCreateType(PdbTypeSymId type) override;
+  CompilerType GetOrCreateTypedefType(PdbGlobalSymId id) override;
+  bool CompleteType(CompilerType ct) override;
+
+  void ParseDeclsForContext(CompilerDeclContext context) override;
+
+  CompilerDeclContext FindNamespaceDecl(CompilerDeclContext parent_ctx,
+                                        llvm::StringRef name) override;
+
+  void Dump(Stream &stream, llvm::StringRef filter, bool show_color) override;
+
+  // Clang-specific
+  clang::QualType GetBasicType(lldb::BasicType type);
+  clang::QualType GetOrCreateClangType(PdbTypeSymId type);
+  clang::DeclContext *GetOrCreateClangDeclContextForUid(PdbSymUid uid);
+
+  CompilerDecl ToCompilerDecl(clang::Decl *decl);
+  CompilerType ToCompilerType(clang::QualType qt);
+  CompilerDeclContext ToCompilerDeclContext(clang::DeclContext *context);
+  clang::QualType FromCompilerType(CompilerType ct);
+  clang::Decl *FromCompilerDecl(CompilerDecl decl);
+  clang::DeclContext *FromCompilerDeclContext(CompilerDeclContext context);
+
+  bool CompleteTagDecl(clang::TagDecl &tag);
+
+  TypeSystemClang &clang() { return m_clang; }
+  ClangASTImporter &GetClangASTImporter() { return m_importer; }
+
+private:
+  CompilerDeclContext GetTranslationUnitDecl();
+  clang::DeclContext *GetParentClangDeclContext(PdbSymUid uid);
+
+  clang::Decl *TryGetDecl(PdbSymUid uid) const;
+
+  clang::FunctionDecl *GetOrCreateFunctionDecl(PdbCompilandSymId func_id);
+  clang::FunctionDecl *
+  GetOrCreateInlinedFunctionDecl(PdbCompilandSymId inlinesite_id);
+  clang::BlockDecl *GetOrCreateBlockDecl(PdbCompilandSymId block_id);
+  clang::VarDecl *GetOrCreateVariableDecl(PdbCompilandSymId scope_id,
+                                          PdbCompilandSymId var_id);
+  clang::VarDecl *GetOrCreateVariableDecl(PdbGlobalSymId var_id);
+
+  using TypeIndex = llvm::codeview::TypeIndex;
+
+  clang::QualType
+  CreatePointerType(const llvm::codeview::PointerRecord &pointer);
+  clang::QualType
+  CreateModifierType(const llvm::codeview::ModifierRecord &modifier);
+  clang::QualType CreateArrayType(const llvm::codeview::ArrayRecord &array);
+  clang::QualType CreateRecordType(PdbTypeSymId id,
+                                   const llvm::codeview::TagRecord &record);
+  clang::QualType CreateEnumType(PdbTypeSymId id,
+                                 const llvm::codeview::EnumRecord &record);
+  clang::QualType
+  CreateFunctionType(TypeIndex args_type_idx, TypeIndex return_type_idx,
+                     llvm::codeview::CallingConvention calling_convention);
+  clang::QualType CreateType(PdbTypeSymId type);
+
+  void CreateFunctionParameters(PdbCompilandSymId func_id,
+                                clang::FunctionDecl &function_decl,
+                                uint32_t param_count);
+  clang::Decl *GetOrCreateSymbolForId(PdbCompilandSymId id);
+  clang::VarDecl *CreateVariableDecl(PdbSymUid uid,
+                                     llvm::codeview::CVSymbol sym,
+                                     clang::DeclContext &scope);
+  clang::NamespaceDecl *GetOrCreateNamespaceDecl(const char *name,
+                                                 clang::DeclContext &context);
+  clang::FunctionDecl *CreateFunctionDeclFromId(PdbTypeSymId func_tid,
+                                                PdbCompilandSymId func_sid);
+  clang::FunctionDecl *
+  CreateFunctionDecl(PdbCompilandSymId func_id, llvm::StringRef func_name,
+                     TypeIndex func_ti, CompilerType func_ct,
+                     uint32_t param_count, clang::StorageClass func_storage,
+                     bool is_inline, clang::DeclContext *parent);
+  void ParseNamespace(clang::DeclContext &parent);
+  void ParseAllTypes();
+  void ParseAllFunctionsAndNonLocalVars();
+  void ParseDeclsForSimpleContext(clang::DeclContext &context);
+  void ParseBlockChildren(PdbCompilandSymId block_id);
+
+  std::pair<clang::DeclContext *, std::string>
+  CreateDeclInfoForType(const llvm::codeview::TagRecord &record, TypeIndex ti);
+  std::pair<clang::DeclContext *, std::string>
+  CreateDeclInfoForUndecoratedName(llvm::StringRef uname);
+  clang::QualType CreateSimpleType(TypeIndex ti);
+
+  TypeSystemClang &m_clang;
+
+  ClangASTImporter m_importer;
+  llvm::once_flag m_parse_functions_and_non_local_vars;
+  llvm::once_flag m_parse_all_types;
+  llvm::DenseMap<clang::Decl *, DeclStatus> m_decl_to_status;
+  llvm::DenseMap<lldb::user_id_t, clang::Decl *> m_uid_to_decl;
+  llvm::DenseMap<lldb::user_id_t, clang::QualType> m_uid_to_type;
+
+  // From class/struct's opaque_compiler_type_t to a set containing the pairs of
+  // method's name and CompilerType.
+  llvm::DenseMap<lldb::opaque_compiler_type_t,
+                 llvm::SmallSet<std::pair<llvm::StringRef, CompilerType>, 8>>
+      m_cxx_record_map;
+
+  using NamespaceSet = llvm::DenseSet<clang::NamespaceDecl *>;
+
+  // These namespaces are fully parsed
+  NamespaceSet m_parsed_namespaces;
+
+  // We know about these namespaces, but they might not be completely parsed yet
+  NamespaceSet m_known_namespaces;
+  llvm::DenseMap<clang::DeclContext *, NamespaceSet> m_parent_to_namespaces;
+};
+
+} // namespace npdb
+} // namespace lldb_private
+
+#endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_NATIVEPDB_PDBASTBUILDERCLANG_H

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.h
@@ -1,4 +1,4 @@
-//===-- PdbAstBuilderClang.h ------------------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -2425,10 +2425,7 @@ CompilerDecl SymbolFileNativePDB::GetDeclForUID(lldb::user_id_t uid) {
   auto ts = *ts_or_err;
   if (!ts)
     return {};
-
-  if (auto decl = ts->GetNativePDBParser()->GetOrCreateDeclForUid(uid))
-    return *decl;
-  return CompilerDecl();
+  return ts->GetNativePDBParser()->GetOrCreateDeclForUid(uid);
 }
 
 CompilerDeclContext

--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.cpp
@@ -1,6 +1,6 @@
 #include "UdtRecordCompleter.h"
 
-#include "PdbAstBuilder.h"
+#include "PdbAstBuilderClang.h"
 #include "PdbIndex.h"
 #include "PdbSymUid.h"
 #include "PdbUtil.h"
@@ -36,7 +36,7 @@ using Error = llvm::Error;
 
 UdtRecordCompleter::UdtRecordCompleter(
     PdbTypeSymId id, CompilerType &derived_ct, clang::TagDecl &tag_decl,
-    PdbAstBuilder &ast_builder, PdbIndex &index,
+    PdbAstBuilderClang &ast_builder, PdbIndex &index,
     llvm::DenseMap<clang::Decl *, DeclStatus> &decl_to_status,
     llvm::DenseMap<lldb::opaque_compiler_type_t,
                    llvm::SmallSet<std::pair<llvm::StringRef, CompilerType>, 8>>

--- a/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/UdtRecordCompleter.h
@@ -9,7 +9,7 @@
 #ifndef LLDB_SOURCE_PLUGINS_SYMBOLFILE_NATIVEPDB_UDTRECORDCOMPLETER_H
 #define LLDB_SOURCE_PLUGINS_SYMBOLFILE_NATIVEPDB_UDTRECORDCOMPLETER_H
 
-#include "PdbAstBuilder.h"
+#include "PdbAstBuilderClang.h"
 #include "PdbSymUid.h"
 #include "PdbUtil.h"
 #include "Plugins/ExpressionParser/Clang/ClangASTImporter.h"
@@ -35,7 +35,6 @@ namespace lldb_private {
 class Type;
 class CompilerType;
 namespace npdb {
-class PdbAstBuilder;
 class PdbIndex;
 
 class UdtRecordCompleter : public llvm::codeview::TypeVisitorCallbacks {
@@ -46,7 +45,7 @@ class UdtRecordCompleter : public llvm::codeview::TypeVisitorCallbacks {
   PdbTypeSymId m_id;
   CompilerType &m_derived_ct;
   clang::TagDecl &m_tag_decl;
-  PdbAstBuilder &m_ast_builder;
+  PdbAstBuilderClang &m_ast_builder;
   PdbIndex &m_index;
   std::vector<IndexedBase> m_bases;
   ClangASTImporter::LayoutInfo m_layout;
@@ -58,7 +57,7 @@ class UdtRecordCompleter : public llvm::codeview::TypeVisitorCallbacks {
 public:
   UdtRecordCompleter(
       PdbTypeSymId id, CompilerType &derived_ct, clang::TagDecl &tag_decl,
-      PdbAstBuilder &ast_builder, PdbIndex &index,
+      PdbAstBuilderClang &ast_builder, PdbIndex &index,
       llvm::DenseMap<clang::Decl *, DeclStatus> &decl_to_status,
       llvm::DenseMap<lldb::opaque_compiler_type_t,
                      llvm::SmallSet<std::pair<llvm::StringRef, CompilerType>,

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -81,8 +81,8 @@
 
 #include "Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserClang.h"
-#include "Plugins/SymbolFile/PDB/PDBASTParser.h"
 #include "Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.h"
+#include "Plugins/SymbolFile/PDB/PDBASTParser.h"
 
 #include <cstdio>
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -82,7 +82,7 @@
 #include "Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserClang.h"
 #include "Plugins/SymbolFile/PDB/PDBASTParser.h"
-#include "Plugins/SymbolFile/NativePDB/PdbAstBuilder.h"
+#include "Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.h"
 
 #include <cstdio>
 
@@ -9159,7 +9159,8 @@ PDBASTParser *TypeSystemClang::GetPDBParser() {
 
 npdb::PdbAstBuilder *TypeSystemClang::GetNativePDBParser() {
   if (!m_native_pdb_ast_parser_up)
-    m_native_pdb_ast_parser_up = std::make_unique<npdb::PdbAstBuilder>(*this);
+    m_native_pdb_ast_parser_up =
+        std::make_unique<npdb::PdbAstBuilderClang>(*this);
   return m_native_pdb_ast_parser_up.get();
 }
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -44,6 +44,12 @@
 class DWARFASTParserClang;
 class PDBASTParser;
 
+namespace lldb_private {
+namespace npdb {
+class PdbAstBuilderClang;
+} // namespace npdb
+} // namespace lldb_private
+
 namespace clang {
 class FileManager;
 class HeaderSearch;
@@ -1222,7 +1228,7 @@ private:
   std::unique_ptr<clang::ModuleMap> m_module_map_up;
   std::unique_ptr<DWARFASTParserClang> m_dwarf_ast_parser_up;
   std::unique_ptr<PDBASTParser> m_pdb_ast_parser_up;
-  std::unique_ptr<npdb::PdbAstBuilder> m_native_pdb_ast_parser_up;
+  std::unique_ptr<npdb::PdbAstBuilderClang> m_native_pdb_ast_parser_up;
   std::unique_ptr<clang::MangleContext> m_mangle_ctx_up;
   uint32_t m_pointer_byte_size = 0;
   bool m_ast_owned = false;

--- a/llvm/utils/gn/secondary/lldb/source/Plugins/SymbolFile/NativePDB/BUILD.gn
+++ b/llvm/utils/gn/secondary/lldb/source/Plugins/SymbolFile/NativePDB/BUILD.gn
@@ -25,7 +25,7 @@ static_library("NativePDB") {
     "CodeViewRegisterMapping.cpp",
     "CompileUnitIndex.cpp",
     "DWARFLocationExpression.cpp",
-    "PdbAstBuilder.cpp",
+    "PdbAstBuilderClang.cpp",
     "PdbFPOProgramToDWARFExpression.cpp",
     "PdbIndex.cpp",
     "PdbSymUid.cpp",


### PR DESCRIPTION
This changes `PdbAstBuilder` to a language-neutral abstract interface and moves all of its functionality to the `PdbAstBuilderClang` derived class.

All Clang-specific methods with external callers are now public methods on `PdbAstBuilderClang`. `TypeSystemClang` and `UdtRecordCompleter` use `PdbAstBuilderClang` directly.

Did my best to clean up includes and unused methods.

RFC for context:
https://discourse.llvm.org/t/rfc-lldb-make-pdbastbuilder-language-agnostic/89117