### PR TITLE
[ADT] Hide no_unique_address behind a macro

### DIFF
--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -17,7 +17,7 @@
 #ifndef LLVM_ADT_STLFORWARDCOMPAT_H
 #define LLVM_ADT_STLFORWARDCOMPAT_H
 
-#include <functional>
+#include "llvm/Support/Compiler.h"
 #include <optional>
 #include <tuple>
 #include <type_traits>
@@ -227,7 +227,7 @@ class BindStorage<BindFront, BoundArgsTupleT, FnStorageT,
                   std::index_sequence<Indices...>> {
   BoundArgsTupleT BoundArgs;
   // This may be empty for const functions, hence the `no_unique_address`.
-  [[no_unique_address]] FnStorageT FnStorage;
+  LLVM_NO_UNIQUE_ADDRESS FnStorageT FnStorage;
 
 public:
   // Constructor for FnHolder (runtime callable).

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -443,6 +443,8 @@
 
 #if LLVM_HAS_CPP_ATTRIBUTE(no_unique_address)
 #define LLVM_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#elif LLVM_HAS_CPP_ATTRIBUTE(msvc::no_unique_address)
+#define LLVM_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 #else
 #define LLVM_NO_UNIQUE_ADDRESS
 #endif

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -441,6 +441,12 @@
 #define LLVM_CTOR_NODISCARD
 #endif
 
+#if LLVM_HAS_CPP_ATTRIBUTE(no_unique_address)
+#define LLVM_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#else
+#define LLVM_NO_UNIQUE_ADDRESS
+#endif
+
 /// LLVM_EXTENSION - Support compilers where we have a keyword to suppress
 /// pedantic diagnostics.
 #ifdef __GNUC__


### PR DESCRIPTION
This attribute was introduced in C++20 and not available across all compilers.