### PR TITLE
[ADT] Fix up return type of `bind_` functions

### DIFF
--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -242,7 +242,7 @@ public:
       : BoundArgs(std::forward<BoundArgsArgT>(Args)...), FnStorage() {}
 
   template <typename... CallArgsT>
-  constexpr auto operator()(CallArgsT &&...CallArgs) {
+  constexpr decltype(auto) operator()(CallArgsT &&...CallArgs) {
     if constexpr (BindFront)
       return llvm::invoke(FnStorage.get(), std::get<Indices>(BoundArgs)...,
                           std::forward<CallArgsT>(CallArgs)...);
@@ -252,7 +252,7 @@ public:
   }
 
   template <typename... CallArgsT>
-  constexpr auto operator()(CallArgsT &&...CallArgs) const {
+  constexpr decltype(auto) operator()(CallArgsT &&...CallArgs) const {
     if constexpr (BindFront)
       return llvm::invoke(FnStorage.get(), std::get<Indices>(BoundArgs)...,
                           std::forward<CallArgsT>(CallArgs)...);

--- a/llvm/unittests/ADT/STLForwardCompatTest.cpp
+++ b/llvm/unittests/ADT/STLForwardCompatTest.cpp
@@ -500,6 +500,28 @@ TEST(STLForwardCompatTest, BindFrontBindBackConstexpr) {
   static_assert(Fn2(3) == 4);
 }
 
+// Test that reference return types are preserved (with `decltype(auto)`).
+TEST(STLForwardCompatTest, BindPreservesReferenceReturn) {
+  int X = 10;
+  auto GetRef = [&X]() -> int & { return X; };
+
+  auto BoundFront = bind_front(GetRef);
+  static_assert(std::is_same_v<decltype(BoundFront()), int &>);
+  BoundFront() = 20;
+  EXPECT_EQ(X, 20);
+
+  const auto BoundFrontConst = bind_front(GetRef);
+  static_assert(std::is_same_v<decltype(BoundFrontConst()), int &>);
+
+  auto BoundBack = bind_back(GetRef);
+  static_assert(std::is_same_v<decltype(BoundBack()), int &>);
+  BoundBack() = 30;
+  EXPECT_EQ(X, 30);
+
+  const auto BoundBackConst = bind_back(GetRef);
+  static_assert(std::is_same_v<decltype(BoundBackConst()), int &>);
+}
+
 // Use std::ref/std::cref to bind references (bound args are decay-copied).
 TEST(STLForwardCompatTest, BindWithReferenceWrapper) {
   int X = 1;


### PR DESCRIPTION
Use `decltype(auto)` and add tests.