### PR TITLE
[SelectionDAG] Fix zext assertion check for scalable vectors

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -1569,12 +1569,14 @@ SDValue SelectionDAG::getZeroExtendInReg(SDValue Op, const SDLoc &DL, EVT VT) {
   assert((!VT.isVector() ||
           VT.getVectorElementCount() == OpVT.getVectorElementCount()) &&
          "Vector element counts must match in getZeroExtendInReg");
-  assert(VT.bitsLE(OpVT) && "Not extending!");
+  assert(VT.getScalarType().bitsLE(OpVT.getScalarType()) && "Not extending!");
   if (OpVT == VT)
     return Op;
   // TODO: Use computeKnownBits instead of AssertZext.
-  if (Op.getOpcode() == ISD::AssertZext &&
-      cast<VTSDNode>(Op.getOperand(1))->getVT().bitsLE(VT))
+  if (Op.getOpcode() == ISD::AssertZext && cast<VTSDNode>(Op.getOperand(1))
+                                               ->getVT()
+                                               .getScalarType()
+                                               .bitsLE(VT.getScalarType()))
     return Op;
   APInt Imm = APInt::getLowBitsSet(OpVT.getScalarSizeInBits(),
                                    VT.getScalarSizeInBits());
@@ -1591,7 +1593,7 @@ SDValue SelectionDAG::getVPZeroExtendInReg(SDValue Op, SDValue Mask,
          "getVPZeroExtendInReg type and operand type should be vector!");
   assert(VT.getVectorElementCount() == OpVT.getVectorElementCount() &&
          "Vector element counts must match in getZeroExtendInReg");
-  assert(VT.bitsLE(OpVT) && "Not extending!");
+  assert(VT.getScalarType().bitsLE(OpVT.getScalarType()) && "Not extending!");
   if (OpVT == VT)
     return Op;
   APInt Imm = APInt::getLowBitsSet(OpVT.getScalarSizeInBits(),
@@ -7910,7 +7912,7 @@ SDValue SelectionDAG::getNode(unsigned Opcode, const SDLoc &DL, EVT VT,
     assert((!EVT.isVector() ||
             EVT.getVectorElementCount() == VT.getVectorElementCount()) &&
            "Vector element counts must match in SIGN_EXTEND_INREG");
-    assert(EVT.bitsLE(VT) && "Not extending!");
+    assert(EVT.getScalarType().bitsLE(VT.getScalarType()) && "Not extending!");
     if (EVT == VT) return N1;  // Not actually extending
     break;
   }

--- a/llvm/test/CodeGen/AArch64/aarch64-sve-setcc-promote-nxv8i8-crash.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-sve-setcc-promote-nxv8i8-crash.ll
@@ -1,10 +1,7 @@
 ; RUN: llc -mtriple=aarch64-unknown-linux-gnu -mattr=+sve -o - %s | FileCheck %s
 
-target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
-target triple = "aarch64-unknown-linux-gnu"
-
 ; Just check that llc does not crash
-define void @sve_setcc_promote_nxv8i8_crash(ptr %0, <vscale x 8 x i8> %1, <vscale x 8 x i8> %2) #0 {
+define void @sve_setcc_promote_nxv8i8_crash(ptr %0, <vscale x 8 x i8> %1, <vscale x 8 x i8> %2) {
 ; CHECK-LABEL: sve_setcc_promote_nxv8i8_crash:
 iter.check:
   %wide.load61.pre = load <vscale x 8 x i8>, ptr null, align 1
@@ -20,4 +17,3 @@ vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.b
   br label %vec.epilog.vector.body
 }
 
-attributes #0 = { "target-cpu"="neoverse-v2" }

--- a/llvm/test/CodeGen/AArch64/aarch64-sve-setcc-promote-nxv8i8-crash.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-sve-setcc-promote-nxv8i8-crash.ll
@@ -1,0 +1,23 @@
+; RUN: llc -mtriple=aarch64-unknown-linux-gnu -mattr=+sve -o - %s | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-gnu"
+
+; Just check that llc does not crash
+define void @sve_setcc_promote_nxv8i8_crash(ptr %0, <vscale x 8 x i8> %1, <vscale x 8 x i8> %2) #0 {
+; CHECK-LABEL: sve_setcc_promote_nxv8i8_crash:
+iter.check:
+  %wide.load61.pre = load <vscale x 8 x i8>, ptr null, align 1
+  br label %vec.epilog.vector.body
+
+vec.epilog.vector.body:                           ; preds = %vec.epilog.vector.body, %iter.check
+  %3 = icmp eq <vscale x 8 x i8> %wide.load61.pre, zeroinitializer
+  %4 = icmp slt <vscale x 8 x i8> %wide.load61.pre, zeroinitializer
+  %5 = select <vscale x 8 x i1> %3, <vscale x 8 x i8> zeroinitializer, <vscale x 8 x i8> %1
+  %6 = select <vscale x 8 x i1> %4, <vscale x 8 x i8> zeroinitializer, <vscale x 8 x i8> %2
+  %7 = xor <vscale x 8 x i8> %5, %6
+  store <vscale x 8 x i8> %7, ptr %0, align 1
+  br label %vec.epilog.vector.body
+}
+
+attributes #0 = { "target-cpu"="neoverse-v2" }


### PR DESCRIPTION
Use element type comparisons in getZeroExtendInReg to avoid comparing scalable and fixed types.

Fixes #176037