### PR TITLE
[RISCV] Fix fcanonicalize for Z*inx

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoD.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoD.td
@@ -409,8 +409,10 @@ foreach Ext = DExts in {
   defm : PatFprFpr_m<fmaximumnum, FMAX_D, Ext>;
   defm : PatFprFpr_m<riscv_fmin, FMIN_D, Ext>;
   defm : PatFprFpr_m<riscv_fmax, FMAX_D, Ext>;
-  let Predicates = Ext.Predicates in
-  def : Pat<(f64 (fcanonicalize FPR64:$rs1)), (FMIN_D $rs1, $rs1)>;
+  let Predicates = Ext.Predicates in {
+    def : Pat<(f64 (fcanonicalize Ext.PrimaryTy:$rs1)),
+              (!cast<Instruction>("FMIN_D"#Ext.Suffix) $rs1, $rs1)>;
+  }
 }
 
 /// Setcc

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoF.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoF.td
@@ -659,8 +659,10 @@ foreach Ext = FExts in {
   defm : PatFprFpr_m<fmaximumnum, FMAX_S, Ext>;
   defm : PatFprFpr_m<riscv_fmin, FMIN_S, Ext>;
   defm : PatFprFpr_m<riscv_fmax, FMAX_S, Ext>;
-  let Predicates = Ext.Predicates in
-  def : Pat<(f32 (fcanonicalize FPR32:$rs1)), (FMIN_S $rs1, $rs1)>;
+  let Predicates = Ext.Predicates in {
+    def : Pat<(f32 (fcanonicalize Ext.PrimaryTy:$rs1)),
+              (!cast<Instruction>("FMIN_S"#Ext.Suffix) $rs1, $rs1)>;
+  }
 }
 
 /// Setcc

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZfh.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZfh.td
@@ -381,8 +381,10 @@ foreach Ext = ZfhExts in {
   defm : PatFprFpr_m<fmaximumnum, FMAX_H, Ext>;
   defm : PatFprFpr_m<riscv_fmin, FMIN_H, Ext>;
   defm : PatFprFpr_m<riscv_fmax, FMAX_H, Ext>;
-  let Predicates = Ext.Predicates in
-  def : Pat<(f16 (fcanonicalize FPR16:$rs1)), (FMIN_H $rs1, $rs1)>;
+  let Predicates = Ext.Predicates in {
+    def : Pat<(f16 (fcanonicalize Ext.PrimaryTy:$rs1)),
+              (!cast<Instruction>("FMIN_H"#Ext.Suffix) $rs1, $rs1)>;
+  }
 }
 
 /// Setcc


### PR DESCRIPTION
Previous tablegen patterns for `fcanonicalize` hardcoded standard floating point registers. This caused a crash during instruction selection for extensions that utilize integer registers. This patch generalizes the patterns to use the dynamically resolved register class `Ext.PrimaryTy`.

Existing tests in `fp-fcanonicalize.ll` have been updated to verify correctness for Zfinx, Zdinx, and Zhinx.
