### PR TITLE
[lldb-dap] Move targetId and debuggerId into a session property

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -874,8 +874,7 @@ class DebugCommunication(object):
         *,
         program: Optional[str] = None,
         pid: Optional[int] = None,
-        debuggerId: Optional[int] = None,
-        targetId: Optional[int] = None,
+        session: Optional[dict[str, int]] = None,
         waitFor=False,
         initCommands: Optional[list[str]] = None,
         preRunCommands: Optional[list[str]] = None,
@@ -895,10 +894,8 @@ class DebugCommunication(object):
             args_dict["pid"] = pid
         if program is not None:
             args_dict["program"] = program
-        if debuggerId is not None:
-            args_dict["debuggerId"] = debuggerId
-        if targetId is not None:
-            args_dict["targetId"] = targetId
+        if session is not None:
+            args_dict["session"] = session
         if waitFor:
             args_dict["waitFor"] = waitFor
         args_dict["initCommands"] = self.init_commands

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -94,7 +94,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
             if self.spawn_thread.is_alive():
                 self.spawn_thread.join(timeout=10)
 
-    def test_attach_with_missing_debuggerId_or_targetId(self):
+    def test_attach_with_missing_session_debugger(self):
         """
         Test that attaching with only one of debuggerId/targetId specified
         fails with the expected error message.
@@ -102,14 +102,14 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         self.build_and_create_debug_adapter()
 
         # Test with only targetId specified (no debuggerId)
-        resp = self.attach(targetId=99999, waitForResponse=True)
+        session = {"targetId": 99999}
+        resp = self.attach(session=session, waitForResponse=True)
         self.assertFalse(resp["success"])
-        self.assertIn(
-            "Both 'debuggerId' and 'targetId' must be specified together",
+        self.assertIn("missing value at arguments.session.debuggerId", 
             resp["body"]["error"]["format"],
         )
 
-    def test_attach_with_invalid_debuggerId_and_targetId(self):
+    def test_attach_with_invalid_session(self):
         """
         Test that attaching with both debuggerId and targetId specified but
         invalid fails with an appropriate error message.
@@ -119,7 +119,8 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         # Attach with both debuggerId=9999 and targetId=99999 (both invalid).
         # Since debugger ID 9999 likely doesn't exist in the global registry,
         # we expect a validation error.
-        resp = self.attach(debuggerId=9999, targetId=99999, waitForResponse=True)
+        session = {"debuggerId": 9999, "targetId": 9999}
+        resp = self.attach(session=session, waitForResponse=True)
         self.assertFalse(resp["success"])
         error_msg = resp["body"]["error"]["format"]
         # Either error is acceptable - both indicate the debugger reuse

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -105,7 +105,8 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         session = {"targetId": 99999}
         resp = self.attach(session=session, waitForResponse=True)
         self.assertFalse(resp["success"])
-        self.assertIn("missing value at arguments.session.debuggerId", 
+        self.assertIn(
+            "missing value at arguments.session.debuggerId",
             resp["body"]["error"]["format"],
         )
 

--- a/lldb/test/API/tools/lldb-dap/startDebugging/TestDAP_startDebugging.py
+++ b/lldb/test/API/tools/lldb-dap/startDebugging/TestDAP_startDebugging.py
@@ -53,13 +53,14 @@ class TestDAP_startDebugging(lldbdap_testcase.DAPTestCaseBase):
 
         # Use mock IDs to test the infrastructure
         # In a real scenario, these would come from the parent session
-        test_debugger_id = 1
-        test_target_id = 100
+        debugger_id = 1
+        target_id = 100
 
         # Send a startDebugging request with debuggerId and targetId
         # This simulates creating a child DAP session that reuses the debugger
+        session = {"session": {"debuggerId": debugger_id, "targetId": target_id}}
         self.dap_server.request_evaluate(
-            f'`lldb-dap start-debugging attach \'{{"debuggerId":{test_debugger_id},"targetId":{test_target_id}}}\'',
+            f"`lldb-dap start-debugging attach '{json.dumps(session)}'",
             context="repl",
         )
 
@@ -76,14 +77,14 @@ class TestDAP_startDebugging(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(request["command"], "startDebugging")
         self.assertEqual(request["arguments"]["request"], "attach")
 
-        config = request["arguments"]["configuration"]
+        session = request["arguments"]["configuration"]["session"]
         self.assertEqual(
-            config["debuggerId"],
-            test_debugger_id,
+            session["debuggerId"],
+            debugger_id,
             "Reverse request should include debugger ID",
         )
         self.assertEqual(
-            config["targetId"],
-            test_target_id,
+            session["targetId"],
+            target_id,
             "Reverse request should include target ID",
         )

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -1310,17 +1310,16 @@ void DAP::StartEventThreads() {
   StartEventThread();
 }
 
-llvm::Error DAP::InitializeDebugger(int debugger_id,
-                                    lldb::user_id_t target_id) {
+llvm::Error DAP::InitializeDebugger(const DAPSession &session) {
   // Find the existing debugger by ID
-  debugger = lldb::SBDebugger::FindDebuggerWithID(debugger_id);
+  debugger = lldb::SBDebugger::FindDebuggerWithID(session.debuggerId);
   if (!debugger.IsValid()) {
     return llvm::createStringError(
         "Unable to find existing debugger for debugger ID");
   }
 
   // Find the target within the debugger by its globally unique ID
-  lldb::SBTarget target = debugger.FindTargetByGloballyUniqueID(target_id);
+  lldb::SBTarget target = debugger.FindTargetByGloballyUniqueID(session.targetId);
   if (!target.IsValid()) {
     return llvm::createStringError(
         "Unable to find existing target for target ID");

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -1319,7 +1319,8 @@ llvm::Error DAP::InitializeDebugger(const DAPSession &session) {
   }
 
   // Find the target within the debugger by its globally unique ID
-  lldb::SBTarget target = debugger.FindTargetByGloballyUniqueID(session.targetId);
+  lldb::SBTarget target =
+      debugger.FindTargetByGloballyUniqueID(session.targetId);
   if (!target.IsValid()) {
     return llvm::createStringError(
         "Unable to find existing target for target ID");

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -432,12 +432,9 @@ struct DAP final : public DAPTransport::MessageHandler {
   /// Perform complete DAP initialization by reusing an existing debugger and
   /// target.
   ///
-  /// \param[in] debugger_id
-  ///     The ID of the existing debugger to reuse.
-  ///
-  /// \param[in] target_id
-  ///     The globally unique ID of the existing target to reuse.
-  llvm::Error InitializeDebugger(int debugger_id, lldb::user_id_t target_id);
+  /// \param[in] session
+  ///     A session consisting of an existing debugger and target.
+  llvm::Error InitializeDebugger(const protocol::DAPSession &session);
 
   /// Start event handling threads based on client capabilities.
   void StartEventThreads();

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -466,10 +466,11 @@ static void HandleTargetEvent(const lldb::SBEvent &event, Log &log) {
     // FindTargetByGloballyUniqueID.
     llvm::json::Object configuration;
     configuration.try_emplace("type", "lldb");
-    configuration.try_emplace("debuggerId",
-                              created_target.GetDebugger().GetID());
-    configuration.try_emplace("targetId", created_target.GetGloballyUniqueID());
     configuration.try_emplace("name", created_target.GetTargetSessionName());
+
+    json::Object session{{"targetId", created_target.GetGloballyUniqueID()},
+                         {"debuggerId", created_target.GetDebugger().GetID()}};
+    configuration.try_emplace("session", std::move(session));
 
     llvm::json::Object request;
     request.try_emplace("request", "attach");

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.cpp
@@ -331,6 +331,15 @@ bool fromJSON(const json::Value &Params, LaunchRequestArguments &LRA,
   return true;
 }
 
+bool fromJSON(const llvm::json::Value &Params, DAPSession &Ses,
+              llvm::json::Path P) {
+
+  json::ObjectMapper O(Params, P);
+  // Validate that both debuggerID and targetId are provided.
+  return O && O.map("targetId", Ses.targetId) &&
+         O.map("debuggerId", Ses.debuggerId);
+}
+
 bool fromJSON(const json::Value &Params, AttachRequestArguments &ARA,
               json::Path P) {
   json::ObjectMapper O(Params, P);
@@ -341,16 +350,15 @@ bool fromJSON(const json::Value &Params, AttachRequestArguments &ARA,
                  O.mapOptional("gdb-remote-port", ARA.gdbRemotePort) &&
                  O.mapOptional("gdb-remote-hostname", ARA.gdbRemoteHostname) &&
                  O.mapOptional("coreFile", ARA.coreFile) &&
-                 O.mapOptional("targetId", ARA.targetId) &&
-                 O.mapOptional("debuggerId", ARA.debuggerId);
+                 O.mapOptional("session", ARA.session);
   if (!success)
     return false;
   // Validate that we have a well formed attach request.
   if (ARA.attachCommands.empty() && ARA.coreFile.empty() &&
       ARA.configuration.program.empty() && ARA.pid == LLDB_INVALID_PROCESS_ID &&
-      ARA.gdbRemotePort == LLDB_DAP_INVALID_PORT && !ARA.targetId.has_value()) {
+      ARA.gdbRemotePort == LLDB_DAP_INVALID_PORT && !ARA.session.has_value()) {
     P.report("expected one of 'pid', 'program', 'attachCommands', "
-             "'coreFile', 'gdb-remote-port', or 'targetId' to be specified");
+             "'coreFile', 'gdb-remote-port', or 'session' to be specified");
     return false;
   }
   // Check if we have mutually exclusive arguments.
@@ -359,13 +367,7 @@ bool fromJSON(const json::Value &Params, AttachRequestArguments &ARA,
     P.report("'pid' and 'gdb-remote-port' are mutually exclusive");
     return false;
   }
-  // Validate that both debugger_id and target_id are provided together.
-  if (ARA.debuggerId.has_value() != ARA.targetId.has_value()) {
-    P.report(
-        "Both 'debuggerId' and 'targetId' must be specified together for "
-        "debugger reuse, or both must be omitted to create a new debugger");
-    return false;
-  }
+
   return true;
 }
 

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -322,7 +322,7 @@ struct DAPSession {
   lldb::user_id_t targetId;
 
   /// ID of an existing debugger instance to use.
-  int debuggerId;
+  lldb::user_id_t debuggerId;
 };
 bool fromJSON(const llvm::json::Value &, DAPSession &, llvm::json::Path);
 

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -317,6 +317,15 @@ using LaunchResponse = VoidResponse;
 /// An invalid 'frameId' default value.
 #define LLDB_DAP_INVALID_FRAME_ID UINT64_MAX
 
+struct DAPSession {
+  /// Unique ID of an existing target to attach to.
+  lldb::user_id_t targetId;
+
+  /// ID of an existing debugger instance to use.
+  int debuggerId;
+};
+bool fromJSON(const llvm::json::Value &, DAPSession &, llvm::json::Path);
+
 /// lldb-dap specific attach arguments.
 struct AttachRequestArguments {
   /// Common lldb-dap configuration values for launching/attaching operations.
@@ -351,11 +360,8 @@ struct AttachRequestArguments {
   /// Path to the core file to debug.
   std::string coreFile;
 
-  /// Unique ID of an existing target to attach to.
-  std::optional<lldb::user_id_t> targetId;
-
-  /// ID of an existing debugger instance to use.
-  std::optional<int> debuggerId;
+  /// An Existing session that consist of a target and debugger.
+  std::optional<DAPSession> session;
 
   /// @}
 };

--- a/lldb/tools/lldb-dap/extension/package.json
+++ b/lldb/tools/lldb-dap/extension/package.json
@@ -795,9 +795,21 @@
                 "description": "Custom commands that are executed instead of attaching to a process ID or to a process by name. These commands may optionally create a new target and must perform an attach. A valid process must exist after these commands complete or the \"attach\" will fail.",
                 "default": []
               },
-              "targetId": {
-                "type": "number",
-                "description": "The globally unique target id to attach to. Used when a target is dynamically created."
+              "session": {
+                "type": "object",
+                "properties": {
+                  "targetId": {
+                    "type": "number",
+                    "description": "The globally unique target id to attach to. Use when a target is dynamically created."
+                  },
+                  "debuggerId": {
+                    "type": "number",
+                    "description": "ID of an existing debugger instance to use."
+                  },
+                  "additionalProperties": false,
+                  "required": ["targetId", "debuggerId"]
+                },
+                "description": "This property is Experimental.\nAttach to an existing debugging session.\nAdded in version 22.0."
               },
               "initCommands": {
                 "type": "array",

--- a/lldb/unittests/DAP/ProtocolTypesTest.cpp
+++ b/lldb/unittests/DAP/ProtocolTypesTest.cpp
@@ -1262,3 +1262,12 @@ TEST(ProtocolTypesTest, StackFrame) {
   ASSERT_THAT_EXPECTED(expected_frame, llvm::Succeeded());
   EXPECT_EQ(pp(*expected_frame), pp(frame));
 }
+
+TEST(ProtocolTypesTest, DAPSession) {
+  const DAPSession session{/*targetId*/ 1000, /*debuggerId*/ 300};
+
+  auto expected = parse<DAPSession>(R"({"targetId": 1000, "debuggerId": 300})");
+  ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
+  EXPECT_EQ(expected->debuggerId, session.debuggerId);
+  EXPECT_EQ(expected->targetId, session.targetId);
+}


### PR DESCRIPTION
This makes it clear the fields required for attaching to an existing debug session.

It also makes it easier to check mutually exclusive fields required to attach.