### PR TITLE
release/22.x: [FMV][AArch64] Release notes for clang/llvm 22

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -716,7 +716,7 @@ Arm and AArch64 Support
 - Support level for Function Multi-Versioning (FMV) has been upgraded to Release in ACLE.
   - Resolver functions can use the PAC and BTI hardening settings.
   - Users can override function version priority.
-  - Unreachable functions versions are diagnosed and ignored.
+  - Unreachable function versions are diagnosed and ignored.
 
 Android Support
 ^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -713,6 +713,11 @@ Arm and AArch64 Support
 - More intrinsics for the following AArch64 instructions:
   FCVTZ[US], FCVTN[US], FCVTM[US], FCVTP[US], FCVTA[US]
 
+- Support level for Function Multi-Versioning (FMV) has been upgraded to Release in ACLE.
+  - Resolver functions can use the PAC and BTI hardening settings.
+  - Users can override function version priority.
+  - Unreachable functions versions are diagnosed and ignored.
+
 Android Support
 ^^^^^^^^^^^^^^^
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -94,6 +94,9 @@ Changes to Interprocedural Optimizations
 * Added `-enable-machine-outliner={optimistic-pgo,conservative-pgo}` to read
   profile data to guide the machine outliner
   ([#154437](https://github.com/llvm/llvm-project/pull/154437)).
+* Fixed static resolution of indirect calls to versioned functions on AArch64,
+  by separating unrelated caller versions which were previously mixed together.
+  Also improved the accuracy of the algorithm for low version counts.
 
 Changes to Vectorizers
 ----------------------------------------


### PR DESCRIPTION
Clang (support level upgraded to Release in ACLE)

  - Resolver functions can use the PAC and BTI hardening settings.
  - Users can override function version priority.
  - Unreachable function versions are diagnosed and ignored.

LLVM (bug fix and improvements in IPO/GlobalOpt)

  - Fixed static resolution of indirect calls to versioned functions, by separating unrelated caller versions which were mixed together.
  - Improved the accuracy of the algorithm for low version counts.