### PR TITLE
[ReachingDefAnalysis] Track live-in registers.

### DIFF
--- a/llvm/include/llvm/CodeGen/ReachingDefAnalysis.h
+++ b/llvm/include/llvm/CodeGen/ReachingDefAnalysis.h
@@ -193,8 +193,10 @@ public:
 
   /// Return the local MI that produces the live out value for Reg, or
   /// nullptr for a non-live out or non-local def.
-  MachineInstr *getLocalLiveOutMIDef(MachineBasicBlock *MBB,
-                                     Register Reg) const;
+  /// Sets IsFunctionLiveIn to `true` if `MBB` is an entry block, `Reg` is a
+  /// function live-in and it does not get defined in `MBB`.
+  MachineInstr *getLocalLiveOutMIDef(MachineBasicBlock *MBB, Register Reg,
+                                     bool &IsFunctionLiveIn) const;
 
   /// If a single MachineInstr creates the reaching definition, then return it.
   /// Otherwise return null.
@@ -230,9 +232,13 @@ public:
 
   /// Search MBB for a definition of Reg and insert it into Defs. If no
   /// definition is found, recursively search the predecessor blocks for them.
+  /// HasLiveInPath is set to `true` if `Reg` is live-in on function entry and
+  /// there is at least one path from function entry to the end of `MBB` along
+  /// which `Reg` is not modified.
   void getLiveOuts(MachineBasicBlock *MBB, Register Reg, InstSet &Defs,
-                   BlockSet &VisitedBBs) const;
-  void getLiveOuts(MachineBasicBlock *MBB, Register Reg, InstSet &Defs) const;
+                   BlockSet &VisitedBBs, bool &HasLiveInPath) const;
+  void getLiveOuts(MachineBasicBlock *MBB, Register Reg, InstSet &Defs,
+                   bool &HasLiveInPath) const;
 
   /// For the given block, collect the instructions that use the live-in
   /// value of the provided register. Return whether the value is still
@@ -245,8 +251,11 @@ public:
 
   /// Collect all possible definitions of the value stored in Reg, which is
   /// used by MI.
-  void getGlobalReachingDefs(MachineInstr *MI, Register Reg,
-                             InstSet &Defs) const;
+  /// HasLiveInPath set to `true` if `Reg` is live-in on function entry and
+  /// there is at least one path from function entry to MI along which `Reg` is
+  /// not modified.
+  void getGlobalReachingDefs(MachineInstr *MI, Register Reg, InstSet &Defs,
+                             bool &HasLiveInPath) const;
 
   /// Return whether From can be moved forwards to just before To.
   bool isSafeToMoveForwards(MachineInstr *From, MachineInstr *To) const;

--- a/llvm/include/llvm/CodeGen/ReachingDefAnalysis.h
+++ b/llvm/include/llvm/CodeGen/ReachingDefAnalysis.h
@@ -153,7 +153,7 @@ private:
   /// Default values are 'nothing happened a long time ago'.
   static constexpr int ReachingDefDefaultVal = -(1 << 21);
   /// Special values for function live-ins.
-  static constexpr int FunctionLiveInMarker = -1;
+  static constexpr int FunctionLiveInMarker = ReachingDefDefaultVal + 1;
 
   using InstSet = SmallPtrSetImpl<MachineInstr*>;
   using BlockSet = SmallPtrSetImpl<MachineBasicBlock*>;

--- a/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
+++ b/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
@@ -549,7 +549,7 @@ void ReachingDefInfo::getGlobalReachingDefs(MachineInstr *MI, Register Reg,
                                             bool &HasLiveInPath) const {
   // If there's a local def before MI, return it.
   int DefInstrId = getReachingDef(MI, Reg);
-  if (DefInstrId == -1) {
+  if (DefInstrId == FunctionLiveInMarker) {
     HasLiveInPath = true;
     return;
   }

--- a/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
+++ b/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
@@ -179,7 +179,8 @@ void ReachingDefInfo::leaveBasicBlock(MachineBasicBlock *MBB) {
   // only cares about the clearance from the end of the block, so adjust
   // everything to be relative to the end of the basic block.
   for (int &OutLiveReg : MBBOutRegsInfos[MBBNumber])
-    if (OutLiveReg != ReachingDefDefaultVal)
+    if (OutLiveReg != ReachingDefDefaultVal &&
+        OutLiveReg != FunctionLiveInMarker)
       OutLiveReg -= CurInstr;
   LiveRegs.clear();
 }

--- a/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
+++ b/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
@@ -549,18 +549,19 @@ void ReachingDefInfo::getGlobalReachingDefs(MachineInstr *MI, Register Reg,
                                             bool &HasLiveInPath) const {
   // If there's a local def before MI, return it.
   int DefInstrId = getReachingDef(MI, Reg);
-  if (DefInstrId == FunctionLiveInMarker) {
+  if (DefInstrId == FunctionLiveInMarker)
     HasLiveInPath = true;
-    return;
-  }
   if (DefInstrId >= 0) {
     MachineInstr *LocalDef = getInstFromId(MI->getParent(), DefInstrId);
     Defs.insert(LocalDef);
     return;
   }
 
-  for (auto *MBB : MI->getParent()->predecessors())
-    getLiveOuts(MBB, Reg, Defs, HasLiveInPath);
+  for (auto *MBB : MI->getParent()->predecessors()) {
+    bool HasLiveInPathToPred = false;
+    getLiveOuts(MBB, Reg, Defs, HasLiveInPathToPred);
+    HasLiveInPath |= HasLiveInPathToPred;
+  }
 }
 
 void ReachingDefInfo::getLiveOuts(MachineBasicBlock *MBB, Register Reg,

--- a/llvm/lib/Target/ARM/ARMFixCortexA57AES1742098Pass.cpp
+++ b/llvm/lib/Target/ARM/ARMFixCortexA57AES1742098Pass.cpp
@@ -288,7 +288,8 @@ void ARMFixCortexA57AES1742098::analyzeMF(
       // Inspect all operands, choosing whether to insert a fixup.
       for (MachineOperand &MOp : MI.uses()) {
         SmallPtrSet<MachineInstr *, 1> AllDefs{};
-        RDI.getGlobalReachingDefs(&MI, MOp.getReg(), AllDefs);
+        bool HasLiveInPath = false;
+        RDI.getGlobalReachingDefs(&MI, MOp.getReg(), AllDefs, HasLiveInPath);
 
         // Planned Fixup: This should be added to FixupLocsForFn at most once.
         AESFixupLocation NewLoc{&MBB, &MI, &MOp};

--- a/llvm/test/CodeGen/RISCV/rda-liveins.mir
+++ b/llvm/test/CodeGen/RISCV/rda-liveins.mir
@@ -135,9 +135,6 @@ body:             |
 ---
 name:            test5
 tracksRegLiveness: true
-stack:
-  - { id: 0, name: '', type: default, offset: 0, size: 8, alignment: 8,
-      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
 body:             |
   bb.0.entry:
     liveins: $x10
@@ -147,11 +144,29 @@ body:             |
   bb.1:
     liveins: $x10
     $x10 = ADDI, $x10, 2
-    SD $x10, %stack.0, 0 :: (store (s64))
-    SD $x10, %stack.0, 0 :: (store (s64))
-    SD $x10, %stack.0, 0 :: (store (s64))
-    PseudoBR %bb.2, implicit-def $x10
 
   bb.2:
     liveins: $x10
     PseudoRET implicit $x10
+
+---
+name:            test6
+tracksRegLiveness: true
+body:             |
+  ; CHECK-LABEL: Reaching definitions for for machine function: entry_bb_is_a_loop
+  ; CHECK-NEXT: %bb.0:
+  ; CHECK-NEXT: $x10:{ 0 livein }
+  ; CHECK-NEXT: 0: $x10 = ADDI $x10, 1
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: $x10:{ 1 }
+  ; CHECK-NEXT: $x0:{ }
+  ; CHECK-NEXT: 2: BNE $x10, $x0, %bb.0
+  bb.0.entry:
+    liveins: $x10
+    $x10 = ADDI $x10, 1
+    BNE $x10, $x0, %bb.0
+
+  bb.1:
+    PseudoRET
+
+...

--- a/llvm/test/CodeGen/RISCV/rda-liveins.mir
+++ b/llvm/test/CodeGen/RISCV/rda-liveins.mir
@@ -6,7 +6,7 @@ tracksRegLiveness: true
 body:             |
   ; CHECK-LABEL: Reaching definitions for for machine function: test0
   ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: implicit $x10:{ }
+  ; CHECK-NEXT: implicit $x10:{ livein }
   ; CHECK-NEXT: 0: PseudoRET implicit $x10
 
   bb.0.entry:
@@ -21,7 +21,7 @@ tracksRegLiveness: true
 body:             |
   ; CHECK-LABEL: Reaching definitions for for machine function: test1
   ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: 0: $x10 = ADDI $x10, 1
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: implicit $x10:{ 0 }
@@ -39,19 +39,19 @@ tracksRegLiveness: true
 body:             |
   ; CHECK-LABEL: Reaching definitions for for machine function: test2
   ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: $x0:{ }
   ; CHECK-NEXT: 0: BEQ $x10, $x0, %bb.2
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %bb.1:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: 1: $x10 = ADDI $x10, 1
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: implicit $x10:{ 1 }
   ; CHECK-NEXT: 2: PseudoRET implicit $x10
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %bb.2
-  ; CHECK-NEXT: implicit $x10:{ }
+  ; CHECK-NEXT: implicit $x10:{ livein }
   ; CHECK-NEXT: 3: PseudoRET implicit $x10
   bb.0.entry:
     liveins: $x10
@@ -77,25 +77,25 @@ stack:
 body:             |
   ; CHECK-LABEL: Reaching definitions for for machine function: test3
   ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: $x0:{ }
   ; CHECK-NEXT: 0: BEQ $x10, $x0, %bb.2
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %bb.1:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: 1: $x10 = ADDI $x10, 1
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: 2: PseudoBR %bb.3
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %bb.2:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: %stack.0:{ }
   ; CHECK-NEXT: 3: SD $x10, %stack.0, 0 :: (store (s64))
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: 4: PseudoBR %bb.3
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %bb.3:
-  ; CHECK-NEXT: implicit $x10:{ 1 }
+  ; CHECK-NEXT: implicit $x10:{ 1 livein }
   ; CHECK-NEXT: 5: PseudoRET implicit $x10
   bb.0.entry:
     liveins: $x10

--- a/llvm/test/CodeGen/RISCV/rda-liveins.mir
+++ b/llvm/test/CodeGen/RISCV/rda-liveins.mir
@@ -115,3 +115,43 @@ body:             |
     liveins: $x10
     PseudoRET implicit $x10
 ...
+
+---
+name:            test4
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    BEQ $x10, $x0, %bb.2
+
+  bb.1:
+    liveins: $x10
+    PseudoBR %bb.2, implicit-def $x10
+
+  bb.2:
+    liveins: $x10
+    PseudoRET implicit $x10
+
+---
+name:            test5
+tracksRegLiveness: true
+stack:
+  - { id: 0, name: '', type: default, offset: 0, size: 8, alignment: 8,
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+body:             |
+  bb.0.entry:
+    liveins: $x10
+    $x10 = ADDI, $x10, 1
+    BEQ $x10, $x0, %bb.2
+
+  bb.1:
+    liveins: $x10
+    $x10 = ADDI, $x10, 2
+    SD $x10, %stack.0, 0 :: (store (s64))
+    SD $x10, %stack.0, 0 :: (store (s64))
+    SD $x10, %stack.0, 0 :: (store (s64))
+    PseudoBR %bb.2, implicit-def $x10
+
+  bb.2:
+    liveins: $x10
+    PseudoRET implicit $x10

--- a/llvm/test/CodeGen/RISCV/rda-stack.mir
+++ b/llvm/test/CodeGen/RISCV/rda-stack.mir
@@ -106,12 +106,12 @@ stack:
 body:             |
   ; CHECK-LABEL: Reaching definitions for for machine function: test3
   ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: $x0:{ }
   ; CHECK-NEXT: 0: BEQ $x10, $x0, %bb.2
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %bb.1:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: 1: $x10 = ADDI $x10, 1
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: $x10:{ 1 }
@@ -121,7 +121,7 @@ body:             |
   ; CHECK-NEXT: 3: PseudoBR %bb.3
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %bb.2:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: 4: $x10 = ADDI $x10, 2
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: $x10:{ 4 }
@@ -170,19 +170,19 @@ stack:
 body:             |
   ; CHECK-LABEL: Reaching definitions for for machine function: test4
   ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: %stack.0:{ }
   ; CHECK-NEXT: 0: SD $x10, %stack.0, 0 :: (store (s64))
   ; CHECK-EMPTY:
-  ; CHECK-NEXT: $x11:{ }
+  ; CHECK-NEXT: $x11:{ livein }
   ; CHECK-NEXT: %stack.0:{ 0 }
   ; CHECK-NEXT: 1: SD $x11, %stack.0, 0 :: (store (s64))
   ; CHECK-EMPTY:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: %stack.1:{ }
   ; CHECK-NEXT: 2: SD $x10, %stack.1, 0 :: (store (s64))
   ; CHECK-EMPTY:
-  ; CHECK-NEXT: $x11:{ }
+  ; CHECK-NEXT: $x11:{ livein }
   ; CHECK-NEXT: %stack.1:{ 2 }
   ; CHECK-NEXT: 3: SD $x11, %stack.1, 0 :: (store (s64))
   ; CHECK-EMPTY:


### PR DESCRIPTION
Make `getGlobalReachingDefs` set a flag `HasLiveInPath` which indicates if there is at least one path from function entry to `MI` along which a entry's live-in register is not modified.