### PR TITLE
[CFIInstrInserter][NFC] Move `class CSRSavedLocation` definition.

### DIFF
--- a/llvm/lib/CodeGen/CFIInstrInserter.cpp
+++ b/llvm/lib/CodeGen/CFIInstrInserter.cpp
@@ -65,26 +65,7 @@ class CFIInstrInserter : public MachineFunctionPass {
     return insertedCFI;
   }
 
- private:
-  struct MBBCFAInfo {
-    MachineBasicBlock *MBB;
-    /// Value of cfa offset valid at basic block entry.
-    int64_t IncomingCFAOffset = -1;
-    /// Value of cfa offset valid at basic block exit.
-    int64_t OutgoingCFAOffset = -1;
-    /// Value of cfa register valid at basic block entry.
-    unsigned IncomingCFARegister = 0;
-    /// Value of cfa register valid at basic block exit.
-    unsigned OutgoingCFARegister = 0;
-    /// Set of callee saved registers saved at basic block entry.
-    BitVector IncomingCSRSaved;
-    /// Set of callee saved registers saved at basic block exit.
-    BitVector OutgoingCSRSaved;
-    /// If in/out cfa offset and register values for this block have already
-    /// been set or not.
-    bool Processed = false;
-  };
-
+private:
   /// contains the location where CSR register is saved.
   class CSRSavedLocation {
   public:
@@ -157,6 +138,25 @@ class CFIInstrInserter : public MachineFunctionPass {
         break;
       }
     }
+  };
+
+  struct MBBCFAInfo {
+    MachineBasicBlock *MBB;
+    /// Value of cfa offset valid at basic block entry.
+    int64_t IncomingCFAOffset = -1;
+    /// Value of cfa offset valid at basic block exit.
+    int64_t OutgoingCFAOffset = -1;
+    /// Value of cfa register valid at basic block entry.
+    unsigned IncomingCFARegister = 0;
+    /// Value of cfa register valid at basic block exit.
+    unsigned OutgoingCFARegister = 0;
+    /// Set of callee saved registers saved at basic block entry.
+    BitVector IncomingCSRSaved;
+    /// Set of callee saved registers saved at basic block exit.
+    BitVector OutgoingCSRSaved;
+    /// If in/out cfa offset and register values for this block have already
+    /// been set or not.
+    bool Processed = false;
   };
 
   /// Contains cfa offset and register values valid at entry and exit of basic


### PR DESCRIPTION
This is needed to minimize diff for the future commit where we plan to use `CSRSavedLocation` in `stuct MBBCFAInfo`.