### PR TITLE
Add support for DW_FORM_GNU_ref_alt and DW_FORM_GNU_strp_alt.

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.cpp
@@ -76,6 +76,8 @@ bool DWARFFormValue::ExtractValue(const DWARFDataExtractor &data,
     case DW_FORM_strp:
     case DW_FORM_line_strp:
     case DW_FORM_sec_offset:
+    case DW_FORM_GNU_ref_alt:
+    case DW_FORM_GNU_strp_alt:
       assert(m_unit);
       m_value.uval = data.GetMaxU64(
           offset_ptr, m_unit->GetFormParams().getDwarfOffsetByteSize());
@@ -280,6 +282,8 @@ bool DWARFFormValue::SkipValue(dw_form_t form,
     case DW_FORM_sec_offset:
     case DW_FORM_strp:
     case DW_FORM_line_strp:
+    case DW_FORM_GNU_ref_alt:
+    case DW_FORM_GNU_strp_alt:
       assert(unit);
       *offset_ptr += unit->GetFormParams().getDwarfOffsetByteSize();
       return true;
@@ -416,6 +420,13 @@ void DWARFFormValue::Dump(Stream &s) const {
                 m_unit->GetFormParams().getRefAddrByteSize());
     break;
   }
+  case DW_FORM_GNU_ref_alt:
+  case DW_FORM_GNU_strp_alt: {
+    assert(m_unit);
+    DumpAddress(s.AsRawOstream(), uvalue,
+                m_unit->GetFormParams().getDwarfOffsetByteSize());
+    break;
+  }
   case DW_FORM_ref1:
     unit_relative_offset = true;
     break;
@@ -439,6 +450,7 @@ void DWARFFormValue::Dump(Stream &s) const {
     break;
   case DW_FORM_flag_present:
     break;
+
   default:
     s.Printf("DW_FORM(0x%4.4x)", m_form);
     break;
@@ -660,6 +672,8 @@ bool DWARFFormValue::FormIsSupported(dw_form_t form) {
     case DW_FORM_GNU_str_index:
     case DW_FORM_GNU_addr_index:
     case DW_FORM_implicit_const:
+    case DW_FORM_GNU_ref_alt:
+    case DW_FORM_GNU_strp_alt:
       return true;
     default:
       break;

--- a/lldb/test/Shell/SymbolFile/DWARF/Inputs/gnu-ref-strp-alt.yaml
+++ b/lldb/test/Shell/SymbolFile/DWARF/Inputs/gnu-ref-strp-alt.yaml
@@ -1,0 +1,53 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+  Entry:           0x1000
+DWARF:
+  debug_str:
+    - ''
+    - bar
+  debug_abbrev:
+    - ID:              0
+      Table:
+        - Code:            0x1
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_GNU_strp_alt
+            - Attribute:       DW_AT_language
+              Form:            DW_FORM_udata
+        - Code:            0x2
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_type
+              Form:            DW_FORM_GNU_ref_alt
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_addr
+  debug_info:
+    - Length:          0x27
+      Version:         4
+      AbbrevTableID:   0
+      AbbrOffset:      0x0
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x1
+          Values:
+            - Value:           0x123
+            - Value:           0x2
+        - AbbrCode:        0x2
+          Values:
+            - Value:           0x1
+            - Value:           0x12
+            - Value:           0x1000
+            - Value:           0x1100
+        - AbbrCode:        0x0
+...

--- a/lldb/test/Shell/SymbolFile/DWARF/gnu-ref-strp-alt.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/gnu-ref-strp-alt.test
@@ -8,5 +8,5 @@
 # RUN: %lldb %t -b -o 'b bar' | FileCheck %s
 
 # CHECK:      (lldb) b bar
-# CHECK-NOT:  warning: (x86_64) /tmp/b.out unsupported DW_FORM values: 0x1f20 0x1f21
+# CHECK-NOT:  unsupported DW_FORM values:
 # CHECK:      Breakpoint 1: address = 0x0000000000001000

--- a/lldb/test/Shell/SymbolFile/DWARF/gnu-ref-strp-alt.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/gnu-ref-strp-alt.test
@@ -1,0 +1,12 @@
+# This test verifies that LLDB can read DWARF file that contains DW_FORM values
+# encoded with the DW_FORM_GNU_ref_alt and DW_FORM_GNU_strp_alt. If any file was
+# loaded into LLDB prior to adding support LLDB wouldn't be able to parse any
+# of the DWARF as it wouldn't know how to parse these entries and since DWARF is
+# a stream, nothing after that could be parsed.
+
+# RUN: yaml2obj %S/Inputs/gnu-ref-strp-alt.yaml > %t
+# RUN: %lldb %t -b -o 'b bar' | FileCheck %s
+
+# CHECK:      (lldb) b bar
+# CHECK-NOT:  warning: (x86_64) /tmp/b.out unsupported DW_FORM values: 0x1f20 0x1f21
+# CHECK:      Breakpoint 1: address = 0x0000000000001000


### PR DESCRIPTION
LLDB's DWARF parser didn't support parsing DW_FORM_GNU_ref_alt and DW_FORM_GNU_strp_alt forms which would cause any file loaded by LLDB to fail to parse any DWARF. Added support for parsing this information only, not for actually finding the debug info reference to an alternate file or a string in an alternate file. These extensions are used by DWZ files which are present in some linux distros, so it will be good for LLDB to just be able to parse these without emitting an error like:

(lldb) b bar
warning: (arm64) /tmp/a.out unsupported DW_FORM values: 0x1f20 0x1f21