### PR TITLE
[libc+][stack] P3372R3: `constexpr <queue>`

### DIFF
--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -293,10 +293,12 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Container>
-_LIBCPP_HIDE_FROM_ABI bool operator==(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y);
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool
+operator==(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y);
 
 template <class _Tp, class _Container>
-_LIBCPP_HIDE_FROM_ABI bool operator<(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y);
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool
+operator<(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y);
 
 template <class _Tp, class _Container /*= deque<_Tp>*/>
 class queue {
@@ -312,84 +314,98 @@ protected:
   container_type c;
 
 public:
-  _LIBCPP_HIDE_FROM_ABI queue() _NOEXCEPT_(is_nothrow_default_constructible<container_type>::value) : c() {}
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 queue()
+      _NOEXCEPT_(is_nothrow_default_constructible<container_type>::value)
+      : c() {}
 
-  _LIBCPP_HIDE_FROM_ABI queue(const queue& __q) : c(__q.c) {}
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 queue(const queue& __q) : c(__q.c) {}
 
 #  if _LIBCPP_STD_VER >= 23
   template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI queue(_InputIterator __first, _InputIterator __last) : c(__first, __last) {}
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 queue(_InputIterator __first, _InputIterator __last)
+      : c(__first, __last) {}
 
   template <_ContainerCompatibleRange<_Tp> _Range>
-  _LIBCPP_HIDE_FROM_ABI queue(from_range_t, _Range&& __range) : c(from_range, std::forward<_Range>(__range)) {}
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 queue(from_range_t, _Range&& __range)
+      : c(from_range, std::forward<_Range>(__range)) {}
 
   template <class _InputIterator,
             class _Alloc,
             __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
             __enable_if_t<uses_allocator<container_type, _Alloc>::value, int>        = 0>
-  _LIBCPP_HIDE_FROM_ABI queue(_InputIterator __first, _InputIterator __second, const _Alloc& __alloc)
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26
+  queue(_InputIterator __first, _InputIterator __second, const _Alloc& __alloc)
       : c(__first, __second, __alloc) {}
 
   template <_ContainerCompatibleRange<_Tp> _Range,
             class _Alloc,
             __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI queue(from_range_t, _Range&& __range, const _Alloc& __alloc)
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 queue(from_range_t, _Range&& __range, const _Alloc& __alloc)
       : c(from_range, std::forward<_Range>(__range), __alloc) {}
 
 #  endif
 
-  _LIBCPP_HIDE_FROM_ABI queue& operator=(const queue& __q) {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 queue& operator=(const queue& __q) {
     c = __q.c;
     return *this;
   }
 
 #  ifndef _LIBCPP_CXX03_LANG
-  _LIBCPP_HIDE_FROM_ABI queue(queue&& __q) noexcept(is_nothrow_move_constructible<container_type>::value)
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26
+  queue(queue&& __q) noexcept(is_nothrow_move_constructible<container_type>::value)
       : c(std::move(__q.c)) {}
 
-  _LIBCPP_HIDE_FROM_ABI queue& operator=(queue&& __q) noexcept(is_nothrow_move_assignable<container_type>::value) {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 queue&
+  operator=(queue&& __q) noexcept(is_nothrow_move_assignable<container_type>::value) {
     c = std::move(__q.c);
     return *this;
   }
 #  endif // _LIBCPP_CXX03_LANG
 
-  _LIBCPP_HIDE_FROM_ABI explicit queue(const container_type& __c) : c(__c) {}
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 explicit queue(const container_type& __c) : c(__c) {}
 #  ifndef _LIBCPP_CXX03_LANG
-  _LIBCPP_HIDE_FROM_ABI explicit queue(container_type&& __c) : c(std::move(__c)) {}
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 explicit queue(container_type&& __c) : c(std::move(__c)) {}
 #  endif // _LIBCPP_CXX03_LANG
 
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI explicit queue(const _Alloc& __a) : c(__a) {}
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 explicit queue(const _Alloc& __a) : c(__a) {}
 
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI queue(const queue& __q, const _Alloc& __a) : c(__q.c, __a) {}
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 queue(const queue& __q, const _Alloc& __a) : c(__q.c, __a) {}
 
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI queue(const container_type& __c, const _Alloc& __a) : c(__c, __a) {}
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 queue(const container_type& __c, const _Alloc& __a)
+      : c(__c, __a) {}
 
 #  ifndef _LIBCPP_CXX03_LANG
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI queue(container_type&& __c, const _Alloc& __a) : c(std::move(__c), __a) {}
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 queue(container_type&& __c, const _Alloc& __a)
+      : c(std::move(__c), __a) {}
 
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI queue(queue&& __q, const _Alloc& __a) : c(std::move(__q.c), __a) {}
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 queue(queue&& __q, const _Alloc& __a)
+      : c(std::move(__q.c), __a) {}
 #  endif // _LIBCPP_CXX03_LANG
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool empty() const { return c.empty(); }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_type size() const { return c.size(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool empty() const { return c.empty(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 size_type size() const { return c.size(); }
 
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI reference front() { return c.front(); }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reference front() const { return c.front(); }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI reference back() { return c.back(); }
-  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const_reference back() const { return c.back(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 reference front() { return c.front(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 const_reference front() const {
+    return c.front();
+  }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 reference back() { return c.back(); }
+  [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 const_reference back() const {
+    return c.back();
+  }
 
-  _LIBCPP_HIDE_FROM_ABI void push(const value_type& __v) { c.push_back(__v); }
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void push(const value_type& __v) { c.push_back(__v); }
 #  ifndef _LIBCPP_CXX03_LANG
-  _LIBCPP_HIDE_FROM_ABI void push(value_type&& __v) { c.push_back(std::move(__v)); }
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void push(value_type&& __v) { c.push_back(std::move(__v)); }
 
 #    if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
-  _LIBCPP_HIDE_FROM_ABI void push_range(_Range&& __range) {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void push_range(_Range&& __range) {
     if constexpr (requires(container_type& __c) { __c.append_range(std::forward<_Range>(__range)); }) {
       c.append_range(std::forward<_Range>(__range));
     } else {
@@ -401,20 +417,19 @@ public:
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI
 #    if _LIBCPP_STD_VER >= 17
-  decltype(auto)
-  emplace(_Args&&... __args) {
+  _LIBCPP_CONSTEXPR_SINCE_CXX26 decltype(auto) emplace(_Args&&... __args) {
     return c.emplace_back(std::forward<_Args>(__args)...);
   }
 #    else
-  void
-  emplace(_Args&&... __args) {
+  void emplace(_Args&&... __args) {
     c.emplace_back(std::forward<_Args>(__args)...);
   }
 #    endif
 #  endif // _LIBCPP_CXX03_LANG
-  _LIBCPP_HIDE_FROM_ABI void pop() { c.pop_front(); }
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void pop() { c.pop_front(); }
 
-  _LIBCPP_HIDE_FROM_ABI void swap(queue& __q) _NOEXCEPT_(__is_nothrow_swappable_v<container_type>) {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void swap(queue& __q)
+      _NOEXCEPT_(__is_nothrow_swappable_v<container_type>) {
     using std::swap;
     swap(c, __q.c);
   }
@@ -422,16 +437,16 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const _Container& __get_container() const { return c; }
 
   template <class _T1, class _OtherContainer>
-  friend _LIBCPP_HIDE_FROM_ABI bool
+  friend _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool
   operator==(const queue<_T1, _OtherContainer>& __x, const queue<_T1, _OtherContainer>& __y);
 
   template <class _T1, class _OtherContainer>
-  friend _LIBCPP_HIDE_FROM_ABI bool
+  friend _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool
   operator<(const queue<_T1, _OtherContainer>& __x, const queue<_T1, _OtherContainer>& __y);
 
 #  if _LIBCPP_STD_VER >= 20
   template <class _T1, three_way_comparable _OtherContainer>
-  friend _LIBCPP_HIDE_FROM_ABI compare_three_way_result_t<_OtherContainer>
+  friend _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 compare_three_way_result_t<_OtherContainer>
   operator<=>(const queue<_T1, _OtherContainer>& __x, const queue<_T1, _OtherContainer>& __y);
 #  endif
 };
@@ -467,39 +482,45 @@ queue(from_range_t, _Range&&, _Alloc)
 #  endif
 
 template <class _Tp, class _Container>
-inline _LIBCPP_HIDE_FROM_ABI bool operator==(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool
+operator==(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
   return __x.c == __y.c;
 }
 
 template <class _Tp, class _Container>
-inline _LIBCPP_HIDE_FROM_ABI bool operator<(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool
+operator<(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
   return __x.c < __y.c;
 }
 
 template <class _Tp, class _Container>
-inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool
+operator!=(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
   return !(__x == __y);
 }
 
 template <class _Tp, class _Container>
-inline _LIBCPP_HIDE_FROM_ABI bool operator>(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool
+operator>(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
   return __y < __x;
 }
 
 template <class _Tp, class _Container>
-inline _LIBCPP_HIDE_FROM_ABI bool operator>=(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool
+operator>=(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
   return !(__x < __y);
 }
 
 template <class _Tp, class _Container>
-inline _LIBCPP_HIDE_FROM_ABI bool operator<=(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 bool
+operator<=(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
   return !(__y < __x);
 }
 
 #  if _LIBCPP_STD_VER >= 20
 
 template <class _Tp, three_way_comparable _Container>
-_LIBCPP_HIDE_FROM_ABI compare_three_way_result_t<_Container>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 compare_three_way_result_t<_Container>
 operator<=>(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
   return __x.c <=> __y.c;
 }
@@ -507,8 +528,8 @@ operator<=>(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y
 #  endif
 
 template <class _Tp, class _Container, __enable_if_t<__is_swappable_v<_Container>, int> = 0>
-inline _LIBCPP_HIDE_FROM_ABI void swap(queue<_Tp, _Container>& __x, queue<_Tp, _Container>& __y)
-    _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y))) {
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void
+swap(queue<_Tp, _Container>& __x, queue<_Tp, _Container>& __y) _NOEXCEPT_(_NOEXCEPT_(__x.swap(__y))) {
   __x.swap(__y);
 }
 

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons.alloc/ctor_alloc.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons.alloc/ctor_alloc.pass.cpp
@@ -29,9 +29,19 @@ struct test : private std::queue<int, std::deque<int, test_allocator<int> > > {
   test_allocator<int> get_allocator() { return c.get_allocator(); }
 };
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   test q(test_allocator<int>(3));
   assert(q.get_allocator() == test_allocator<int>(3));
 
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
+
   return 0;
 }
+

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons.alloc/ctor_container_alloc.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons.alloc/ctor_container_alloc.pass.cpp
@@ -19,7 +19,7 @@
 #include "test_allocator.h"
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push_back(i);
@@ -40,7 +40,7 @@ struct test : public std::queue<int, C> {
   test_allocator<int> get_allocator() { return c.get_allocator(); }
 };
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   C d = make<C>(5);
   test q(d, test_allocator<int>(4));
   assert(q.get_allocator() == test_allocator<int>(4));
@@ -49,6 +49,15 @@ int main(int, char**) {
     assert(q.front() == d[i]);
     q.pop();
   }
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons.alloc/ctor_iterators.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons.alloc/ctor_iterators.pass.cpp
@@ -32,7 +32,7 @@ public:
   }
 };
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   const int a[] = {4, 3, 2, 1};
   test_allocator_statistics stats{};
   GetAlloc queue(stats, a, a + 4);
@@ -45,6 +45,15 @@ int main(int, char**) {
   assert(queue.front() == 1);
   queue.pop();
   assert(queue.empty());
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons.alloc/ctor_queue_alloc.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons.alloc/ctor_queue_alloc.pass.cpp
@@ -18,7 +18,7 @@
 #include "test_allocator.h"
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push_back(i);
@@ -39,11 +39,20 @@ struct test : public std::queue<T, C> {
   allocator_type get_allocator() { return this->c.get_allocator(); }
 };
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   test<int> q(make<C>(5), test_allocator<int>(4));
   test<int> q2(q, test_allocator<int>(5));
   assert(q2.get_allocator() == test_allocator<int>(5));
   assert(q2.size() == 5);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons.alloc/ctor_rcontainer_alloc.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons.alloc/ctor_rcontainer_alloc.pass.cpp
@@ -21,7 +21,7 @@
 #include "MoveOnly.h"
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push_back(MoveOnly(i));
@@ -43,10 +43,19 @@ struct test : public std::queue<T, C> {
   allocator_type get_allocator() { return this->c.get_allocator(); }
 };
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   test<MoveOnly> q(make<C>(5), test_allocator<MoveOnly>(4));
   assert(q.get_allocator() == test_allocator<MoveOnly>(4));
   assert(q.size() == 5);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons.alloc/ctor_rqueue_alloc.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons.alloc/ctor_rqueue_alloc.pass.cpp
@@ -21,7 +21,7 @@
 #include "MoveOnly.h"
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push_back(MoveOnly(i));
@@ -43,11 +43,20 @@ struct test : public std::queue<T, C> {
   allocator_type get_allocator() { return this->c.get_allocator(); }
 };
 
-int main(int, char**) {
+TEST_CONSTEXPR bool test() {
   test<MoveOnly> q(make<C>(5), test_allocator<MoveOnly>(4));
   test<MoveOnly> q2(std::move(q), test_allocator<MoveOnly>(5));
   assert(q2.get_allocator() == test_allocator<MoveOnly>(5));
   assert(q2.size() == 5);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons/ctor_container.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons/ctor_container.pass.cpp
@@ -20,14 +20,14 @@
 #endif
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push_back(i);
   return c;
 }
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   typedef std::deque<int> Container;
   typedef std::queue<int> Q;
   Container d = make<Container>(5);
@@ -40,6 +40,15 @@ int main(int, char**) {
 
 #if TEST_STD_VER >= 11
   static_assert(!test_convertible<Q, const Container&>(), "");
+#endif
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
 #endif
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons/ctor_copy.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons/ctor_copy.pass.cpp
@@ -16,17 +16,26 @@
 #include "test_macros.h"
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push_back(i);
   return c;
 }
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<int> q(make<std::deque<int> >(5));
   std::queue<int> q2 = q;
   assert(q2 == q);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons/ctor_default.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons/ctor_default.pass.cpp
@@ -21,7 +21,7 @@
 #  include "test_convertible.h"
 #endif
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   typedef std::vector<int, limited_allocator<int, 10> > Container;
   typedef std::queue<int, Container> Q;
   Q q;
@@ -35,6 +35,15 @@ int main(int, char**) {
 #if TEST_STD_VER >= 11
   // It should be explicit, so not convertible before C++20.
   static_assert(test_convertible<Q>(), "");
+#endif
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
 #endif
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons/ctor_iterators.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons/ctor_iterators.pass.cpp
@@ -38,7 +38,7 @@ struct alloc : test_allocator<T> {
 static_assert(
     std::is_constructible_v<std::queue<int, std::deque<int, alloc<int>>>, int*, int*, test_allocator_statistics*>);
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   const int a[] = {4, 3, 2, 1};
   std::queue<int> queue(a, a + 4);
   assert(queue.front() == 4);
@@ -50,6 +50,15 @@ int main(int, char**) {
   assert(queue.front() == 1);
   queue.pop();
   assert(queue.empty());
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons/ctor_move.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons/ctor_move.pass.cpp
@@ -19,18 +19,27 @@
 #include "MoveOnly.h"
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push_back(MoveOnly(i));
   return c;
 }
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<MoveOnly> q(make<std::deque<MoveOnly> >(5));
   std::queue<MoveOnly> q2 = std::move(q);
   assert(q2.size() == 5);
   assert(q.empty());
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons/ctor_rcontainer.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons/ctor_rcontainer.pass.cpp
@@ -24,14 +24,14 @@
 #endif
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push_back(MoveOnly(i));
   return c;
 }
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   typedef std::deque<MoveOnly> Container;
   typedef std::queue<MoveOnly> Q;
   Q q(make<std::deque<MoveOnly> >(5));
@@ -39,6 +39,15 @@ int main(int, char**) {
 
 #if TEST_STD_VER >= 11
   static_assert(!test_convertible<Q, Container&&>(), "");
+#endif
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
 #endif
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons/deduct.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons/deduct.pass.cpp
@@ -36,7 +36,7 @@
 
 struct A {};
 
-int main(int, char**) {
+constexpr bool test() {
   //  Test the explicit deduction guides
   {
     std::list<int> l{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -169,5 +169,15 @@ int main(int, char**) {
 
   ContainerAdaptorDeductionGuidesSfinaeAway<std::queue, std::queue<int>>();
 
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
+
   return 0;
 }
+

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons/deduct.verify.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons/deduct.verify.cpp
@@ -15,7 +15,7 @@
 #include <cassert>
 #include <cstddef>
 
-int main(int, char**) {
+void test() {
   //  Test the explicit deduction guides
   {
     //  queue(const Container&, const Alloc&);
@@ -41,6 +41,4 @@ int main(int, char**) {
     //  Also, we can't use {} instead of parens, because that constructs a
     //      stack<allocator<int>, allocator<allocator<int>>>
   }
-
-  return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.cons/from_range.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.cons/from_range.pass.cpp
@@ -17,7 +17,7 @@
 // template<container-compatible-range<T> R, class Alloc>
 //   queue(from_range_t, R&& rg, const Alloc&); // since C++23
 
-int main(int, char**) {
+constexpr bool test() {
   for_all_iterators_and_allocators<int>([]<class Iter, class Sent, class Alloc>() {
     test_container_adaptor<std::queue, std::deque, int, Iter, Sent, Alloc>();
   });
@@ -27,6 +27,15 @@ int main(int, char**) {
 
   test_exception_safety_throwing_copy<std::queue>();
   test_exception_safety_throwing_allocator<std::queue, int>();
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/assign_copy.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/assign_copy.pass.cpp
@@ -16,18 +16,27 @@
 #include "test_macros.h"
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push_back(i);
   return c;
 }
 
-int main(int, char**) {
+TEST_CONSTEXPR bool test() {
   std::queue<int> q(make<std::deque<int> >(5));
   std::queue<int> q2;
   q2 = q;
   assert(q2 == q);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/assign_move.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/assign_move.pass.cpp
@@ -19,19 +19,29 @@
 #include "MoveOnly.h"
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push_back(MoveOnly(i));
   return c;
 }
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<MoveOnly> q(make<std::deque<MoveOnly> >(5));
   std::queue<MoveOnly> q2;
   q2 = std::move(q);
   assert(q2.size() == 5);
   assert(q.empty());
 
+  return bool;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
+
   return 0;
 }
+

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/back.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/back.pass.cpp
@@ -15,7 +15,7 @@
 
 #include "test_macros.h"
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<int> q;
   assert(q.size() == 0);
   q.push(1);
@@ -23,6 +23,15 @@ int main(int, char**) {
   q.push(3);
   int& ir = q.back();
   assert(ir == 3);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/back_const.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/back_const.pass.cpp
@@ -15,7 +15,7 @@
 
 #include "test_macros.h"
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<int> q;
   assert(q.size() == 0);
   q.push(1);
@@ -24,6 +24,15 @@ int main(int, char**) {
   const std::queue<int>& cqr = q;
   const int& cir             = cqr.back();
   assert(cir == 3);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/emplace.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/emplace.pass.cpp
@@ -36,7 +36,7 @@ void test_return_type() {
 #endif
 }
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   test_return_type<std::queue<int> >();
   test_return_type<std::queue<int, std::list<int> > >();
 
@@ -59,6 +59,15 @@ int main(int, char**) {
   assert(q.size() == 3);
   assert(q.front() == Emplaceable(1, 2.5));
   assert(q.back() == Emplaceable(3, 4.5));
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/empty.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/empty.pass.cpp
@@ -15,13 +15,22 @@
 
 #include "test_macros.h"
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<int> q;
   assert(q.empty());
   q.push(1);
   assert(!q.empty());
   q.pop();
   assert(q.empty());
+
+  return 0;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/front.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/front.pass.cpp
@@ -15,7 +15,7 @@
 
 #include "test_macros.h"
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<int> q;
   assert(q.size() == 0);
   q.push(1);
@@ -23,6 +23,15 @@ int main(int, char**) {
   q.push(3);
   int& ir = q.front();
   assert(ir == 1);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/front_const.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/front_const.pass.cpp
@@ -15,7 +15,7 @@
 
 #include "test_macros.h"
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<int> q;
   assert(q.size() == 0);
   q.push(1);
@@ -24,6 +24,15 @@ int main(int, char**) {
   const std::queue<int>& cqr = q;
   const int& cir             = cqr.front();
   assert(cir == 1);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/pop.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/pop.pass.cpp
@@ -15,7 +15,7 @@
 
 #include "test_macros.h"
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<int> q;
   assert(q.size() == 0);
   q.push(1);
@@ -34,6 +34,15 @@ int main(int, char**) {
   assert(q.back() == 3);
   q.pop();
   assert(q.size() == 0);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/push.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/push.pass.cpp
@@ -15,7 +15,7 @@
 
 #include "test_macros.h"
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<int> q;
   q.push(1);
   assert(q.size() == 1);
@@ -29,6 +29,15 @@ int main(int, char**) {
   assert(q.size() == 3);
   assert(q.front() == 1);
   assert(q.back() == 3);
+
+  return 0;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/push_range.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/push_range.pass.cpp
@@ -17,7 +17,7 @@
 #include "../../push_range_container_adaptors.h"
 #include "test_macros.h"
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   for_all_iterators_and_allocators<int, const int*>([]<class Iter, class Sent, class Alloc>() {
     test_push_range<std::queue<int, std::deque<int, Alloc>>, Iter, Sent>();
   });
@@ -28,6 +28,15 @@ int main(int, char**) {
 
   test_push_range_exception_safety_throwing_copy<std::queue>();
   test_push_range_exception_safety_throwing_allocator<std::queue, std::deque, int>();
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/push_rv.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/push_rv.pass.cpp
@@ -18,7 +18,7 @@
 #include "test_macros.h"
 #include "MoveOnly.h"
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<MoveOnly> q;
   q.push(MoveOnly(1));
   assert(q.size() == 1);
@@ -32,6 +32,15 @@ int main(int, char**) {
   assert(q.size() == 3);
   assert(q.front() == MoveOnly(1));
   assert(q.back() == MoveOnly(3));
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/size.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/size.pass.cpp
@@ -15,11 +15,20 @@
 
 #include "test_macros.h"
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<int> q;
   assert(q.size() == 0);
   q.push(1);
   assert(q.size() == 1);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.defn/swap.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.defn/swap.pass.cpp
@@ -16,14 +16,14 @@
 #include "test_macros.h"
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push(i);
   return c;
 }
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<int> q1      = make<std::queue<int> >(5);
   std::queue<int> q2      = make<std::queue<int> >(10);
   std::queue<int> q1_save = q1;
@@ -31,6 +31,15 @@ int main(int, char**) {
   q1.swap(q2);
   assert(q1 == q2_save);
   assert(q2 == q1_save);
+
+  return 0;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.ops/compare.three_way.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.ops/compare.three_way.pass.cpp
@@ -23,10 +23,20 @@
 #include "nasty_containers.h"
 #include "test_container_comparisons.h"
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   assert((test_sequence_container_adaptor_spaceship<std::queue, std::deque>()));
   assert((test_sequence_container_adaptor_spaceship<std::queue, std::list>()));
   assert((test_sequence_container_adaptor_spaceship<std::queue, nasty_list>()));
-  // `std::queue` is not constexpr, so no `static_assert` test here.
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
+
   return 0;
 }
+

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.ops/eq.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.ops/eq.pass.cpp
@@ -20,14 +20,14 @@
 #include "test_macros.h"
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push(i);
   return c;
 }
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 {
   std::queue<int> q1      = make<std::queue<int> >(5);
   std::queue<int> q2      = make<std::queue<int> >(10);
   std::queue<int> q1_save = q1;
@@ -35,6 +35,16 @@ int main(int, char**) {
   assert(q1 == q1_save);
   assert(q1 != q2);
   assert(q2 == q2_save);
+
+  return true;
+}
+
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.ops/lt.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.ops/lt.pass.cpp
@@ -26,14 +26,14 @@
 #include "test_macros.h"
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push(i);
   return c;
 }
 
-int main(int, char**) {
+TEST_CONSTEXPR_CXX26 bool test() {
   std::queue<int> q1 = make<std::queue<int> >(5);
   std::queue<int> q2 = make<std::queue<int> >(10);
   assert(q1 < q2);
@@ -41,5 +41,15 @@ int main(int, char**) {
   assert(q1 <= q2);
   assert(q2 >= q1);
 
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
+
   return 0;
 }
+

--- a/libcxx/test/std/containers/container.adaptors/queue/queue.special/swap.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/queue/queue.special/swap.pass.cpp
@@ -17,14 +17,14 @@
 #include "test_macros.h"
 
 template <class C>
-C make(int n) {
+TEST_CONSTEXPR_CXX26 C make(int n) {
   C c;
   for (int i = 0; i < n; ++i)
     c.push(i);
   return c;
 }
 
-int main(int, char**) {
+TEST_CONSTEXPR bool test() {
   std::queue<int> q1      = make<std::queue<int> >(5);
   std::queue<int> q2      = make<std::queue<int> >(10);
   std::queue<int> q1_save = q1;
@@ -32,6 +32,15 @@ int main(int, char**) {
   swap(q1, q2);
   assert(q1 == q2_save);
   assert(q2 == q1_save);
+
+  return true;
+}
+
+int main(int, char**) {
+  test();
+#if TEST_STD_VER >= 26
+  static_assert(test());
+#endif
 
   return 0;
 }


### PR DESCRIPTION
Implements `<queue> `as per P3372R3: constexpr containers and adaptors

- https://wg21.link/P3372R3

Closes #128670

This should be a fairly straightforward implementation, as std::stack is a container adaptor, and most of the work is done in the underlying container.

Depends on #128656 Part of #127876

- https://wg21.link/P3372R3
- https://wg21.link/#containers
  - https://wg21.link/container.adaptors#queue.syn
    - https://wg21.link/queue.syn
    - https://wg21.link/queue