### PR TITLE
[MemProf] Handle weak alias and aliasee prevailing in different modules

### DIFF
--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -111,6 +111,8 @@ STATISTIC(NumImportantContextIds, "Number of important context ids");
 STATISTIC(NumFixupEdgeIdsInserted, "Number of fixup edge ids inserted");
 STATISTIC(NumFixupEdgesAdded, "Number of fixup edges added");
 STATISTIC(NumFixedContexts, "Number of contexts with fixed edges");
+STATISTIC(AliaseesPrevailingInDiffModuleFromAlias,
+          "Number of aliasees prevailing in a different module than its alias");
 
 static cl::opt<std::string> DotFilePathPrefix(
     "memprof-dot-file-path-prefix", cl::init(""), cl::Hidden,
@@ -1083,6 +1085,7 @@ private:
                            unsigned CloneNo);
   std::string getLabel(const FunctionSummary *Func, const IndexCall &Call,
                        unsigned CloneNo) const;
+  DenseSet<GlobalValue::GUID> findAliaseeGUIDsPrevailingInDifferentModule();
 
   // Saves mapping from function summaries containing memprof records back to
   // its VI, for use in checking and debugging.
@@ -2467,17 +2470,61 @@ ModuleCallsiteContextGraph::ModuleCallsiteContextGraph(
       Call.call()->setMetadata(LLVMContext::MD_callsite, nullptr);
 }
 
+// Finds the set of GUIDs for weak aliasees that are prevailing in different
+// modules than any of their aliases. We need to handle these specially.
+DenseSet<GlobalValue::GUID>
+IndexCallsiteContextGraph::findAliaseeGUIDsPrevailingInDifferentModule() {
+  DenseSet<GlobalValue::GUID> AliaseeGUIDs;
+  for (auto &I : Index) {
+    auto VI = Index.getValueInfo(I);
+    for (auto &S : VI.getSummaryList()) {
+      // We only care about aliases to functions.
+      auto *AS = dyn_cast<AliasSummary>(S.get());
+      if (!AS)
+        continue;
+      auto *AliaseeSummary = &AS->getAliasee();
+      auto *AliaseeFS = dyn_cast<FunctionSummary>(AliaseeSummary);
+      if (!AliaseeFS)
+        continue;
+      // Skip this summary if it is not for the prevailing symbol for this GUID.
+      // The linker doesn't resolve local linkage values so don't check whether
+      // those are prevailing.
+      if (!GlobalValue::isLocalLinkage(S->linkage()) &&
+          !isPrevailing(VI.getGUID(), S.get()))
+        continue;
+      // Prevailing aliasee could be in a different module only if it is weak.
+      if (!GlobalValue::isWeakForLinker(AliaseeSummary->linkage()))
+        continue;
+      auto AliaseeGUID = AS->getAliaseeGUID();
+      // If the aliasee copy in this module is not prevailing, record it.
+      if (!isPrevailing(AliaseeGUID, AliaseeSummary))
+        AliaseeGUIDs.insert(AliaseeGUID);
+    }
+  }
+  AliaseesPrevailingInDiffModuleFromAlias += AliaseeGUIDs.size();
+  return AliaseeGUIDs;
+}
+
 IndexCallsiteContextGraph::IndexCallsiteContextGraph(
     ModuleSummaryIndex &Index,
     llvm::function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
         isPrevailing)
     : Index(Index), isPrevailing(isPrevailing) {
+  // Since we use the aliasee summary info to create the necessary clones for
+  // its aliases, conservatively skip recording the aliasee function's callsites
+  // in the CCG for any that are prevailing in a different module than one of
+  // its aliases. We could record the necessary information to do this in the
+  // summary, but this case should not be common.
+  DenseSet<GlobalValue::GUID> GUIDsToSkip =
+      findAliaseeGUIDsPrevailingInDifferentModule();
   // Map for keeping track of the largest cold contexts up to the number given
   // by MemProfTopNImportant. Must be a std::map (not DenseMap) because keys
   // must be sorted.
   std::map<uint64_t, uint32_t> TotalSizeToContextIdTopNCold;
   for (auto &I : Index) {
     auto VI = Index.getValueInfo(I);
+    if (GUIDsToSkip.contains(VI.getGUID()))
+      continue;
     for (auto &S : VI.getSummaryList()) {
       // We should only add the prevailing nodes. Otherwise we may try to clone
       // in a weak copy that won't be linked (and may be different than the

--- a/llvm/test/ThinLTO/X86/memprof-weak-alias.ll
+++ b/llvm/test/ThinLTO/X86/memprof-weak-alias.ll
@@ -1,0 +1,132 @@
+;; Test handling of memprof ThinLTO when the call to update is a weak alias
+;; where the prevailing weak aliasee is defined in a different module.
+
+;; Preparation steps to generate the bitcode and perform the thin link.
+; RUN: rm -rf %t && split-file %s %t && cd %t
+; RUN: opt -thinlto-bc src1.ll >src1.o
+; RUN: opt -thinlto-bc src2.ll >src2.o
+
+;; First run the case where alias (_Z8fooAliasv) and aliasee (_Z3foov)
+;; are prevailing in the same module.
+; RUN: llvm-lto2 run src1.o src2.o -enable-memprof-context-disambiguation \
+; RUN:	-supports-hot-cold-new \
+; RUN:  -thinlto-distributed-indexes \
+; RUN:	-r=src1.o,main,plx \
+; RUN:	-r=src1.o,_Znam, \
+; RUN:	-r=src1.o,_Z8fooAliasv, \
+; RUN:	-r=src1.o,_Z3foov,lx \
+; RUN:	-r=src2.o,_Znam, \
+; RUN:	-r=src2.o,_Z8fooAliasv,plx \
+; RUN:	-r=src2.o,_Z3foov,plx \
+; RUN:	-o %t.out
+
+;; Run ThinLTO backends. We should be able to clone correctly.
+; RUN: opt -passes=memprof-context-disambiguation \
+; RUN:	-memprof-import-summary=src1.o.thinlto.bc \
+; RUN:  -pass-remarks=memprof-context-disambiguation \
+; RUN:  src1.o -S 2>&1 | FileCheck %s --check-prefix=IR-MOD1 --implicit-check-not=_Z3foov.memprof
+; RUN: opt -passes=memprof-context-disambiguation \
+; RUN:	-memprof-import-summary=src2.o.thinlto.bc \
+; RUN:  -pass-remarks=memprof-context-disambiguation \
+; RUN:  src2.o -S 2>&1 | FileCheck %s --check-prefix=IR-MOD2
+
+;; Now try where the aliasee is prevailing in the first module instead,
+;; which only has the alias declaration.
+; RUN: llvm-lto2 run src1.o src2.o -enable-memprof-context-disambiguation \
+; RUN:	-supports-hot-cold-new \
+; RUN:  -thinlto-distributed-indexes \
+; RUN:	-r=src1.o,main,plx \
+; RUN:	-r=src1.o,_Znam, \
+; RUN:	-r=src1.o,_Z8fooAliasv, \
+; RUN:	-r=src1.o,_Z3foov,plx \
+; RUN:	-r=src2.o,_Znam, \
+; RUN:	-r=src2.o,_Z8fooAliasv,plx \
+; RUN:	-r=src2.o,_Z3foov,lx \
+; RUN:	-o %t.out
+
+;; Run ThinLTO backends. We should conservatively disable cloning.
+; RUN: opt -passes=memprof-context-disambiguation \
+; RUN:	-memprof-import-summary=src1.o.thinlto.bc \
+; RUN:  -pass-remarks=memprof-context-disambiguation \
+; RUN:  src1.o -S 2>&1 | FileCheck %s --implicit-check-not "memprof.1"
+; RUN: opt -passes=memprof-context-disambiguation \
+; RUN:	-memprof-import-summary=src2.o.thinlto.bc \
+; RUN:  -pass-remarks=memprof-context-disambiguation \
+; RUN:  src2.o -S 2>&1 | FileCheck %s --implicit-check-not "memprof.1"
+
+;--- src1.ll
+source_filename = "memprof-distrib-alias.ll"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @main() #0 {
+entry:
+  ;; The first call to fooAlias does not allocate cold memory. It should call
+  ;; the original function alias, which calls the original allocation decorated
+  ;; with a "notcold" attribute.
+  ; IR-MOD1:   call {{.*}} @_Z8fooAliasv()
+  %call = call ptr @_Z8fooAliasv(), !callsite !0
+  ;; The second call to fooAlias allocates cold memory. It should call the
+  ;; cloned function which calls a cloned allocation decorated with a "cold"
+  ;; attribute.
+  ; IR-MOD1:   call {{.*}} @_Z8fooAliasv.memprof.1()
+  %call1 = call ptr @_Z8fooAliasv(), !callsite !1
+  ret i32 0
+}
+
+; IR-MOD1: declare {{.*}} @_Z8fooAliasv.memprof.1()
+
+declare ptr @_Znam(i64)
+
+;; In this module the alias symbol is a declaration. It aliases with
+;; weak_odr symbol _Z3foov which is defined in both modules.
+declare ptr @_Z8fooAliasv()
+
+define weak_odr ptr @_Z3foov() #0 {
+entry:
+  %call = call ptr @_Znam(i64 0), !memprof !2, !callsite !7
+  ret ptr null
+}
+
+attributes #0 = { noinline optnone }
+
+!0 = !{i64 8632435727821051414}
+!1 = !{i64 -3421689549917153178}
+!2 = !{!3, !5}
+!3 = !{!4, !"notcold"}
+!4 = !{i64 9086428284934609951, i64 8632435727821051414}
+!5 = !{!6, !"cold"}
+!6 = !{i64 9086428284934609951, i64 -3421689549917153178}
+!7 = !{i64 9086428284934609951}
+
+;--- src2.ll
+source_filename = "memprof-distrib-alias2.ll"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare ptr @_Znam(i64)
+
+;; In this module the alias symbol is a weak_odr alias to weak_odr aliasee.
+@_Z8fooAliasv = weak_odr alias ptr (...), ptr @_Z3foov
+
+define weak_odr ptr @_Z3foov() #0 {
+entry:
+  %call = call ptr @_Znam(i64 0), !memprof !2, !callsite !7
+  ret ptr null
+}
+
+; IR-MOD2: define weak_odr {{.*}} @_Z3foov()
+; IR-MOD2:   call {{.*}} @_Znam(i64 0) #[[NOTCOLD:[0-9]+]]
+; IR-MOD2: define weak_odr {{.*}} @_Z3foov.memprof.1()
+; IR-MOD2:   call {{.*}} @_Znam(i64 0) #[[COLD:[0-9]+]]
+; IR-MOD2: attributes #[[NOTCOLD]] = { "memprof"="notcold" }
+; IR-MOD2: attributes #[[COLD]] = { "memprof"="cold" }
+
+attributes #0 = { noinline optnone }
+
+!2 = !{!3, !5}
+!3 = !{!4, !"notcold"}
+!4 = !{i64 9086428284934609951, i64 8632435727821051414}
+!5 = !{!6, !"cold"}
+!6 = !{i64 9086428284934609951, i64 -3421689549917153178}
+!7 = !{i64 9086428284934609951}

--- a/llvm/test/ThinLTO/X86/memprof-weak-alias.ll
+++ b/llvm/test/ThinLTO/X86/memprof-weak-alias.ll
@@ -1,48 +1,65 @@
 ;; Test handling of memprof ThinLTO when the call to update is a weak alias
 ;; where the prevailing weak aliasee is defined in a different module.
 
+;; -stats requires asserts
+; REQUIRES: asserts
+
 ;; Preparation steps to generate the bitcode and perform the thin link.
 ; RUN: rm -rf %t && split-file %s %t && cd %t
 ; RUN: opt -thinlto-bc src1.ll >src1.o
 ; RUN: opt -thinlto-bc src2.ll >src2.o
 
-;; First run the case where alias (_Z8fooAliasv) and aliasee (_Z3foov)
-;; are prevailing in the same module.
+;; First run the case where aliases (_Z8fooAliasv and _Z8fooAliasv2) and
+;; aliasees (_Z3foov and _Z3foov2, respectively) are prevailing in the same
+;; module.
 ; RUN: llvm-lto2 run src1.o src2.o -enable-memprof-context-disambiguation \
 ; RUN:	-supports-hot-cold-new \
 ; RUN:  -thinlto-distributed-indexes \
 ; RUN:	-r=src1.o,main,plx \
 ; RUN:	-r=src1.o,_Znam, \
 ; RUN:	-r=src1.o,_Z8fooAliasv, \
+; RUN:	-r=src1.o,_Z8fooAliasv2, \
 ; RUN:	-r=src1.o,_Z3foov,lx \
+; RUN:	-r=src1.o,_Z3foov2,lx \
 ; RUN:	-r=src2.o,_Znam, \
 ; RUN:	-r=src2.o,_Z8fooAliasv,plx \
+; RUN:	-r=src2.o,_Z8fooAliasv2,plx \
 ; RUN:	-r=src2.o,_Z3foov,plx \
-; RUN:	-o %t.out
+; RUN:	-r=src2.o,_Z3foov2,plx \
+; RUN:	-stats \
+; RUN:	-o %t.out 2>&1 | FileCheck %s --implicit-check-not="prevailing in a different module"
 
 ;; Run ThinLTO backends. We should be able to clone correctly.
 ; RUN: opt -passes=memprof-context-disambiguation \
 ; RUN:	-memprof-import-summary=src1.o.thinlto.bc \
 ; RUN:  -pass-remarks=memprof-context-disambiguation \
-; RUN:  src1.o -S 2>&1 | FileCheck %s --check-prefix=IR-MOD1 --implicit-check-not=_Z3foov.memprof
+; RUN:  src1.o -S 2>&1 | FileCheck %s --check-prefix=IR-MOD1 --implicit-check-not=_Z3foov.memprof --implicit-check-not=_Z3foov2.memprof
 ; RUN: opt -passes=memprof-context-disambiguation \
 ; RUN:	-memprof-import-summary=src2.o.thinlto.bc \
 ; RUN:  -pass-remarks=memprof-context-disambiguation \
 ; RUN:  src2.o -S 2>&1 | FileCheck %s --check-prefix=IR-MOD2
 
-;; Now try where the aliasee is prevailing in the first module instead,
-;; which only has the alias declaration.
+;; Now try where the aliasees are prevailing in the first module instead,
+;; which only has the alias declarations.
 ; RUN: llvm-lto2 run src1.o src2.o -enable-memprof-context-disambiguation \
 ; RUN:	-supports-hot-cold-new \
 ; RUN:  -thinlto-distributed-indexes \
 ; RUN:	-r=src1.o,main,plx \
 ; RUN:	-r=src1.o,_Znam, \
 ; RUN:	-r=src1.o,_Z8fooAliasv, \
+; RUN:	-r=src1.o,_Z8fooAliasv2, \
 ; RUN:	-r=src1.o,_Z3foov,plx \
+; RUN:	-r=src1.o,_Z3foov2,plx \
 ; RUN:	-r=src2.o,_Znam, \
 ; RUN:	-r=src2.o,_Z8fooAliasv,plx \
+; RUN:	-r=src2.o,_Z8fooAliasv2,plx \
 ; RUN:	-r=src2.o,_Z3foov,lx \
-; RUN:	-o %t.out
+; RUN:	-r=src2.o,_Z3foov2,lx \
+; RUN:	-stats \
+; RUN:	-o %t.out 2>&1 | FileCheck %s --check-prefix=STATS
+
+;; We should have detected both aliasees and handle them conservatively.
+; STATS: 2 memprof-context-disambiguation - Number of aliasees prevailing in a different module than its alias
 
 ;; Run ThinLTO backends. We should conservatively disable cloning.
 ; RUN: opt -passes=memprof-context-disambiguation \
@@ -67,24 +84,42 @@ entry:
   ; IR-MOD1:   call {{.*}} @_Z8fooAliasv()
   %call = call ptr @_Z8fooAliasv(), !callsite !0
   ;; The second call to fooAlias allocates cold memory. It should call the
-  ;; cloned function which calls a cloned allocation decorated with a "cold"
+  ;; cloned alias which calls a cloned allocation decorated with a "cold"
   ;; attribute.
   ; IR-MOD1:   call {{.*}} @_Z8fooAliasv.memprof.1()
   %call1 = call ptr @_Z8fooAliasv(), !callsite !1
+  ;; The first call to fooAlias2 does not allocate cold memory. It should call
+  ;; the original function alias, which calls the original allocation decorated
+  ;; with a "notcold" attribute.
+  ; IR-MOD1:   call {{.*}} @_Z8fooAliasv2()
+  %call2 = call ptr @_Z8fooAliasv2(), !callsite !9
+  ;; The second call to fooAlias2 allocates cold memory. It should call the
+  ;; cloned alias which calls a cloned allocation decorated with a "cold"
+  ;; attribute.
+  ; IR-MOD1:   call {{.*}} @_Z8fooAliasv2.memprof.1()
+  %call3 = call ptr @_Z8fooAliasv2(), !callsite !10
   ret i32 0
 }
 
 ; IR-MOD1: declare {{.*}} @_Z8fooAliasv.memprof.1()
+; IR-MOD1: declare {{.*}} @_Z8fooAliasv2.memprof.1()
 
 declare ptr @_Znam(i64)
 
-;; In this module the alias symbol is a declaration. It aliases with
-;; weak_odr symbol _Z3foov which is defined in both modules.
+;; In this module the alias symbols are declarations. They alias with
+;; weak_odr symbols _Z3foov and _Z3foov2 which are defined in both modules.
 declare ptr @_Z8fooAliasv()
+declare ptr @_Z8fooAliasv2()
 
 define weak_odr ptr @_Z3foov() #0 {
 entry:
   %call = call ptr @_Znam(i64 0), !memprof !2, !callsite !7
+  ret ptr null
+}
+
+define weak_odr ptr @_Z3foov2() #0 {
+entry:
+  %call = call ptr @_Znam(i64 0), !memprof !11, !callsite !16
   ret ptr null
 }
 
@@ -98,6 +133,14 @@ attributes #0 = { noinline optnone }
 !5 = !{!6, !"cold"}
 !6 = !{i64 9086428284934609951, i64 -3421689549917153178}
 !7 = !{i64 9086428284934609951}
+!9 = !{i64 123}
+!10 = !{i64 234}
+!11 = !{!12, !14}
+!12 = !{!13, !"notcold"}
+!13 = !{i64 345, i64 123}
+!14 = !{!15, !"cold"}
+!15 = !{i64 345, i64 234}
+!16 = !{i64 345}
 
 ;--- src2.ll
 source_filename = "memprof-distrib-alias2.ll"
@@ -106,12 +149,19 @@ target triple = "x86_64-unknown-linux-gnu"
 
 declare ptr @_Znam(i64)
 
-;; In this module the alias symbol is a weak_odr alias to weak_odr aliasee.
+;; In this module the alias symbols are weak_odr aliases to weak_odr aliasees.
 @_Z8fooAliasv = weak_odr alias ptr (...), ptr @_Z3foov
+@_Z8fooAliasv2 = weak_odr alias ptr (...), ptr @_Z3foov2
 
 define weak_odr ptr @_Z3foov() #0 {
 entry:
   %call = call ptr @_Znam(i64 0), !memprof !2, !callsite !7
+  ret ptr null
+}
+
+define weak_odr ptr @_Z3foov2() #0 {
+entry:
+  %call = call ptr @_Znam(i64 0), !memprof !11, !callsite !16
   ret ptr null
 }
 
@@ -130,3 +180,9 @@ attributes #0 = { noinline optnone }
 !5 = !{!6, !"cold"}
 !6 = !{i64 9086428284934609951, i64 -3421689549917153178}
 !7 = !{i64 9086428284934609951}
+!11 = !{!12, !14}
+!12 = !{!13, !"notcold"}
+!13 = !{i64 345, i64 123}
+!14 = !{!15, !"cold"}
+!15 = !{i64 345, i64 234}
+!16 = !{i64 345}


### PR DESCRIPTION
For ThinLTO we only have the cloning information in the FunctionSummary,
so for aliases we create as many clones as there are aliasee clones in
the LTO backend. However, that information is only in the prevailing
symbol's summary, as we don't keep the memprof summary information for
other copies (to reduce memory and compile time).

In the case of weak aliases, it is possible that the prevailing copy
of the alias may be in a different module than the prevailing copy of
the aliasee (e.g. when a module with a weak_odr aliasee definition does
not have a def of the weak_odr alias and is listed first on the link
line). In that case, we were not creating the expected clones of the
alias.

Rather than a more complex solution that adds additional summary
information, detect this case and simply don't add the callsites in the
aliasee function to the callsite context graph. This will result in
conservativeness (because we can't clone through that function), but
this should be a corner case.
