### PR TITLE
[SystemZ] Add SP alignment to the DataLayout string.

### DIFF
--- a/clang/test/CodeGen/target-data.c
+++ b/clang/test/CodeGen/target-data.c
@@ -207,11 +207,11 @@
 // RUN: FileCheck %s -check-prefix=SYSTEMZ
 // RUN: %clang_cc1 -triple s390x-unknown -target-cpu z13 -target-feature +soft-float -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=SYSTEMZ
-// SYSTEMZ: target datalayout = "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64"
+// SYSTEMZ: target datalayout = "E-S64-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64"
 
 // RUN: %clang_cc1 -triple s390x-unknown -target-cpu z13 -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=SYSTEMZ-VECTOR
-// SYSTEMZ-VECTOR: target datalayout = "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64"
+// SYSTEMZ-VECTOR: target datalayout = "E-S64-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64"
 
 // RUN: %clang_cc1 -triple s390x-none-zos -target-cpu z10 -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=ZOS
@@ -219,7 +219,7 @@
 // RUN: FileCheck %s -check-prefix=ZOS
 // RUN: %clang_cc1 -triple s390x-none-zos -target-cpu z13 -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=ZOS
-// ZOS: target datalayout = "E-m:l-p1:32:32-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64"
+// ZOS: target datalayout = "E-S64-m:l-p1:32:32-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64"
 
 // RUN: %clang_cc1 -triple msp430-unknown -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=MSP430

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -6532,6 +6532,13 @@ std::string llvm::UpgradeDataLayoutString(StringRef DL, StringRef TT) {
     return Res;
   }
 
+  if (T.isSystemZ() && !DL.empty()) {
+    // Make sure the stack alignment is present.
+    if (!DL.contains("-S64"))
+      return "E-S64" + DL.drop_front(1).str();
+    return DL.str();
+  }
+
   auto AddPtr32Ptr64AddrSpaces = [&DL, &Res]() {
     // If the datalayout matches the expected format, add pointer size address
     // spaces to the datalayout.

--- a/llvm/lib/TargetParser/TargetDataLayout.cpp
+++ b/llvm/lib/TargetParser/TargetDataLayout.cpp
@@ -357,6 +357,9 @@ static std::string computeSystemZDataLayout(const Triple &TT) {
   // Big endian.
   Ret += "E";
 
+  // The natural stack alignment is 64 bits.
+  Ret += "-S64";
+
   // Data mangling.
   Ret += getManglingComponent(TT);
 

--- a/llvm/test/CodeGen/SystemZ/stack-align.ll
+++ b/llvm/test/CodeGen/SystemZ/stack-align.ll
@@ -1,0 +1,17 @@
+; RUN: opt < %s -mtriple=s390x-unknown-linux-gnu -mcpu=z16 -S -passes=infer-alignment \
+; RUN:   2>&1 | FileCheck %s
+;
+; Test that the alignment of the alloca is not increased beyond the stack
+; alignment of 8 bytes.
+
+declare void @foo(ptr)
+
+define void @f1(<4 x i64> %Arg) {
+; CHECK-LABEL: define void @f1
+; CHECK-NEXT:    %param = alloca <4 x i64>, align 8
+; CHECK-NEXT:    store <4 x i64> %Arg, ptr %param, align 8
+  %param = alloca <4 x i64>, align 8
+  store <4 x i64> %Arg, ptr %param, align 8
+  call void @foo(ptr %param)
+  ret void
+}

--- a/llvm/unittests/Bitcode/DataLayoutUpgradeTest.cpp
+++ b/llvm/unittests/Bitcode/DataLayoutUpgradeTest.cpp
@@ -68,6 +68,13 @@ TEST(DataLayoutUpgradeTest, ValidDataLayoutUpgrade) {
       "1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9-p7:160:256:256:32-p8:128:128:"
       "128:48-p9:192:256:256:32");
 
+  // Check that SystemZ adds -S64 if needed.
+  EXPECT_EQ(
+      UpgradeDataLayoutString(
+          "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64",
+          "systemz"),
+          "E-S64-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64");
+
   // Check that RISCV64 upgrades -n64 to -n32:64.
   EXPECT_EQ(UpgradeDataLayoutString("e-m:e-p:64:64-i64:64-i128:128-n64-S128",
                                     "riscv64"),

--- a/llvm/unittests/Bitcode/DataLayoutUpgradeTest.cpp
+++ b/llvm/unittests/Bitcode/DataLayoutUpgradeTest.cpp
@@ -69,11 +69,10 @@ TEST(DataLayoutUpgradeTest, ValidDataLayoutUpgrade) {
       "128:48-p9:192:256:256:32");
 
   // Check that SystemZ adds -S64 if needed.
-  EXPECT_EQ(
-      UpgradeDataLayoutString(
-          "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64",
-          "systemz"),
-          "E-S64-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64");
+  EXPECT_EQ(UpgradeDataLayoutString(
+                "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64",
+                "systemz"),
+            "E-S64-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64");
 
   // Check that RISCV64 upgrades -n64 to -n32:64.
   EXPECT_EQ(UpgradeDataLayoutString("e-m:e-p:64:64-i64:64-i128:128-n64-S128",


### PR DESCRIPTION
Add '-S64' to the SystemZ datalayout string, to avoid overalignment of stack objects.

Fixes #173402

This changes 25 files on SPEC over 5 benchmarks, with fewer cases of runtime-alignment (NILL instructions).

@uweigand @nikic 