### PR TITLE
[clang][bytecode] Remove base casts in builtin_object_size

### DIFF
--- a/clang/test/AST/ByteCode/builtin-object-size-codegen.cpp
+++ b/clang/test/AST/ByteCode/builtin-object-size-codegen.cpp
@@ -85,3 +85,20 @@ void test2() {
   // CHECK: store i32 16
   gi = __builtin_object_size(&c->bs[0].buf[0], 3);
 }
+
+void test3() {
+  struct A {
+    int a;
+  };
+  struct B {
+    int b;
+  };
+  struct C : A, B {};
+
+  C c;
+
+  int gi;
+  // CHECK: store i32 8
+  gi = __builtin_object_size((B*)&c, 3);
+
+}


### PR DESCRIPTION
If UseFieldDesc is set, we should use the "closest surrounding subobject", which apparently cannot be a subclass pointer.

Fixes https://github.com/llvm/llvm-project/issues/176079