### PR TITLE
[lldb] Fix setting CanJIT if memory cannot be allocated

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/gdbclientutils.py
+++ b/lldb/packages/Python/lldbsuite/test/gdbclientutils.py
@@ -261,6 +261,13 @@ class MockGDBServerResponder:
             return self.qRegisterInfo(regnum)
         if packet == "k":
             return self.k()
+        if packet[0:2] == "_M":
+            size_str, permissions = packet[2:].split(",")
+            size = int(size_str, 16)
+            return self._M(size, permissions)
+        if packet[0:2] == "_m":
+            addr = int(packet[2:], 16)
+            return self._m(addr)
 
         return self.other(packet)
 
@@ -408,6 +415,12 @@ class MockGDBServerResponder:
 
     def k(self):
         return ["W01", self.RESPONSE_DISCONNECT]
+
+    def _M(self, size, permissions):
+        return ""
+
+    def _m(self, addr):
+        return ""
 
     """
     Raised when we receive a packet for which there is no default action.

--- a/lldb/packages/Python/lldbsuite/test/lldbgdbclient.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbgdbclient.py
@@ -32,7 +32,7 @@ class GDBRemoteTestBase(TestBase):
         self.server.stop()
         TestBase.tearDown(self)
 
-    def createTarget(self, yaml_path):
+    def createTarget(self, yaml_path, triple=""):
         """
         Create a target by auto-generating the object based on the given yaml
         instructions.
@@ -43,7 +43,10 @@ class GDBRemoteTestBase(TestBase):
         yaml_base, ext = os.path.splitext(yaml_path)
         obj_path = self.getBuildArtifact(yaml_base)
         self.yaml2obj(yaml_path, obj_path)
-        return self.dbg.CreateTarget(obj_path)
+        if triple:
+            return self.dbg.CreateTargetWithFileAndTargetTriple(obj_path, triple)
+        else:
+            return self.dbg.CreateTarget(obj_path)
 
     def connect(self, target, plugin="gdb-remote"):
         """

--- a/lldb/packages/Python/lldbsuite/test/lldbgdbclient.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbgdbclient.py
@@ -43,10 +43,7 @@ class GDBRemoteTestBase(TestBase):
         yaml_base, ext = os.path.splitext(yaml_path)
         obj_path = self.getBuildArtifact(yaml_base)
         self.yaml2obj(yaml_path, obj_path)
-        if triple:
-            return self.dbg.CreateTargetWithFileAndTargetTriple(obj_path, triple)
-        else:
-            return self.dbg.CreateTarget(obj_path)
+        return self.dbg.CreateTargetWithFileAndTargetTriple(obj_path, triple)
 
     def connect(self, target, plugin="gdb-remote"):
         """

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -3170,9 +3170,9 @@ lldb::addr_t ProcessGDBRemote::DoAllocateMemory(size_t size,
 
   if (m_gdb_comm.SupportsAllocDeallocMemory() != eLazyBoolNo) {
     allocated_addr = m_gdb_comm.AllocateMemory(size, permissions);
-    if (allocated_addr != LLDB_INVALID_ADDRESS ||
-        m_gdb_comm.SupportsAllocDeallocMemory() == eLazyBoolYes)
-      return allocated_addr;
+    assert((allocated_addr == LLDB_INVALID_ADDRESS ||
+            m_gdb_comm.SupportsAllocDeallocMemory() == eLazyBoolYes) &&
+           "Memory can only be allocated if the support is enabled");
   }
 
   if (m_gdb_comm.SupportsAllocDeallocMemory() == eLazyBoolNo) {

--- a/lldb/test/API/functionalities/gdb_remote_client/TestExprNoAlloc.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestExprNoAlloc.py
@@ -13,7 +13,16 @@ class MyResponder(MockGDBServerResponder):
         return "E01"
 
     def readRegisters(self):
-        return "20000000000000002000000000000000f0c154bfffff00005daa985a8fea0b48f0b954bfffff0000ad13cce570150b48380000000000000070456abfffff0000a700000000000000000000000000000001010101010101010000000000000000f0c154bfffff00000f2700000000000008e355bfffff0000080e55bfffff0000281041000000000010de61bfffff00005c05000000000000f0c154bfffff000090fcffffffff00008efcffffffff00008ffcffffffff00000000000000000000001000000000000090fcffffffff000000d06cbfffff0000f0c154bfffff00000100000000000000d0b954bfffff0000e407400000000000d0b954bfffff0000e40740000000000000100000"
+        return "".join(
+            [
+                # x0
+                "2000000000000000",
+                # x1..x30, sp, pc
+                32 * "0000000000000000",
+                # cpsr
+                "00000000",
+            ]
+        )
 
 
 class TestExprNoAlloc(GDBRemoteTestBase):
@@ -37,4 +46,4 @@ class TestExprNoAlloc(GDBRemoteTestBase):
             self, self.dbg.GetListener(), process, [lldb.eStateStopped]
         )
 
-        self.expect_expr("$x1", result_type="unsigned long", result_value="32")
+        self.expect_expr("$x0", result_type="unsigned long", result_value="32")

--- a/lldb/test/API/functionalities/gdb_remote_client/TestExprNoAlloc.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestExprNoAlloc.py
@@ -6,11 +6,8 @@ from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
 
 
 class MyResponder(MockGDBServerResponder):
-    def other(self, packet) -> str:
-        if packet.startswith("_M"):
-            return "E04"
-        else:
-            return super().other(packet)
+    def _M(self, size, permissions) -> str:
+        return "E04"
 
     def readRegister(self, regnum):
         return "E01"

--- a/lldb/test/API/functionalities/gdb_remote_client/TestExprNoAlloc.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestExprNoAlloc.py
@@ -47,3 +47,9 @@ class TestExprNoAlloc(GDBRemoteTestBase):
         )
 
         self.expect_expr("$x0", result_type="unsigned long", result_value="32")
+        res = self.target.EvaluateExpression("(int)foo()")
+        self.assertFalse(res.GetError().Success())
+        self.assertIn(
+            "Can't evaluate the expression without a running target",
+            res.GetError().GetCString(),
+        )

--- a/lldb/test/API/functionalities/gdb_remote_client/TestExprNoAlloc.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestExprNoAlloc.py
@@ -1,4 +1,3 @@
-from textwrap import dedent
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *

--- a/lldb/test/API/functionalities/gdb_remote_client/TestExprNoAlloc.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestExprNoAlloc.py
@@ -30,10 +30,10 @@ class TestExprNoAlloc(GDBRemoteTestBase):
     @skipIfLLVMTargetMissing("AArch64")
     def test(self):
         """
-        Test that a simple expression can be evaluated when the server supports the '_M'
-        packet, but memory cannot be allocated, and it returns an error code response.
-        In this case, 'CanJIT' used to be set to 'eCanJITYes', so 'IRMemoryMap' tried to
-        allocated memory in the inferior process and failed.
+        We should be able to evaluate an expression that requires no allocations,
+        even if the server responds to '_M' with an error. 'CanJIT' should be set
+        to 'eCanJITNo' for this response; otherwise, 'IRMemoryMap' would attempt
+        to allocate memory in the inferior process and fail.
         """
 
         self.server.responder = MyResponder()

--- a/lldb/test/API/functionalities/gdb_remote_client/TestExprNoAlloc.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestExprNoAlloc.py
@@ -1,0 +1,44 @@
+from textwrap import dedent
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test.gdbclientutils import *
+from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
+
+
+class MyResponder(MockGDBServerResponder):
+    def other(self, packet) -> str:
+        if packet.startswith("_M"):
+            return "E04"
+        else:
+            return super().other(packet)
+
+    def readRegister(self, regnum):
+        return "E01"
+
+    def readRegisters(self):
+        return "20000000000000002000000000000000f0c154bfffff00005daa985a8fea0b48f0b954bfffff0000ad13cce570150b48380000000000000070456abfffff0000a700000000000000000000000000000001010101010101010000000000000000f0c154bfffff00000f2700000000000008e355bfffff0000080e55bfffff0000281041000000000010de61bfffff00005c05000000000000f0c154bfffff000090fcffffffff00008efcffffffff00008ffcffffffff00000000000000000000001000000000000090fcffffffff000000d06cbfffff0000f0c154bfffff00000100000000000000d0b954bfffff0000e407400000000000d0b954bfffff0000e40740000000000000100000"
+
+
+class TestExprNoAlloc(GDBRemoteTestBase):
+    @skipIfRemote
+    @skipIfLLVMTargetMissing("AArch64")
+    def test(self):
+        """
+        Test that a simple expression can be evaluated when the server supports the '_M'
+        packet, but memory cannot be allocated, and it returns an error code response.
+        In this case, 'CanJIT' used to be set to 'eCanJITYes', so 'IRMemoryMap' tried to
+        allocated memory in the inferior process and failed.
+        """
+
+        self.server.responder = MyResponder()
+        # Note: DynamicLoaderStatic disables JIT by calling 'm_process->SetCanJIT(false)'
+        # in LoadAllImagesAtFileAddresses(). Specifying a triple with "-linux" enables
+        # DynamicLoaderPOSIXDYLD to be used instead.
+        self.target = self.createTarget("basic_eh_frame-aarch64.yaml", "aarch64-linux")
+        process = self.connect(self.target)
+        lldbutil.expect_state_changes(
+            self, self.dbg.GetListener(), process, [lldb.eStateStopped]
+        )
+
+        self.expect_expr("$x1", result_type="unsigned long", result_value="32")


### PR DESCRIPTION
When a server is unable to allocate memory for the `_M` packet, it may respond with an error code. In this case,
`GDBRemoteCommunicationClient::AllocateMemory()` sets `m_supports_alloc_dealloc_memory` to `eLazyBoolYes`; `eLazyBoolNo` is only used if the server cannot handle the packet at all. Before this patch, `ProcessGDBRemote::DoAllocateMemory()` checked this flag and returned `LLDB_INVALID_ADDRESS` without setting an error, which caused `Process::CanJIT()` to set `m_can_jit = eCanJITYes`, resulting in `IRMemoryMap::FindSpace()` attempting to allocate memory in the inferior process and failing. With the patch,
`ProcessGDBRemote::DoAllocateMemory()` returns an error and `m_can_jit` is set to `eCanJITNo`.

Example debug session:
```
(lldb) platform connect...
(lldb) file test
(lldb) br set...
(lldb) run
Process 100 launched:...
Process 100 stopped
* thread #1,...
(lldb) expr $x0
error: Couldn't allocate space for materialized struct: Couldn't malloc: address space is full
error: errored out in virtual lldb_private::LLVMUserExpression::DoExecute, couldn't PrepareToExecuteJITExpression
```