### PR TITLE
[clang] Fix options handling in ClangExtDefMapGen.cpp

### DIFF
--- a/clang/test/Tooling/clang-extdef-mapping-no-args.cpp
+++ b/clang/test/Tooling/clang-extdef-mapping-no-args.cpp
@@ -1,0 +1,3 @@
+// RUN: not clang-extdef-mapping 2>&1 | FileCheck %s
+
+// CHECK: Not enough positional command line arguments specified!

--- a/clang/test/Tooling/clang-extdef-mapping.cpp
+++ b/clang/test/Tooling/clang-extdef-mapping.cpp
@@ -1,0 +1,4 @@
+// RUN: clang-extdef-mapping "%s" 2>&1 | FileCheck %s
+
+// CHECK: 8:c:@F@foo {{.*}}clang-extdef-mapping.cpp
+extern "C" int foo() { return 0; }

--- a/clang/tools/clang-extdef-mapping/ClangExtDefMapGen.cpp
+++ b/clang/tools/clang-extdef-mapping/ClangExtDefMapGen.cpp
@@ -17,15 +17,14 @@
 #include "clang/Basic/SourceManager.h"
 #include "clang/CrossTU/CrossTranslationUnit.h"
 #include "clang/Frontend/CompilerInstance.h"
-#include "clang/Frontend/FrontendActions.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/WithColor.h"
 #include <optional>
-#include <sstream>
 #include <string>
 
 using namespace llvm;
@@ -211,9 +210,9 @@ int main(int argc, const char **argv) {
                          "with compile database or .ast files that are "
                          "created from clang's -emit-ast option.\n";
   auto ExpectedParser = CommonOptionsParser::create(
-      argc, argv, ClangExtDefMapGenCategory, cl::ZeroOrMore, Overview);
+      argc, argv, ClangExtDefMapGenCategory, cl::OneOrMore, Overview);
   if (!ExpectedParser) {
-    llvm::errs() << ExpectedParser.takeError();
+    llvm::WithColor::error() << llvm::toString(ExpectedParser.takeError());
     return 1;
   }
   CommonOptionsParser &OptionsParser = ExpectedParser.get();


### PR DESCRIPTION
Also, remove some unused includes.

Fixes https://github.com/llvm/llvm-project/issues/176118

Now, running `clang-extdef-mapping` with no options results in the following error message:

```sh
error: clang-extdef-mapping: Not enough positional command line arguments specified!
Must specify at least 1 positional argument: See: ./build/Debug/bin/clang-extdef-mapping --help
```