### PR TITLE
GlobalMerge: Do not merge globals with non-dbg metadata.

### DIFF
--- a/llvm/include/llvm/IR/GlobalObject.h
+++ b/llvm/include/llvm/IR/GlobalObject.h
@@ -143,6 +143,8 @@ public:
   using Value::hasMetadata;
   using Value::setMetadata;
 
+  bool hasMetadataOtherThanDebugLoc() const;
+  
   /// Copy metadata from Src, adjusting offsets by Offset.
   LLVM_ABI void copyMetadata(const GlobalObject *Src, unsigned Offset);
 

--- a/llvm/include/llvm/IR/GlobalObject.h
+++ b/llvm/include/llvm/IR/GlobalObject.h
@@ -144,7 +144,7 @@ public:
   using Value::setMetadata;
 
   bool hasMetadataOtherThanDebugLoc() const;
-  
+
   /// Copy metadata from Src, adjusting offsets by Offset.
   LLVM_ABI void copyMetadata(const GlobalObject *Src, unsigned Offset);
 

--- a/llvm/include/llvm/IR/GlobalObject.h
+++ b/llvm/include/llvm/IR/GlobalObject.h
@@ -143,7 +143,7 @@ public:
   using Value::hasMetadata;
   using Value::setMetadata;
 
-  bool hasMetadataOtherThanDebugLoc() const;
+  LLVM_ABI bool hasMetadataOtherThanDebugLoc() const;
 
   /// Copy metadata from Src, adjusting offsets by Offset.
   LLVM_ABI void copyMetadata(const GlobalObject *Src, unsigned Offset);

--- a/llvm/lib/CodeGen/GlobalMerge.cpp
+++ b/llvm/lib/CodeGen/GlobalMerge.cpp
@@ -740,7 +740,7 @@ bool GlobalMergeImpl::run(Module &M) {
     // already run).
     if (GV.hasMetadataOtherThanDebugLoc())
       continue;
-    
+
     Type *Ty = GV.getValueType();
     TypeSize AllocSize = DL.getTypeAllocSize(Ty);
     bool CanMerge = AllocSize < Opt.MaxOffset && AllocSize >= Opt.MinSize;

--- a/llvm/lib/CodeGen/GlobalMerge.cpp
+++ b/llvm/lib/CodeGen/GlobalMerge.cpp
@@ -731,6 +731,16 @@ bool GlobalMergeImpl::run(Module &M) {
     if (GV.isTagged())
       continue;
 
+    // Don't merge globals with metadata other than !dbg, as this is essentially
+    // equivalent to adding metadata to an existing global, which is not
+    // necessarily a correct transformation depending on the specific metadata's
+    // semantics. We will later use copyMetadata() to copy metadata from
+    // component globals to the combined global, which only knows how to do this
+    // correctly for !dbg (and !type, but by this point LowerTypeTests will have
+    // already run).
+    if (GV.hasMetadataOtherThanDebugLoc())
+      continue;
+    
     Type *Ty = GV.getValueType();
     TypeSize AllocSize = DL.getTypeAllocSize(Ty);
     bool CanMerge = AllocSize < Opt.MaxOffset && AllocSize >= Opt.MinSize;

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -388,6 +388,15 @@ bool GlobalObject::canIncreaseAlignment() const {
   return true;
 }
 
+bool GlobalObject::hasMetadataOtherThanDebugLoc() const {
+  SmallVector<std::pair<unsigned, MDNode *>, 4> MDs;
+  getAllMetadata(MDs);
+  for (const auto &V : MDs)
+    if (V.first != LLVMContext::MD_dbg)
+      return true;
+  return false;
+}
+
 template <typename Operation>
 static const GlobalObject *
 findBaseObject(const Constant *C, DenseSet<const GlobalAlias *> &Aliases,

--- a/llvm/lib/Transforms/IPO/ConstantMerge.cpp
+++ b/llvm/lib/Transforms/IPO/ConstantMerge.cpp
@@ -66,15 +66,6 @@ static bool IsBetterCanonical(const GlobalVariable &A,
   return A.hasGlobalUnnamedAddr();
 }
 
-static bool hasMetadataOtherThanDebugLoc(const GlobalVariable *GV) {
-  SmallVector<std::pair<unsigned, MDNode *>, 4> MDs;
-  GV->getAllMetadata(MDs);
-  for (const auto &V : MDs)
-    if (V.first != LLVMContext::MD_dbg)
-      return true;
-  return false;
-}
-
 static void copyDebugLocMetadata(const GlobalVariable *From,
                                  GlobalVariable *To) {
   SmallVector<DIGlobalVariableExpression *, 1> MDs;
@@ -104,9 +95,9 @@ enum class CanMerge { No, Yes };
 static CanMerge makeMergeable(GlobalVariable *Old, GlobalVariable *New) {
   if (!Old->hasGlobalUnnamedAddr() && !New->hasGlobalUnnamedAddr())
     return CanMerge::No;
-  if (hasMetadataOtherThanDebugLoc(Old))
+  if (Old->hasMetadataOtherThanDebugLoc())
     return CanMerge::No;
-  assert(!hasMetadataOtherThanDebugLoc(New));
+  assert(!New->hasMetadataOtherThanDebugLoc());
   if (!Old->hasGlobalUnnamedAddr())
     New->setUnnamedAddr(GlobalValue::UnnamedAddr::None);
   return CanMerge::Yes;
@@ -172,7 +163,7 @@ static bool mergeConstants(Module &M) {
         continue;
 
       // Don't touch globals with metadata other then !dbg.
-      if (hasMetadataOtherThanDebugLoc(&GV))
+      if (GV.hasMetadataOtherThanDebugLoc())
         continue;
 
       Constant *Init = GV.getInitializer();

--- a/llvm/test/Transforms/GlobalMerge/metadata1.ll
+++ b/llvm/test/Transforms/GlobalMerge/metadata1.ll
@@ -1,0 +1,15 @@
+; RUN: opt -global-merge -global-merge-max-offset=100 -S -o - %s | FileCheck %s
+; RUN: opt -passes='global-merge<max-offset=100>' -S -o - %s | FileCheck %s
+
+target datalayout = "e-p:64:64"
+target triple = "x86_64-unknown-linux-gnu"
+; CHECK-NOT: @_MergedGlobals
+
+@a = internal global i32 1, !foo !{}
+@b = internal global i32 2
+
+define void @use1() {
+  %x = load i32, ptr @a
+  %y = load i32, ptr @b
+  ret void
+}

--- a/llvm/test/Transforms/GlobalMerge/metadata2.ll
+++ b/llvm/test/Transforms/GlobalMerge/metadata2.ll
@@ -1,0 +1,15 @@
+; RUN: opt -global-merge -global-merge-max-offset=100 -S -o - %s | FileCheck %s
+; RUN: opt -passes='global-merge<max-offset=100>' -S -o - %s | FileCheck %s
+
+target datalayout = "e-p:64:64"
+target triple = "x86_64-unknown-linux-gnu"
+; CHECK-NOT: @_MergedGlobals
+
+@a = internal global i32 1
+@b = internal global i32 2, !foo !{}
+
+define void @use1() {
+  %x = load i32, ptr @a
+  %y = load i32, ptr @b
+  ret void
+}


### PR DESCRIPTION
As noticed during the review of #149260, this transformation
is not necessarily correct for all metadata types.
