### PR TITLE
[flang] Fix parse error on !$ACC ROUTINE

### DIFF
--- a/flang/lib/Parser/program-parsers.cpp
+++ b/flang/lib/Parser/program-parsers.cpp
@@ -77,7 +77,7 @@ static constexpr auto globalCompilerDirective{
 
 static constexpr auto globalOpenACCCompilerDirective{
     construct<ProgramUnit>(indirect(skipStuffBeforeStatement >>
-        "!$ACC "_sptok >> Parser<OpenACCRoutineConstruct>{}))};
+        "!$ACC "_sptok >> Parser<OpenACCRoutineConstruct>{} / endOfLine))};
 
 // R501 program -> program-unit [program-unit]...
 // This is the top-level production for the Fortran language.

--- a/flang/test/Parser/bug135964.f90
+++ b/flang/test/Parser/bug135964.f90
@@ -1,0 +1,8 @@
+! RUN: %flang_fc1 -fopenacc -fdebug-unparse %s | FileCheck %s
+!CHECK: !$ACC ROUTINE(square) BIND(asdf)
+
+function square(x)
+  square = x * x
+end
+
+!$acc routine(square) bind(asdf)


### PR DESCRIPTION
!$ACC ROUTINE is allowed to appear between program units, but we fail to parse it when it is not followed by one, because its parser in program-parsers.cpp doesn't consume the end of the line.  Fix.

Fixes https://github.com/llvm/llvm-project/issues/135964.