### PR TITLE
[CFIInstrInserter] Fix a test.

### DIFF
--- a/llvm/test/CodeGen/RISCV/cfi-multiple-locations.mir
+++ b/llvm/test/CodeGen/RISCV/cfi-multiple-locations.mir
@@ -13,8 +13,7 @@ tracksRegLiveness: true
 body:             |
   bb.0.entry:
     liveins: $x10, $x9, $x2
-    BEQ $x10, $x0, %bb.3
-    PseudoBR %bb.2
+    BEQ $x10, $x0, %bb.2
 
   bb.1:
     liveins: $x10, $x9, $x2


### PR DESCRIPTION
In the test `cfi-multiple-locations.mir` the block `bb.1` was unreachable.