### PR TITLE
[LLVM][CodeGen] Rename `gc-empty-basic-blocks` to `enable-gc-empty-basic-blocks`

### DIFF
--- a/llvm/include/llvm/Target/CGPassBuilderOption.h
+++ b/llvm/include/llvm/Target/CGPassBuilderOption.h
@@ -62,7 +62,7 @@ struct CGPassBuilderOption {
   bool EnableLoopTermFold = false;
   bool MISchedPostRA = false;
   bool EarlyLiveIntervals = false;
-  bool GCEmptyBlocks = false;
+  bool EnableGCEmptyBlocks = false;
 
   bool DisableLSR = false;
   bool DisableCGP = false;

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -270,6 +270,13 @@ static cl::opt<bool> EnableGCEmptyBlocks(
     "enable-gc-empty-basic-blocks", cl::init(false), cl::Hidden,
     cl::desc("Enable garbage-collecting empty basic blocks"));
 
+// TODO: remove this once all downstream users have migrated to using
+// enable-gc-empty-basic-blocks.
+static cl::alias
+    EnableGCEmptyBlocksAlias("gc-empty-basic-blocks",
+                             cl::desc("Alias for enable-gc-empty-basic-blocks"),
+                             cl::aliasopt(EnableGCEmptyBlocks));
+
 static cl::opt<bool>
     SplitStaticData("split-static-data", cl::Hidden, cl::init(false),
                     cl::desc("Split static data sections into hot and cold "

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -266,9 +266,9 @@ static cl::opt<bool> DisableSelectOptimize(
     cl::desc("Disable the select-optimization pass from running"));
 
 /// Enable garbage-collecting empty basic blocks.
-static cl::opt<bool>
-    GCEmptyBlocks("gc-empty-basic-blocks", cl::init(false), cl::Hidden,
-                  cl::desc("Enable garbage-collecting empty basic blocks"));
+static cl::opt<bool> EnableGCEmptyBlocks(
+    "enable-gc-empty-basic-blocks", cl::init(false), cl::Hidden,
+    cl::desc("Enable garbage-collecting empty basic blocks"));
 
 static cl::opt<bool>
     SplitStaticData("split-static-data", cl::Hidden, cl::init(false),
@@ -510,7 +510,7 @@ CGPassBuilderOption llvm::getCGPassBuilderOption() {
   SET_OPTION(DisableExpandReductions)
   SET_OPTION(PrintAfterISel)
   SET_OPTION(FSProfileFile)
-  SET_OPTION(GCEmptyBlocks)
+  SET_OPTION(EnableGCEmptyBlocks)
 
 #define SET_BOOLEAN_OPTION(Option) Opt.Option = Option;
 
@@ -1249,7 +1249,7 @@ void TargetPassConfig::addMachinePasses() {
       addPass(createMachineOutlinerPass(EnableMachineOutliner));
   }
 
-  if (GCEmptyBlocks)
+  if (EnableGCEmptyBlocks)
     addPass(llvm::createGCEmptyBasicBlocksLegacyPass());
 
   if (EnableFSDiscriminator)

--- a/llvm/test/CodeGen/X86/basic-block-address-map-empty-block.ll
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-empty-block.ll
@@ -1,5 +1,5 @@
-;; This test verifies that with -gc-empty-basic-blocks SHT_LLVM_BB_ADDR_MAP will not include entries for empty blocks.
-; RUN: llc < %s -mtriple=x86_64 -O0 -basic-block-address-map -gc-empty-basic-blocks | FileCheck --check-prefix=CHECK %s
+;; This test verifies that with -enable-gc-empty-basic-blocks SHT_LLVM_BB_ADDR_MAP will not include entries for empty blocks.
+; RUN: llc < %s -mtriple=x86_64 -O0 -basic-block-address-map -enable-gc-empty-basic-blocks | FileCheck --check-prefix=CHECK %s
 
 define void @foo(i1 zeroext %0) nounwind {
   br i1 %0, label %2, label %empty_block

--- a/llvm/test/CodeGen/X86/gc-empty-basic-blocks.ll
+++ b/llvm/test/CodeGen/X86/gc-empty-basic-blocks.ll
@@ -1,6 +1,6 @@
-;; This test verifies that -gc-empty-basic-blocks removes regular empty blocks
-;; but does not remove empty blocks which have their address taken.
-; RUN: llc < %s -mtriple=x86_64 -O0 -gc-empty-basic-blocks | FileCheck %s
+;; This test verifies that -enable-gc-empty-basic-blocks removes regular empty
+;; blocks but does not remove empty blocks which have their address taken.
+; RUN: llc < %s -mtriple=x86_64 -O0 -enable-gc-empty-basic-blocks | FileCheck %s
 
 ;; This function has a regular empty block.
 define void @foo(i1 zeroext %0) nounwind {
@@ -33,7 +33,7 @@ empty_block:                                     ; preds = %1
 }
 
 ;; This function has an empty block which has its address taken. Check that it
-;; is not removed by -gc-empty-basic-blocks.
+;; is not removed by -enable-gc-empty-basic-blocks.
 define void @bar(i1 zeroext %0) nounwind {
 entry:
   %1 = select i1 %0, ptr blockaddress(@bar, %empty_block), ptr blockaddress(@bar, %bb2) ; <ptr> [#uses=1]


### PR DESCRIPTION
Rename the `gc-empty-basic-blocks` command line option to `enable-gc-empty-basic-blocks` in preparation of adding calls to initializing the pass in `initializeCodeGen` and also make the flag more consistent with other existing flags to enable or disable passes.

Keep `gc-empty-basic-blocks` as an alias to allow all users to migrate to the new option.