### PR TITLE
[clang][docs] Redirect folks from CSA sections for usual Clang crashes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -216,10 +216,8 @@ Static Analyzer
 New features
 ^^^^^^^^^^^^
 
-Crash and bug fixes
-^^^^^^^^^^^^^^^^^^^
-
-You probably want "Miscellaneous Clang Crashes Fixed" instead!
+Static Analyzer crash and bug fixes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Improvements
 ^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -219,6 +219,8 @@ New features
 Crash and bug fixes
 ^^^^^^^^^^^^^^^^^^^
 
+You probably want "Miscellaneous Clang Crashes Fixed" instead!
+
 Improvements
 ^^^^^^^^^^^^
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -213,17 +213,13 @@ Code Completion
 Static Analyzer
 ---------------
 
-New features
-^^^^^^^^^^^^
-
-Static Analyzer crash and bug fixes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Improvements
-^^^^^^^^^^^^
-
-Moved checkers
-^^^^^^^^^^^^^^
+.. comment:
+  This is for the Static Analyzer.
+  Using the caret `^^^` underlining for subsections:
+    - Crash and bug fixes
+    - New checkers and features
+    - Improvements
+    - Moved checkers
 
 .. _release-notes-sanitizers:
 

--- a/clang/docs/ReleaseNotesTemplate.txt
+++ b/clang/docs/ReleaseNotesTemplate.txt
@@ -205,17 +205,13 @@ Code Completion
 Static Analyzer
 ---------------
 
-New features
-^^^^^^^^^^^^
-
-Static Analyzer crash and bug fixes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Improvements
-^^^^^^^^^^^^
-
-Moved checkers
-^^^^^^^^^^^^^^
+.. comment:
+  This is for the Static Analyzer.
+  Using the caret `^^^` underlining for subsections:
+    - Crash and bug fixes
+    - New checkers and features
+    - Improvements
+    - Moved checkers
 
 .. _release-notes-sanitizers:
 

--- a/clang/docs/ReleaseNotesTemplate.txt
+++ b/clang/docs/ReleaseNotesTemplate.txt
@@ -208,8 +208,8 @@ Static Analyzer
 New features
 ^^^^^^^^^^^^
 
-Crash and bug fixes
-^^^^^^^^^^^^^^^^^^^
+Static Analyzer crash and bug fixes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Improvements
 ^^^^^^^^^^^^


### PR DESCRIPTION
Almost in every release there are contributors adding non-CSA entries to the CSA release docs sections due to confusion.
To reduce the temptation in the future, let's add a reminder.

Note that it's not the end of the world if entries are put in the wrong section, because I always moved them in the past. It would be simply more convenient to avoid this.