### PR TITLE
[CodeGen] Remove legacy getTgtMemIntrinsic overload

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -1250,26 +1250,8 @@ public:
   /// access multiple memory locations.
   virtual void getTgtMemIntrinsic(SmallVectorImpl<IntrinsicInfo> &Infos,
                                   const CallBase &I, MachineFunction &MF,
-                                  unsigned Intrinsic) const {
-    // The default implementation forwards to the legacy single-info overload
-    // for compatibility.
-    IntrinsicInfo Info;
-    if (getTgtMemIntrinsic(Info, I, MF, Intrinsic))
-      Infos.push_back(Info);
-  }
+                                  unsigned Intrinsic) const {}
 
-protected:
-  /// This is a legacy single-info overload. New code should override the
-  /// SmallVectorImpl overload instead to support multiple memory operands.
-  ///
-  /// TODO: Remove this once the refactoring is complete.
-  virtual bool getTgtMemIntrinsic(IntrinsicInfo &, const CallBase &,
-                                  MachineFunction &,
-                                  unsigned /*Intrinsic*/) const {
-    return false;
-  }
-
-public:
   /// Returns true if the target can instruction select the specified FP
   /// immediate natively. If false, the legalizer will materialize the FP
   /// immediate as a load from a constant pool.


### PR DESCRIPTION
It is now fully unused.

---

**Stack**:
- [2/2] #179469
- [1/2] #175846 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/nhaehnle/spr). Merging this PR using the GitHub UI may have unexpected results.*