### PR TITLE
[profcheck] Reorder the FileCheck substitution.

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -31,8 +31,8 @@ if lit_shell_env:
 # testFormat: The test format to use to interpret tests.
 extra_substitutions = extra_substitutions = (
     [
-        (r"FileCheck .*", "cat > /dev/null"),
         (r"not FileCheck .*", "cat > /dev/null"),
+        (r"FileCheck .*", "cat > /dev/null"),
     ]
     if config.enable_profcheck
     else []


### PR DESCRIPTION
In the profcheck build, FileCheck commands are substituted with cat > /dev/null to disable output verification. In a test/Transforms/SamplePrfile/remarks-hotness.ll we have both "FileCheck" and "not FileCheck" statements. Replacing the positive one first results in "not cat".
https://github.com/llvm/llvm-project/blob/main/llvm/test/Transforms/SampleProfile/remarks-hotness.ll#L18

Run the not substitution first to fix this.