### PR TITLE
[InstCombine] Add new pattern to foldICmpAddConstant

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -3159,13 +3159,14 @@ Instruction *InstCombinerImpl::foldICmpAddConstant(ICmpInst &Cmp,
       return replaceInstUsesWith(Cmp, Cond);
   }
 
-  // icmp ult (add nuw X, (lshr A, ShAmtC)), C --> icmp ult A, C
+  // icmp ult (add nuw A, (lshr A, ShAmtC)), C --> icmp ult A, C
   // when C <= (1 << ShAmtC).
   const APInt *ShAmtC;
   Value *A;
   unsigned BitWidth = C.getBitWidth();
-  if (Pred == ICmpInst::ICMP_ULT && Add->hasNoUnsignedWrap() &&
-      match(Add, m_c_Add(m_Value(A), m_LShr(m_Deferred(A), m_APInt(ShAmtC)))) &&
+  if (Pred == ICmpInst::ICMP_ULT &&
+      match(Add,
+            m_c_NUWAdd(m_Value(A), m_LShr(m_Deferred(A), m_APInt(ShAmtC)))) &&
       ShAmtC->ult(BitWidth) &&
       C.ule(APInt::getOneBitSet(BitWidth, ShAmtC->getZExtValue())))
     return new ICmpInst(Pred, A, ConstantInt::get(A->getType(), C));

--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -3158,6 +3158,18 @@ Instruction *InstCombinerImpl::foldICmpAddConstant(ICmpInst &Cmp,
             createLogicFromTable(Table, Op0, Op1, Builder, Add->hasOneUse()))
       return replaceInstUsesWith(Cmp, Cond);
   }
+
+  // icmp ult (add nuw X, (lshr A, ShAmtC)), C --> icmp ult A, C
+  // when C <= (1 << ShAmtC).
+  const APInt *ShAmtC;
+  Value *A;
+  unsigned BitWidth = C.getBitWidth();
+  if (Pred == ICmpInst::ICMP_ULT && Add->hasNoUnsignedWrap() &&
+      match(Add, m_c_Add(m_Value(A), m_LShr(m_Deferred(A), m_APInt(ShAmtC)))) &&
+      ShAmtC->ult(BitWidth) &&
+      C.ule(APInt::getOneBitSet(BitWidth, ShAmtC->getZExtValue())))
+    return new ICmpInst(Pred, A, ConstantInt::get(A->getType(), C));
+
   const APInt *C2;
   if (Cmp.isEquality() || !match(Y, m_APInt(C2)))
     return nullptr;

--- a/llvm/test/Transforms/InstCombine/icmp-add.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-add.ll
@@ -3516,3 +3516,66 @@ entry:
   %cmp = icmp samesign ult i32 %v0, 10
   ret i1 %cmp
 }
+
+; icmp ult (add nuw X, (lshr X, S)), C --> icmp ult X, C when C <= (1 << S)
+define i1 @icmp_ult_add_nuw_lshr(i32 %arg0) {
+; CHECK-LABEL: @icmp_ult_add_nuw_lshr(
+; CHECK-NEXT:    [[V2:%.*]] = icmp ult i32 [[ARG0:%.*]], 256
+; CHECK-NEXT:    ret i1 [[V2]]
+;
+  %v0 = lshr i32 %arg0, 9
+  %v1 = add nuw i32 %v0, %arg0
+  %v2 = icmp ult i32 %v1, 256
+  ret i1 %v2
+}
+
+define i1 @icmp_ult_add_nuw_lshr_commuted(i32 %arg0) {
+; CHECK-LABEL: @icmp_ult_add_nuw_lshr_commuted(
+; CHECK-NEXT:    [[V2:%.*]] = icmp ult i32 [[ARG0:%.*]], 256
+; CHECK-NEXT:    ret i1 [[V2]]
+;
+  %v0 = lshr i32 %arg0, 9
+  %v1 = add nuw i32 %arg0, %v0
+  %v2 = icmp ult i32 %v1, 256
+  ret i1 %v2
+}
+
+; C = (1 << S) is the boundary case
+define i1 @icmp_ult_add_nuw_lshr_boundary(i32 %arg0) {
+; CHECK-LABEL: @icmp_ult_add_nuw_lshr_boundary(
+; CHECK-NEXT:    [[V2:%.*]] = icmp ult i32 [[ARG0:%.*]], 512
+; CHECK-NEXT:    ret i1 [[V2]]
+;
+  %v0 = lshr i32 %arg0, 9
+  %v1 = add nuw i32 %v0, %arg0
+  %v2 = icmp ult i32 %v1, 512
+  ret i1 %v2
+}
+
+; Negative test: C > (1 << S)
+define i1 @icmp_ult_add_nuw_lshr_neg_c_too_large(i32 %arg0) {
+; CHECK-LABEL: @icmp_ult_add_nuw_lshr_neg_c_too_large(
+; CHECK-NEXT:    [[V0:%.*]] = lshr i32 [[ARG0:%.*]], 9
+; CHECK-NEXT:    [[V1:%.*]] = add nuw i32 [[V0]], [[ARG0]]
+; CHECK-NEXT:    [[V2:%.*]] = icmp ult i32 [[V1]], 513
+; CHECK-NEXT:    ret i1 [[V2]]
+;
+  %v0 = lshr i32 %arg0, 9
+  %v1 = add nuw i32 %v0, %arg0
+  %v2 = icmp ult i32 %v1, 513
+  ret i1 %v2
+}
+
+; Negative test: no nuw flag
+define i1 @icmp_ult_add_lshr_neg_no_nuw(i32 %arg0) {
+; CHECK-LABEL: @icmp_ult_add_lshr_neg_no_nuw(
+; CHECK-NEXT:    [[V0:%.*]] = lshr i32 [[ARG0:%.*]], 9
+; CHECK-NEXT:    [[V1:%.*]] = add i32 [[V0]], [[ARG0]]
+; CHECK-NEXT:    [[V2:%.*]] = icmp ult i32 [[V1]], 256
+; CHECK-NEXT:    ret i1 [[V2]]
+;
+  %v0 = lshr i32 %arg0, 9
+  %v1 = add i32 %v0, %arg0
+  %v2 = icmp ult i32 %v1, 256
+  ret i1 %v2
+}


### PR DESCRIPTION
icmp ult (add nuw X, (lshr A, ShAmtC)), C --> icmp ult A, C 
when C <= (1 << ShAmtC)
Pattern found in ffmpeg according to the report

https://alive2.llvm.org/ce/z/rpY8LY

Fixes https://github.com/llvm/llvm-project/issues/167178