### PR TITLE
[libc++][pstl] Generic implementation of parallel std::is_sorted

### DIFF
--- a/libcxx/include/__algorithm/pstl.h
+++ b/libcxx/include/__algorithm/pstl.h
@@ -658,7 +658,8 @@ template <class _ExecutionPolicy,
           class _ForwardIterator,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI bool is_sorted(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
+is_sorted(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "is_sorted requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__is_sorted, __pstl::__current_configuration, _RawPolicy>;
   return __pstl::__handle_exception<_Implementation>(
@@ -670,7 +671,7 @@ template <class _ExecutionPolicy,
           class _Comp,
           class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
           enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
-_LIBCPP_HIDE_FROM_ABI bool
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI bool
 is_sorted(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Comp __comp) {
   _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "is_sorted requires ForwardIterators");
   using _Implementation = __pstl::__dispatch<__pstl::__is_sorted, __pstl::__current_configuration, _RawPolicy>;

--- a/libcxx/include/__algorithm/pstl.h
+++ b/libcxx/include/__algorithm/pstl.h
@@ -654,6 +654,30 @@ _LIBCPP_HIDE_FROM_ABI _ForwardOutIterator transform(
       std::move(__op));
 }
 
+template <class _ExecutionPolicy,
+          class _ForwardIterator,
+          class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
+          enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
+_LIBCPP_HIDE_FROM_ABI bool is_sorted(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last) {
+  _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "is_sorted requires ForwardIterators");
+  using _Implementation = __pstl::__dispatch<__pstl::__is_sorted, __pstl::__current_configuration, _RawPolicy>;
+  return __pstl::__handle_exception<_Implementation>(
+      std::forward<_ExecutionPolicy>(__policy), std::move(__first), std::move(__last), less{});
+}
+
+template <class _ExecutionPolicy,
+          class _ForwardIterator,
+          class _Comp,
+          class _RawPolicy                                    = __remove_cvref_t<_ExecutionPolicy>,
+          enable_if_t<is_execution_policy_v<_RawPolicy>, int> = 0>
+_LIBCPP_HIDE_FROM_ABI bool
+is_sorted(_ExecutionPolicy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Comp __comp) {
+  _LIBCPP_REQUIRE_CPP17_FORWARD_ITERATOR(_ForwardIterator, "is_sorted requires ForwardIterators");
+  using _Implementation = __pstl::__dispatch<__pstl::__is_sorted, __pstl::__current_configuration, _RawPolicy>;
+  return __pstl::__handle_exception<_Implementation>(
+      std::forward<_ExecutionPolicy>(__policy), std::move(__first), std::move(__last), std::move(__comp));
+}
+
 _LIBCPP_END_NAMESPACE_STD
 
 #endif // _LIBCPP_HAS_EXPERIMENTAL_PSTL && _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__pstl/backend_fwd.h
+++ b/libcxx/include/__pstl/backend_fwd.h
@@ -297,6 +297,12 @@ struct __reduce;
 // operator()(_Policy&&, _ForwardIterator __first, _ForwardIterator __last,
 //                       _Tp __init, _BinaryOperation __op) const noexcept;
 
+template <class _Backend, class _ExecutionPolicy>
+struct __is_sorted;
+// template <class _Policy, class _ForwardIterator, class _Comp>
+// optional<bool>
+// operator()(_Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Comp&& __comp) const noexcept;
+
 } // namespace __pstl
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__pstl/backends/default.h
+++ b/libcxx/include/__pstl/backends/default.h
@@ -20,6 +20,7 @@
 #include <__functional/operations.h>
 #include <__iterator/concepts.h>
 #include <__iterator/iterator_traits.h>
+#include <__iterator/next.h>
 #include <__pstl/backend_fwd.h>
 #include <__pstl/dispatch.h>
 #include <__utility/empty.h>
@@ -398,11 +399,10 @@ struct __is_sorted<__default_backend_tag, _ExecutionPolicy> {
     if constexpr (__has_bidirectional_iterator_category<_ForwardIterator>::value) {
       if (__first == __last)
         return true; // Empty, sorted by definition
-      _ForwardIterator __first2 = __first;
-      ++__first2; // __first2 = __first + 1
+      _ForwardIterator __first2 = std::next(__first);
       if (__first2 == __last)
         return true; // Only one element, sorted by definition
-      --__last;      // __last = __last - 1
+      --__last;      // Make two iterator ranges: [__first, __first + n - 1) and [__first + 1, __first + n)
       using _TransformReduce = __dispatch<__transform_reduce_binary, __current_configuration, _ExecutionPolicy>;
       using _Ref             = __iterator_reference<_ForwardIterator>;
       return _TransformReduce()(

--- a/libcxx/include/__pstl/backends/default.h
+++ b/libcxx/include/__pstl/backends/default.h
@@ -410,7 +410,7 @@ struct __is_sorted<__default_backend_tag, _ExecutionPolicy> {
           std::move(__first2),
           true,
           std::logical_and{},
-          [&](_Ref __first, _Ref __second) -> bool { return !__comp(__second, __first); });
+          [&](_Ref __left, _Ref __right) -> bool { return !__comp(__right, __left); });
     } else {
       // Currently anything outside random access iterators has to be processed serially
       return std::is_sorted(std::move(__first), std::move(__last), std::forward<_Comp>(__comp));

--- a/libcxx/include/__pstl/backends/default.h
+++ b/libcxx/include/__pstl/backends/default.h
@@ -414,7 +414,7 @@ struct __is_sorted<__default_backend_tag, _ExecutionPolicy> {
           std::logical_and{},
           [&](_Ref __left, _Ref __right) -> bool { return !__comp(__right, __left); });
     } else {
-      // Currently anything outside random access iterators has to be processed serially
+      // Currently anything outside bidirectional iterators has to be processed serially
       return std::is_sorted(std::move(__first), std::move(__last), std::forward<_Comp>(__comp));
     }
   }

--- a/libcxx/include/__pstl/backends/default.h
+++ b/libcxx/include/__pstl/backends/default.h
@@ -81,6 +81,7 @@ namespace __pstl {
 // - count
 // - equal(3 legs)
 // - equal
+// - is_sorted
 // - reduce
 //
 // transform and transform_binary family
@@ -394,13 +395,14 @@ struct __is_sorted<__default_backend_tag, _ExecutionPolicy> {
   template <class _Policy, class _ForwardIterator, class _Comp>
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI optional<bool>
   operator()(_Policy&& __policy, _ForwardIterator __first, _ForwardIterator __last, _Comp&& __comp) const noexcept {
-    if constexpr (__has_random_access_iterator_category<_ForwardIterator>::value) {
+    if constexpr (__has_bidirectional_iterator_category<_ForwardIterator>::value) {
       if (__first == __last)
         return true; // Empty, sorted by definition
-      _ForwardIterator __first2 = __first + 1;
+      _ForwardIterator __first2 = __first;
+      ++__first2; // __first2 = __first + 1
       if (__first2 == __last)
         return true; // Only one element, sorted by definition
-      --__last;
+      --__last;      // __last = __last - 1
       using _TransformReduce = __dispatch<__transform_reduce_binary, __current_configuration, _ExecutionPolicy>;
       using _Ref             = __iterator_reference<_ForwardIterator>;
       return _TransformReduce()(

--- a/libcxx/test/libcxx/algorithms/pstl.nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/algorithms/pstl.nodiscard.verify.cpp
@@ -48,4 +48,8 @@ void test() {
   std::find(std::execution::par, std::begin(a), std::end(a), 1);
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::is_partitioned(std::execution::par, std::begin(a), std::end(a), pred);
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::is_sorted(std::execution::par, std::begin(a), std::end(a));
+  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
+  std::is_sorted(std::execution::par, std::begin(a), std::end(a), pred2);
 }

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted.pass.cpp
@@ -10,7 +10,7 @@
 
 // UNSUPPORTED: libcpp-has-no-incomplete-pstl
 
-// template<class ExecutionPolicy, class ForwardIterator,
+// template<class ExecutionPolicy, class ForwardIterator>
 //   bool is_sorted(ExecutionPolicy&& exec,
 //                  ForwardIterator first, ForwardIterator last);
 
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <functional>
 #include <numeric>
+#include <limits>
 
 #include "test_execution_policies.h"
 #include "test_iterators.h"
@@ -174,6 +175,46 @@ struct Test {
       int a[]     = {1, 1, 1, 1};
       unsigned sa = sizeof(a) / sizeof(a[0]);
       assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::max(),
+                     std::numeric_limits<int>::max()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::max(),
+                     std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::max()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[] = {
+          std::numeric_limits<int>::min(),
+          std::numeric_limits<int>::min() / 2,
+          -1,
+          0,
+          1,
+          std::numeric_limits<int>::max() / 2,
+          std::numeric_limits<int>::max()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[] = {
+          std::numeric_limits<int>::min(),
+          std::numeric_limits<int>::min() / 2,
+          1,
+          0,
+          -1,
+          std::numeric_limits<int>::max() / 2,
+          std::numeric_limits<int>::max()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
     }
   }
 };

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted.pass.cpp
@@ -1,0 +1,188 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// UNSUPPORTED: libcpp-has-no-incomplete-pstl
+
+// template<class ExecutionPolicy, class ForwardIterator,
+//   bool is_sorted(ExecutionPolicy&& exec,
+//                  ForwardIterator first, ForwardIterator last);
+
+#include <algorithm>
+#include <cassert>
+#include <functional>
+#include <numeric>
+
+#include "test_execution_policies.h"
+#include "test_iterators.h"
+#include "test_macros.h"
+
+template <class Iter>
+struct Test {
+  template <class ExecutionPolicy>
+  void operator()(ExecutionPolicy&& policy) {
+    {
+      int a[]     = {0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a)));
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+
+    {
+      int a[]     = {0, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {0, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {0, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {0, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+
+    {
+      int a[]     = {0, 0, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {0, 0, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {0, 0, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {0, 0, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {0, 1, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {0, 1, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {0, 1, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {0, 1, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 0, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 0, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 0, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 0, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 1, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 1, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 1, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+    {
+      int a[]     = {1, 1, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa)));
+    }
+  }
+};
+
+int main(int, char**) {
+  types::for_each(types::concatenate_t<types::forward_iterator_list<int*>,
+                                       types::bidirectional_iterator_list<int*>,
+                                       types::random_access_iterator_list<int*>>{},
+                  TestIteratorWithPolicies<Test>{});
+
+  return 0;
+}

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted.pass.cpp
@@ -17,8 +17,8 @@
 #include <algorithm>
 #include <cassert>
 #include <functional>
-#include <numeric>
 #include <limits>
+#include <numeric>
 
 #include "test_execution_policies.h"
 #include "test_iterators.h"

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_comp.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_comp.pass.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cassert>
 #include <functional>
+#include <limits>
 #include <numeric>
 
 #include "test_execution_policies.h"

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_comp.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_comp.pass.cpp
@@ -1,0 +1,189 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// UNSUPPORTED: libcpp-has-no-incomplete-pstl
+
+// template<class ExecutionPolicy, class ForwardIterator, class Comp>
+//   bool is_sorted(ExecutionPolicy&& exec,
+//                  ForwardIterator first, ForwardIterator last,
+//                  Comp comp);
+
+#include <algorithm>
+#include <cassert>
+#include <functional>
+#include <numeric>
+
+#include "test_execution_policies.h"
+#include "test_iterators.h"
+#include "test_macros.h"
+
+template <class Iter>
+struct Test {
+  template <class ExecutionPolicy>
+  void operator()(ExecutionPolicy&& policy) {
+    {
+      int a[]     = {0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a)));
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+
+    {
+      int a[]     = {0, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {0, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {0, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {0, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+
+    {
+      int a[]     = {0, 0, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {0, 0, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {0, 0, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {0, 0, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {0, 1, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {0, 1, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {0, 1, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {0, 1, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 0, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 0, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 0, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 0, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 1, 0, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 1, 0, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 1, 1, 0};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {1, 1, 1, 1};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+  }
+};
+
+int main(int, char**) {
+  types::for_each(types::concatenate_t<types::forward_iterator_list<int*>,
+                                       types::bidirectional_iterator_list<int*>,
+                                       types::random_access_iterator_list<int*>>{},
+                  TestIteratorWithPolicies<Test>{});
+
+  return 0;
+}

--- a/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_comp.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.sort/is.sorted/pstl.is_sorted_comp.pass.cpp
@@ -176,6 +176,46 @@ struct Test {
       unsigned sa = sizeof(a) / sizeof(a[0]);
       assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
     }
+    {
+      int a[]     = {std::numeric_limits<int>::max(),
+                     std::numeric_limits<int>::max(),
+                     std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::min()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[]     = {std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::max(),
+                     std::numeric_limits<int>::min(),
+                     std::numeric_limits<int>::max()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[] = {
+          std::numeric_limits<int>::max(),
+          std::numeric_limits<int>::max() / 2,
+          1,
+          0,
+          -1,
+          std::numeric_limits<int>::min() / 2,
+          std::numeric_limits<int>::min()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
+    {
+      int a[] = {
+          std::numeric_limits<int>::max(),
+          std::numeric_limits<int>::max() / 2,
+          -1,
+          0,
+          1,
+          std::numeric_limits<int>::min() / 2,
+          std::numeric_limits<int>::min()};
+      unsigned sa = sizeof(a) / sizeof(a[0]);
+      assert(!std::is_sorted(policy, Iter(a), Iter(a + sa), std::greater<int>()));
+    }
   }
 };
 

--- a/libcxx/test/std/algorithms/pstl.exception_handling.pass.cpp
+++ b/libcxx/test/std/algorithms/pstl.exception_handling.pass.cpp
@@ -282,6 +282,14 @@ int main(int, char**) {
         assert_non_throwing([=, &policy] {
           (void)std::stable_sort(policy, std::move(first1), std::move(last1), compare);
         });
+
+        // is_sorted(first, last)
+        assert_non_throwing([=, &policy] { (void)std::is_sorted(policy, std::move(first1), std::move(last1)); });
+
+        // is_sorted(first, last, comp)
+        assert_non_throwing([=, &policy] {
+          (void)std::is_sorted(policy, std::move(first1), std::move(last1), compare);
+        });
       }
 
       {


### PR DESCRIPTION
This PR implements a generic backend-agnostic parallel `std::is_sorted` based on `std::transform_reduce`.

While this approach is suboptimal comparing a direct backend-specific implementation, since it doesn't support early termination and requires a reduction operation, it does show speedup when the dataset is large enough and the comparator is not absolutely trivial. For instance, this was measured on Apple M1 with `libdispatch` backend:

```
 | -------------------------------------------------------------------------------------------
 | Benchmark                                                 Time             CPU   Iterations
 | -------------------------------------------------------------------------------------------
 | std::is_sorted(vector<int>, pred)/8                    10.7 ns         9.77 ns     65611878
 | std::is_sorted(vector<int>, pred)/1024                 1362 ns         1348 ns       499533
 | std::is_sorted(vector<int>, pred)/8192                11113 ns        10852 ns        64454
 | std::is_sorted(vector<int>, pred)/65536               90459 ns        87574 ns         8203
 | std::is_sorted(vector<int>, pred)/1048576           1429824 ns      1396586 ns          498
 | std::is_sorted(vector<int>, pred)/16777216         23026696 ns     22378839 ns           31
 | std::is_sorted(vector<int>, pred)/134217728       191726083 ns    185843667 ns            3
 | std::is_sorted(par, vector<int>, pred)/8               49.1 ns         47.6 ns     14658274
 | std::is_sorted(par, vector<int>, pred)/1024            1902 ns         1742 ns       395710
 | std::is_sorted(par, vector<int>, pred)/8192           11427 ns        10409 ns        65290
 | std::is_sorted(par, vector<int>, pred)/65536          55246 ns        51234 ns        12937
 | std::is_sorted(par, vector<int>, pred)/1048576       527596 ns       473740 ns         1363
 | std::is_sorted(par, vector<int>, pred)/16777216     8287237 ns      5356766 ns          124
 | std::is_sorted(par, vector<int>, pred)/134217728   58021476 ns     46045357 ns           14
 `-----------------------------

  auto std_is_sorted_pred = [](auto first, auto last) {
    return std::is_sorted(first, last, [](auto x, auto y) {
      benchmark::DoNotOptimize(x);
      benchmark::DoNotOptimize(y);
      return sqrt(x) < sqrt(y);
    });
  };
  auto std_is_sorted_pred_par = [](auto first, auto last) {
    return std::is_sorted(std::execution::par, first, last, [](auto x, auto y) {
      benchmark::DoNotOptimize(x);
      benchmark::DoNotOptimize(y);
      return sqrt(x) < sqrt(y);
    });
  };
```

Parent issue: #99938