### PR TITLE
[clang][bytecode] Reject all function calls in C

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1617,6 +1617,11 @@ bool CallVar(InterpState &S, CodePtr OpPC, const Function *Func,
 }
 bool Call(InterpState &S, CodePtr OpPC, const Function *Func,
           uint32_t VarArgSize) {
+
+  // C doesn't have constexpr functions.
+  if (!S.getLangOpts().CPlusPlus)
+    return Invalid(S, OpPC);
+
   assert(Func);
   auto cleanup = [&]() -> bool {
     cleanupAfterFunctionCall(S, OpPC, Func);

--- a/clang/test/AST/ByteCode/c.c
+++ b/clang/test/AST/ByteCode/c.c
@@ -411,3 +411,9 @@ _Static_assert((((I64){}, 1)), ""); // all-warning {{left operand of comma opera
 char func_(void);
 typedef V(2) char VC2;
 void CopyArrayToFnPtr(void) { *(VC2 *)func_ = C2; }
+
+_Complex double returnsComplex(); // pedantic-warning {{a function declaration without a prototype is deprecated in all versions of C}}
+void callReturnsComplex(void) {
+  _Complex double c;
+  c = foo(0.);
+}


### PR DESCRIPTION
C doesn't have constexpr functions, so this can't ever work anyway.

Fixes https://github.com/llvm/llvm-project/issues/175877