### PR TITLE
Nominate Michael Klemm as lead maintainer of OpenMP

### DIFF
--- a/openmp/Maintainers.md
+++ b/openmp/Maintainers.md
@@ -4,10 +4,13 @@ This file is a list of the
 [maintainers](https://llvm.org/docs/DeveloperPolicy.html#maintainers) for
 the LLVM OpenMP library.
 
-# Current Maintainers
+# Lead Maintainer
 
 Michael Klemm \
 michael.klemm@amd.com (email), [mjklemm](https://github.com/mjklemm) (GitHub)
+
+
+# Current Maintainers
 
 Terry Wilmarth \
 terry.l.wilmarth@intel.com (email), [TerryLWilmarth](https://github.com/TerryLWilmarth) (GitHub)


### PR DESCRIPTION
We discussed this during the OpenMP sync-up call on 1/14 and he's still actively maintaining this component and would be happy to act as lead for it.