### PR TITLE
[clang] Fix assertion failure when transforming co_yield in invalid coroutine

### DIFF
--- a/clang/test/SemaCXX/coroutine-final-suspend-crash.cpp
+++ b/clang/test/SemaCXX/coroutine-final-suspend-crash.cpp
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+#include "Inputs/std-coroutine.h"
+
+struct Tag {};
+struct Y {
+  bool await_ready() const;
+  void await_suspend(std::coroutine_handle<>) const;
+  void await_resume() const;
+};
+
+struct Promise {
+  Tag get_return_object();
+  std::suspend_always initial_suspend();
+  // We intentionally omit final_suspend to trigger the error path
+  void unhandled_exception();
+  Y yield_value(int);
+  void return_void();
+};
+
+template <class... Args> struct std::coroutine_traits<Tag, Args...> {
+  using promise_type = Promise;
+};
+
+template <class T> struct S {
+  // The error is diagnosed at the function declaration, not the yield statement.
+  template <class U> static Tag f() { // expected-error {{no member named 'final_suspend' in 'Promise'}}
+    co_yield 0;
+  }
+};
+
+Tag g() { return S<int>::f<void>(); }


### PR DESCRIPTION
Clang would previously crash with an assertion failure in `LocalInstantiationScope::findInstantiationOf` when compiling a C++20 coroutine that was missing `promise_type::final_suspend`.

The crash occurred during `TreeTransform::TransformCoyieldExpr` because the compiler attempted to rebuild the coroutine body even after the promise object failed to form correctly. This led to a lookup for a declaration that was never instantiated.

This patch adds a check for `CoroutinePromise` validity in `TransformCoyieldExpr`. If the promise is null or invalid, we now bail out early, preventing the assertion and allowing the compiler to recover gracefully after emitting the error.

Fixes #175720