### PR TITLE
[libc++abi] Remove old workaround for detecting libunwind

### DIFF
--- a/libcxxabi/src/cxa_personality.cpp
+++ b/libcxxabi/src/cxa_personality.cpp
@@ -67,15 +67,6 @@
 #  pragma clang diagnostic ignored "-Wmissing-prototypes"
 #endif
 
-// TODO: This is a temporary workaround for libc++abi to recognize that it's being
-// built against LLVM's libunwind. LLVM's libunwind started reporting _LIBUNWIND_VERSION
-// in LLVM 15 -- we can remove this workaround after shipping LLVM 17. Once we remove
-// this workaround, it won't be possible to build libc++abi against libunwind headers
-// from LLVM 14 and before anymore.
-#if defined(____LIBUNWIND_CONFIG_H__) && !defined(_LIBUNWIND_VERSION)
-#   define _LIBUNWIND_VERSION
-#endif
-
 #if defined(__SEH__) && !defined(__USING_SJLJ_EXCEPTIONS__)
 #include <windows.h>
 #include <winnt.h>


### PR DESCRIPTION
This workaround should no longer be relevant since we don't support building against libunwind headers from LLVM 14.