### PR TITLE
workflows/release-binaries: Run this job once a week to catch regressions

### DIFF
--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   schedule:
-    - cron: "0 0 16 * *"
+    - cron: "0 0 * * 6"
   workflow_dispatch:
     inputs:
       release-version:

--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -4,6 +4,8 @@ permissions:
   contents: read # Default everything to read-only
 
 on:
+  schedule:
+    - cron: "0 0 16 * *"
   workflow_dispatch:
     inputs:
       release-version:
@@ -67,7 +69,7 @@ jobs:
         run: |
           upload="${{ inputs.upload }}"
           release_version="${{ inputs.release-version }}"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "schedule" ]; then
             upload="false"
             release_version=""
           fi


### PR DESCRIPTION
This will increase the chances that we can have this job working for the first release candidate.