### PR TITLE
[lldb][CMake] Don't condition libc++ requirement on LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -202,7 +202,7 @@ if(TARGET clang)
     else()
       # We require libcxx for the test suite, so if we aren't building it,
       # provide a helpful error about how to resolve the situation.
-      if(LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS AND NOT LLDB_HAS_LIBCXX)
+      if(NOT LLDB_HAS_LIBCXX)
         message(SEND_ERROR
           "LLDB test suite requires libc++, but it is currently disabled. "
           "Please add `libcxx` to `LLVM_ENABLE_RUNTIMES` or disable tests via "


### PR DESCRIPTION
This reverts:
```
commit 78769d51c6b183b6d88fbd1ef825fff7cf3aad21
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Nov 4 08:29:47 2025 -0800

    [LLDB] Don't check for libcxx if LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS is off
```

This was needed as an [escape hatch for our ASAN bot](https://github.com/llvm/llvm-zorg/commit/e78725d94b72227e4e524e9b76900ed197791419) because we couldn't build libc++ on it. Ever since https://github.com/llvm/llvm-zorg/pull/702 we can.

Most people wouldn't know to `LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS` when building LLDB. Which means they'd never know to build libc++, and thus would have worse test-coverage for our data-formatters.

If we really want such an escape hatch, we might want to name it something more explicit like `RELAX_DARWIN_LIBCXX_TEST_REQUIREMENTS`.

An alternative is to enable `LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS` by default.