### PR TITLE
[ValueTracking] Allow dereferenceable(0) to be applied to a null pointer

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -1572,8 +1572,8 @@ Currently, only the following parameter attributes are defined:
     dereferenceability (consider a pointer to one element past the end of an
     array), however ``dereferenceable(<n>)`` does imply ``nonnull`` in
     ``addrspace(0)`` (which is the default address space), except if the
-    ``null_pointer_is_valid`` function attribute is present or ``n == 0``.
-    ``n`` should be a non-negative number. The pointer should be well defined,
+    ``null_pointer_is_valid`` function attribute is present.
+    ``n`` should be a positive number. The pointer should be well defined,
     otherwise it is undefined behavior. This means ``dereferenceable(<n>)``
     implies ``noundef``. When used in an assume operand bundle, more restricted
     semantics apply. See  :ref:`assume operand bundles <assume_opbundles>` for
@@ -3115,6 +3115,7 @@ the behavior is undefined, unless one of the following exceptions applies:
 * ``dereferenceable(<n>)`` operand bundles only guarantee the pointer is
   dereferenceable at the point of the assumption. The pointer may not be
   dereferenceable at later pointers, e.g., because it could have been freed.
+  Only ``n > 0`` implies that the pointer is dereferenceable.
 
 In addition to allowing operand bundles encoding function and parameter
 attributes, an assume operand bundle may also encode a ``separate_storage``

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -1572,8 +1572,8 @@ Currently, only the following parameter attributes are defined:
     dereferenceability (consider a pointer to one element past the end of an
     array), however ``dereferenceable(<n>)`` does imply ``nonnull`` in
     ``addrspace(0)`` (which is the default address space), except if the
-    ``null_pointer_is_valid`` function attribute is present.
-    ``n`` should be a positive number. The pointer should be well defined,
+    ``null_pointer_is_valid`` function attribute is present or ``n == 0``.
+    ``n`` should be a non-negative number. The pointer should be well defined,
     otherwise it is undefined behavior. This means ``dereferenceable(<n>)``
     implies ``noundef``. When used in an assume operand bundle, more restricted
     semantics apply. See  :ref:`assume operand bundles <assume_opbundles>` for

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -844,14 +844,11 @@ static bool isKnownNonZeroFromAssume(const Value *V, const SimplifyQuery &Q) {
             if (NullPointerIsDefined(Q.CxtI->getFunction(),
                                      V->getType()->getPointerAddressSpace()))
               return false;
+            assert(RK.IRArgValue &&
+                   "Dereferenceable attribute without IR argument?");
 
-            if (!RK.IRArgValue)
-              return true;
-
-            if (auto *CI = dyn_cast<ConstantInt>(RK.IRArgValue))
-              return !CI->isZero();
-
-            return false;
+            auto *CI = dyn_cast<ConstantInt>(RK.IRArgValue);
+            return CI && !CI->isZero();
           }
 
           return false;

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -848,7 +848,7 @@ static bool isKnownNonZeroFromAssume(const Value *V, const SimplifyQuery &Q) {
             if (!RK.IRArgValue)
               return true;
 
-            if(auto* CI = dyn_cast<ConstantInt>(RK.IRArgValue))
+            if (auto *CI = dyn_cast<ConstantInt>(RK.IRArgValue))
               return !CI->isZero();
 
             return false;

--- a/llvm/test/Analysis/ValueTracking/assume.ll
+++ b/llvm/test/Analysis/ValueTracking/assume.ll
@@ -159,3 +159,73 @@ A:
   %6 = phi i32 [ %4, %3 ], [ 0, %A ]
   ret i32 %6
 }
+
+define dso_local i32 @test5(ptr readonly %0, i1 %cond, i32 %bytes) nofree nosync {
+; CHECK-LABEL: @test5(
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[TMP0:%.*]], i32 [[BYTES:%.*]]) ]
+; CHECK-NEXT:    br i1 [[COND:%.*]], label [[A:%.*]], label [[B:%.*]]
+; CHECK:       B:
+; CHECK-NEXT:    br label [[A]]
+; CHECK:       A:
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq ptr [[TMP0]], null
+; CHECK-NEXT:    br i1 [[TMP2]], label [[TMP4:%.*]], label [[TMP6:%.*]]
+; CHECK:       3:
+; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[TMP0]], align 4
+; CHECK-NEXT:    br label [[TMP4]]
+; CHECK:       5:
+; CHECK-NEXT:    [[TMP5:%.*]] = phi i32 [ [[TMP3]], [[TMP6]] ], [ 0, [[A]] ]
+; CHECK-NEXT:    ret i32 [[TMP5]]
+;
+  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %0, i32 %bytes)]
+  br i1 %cond, label %A, label %B
+
+B:
+  br label %A
+
+A:
+  %2 = icmp eq ptr %0, null
+  br i1 %2, label %5, label %3
+
+3:                                                ; preds = %1
+  %4 = load i32, ptr %0, align 4
+  br label %5
+
+5:                                                ; preds = %1, %3
+  %6 = phi i32 [ %4, %3 ], [ 0, %A ]
+  ret i32 %6
+}
+
+define dso_local i32 @test6(ptr readonly %0, i1 %cond) nofree nosync {
+; CHECK-LABEL: @test6(
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[TMP0:%.*]], i32 0) ]
+; CHECK-NEXT:    br i1 [[COND:%.*]], label [[A:%.*]], label [[B:%.*]]
+; CHECK:       B:
+; CHECK-NEXT:    br label [[A]]
+; CHECK:       A:
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq ptr [[TMP0]], null
+; CHECK-NEXT:    br i1 [[TMP2]], label [[TMP4:%.*]], label [[TMP6:%.*]]
+; CHECK:       3:
+; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[TMP0]], align 4
+; CHECK-NEXT:    br label [[TMP4]]
+; CHECK:       5:
+; CHECK-NEXT:    [[TMP5:%.*]] = phi i32 [ [[TMP3]], [[TMP6]] ], [ 0, [[A]] ]
+; CHECK-NEXT:    ret i32 [[TMP5]]
+;
+  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %0, i32 0)]
+  br i1 %cond, label %A, label %B
+
+B:
+  br label %A
+
+A:
+  %2 = icmp eq ptr %0, null
+  br i1 %2, label %5, label %3
+
+3:                                                ; preds = %1
+  %4 = load i32, ptr %0, align 4
+  br label %5
+
+5:                                                ; preds = %1, %3
+  %6 = phi i32 [ %4, %3 ], [ 0, %A ]
+  ret i32 %6
+}

--- a/llvm/test/Analysis/ValueTracking/assume.ll
+++ b/llvm/test/Analysis/ValueTracking/assume.ll
@@ -160,72 +160,34 @@ A:
   ret i32 %6
 }
 
-define dso_local i32 @test5(ptr readonly %0, i1 %cond, i32 %bytes) nofree nosync {
+define dso_local i1 @test5(ptr readonly %0, i1 %cond, i32 %bytes) nofree nosync {
 ; CHECK-LABEL: @test5(
 ; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[TMP0:%.*]], i32 [[BYTES:%.*]]) ]
-; CHECK-NEXT:    br i1 [[COND:%.*]], label [[A:%.*]], label [[B:%.*]]
-; CHECK:       B:
-; CHECK-NEXT:    br label [[A]]
-; CHECK:       A:
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq ptr [[TMP0]], null
-; CHECK-NEXT:    br i1 [[TMP2]], label [[TMP4:%.*]], label [[TMP6:%.*]]
-; CHECK:       3:
-; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[TMP0]], align 4
-; CHECK-NEXT:    br label [[TMP4]]
-; CHECK:       5:
-; CHECK-NEXT:    [[TMP5:%.*]] = phi i32 [ [[TMP3]], [[TMP6]] ], [ 0, [[A]] ]
-; CHECK-NEXT:    ret i32 [[TMP5]]
+; CHECK-NEXT:    ret i1 [[TMP2]]
 ;
   call void @llvm.assume(i1 true) ["dereferenceable"(ptr %0, i32 %bytes)]
-  br i1 %cond, label %A, label %B
-
-B:
-  br label %A
-
-A:
   %2 = icmp eq ptr %0, null
-  br i1 %2, label %5, label %3
-
-3:                                                ; preds = %1
-  %4 = load i32, ptr %0, align 4
-  br label %5
-
-5:                                                ; preds = %1, %3
-  %6 = phi i32 [ %4, %3 ], [ 0, %A ]
-  ret i32 %6
+  ret i1 %2
 }
 
-define dso_local i32 @test6(ptr readonly %0, i1 %cond) nofree nosync {
+define dso_local i1 @test6(ptr readonly %0, i1 %cond) nofree nosync {
 ; CHECK-LABEL: @test6(
 ; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[TMP0:%.*]], i32 0) ]
-; CHECK-NEXT:    br i1 [[COND:%.*]], label [[A:%.*]], label [[B:%.*]]
-; CHECK:       B:
-; CHECK-NEXT:    br label [[A]]
-; CHECK:       A:
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq ptr [[TMP0]], null
-; CHECK-NEXT:    br i1 [[TMP2]], label [[TMP4:%.*]], label [[TMP6:%.*]]
-; CHECK:       3:
-; CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[TMP0]], align 4
-; CHECK-NEXT:    br label [[TMP4]]
-; CHECK:       5:
-; CHECK-NEXT:    [[TMP5:%.*]] = phi i32 [ [[TMP3]], [[TMP6]] ], [ 0, [[A]] ]
-; CHECK-NEXT:    ret i32 [[TMP5]]
+; CHECK-NEXT:    ret i1 [[TMP2]]
 ;
   call void @llvm.assume(i1 true) ["dereferenceable"(ptr %0, i32 0)]
-  br i1 %cond, label %A, label %B
-
-B:
-  br label %A
-
-A:
   %2 = icmp eq ptr %0, null
-  br i1 %2, label %5, label %3
+  ret i1 %2
+}
 
-3:                                                ; preds = %1
-  %4 = load i32, ptr %0, align 4
-  br label %5
-
-5:                                                ; preds = %1, %3
-  %6 = phi i32 [ %4, %3 ], [ 0, %A ]
-  ret i32 %6
+define dso_local i1 @test7(ptr readonly %0, i1 %cond) nofree nosync {
+; CHECK-LABEL: @test7(
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[TMP0:%.*]], i32 1) ]
+; CHECK-NEXT:    ret i1 false
+;
+  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %0, i32 1)]
+  %2 = icmp eq ptr %0, null
+  ret i1 %2
 }

--- a/llvm/test/Analysis/ValueTracking/assume.ll
+++ b/llvm/test/Analysis/ValueTracking/assume.ll
@@ -160,34 +160,34 @@ A:
   ret i32 %6
 }
 
-define dso_local i1 @test5(ptr readonly %0, i1 %cond, i32 %bytes) nofree nosync {
-; CHECK-LABEL: @test5(
+define i1 @test_dereferenceable_unknown_size_not_nonnull(ptr %ptr, i32 %bytes) {
+; CHECK-LABEL: @test_dereferenceable_unknown_size_not_nonnull(
 ; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[TMP0:%.*]], i32 [[BYTES:%.*]]) ]
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq ptr [[TMP0]], null
 ; CHECK-NEXT:    ret i1 [[TMP2]]
 ;
-  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %0, i32 %bytes)]
-  %2 = icmp eq ptr %0, null
+  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %ptr, i32 %bytes)]
+  %2 = icmp eq ptr %ptr, null
   ret i1 %2
 }
 
-define dso_local i1 @test6(ptr readonly %0, i1 %cond) nofree nosync {
-; CHECK-LABEL: @test6(
+define i1 @test_dereferenceable_zero_size_not_nonnull(ptr %ptr) {
+; CHECK-LABEL: @test_dereferenceable_zero_size_not_nonnull(
 ; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[TMP0:%.*]], i32 0) ]
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq ptr [[TMP0]], null
 ; CHECK-NEXT:    ret i1 [[TMP2]]
 ;
-  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %0, i32 0)]
-  %2 = icmp eq ptr %0, null
+  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %ptr, i32 0)]
+  %2 = icmp eq ptr %ptr, null
   ret i1 %2
 }
 
-define dso_local i1 @test7(ptr readonly %0, i1 %cond) nofree nosync {
-; CHECK-LABEL: @test7(
+define i1 @test_dereferenceable_non_zero_size_is_nonnull(ptr %ptr) {
+; CHECK-LABEL: @test_dereferenceable_non_zero_size_is_nonnull(
 ; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[TMP0:%.*]], i32 1) ]
 ; CHECK-NEXT:    ret i1 false
 ;
-  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %0, i32 1)]
-  %2 = icmp eq ptr %0, null
+  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %ptr, i32 1)]
+  %2 = icmp eq ptr %ptr, null
   ret i1 %2
 }


### PR DESCRIPTION
`dereferenceable(<n>)` with n being potentially zero can come up when using an operand bundle with a variable size. Currently this implies that the pointer is non-null, even though `[nullptr, nullptr)` is a valid range in any programming language I'm aware of. This patch removes this implication and updates the language reference to reflect that `dereferenceable` with a zero argument is valid.
