### PR TITLE
[clang][c23] Avoid assertion on an invalid static constexpr variable

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -14122,7 +14122,10 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
     // C99 6.7.8p4: All the expressions in an initializer for an object that has
     // static storage duration shall be constant expressions or string literals.
     } else if (VDecl->getStorageClass() == SC_Static) {
-      CheckForConstantInitializer(Init);
+      // Avoid evaluating the initializer twice for constexpr variables. It will
+      // be evaluated later.
+      if (!VDecl->isConstexpr())
+        CheckForConstantInitializer(Init);
 
       // C89 is stricter than C99 for aggregate initializers.
       // C89 6.5.7p3: All the expressions [...] in an initializer list

--- a/clang/test/Sema/constexpr.c
+++ b/clang/test/Sema/constexpr.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -std=c23 -verify -triple x86_64 -pedantic -Wno-conversion -Wno-constant-conversion -Wno-div-by-zero %s
+// RUN: %clang_cc1 -std=c23 -verify -triple x86_64 -pedantic -Wno-conversion -Wno-constant-conversion -Wno-div-by-zero -fexperimental-new-constant-interpreter %s
 
 // Check that constexpr only applies to variables.
 constexpr void f0() {} // expected-error {{'constexpr' can only be used in variable declarations}}
@@ -415,4 +416,11 @@ long double gh173847_long_double(long double a) {
 void gh173847_test() {
   constexpr double d_const = gh173847_double(2.0);             // expected-error {{constexpr variable 'd_const' must be initialized by a constant expression}}
   constexpr long double ld_const = gh173847_long_double(2.0L); // expected-error {{constexpr variable 'ld_const' must be initialized by a constant expression}}
+}
+
+int gh173605(int x) {
+  static constexpr int c = c; // expected-error {{constexpr variable 'c' must be initialized by a constant expression}}\
+                              // expected-note {{read of object outside its lifetime is not allowed in a constant expression}}
+  static int justincase = justincase; // expected-error {{initializer element is not a compile-time constant}}
+  return x;
 }


### PR DESCRIPTION
In C static variables should have constant expressions in initializers so we were checking this twice for constexpr variables and failing with an assertion that was makes sure we don't do it.
This patch postpones the check just like it is done for static file scope constexpr variables in C already.

Fixes https://github.com/llvm/llvm-project/issues/173605