### PR TITLE
[LLDB] Prevent division by zero in MSVC deque formatter

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
@@ -110,7 +110,7 @@ lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::Update() {
   if (!block_size_decl)
     return lldb::eRefetch;
   Scalar block_size = block_size_decl.GetConstantValue();
-  if (!block_size.IsValid())
+  if (!block_size.IsValid() || block_size <= 0)
     return lldb::eRefetch;
 
   ValueObjectSP offset_sp = storage_sp->GetChildMemberWithName("_Myoff");
@@ -126,7 +126,7 @@ lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::Update() {
     return lldb::eRefetch;
 
   uint64_t map_size = map_size_sp->GetValueAsUnsigned(0, &ok);
-  if (!ok)
+  if (!ok || map_size == 0)
     return lldb::eRefetch;
 
   uint64_t size = size_sp->GetValueAsUnsigned(0, &ok);


### PR DESCRIPTION
To look up an item in a `std::deque` we do https://github.com/llvm/llvm-project/blob/d69335bac9d218ed5dadeebed66b600347d5db8e/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp#L71-L73

This will crash on if `m_block_size` or `m_map_size` is zero. We didn't check that these aren't zero. With this PR, we do.

When running the MSVC STL smoke test, `m_map_size` was randomly zero (the test breaks before the variables are initialized) and the test failed, because LLDB crashed.