### PR TITLE
[AArch64] Add a nvcast tablegen node

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -9169,9 +9169,9 @@ multiclass BaseSIMDThreeSameVectorBF16DotI<bit Q, bit U, string asm,
                       VTPair<ChangeElementTypeToInteger<AccumType>.VT, v4i32>] in {
     def : Pat<(AccumType (int_aarch64_neon_bfdot
                 (AccumType RegType:$Rd), (InputType RegType:$Rn),
-                (InputType (bitconvert
+                (InputType (nvcast
                   (DupTypes.VT0 (AArch64duplane32 (DupTypes.VT1
-                    (bitconvert (v8bf16 V128:$Rm))), VectorIndexS:$Idx)))))),
+                    (nvcast (v8bf16 V128:$Rm))), VectorIndexS:$Idx)))))),
               (!cast<Instruction>(NAME) $Rd, $Rn, $Rm, VectorIndexS:$Idx)>;
   }
 }
@@ -9243,7 +9243,7 @@ class BaseSIMDThreeSameVectorIndexS<bit Q, bit U, bits<2> size, bits<4> opc, str
         [(set (AccumType RegType:$dst),
               (AccumType (OpNode (AccumType RegType:$Rd),
                                  (InputType RegType:$Rn),
-                                 (InputType (bitconvert (AccumType
+                                 (InputType (nvcast (AccumType
                                     (AArch64duplane32 (v4i32 V128:$Rm),
                                         VIdx:$idx)))))))]> {
   bits<2> idx;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1088,6 +1088,19 @@ def AArch64WrapperLarge : SDNode<"AArch64ISD::WrapperLarge",
 /// mode without emitting such REV instructions.
 def AArch64NvCast : SDNode<"AArch64ISD::NVCAST", SDTUnaryOp>;
 
+/// The nvcast node can match either a NVCAST or a bitconvert in LE.
+def nvcast : PatFrags<(ops node:$Rn),
+                      [(bitconvert node:$Rn),
+                       (AArch64NvCast node:$Rn)],
+  [{
+   return Op.getOpcode() == AArch64ISD::NVCAST ||
+          (Op.getOpcode() == ISD::BITCAST && CurDAG->getDataLayout().isLittleEndian());
+  }]> {
+  let GISelPredicateCode = [{
+     return MI.getOpcode() == AArch64::G_BITCAST && STI.isLittleEndian();
+  }];
+}
+
 def SDT_AArch64mull : SDTypeProfile<1, 2, [SDTCisInt<0>, SDTCisInt<1>,
                                     SDTCisSameAs<1, 2>]>;
 def AArch64pmull    : SDNode<"AArch64ISD::PMULL", SDT_AArch64mull,
@@ -1773,7 +1786,7 @@ class BaseSIMDSUDOTIndex<bit Q, string dst_kind, string lhs_kind,
                                         InputType, VectorIndexS, null_frag> {
   let Pattern = [(set (AccumType RegType:$dst),
                       (AccumType (AArch64usdot (AccumType RegType:$Rd),
-                                 (InputType (bitconvert (AccumType
+                                 (InputType (nvcast (AccumType
                                     (AArch64duplane32 (v4i32 V128:$Rm),
                                         VectorIndexS:$idx)))),
                                  (InputType RegType:$Rn))))];
@@ -1990,9 +2003,9 @@ let Predicates = [HasComplxNum, HasNEON, HasFullFP16] in {
   defm : FCMLA_PATS<v8f16, V128>;
 
   defm : FCMLA_LANE_PATS<v4f16, V64,
-                         (v4f16 (bitconvert (v2i32 (AArch64duplane32 (v4i32 V128:$Rm), VectorIndexD:$idx))))>;
+                         (v4f16 (nvcast (v2i32 (AArch64duplane32 (v4i32 V128:$Rm), VectorIndexD:$idx))))>;
   defm : FCMLA_LANE_PATS<v8f16, V128,
-                         (v8f16 (bitconvert (v4i32 (AArch64duplane32 (v4i32 V128:$Rm), VectorIndexS:$idx))))>;
+                         (v8f16 (nvcast (v4i32 (AArch64duplane32 (v4i32 V128:$Rm), VectorIndexS:$idx))))>;
 }
 let Predicates = [HasComplxNum, HasNEON] in {
   defm : FCMLA_PATS<v2f32, V64>;
@@ -2000,7 +2013,7 @@ let Predicates = [HasComplxNum, HasNEON] in {
   defm : FCMLA_PATS<v2f64, V128>;
 
   defm : FCMLA_LANE_PATS<v4f32, V128,
-                         (v4f32 (bitconvert (v2i64 (AArch64duplane64 (v2i64 V128:$Rm), VectorIndexD:$idx))))>;
+                         (v4f32 (nvcast (v2i64 (AArch64duplane64 (v2i64 V128:$Rm), VectorIndexD:$idx))))>;
 }
 
 // v8.3a Pointer Authentication
@@ -7810,7 +7823,7 @@ def : Pat<(v8i8 (vec_ins_or_scal_vec GPR32:$Rn)),
                          (f32 (COPY_TO_REGCLASS GPR32:$Rn, FPR32)), ssub)>;
 
 // The top bits will be zero from the FMOVWSr
-def : Pat<(v8i8 (bitconvert (i64 (zext GPR32:$Rn)))),
+def : Pat<(v8i8 (nvcast (i64 (zext GPR32:$Rn)))),
           (SUBREG_TO_REG (i32 0), (f32 (FMOVWSr GPR32:$Rn)), ssub)>;
 
 def : Pat<(v8i16 (vec_ins_or_scal_vec GPR32:$Rn)),
@@ -10696,10 +10709,10 @@ def : Pat<(v2i32 (add (AArch64zip1 (extract_subvector (v4i32 FPR128:$Rn), (i64 0
                       (AArch64zip2 (extract_subvector (v4i32 FPR128:$Rn), (i64 0)),
                                    (extract_subvector (v4i32 FPR128:$Rn), (i64 2))))),
           (EXTRACT_SUBREG (ADDPv4i32 $Rn, $Rn), dsub)>;
-def : Pat<(v4i16 (add (trunc (v4i32 (bitconvert FPR128:$Rn))),
+def : Pat<(v4i16 (add (trunc (v4i32 (nvcast FPR128:$Rn))),
                       (extract_subvector (AArch64uzp2 (v8i16 FPR128:$Rn), undef), (i64 0)))),
           (EXTRACT_SUBREG (ADDPv8i16 $Rn, $Rn), dsub)>;
-def : Pat<(v8i8  (add (trunc (v8i16 (bitconvert FPR128:$Rn))),
+def : Pat<(v8i8  (add (trunc (v8i16 (nvcast FPR128:$Rn))),
                       (extract_subvector (AArch64uzp2 (v16i8 FPR128:$Rn), undef), (i64 0)))),
           (EXTRACT_SUBREG (ADDPv16i8 $Rn, $Rn), dsub)>;
 

--- a/llvm/test/CodeGen/AArch64/arm64-popcnt.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-popcnt.ll
@@ -36,7 +36,9 @@ define i32 @cnt32_advsimd(i32 %x) nounwind readnone {
 ;
 ; CHECK-BE-LABEL: cnt32_advsimd:
 ; CHECK-BE:       // %bb.0:
-; CHECK-BE-NEXT:    fmov s0, w0
+; CHECK-BE-NEXT:    mov w8, w0
+; CHECK-BE-NEXT:    fmov d0, x8
+; CHECK-BE-NEXT:    rev64 v0.8b, v0.8b
 ; CHECK-BE-NEXT:    cnt v0.8b, v0.8b
 ; CHECK-BE-NEXT:    addv b0, v0.8b
 ; CHECK-BE-NEXT:    fmov w0, s0
@@ -83,7 +85,8 @@ define i32 @cnt32_advsimd_2(<2 x i32> %x) {
 ; CHECK-BE:       // %bb.0:
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    fmov w8, s0
-; CHECK-BE-NEXT:    fmov s0, w8
+; CHECK-BE-NEXT:    fmov d0, x8
+; CHECK-BE-NEXT:    rev64 v0.8b, v0.8b
 ; CHECK-BE-NEXT:    cnt v0.8b, v0.8b
 ; CHECK-BE-NEXT:    addv b0, v0.8b
 ; CHECK-BE-NEXT:    fmov w0, s0
@@ -414,7 +417,7 @@ define i1 @ctpop32_ne_one_nonzero(i32 %x) {
 ; CHECK-CSSC-LABEL: ctpop32_ne_one_nonzero:
 ; CHECK-CSSC:       // %bb.0: // %entry
 ; CHECK-CSSC-NEXT:    sub w8, w0, #1
-; CHECK-CSSC-NEXT:    and	w8, w0, w8
+; CHECK-CSSC-NEXT:    and w8, w0, w8
 ; CHECK-CSSC-NEXT:    umin w0, w8, #1
 ; CHECK-CSSC-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/AArch64/neon-dot-product.ll
+++ b/llvm/test/CodeGen/AArch64/neon-dot-product.ll
@@ -214,10 +214,12 @@ define <2 x i32> @test_vdot_lane_u32(<2 x i32> %a, <8 x i8> %b, <8 x i8> %c) {
 ;
 ; CHECK-BE-LABEL: test_vdot_lane_u32:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.2s, v2.2s
 ; CHECK-BE-NEXT:    rev64 v1.8b, v1.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
-; CHECK-BE-NEXT:    rev64 v2.2s, v2.2s
-; CHECK-BE-NEXT:    udot v0.2s, v1.8b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.8b, v2.8b
+; CHECK-BE-NEXT:    udot v0.2s, v1.8b, v2.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ret
 entry:
@@ -237,13 +239,15 @@ define <4 x i32> @test_vdotq_lane_u32(<4 x i32> %a, <16 x i8> %b, <8 x i8> %c) {
 ;
 ; CHECK-BE-LABEL: test_vdotq_lane_u32:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    // kill: def $d2 killed $d2 def $q2
 ; CHECK-BE-NEXT:    rev64 v1.16b, v1.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
-; CHECK-BE-NEXT:    // kill: def $d2 killed $d2 def $q2
 ; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    udot v0.4s, v1.16b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.4s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.16b, v2.16b
+; CHECK-BE-NEXT:    udot v0.4s, v1.16b, v2.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -267,7 +271,9 @@ define <2 x i32> @test_vdot_laneq_u32(<2 x i32> %a, <8 x i8> %b, <16 x i8> %c) {
 ; CHECK-BE-NEXT:    rev64 v1.8b, v1.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    udot v0.2s, v1.8b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.8b, v2.8b
+; CHECK-BE-NEXT:    udot v0.2s, v1.8b, v2.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ret
 entry:
@@ -286,13 +292,15 @@ define <4 x i32> @test_vdotq_laneq_u32(<4 x i32> %a, <16 x i8> %b, <16 x i8> %c)
 ;
 ; CHECK-BE-LABEL: test_vdotq_laneq_u32:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
 ; CHECK-BE-NEXT:    rev64 v1.16b, v1.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
-; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
+; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    udot v0.4s, v1.16b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.4s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.16b, v2.16b
+; CHECK-BE-NEXT:    udot v0.4s, v1.16b, v2.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -322,10 +330,12 @@ define <2 x i32> @test_vdot_lane_u32_zero(<2 x i32> %a, <8 x i8> %b, <8 x i8> %c
 ;
 ; CHECK-BE-LABEL: test_vdot_lane_u32_zero:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.2s, v2.2s
 ; CHECK-BE-NEXT:    rev64 v1.8b, v1.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
-; CHECK-BE-NEXT:    rev64 v2.2s, v2.2s
-; CHECK-BE-NEXT:    udot v0.2s, v1.8b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.8b, v2.8b
+; CHECK-BE-NEXT:    udot v0.2s, v1.8b, v2.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ret
 entry:
@@ -354,13 +364,15 @@ define <4 x i32> @test_vdotq_lane_u32_zero(<4 x i32> %a, <16 x i8> %b, <8 x i8> 
 ;
 ; CHECK-BE-LABEL: test_vdotq_lane_u32_zero:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    // kill: def $d2 killed $d2 def $q2
 ; CHECK-BE-NEXT:    rev64 v1.16b, v1.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
-; CHECK-BE-NEXT:    // kill: def $d2 killed $d2 def $q2
 ; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    udot v0.4s, v1.16b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.4s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.16b, v2.16b
+; CHECK-BE-NEXT:    udot v0.4s, v1.16b, v2.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -392,7 +404,9 @@ define <2 x i32> @test_vdot_laneq_u32_zero(<2 x i32> %a, <8 x i8> %b, <16 x i8> 
 ; CHECK-BE-NEXT:    rev64 v1.8b, v1.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    udot v0.2s, v1.8b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.8b, v2.8b
+; CHECK-BE-NEXT:    udot v0.2s, v1.8b, v2.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ret
 entry:
@@ -419,13 +433,15 @@ define <4 x i32> @test_vdotq_laneq_u32_zero(<4 x i32> %a, <16 x i8> %b, <16 x i8
 ;
 ; CHECK-BE-LABEL: test_vdotq_laneq_u32_zero:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
 ; CHECK-BE-NEXT:    rev64 v1.16b, v1.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
-; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
+; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    udot v0.4s, v1.16b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.4s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.16b, v2.16b
+; CHECK-BE-NEXT:    udot v0.4s, v1.16b, v2.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -448,10 +464,12 @@ define <2 x i32> @test_vdot_lane_s32(<2 x i32> %a, <8 x i8> %b, <8 x i8> %c) {
 ;
 ; CHECK-BE-LABEL: test_vdot_lane_s32:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.2s, v2.2s
 ; CHECK-BE-NEXT:    rev64 v1.8b, v1.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
-; CHECK-BE-NEXT:    rev64 v2.2s, v2.2s
-; CHECK-BE-NEXT:    sdot v0.2s, v1.8b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.8b, v2.8b
+; CHECK-BE-NEXT:    sdot v0.2s, v1.8b, v2.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ret
 entry:
@@ -471,13 +489,15 @@ define <4 x i32> @test_vdotq_lane_s32(<4 x i32> %a, <16 x i8> %b, <8 x i8> %c) {
 ;
 ; CHECK-BE-LABEL: test_vdotq_lane_s32:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    // kill: def $d2 killed $d2 def $q2
 ; CHECK-BE-NEXT:    rev64 v1.16b, v1.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
-; CHECK-BE-NEXT:    // kill: def $d2 killed $d2 def $q2
 ; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    sdot v0.4s, v1.16b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.4s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.16b, v2.16b
+; CHECK-BE-NEXT:    sdot v0.4s, v1.16b, v2.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -501,7 +521,9 @@ define <2 x i32> @test_vdot_laneq_s32(<2 x i32> %a, <8 x i8> %b, <16 x i8> %c) {
 ; CHECK-BE-NEXT:    rev64 v1.8b, v1.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    sdot v0.2s, v1.8b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.8b, v2.8b
+; CHECK-BE-NEXT:    sdot v0.2s, v1.8b, v2.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ret
 entry:
@@ -520,13 +542,15 @@ define <4 x i32> @test_vdotq_laneq_s32(<4 x i32> %a, <16 x i8> %b, <16 x i8> %c)
 ;
 ; CHECK-BE-LABEL: test_vdotq_laneq_s32:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
 ; CHECK-BE-NEXT:    rev64 v1.16b, v1.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
-; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
+; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    sdot v0.4s, v1.16b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.4s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.16b, v2.16b
+; CHECK-BE-NEXT:    sdot v0.4s, v1.16b, v2.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -556,10 +580,12 @@ define <2 x i32> @test_vdot_lane_s32_zero(<2 x i32> %a, <8 x i8> %b, <8 x i8> %c
 ;
 ; CHECK-BE-LABEL: test_vdot_lane_s32_zero:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.2s, v2.2s
 ; CHECK-BE-NEXT:    rev64 v1.8b, v1.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
-; CHECK-BE-NEXT:    rev64 v2.2s, v2.2s
-; CHECK-BE-NEXT:    sdot v0.2s, v1.8b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.8b, v2.8b
+; CHECK-BE-NEXT:    sdot v0.2s, v1.8b, v2.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ret
 entry:
@@ -588,13 +614,15 @@ define <4 x i32> @test_vdotq_lane_s32_zero(<4 x i32> %a, <16 x i8> %b, <8 x i8> 
 ;
 ; CHECK-BE-LABEL: test_vdotq_lane_s32_zero:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    // kill: def $d2 killed $d2 def $q2
 ; CHECK-BE-NEXT:    rev64 v1.16b, v1.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
-; CHECK-BE-NEXT:    // kill: def $d2 killed $d2 def $q2
 ; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    sdot v0.4s, v1.16b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.4s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.16b, v2.16b
+; CHECK-BE-NEXT:    sdot v0.4s, v1.16b, v2.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -626,7 +654,9 @@ define <2 x i32> @test_vdot_laneq_s32_zero(<2 x i32> %a, <8 x i8> %b, <16 x i8> 
 ; CHECK-BE-NEXT:    rev64 v1.8b, v1.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    sdot v0.2s, v1.8b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.8b, v2.8b
+; CHECK-BE-NEXT:    sdot v0.2s, v1.8b, v2.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ret
 entry:
@@ -653,13 +683,15 @@ define <4 x i32> @test_vdotq_laneq_s32_zero(<4 x i32> %a, <16 x i8> %b, <16 x i8
 ;
 ; CHECK-BE-LABEL: test_vdotq_laneq_s32_zero:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
 ; CHECK-BE-NEXT:    rev64 v1.16b, v1.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
-; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
+; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    sdot v0.4s, v1.16b, v2.4b[1]
+; CHECK-BE-NEXT:    dup v2.4s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.16b, v2.16b
+; CHECK-BE-NEXT:    sdot v0.4s, v1.16b, v2.16b
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -691,7 +723,9 @@ define <2 x i32> @be_vdot_lane_s32(<2 x i32> %r_val, <8 x i8> %a_val, <8 x i8> %
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    rev64 v1.8b, v1.8b
 ; CHECK-BE-NEXT:    rev32 v2.16b, v2.16b
-; CHECK-BE-NEXT:    sdot v0.2s, v1.8b, v2.4b[0]
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[0]
+; CHECK-BE-NEXT:    rev32 v2.8b, v2.8b
+; CHECK-BE-NEXT:    sdot v0.2s, v1.8b, v2.8b
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    rev64 v0.2s, v0.2s
 ; CHECK-BE-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/neon-vcmla.ll
+++ b/llvm/test/CodeGen/AArch64/neon-vcmla.ll
@@ -31,10 +31,12 @@ define <4 x half> @test_16x4_lane_1(<4 x half> %a, <4 x half> %b, <4 x half> %c)
 ;
 ; CHECK-BE-LABEL: test_16x4_lane_1:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.2s, v2.2s
 ; CHECK-BE-NEXT:    rev64 v1.4h, v1.4h
 ; CHECK-BE-NEXT:    rev64 v0.4h, v0.4h
-; CHECK-BE-NEXT:    rev64 v2.2s, v2.2s
-; CHECK-BE-NEXT:    fcmla v0.4h, v1.4h, v2.h[1], #0
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.4h, v2.4h
+; CHECK-BE-NEXT:    fcmla v0.4h, v1.4h, v2.4h, #0
 ; CHECK-BE-NEXT:    rev64 v0.4h, v0.4h
 ; CHECK-BE-NEXT:    ret
 entry:
@@ -73,10 +75,12 @@ define <4 x half> @test_rot90_16x4_lane_0(<4 x half> %a, <4 x half> %b, <4 x hal
 ;
 ; CHECK-BE-LABEL: test_rot90_16x4_lane_0:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.2s, v2.2s
 ; CHECK-BE-NEXT:    rev64 v1.4h, v1.4h
 ; CHECK-BE-NEXT:    rev64 v0.4h, v0.4h
-; CHECK-BE-NEXT:    rev64 v2.2s, v2.2s
-; CHECK-BE-NEXT:    fcmla v0.4h, v1.4h, v2.h[0], #90
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[0]
+; CHECK-BE-NEXT:    rev32 v2.4h, v2.4h
+; CHECK-BE-NEXT:    fcmla v0.4h, v1.4h, v2.4h, #90
 ; CHECK-BE-NEXT:    rev64 v0.4h, v0.4h
 ; CHECK-BE-NEXT:    ret
 entry:
@@ -118,7 +122,9 @@ define <4 x half> @test_rot180_16x4_lane_0(<4 x half> %a, <4 x half> %b, <8 x ha
 ; CHECK-BE-NEXT:    rev64 v1.4h, v1.4h
 ; CHECK-BE-NEXT:    rev64 v0.4h, v0.4h
 ; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    fcmla v0.4h, v1.4h, v2.h[0], #180
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[0]
+; CHECK-BE-NEXT:    rev32 v2.4h, v2.4h
+; CHECK-BE-NEXT:    fcmla v0.4h, v1.4h, v2.4h, #180
 ; CHECK-BE-NEXT:    rev64 v0.4h, v0.4h
 ; CHECK-BE-NEXT:    ret
 entry:
@@ -256,13 +262,15 @@ define <8 x half> @test_16x8_lane_0(<8 x half> %a, <8 x half> %b, <8 x half> %c)
 ;
 ; CHECK-BE-LABEL: test_16x8_lane_0:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
 ; CHECK-BE-NEXT:    rev64 v1.8h, v1.8h
 ; CHECK-BE-NEXT:    rev64 v0.8h, v0.8h
-; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
+; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    fcmla v0.8h, v1.8h, v2.h[0], #0
+; CHECK-BE-NEXT:    dup v2.4s, v2.s[0]
+; CHECK-BE-NEXT:    rev32 v2.8h, v2.8h
+; CHECK-BE-NEXT:    fcmla v0.8h, v1.8h, v2.8h, #0
 ; CHECK-BE-NEXT:    rev64 v0.8h, v0.8h
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -305,13 +313,15 @@ define <8 x half> @test_rot90_16x8_lane_1(<8 x half> %a, <8 x half> %b, <8 x hal
 ;
 ; CHECK-BE-LABEL: test_rot90_16x8_lane_1:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
 ; CHECK-BE-NEXT:    rev64 v1.8h, v1.8h
 ; CHECK-BE-NEXT:    rev64 v0.8h, v0.8h
-; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
+; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    fcmla v0.8h, v1.8h, v2.h[1], #90
+; CHECK-BE-NEXT:    dup v2.4s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.8h, v2.8h
+; CHECK-BE-NEXT:    fcmla v0.8h, v1.8h, v2.8h, #90
 ; CHECK-BE-NEXT:    rev64 v0.8h, v0.8h
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -354,13 +364,15 @@ define <8 x half> @test_rot180_16x8_lane_1(<8 x half> %a, <8 x half> %b, <8 x ha
 ;
 ; CHECK-BE-LABEL: test_rot180_16x8_lane_1:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
 ; CHECK-BE-NEXT:    rev64 v1.8h, v1.8h
 ; CHECK-BE-NEXT:    rev64 v0.8h, v0.8h
-; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
+; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    fcmla v0.8h, v1.8h, v2.h[1], #180
+; CHECK-BE-NEXT:    dup v2.4s, v2.s[1]
+; CHECK-BE-NEXT:    rev32 v2.8h, v2.8h
+; CHECK-BE-NEXT:    fcmla v0.8h, v1.8h, v2.8h, #180
 ; CHECK-BE-NEXT:    rev64 v0.8h, v0.8h
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -403,13 +415,15 @@ define <8 x half> @test_rot270_16x8_lane_0(<8 x half> %a, <8 x half> %b, <8 x ha
 ;
 ; CHECK-BE-LABEL: test_rot270_16x8_lane_0:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
 ; CHECK-BE-NEXT:    rev64 v1.8h, v1.8h
 ; CHECK-BE-NEXT:    rev64 v0.8h, v0.8h
-; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
+; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    fcmla v0.8h, v1.8h, v2.h[0], #270
+; CHECK-BE-NEXT:    dup v2.4s, v2.s[0]
+; CHECK-BE-NEXT:    rev32 v2.8h, v2.8h
+; CHECK-BE-NEXT:    fcmla v0.8h, v1.8h, v2.8h, #270
 ; CHECK-BE-NEXT:    rev64 v0.8h, v0.8h
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -452,12 +466,14 @@ define <4 x float> @test_32x4_lane_0(<4 x float> %a, <4 x float> %b, <4 x float>
 ;
 ; CHECK-BE-LABEL: test_32x4_lane_0:
 ; CHECK-BE:       // %bb.0: // %entry
+; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
 ; CHECK-BE-NEXT:    rev64 v1.4s, v1.4s
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
-; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
+; CHECK-BE-NEXT:    dup v2.2d, v2.d[0]
 ; CHECK-BE-NEXT:    ext v1.16b, v1.16b, v1.16b, #8
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
-; CHECK-BE-NEXT:    fcmla v0.4s, v1.4s, v2.s[0], #0
+; CHECK-BE-NEXT:    rev64 v2.4s, v2.4s
+; CHECK-BE-NEXT:    fcmla v0.4s, v1.4s, v2.4s, #0
 ; CHECK-BE-NEXT:    rev64 v0.4s, v0.4s
 ; CHECK-BE-NEXT:    ext v0.16b, v0.16b, v0.16b, #8
 ; CHECK-BE-NEXT:    ret
@@ -837,7 +853,9 @@ define <4 x half> @be_vcmla_lane_f16(<4 x half> %0, <4 x half> %1, <4 x i32> %2)
 ; CHECK-BE-NEXT:    rev64 v1.4h, v1.4h
 ; CHECK-BE-NEXT:    rev64 v0.4h, v0.4h
 ; CHECK-BE-NEXT:    ext v2.16b, v2.16b, v2.16b, #8
-; CHECK-BE-NEXT:    fcmla v0.4h, v1.4h, v2.h[0], #0
+; CHECK-BE-NEXT:    dup v2.2s, v2.s[0]
+; CHECK-BE-NEXT:    rev32 v2.4h, v2.4h
+; CHECK-BE-NEXT:    fcmla v0.4h, v1.4h, v2.4h, #0
 ; CHECK-BE-NEXT:    rev64 v0.4h, v0.4h
 ; CHECK-BE-NEXT:    rev64 v0.4h, v0.4h
 ; CHECK-BE-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/popcount.ll
+++ b/llvm/test/CodeGen/AArch64/popcount.ll
@@ -845,7 +845,8 @@ define i32 @ctpop_into_extract(ptr %p) {
 ; BE-NEXT:    mov x8, x0
 ; BE-NEXT:    mov w0, wzr
 ; BE-NEXT:    fmov w9, s0
-; BE-NEXT:    fmov s1, w9
+; BE-NEXT:    fmov d1, x9
+; BE-NEXT:    rev64 v1.8b, v1.8b
 ; BE-NEXT:    cnt v1.8b, v1.8b
 ; BE-NEXT:    addv b1, v1.8b
 ; BE-NEXT:    mov v2.s[1], v1.s[0]
@@ -918,8 +919,10 @@ define <8 x i8> @bitcast_upper_bits(i32 %b, <8 x i8> %v) {
 ;
 ; BE-LABEL: bitcast_upper_bits:
 ; BE:       // %bb.0:
+; BE-NEXT:    mov w8, w0
 ; BE-NEXT:    rev64 v0.8b, v0.8b
-; BE-NEXT:    fmov s1, w0
+; BE-NEXT:    fmov d1, x8
+; BE-NEXT:    rev64 v1.8b, v1.8b
 ; BE-NEXT:    add v0.8b, v1.8b, v0.8b
 ; BE-NEXT:    rev64 v0.8b, v0.8b
 ; BE-NEXT:    ret


### PR DESCRIPTION
A bitcast / bitconvert will work differently in LE and BE depending on the types cast between, where on BE it can perform more lane reordering. This adds a ncvcast tablegen node that can be used for patterns that convert from one vector type to another, but do not expect the lane ordering to be changed. It is matched against either a AArch64ISD::NVCAST or a ISD::BITCAST under LE, and should prevent some incorrect folds under BE.

Hopefully fixes #166190