### PR TITLE
[DebugInfo] Only generate template parameters in the skeleton CU for a template function/type with simplified name (3/3).

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -1943,6 +1943,8 @@ public:
     return cast_or_null<DIType>(getRawSpecification());
   }
 
+  bool isNameSimplified() const { return getFlags() & FlagNameIsSimplified; }
+
   Metadata *getRawBitStride() const {
     return getOperand(MY_FIRST_OPERAND + 12);
   }
@@ -2448,6 +2450,7 @@ public:
   }
   bool isExplicit() const { return getFlags() & FlagExplicit; }
   bool isPrototyped() const { return getFlags() & FlagPrototyped; }
+  bool isNameSimplified() const { return getFlags() & FlagNameIsSimplified; }
   bool areAllCallsDescribed() const {
     return getFlags() & FlagAllCallsDescribed;
   }

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -1076,8 +1076,12 @@ void DwarfUnit::constructTypeDIE(DIE &Buffer, const DICompositeType *CTy) {
 
     // Add template parameters to a class, structure or union types.
     if (Tag == dwarf::DW_TAG_class_type ||
-        Tag == dwarf::DW_TAG_structure_type || Tag == dwarf::DW_TAG_union_type)
-      addTemplateParams(Buffer, CTy->getTemplateParams());
+        Tag == dwarf::DW_TAG_structure_type ||
+        Tag == dwarf::DW_TAG_union_type) {
+      if (!(DD->useSplitDwarf() && !getCU().getSkeleton()) ||
+          CTy->isNameSimplified())
+        addTemplateParams(Buffer, CTy->getTemplateParams());
+    }
 
     // Add elements to structure type.
     DINodeArray Elements = CTy->getElements();
@@ -1420,7 +1424,8 @@ bool DwarfUnit::applySubprogramDefinitionAttributes(const DISubprogram *SP,
   }
 
   // Add function template parameters.
-  addTemplateParams(SPDie, SP->getTemplateParams());
+  if (!Minimal || SP->isNameSimplified())
+    addTemplateParams(SPDie, SP->getTemplateParams());
 
   // Add the linkage name if we have one and it isn't in the Decl.
   StringRef LinkageName = SP->getLinkageName();

--- a/llvm/test/DebugInfo/X86/fission-simple-template-names.ll
+++ b/llvm/test/DebugInfo/X86/fission-simple-template-names.ll
@@ -1,0 +1,79 @@
+; Check that we handle template types for split-dwarf-inlining and simple-template-names correctly.
+; RUN: llc -split-dwarf-file=%t.dwo -O2 < %s -dwarf-version=5 -mtriple=x86_64-unknown-linux-gnu -filetype=obj -o -  | llvm-dwarfdump - | FileCheck %s
+;
+; The test case is generated from the following code
+; clang -cc1 -emit-llvm -fdebug-info-for-profiling -fsplit-dwarf-inlining -gsimple-template-names=simple -debug-info-kind=constructor -dwarf-version=5 -split-dwarf-file temp.dwo -O2
+;
+; void f1();
+;
+; template <typename T>
+; void f2() {
+;   f1();
+; }
+;
+; void f3() {
+;   f2<int>();
+; }
+
+; CHECK:      .debug_info contents:
+; CHECK:        DW_TAG_skeleton_unit
+; CHECK:          DW_TAG_subprogram
+; CHECK-NEXT:     DW_AT_linkage_name	("_Z2f2IiEvv")
+; CHECK-NEXT:     DW_AT_name	("f2")
+; CHECK:          DW_TAG_template_type_parameter
+; CHECK-NEXT:       DW_AT_type	(0x{{.*}} "int")
+; CHECK-NEXT:       DW_AT_name	("T")
+; CHECK:      .debug_info.dwo contents:
+; CHECK:        DW_TAG_compile_unit
+; CHECK:          DW_TAG_subprogram
+; CHECK-NEXT:     DW_AT_linkage_name	("_Z2f2IiEvv")
+; CHECK-NEXT:     DW_AT_name	("f2")
+; CHECK:          DW_TAG_template_type_parameter
+; CHECK-NEXT:       DW_AT_type	(0x{{.*}} "int")
+; CHECK-NEXT:       DW_AT_name	("T")
+
+; ModuleID = 'fission-simple-template-names.cpp'
+source_filename = "fission-simple-template-names.cpp"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: mustprogress nounwind
+define dso_local void @_Z2f3v() local_unnamed_addr #0 !dbg !10 {
+entry:
+  tail call void @_Z2f1v() #2, !dbg !14
+  ret void, !dbg !20
+}
+
+declare !dbg !21 void @_Z2f1v() local_unnamed_addr #1
+
+attributes #0 = { mustprogress nounwind "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-features"="+cx8,+mmx,+sse,+sse2,+x87" }
+attributes #1 = { "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-features"="+cx8,+mmx,+sse,+sse2,+x87" }
+attributes #2 = { nounwind }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4}
+!llvm.ident = !{!5}
+!llvm.errno.tbaa = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 22.0.0", isOptimized: true, runtimeVersion: 0, splitDebugFilename: "temp.dwo", emissionKind: FullDebug, debugInfoForProfiling: true, nameTableKind: None)
+!1 = !DIFile(filename: "<stdin>", directory: "", checksumkind: CSK_MD5, checksum: "f34ede93f4bfefbee3dbe78d1a033274")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{!"clang version 22.0.0"}
+!6 = !{!7, !7, i64 0}
+!7 = !{!"int", !8, i64 0}
+!8 = !{!"omnipotent char", !9, i64 0}
+!9 = !{!"Simple C++ TBAA"}
+!10 = distinct !DISubprogram(name: "f3", linkageName: "_Z2f3v", scope: !11, file: !11, line: 8, type: !12, scopeLine: 8, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!11 = !DIFile(filename: "fission-simple-template-names.cpp", directory: "", checksumkind: CSK_MD5, checksum: "f34ede93f4bfefbee3dbe78d1a033274")
+!12 = !DISubroutineType(types: !13)
+!13 = !{null}
+!14 = !DILocation(line: 5, column: 3, scope: !15, inlinedAt: !19)
+!15 = distinct !DISubprogram(name: "f2", linkageName: "_Z2f2IiEvv", scope: !11, file: !11, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped | DIFlagAllCallsDescribed | DIFlagNameIsSimplified, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, templateParams: !16)
+!16 = !{!17}
+!17 = !DITemplateTypeParameter(name: "T", type: !18)
+!18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!19 = distinct !DILocation(line: 9, column: 3, scope: !10)
+!20 = !DILocation(line: 10, column: 1, scope: !10)
+!21 = !DISubprogram(name: "f1", linkageName: "_Z2f1v", scope: !11, file: !11, line: 1, type: !12, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)

--- a/llvm/test/DebugInfo/X86/fission-template.ll
+++ b/llvm/test/DebugInfo/X86/fission-template.ll
@@ -20,9 +20,6 @@
 ; CHECK:          DW_TAG_subprogram
 ; CHECK-NEXT:     DW_AT_linkage_name	("_Z2f2IiEvv")
 ; CHECK-NEXT:     DW_AT_name	("f2<int>")
-; CHECK:          DW_TAG_template_type_parameter
-; CHECK-NEXT:       DW_AT_type	(0x{{.*}} "int")
-; CHECK-NEXT:       DW_AT_name	("T")
 ; CHECK:      .debug_info.dwo contents:
 ; CHECK:        DW_TAG_compile_unit
 ; CHECK:          DW_TAG_subprogram


### PR DESCRIPTION
Currently, when generating debug info for skeleton units, all template parameters are emitted unconditionally. To optimize debug info size, the emission should be conditional — providing parameters only for template types/functions whose names have actually been simplified. As described in [this RFC](https://discourse.llvm.org/t/rfc-debuginfo-selectively-generate-template-parameters-in-the-skeleton-cu/89395).
Previous patches: #175130, #175708 