### PR TITLE
[Clang] Update target parser for address spaces for AMDGPU

### DIFF
--- a/clang/test/TableGen/target-builtins-prototype-parser.td
+++ b/clang/test/TableGen/target-builtins-prototype-parser.td
@@ -63,6 +63,12 @@ def : Builtin {
   let Spellings = ["__builtin_09"];
 }
 
+def : Builtin {
+// CHECK: Builtin::Info{{.*}} __builtin_10 {{.*}} /* V2i*0 */
+  let Prototype = "_Vector<2, int address_space<0> *>()";
+  let Spellings = ["__builtin_10"];
+}
+
 #ifdef ERROR_EXPECTED_LANES
 def : Builtin {
 // ERROR_EXPECTED_LANES: :[[# @LINE + 1]]:7: error: Expected number of lanes after '_ExtVector<'


### PR DESCRIPTION
Summary:
This does three things:
1. Allows address_space<0>, this is not a no-op currently as it has real
   type checking signficange. The SPIR-V backend also does not currently
   use `0` as a generic address space.
2. Allows parsing address space pointers inside vectors, this required
   parsing the correct closing bracket instead of the first found
3. Adds the two missing AMDGPU builtin types.

Split off from https://github.com/llvm/llvm-project/pull/175873
