### PR TITLE
[ORC][MachO] Clean up incompatible-arch-in-object error message.

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/MachO.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MachO.cpp
@@ -26,7 +26,7 @@ static std::string objDesc(const MemoryBufferRef &Obj, const Triple &TT,
                            bool ObjIsSlice) {
   std::string Desc;
   if (ObjIsSlice)
-    Desc += (TT.getArchName() + " slice of universal binary").str();
+    Desc += (TT.getArchName() + " slice of universal binary ").str();
   Desc += Obj.getBufferIdentifier();
   return Desc;
 }
@@ -48,11 +48,12 @@ static Error checkMachORelocatableObject(MemoryBufferRef Obj,
                                        " is not a MachO relocatable object",
                                    inconvertibleErrorCode());
 
-  auto ObjArch = object::MachOObjectFile::getArch(Hdr.cputype, Hdr.cpusubtype);
-  if (ObjArch != TT.getArch())
+  auto ObjArchTT =
+      object::MachOObjectFile::getArchTriple(Hdr.cputype, Hdr.cpusubtype);
+  if (ObjArchTT.getArch() != TT.getArch())
     return make_error<StringError>(
-        objDesc(Obj, TT, ObjIsSlice) + Triple::getArchTypeName(ObjArch) +
-            ", cannot be loaded into " + TT.str() + " process",
+        objDesc(Obj, TT, ObjIsSlice) + " (" + ObjArchTT.getArchName() +
+            "), cannot be loaded into " + TT.str() + " process",
         inconvertibleErrorCode());
 
   return Error::success();


### PR DESCRIPTION
Add missing spaces to error messages, use Triple::getArchName (gives canonical arch name on Darwin, e.g. "arm64" rather than "aarch64").

No testcase for this one: the change is cosmetic, and the error message format not relied upon anywhere.