### PR TITLE
[flang][OpenMP] Fix LINEAR clause validation to report all errors

### DIFF
--- a/flang/lib/Semantics/check-omp-loop.cpp
+++ b/flang/lib/Semantics/check-omp-loop.cpp
@@ -764,7 +764,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Linear &x) {
         context_.Say(clauseSource,
             "A modifier may not be specified in a LINEAR clause on the %s directive"_err_en_US,
             ContextDirectiveAsFortran());
-        return;
+        // Don't return early - continue to check other restrictions
       }
 
       auto &desc{OmpGetDescriptor<parser::OmpLinearModifier>()};

--- a/flang/test/Semantics/OpenMP/clause-validity01.f90
+++ b/flang/test/Semantics/OpenMP/clause-validity01.f90
@@ -201,7 +201,7 @@ use omp_lib
   enddo
 
   !ERROR: A modifier may not be specified in a LINEAR clause on the DO directive
-  !$omp do linear(ref(b))
+  !$omp do linear(b: val)
   do i = 1, N
      a = 3.14
   enddo
@@ -408,7 +408,7 @@ use omp_lib
 
   !ERROR: At most one PROC_BIND clause can appear on the PARALLEL DO directive
   !ERROR: A modifier may not be specified in a LINEAR clause on the PARALLEL DO directive
-  !$omp parallel do proc_bind(master) proc_bind(close) linear(val(b))
+  !$omp parallel do proc_bind(master) proc_bind(close) linear(b: val)
   do i = 1, N
      a = 3.14
   enddo

--- a/flang/test/Semantics/OpenMP/linear-clause01.f90
+++ b/flang/test/Semantics/OpenMP/linear-clause01.f90
@@ -7,11 +7,9 @@
 ! Case 1
 subroutine linear_clause_01(arg)
     integer, intent(in) :: arg(:)
-!    !ERROR: A modifier may not be specified in a LINEAR clause on the DO directive
-!    !ERROR: List item 'arg' in LINEAR clause must be a scalar variable
-! TODO: the following line currently breaks buildbots. Disabling it until the author
-! of the breaking change can fix it.
-!    !$omp do linear(uval(arg))
+    !ERROR: A modifier may not be specified in a LINEAR clause on the DO directive
+    !ERROR: List item 'arg' in LINEAR clause must be a scalar variable
+    !$omp do linear(uval(arg))
     do i = 1, 5
         print *, arg(i)
     end do


### PR DESCRIPTION
Fixes #175688 

After #175383 was merged, test failures occurred because removing the early return exposed additional errors that tests weren't expecting.

This PR comprehensively fixes the issue by:

1. **Removes the early return** in check-omp-loop.cpp (line 767) after detecting a modifier error on DO/SIMD directives. Previously, when a modifier error was found, the function would return immediately without checking other restrictions like the scalar requirement. Now all applicable errors are reported, improving diagnostics.

2. **Updates linear-clause01.f90** to expect both the modifier error AND the scalar error for Case 1 and Case 2, where arrays are used incorrectly in LINEAR clauses.

3. **Updates clause-validity01.f90** to use the new OpenMP 5.2 syntax (`linear(b: val)` instead of `linear(val(b))`). The old syntax triggers deprecation warnings, which are now caught because we no longer return early after the modifier error.

Thanks to @ergawy for identifying the clause-validity01.f90 fix needed.

The changes ensure better error reporting for users - they now see all issues with their LINEAR clauses instead of just the first error.