### PR TITLE
Revert "[LLDB] Fix MS STL `variant` with non-trivial types"

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVariant.cpp
@@ -67,18 +67,12 @@ std::optional<int64_t> GetIndexValue(ValueObject &valobj) {
 ValueObjectSP GetNthStorage(ValueObject &outer, int64_t index) {
   // We need to find the std::_Variant_storage base class.
 
-  // Navigate "down" to std::_Variant_base by finding the holder of "_Which".
-  // This might be down a few levels if a variant member isn't trivially
-  // destructible/copyable/etc.
-  ValueObjectSP which_sp = outer.GetChildMemberWithName("_Which");
-  if (!which_sp)
+  // -> std::_SMF_control (typedef to std::_Variant_base)
+  ValueObjectSP container_sp = outer.GetSP()->GetChildAtIndex(0);
+  if (!container_sp)
     return nullptr;
-  ValueObject *parent = which_sp->GetParent();
-  if (!parent)
-    return nullptr;
-
-  // Now go to std::_Variant_storage.
-  ValueObjectSP container_sp = parent->GetChildAtIndex(0);
+  // -> std::_Variant_storage
+  container_sp = container_sp->GetChildAtIndex(0);
   if (!container_sp)
     return nullptr;
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/variant/TestDataFormatterStdVariant.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/variant/TestDataFormatterStdVariant.py
@@ -50,14 +50,6 @@ class StdVariantDataFormatterTestCase(TestBase):
             ],
         )
 
-        self.expect_expr(
-            "v4",
-            result_summary=" Active Type = int ",
-            result_children=[
-                ValueCheck(name="Value", value="4"),
-            ],
-        )
-
         lldbutil.continue_to_breakpoint(self.process, bkpt)
 
         self.expect(
@@ -75,19 +67,6 @@ class StdVariantDataFormatterTestCase(TestBase):
         self.expect(
             "frame variable v3",
             substrs=["v3 =  Active Type = char  {", "Value = 'A'", "}"],
-        )
-
-        string_name = (
-            "std::basic_string<char, std::char_traits<char>, std::allocator<char>>"
-            if self.getDebugInfo() == "pdb"
-            else "std::basic_string<char>"
-        )
-        self.expect_expr(
-            "v4",
-            result_summary=f" Active Type = {string_name} ",
-            result_children=[
-                ValueCheck(name="Value", summary='"a string"'),
-            ],
         )
 
         self.expect("frame variable v_valueless", substrs=["v_valueless =  No Value"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/variant/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/variant/main.cpp
@@ -49,8 +49,6 @@ int main() {
       S>
       v_300_types_valueless;
 
-  std::variant<int, bool, std::string> v4 = 4;
-
   v_valueless = 5;
   v_300_types_valueless.emplace<0>(10);
 
@@ -72,9 +70,6 @@ int main() {
   // state when we change its value.
   v1 = 2.0;
   d = std::get<double>(v1);
-
-  v4 = "a string";
-
   printf("%f\n", d); // break here
 
   try {


### PR DESCRIPTION
Reverts llvm/llvm-project#171489 because it causes `TestDataFormatterStdVariant.py` to fail on Darwin.

Affected bots:

- https://ci.swift.org/view/all/job/llvm.org/view/LLDB/job/as-lldb-cmake/
- https://ci.swift.org/view/all/job/llvm.org/view/LLDB/job/lldb-cmake/

