### PR TITLE
[Github] Bump clang-format version to 21.1.8 for formatting job

### DIFF
--- a/.github/workflows/containers/github-action-ci-tooling/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-tooling/Dockerfile
@@ -1,4 +1,4 @@
-ARG LLVM_VERSION=21.1.0
+ARG LLVM_VERSION=21.1.8
 # FIXME: Use "${LLVM_VERSION%%.*}" instead of "LLVM_VERSION_MAJOR" once we update runners to Ubuntu-26.04 with Buildah >= 1.37
 ARG LLVM_VERSION_MAJOR=21
 


### PR DESCRIPTION
In line with the current de-facto support policy of bumping to the first/last versions of a release.