### PR TITLE
[flang][acc] Fix build with ACCUseDeviceCanonicalizer dependency

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_flang_library(FIROpenACCTransforms
   FIRAnalysis
   FIRBuilder
   FIRDialect
+  FIRDialectSupport
   FIROpenACCAnalysis
   HLFIRDialect
 


### PR DESCRIPTION
There is a missing library dependency which causes a link error due to missing: fir::getKindMapping