### PR TITLE
ids-check: Only run the workflow on main

### DIFF
--- a/.github/workflows/ids-check.yml
+++ b/.github/workflows/ids-check.yml
@@ -1,6 +1,8 @@
 name: "Check LLVM ABI annotations"
 on:
   pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
This was causing issues on release branches. The workflow can be run on release branches at a later time.