### PR TITLE
[DSE][Verifier] Respect the calling convention of the function specified by "alloc-variant-zeroed"

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -2535,6 +2535,11 @@ void Verifier::verifyFunctionAttrs(FunctionType *FT, AttributeList Attrs,
       Check(FT == Variant->getFunctionType(),
             "'alloc-variant-zeroed' must name a function with the same "
             "signature");
+
+      if (const Function *F = dyn_cast<Function>(V))
+        Check(F->getCallingConv() == Variant->getCallingConv(),
+              "'alloc-variant-zeroed' must name a function with the same "
+              "calling convention");
     }
   }
 

--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -2079,9 +2079,13 @@ struct DSEState {
               .removeFnAttribute(Ctx, "alloc-variant-zeroed");
       FunctionCallee ZeroedVariant = Malloc->getModule()->getOrInsertFunction(
           ZeroedVariantName, InnerCallee->getFunctionType(), Attrs);
+      cast<Function>(ZeroedVariant.getCallee())
+          ->setCallingConv(Malloc->getCallingConv());
       SmallVector<Value *, 3> Args;
       Args.append(Malloc->arg_begin(), Malloc->arg_end());
-      Calloc = IRB.CreateCall(ZeroedVariant, Args, ZeroedVariantName);
+      CallInst *CI = IRB.CreateCall(ZeroedVariant, Args, ZeroedVariantName);
+      CI->setCallingConv(Malloc->getCallingConv());
+      Calloc = CI;
     } else {
       Type *SizeTTy = Malloc->getArgOperand(0)->getType();
       Calloc =

--- a/llvm/test/Transforms/DeadStoreElimination/noop-stores.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/noop-stores.ll
@@ -387,6 +387,20 @@ define ptr @customalloc_memset(i64 %size, i64 %align) {
 declare ptr @customalloc(i64, i64) allockind("alloc") "alloc-family"="customalloc" "alloc-variant-zeroed"="customalloc_zeroed"
 declare ptr @customalloc_zeroed(i64, i64) allockind("alloc,zeroed") "alloc-family"="customalloc"
 
+; This should create a customalloc_zeroed_custom_cc call and eliminate the memset while
+; respecting the custom calling convention of the zeroed variant.
+define cc99 ptr @customalloc_memset_custom_cc(i64 %size, i64 %align) {
+; CHECK-LABEL: @customalloc_memset_custom_cc
+; CHECK-NEXT:  [[CALL:%.*]] = call cc99 ptr @customalloc_zeroed_custom_cc(i64 [[SIZE:%.*]], i64 [[ALIGN:%.*]])
+; CHECK-NEXT:  ret ptr [[CALL]]
+  %call = call cc99 ptr @customalloc_custom_cc(i64 %size, i64 %align)
+  call void @llvm.memset.p0.i64(ptr %call, i8 0, i64 %size, i1 false)
+  ret ptr %call
+}
+
+declare cc99 ptr @customalloc_custom_cc(i64, i64) allockind("alloc") "alloc-family"="customalloc_custom_cc" "alloc-variant-zeroed"="customalloc_zeroed_custom_cc"
+declare cc99 ptr @customalloc_zeroed_custom_cc(i64, i64) allockind("alloc,zeroed") "alloc-family"="customalloc_custom_cc"
+
 ; This should not create recursive call to calloc.
 define ptr @calloc(i64 %nmemb, i64 %size) inaccessiblememonly {
 ; CHECK-LABEL: @calloc(

--- a/llvm/test/Verifier/alloc-variant-zeroed.ll
+++ b/llvm/test/Verifier/alloc-variant-zeroed.ll
@@ -17,3 +17,7 @@ declare ptr @d_zeroed(i64) "alloc-family"="D"
 ; CHECK: 'alloc-variant-zeroed' must name a function with the same signature
 declare ptr @e(i64) "alloc-variant-zeroed"="e_zeroed" "alloc-family"="E"
 declare ptr @e_zeroed(i64, i64) "alloc-family"="E" allockind("zeroed")
+
+; CHECK: 'alloc-variant-zeroed' must name a function with the same calling convention
+declare cc99 ptr @f(i64) "alloc-variant-zeroed"="f_zeroed" "alloc-family"="F"
+declare cc100 ptr @f_zeroed(i64) "alloc-family"="F" allockind("zeroed")


### PR DESCRIPTION
Say we are using custom allocators with custom calling convension (`cc99` in this example):

```llvm
declare cc99 noalias noundef ptr @alloc(i64 noundef, i64 allocalign noundef) unnamed_addr #1
declare cc99 noalias noundef ptr @alloc_zeroed(i64 noundef, i64 allocalign noundef) unnamed_addr #2
declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg) #3

attributes #1 = { nounwind nonlazybind allockind("alloc,uninitialized,aligned") allocsize(0) uwtable "alloc-family"="zalloc" "alloc-variant-zeroed"="alloc_zeroed" }
attributes #2 = { nounwind nonlazybind allockind("alloc,zeroed,aligned") allocsize(0) uwtable "alloc-family"="zalloc" }
attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }

define cc99 ptr @foo() {
  %1 = call cc99 ptr @alloc(i64 24, i64 8)
  call void @llvm.memset.p0.i64(ptr align 8 %1, i8 0, i64 24, i1 false)
  ret ptr %1
}
```

Currently `opt -O3` gives:

```llvm
; ModuleID = 'zalloc.ll'
source_filename = "zalloc.ll"

; Function Attrs: nounwind
define cc99 noalias noundef ptr @foo() local_unnamed_addr #0 {
  %alloc_zeroed = tail call align 8 dereferenceable_or_null(24) ptr @alloc_zeroed(i64 24, i64 8)
  ret ptr %alloc_zeroed
}

; Function Attrs: nounwind nonlazybind allockind("alloc,zeroed,aligned") allocsize(0) uwtable
declare noalias noundef ptr @alloc_zeroed(i64 noundef, i64 allocalign noundef) local_unnamed_addr #1

attributes #0 = { nounwind }
attributes #1 = { nounwind nonlazybind allockind("alloc,zeroed,aligned") allocsize(0) uwtable "alloc-family"="zalloc" }
```

While the expected output should be:

```llvm
; ModuleID = 'zalloc.ll'
source_filename = "zalloc.ll"

; Function Attrs: nounwind nonlazybind allockind("alloc,zeroed,aligned") allocsize(0) uwtable
declare cc99 noalias noundef ptr @alloc_zeroed(i64 noundef, i64 allocalign noundef) unnamed_addr #0
;       ^^^^

; Function Attrs: nounwind
define cc99 noalias noundef ptr @foo() local_unnamed_addr #1 {
  %alloc_zeroed = tail call cc99 align 8 dereferenceable_or_null(24) ptr @alloc_zeroed(i64 24, i64 8)
  ;                         ^^^^
  ret ptr %alloc_zeroed
}

attributes #0 = { nounwind nonlazybind allockind("alloc,zeroed,aligned") allocsize(0) uwtable "alloc-family"="zalloc" }
attributes #1 = { nounwind }
```

We can notice that the `tail call` is missing calling conventions, which may lead to invalid code generation.

This PR should fix this issue.