### PR TITLE
[MLIR][shard] checking for correct&full sharding annotations

### DIFF
--- a/mlir/test/Dialect/Arith/shard-partition.mlir
+++ b/mlir/test/Dialect/Arith/shard-partition.mlir
@@ -13,5 +13,6 @@ func.func @test_partition_constant() ->(tensor<1024x1024xf32>)attributes{llvm.em
   %sharding_1 = shard.sharding @grid4x4 split_axes = [[0]] : !shard.sharding
   %sharded_1 = shard.shard %cst to %sharding_1 : tensor<1024x1024xf32>
   %ci = arith.constant 434 : i32
-  return %sharded_1 : tensor<1024x1024xf32>
+  %sharded_r = shard.shard %sharded_1 to %sharding_1 annotate_for_users : tensor<1024x1024xf32>
+  return %sharded_r : tensor<1024x1024xf32>
 }

--- a/mlir/test/Dialect/Shard/invalid_annotated.mlir
+++ b/mlir/test/Dialect/Shard/invalid_annotated.mlir
@@ -1,0 +1,54 @@
+// RUN: mlir-opt \
+// RUN:   --pass-pipeline="builtin.module(func.func(shard-partition,test-single-fold))" \
+// RUN:   -verify-diagnostics %s
+
+shard.grid @grid(shape = 2)
+
+// expected-error @+1 {{Cannot partition: expected a shard.shard op for block argument 0 in block 0}}
+func.func @test_block_arg_missing_shard(%arg0: tensor<6xi32>) -> tensor<6xi32> {
+  %sharding = shard.sharding @grid split_axes = [[0]] : !shard.sharding
+  %2 = tosa.abs %arg0 : (tensor<6xi32>) -> tensor<6xi32>
+  %sharded = shard.shard %2 to %sharding annotate_for_users : tensor<6xi32>
+  return %2 : tensor<6xi32>
+}
+
+func.func @test_operand_missing_annotate(%arg0: tensor<6xi32>) -> tensor<6xi32> {
+  %sharding = shard.sharding @grid split_axes = [[0]] : !shard.sharding
+  %2 = shard.shard %arg0 to %sharding : tensor<6xi32>
+  // expected-error @+1 {{Cannot partition: shard.shard for operand 0 must set 'annotate_for_users'.}}
+  %3 = tosa.rsqrt %2 : (tensor<6xi32>) -> tensor<6xi32>
+  %4 = tosa.rsqrt %3 : (tensor<6xi32>) -> tensor<6xi32>
+  %sharded = shard.shard %4 to %sharding annotate_for_users : tensor<6xi32>
+  return %sharded : tensor<6xi32>
+}
+
+func.func @test_result_missing_sharding() -> tensor<6xi32> {
+  %sharding = shard.sharding @grid split_axes = [[0]] : !shard.sharding
+  // expected-error @+1 {{Cannot partition: user of result 0 must be shard.shard operation.}}
+  %1 = tensor.empty() : tensor<6xi32>
+  %3 = tosa.rsqrt %1 : (tensor<6xi32>) -> tensor<6xi32>
+  %4 = shard.shard %3 to %sharding : tensor<6xi32>
+  %sharded = shard.shard %4 to %sharding annotate_for_users : tensor<6xi32>
+  return %sharded : tensor<6xi32>
+}
+
+func.func @test_multiple_users(%arg0: tensor<6xi32>) -> tensor<6xi32> {
+  %sharding = shard.sharding @grid split_axes = [[0]] : !shard.sharding
+  %1 = shard.shard %arg0 to %sharding : tensor<6xi32>
+  %2 = shard.shard %1 to %sharding annotate_for_users : tensor<6xi32>
+  // expected-error @+1 {{Cannot partition: result 0 must have exactly one use.}}
+  %3 = tosa.rsqrt %2 : (tensor<6xi32>) -> tensor<6xi32>
+  %4 = shard.shard %3 to %sharding : tensor<6xi32>
+  %sharded = shard.shard %3 to %sharding annotate_for_users : tensor<6xi32>
+  return %sharded : tensor<6xi32>
+}
+
+func.func @test_result_invalid_annotate(%arg0: tensor<6xi32>) -> tensor<6xi32> {
+  %sharding = shard.sharding @grid split_axes = [[0]] : !shard.sharding
+  %1 = shard.shard %arg0 to %sharding : tensor<6xi32>
+  %2 = shard.shard %1 to %sharding annotate_for_users : tensor<6xi32>
+  // expected-error @+1 {{Cannot partition: shard.shard for result 0 must not set 'annotate_for_users'.}}
+  %3 = tosa.rsqrt %2 : (tensor<6xi32>) -> tensor<6xi32>
+  %sharded = shard.shard %3 to %sharding annotate_for_users : tensor<6xi32>
+  return %sharded : tensor<6xi32>
+}


### PR DESCRIPTION
Before trying to partition an operation, check that it is fully annotated with `shard.shard` ops. This gives useful error messages instead of random errors later on.