### PR TITLE
[Clang] Check enable_if attribute without delayed diagnostics

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -120,6 +120,7 @@ Bug Fixes to Compiler Builtins
 
 Bug Fixes to Attribute Support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- Fixed a behavioral discrepancy between deleted functions and private members when checking the ``enable_if`` attribute. (#GH175895)
 
 Bug Fixes to C++ Support
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -7551,6 +7551,12 @@ EnableIfAttr *Sema::CheckEnableIf(FunctionDecl *Function,
     return nullptr;
 
   SFINAETrap Trap(*this);
+  // Perform the access checking immediately so any access diagnostics are
+  // caught by the SFINAE trap.
+  llvm::scope_exit UndelayDiags(
+      [&, CurrentState(DelayedDiagnostics.pushUndelayed())] {
+        DelayedDiagnostics.popUndelayed(CurrentState);
+      });
   SmallVector<Expr *, 16> ConvertedArgs;
   // FIXME: We should look into making enable_if late-parsed.
   Expr *DiscardedThis;


### PR DESCRIPTION
We ensure immediate access control checking when evaluating the enable_if attribute to rule out inaccessible constructors during potential overload resolution, treating them as SFINAE errors rather than hard errors, making the behavior more preferable with the nature of the enable_if attribute.

Compared to the last patch, we now avoid switching the DC directly because there are cases where we're checking enable_if attribute within a lambda and getCurLambda() requires a lambda context to distinguish from template instantiation.

This reapplies #175899

Fixes https://github.com/llvm/llvm-project/issues/175895