### PR TITLE
[NFC][MLIR] Remove obsolete target device test from openmp-todo.mlir

### DIFF
--- a/mlir/test/Target/LLVMIR/openmp-todo.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-todo.mlir
@@ -173,15 +173,6 @@ llvm.func @target_allocate(%x : !llvm.ptr) {
 
 // -----
 
-llvm.func @target_device(%x : i32) {
-  omp.target device(%x : i32) {
-    omp.terminator
-  }
-  llvm.return
-}
-
-// -----
-
 omp.declare_reduction @add_f32 : f32
 init {
 ^bb0(%arg: f32):


### PR DESCRIPTION
Remove the target device test from openmp-todo.mlir since MLIR-to-LLVM IR lowering for the OpenMP target device clause is now implemented (#173509, #174665).