### PR TITLE
[llvm-readobj][offload] Fix llvm-readobj --all on MachO

### DIFF
--- a/llvm/lib/Object/OffloadBundle.cpp
+++ b/llvm/lib/Object/OffloadBundle.cpp
@@ -188,7 +188,9 @@ Error OffloadBundleFatBin::extractBundle(const ObjectFile &Source) {
 
 Error object::extractOffloadBundleFatBinary(
     const ObjectFile &Obj, SmallVectorImpl<OffloadBundleFatBin> &Bundles) {
-  assert((Obj.isELF() || Obj.isCOFF()) && "Invalid file type");
+  // Ignore unsupported object formats.
+  if (!Obj.isELF() && !Obj.isCOFF())
+    return Error::success();
 
   // Iterate through Sections until we find an offload_bundle section.
   for (SectionRef Sec : Obj.sections()) {

--- a/llvm/test/tools/llvm-readobj/MachO/all.test
+++ b/llvm/test/tools/llvm-readobj/MachO/all.test
@@ -1,0 +1,34 @@
+# RUN: yaml2obj %s | llvm-readobj --all - | FileCheck %s
+
+# Make sure that --all at least doesn't crash.
+
+# CHECK: Format: Mach-O arm
+# CHECK: Arch: arm
+# CHECK: AddressSize: 32bit
+# CHECK: MachHeader {
+# CHECK:   Magic: Magic (0xFEEDFACE)
+# CHECK:   CpuType: Arm (0xC)
+# CHECK:   CpuSubType: CPU_SUBTYPE_ARM_V7 (0x9)
+# CHECK:   FileType: Relocatable (0x1)
+# CHECK:   NumOfLoadCommands: 0
+# CHECK:   SizeOfLoadCommands: 0
+# CHECK:   Flags [ (0x0)
+# CHECK:   ]
+# CHECK: }
+# CHECK: Sections [
+# CHECK: ]
+# CHECK: Relocations [
+# CHECK: ]
+# CHECK: UnwindInfo not implemented.
+# CHECK: Symbols [
+# CHECK: ]
+
+--- !mach-o
+FileHeader:
+  magic:      0xFEEDFACE
+  cputype:    0xC
+  cpusubtype: 0x9
+  filetype:   0x1
+  ncmds:      0
+  sizeofcmds: 0
+  flags:      0x0

--- a/llvm/test/tools/llvm-readobj/MachO/all.test
+++ b/llvm/test/tools/llvm-readobj/MachO/all.test
@@ -1,6 +1,6 @@
 # RUN: yaml2obj %s | llvm-readobj --all - | FileCheck %s
 
-# Make sure that --all at least doesn't crash.
+## Make sure that --all at least doesn't crash.
 
 # CHECK: Format: Mach-O arm
 # CHECK: Arch: arm


### PR DESCRIPTION
Currently running llvm-readobj --all on any MachO object asserts, because it implies --offload, and the --offload extraction includes an assert on the object format. Instead, we should be silently ignoring.

This regressed in https://github.com/llvm/llvm-project/pull/143342.