### PR TITLE
[Clang] Fix rewrite-includes-bom.c to use POSIX-compliant regex

### DIFF
--- a/clang/test/Frontend/rewrite-includes-bom.c
+++ b/clang/test/Frontend/rewrite-includes-bom.c
@@ -1,6 +1,6 @@
-// RUN: cat %S/Inputs/rewrite-includes-bom.h | od -t x1 | grep -q 'ef\s*bb\s*bf'
+// RUN: cat %S/Inputs/rewrite-includes-bom.h | od -t x1 | grep -q 'ef[[:space:]]*bb[[:space:]]*bf'
 // RUN: %clang_cc1 -E -frewrite-includes -I %S/Inputs %s -o %t.c
-// RUN: cat %t.c | od -t x1 | not grep -q 'ef\s*bb\s*bf'
+// RUN: cat %t.c | od -t x1 | not grep -q 'ef[[:space:]]*bb[[:space:]]*bf'
 // RUN: %clang_cc1 -fsyntax-only -verify %t.c
 // expected-no-diagnostics
 // UNSUPPORTED: system-windows


### PR DESCRIPTION
As `\s` is a GNU extension, it is not supported by the system grep on AIX and thus fails in the [buildbot](https://lab.llvm.org/buildbot/#/builders/64/builds/6835):

```
******************** TEST 'Clang :: Frontend/rewrite-includes-bom.c' FAILED ********************
Exit Code: 1
Command Output (stdout):
--
# RUN: at line 1
cat /home/llvm/llvm-external-buildbots/workers/aix-ppc64/clang-ppc64-aix/llvm-project/clang/test/Frontend/Inputs/rewrite-includes-bom.h | od -t x1 | grep -q 'ef\s*bb\s*bf'
# executed command: cat /home/llvm/llvm-external-buildbots/workers/aix-ppc64/clang-ppc64-aix/llvm-project/clang/test/Frontend/Inputs/rewrite-includes-bom.h
# executed command: od -t x1
# executed command: grep -q 'ef\s*bb\s*bf'
# note: command had no output on stdout or stderr
# error: command failed with exit status: 1
--
********************
```

This change replaces `\s` with the POSIX-compliant `[[:space::]]` so the test is supported on AIX.