### PR TITLE
[llvm][Support] Remove unnecessary allocations when creating StringEr…

### DIFF
--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -1306,7 +1306,7 @@ inline Error createStringError(std::error_code EC, char const *Fmt,
                                const Ts &... Vals) {
   std::string Buffer;
   raw_string_ostream(Buffer) << format(Fmt, Vals...);
-  return make_error<StringError>(Buffer, EC);
+  return make_error<StringError>(std::move(Buffer), EC, true);
 }
 
 LLVM_ABI Error createStringError(std::string &&Msg, std::error_code EC);

--- a/llvm/lib/Support/Error.cpp
+++ b/llvm/lib/Support/Error.cpp
@@ -144,7 +144,7 @@ StringError::StringError(const Twine &S, std::error_code EC)
     : Msg(S.str()), EC(EC), PrintMsgOnly(true) {}
 
 StringError::StringError(std::string &&S, std::error_code EC, bool PrintMsgOnly)
-    : Msg(S), EC(EC), PrintMsgOnly(PrintMsgOnly) {}
+    : Msg(std::move(S)), EC(EC), PrintMsgOnly(PrintMsgOnly) {}
 
 void StringError::log(raw_ostream &OS) const {
   if (PrintMsgOnly) {
@@ -161,7 +161,7 @@ std::error_code StringError::convertToErrorCode() const {
 }
 
 Error createStringError(std::string &&Msg, std::error_code EC) {
-  return make_error<StringError>(Msg, EC);
+  return make_error<StringError>(std::move(Msg), EC, true);
 }
 
 void report_fatal_error(Error Err, bool GenCrashDiag) {


### PR DESCRIPTION
…rors

The String Error class has three constructors .
StringError::StringError(const Twine &S, std::error_code EC)
StringError::StringError(std::error_code EC, const Twine &S) 
StringError::StringError(std::string &&S, std::error_code EC, bool PrintMsgOnly)

When we use the `createStringError(std::error_code, char const *, ... )` it ends up using twine variant and ends up creating a new string twice