### PR TITLE
[mlir][scf] Skip ops having results with warning in forall-to-for pass

### DIFF
--- a/mlir/lib/Dialect/SCF/Transforms/ForallToFor.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/ForallToFor.cpp
@@ -30,6 +30,12 @@ mlir::scf::forallToForLoop(RewriterBase &rewriter, scf::ForallOp forallOp,
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(forallOp);
 
+  if (!forallOp.getOutputs().empty()) {
+    forallOp.emitWarning()
+        << "skipping scf.forall with outputs, currently not supported";
+    return success();
+  }
+
   Location loc = forallOp.getLoc();
   SmallVector<Value> lbs = forallOp.getLowerBound(rewriter);
   SmallVector<Value> ubs = forallOp.getUpperBound(rewriter);


### PR DESCRIPTION
Avoid converting scf.forall ops that have results in forall-to-for pass. Emit a warning instead of failing the pass, so mlir-opt can still produce output on mixed IR.

Fixes https://github.com/llvm/llvm-project/issues/174319