### PR TITLE
[mlir][Analysis][NFC] Clean up `visitNonControlFlowArguments`

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h
@@ -66,11 +66,9 @@ public:
   /// function calls `InferIntRangeInterface` to provide values for block
   /// arguments or tries to reduce the range on loop induction variables with
   /// known bounds.
-  void
-  visitNonControlFlowArguments(Operation *op, const RegionSuccessor &successor,
-                               ValueRange successorInputs,
-                               ArrayRef<IntegerValueRangeLattice *> argLattices,
-                               unsigned firstIndex) override;
+  void visitNonControlFlowArguments(
+      Operation *op, const RegionSuccessor &successor,
+      ArrayRef<IntegerValueRangeLattice *> argLattices) override;
 };
 
 /// Succeeds if an op can be converted to its unsigned equivalent without

--- a/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
@@ -138,8 +138,8 @@ LogicalResult IntegerRangeAnalysis::visitOperation(
 }
 
 void IntegerRangeAnalysis::visitNonControlFlowArguments(
-    Operation *op, const RegionSuccessor &successor, ValueRange successorInputs,
-    ArrayRef<IntegerValueRangeLattice *> argLattices, unsigned firstIndex) {
+    Operation *op, const RegionSuccessor &successor,
+    ArrayRef<IntegerValueRangeLattice *> argLattices) {
   if (auto inferrable = dyn_cast<InferIntRangeInterface>(op)) {
     LDBG() << "Inferring ranges for "
            << OpWithFlags(op, OpPrintingFlags().skipRegions());
@@ -207,8 +207,8 @@ void IntegerRangeAnalysis::visitNonControlFlowArguments(
     std::optional<llvm::SmallVector<Value>> maybeIvs =
         loop.getLoopInductionVars();
     if (!maybeIvs) {
-      return SparseForwardDataFlowAnalysis ::visitNonControlFlowArguments(
-          op, successor, successorInputs, argLattices, firstIndex);
+      return SparseForwardDataFlowAnalysis::visitNonControlFlowArguments(
+          op, successor, argLattices);
     }
     // This shouldn't be returning nullopt if there are indunction variables.
     SmallVector<OpFoldResult> lowerBounds = *loop.getLoopLowerBounds();
@@ -246,5 +246,5 @@ void IntegerRangeAnalysis::visitNonControlFlowArguments(
   }
 
   return SparseForwardDataFlowAnalysis::visitNonControlFlowArguments(
-      op, successor, successorInputs, argLattices, firstIndex);
+      op, successor, argLattices);
 }

--- a/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
@@ -187,8 +187,7 @@ void AbstractSparseForwardDataFlowAnalysis::visitBlock(Block *block) {
 
     // Otherwise, we can't reason about the data-flow.
     return visitNonControlFlowArgumentsImpl(
-        block->getParentOp(), RegionSuccessor(block->getParent()), ValueRange(),
-        argLattices, /*firstIndex=*/0);
+        block->getParentOp(), RegionSuccessor(block->getParent()), argLattices);
   }
 
   // Iterate over the predecessors of the non-entry block.
@@ -314,18 +313,14 @@ void AbstractSparseForwardDataFlowAnalysis::visitRegionSuccessors(
       if (!point->isBlockStart()) {
         if (!inputs.empty())
           firstIndex = cast<OpResult>(inputs.front()).getResultNumber();
-        visitNonControlFlowArgumentsImpl(
-            branch, RegionSuccessor::parent(),
-            branch->getResults().slice(firstIndex, inputs.size()), lattices,
-            firstIndex);
+        visitNonControlFlowArgumentsImpl(branch, RegionSuccessor::parent(),
+                                         lattices);
       } else {
         if (!inputs.empty())
           firstIndex = cast<BlockArgument>(inputs.front()).getArgNumber();
         Region *region = point->getBlock()->getParent();
-        visitNonControlFlowArgumentsImpl(
-            branch, RegionSuccessor(region),
-            region->getArguments().slice(firstIndex, inputs.size()), lattices,
-            firstIndex);
+        visitNonControlFlowArgumentsImpl(branch, RegionSuccessor(region),
+                                         lattices);
       }
     }
 


### PR DESCRIPTION
Remove `successorInputs` and `firstIndex` from `visitNonControlFlowArguments`. These can be queried from the `RegionBranchOpInterface`. If the op does not implement that interface, we can assume that there are no successor inputs.

Depends on #175815.
