### PR TITLE
[Support] Suppress old MSVC warning for [[msvc::no_unique_address]]

### DIFF
--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -441,10 +441,28 @@
 #define LLVM_CTOR_NODISCARD
 #endif
 
+// Macro to suppress the MSVC warning C4848:
+// "support for attribute [[attribute]] in C++17 and earlier is a vendor extension"
+// Prior to version 19.43 MSVC warns about using the [[msvc::no_unique_address]]
+// attribute.
+#if !defined(_MSC_VER) || _MSC_VER >= 1943 || defined(__clang__)
+#define LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_PUSH
+#define LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_POP
+#else // MSVC < 19.43
+#define LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_PUSH \
+    _Pragma("warning(push)") \
+    _Pragma("warning(disable : 4848)")
+#define LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_POP \
+    _Pragma("warning(pop)")
+#endif
+
 #if LLVM_HAS_CPP_ATTRIBUTE(no_unique_address)
 #define LLVM_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #elif LLVM_HAS_CPP_ATTRIBUTE(msvc::no_unique_address)
-#define LLVM_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#define LLVM_NO_UNIQUE_ADDRESS \
+    LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_PUSH \
+    [[msvc::no_unique_address]] \
+    LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_POP
 #else
 #define LLVM_NO_UNIQUE_ADDRESS
 #endif

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -442,27 +442,24 @@
 #endif
 
 // Macro to suppress the MSVC warning C4848:
-// "support for attribute [[attribute]] in C++17 and earlier is a vendor extension"
-// Prior to version 19.43 MSVC warns about using the [[msvc::no_unique_address]]
-// attribute.
+// "support for attribute [[msvc::no_unique_address]] in C++17 and earlier
+// is a vendor extension".
+// This warning is removed in versions >= 19.43.
 #if !defined(_MSC_VER) || _MSC_VER >= 1943 || defined(__clang__)
 #define LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_PUSH
 #define LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_POP
 #else // MSVC < 19.43
-#define LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_PUSH \
-    _Pragma("warning(push)") \
-    _Pragma("warning(disable : 4848)")
-#define LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_POP \
-    _Pragma("warning(pop)")
+#define LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_PUSH                             \
+  _Pragma("warning(push)") _Pragma("warning(disable : 4848)")
+#define LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_POP _Pragma("warning(pop)")
 #endif
 
 #if LLVM_HAS_CPP_ATTRIBUTE(no_unique_address)
 #define LLVM_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #elif LLVM_HAS_CPP_ATTRIBUTE(msvc::no_unique_address)
-#define LLVM_NO_UNIQUE_ADDRESS \
-    LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_PUSH \
-    [[msvc::no_unique_address]] \
-    LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_POP
+#define LLVM_NO_UNIQUE_ADDRESS                                                 \
+  LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_PUSH                                   \
+  [[msvc::no_unique_address]] LLVM_SUPPRESS_MSVC_ATTR_IS_VENDOR_EXT_POP
 #else
 #define LLVM_NO_UNIQUE_ADDRESS
 #endif


### PR DESCRIPTION
MSVC versions prior to 19.43 (Visual Studio 2022 version 17.13) emit a warning when using the [[msvc::no_unique_address]] attribute prior to C++20.

This is now considered a bug and fixed in later releases of MSVC. Suppress the warning for older MSVC versions by disabling the warning around the attribute usage. This allows for warning-free builds when targeting older MSVC versions.

More details and discussion about the warning can be found here: https://developercommunity.visualstudio.com/t/msvc::no_unique_address-Should-Not-W/10118435