### PR TITLE
[llvm/CAS] Introduce `validateObjectID()` and use it in `UnifiedOnDiskActionCache::validate()`

### DIFF
--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -339,6 +339,10 @@ public:
   /// \param Hasher is the hashing function used for objects inside CAS.
   Error validate(bool Deep, HashingFuncT Hasher) const;
 
+  /// Checks that \p ID exists in the index. It is allowed to not have data
+  /// associated with it.
+  LLVM_ABI_FOR_TEST Error validateObjectID(ObjectID ID);
+
   /// How to fault-in nodes if an upstream database is used.
   enum class FaultInPolicy {
     /// Copy only the requested node.

--- a/llvm/lib/CAS/ActionCaches.cpp
+++ b/llvm/lib/CAS/ActionCaches.cpp
@@ -241,25 +241,11 @@ Error UnifiedOnDiskActionCache::validate() const {
       return createStringError(
           llvm::errc::illegal_byte_sequence,
           "bad record at 0x" +
-              utohexstr((unsigned)Offset.get(), /*LowerCase=*/true) +
-              " ref=0x" + utohexstr(ID.getOpaqueData(), /*LowerCase=*/true) +
-              ": " + Msg.str());
+              utohexstr((unsigned)Offset.get(), /*LowerCase=*/true) + ": " +
+              Msg.str());
     };
-    if (ID.getOpaqueData() == 0)
-      return formatError("zero is not a valid ref");
-    // Check containsObject first, because other API assumes a valid ObjectID.
-    if (!UniDB->getGraphDB().containsObject(ID, /*CheckUpstream=*/false))
-      return formatError("ref is not in cas index");
-    auto Hash = UniDB->getGraphDB().getDigest(ID);
-    auto Ref =
-        UniDB->getGraphDB().getExistingReference(Hash, /*CheckUpstream=*/false);
-    assert(Ref && "missing object passed containsObject check?");
-    if (!Ref)
-      return formatError("ref is not in cas index after contains");
-    if (*Ref != ID)
-      return formatError("ref does not match indexed offset " +
-                         utohexstr(Ref->getOpaqueData(), /*LowerCase=*/true) +
-                         " for hash " + toHex(Hash));
+    if (Error E = UniDB->getGraphDB().validateObjectID(ID))
+      return formatError(llvm::toString(std::move(E)));
     return Error::success();
   };
   return UniDB->getKeyValueDB().validate(ValidateRef);

--- a/llvm/unittests/CAS/OnDiskGraphDBTest.cpp
+++ b/llvm/unittests/CAS/OnDiskGraphDBTest.cpp
@@ -59,6 +59,14 @@ TEST_F(OnDiskCASTest, OnDiskGraphDBTest) {
   ASSERT_TRUE(Obj2.has_value());
   EXPECT_EQ(toStringRef(DB->getObjectData(*Obj2)), "world");
 
+  ASSERT_THAT_ERROR(DB->validateObjectID(*ID1), Succeeded());
+  ASSERT_THAT_ERROR(DB->validateObjectID(ObjectID::fromOpaqueData(0)),
+                    Failed());
+  ASSERT_THAT_ERROR(DB->validateObjectID(ObjectID::fromOpaqueData(4)),
+                    Failed());
+  ASSERT_THAT_ERROR(DB->validateObjectID(ObjectID::fromOpaqueData(8)),
+                    Failed());
+
   size_t LargeDataSize = 256LL * 1024LL; // 256K.
   // The precise size number is not important, we mainly check that the large
   // object will be properly accounted for.


### PR DESCRIPTION
This allows object IDs to be valid even if they do not point to actual data yet, like in lazy materialization schemes.