### PR TITLE
[AArch64] Refactor PACM emission in Pointer Authentication (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
@@ -117,7 +117,8 @@ void AArch64PointerAuth::signLR(MachineFunction &MF,
         ->setPreInstrSymbol(MF, MFnI.getSigningInstrLabel());
   } else {
     if (MFnI.branchProtectionPAuthLR()) {
-      BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM)).setMIFlag(MachineInstr::FrameSetup);
+      BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM))
+          .setMIFlag(MachineInstr::FrameSetup);
       emitPACCFI(MBB, MBBI, MachineInstr::FrameSetup, EmitCFI);
     }
     BuildMI(MBB, MBBI, DL,
@@ -173,7 +174,8 @@ void AArch64PointerAuth::authenticateLR(
     } else {
       if (MFnI->branchProtectionPAuthLR()) {
         emitPACSymOffsetIntoX16(*TII, MBB, MBBI, DL, PACSym);
-        BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM)).setMIFlag(MachineInstr::FrameDestroy);
+        BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM))
+            .setMIFlag(MachineInstr::FrameDestroy);
       }
       BuildMI(MBB, TI, DL, TII->get(UseBKey ? AArch64::RETAB : AArch64::RETAA))
           .copyImplicitOps(*MBBI)
@@ -192,7 +194,8 @@ void AArch64PointerAuth::authenticateLR(
     } else {
       if (MFnI->branchProtectionPAuthLR()) {
         emitPACSymOffsetIntoX16(*TII, MBB, MBBI, DL, PACSym);
-        BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM)).setMIFlag(MachineInstr::FrameDestroy);
+        BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM))
+            .setMIFlag(MachineInstr::FrameDestroy);
         emitPACCFI(MBB, MBBI, MachineInstr::FrameDestroy, EmitAsyncCFI);
       }
       BuildMI(MBB, MBBI, DL,

--- a/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PointerAuth.cpp
@@ -69,28 +69,6 @@ static void emitPACSymOffsetIntoX16(const TargetInstrInfo &TII,
       .addImm(0);
 }
 
-// Where PAuthLR support is not known at compile time, it is supported using
-// PACM. PACM is in the hint space so has no effect when PAuthLR is not
-// supported by the hardware, but will alter the behaviour of PACI*SP, AUTI*SP
-// and RETAA/RETAB if the hardware supports PAuthLR.
-static void BuildPACM(const AArch64Subtarget &Subtarget, MachineBasicBlock &MBB,
-                      MachineBasicBlock::iterator MBBI, DebugLoc DL,
-                      MachineInstr::MIFlag Flags, MCSymbol *PACSym = nullptr) {
-  const TargetInstrInfo *TII = Subtarget.getInstrInfo();
-  auto &MFnI = *MBB.getParent()->getInfo<AArch64FunctionInfo>();
-
-  // Offset to PAC*SP using ADRP + ADD.
-  if (PACSym) {
-    assert(Flags == MachineInstr::FrameDestroy);
-    emitPACSymOffsetIntoX16(*TII, MBB, MBBI, DL, PACSym);
-  }
-
-  // Only emit PACM if -mbranch-protection has +pc and the target does not
-  // have feature +pauth-lr.
-  if (MFnI.branchProtectionPAuthLR() && !Subtarget.hasPAuthLR())
-    BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM)).setMIFlag(Flags);
-}
-
 static void emitPACCFI(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
                        MachineInstr::MIFlag Flags, bool EmitCFI) {
   if (!EmitCFI)
@@ -138,9 +116,10 @@ void AArch64PointerAuth::signLR(MachineFunction &MF,
         .setMIFlag(MachineInstr::FrameSetup)
         ->setPreInstrSymbol(MF, MFnI.getSigningInstrLabel());
   } else {
-    BuildPACM(*Subtarget, MBB, MBBI, DL, MachineInstr::FrameSetup);
-    if (MFnI.branchProtectionPAuthLR())
+    if (MFnI.branchProtectionPAuthLR()) {
+      BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM)).setMIFlag(MachineInstr::FrameSetup);
       emitPACCFI(MBB, MBBI, MachineInstr::FrameSetup, EmitCFI);
+    }
     BuildMI(MBB, MBBI, DL,
             TII->get(MFnI.shouldSignWithBKey() ? AArch64::PACIBSP
                                                : AArch64::PACIASP))
@@ -192,7 +171,10 @@ void AArch64PointerAuth::authenticateLR(
           .copyImplicitOps(*MBBI)
           .setMIFlag(MachineInstr::FrameDestroy);
     } else {
-      BuildPACM(*Subtarget, MBB, TI, DL, MachineInstr::FrameDestroy, PACSym);
+      if (MFnI->branchProtectionPAuthLR()) {
+        emitPACSymOffsetIntoX16(*TII, MBB, MBBI, DL, PACSym);
+        BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM)).setMIFlag(MachineInstr::FrameDestroy);
+      }
       BuildMI(MBB, TI, DL, TII->get(UseBKey ? AArch64::RETAB : AArch64::RETAA))
           .copyImplicitOps(*MBBI)
           .setMIFlag(MachineInstr::FrameDestroy);
@@ -208,9 +190,11 @@ void AArch64PointerAuth::authenticateLR(
           .addSym(PACSym)
           .setMIFlag(MachineInstr::FrameDestroy);
     } else {
-      BuildPACM(*Subtarget, MBB, MBBI, DL, MachineInstr::FrameDestroy, PACSym);
-      if (MFnI->branchProtectionPAuthLR())
+      if (MFnI->branchProtectionPAuthLR()) {
+        emitPACSymOffsetIntoX16(*TII, MBB, MBBI, DL, PACSym);
+        BuildMI(MBB, MBBI, DL, TII->get(AArch64::PACM)).setMIFlag(MachineInstr::FrameDestroy);
         emitPACCFI(MBB, MBBI, MachineInstr::FrameDestroy, EmitAsyncCFI);
+      }
       BuildMI(MBB, MBBI, DL,
               TII->get(UseBKey ? AArch64::AUTIBSP : AArch64::AUTIASP))
           .setMIFlag(MachineInstr::FrameDestroy);


### PR DESCRIPTION
Refactor the emission of PACM instructions in the AArch64 Pointer Authentication code to simplify the control flow and reduce duplication.

This change consolidates the PACM generation logic, making the code easier to follow and less error-prone, while preserving the existing behavior and generated output.

No functional change is intended beyond the internal refactoring.