### PR TITLE
[Clang][Sema] Fix crash when __funcref is applied to non-function-pointer types

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -178,6 +178,9 @@ NetBSD Support
 WebAssembly Support
 ^^^^^^^^^^^^^^^^^^^
 
+- Fixed a crash when ``__funcref`` is applied to a non-function pointer type.
+  (#GH118233)
+
 AVR Support
 ^^^^^^^^^^^
 

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -7179,6 +7179,14 @@ static bool HandleWebAssemblyFuncrefAttr(TypeProcessingState &State,
     return true;
   }
 
+  // Check that the type is a function pointer type.
+  QualType Desugared = QT.getDesugaredType(S.Context);
+  const auto *Ptr = dyn_cast<PointerType>(Desugared);
+  if (!Ptr || !Ptr->getPointeeType()->isFunctionType()) {
+    S.Diag(PAttr.getLoc(), diag::err_attribute_webassembly_funcref);
+    return true;
+  }
+
   // Add address space to type based on its attributes.
   LangAS ASIdx = LangAS::wasm_funcref;
   QualType Pointee = QT->getPointeeType();

--- a/clang/test/Sema/wasm-funcref-crash.c
+++ b/clang/test/Sema/wasm-funcref-crash.c
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -triple wasm32 -target-feature +reference-types %s
+
+// Test for issue #118233 - crash when using __funcref on non-pointer type
+
+// Valid usage - __funcref on function pointer type
+typedef void (*__funcref funcref_t)();
+
+// Invalid usage - __funcref on non-pointer types should give error, not crash
+int hsGetFuncRefForGlobal(__funcref function); // expected-error {{type specifier missing, defaults to 'int'}} \
+                                               // expected-error {{'__funcref' attribute can only be applied to a function pointer type}} \
+                                               // expected-error {{'__funcref' attribute only applies to functions pointers}}
+
+typedef __funcref int bad_typedef; // expected-error {{'__funcref' attribute can only be applied to a function pointer type}} \
+                                   // expected-error {{'__funcref' attribute only applies to functions pointers}}
+
+__funcref int global_var; // expected-error {{'__funcref' attribute can only be applied to a function pointer type}} \
+                          // expected-error {{'__funcref' attribute only applies to functions pointers}}
+
+void test_funcref_non_pointer() {
+  __funcref int local_var; // expected-error {{'__funcref' attribute can only be applied to a function pointer type}} \
+                           // expected-error {{'__funcref' attribute only applies to functions pointers}}
+}
+
+// Invalid - __funcref on non-function pointer (pointer to int)
+typedef int *__funcref bad_ptr_typedef; // expected-error {{'__funcref' attribute can only be applied to a function pointer type}} \
+                                        // expected-error {{'__funcref' attribute only applies to functions pointers}}

--- a/clang/test/SemaCXX/wasm-funcref-crash.cpp
+++ b/clang/test/SemaCXX/wasm-funcref-crash.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify -triple wasm32 -target-feature +reference-types %s
+
+// Test for issue #118233 - crash when using __funcref on non-function-pointer types in C++
+
+// Valid usage - __funcref on function pointer type
+int (* __funcref valid_ptr)();
+typedef void (*__funcref funcref_t)();
+
+// Invalid usage - __funcref on non-pointer types should give error, not crash
+__funcref int global_var; // expected-error {{'__funcref' attribute can only be applied to a function pointer type}} \
+                          // expected-error {{'__funcref' attribute only applies to functions pointers}}
+
+typedef __funcref int bad_typedef; // expected-error {{'__funcref' attribute can only be applied to a function pointer type}} \
+                                   // expected-error {{'__funcref' attribute only applies to functions pointers}}
+
+void test_funcref_non_pointer() {
+  __funcref int local_var; // expected-error {{'__funcref' attribute can only be applied to a function pointer type}} \
+                           // expected-error {{'__funcref' attribute only applies to functions pointers}}
+}
+
+// Invalid - __funcref on non-function pointer (pointer to int)
+typedef int *__funcref bad_ptr_typedef; // expected-error {{'__funcref' attribute can only be applied to a function pointer type}} \
+                                        // expected-error {{'__funcref' attribute only applies to functions pointers}}
+
+// Invalid - __funcref with missing type in parameter (C++ requires type)
+void foo(__funcref x); // expected-error {{unknown type name 'x'}} \
+                       // expected-error {{'__funcref' attribute can only be applied to a function pointer type}} \
+                       // expected-error {{'__funcref' attribute only applies to functions pointers}}


### PR DESCRIPTION
Applying the funcref type to a non-function pointer was crashing. Added validation to check that the type is a function pointer before attempting to process it. If validation fails, emit the existing err_attribute_webassembly_funcref diagnostic and return early.

Fixes #118233