### PR TITLE
[Object] Add Identifier parameter to writeArchiveToBuffer().

### DIFF
--- a/llvm/include/llvm/Object/ArchiveWriter.h
+++ b/llvm/include/llvm/Object/ArchiveWriter.h
@@ -73,6 +73,7 @@ LLVM_ABI Expected<std::unique_ptr<MemoryBuffer>>
 writeArchiveToBuffer(ArrayRef<NewArchiveMember> NewMembers,
                      SymtabWritingMode WriteSymtab, object::Archive::Kind Kind,
                      bool Deterministic, bool Thin,
+                     std::optional<StringRef> Identifier = std::nullopt,
                      function_ref<void(Error)> Warn = warnToStderr);
 }
 

--- a/llvm/lib/Object/ArchiveWriter.cpp
+++ b/llvm/lib/Object/ArchiveWriter.cpp
@@ -1348,11 +1348,10 @@ Error writeArchive(StringRef ArcName, ArrayRef<NewArchiveMember> NewMembers,
   return Temp->keep(ArcName);
 }
 
-Expected<std::unique_ptr<MemoryBuffer>>
-writeArchiveToBuffer(ArrayRef<NewArchiveMember> NewMembers,
-                     SymtabWritingMode WriteSymtab, object::Archive::Kind Kind,
-                     bool Deterministic, bool Thin,
-                     function_ref<void(Error)> Warn) {
+Expected<std::unique_ptr<MemoryBuffer>> writeArchiveToBuffer(
+    ArrayRef<NewArchiveMember> NewMembers, SymtabWritingMode WriteSymtab,
+    object::Archive::Kind Kind, bool Deterministic, bool Thin,
+    std::optional<StringRef> Identifier, function_ref<void(Error)> Warn) {
   SmallVector<char, 0> ArchiveBufferVector;
   raw_svector_ostream ArchiveStream(ArchiveBufferVector);
 
@@ -1361,8 +1360,14 @@ writeArchiveToBuffer(ArrayRef<NewArchiveMember> NewMembers,
                                Deterministic, Thin, std::nullopt, Warn))
     return std::move(E);
 
+  if (Identifier)
+    return std::make_unique<SmallVectorMemoryBuffer>(
+        std::move(ArchiveBufferVector), *Identifier,
+        /*RequiresNullTerminator=*/false);
+
   return std::make_unique<SmallVectorMemoryBuffer>(
-      std::move(ArchiveBufferVector), /*RequiresNullTerminator=*/false);
+      std::move(ArchiveBufferVector),
+      /*RequiresNullTerminator=*/false);
 }
 
 } // namespace llvm


### PR DESCRIPTION
It supports returning a MemoryBuffer that contains an specified Identifier. If not pass Identifier parameter to writeArchiveToBuffer(), its Identifier info is "\<in-memory object\>" by default.