### PR TITLE
[libc++] Remove benchmarks for ranges algorithms that have a std equivalent

### DIFF
--- a/libcxx/test/benchmarks/algorithms/modifying/copy.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/copy.bench.cpp
@@ -45,9 +45,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::copy(vector<int>)", std_copy);
     bm.operator()<std::deque<int>>("std::copy(deque<int>)", std_copy);
     bm.operator()<std::list<int>>("std::copy(list<int>)", std_copy);
-    bm.operator()<std::vector<int>>("rng::copy(vector<int>)", std::ranges::copy);
-    bm.operator()<std::deque<int>>("rng::copy(deque<int>)", std::ranges::copy);
-    bm.operator()<std::list<int>>("rng::copy(list<int>)", std::ranges::copy);
   }
 
   // {std,ranges}::copy(vector<bool>)
@@ -70,10 +67,6 @@ int main(int argc, char** argv) {
     };
     bm.operator()<true>("std::copy(vector<bool>) (aligned)", std_copy);
     bm.operator()<false>("std::copy(vector<bool>) (unaligned)", std_copy);
-#if TEST_STD_VER >= 23 // vector<bool>::iterator is not an output_iterator before C++23
-    bm.operator()<true>("rng::copy(vector<bool>) (aligned)", std::ranges::copy);
-    bm.operator()<false>("rng::copy(vector<bool>) (unaligned)", std::ranges::copy);
-#endif
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/copy_backward.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/copy_backward.bench.cpp
@@ -45,9 +45,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::copy_backward(vector<int>)", std_copy_backward);
     bm.operator()<std::deque<int>>("std::copy_backward(deque<int>)", std_copy_backward);
     bm.operator()<std::list<int>>("std::copy_backward(list<int>)", std_copy_backward);
-    bm.operator()<std::vector<int>>("rng::copy_backward(vector<int>)", std::ranges::copy_backward);
-    bm.operator()<std::deque<int>>("rng::copy_backward(deque<int>)", std::ranges::copy_backward);
-    bm.operator()<std::list<int>>("rng::copy_backward(list<int>)", std::ranges::copy_backward);
   }
 
   // {std,ranges}::copy_n(vector<bool>)
@@ -71,10 +68,6 @@ int main(int argc, char** argv) {
     };
     bm.operator()<true>("std::copy_backward(vector<bool>) (aligned)", std_copy_backward);
     bm.operator()<false>("std::copy_backward(vector<bool>) (unaligned)", std_copy_backward);
-#if TEST_STD_VER >= 23 // vector<bool>::iterator is not an output_iterator before C++23
-    bm.operator()<true>("rng::copy_backward(vector<bool>) (aligned)", std::ranges::copy_backward);
-    bm.operator()<false>("rng::copy_backward(vector<bool>) (unaligned)", std::ranges::copy_backward);
-#endif
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/copy_if.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/copy_if.bench.cpp
@@ -52,10 +52,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::copy_if(vector<int>) (every other)", std_copy_if);
     bm.operator()<std::deque<int>>("std::copy_if(deque<int>) (every other)", std_copy_if);
     bm.operator()<std::list<int>>("std::copy_if(list<int>) (every other)", std_copy_if);
-
-    bm.operator()<std::vector<int>>("rng::copy_if(vector<int>) (every other)", std::ranges::copy_if);
-    bm.operator()<std::deque<int>>("rng::copy_if(deque<int>) (every other)", std::ranges::copy_if);
-    bm.operator()<std::list<int>>("rng::copy_if(list<int>) (every other)", std::ranges::copy_if);
   }
 
   // Benchmark {std,ranges}::copy_if where we copy the full range.
@@ -85,10 +81,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::copy_if(vector<int>) (entire range)", std_copy_if);
     bm.operator()<std::deque<int>>("std::copy_if(deque<int>) (entire range)", std_copy_if);
     bm.operator()<std::list<int>>("std::copy_if(list<int>) (entire range)", std_copy_if);
-
-    bm.operator()<std::vector<int>>("rng::copy_if(vector<int>) (entire range)", std::ranges::copy_if);
-    bm.operator()<std::deque<int>>("rng::copy_if(deque<int>) (entire range)", std::ranges::copy_if);
-    bm.operator()<std::list<int>>("rng::copy_if(list<int>) (entire range)", std::ranges::copy_if);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/copy_n.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/copy_n.bench.cpp
@@ -45,9 +45,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::copy_n(vector<int>)", std_copy_n);
     bm.operator()<std::deque<int>>("std::copy_n(deque<int>)", std_copy_n);
     bm.operator()<std::list<int>>("std::copy_n(list<int>)", std_copy_n);
-    bm.operator()<std::vector<int>>("rng::copy_n(vector<int>)", std::ranges::copy_n);
-    bm.operator()<std::deque<int>>("rng::copy_n(deque<int>)", std::ranges::copy_n);
-    bm.operator()<std::list<int>>("rng::copy_n(list<int>)", std::ranges::copy_n);
   }
 
   // {std,ranges}::copy_n(vector<bool>)
@@ -69,10 +66,6 @@ int main(int argc, char** argv) {
     };
     bm.operator()<true>("std::copy_n(vector<bool>) (aligned)", std_copy_n);
     bm.operator()<false>("std::copy_n(vector<bool>) (unaligned)", std_copy_n);
-#if TEST_STD_VER >= 23 // vector<bool>::iterator is not an output_iterator before C++23
-    bm.operator()<true>("rng::copy_n(vector<bool>) (aligned)", std::ranges::copy_n);
-    bm.operator()<false>("rng::copy_n(vector<bool>) (unaligned)", std::ranges::copy_n);
-#endif
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/fill.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/fill.bench.cpp
@@ -49,9 +49,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::fill(vector<int>)", std_fill);
     bm.operator()<std::deque<int>>("std::fill(deque<int>)", std_fill);
     bm.operator()<std::list<int>>("std::fill(list<int>)", std_fill);
-    bm.operator()<std::vector<int>>("rng::fill(vector<int>)", std::ranges::fill);
-    bm.operator()<std::deque<int>>("rng::fill(deque<int>)", std::ranges::fill);
-    bm.operator()<std::list<int>>("rng::fill(list<int>)", std::ranges::fill);
   }
 
   // {std,ranges}::fill(vector<bool>)
@@ -71,9 +68,6 @@ int main(int argc, char** argv) {
       })->Range(64, 1 << 20);
     };
     bm("std::fill(vector<bool>)", std_fill);
-#if TEST_STD_VER >= 23 // vector<bool>::iterator is not an output_iterator before C++23
-    bm("rng::fill(vector<bool>)", std::ranges::fill);
-#endif
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/fill_n.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/fill_n.bench.cpp
@@ -49,9 +49,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::fill_n(vector<int>)", std_fill_n);
     bm.operator()<std::deque<int>>("std::fill_n(deque<int>)", std_fill_n);
     bm.operator()<std::list<int>>("std::fill_n(list<int>)", std_fill_n);
-    bm.operator()<std::vector<int>>("rng::fill_n(vector<int>)", std::ranges::fill_n);
-    bm.operator()<std::deque<int>>("rng::fill_n(deque<int>)", std::ranges::fill_n);
-    bm.operator()<std::list<int>>("rng::fill_n(list<int>)", std::ranges::fill_n);
   }
 
   // {std,ranges}::fill_n(vector<bool>)
@@ -71,9 +68,6 @@ int main(int argc, char** argv) {
       })->Range(64, 1 << 20);
     };
     bm("std::fill_n(vector<bool>)", std_fill_n);
-#if TEST_STD_VER >= 23 // vector<bool>::iterator is not an output_iterator before C++23
-    bm("rng::fill_n(vector<bool>)", std::ranges::fill_n);
-#endif
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/generate.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/generate.bench.cpp
@@ -50,9 +50,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::generate(vector<int>)", std_generate);
     bm.operator()<std::deque<int>>("std::generate(deque<int>)", std_generate);
     bm.operator()<std::list<int>>("std::generate(list<int>)", std_generate);
-    bm.operator()<std::vector<int>>("rng::generate(vector<int>)", std::ranges::generate);
-    bm.operator()<std::deque<int>>("rng::generate(deque<int>)", std::ranges::generate);
-    bm.operator()<std::list<int>>("rng::generate(list<int>)", std::ranges::generate);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/generate_n.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/generate_n.bench.cpp
@@ -50,9 +50,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::generate_n(vector<int>)", std_generate_n);
     bm.operator()<std::deque<int>>("std::generate_n(deque<int>)", std_generate_n);
     bm.operator()<std::list<int>>("std::generate_n(list<int>)", std_generate_n);
-    bm.operator()<std::vector<int>>("rng::generate_n(vector<int>)", std::ranges::generate_n);
-    bm.operator()<std::deque<int>>("rng::generate_n(deque<int>)", std::ranges::generate_n);
-    bm.operator()<std::list<int>>("rng::generate_n(list<int>)", std::ranges::generate_n);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/move.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/move.bench.cpp
@@ -47,9 +47,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::move(vector<int>)", std_move);
     bm.operator()<std::deque<int>>("std::move(deque<int>)", std_move);
     bm.operator()<std::list<int>>("std::move(list<int>)", std_move);
-    bm.operator()<std::vector<int>>("rng::move(vector<int>)", std::ranges::move);
-    bm.operator()<std::deque<int>>("rng::move(deque<int>)", std::ranges::move);
-    bm.operator()<std::list<int>>("rng::move(list<int>)", std::ranges::move);
   }
 
   // {std,ranges}::move(vector<bool>)
@@ -74,10 +71,6 @@ int main(int argc, char** argv) {
     };
     bm.operator()<true>("std::move(vector<bool>) (aligned)", std_move);
     bm.operator()<false>("std::move(vector<bool>) (unaligned)", std_move);
-#if TEST_STD_VER >= 23 // vector<bool>::iterator is not an output_iterator before C++23
-    bm.operator()<true>("rng::move(vector<bool>) (aligned)", std::ranges::move);
-    bm.operator()<false>("rng::move(vector<bool>) (unaligned)", std::ranges::move);
-#endif
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/move_backward.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/move_backward.bench.cpp
@@ -47,9 +47,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::move_backward(vector<int>)", std_move_backward);
     bm.operator()<std::deque<int>>("std::move_backward(deque<int>)", std_move_backward);
     bm.operator()<std::list<int>>("std::move_backward(list<int>)", std_move_backward);
-    bm.operator()<std::vector<int>>("rng::move_backward(vector<int>)", std::ranges::move_backward);
-    bm.operator()<std::deque<int>>("rng::move_backward(deque<int>)", std::ranges::move_backward);
-    bm.operator()<std::list<int>>("rng::move_backward(list<int>)", std::ranges::move_backward);
   }
 
   // {std,ranges}::move_backward(vector<bool>)
@@ -74,10 +71,6 @@ int main(int argc, char** argv) {
     };
     bm.operator()<true>("std::move_backward(vector<bool>) (aligned)", std_move_backward);
     bm.operator()<false>("std::move_backward(vector<bool>) (unaligned)", std_move_backward);
-#if TEST_STD_VER >= 23 // vector<bool>::iterator is not an output_iterator before C++23
-    bm.operator()<true>("rng::move_backward(vector<bool>) (aligned)", std::ranges::move_backward);
-    bm.operator()<false>("rng::move_backward(vector<bool>) (unaligned)", std::ranges::move_backward);
-#endif
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/remove.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/remove.bench.cpp
@@ -27,12 +27,6 @@ int main(int argc, char** argv) {
       return element == value;
     });
   };
-  auto ranges_remove_if = [](auto first, auto last, auto const& value) {
-    return std::ranges::remove_if(first, last, [&](auto element) {
-      benchmark::DoNotOptimize(element);
-      return element == value;
-    });
-  };
 
   // Benchmark {std,ranges}::{remove,remove_if} on a sequence of the form xxxxxxxxxxyyyyyyyyyy
   // where we remove the prefix of x's from the sequence.
@@ -83,17 +77,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::remove(vector<int>) (prefix)", std_remove);
     bm.operator()<std::deque<int>>("std::remove(deque<int>) (prefix)", std_remove);
     bm.operator()<std::list<int>>("std::remove(list<int>) (prefix)", std_remove);
-    bm.operator()<std::vector<int>>("rng::remove(vector<int>) (prefix)", std::ranges::remove);
-    bm.operator()<std::deque<int>>("rng::remove(deque<int>) (prefix)", std::ranges::remove);
-    bm.operator()<std::list<int>>("rng::remove(list<int>) (prefix)", std::ranges::remove);
 
     // {std,ranges}::remove_if
     bm.operator()<std::vector<int>>("std::remove_if(vector<int>) (prefix)", std_remove_if);
     bm.operator()<std::deque<int>>("std::remove_if(deque<int>) (prefix)", std_remove_if);
     bm.operator()<std::list<int>>("std::remove_if(list<int>) (prefix)", std_remove_if);
-    bm.operator()<std::vector<int>>("rng::remove_if(vector<int>) (prefix)", ranges_remove_if);
-    bm.operator()<std::deque<int>>("rng::remove_if(deque<int>) (prefix)", ranges_remove_if);
-    bm.operator()<std::list<int>>("rng::remove_if(list<int>) (prefix)", ranges_remove_if);
   }
 
   // Benchmark {std,ranges}::remove on a sequence of the form xyxyxyxyxyxyxyxyxyxy
@@ -147,17 +135,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::remove(vector<int>) (sprinkled)", std_remove);
     bm.operator()<std::deque<int>>("std::remove(deque<int>) (sprinkled)", std_remove);
     bm.operator()<std::list<int>>("std::remove(list<int>) (sprinkled)", std_remove);
-    bm.operator()<std::vector<int>>("rng::remove(vector<int>) (sprinkled)", std::ranges::remove);
-    bm.operator()<std::deque<int>>("rng::remove(deque<int>) (sprinkled)", std::ranges::remove);
-    bm.operator()<std::list<int>>("rng::remove(list<int>) (sprinkled)", std::ranges::remove);
 
     // {std,ranges}::remove_if
     bm.operator()<std::vector<int>>("std::remove_if(vector<int>) (sprinkled)", std_remove_if);
     bm.operator()<std::deque<int>>("std::remove_if(deque<int>) (sprinkled)", std_remove_if);
     bm.operator()<std::list<int>>("std::remove_if(list<int>) (sprinkled)", std_remove_if);
-    bm.operator()<std::vector<int>>("rng::remove_if(vector<int>) (sprinkled)", ranges_remove_if);
-    bm.operator()<std::deque<int>>("rng::remove_if(deque<int>) (sprinkled)", ranges_remove_if);
-    bm.operator()<std::list<int>>("rng::remove_if(list<int>) (sprinkled)", ranges_remove_if);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/remove_copy.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/remove_copy.bench.cpp
@@ -29,12 +29,6 @@ int main(int argc, char** argv) {
       return element == value;
     });
   };
-  auto ranges_remove_copy_if = [](auto first, auto last, auto out, auto const& value) {
-    return std::ranges::remove_copy_if(first, last, out, [&](auto element) {
-      benchmark::DoNotOptimize(element);
-      return element == value;
-    });
-  };
 
   // Benchmark {std,ranges}::{remove_copy,remove_copy_if} on a sequence of the form xxxxxxxxxxyyyyyyyyyy
   // where we remove the prefix of x's from the sequence.
@@ -70,17 +64,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::remove_copy(vector<int>) (prefix)", std_remove_copy);
     bm.operator()<std::deque<int>>("std::remove_copy(deque<int>) (prefix)", std_remove_copy);
     bm.operator()<std::list<int>>("std::remove_copy(list<int>) (prefix)", std_remove_copy);
-    bm.operator()<std::vector<int>>("rng::remove_copy(vector<int>) (prefix)", std::ranges::remove_copy);
-    bm.operator()<std::deque<int>>("rng::remove_copy(deque<int>) (prefix)", std::ranges::remove_copy);
-    bm.operator()<std::list<int>>("rng::remove_copy(list<int>) (prefix)", std::ranges::remove_copy);
 
     // {std,ranges}::remove_copy_if
     bm.operator()<std::vector<int>>("std::remove_copy_if(vector<int>) (prefix)", std_remove_copy_if);
     bm.operator()<std::deque<int>>("std::remove_copy_if(deque<int>) (prefix)", std_remove_copy_if);
     bm.operator()<std::list<int>>("std::remove_copy_if(list<int>) (prefix)", std_remove_copy_if);
-    bm.operator()<std::vector<int>>("rng::remove_copy_if(vector<int>) (prefix)", ranges_remove_copy_if);
-    bm.operator()<std::deque<int>>("rng::remove_copy_if(deque<int>) (prefix)", ranges_remove_copy_if);
-    bm.operator()<std::list<int>>("rng::remove_copy_if(list<int>) (prefix)", ranges_remove_copy_if);
   }
 
   // Benchmark {std,ranges}::{remove_copy,remove_copy_if} on a sequence of the form xyxyxyxyxyxyxyxyxyxy
@@ -118,17 +106,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::remove_copy(vector<int>) (sprinkled)", std_remove_copy);
     bm.operator()<std::deque<int>>("std::remove_copy(deque<int>) (sprinkled)", std_remove_copy);
     bm.operator()<std::list<int>>("std::remove_copy(list<int>) (sprinkled)", std_remove_copy);
-    bm.operator()<std::vector<int>>("rng::remove_copy(vector<int>) (sprinkled)", std::ranges::remove_copy);
-    bm.operator()<std::deque<int>>("rng::remove_copy(deque<int>) (sprinkled)", std::ranges::remove_copy);
-    bm.operator()<std::list<int>>("rng::remove_copy(list<int>) (sprinkled)", std::ranges::remove_copy);
 
     // {std,ranges}::remove_copy_if
     bm.operator()<std::vector<int>>("std::remove_copy_if(vector<int>) (sprinkled)", std_remove_copy_if);
     bm.operator()<std::deque<int>>("std::remove_copy_if(deque<int>) (sprinkled)", std_remove_copy_if);
     bm.operator()<std::list<int>>("std::remove_copy_if(list<int>) (sprinkled)", std_remove_copy_if);
-    bm.operator()<std::vector<int>>("rng::remove_copy_if(vector<int>) (sprinkled)", ranges_remove_copy_if);
-    bm.operator()<std::deque<int>>("rng::remove_copy_if(deque<int>) (sprinkled)", ranges_remove_copy_if);
-    bm.operator()<std::list<int>>("rng::remove_copy_if(list<int>) (sprinkled)", ranges_remove_copy_if);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/replace.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/replace.bench.cpp
@@ -28,13 +28,6 @@ int main(int argc, char** argv) {
     };
     return std::replace_if(first, last, pred, new_);
   };
-  auto ranges_replace_if = [](auto first, auto last, auto old, auto new_) {
-    auto pred = [&](auto element) {
-      benchmark::DoNotOptimize(element);
-      return element == old;
-    };
-    return std::ranges::replace_if(first, last, pred, new_);
-  };
 
   // Create a sequence of the form xxxxxxxxxxyyyyyyyyyy, replace
   // into zzzzzzzzzzzyyyyyyyyyy and then back.
@@ -73,17 +66,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::replace(vector<int>) (prefix)", std_replace);
     bm.operator()<std::deque<int>>("std::replace(deque<int>) (prefix)", std_replace);
     bm.operator()<std::list<int>>("std::replace(list<int>) (prefix)", std_replace);
-    bm.operator()<std::vector<int>>("rng::replace(vector<int>) (prefix)", std::ranges::replace);
-    bm.operator()<std::deque<int>>("rng::replace(deque<int>) (prefix)", std::ranges::replace);
-    bm.operator()<std::list<int>>("rng::replace(list<int>) (prefix)", std::ranges::replace);
 
     // {std,ranges}::replace_if
     bm.operator()<std::vector<int>>("std::replace_if(vector<int>) (prefix)", std_replace_if);
     bm.operator()<std::deque<int>>("std::replace_if(deque<int>) (prefix)", std_replace_if);
     bm.operator()<std::list<int>>("std::replace_if(list<int>) (prefix)", std_replace_if);
-    bm.operator()<std::vector<int>>("rng::replace_if(vector<int>) (prefix)", ranges_replace_if);
-    bm.operator()<std::deque<int>>("rng::replace_if(deque<int>) (prefix)", ranges_replace_if);
-    bm.operator()<std::list<int>>("rng::replace_if(list<int>) (prefix)", ranges_replace_if);
   }
 
   // Sprinkle elements to replace inside the range, like xyxyxyxyxyxyxyxyxyxy.
@@ -120,17 +107,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::replace(vector<int>) (sprinkled)", std_replace);
     bm.operator()<std::deque<int>>("std::replace(deque<int>) (sprinkled)", std_replace);
     bm.operator()<std::list<int>>("std::replace(list<int>) (sprinkled)", std_replace);
-    bm.operator()<std::vector<int>>("rng::replace(vector<int>) (sprinkled)", std::ranges::replace);
-    bm.operator()<std::deque<int>>("rng::replace(deque<int>) (sprinkled)", std::ranges::replace);
-    bm.operator()<std::list<int>>("rng::replace(list<int>) (sprinkled)", std::ranges::replace);
 
     // {std,ranges}::replace_if
     bm.operator()<std::vector<int>>("std::replace_if(vector<int>) (sprinkled)", std_replace_if);
     bm.operator()<std::deque<int>>("std::replace_if(deque<int>) (sprinkled)", std_replace_if);
     bm.operator()<std::list<int>>("std::replace_if(list<int>) (sprinkled)", std_replace_if);
-    bm.operator()<std::vector<int>>("rng::replace_if(vector<int>) (sprinkled)", ranges_replace_if);
-    bm.operator()<std::deque<int>>("rng::replace_if(deque<int>) (sprinkled)", ranges_replace_if);
-    bm.operator()<std::list<int>>("rng::replace_if(list<int>) (sprinkled)", ranges_replace_if);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/reverse.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/reverse.bench.cpp
@@ -41,9 +41,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::reverse(vector<int>)", std_reverse);
     bm.operator()<std::deque<int>>("std::reverse(deque<int>)", std_reverse);
     bm.operator()<std::list<int>>("std::reverse(list<int>)", std_reverse);
-    bm.operator()<std::vector<int>>("rng::reverse(vector<int>)", std::ranges::reverse);
-    bm.operator()<std::deque<int>>("rng::reverse(deque<int>)", std::ranges::reverse);
-    bm.operator()<std::list<int>>("rng::reverse(list<int>)", std::ranges::reverse);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/reverse_copy.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/reverse_copy.bench.cpp
@@ -44,9 +44,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::reverse_copy(vector<int>)", std_reverse_copy);
     bm.operator()<std::deque<int>>("std::reverse_copy(deque<int>)", std_reverse_copy);
     bm.operator()<std::list<int>>("std::reverse_copy(list<int>)", std_reverse_copy);
-    bm.operator()<std::vector<int>>("rng::reverse_copy(vector<int>)", std::ranges::reverse_copy);
-    bm.operator()<std::deque<int>>("rng::reverse_copy(deque<int>)", std::ranges::reverse_copy);
-    bm.operator()<std::list<int>>("rng::reverse_copy(list<int>)", std::ranges::reverse_copy);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/rotate.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/rotate.bench.cpp
@@ -50,33 +50,18 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::rotate(vector<int>) (by 1/4)", std_rotate, 0.25);
     bm.operator()<std::deque<int>>("std::rotate(deque<int>) (by 1/4)", std_rotate, 0.25);
     bm.operator()<std::list<int>>("std::rotate(list<int>) (by 1/4)", std_rotate, 0.25);
-    bm.operator()<std::vector<int>>("rng::rotate(vector<int>) (by 1/4)", std::ranges::rotate, 0.25);
-    bm.operator()<std::deque<int>>("rng::rotate(deque<int>) (by 1/4)", std::ranges::rotate, 0.25);
-    bm.operator()<std::list<int>>("rng::rotate(list<int>) (by 1/4)", std::ranges::rotate, 0.25);
 
     bm.operator()<std::vector<int>>("std::rotate(vector<int>) (by 1/3)", std_rotate, 0.33);
     bm.operator()<std::deque<int>>("std::rotate(deque<int>) (by 1/3)", std_rotate, 0.33);
     bm.operator()<std::list<int>>("std::rotate(list<int>) (by 1/3)", std_rotate, 0.33);
-    bm.operator()<std::vector<int>>("rng::rotate(vector<int>) (by 1/3)", std::ranges::rotate, 0.33);
-    bm.operator()<std::deque<int>>("rng::rotate(deque<int>) (by 1/3)", std::ranges::rotate, 0.33);
-    bm.operator()<std::list<int>>("rng::rotate(list<int>) (by 1/3)", std::ranges::rotate, 0.33);
 
     bm.operator()<std::vector<int>>("std::rotate(vector<int>) (by 1/2)", std_rotate, 0.50);
     bm.operator()<std::deque<int>>("std::rotate(deque<int>) (by 1/2)", std_rotate, 0.50);
     bm.operator()<std::list<int>>("std::rotate(list<int>) (by 1/2)", std_rotate, 0.50);
-    bm.operator()<std::vector<int>>("rng::rotate(vector<int>) (by 1/2)", std::ranges::rotate, 0.50);
-    bm.operator()<std::deque<int>>("rng::rotate(deque<int>) (by 1/2)", std::ranges::rotate, 0.50);
-    bm.operator()<std::list<int>>("rng::rotate(list<int>) (by 1/2)", std::ranges::rotate, 0.50);
 
     bm.operator()<std::vector<bool>>("std::rotate(vector<bool>) (by 1/4)", std_rotate, 0.25);
     bm.operator()<std::vector<bool>>("std::rotate(vector<bool>) (by 1/3)", std_rotate, 0.33);
     bm.operator()<std::vector<bool>>("std::rotate(vector<bool>) (by 1/2)", std_rotate, 0.50);
-
-#if TEST_STD_VER >= 23 // vector<bool>::iterator is not std::permutable before C++23
-    bm.operator()<std::vector<bool>>("rng::rotate(vector<bool>) (by 1/4)", std::ranges::rotate, 0.25);
-    bm.operator()<std::vector<bool>>("rng::rotate(vector<bool>) (by 1/3)", std::ranges::rotate, 0.33);
-    bm.operator()<std::vector<bool>>("rng::rotate(vector<bool>) (by 1/2)", std::ranges::rotate, 0.50);
-#endif
   }
 
   // Benchmark {std,ranges}::rotate where we rotate a single element from the beginning to the end of the range.
@@ -105,14 +90,8 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::rotate(vector<int>) (1 element forward)", std_rotate);
     bm.operator()<std::deque<int>>("std::rotate(deque<int>) (1 element forward)", std_rotate);
     bm.operator()<std::list<int>>("std::rotate(list<int>) (1 element forward)", std_rotate);
-    bm.operator()<std::vector<int>>("rng::rotate(vector<int>) (1 element forward)", std::ranges::rotate);
-    bm.operator()<std::deque<int>>("rng::rotate(deque<int>) (1 element forward)", std::ranges::rotate);
-    bm.operator()<std::list<int>>("rng::rotate(list<int>) (1 element forward)", std::ranges::rotate);
 
     bm.operator()<std::vector<bool>>("std::rotate(vector<bool>) (1 element forward)", std_rotate);
-#if TEST_STD_VER >= 23 // vector<bool>::iterator is not std::permutable before C++23
-    bm.operator()<std::vector<bool>>("rng::rotate(vector<bool>) (1 element forward)", std::ranges::rotate);
-#endif
   }
 
   // Benchmark {std,ranges}::rotate where we rotate a single element from the end to the beginning of the range.
@@ -141,14 +120,8 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::rotate(vector<int>) (1 element backward)", std_rotate);
     bm.operator()<std::deque<int>>("std::rotate(deque<int>) (1 element backward)", std_rotate);
     bm.operator()<std::list<int>>("std::rotate(list<int>) (1 element backward)", std_rotate);
-    bm.operator()<std::vector<int>>("rng::rotate(vector<int>) (1 element backward)", std::ranges::rotate);
-    bm.operator()<std::deque<int>>("rng::rotate(deque<int>) (1 element backward)", std::ranges::rotate);
-    bm.operator()<std::list<int>>("rng::rotate(list<int>) (1 element backward)", std::ranges::rotate);
 
     bm.operator()<std::vector<bool>>("std::rotate(vector<bool>) (1 element backward)", std_rotate);
-#if TEST_STD_VER >= 23 // vector<bool>::iterator is not std::permutable before C++23
-    bm.operator()<std::vector<bool>>("rng::rotate(vector<bool>) (1 element backward)", std::ranges::rotate);
-#endif
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/rotate_copy.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/rotate_copy.bench.cpp
@@ -53,9 +53,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::rotate_copy(vector<int>)", std_rotate_copy);
     bm.operator()<std::deque<int>>("std::rotate_copy(deque<int>)", std_rotate_copy);
     bm.operator()<std::list<int>>("std::rotate_copy(list<int>)", std_rotate_copy);
-    bm.operator()<std::vector<int>>("rng::rotate_copy(vector<int>)", std::ranges::rotate_copy);
-    bm.operator()<std::deque<int>>("rng::rotate_copy(deque<int>)", std::ranges::rotate_copy);
-    bm.operator()<std::list<int>>("rng::rotate_copy(list<int>)", std::ranges::rotate_copy);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/sample.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/sample.bench.cpp
@@ -54,9 +54,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::sample(vector<int>)", std_sample);
     bm.operator()<std::deque<int>>("std::sample(deque<int>)", std_sample);
     bm.operator()<std::list<int>>("std::sample(list<int>)", std_sample);
-    bm.operator()<std::vector<int>>("rng::sample(vector<int>)", std::ranges::sample);
-    bm.operator()<std::deque<int>>("rng::sample(deque<int>)", std::ranges::sample);
-    bm.operator()<std::list<int>>("rng::sample(list<int>)", std::ranges::sample);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/shuffle.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/shuffle.bench.cpp
@@ -46,8 +46,6 @@ int main(int argc, char** argv) {
     };
     bm.operator()<std::vector<int>>("std::shuffle(vector<int>)", std_shuffle);
     bm.operator()<std::deque<int>>("std::shuffle(deque<int>)", std_shuffle);
-    bm.operator()<std::vector<int>>("rng::shuffle(vector<int>)", std::ranges::shuffle);
-    bm.operator()<std::deque<int>>("rng::shuffle(deque<int>)", std::ranges::shuffle);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/swap_ranges.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/swap_ranges.bench.cpp
@@ -53,9 +53,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::swap_ranges(vector<int>)", std_swap_ranges);
     bm.operator()<std::deque<int>>("std::swap_ranges(deque<int>)", std_swap_ranges);
     bm.operator()<std::list<int>>("std::swap_ranges(list<int>)", std_swap_ranges);
-    bm.operator()<std::vector<int>>("rng::swap_ranges(vector<int>)", std::ranges::swap_ranges);
-    bm.operator()<std::deque<int>>("rng::swap_ranges(deque<int>)", std::ranges::swap_ranges);
-    bm.operator()<std::list<int>>("rng::swap_ranges(list<int>)", std::ranges::swap_ranges);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/transform.binary.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/transform.binary.bench.cpp
@@ -60,9 +60,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::transform(vector<int>, vector<int>)", std_transform);
     bm.operator()<std::deque<int>>("std::transform(deque<int>, deque<int>)", std_transform);
     bm.operator()<std::list<int>>("std::transform(list<int>, list<int>)", std_transform);
-    bm.operator()<std::vector<int>>("rng::transform(vector<int>, vector<int>)", std::ranges::transform);
-    bm.operator()<std::deque<int>>("rng::transform(deque<int>, deque<int>)", std::ranges::transform);
-    bm.operator()<std::list<int>>("rng::transform(list<int>, list<int>)", std::ranges::transform);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/transform.unary.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/transform.unary.bench.cpp
@@ -55,9 +55,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::transform(vector<int>) (identity transform)", std_transform);
     bm.operator()<std::deque<int>>("std::transform(deque<int>) (identity transform)", std_transform);
     bm.operator()<std::list<int>>("std::transform(list<int>) (identity transform)", std_transform);
-    bm.operator()<std::vector<int>>("rng::transform(vector<int>) (identity transform)", std::ranges::transform);
-    bm.operator()<std::deque<int>>("rng::transform(deque<int>) (identity transform)", std::ranges::transform);
-    bm.operator()<std::list<int>>("rng::transform(list<int>) (identity transform)", std::ranges::transform);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/unique.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/unique.bench.cpp
@@ -28,13 +28,6 @@ int main(int argc, char** argv) {
       return a == b;
     });
   };
-  auto ranges_unique_pred = [](auto first, auto last) {
-    return std::ranges::unique(first, last, [](auto a, auto b) {
-      benchmark::DoNotOptimize(a);
-      benchmark::DoNotOptimize(b);
-      return a == b;
-    });
-  };
 
   // Create a sequence of the form xxxxxxxxxxyyyyyyyyyy and unique the
   // adjacent equal elements.
@@ -84,17 +77,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::unique(vector<int>) (contiguous)", std_unique);
     bm.operator()<std::deque<int>>("std::unique(deque<int>) (contiguous)", std_unique);
     bm.operator()<std::list<int>>("std::unique(list<int>) (contiguous)", std_unique);
-    bm.operator()<std::vector<int>>("rng::unique(vector<int>) (contiguous)", std::ranges::unique);
-    bm.operator()<std::deque<int>>("rng::unique(deque<int>) (contiguous)", std::ranges::unique);
-    bm.operator()<std::list<int>>("rng::unique(list<int>) (contiguous)", std::ranges::unique);
 
     // {std,ranges}::unique(it, it, pred)
     bm.operator()<std::vector<int>>("std::unique(vector<int>, pred) (contiguous)", std_unique_pred);
     bm.operator()<std::deque<int>>("std::unique(deque<int>, pred) (contiguous)", std_unique_pred);
     bm.operator()<std::list<int>>("std::unique(list<int>, pred) (contiguous)", std_unique_pred);
-    bm.operator()<std::vector<int>>("rng::unique(vector<int>, pred) (contiguous)", ranges_unique_pred);
-    bm.operator()<std::deque<int>>("rng::unique(deque<int>, pred) (contiguous)", ranges_unique_pred);
-    bm.operator()<std::list<int>>("rng::unique(list<int>, pred) (contiguous)", ranges_unique_pred);
   }
 
   // Create a sequence of the form xxyyxxyyxxyyxxyyxxyy and unique
@@ -151,17 +138,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::unique(vector<int>) (sprinkled)", std_unique);
     bm.operator()<std::deque<int>>("std::unique(deque<int>) (sprinkled)", std_unique);
     bm.operator()<std::list<int>>("std::unique(list<int>) (sprinkled)", std_unique);
-    bm.operator()<std::vector<int>>("rng::unique(vector<int>) (sprinkled)", std::ranges::unique);
-    bm.operator()<std::deque<int>>("rng::unique(deque<int>) (sprinkled)", std::ranges::unique);
-    bm.operator()<std::list<int>>("rng::unique(list<int>) (sprinkled)", std::ranges::unique);
 
     // {std,ranges}::unique(it, it, pred)
     bm.operator()<std::vector<int>>("std::unique(vector<int>, pred) (sprinkled)", std_unique_pred);
     bm.operator()<std::deque<int>>("std::unique(deque<int>, pred) (sprinkled)", std_unique_pred);
     bm.operator()<std::list<int>>("std::unique(list<int>, pred) (sprinkled)", std_unique_pred);
-    bm.operator()<std::vector<int>>("rng::unique(vector<int>, pred) (sprinkled)", ranges_unique_pred);
-    bm.operator()<std::deque<int>>("rng::unique(deque<int>, pred) (sprinkled)", ranges_unique_pred);
-    bm.operator()<std::list<int>>("rng::unique(list<int>, pred) (sprinkled)", ranges_unique_pred);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/modifying/unique_copy.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/unique_copy.bench.cpp
@@ -28,13 +28,6 @@ int main(int argc, char** argv) {
       return a == b;
     });
   };
-  auto ranges_unique_copy_pred = [](auto first, auto last, auto out) {
-    return std::ranges::unique_copy(first, last, out, [](auto a, auto b) {
-      benchmark::DoNotOptimize(a);
-      benchmark::DoNotOptimize(b);
-      return a == b;
-    });
-  };
 
   // Create a sequence of the form xxxxxxxxxxyyyyyyyyyy and unique the
   // adjacent equal elements.
@@ -69,17 +62,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::unique_copy(vector<int>) (contiguous)", std_unique_copy);
     bm.operator()<std::deque<int>>("std::unique_copy(deque<int>) (contiguous)", std_unique_copy);
     bm.operator()<std::list<int>>("std::unique_copy(list<int>) (contiguous)", std_unique_copy);
-    bm.operator()<std::vector<int>>("rng::unique_copy(vector<int>) (contiguous)", std::ranges::unique_copy);
-    bm.operator()<std::deque<int>>("rng::unique_copy(deque<int>) (contiguous)", std::ranges::unique_copy);
-    bm.operator()<std::list<int>>("rng::unique_copy(list<int>) (contiguous)", std::ranges::unique_copy);
 
     // {std,ranges}::unique_copy(it, it, out, pred)
     bm.operator()<std::vector<int>>("std::unique_copy(vector<int>, pred) (contiguous)", std_unique_copy_pred);
     bm.operator()<std::deque<int>>("std::unique_copy(deque<int>, pred) (contiguous)", std_unique_copy_pred);
     bm.operator()<std::list<int>>("std::unique_copy(list<int>, pred) (contiguous)", std_unique_copy_pred);
-    bm.operator()<std::vector<int>>("rng::unique_copy(vector<int>, pred) (contiguous)", ranges_unique_copy_pred);
-    bm.operator()<std::deque<int>>("rng::unique_copy(deque<int>, pred) (contiguous)", ranges_unique_copy_pred);
-    bm.operator()<std::list<int>>("rng::unique_copy(list<int>, pred) (contiguous)", ranges_unique_copy_pred);
   }
 
   // Create a sequence of the form xxyyxxyyxxyyxxyyxxyy and unique
@@ -124,17 +111,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::unique_copy(vector<int>) (sprinkled)", std_unique_copy);
     bm.operator()<std::deque<int>>("std::unique_copy(deque<int>) (sprinkled)", std_unique_copy);
     bm.operator()<std::list<int>>("std::unique_copy(list<int>) (sprinkled)", std_unique_copy);
-    bm.operator()<std::vector<int>>("rng::unique_copy(vector<int>) (sprinkled)", std::ranges::unique_copy);
-    bm.operator()<std::deque<int>>("rng::unique_copy(deque<int>) (sprinkled)", std::ranges::unique_copy);
-    bm.operator()<std::list<int>>("rng::unique_copy(list<int>) (sprinkled)", std::ranges::unique_copy);
 
     // {std,ranges}::unique_copy(it, it, out, pred)
     bm.operator()<std::vector<int>>("std::unique_copy(vector<int>, pred) (sprinkled)", std_unique_copy_pred);
     bm.operator()<std::deque<int>>("std::unique_copy(deque<int>, pred) (sprinkled)", std_unique_copy_pred);
     bm.operator()<std::list<int>>("std::unique_copy(list<int>, pred) (sprinkled)", std_unique_copy_pred);
-    bm.operator()<std::vector<int>>("rng::unique_copy(vector<int>, pred) (sprinkled)", ranges_unique_copy_pred);
-    bm.operator()<std::deque<int>>("rng::unique_copy(deque<int>, pred) (sprinkled)", ranges_unique_copy_pred);
-    bm.operator()<std::list<int>>("rng::unique_copy(list<int>, pred) (sprinkled)", ranges_unique_copy_pred);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/adjacent_find.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/adjacent_find.bench.cpp
@@ -27,13 +27,6 @@ int main(int argc, char** argv) {
       return x == y;
     });
   };
-  auto ranges_adjacent_find_pred = [](auto first, auto last) {
-    return std::ranges::adjacent_find(first, last, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
-  };
 
   // Benchmark {std,ranges}::adjacent_find on a sequence of the form xyxyxyxyxyxyxyxyxyxy,
   // which means we never find adjacent equal elements (the worst case of the algorithm).
@@ -68,17 +61,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::adjacent_find(vector<int>)", std_adjacent_find);
     bm.operator()<std::deque<int>>("std::adjacent_find(deque<int>)", std_adjacent_find);
     bm.operator()<std::list<int>>("std::adjacent_find(list<int>)", std_adjacent_find);
-    bm.operator()<std::vector<int>>("rng::adjacent_find(vector<int>)", std::ranges::adjacent_find);
-    bm.operator()<std::deque<int>>("rng::adjacent_find(deque<int>)", std::ranges::adjacent_find);
-    bm.operator()<std::list<int>>("rng::adjacent_find(list<int>)", std::ranges::adjacent_find);
 
     // {std,ranges}::adjacent_find(pred)
     bm.operator()<std::vector<int>>("std::adjacent_find(vector<int>, pred)", std_adjacent_find_pred);
     bm.operator()<std::deque<int>>("std::adjacent_find(deque<int>, pred)", std_adjacent_find_pred);
     bm.operator()<std::list<int>>("std::adjacent_find(list<int>, pred)", std_adjacent_find_pred);
-    bm.operator()<std::vector<int>>("rng::adjacent_find(vector<int>, pred)", ranges_adjacent_find_pred);
-    bm.operator()<std::deque<int>>("rng::adjacent_find(deque<int>, pred)", ranges_adjacent_find_pred);
-    bm.operator()<std::list<int>>("rng::adjacent_find(list<int>, pred)", ranges_adjacent_find_pred);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/any_all_none_of.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/any_all_none_of.bench.cpp
@@ -30,15 +30,6 @@ int main(int argc, char** argv) {
     return !std::none_of(first, last, pred);
   };
 
-  auto ranges_all_of = [](auto first, auto last, auto pred) {
-    // match semantics of any_of
-    return !std::ranges::all_of(first, last, [pred](auto x) { return !pred(x); });
-  };
-  auto ranges_none_of = [](auto first, auto last, auto pred) {
-    // match semantics of any_of
-    return !std::ranges::none_of(first, last, pred);
-  };
-
   // Benchmark {std,ranges}::{any_of,all_of,none_of} where we process the whole sequence,
   // which is the worst case.
   {
@@ -72,25 +63,16 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::any_of(vector<int>) (process all)", std_any_of);
     bm.operator()<std::deque<int>>("std::any_of(deque<int>) (process all)", std_any_of);
     bm.operator()<std::list<int>>("std::any_of(list<int>) (process all)", std_any_of);
-    bm.operator()<std::vector<int>>("rng::any_of(vector<int>) (process all)", std::ranges::any_of);
-    bm.operator()<std::deque<int>>("rng::any_of(deque<int>) (process all)", std::ranges::any_of);
-    bm.operator()<std::list<int>>("rng::any_of(list<int>) (process all)", std::ranges::any_of);
 
     // all_of
     bm.operator()<std::vector<int>>("std::all_of(vector<int>) (process all)", std_all_of);
     bm.operator()<std::deque<int>>("std::all_of(deque<int>) (process all)", std_all_of);
     bm.operator()<std::list<int>>("std::all_of(list<int>) (process all)", std_all_of);
-    bm.operator()<std::vector<int>>("rng::all_of(vector<int>) (process all)", ranges_all_of);
-    bm.operator()<std::deque<int>>("rng::all_of(deque<int>) (process all)", ranges_all_of);
-    bm.operator()<std::list<int>>("rng::all_of(list<int>) (process all)", ranges_all_of);
 
     // none_of
     bm.operator()<std::vector<int>>("std::none_of(vector<int>) (process all)", std_none_of);
     bm.operator()<std::deque<int>>("std::none_of(deque<int>) (process all)", std_none_of);
     bm.operator()<std::list<int>>("std::none_of(list<int>) (process all)", std_none_of);
-    bm.operator()<std::vector<int>>("rng::none_of(vector<int>) (process all)", ranges_none_of);
-    bm.operator()<std::deque<int>>("rng::none_of(deque<int>) (process all)", ranges_none_of);
-    bm.operator()<std::list<int>>("rng::none_of(list<int>) (process all)", ranges_none_of);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/count.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/count.bench.cpp
@@ -27,14 +27,6 @@ int main(int argc, char** argv) {
     });
   };
 
-  auto ranges_count = [](auto first, auto last, auto const& value) { return std::ranges::count(first, last, value); };
-  auto ranges_count_if = [](auto first, auto last, auto const& value) {
-    return std::ranges::count_if(first, last, [&](auto element) {
-      benchmark::DoNotOptimize(element);
-      return element == value;
-    });
-  };
-
   // Benchmark {std,ranges}::{count,count_if} on a sequence where every other element is counted.
   {
     auto bm = []<class Container>(std::string name, auto count) {
@@ -67,17 +59,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::count(vector<int>) (every other)", std_count);
     bm.operator()<std::deque<int>>("std::count(deque<int>) (every other)", std_count);
     bm.operator()<std::list<int>>("std::count(list<int>) (every other)", std_count);
-    bm.operator()<std::vector<int>>("rng::count(vector<int>) (every other)", ranges_count);
-    bm.operator()<std::deque<int>>("rng::count(deque<int>) (every other)", ranges_count);
-    bm.operator()<std::list<int>>("rng::count(list<int>) (every other)", ranges_count);
 
     // count_if
     bm.operator()<std::vector<int>>("std::count_if(vector<int>) (every other)", std_count_if);
     bm.operator()<std::deque<int>>("std::count_if(deque<int>) (every other)", std_count_if);
     bm.operator()<std::list<int>>("std::count_if(list<int>) (every other)", std_count_if);
-    bm.operator()<std::vector<int>>("rng::count_if(vector<int>) (every other)", ranges_count_if);
-    bm.operator()<std::deque<int>>("rng::count_if(deque<int>) (every other)", ranges_count_if);
-    bm.operator()<std::list<int>>("rng::count_if(list<int>) (every other)", ranges_count_if);
   }
 
   // Benchmark {std,ranges}::count(vector<bool>)
@@ -101,7 +87,6 @@ int main(int argc, char** argv) {
           ->Arg(1 << 20);
     };
     bm.operator()("std::count(vector<bool>)", std_count);
-    bm.operator()("rng::count(vector<bool>)", ranges_count);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/equal.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/equal.bench.cpp
@@ -37,13 +37,6 @@ int main(int argc, char** argv) {
       return x == y;
     });
   };
-  auto ranges_equal_4leg_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::ranges::equal(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
-  };
 
   // Benchmark {std,ranges}::equal where we determine inequality at the very end (worst case).
   {
@@ -87,17 +80,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::equal(vector<int>) (it, it, it, it)", std_equal_4leg);
     bm.operator()<std::deque<int>>("std::equal(deque<int>) (it, it, it, it)", std_equal_4leg);
     bm.operator()<std::list<int>>("std::equal(list<int>) (it, it, it, it)", std_equal_4leg);
-    bm.operator()<std::vector<int>>("rng::equal(vector<int>) (it, it, it, it)", std::ranges::equal);
-    bm.operator()<std::deque<int>>("rng::equal(deque<int>) (it, it, it, it)", std::ranges::equal);
-    bm.operator()<std::list<int>>("rng::equal(list<int>) (it, it, it, it)", std::ranges::equal);
 
     // {std,ranges}::equal(it, it, it, it, pred)
     bm.operator()<std::vector<int>>("std::equal(vector<int>) (it, it, it, it, pred)", std_equal_4leg_pred);
     bm.operator()<std::deque<int>>("std::equal(deque<int>) (it, it, it, it, pred)", std_equal_4leg_pred);
     bm.operator()<std::list<int>>("std::equal(list<int>) (it, it, it, it, pred)", std_equal_4leg_pred);
-    bm.operator()<std::vector<int>>("rng::equal(vector<int>) (it, it, it, it, pred)", ranges_equal_4leg_pred);
-    bm.operator()<std::deque<int>>("rng::equal(deque<int>) (it, it, it, it, pred)", ranges_equal_4leg_pred);
-    bm.operator()<std::list<int>>("rng::equal(list<int>) (it, it, it, it, pred)", ranges_equal_4leg_pred);
   }
 
   // Benchmark {std,ranges}::equal on vector<bool>.
@@ -129,11 +116,9 @@ int main(int argc, char** argv) {
 
     // {std,ranges}::equal(vector<bool>) (aligned)
     bm("std::equal(vector<bool>) (aligned)", std_equal_4leg, true);
-    bm("rng::equal(vector<bool>) (aligned)", std::ranges::equal, true);
 
     // {std,ranges}::equal(vector<bool>) (unaligned)
     bm("std::equal(vector<bool>) (unaligned)", std_equal_4leg, false);
-    bm("rng::equal(vector<bool>) (unaligned)", std::ranges::equal, false);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/find.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/find.bench.cpp
@@ -45,32 +45,17 @@ int main(int argc, char** argv) {
     bm.template operator()<std::deque<int>>("std::find(deque<int>) (" + comment + ")", std_find);
     bm.template operator()<std::list<int>>("std::find(list<int>) (" + comment + ")", std_find);
 
-    bm.template operator()<std::vector<char>>("rng::find(vector<char>) (" + comment + ")", ranges_find);
-    bm.template operator()<std::vector<int>>("rng::find(vector<int>) (" + comment + ")", ranges_find);
-    bm.template operator()<std::deque<int>>("rng::find(deque<int>) (" + comment + ")", ranges_find);
-    bm.template operator()<std::list<int>>("rng::find(list<int>) (" + comment + ")", ranges_find);
-
     // find_if
     bm.template operator()<std::vector<char>>("std::find_if(vector<char>) (" + comment + ")", std_find_if);
     bm.template operator()<std::vector<int>>("std::find_if(vector<int>) (" + comment + ")", std_find_if);
     bm.template operator()<std::deque<int>>("std::find_if(deque<int>) (" + comment + ")", std_find_if);
     bm.template operator()<std::list<int>>("std::find_if(list<int>) (" + comment + ")", std_find_if);
 
-    bm.template operator()<std::vector<char>>("rng::find_if(vector<char>) (" + comment + ")", ranges_find_if);
-    bm.template operator()<std::vector<int>>("rng::find_if(vector<int>) (" + comment + ")", ranges_find_if);
-    bm.template operator()<std::deque<int>>("rng::find_if(deque<int>) (" + comment + ")", ranges_find_if);
-    bm.template operator()<std::list<int>>("rng::find_if(list<int>) (" + comment + ")", ranges_find_if);
-
     // find_if_not
     bm.template operator()<std::vector<char>>("std::find_if_not(vector<char>) (" + comment + ")", std_find_if_not);
     bm.template operator()<std::vector<int>>("std::find_if_not(vector<int>) (" + comment + ")", std_find_if_not);
     bm.template operator()<std::deque<int>>("std::find_if_not(deque<int>) (" + comment + ")", std_find_if_not);
     bm.template operator()<std::list<int>>("std::find_if_not(list<int>) (" + comment + ")", std_find_if_not);
-
-    bm.template operator()<std::vector<char>>("rng::find_if_not(vector<char>) (" + comment + ")", ranges_find_if_not);
-    bm.template operator()<std::vector<int>>("rng::find_if_not(vector<int>) (" + comment + ")", ranges_find_if_not);
-    bm.template operator()<std::deque<int>>("rng::find_if_not(deque<int>) (" + comment + ")", ranges_find_if_not);
-    bm.template operator()<std::list<int>>("rng::find_if_not(list<int>) (" + comment + ")", ranges_find_if_not);
   };
 
   auto register_nested_container_benchmarks = [&](auto bm, std::string comment) {

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/find_end.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/find_end.bench.cpp
@@ -31,13 +31,6 @@ int main(int argc, char** argv) {
       return x == y;
     });
   };
-  auto ranges_find_end_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::ranges::find_end(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
-  };
 
   auto register_benchmarks = [&](auto bm, std::string comment) {
     // {std,ranges}::find_end(it1, it1, it2, it2)
@@ -45,11 +38,6 @@ int main(int argc, char** argv) {
     bm.template operator()<std::deque<int>>("std::find_end(deque<int>) (" + comment + ")", std_find_end);
     bm.template operator()<std::list<int>>("std::find_end(list<int>) (" + comment + ")", std_find_end);
     bm.template operator()<std::forward_list<int>>("std::find_end(forward_list<int>) (" + comment + ")", std_find_end);
-    bm.template operator()<std::vector<int>>("rng::find_end(vector<int>) (" + comment + ")", std::ranges::find_end);
-    bm.template operator()<std::deque<int>>("rng::find_end(deque<int>) (" + comment + ")", std::ranges::find_end);
-    bm.template operator()<std::list<int>>("rng::find_end(list<int>) (" + comment + ")", std::ranges::find_end);
-    bm.template operator()<std::forward_list<int>>(
-        "rng::find_end(forward_list<int>) (" + comment + ")", std::ranges::find_end);
 
     // {std,ranges}::find_end(it1, it1, it2, it2, pred)
     bm.template operator()<std::vector<int>>("std::find_end(vector<int>, pred) (" + comment + ")", std_find_end_pred);
@@ -57,12 +45,6 @@ int main(int argc, char** argv) {
     bm.template operator()<std::list<int>>("std::find_end(list<int>, pred) (" + comment + ")", std_find_end_pred);
     bm.template operator()<std::forward_list<int>>(
         "std::find_end(forward_list<int>, pred) (" + comment + ")", std_find_end_pred);
-    bm.template operator()<std::vector<int>>(
-        "rng::find_end(vector<int>, pred) (" + comment + ")", ranges_find_end_pred);
-    bm.template operator()<std::deque<int>>("rng::find_end(deque<int>, pred) (" + comment + ")", ranges_find_end_pred);
-    bm.template operator()<std::list<int>>("rng::find_end(list<int>, pred) (" + comment + ")", ranges_find_end_pred);
-    bm.template operator()<std::forward_list<int>>(
-        "rng::find_end(forward_list<int>, pred) (" + comment + ")", ranges_find_end_pred);
   };
 
   // Benchmark {std,ranges}::find_end where we never find the needle, which is the

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/find_first_of.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/find_first_of.bench.cpp
@@ -30,13 +30,6 @@ int main(int argc, char** argv) {
       return x == y;
     });
   };
-  auto ranges_find_first_of_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::ranges::find_first_of(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
-  };
 
   // Benchmark {std,ranges}::find_first_of where we never find a match in the needle, and the needle is small.
   // This is the worst case of the most common case (a small needle).
@@ -68,17 +61,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::find_first_of(vector<int>) (small needle)", std_find_first_of);
     bm.operator()<std::deque<int>>("std::find_first_of(deque<int>) (small needle)", std_find_first_of);
     bm.operator()<std::list<int>>("std::find_first_of(list<int>) (small needle)", std_find_first_of);
-    bm.operator()<std::vector<int>>("rng::find_first_of(vector<int>) (small needle)", std::ranges::find_first_of);
-    bm.operator()<std::deque<int>>("rng::find_first_of(deque<int>) (small needle)", std::ranges::find_first_of);
-    bm.operator()<std::list<int>>("rng::find_first_of(list<int>) (small needle)", std::ranges::find_first_of);
 
     // {std,ranges}::find_first_of(it1, it1, it2, it2, pred)
     bm.operator()<std::vector<int>>("std::find_first_of(vector<int>, pred) (small needle)", std_find_first_of_pred);
     bm.operator()<std::deque<int>>("std::find_first_of(deque<int>, pred) (small needle)", std_find_first_of_pred);
     bm.operator()<std::list<int>>("std::find_first_of(list<int>, pred) (small needle)", std_find_first_of_pred);
-    bm.operator()<std::vector<int>>("rng::find_first_of(vector<int>, pred) (small needle)", ranges_find_first_of_pred);
-    bm.operator()<std::deque<int>>("rng::find_first_of(deque<int>, pred) (small needle)", ranges_find_first_of_pred);
-    bm.operator()<std::list<int>>("rng::find_first_of(list<int>, pred) (small needle)", ranges_find_first_of_pred);
   }
 
   // Special case: the needle is large compared to the haystack, and we find a match early in the haystack.
@@ -113,17 +100,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::find_first_of(vector<int>) (large needle)", std_find_first_of);
     bm.operator()<std::deque<int>>("std::find_first_of(deque<int>) (large needle)", std_find_first_of);
     bm.operator()<std::list<int>>("std::find_first_of(list<int>) (large needle)", std_find_first_of);
-    bm.operator()<std::vector<int>>("rng::find_first_of(vector<int>) (large needle)", std::ranges::find_first_of);
-    bm.operator()<std::deque<int>>("rng::find_first_of(deque<int>) (large needle)", std::ranges::find_first_of);
-    bm.operator()<std::list<int>>("rng::find_first_of(list<int>) (large needle)", std::ranges::find_first_of);
 
     // {std,ranges}::find_first_of(it1, it1, it2, it2, pred)
     bm.operator()<std::vector<int>>("std::find_first_of(vector<int>, pred) (large needle)", std_find_first_of_pred);
     bm.operator()<std::deque<int>>("std::find_first_of(deque<int>, pred) (large needle)", std_find_first_of_pred);
     bm.operator()<std::list<int>>("std::find_first_of(list<int>, pred) (large needle)", std_find_first_of_pred);
-    bm.operator()<std::vector<int>>("rng::find_first_of(vector<int>, pred) (large needle)", ranges_find_first_of_pred);
-    bm.operator()<std::deque<int>>("rng::find_first_of(deque<int>, pred) (large needle)", ranges_find_first_of_pred);
-    bm.operator()<std::list<int>>("rng::find_first_of(list<int>, pred) (large needle)", ranges_find_first_of_pred);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/for_each.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/for_each.bench.cpp
@@ -50,9 +50,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::for_each(vector<int>)", std_for_each);
     bm.operator()<std::deque<int>>("std::for_each(deque<int>)", std_for_each);
     bm.operator()<std::list<int>>("std::for_each(list<int>)", std_for_each);
-    bm.operator()<std::vector<int>>("rng::for_each(vector<int>)", std::ranges::for_each);
-    bm.operator()<std::deque<int>>("rng::for_each(deque<int>)", std::ranges::for_each);
-    bm.operator()<std::list<int>>("rng::for_each(list<int>)", std::ranges::for_each);
   }
 
   // std::{,range::}for_each for associative containers
@@ -80,11 +77,11 @@ int main(int argc, char** argv) {
           ->Arg(50) // non power-of-two
           ->Arg(8192);
     };
-    iterator_bm(std::type_identity<std::set<int>>{}, std::false_type{}, "rng::for_each(set<int>::iterator)");
-    iterator_bm(std::type_identity<std::multiset<int>>{}, std::false_type{}, "rng::for_each(multiset<int>::iterator)");
-    iterator_bm(std::type_identity<std::map<int, int>>{}, std::true_type{}, "rng::for_each(map<int>::iterator)");
+    iterator_bm(std::type_identity<std::set<int>>{}, std::false_type{}, "std::for_each(set<int>::iterator)");
+    iterator_bm(std::type_identity<std::multiset<int>>{}, std::false_type{}, "std::for_each(multiset<int>::iterator)");
+    iterator_bm(std::type_identity<std::map<int, int>>{}, std::true_type{}, "std::for_each(map<int>::iterator)");
     iterator_bm(
-        std::type_identity<std::multimap<int, int>>{}, std::true_type{}, "rng::for_each(multimap<int>::iterator)");
+        std::type_identity<std::multimap<int, int>>{}, std::true_type{}, "std::for_each(multimap<int>::iterator)");
 
     auto container_bm = []<class Container, bool IsMapLike>(
                             std::type_identity<Container>, std::bool_constant<IsMapLike>, std::string name) {
@@ -150,7 +147,6 @@ int main(int argc, char** argv) {
           ->Arg(8192);
     };
     bm.operator()<std::vector<std::vector<int>>>("std::for_each(join_view(vector<vector<int>>))", std_for_each);
-    bm.operator()<std::vector<std::vector<int>>>("rng::for_each(join_view(vector<vector<int>>)", std::ranges::for_each);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/for_each_n.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/for_each_n.bench.cpp
@@ -46,9 +46,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::for_each_n(vector<int>)", std_for_each_n);
     bm.operator()<std::deque<int>>("std::for_each_n(deque<int>)", std_for_each_n);
     bm.operator()<std::list<int>>("std::for_each_n(list<int>)", std_for_each_n);
-    bm.operator()<std::vector<int>>("rng::for_each_n(vector<int>)", std::ranges::for_each_n);
-    bm.operator()<std::deque<int>>("rng::for_each_n(deque<int>)", std::ranges::for_each_n);
-    bm.operator()<std::list<int>>("rng::for_each_n(list<int>)", std::ranges::for_each_n);
   }
 
   // {std,ranges}::for_each_n for join_view
@@ -82,8 +79,6 @@ int main(int argc, char** argv) {
           ->Arg(8192);
     };
     bm.operator()<std::vector<std::vector<int>>>("std::for_each_n(join_view(vector<vector<int>>))", std_for_each_n);
-    bm.operator()<std::vector<std::vector<int>>>(
-        "rng::for_each_n(join_view(vector<vector<int>>)", std::ranges::for_each_n);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/is_permutation.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/is_permutation.bench.cpp
@@ -40,13 +40,6 @@ int main(int argc, char** argv) {
       return x == y;
     });
   };
-  auto ranges_is_permutation_4leg_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::ranges::is_permutation(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
-  };
 
   auto register_benchmarks = [&](auto bm, std::string comment) {
     // std::is_permutation(it, it, it)
@@ -72,12 +65,6 @@ int main(int argc, char** argv) {
         "std::is_permutation(deque<int>) (4leg) (" + comment + ")", std_is_permutation_4leg);
     bm.template operator()<std::list<int>>(
         "std::is_permutation(list<int>) (4leg) (" + comment + ")", std_is_permutation_4leg);
-    bm.template operator()<std::vector<int>>(
-        "rng::is_permutation(vector<int>) (4leg) (" + comment + ")", std::ranges::is_permutation);
-    bm.template operator()<std::deque<int>>(
-        "rng::is_permutation(deque<int>) (4leg) (" + comment + ")", std::ranges::is_permutation);
-    bm.template operator()<std::list<int>>(
-        "rng::is_permutation(list<int>) (4leg) (" + comment + ")", std::ranges::is_permutation);
 
     // {std,ranges}::is_permutation(it, it, it, it, pred)
     bm.template operator()<std::vector<int>>(
@@ -86,12 +73,6 @@ int main(int argc, char** argv) {
         "std::is_permutation(deque<int>) (4leg, pred) (" + comment + ")", std_is_permutation_4leg_pred);
     bm.template operator()<std::list<int>>(
         "std::is_permutation(list<int>) (4leg, pred) (" + comment + ")", std_is_permutation_4leg_pred);
-    bm.template operator()<std::vector<int>>(
-        "rng::is_permutation(vector<int>) (4leg, pred) (" + comment + ")", ranges_is_permutation_4leg_pred);
-    bm.template operator()<std::deque<int>>(
-        "rng::is_permutation(deque<int>) (4leg, pred) (" + comment + ")", ranges_is_permutation_4leg_pred);
-    bm.template operator()<std::list<int>>(
-        "rng::is_permutation(list<int>) (4leg, pred) (" + comment + ")", ranges_is_permutation_4leg_pred);
   };
 
   // Benchmark {std,ranges}::is_permutation where both sequences share a common prefix (this can be optimized).

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/mismatch.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/mismatch.bench.cpp
@@ -39,13 +39,6 @@ int main(int argc, char** argv) {
       return x == y;
     });
   };
-  auto ranges_mismatch_4leg_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::ranges::mismatch(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
-  };
 
   // Benchmark {std,ranges}::mismatch where we find the mismatching element at the very end (worst case).
   //
@@ -92,17 +85,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::mismatch(vector<int>) (it, it, it, it)", std_mismatch_4leg);
     bm.operator()<std::deque<int>>("std::mismatch(deque<int>) (it, it, it, it)", std_mismatch_4leg);
     bm.operator()<std::list<int>>("std::mismatch(list<int>) (it, it, it, it)", std_mismatch_4leg);
-    bm.operator()<std::vector<int>>("rng::mismatch(vector<int>) (it, it, it, it)", std::ranges::mismatch);
-    bm.operator()<std::deque<int>>("rng::mismatch(deque<int>) (it, it, it, it)", std::ranges::mismatch);
-    bm.operator()<std::list<int>>("rng::mismatch(list<int>) (it, it, it, it)", std::ranges::mismatch);
 
     // {std,ranges}::mismatch(it, it, it, it, pred)
     bm.operator()<std::vector<int>>("std::mismatch(vector<int>) (it, it, it, it, pred)", std_mismatch_4leg_pred);
     bm.operator()<std::deque<int>>("std::mismatch(deque<int>) (it, it, it, it, pred)", std_mismatch_4leg_pred);
     bm.operator()<std::list<int>>("std::mismatch(list<int>) (it, it, it, it, pred)", std_mismatch_4leg_pred);
-    bm.operator()<std::vector<int>>("rng::mismatch(vector<int>) (it, it, it, it, pred)", ranges_mismatch_4leg_pred);
-    bm.operator()<std::deque<int>>("rng::mismatch(deque<int>) (it, it, it, it, pred)", ranges_mismatch_4leg_pred);
-    bm.operator()<std::list<int>>("rng::mismatch(list<int>) (it, it, it, it, pred)", ranges_mismatch_4leg_pred);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/search.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/search.bench.cpp
@@ -30,13 +30,6 @@ int main(int argc, char** argv) {
       return x == y;
     });
   };
-  auto ranges_search_pred = [](auto first1, auto last1, auto first2, auto last2) {
-    return std::ranges::search(first1, last1, first2, last2, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
-  };
 
   // Benchmark {std,ranges}::search where the needle is never found (worst case).
   {
@@ -67,17 +60,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::search(vector<int>) (no match)", std_search);
     bm.operator()<std::deque<int>>("std::search(deque<int>) (no match)", std_search);
     bm.operator()<std::list<int>>("std::search(list<int>) (no match)", std_search);
-    bm.operator()<std::vector<int>>("rng::search(vector<int>) (no match)", std::ranges::search);
-    bm.operator()<std::deque<int>>("rng::search(deque<int>) (no match)", std::ranges::search);
-    bm.operator()<std::list<int>>("rng::search(list<int>) (no match)", std::ranges::search);
 
     // {std,ranges}::search(pred)
     bm.operator()<std::vector<int>>("std::search(vector<int>, pred) (no match)", std_search_pred);
     bm.operator()<std::deque<int>>("std::search(deque<int>, pred) (no match)", std_search_pred);
     bm.operator()<std::list<int>>("std::search(list<int>, pred) (no match)", std_search_pred);
-    bm.operator()<std::vector<int>>("rng::search(vector<int>, pred) (no match)", ranges_search_pred);
-    bm.operator()<std::deque<int>>("rng::search(deque<int>, pred) (no match)", ranges_search_pred);
-    bm.operator()<std::list<int>>("rng::search(list<int>, pred) (no match)", ranges_search_pred);
   }
 
   // Benchmark {std,ranges}::search where we intersperse "near matches" inside the haystack.
@@ -119,17 +106,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::search(vector<int>) (near matches)", std_search);
     bm.operator()<std::deque<int>>("std::search(deque<int>) (near matches)", std_search);
     bm.operator()<std::list<int>>("std::search(list<int>) (near matches)", std_search);
-    bm.operator()<std::vector<int>>("rng::search(vector<int>) (near matches)", std::ranges::search);
-    bm.operator()<std::deque<int>>("rng::search(deque<int>) (near matches)", std::ranges::search);
-    bm.operator()<std::list<int>>("rng::search(list<int>) (near matches)", std::ranges::search);
 
     // {std,ranges}::search(pred)
     bm.operator()<std::vector<int>>("std::search(vector<int>, pred) (near matches)", std_search_pred);
     bm.operator()<std::deque<int>>("std::search(deque<int>, pred) (near matches)", std_search_pred);
     bm.operator()<std::list<int>>("std::search(list<int>, pred) (near matches)", std_search_pred);
-    bm.operator()<std::vector<int>>("rng::search(vector<int>, pred) (near matches)", ranges_search_pred);
-    bm.operator()<std::deque<int>>("rng::search(deque<int>, pred) (near matches)", ranges_search_pred);
-    bm.operator()<std::list<int>>("rng::search(list<int>, pred) (near matches)", ranges_search_pred);
   }
 
   // Special case: the two ranges are the same length (and they are equal, which is the worst case).
@@ -159,17 +140,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::search(vector<int>) (same length)", std_search);
     bm.operator()<std::deque<int>>("std::search(deque<int>) (same length)", std_search);
     bm.operator()<std::list<int>>("std::search(list<int>) (same length)", std_search);
-    bm.operator()<std::vector<int>>("rng::search(vector<int>) (same length)", std::ranges::search);
-    bm.operator()<std::deque<int>>("rng::search(deque<int>) (same length)", std::ranges::search);
-    bm.operator()<std::list<int>>("rng::search(list<int>) (same length)", std::ranges::search);
 
     // {std,ranges}::search(pred)
     bm.operator()<std::vector<int>>("std::search(vector<int>, pred) (same length)", std_search_pred);
     bm.operator()<std::deque<int>>("std::search(deque<int>, pred) (same length)", std_search_pred);
     bm.operator()<std::list<int>>("std::search(list<int>, pred) (same length)", std_search_pred);
-    bm.operator()<std::vector<int>>("rng::search(vector<int>, pred) (same length)", ranges_search_pred);
-    bm.operator()<std::deque<int>>("rng::search(deque<int>, pred) (same length)", ranges_search_pred);
-    bm.operator()<std::list<int>>("rng::search(list<int>, pred) (same length)", ranges_search_pred);
   }
 
   // Special case: the needle contains a single element (which we never find, i.e. the worst case).
@@ -200,17 +175,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::search(vector<int>) (single element)", std_search);
     bm.operator()<std::deque<int>>("std::search(deque<int>) (single element)", std_search);
     bm.operator()<std::list<int>>("std::search(list<int>) (single element)", std_search);
-    bm.operator()<std::vector<int>>("rng::search(vector<int>) (single element)", std::ranges::search);
-    bm.operator()<std::deque<int>>("rng::search(deque<int>) (single element)", std::ranges::search);
-    bm.operator()<std::list<int>>("rng::search(list<int>) (single element)", std::ranges::search);
 
     // {std,ranges}::search(pred)
     bm.operator()<std::vector<int>>("std::search(vector<int>, pred) (single element)", std_search_pred);
     bm.operator()<std::deque<int>>("std::search(deque<int>, pred) (single element)", std_search_pred);
     bm.operator()<std::list<int>>("std::search(list<int>, pred) (single element)", std_search_pred);
-    bm.operator()<std::vector<int>>("rng::search(vector<int>, pred) (single element)", ranges_search_pred);
-    bm.operator()<std::deque<int>>("rng::search(deque<int>, pred) (single element)", ranges_search_pred);
-    bm.operator()<std::list<int>>("rng::search(list<int>, pred) (single element)", ranges_search_pred);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/nonmodifying/search_n.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/nonmodifying/search_n.bench.cpp
@@ -30,13 +30,6 @@ int main(int argc, char** argv) {
       return x == y;
     });
   };
-  auto ranges_search_n_pred = [](auto first, auto last, auto n, auto const& value) {
-    return std::ranges::search_n(first, last, n, value, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x == y;
-    });
-  };
 
   // Benchmark {std,ranges}::search_n where the needle is never found (worst case).
   {
@@ -67,17 +60,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::search_n(vector<int>) (no match)", std_search_n);
     bm.operator()<std::deque<int>>("std::search_n(deque<int>) (no match)", std_search_n);
     bm.operator()<std::list<int>>("std::search_n(list<int>) (no match)", std_search_n);
-    bm.operator()<std::vector<int>>("rng::search_n(vector<int>) (no match)", std::ranges::search_n);
-    bm.operator()<std::deque<int>>("rng::search_n(deque<int>) (no match)", std::ranges::search_n);
-    bm.operator()<std::list<int>>("rng::search_n(list<int>) (no match)", std::ranges::search_n);
 
     // {std,ranges}::search_n(pred)
     bm.operator()<std::vector<int>>("std::search_n(vector<int>, pred) (no match)", std_search_n_pred);
     bm.operator()<std::deque<int>>("std::search_n(deque<int>, pred) (no match)", std_search_n_pred);
     bm.operator()<std::list<int>>("std::search_n(list<int>, pred) (no match)", std_search_n_pred);
-    bm.operator()<std::vector<int>>("rng::search_n(vector<int>, pred) (no match)", ranges_search_n_pred);
-    bm.operator()<std::deque<int>>("rng::search_n(deque<int>, pred) (no match)", ranges_search_n_pred);
-    bm.operator()<std::list<int>>("rng::search_n(list<int>, pred) (no match)", ranges_search_n_pred);
   }
 
   // Benchmark {std,ranges}::search_n where the needle almost matches a lot.
@@ -114,17 +101,11 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::search_n(vector<int>) (no match)", std_search_n);
     bm.operator()<std::deque<int>>("std::search_n(deque<int>) (no match)", std_search_n);
     bm.operator()<std::list<int>>("std::search_n(list<int>) (no match)", std_search_n);
-    bm.operator()<std::vector<int>>("rng::search_n(vector<int>) (no match)", std::ranges::search_n);
-    bm.operator()<std::deque<int>>("rng::search_n(deque<int>) (no match)", std::ranges::search_n);
-    bm.operator()<std::list<int>>("rng::search_n(list<int>) (no match)", std::ranges::search_n);
 
     // {std,ranges}::search_n(pred)
     bm.operator()<std::vector<int>>("std::search_n(vector<int>, pred) (no match)", std_search_n_pred);
     bm.operator()<std::deque<int>>("std::search_n(deque<int>, pred) (no match)", std_search_n_pred);
     bm.operator()<std::list<int>>("std::search_n(list<int>, pred) (no match)", std_search_n_pred);
-    bm.operator()<std::vector<int>>("rng::search_n(vector<int>, pred) (no match)", ranges_search_n_pred);
-    bm.operator()<std::deque<int>>("rng::search_n(deque<int>, pred) (no match)", ranges_search_n_pred);
-    bm.operator()<std::list<int>>("rng::search_n(list<int>, pred) (no match)", ranges_search_n_pred);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/partitions/is_partitioned.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/partitions/is_partitioned.bench.cpp
@@ -78,17 +78,6 @@ int main(int argc, char** argv) {
   bm.operator()<std::list<int>, true>("std::is_partitioned(list<int>) (partitioned)", std_is_partitioned);
   bm.operator()<std::list<int>, false>("std::is_partitioned(list<int>) (unpartitioned)", std_is_partitioned);
 
-  // ranges::is_partitioned
-  bm.operator()<std::vector<int>, true>("rng::is_partitioned(vector<int>) (partitioned)", std::ranges::is_partitioned);
-  bm.operator()<std::vector<int>, false>(
-      "rng::is_partitioned(vector<int>) (unpartitioned)", std::ranges::is_partitioned);
-
-  bm.operator()<std::deque<int>, true>("rng::is_partitioned(deque<int>) (partitioned)", std::ranges::is_partitioned);
-  bm.operator()<std::deque<int>, false>("rng::is_partitioned(deque<int>) (unpartitioned)", std::ranges::is_partitioned);
-
-  bm.operator()<std::list<int>, true>("rng::is_partitioned(list<int>) (partitioned)", std::ranges::is_partitioned);
-  bm.operator()<std::list<int>, false>("rng::is_partitioned(list<int>) (unpartitioned)", std::ranges::is_partitioned);
-
   benchmark::Initialize(&argc, argv);
   benchmark::RunSpecifiedBenchmarks();
   benchmark::Shutdown();

--- a/libcxx/test/benchmarks/algorithms/partitions/partition.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/partitions/partition.bench.cpp
@@ -71,11 +71,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::partition(vector<int>) (dense)", std_partition);
     bm.operator()<std::deque<int>>("std::partition(deque<int>) (dense)", std_partition);
     bm.operator()<std::list<int>>("std::partition(list<int>) (dense)", std_partition);
-
-    // ranges::partition
-    bm.operator()<std::vector<int>>("rng::partition(vector<int>) (dense)", std::ranges::partition);
-    bm.operator()<std::deque<int>>("rng::partition(deque<int>) (dense)", std::ranges::partition);
-    bm.operator()<std::list<int>>("rng::partition(list<int>) (dense)", std::ranges::partition);
   }
 
   // Benchmark {std,ranges}::partition on a mostly partitioned sequence, i.e. only 10% of the elements
@@ -119,11 +114,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::partition(vector<int>) (sparse)", std_partition);
     bm.operator()<std::deque<int>>("std::partition(deque<int>) (sparse)", std_partition);
     bm.operator()<std::list<int>>("std::partition(list<int>) (sparse)", std_partition);
-
-    // ranges::partition
-    bm.operator()<std::vector<int>>("rng::partition(vector<int>) (sparse)", std::ranges::partition);
-    bm.operator()<std::deque<int>>("rng::partition(deque<int>) (sparse)", std::ranges::partition);
-    bm.operator()<std::list<int>>("rng::partition(list<int>) (sparse)", std::ranges::partition);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/partitions/partition_copy.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/partitions/partition_copy.bench.cpp
@@ -64,11 +64,6 @@ int main(int argc, char** argv) {
   bm.operator()<std::deque<int>>("std::partition_copy(deque<int>)", std_partition_copy);
   bm.operator()<std::list<int>>("std::partition_copy(list<int>)", std_partition_copy);
 
-  // ranges::partition_copy
-  bm.operator()<std::vector<int>>("rng::partition_copy(vector<int>)", std::ranges::partition_copy);
-  bm.operator()<std::deque<int>>("rng::partition_copy(deque<int>)", std::ranges::partition_copy);
-  bm.operator()<std::list<int>>("rng::partition_copy(list<int>)", std::ranges::partition_copy);
-
   benchmark::Initialize(&argc, argv);
   benchmark::RunSpecifiedBenchmarks();
   benchmark::Shutdown();

--- a/libcxx/test/benchmarks/algorithms/partitions/partition_point.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/partitions/partition_point.bench.cpp
@@ -62,11 +62,6 @@ int main(int argc, char** argv) {
   bm.operator()<std::deque<int>>("std::partition_point(deque<int>)", std_partition_point);
   bm.operator()<std::list<int>>("std::partition_point(list<int>)", std_partition_point);
 
-  // ranges::partition_point
-  bm.operator()<std::vector<int>>("rng::partition_point(vector<int>)", std::ranges::partition_point);
-  bm.operator()<std::deque<int>>("rng::partition_point(deque<int>)", std::ranges::partition_point);
-  bm.operator()<std::list<int>>("rng::partition_point(list<int>)", std::ranges::partition_point);
-
   benchmark::Initialize(&argc, argv);
   benchmark::RunSpecifiedBenchmarks();
   benchmark::Shutdown();

--- a/libcxx/test/benchmarks/algorithms/partitions/stable_partition.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/partitions/stable_partition.bench.cpp
@@ -71,11 +71,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::stable_partition(vector<int>) (dense)", std_stable_partition);
     bm.operator()<std::deque<int>>("std::stable_partition(deque<int>) (dense)", std_stable_partition);
     bm.operator()<std::list<int>>("std::stable_partition(list<int>) (dense)", std_stable_partition);
-
-    // ranges::stable_partition
-    bm.operator()<std::vector<int>>("rng::stable_partition(vector<int>) (dense)", std::ranges::stable_partition);
-    bm.operator()<std::deque<int>>("rng::stable_partition(deque<int>) (dense)", std::ranges::stable_partition);
-    bm.operator()<std::list<int>>("rng::stable_partition(list<int>) (dense)", std::ranges::stable_partition);
   }
 
   // Benchmark {std,ranges}::stable_partition on a mostly partitioned sequence, i.e. only 10% of the elements
@@ -119,11 +114,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::stable_partition(vector<int>) (sparse)", std_stable_partition);
     bm.operator()<std::deque<int>>("std::stable_partition(deque<int>) (sparse)", std_stable_partition);
     bm.operator()<std::list<int>>("std::stable_partition(list<int>) (sparse)", std_stable_partition);
-
-    // ranges::stable_partition
-    bm.operator()<std::vector<int>>("rng::stable_partition(vector<int>) (sparse)", std::ranges::stable_partition);
-    bm.operator()<std::deque<int>>("rng::stable_partition(deque<int>) (sparse)", std::ranges::stable_partition);
-    bm.operator()<std::list<int>>("rng::stable_partition(list<int>) (sparse)", std::ranges::stable_partition);
   }
 
   // Benchmark {std,ranges}::stable_partition when memory allocation fails. The algorithm must fall back to
@@ -169,11 +159,6 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::stable_partition(vector<int>) (alloc fails)", std_stable_partition);
     bm.operator()<std::deque<int>>("std::stable_partition(deque<int>) (alloc fails)", std_stable_partition);
     bm.operator()<std::list<int>>("std::stable_partition(list<int>) (alloc fails)", std_stable_partition);
-
-    // ranges::stable_partition
-    bm.operator()<std::vector<int>>("rng::stable_partition(vector<int>) (alloc fails)", std::ranges::stable_partition);
-    bm.operator()<std::deque<int>>("rng::stable_partition(deque<int>) (alloc fails)", std::ranges::stable_partition);
-    bm.operator()<std::list<int>>("rng::stable_partition(list<int>) (alloc fails)", std::ranges::stable_partition);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/sorting/is_sorted.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/sorting/is_sorted.bench.cpp
@@ -28,13 +28,6 @@ int main(int argc, char** argv) {
       return x < y;
     });
   };
-  auto ranges_is_sorted_pred = [](auto first, auto last) {
-    return std::ranges::is_sorted(first, last, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x < y;
-    });
-  };
 
   // Benchmark {std,ranges}::is_sorted on a sorted sequence (the worst case).
   {
@@ -63,16 +56,10 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::is_sorted(vector<int>)", std_is_sorted);
     bm.operator()<std::deque<int>>("std::is_sorted(deque<int>)", std_is_sorted);
     bm.operator()<std::list<int>>("std::is_sorted(list<int>)", std_is_sorted);
-    bm.operator()<std::vector<int>>("rng::is_sorted(vector<int>)", std::ranges::is_sorted);
-    bm.operator()<std::deque<int>>("rng::is_sorted(deque<int>)", std::ranges::is_sorted);
-    bm.operator()<std::list<int>>("rng::is_sorted(list<int>)", std::ranges::is_sorted);
 
     bm.operator()<std::vector<int>>("std::is_sorted(vector<int>, pred)", std_is_sorted_pred);
     bm.operator()<std::deque<int>>("std::is_sorted(deque<int>, pred)", std_is_sorted_pred);
     bm.operator()<std::list<int>>("std::is_sorted(list<int>, pred)", std_is_sorted_pred);
-    bm.operator()<std::vector<int>>("rng::is_sorted(vector<int>, pred)", ranges_is_sorted_pred);
-    bm.operator()<std::deque<int>>("rng::is_sorted(deque<int>, pred)", ranges_is_sorted_pred);
-    bm.operator()<std::list<int>>("rng::is_sorted(list<int>, pred)", ranges_is_sorted_pred);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/sorting/is_sorted_until.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/sorting/is_sorted_until.bench.cpp
@@ -28,13 +28,6 @@ int main(int argc, char** argv) {
       return x < y;
     });
   };
-  auto ranges_is_sorted_until_pred = [](auto first, auto last) {
-    return std::ranges::is_sorted_until(first, last, [](auto x, auto y) {
-      benchmark::DoNotOptimize(x);
-      benchmark::DoNotOptimize(y);
-      return x < y;
-    });
-  };
 
   // Benchmark {std,ranges}::is_sorted_until on a sorted sequence (the worst case).
   {
@@ -63,16 +56,10 @@ int main(int argc, char** argv) {
     bm.operator()<std::vector<int>>("std::is_sorted_until(vector<int>)", std_is_sorted_until);
     bm.operator()<std::deque<int>>("std::is_sorted_until(deque<int>)", std_is_sorted_until);
     bm.operator()<std::list<int>>("std::is_sorted_until(list<int>)", std_is_sorted_until);
-    bm.operator()<std::vector<int>>("rng::is_sorted_until(vector<int>)", std::ranges::is_sorted_until);
-    bm.operator()<std::deque<int>>("rng::is_sorted_until(deque<int>)", std::ranges::is_sorted_until);
-    bm.operator()<std::list<int>>("rng::is_sorted_until(list<int>)", std::ranges::is_sorted_until);
 
     bm.operator()<std::vector<int>>("std::is_sorted_until(vector<int>, pred)", std_is_sorted_until_pred);
     bm.operator()<std::deque<int>>("std::is_sorted_until(deque<int>, pred)", std_is_sorted_until_pred);
     bm.operator()<std::list<int>>("std::is_sorted_until(list<int>, pred)", std_is_sorted_until_pred);
-    bm.operator()<std::vector<int>>("rng::is_sorted_until(vector<int>, pred)", ranges_is_sorted_until_pred);
-    bm.operator()<std::deque<int>>("rng::is_sorted_until(deque<int>, pred)", ranges_is_sorted_until_pred);
-    bm.operator()<std::list<int>>("rng::is_sorted_until(list<int>, pred)", ranges_is_sorted_until_pred);
   }
 
   benchmark::Initialize(&argc, argv);

--- a/libcxx/test/benchmarks/algorithms/sorting/partial_sort.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/sorting/partial_sort.bench.cpp
@@ -72,11 +72,6 @@ int main(int argc, char** argv) {
       bm.operator()<std::vector<support::NonIntegral>>(
           name("std::partial_sort(vector<NonIntegral>)"), std_partial_sort, gen2);
       bm.operator()<std::deque<int>>(name("std::partial_sort(deque<int>)"), std_partial_sort, generate);
-
-      bm.operator()<std::vector<int>>(name("rng::partial_sort(vector<int>)"), std::ranges::partial_sort, generate);
-      bm.operator()<std::vector<support::NonIntegral>>(
-          name("rng::partial_sort(vector<NonIntegral>)"), std::ranges::partial_sort, gen2);
-      bm.operator()<std::deque<int>>(name("rng::partial_sort(deque<int>)"), std::ranges::partial_sort, generate);
     };
 
     register_bm(support::quicksort_adversarial_data<int>, "qsort adversarial");

--- a/libcxx/test/benchmarks/algorithms/sorting/partial_sort_copy.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/sorting/partial_sort_copy.bench.cpp
@@ -63,15 +63,6 @@ int main(int argc, char** argv) {
           name("std::partial_sort_copy(vector<NonIntegral>)"), std_partial_sort_copy, gen2);
       bm.operator()<std::deque<int>>(name("std::partial_sort_copy(deque<int>)"), std_partial_sort_copy, generate);
       bm.operator()<std::list<int>>(name("std::partial_sort_copy(list<int>)"), std_partial_sort_copy, generate);
-
-      bm.operator()<std::vector<int>>(
-          name("rng::partial_sort_copy(vector<int>)"), std::ranges::partial_sort_copy, generate);
-      bm.operator()<std::vector<support::NonIntegral>>(
-          name("rng::partial_sort_copy(vector<NonIntegral>)"), std::ranges::partial_sort_copy, gen2);
-      bm.operator()<std::deque<int>>(
-          name("rng::partial_sort_copy(deque<int>)"), std::ranges::partial_sort_copy, generate);
-      bm.operator()<std::list<int>>(
-          name("rng::partial_sort_copy(list<int>)"), std::ranges::partial_sort_copy, generate);
     };
 
     register_bm(support::quicksort_adversarial_data<int>, "qsort adversarial");

--- a/libcxx/test/benchmarks/algorithms/sorting/sort.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/sorting/sort.bench.cpp
@@ -69,10 +69,6 @@ int main(int argc, char** argv) {
       bm.operator()<std::vector<int>>(name("std::sort(vector<int>)"), std_sort, generate);
       bm.operator()<std::vector<support::NonIntegral>>(name("std::sort(vector<NonIntegral>)"), std_sort, gen2);
       bm.operator()<std::deque<int>>(name("std::sort(deque<int>)"), std_sort, generate);
-
-      bm.operator()<std::vector<int>>(name("rng::sort(vector<int>)"), std::ranges::sort, generate);
-      bm.operator()<std::vector<support::NonIntegral>>(name("rng::sort(vector<NonIntegral>)"), std::ranges::sort, gen2);
-      bm.operator()<std::deque<int>>(name("rng::sort(deque<int>)"), std::ranges::sort, generate);
     };
 
     register_bm(support::quicksort_adversarial_data<int>, "qsort adversarial");

--- a/libcxx/test/benchmarks/algorithms/sorting/stable_sort.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/sorting/stable_sort.bench.cpp
@@ -71,11 +71,6 @@ int main(int argc, char** argv) {
       bm.operator()<std::vector<support::NonIntegral>>(
           name("std::stable_sort(vector<NonIntegral>)"), std_stable_sort, gen2);
       bm.operator()<std::deque<int>>(name("std::stable_sort(deque<int>)"), std_stable_sort, generate);
-
-      bm.operator()<std::vector<int>>(name("rng::stable_sort(vector<int>)"), std::ranges::stable_sort, generate);
-      bm.operator()<std::vector<support::NonIntegral>>(
-          name("rng::stable_sort(vector<NonIntegral>)"), std::ranges::stable_sort, gen2);
-      bm.operator()<std::deque<int>>(name("rng::stable_sort(deque<int>)"), std::ranges::stable_sort, generate);
     };
 
     register_bm(support::quicksort_adversarial_data<int>, "qsort adversarial");
@@ -136,11 +131,6 @@ int main(int argc, char** argv) {
       bm.operator()<std::vector<support::NonIntegral>>(
           name("std::stable_sort(vector<NonIntegral>)"), std_stable_sort, gen2);
       bm.operator()<std::deque<int>>(name("std::stable_sort(deque<int>)"), std_stable_sort, generate);
-
-      bm.operator()<std::vector<int>>(name("rng::stable_sort(vector<int>)"), std::ranges::stable_sort, generate);
-      bm.operator()<std::vector<support::NonIntegral>>(
-          name("rng::stable_sort(vector<NonIntegral>)"), std::ranges::stable_sort, gen2);
-      bm.operator()<std::deque<int>>(name("rng::stable_sort(deque<int>)"), std::ranges::stable_sort, generate);
     };
 
     register_bm(support::quicksort_adversarial_data<int>, "qsort adversarial");

--- a/libcxx/test/benchmarks/iterators/distance.bench.cpp
+++ b/libcxx/test/benchmarks/iterators/distance.bench.cpp
@@ -41,7 +41,6 @@ int main(int argc, char** argv) {
           ->Arg(8192);
     };
     bm.operator()("std::distance(deque<int>)", std_distance);
-    bm.operator()("rng::distance(deque<int>)", std::ranges::distance);
   }
 
   // {std,ranges}::distance(std::join_view)
@@ -73,8 +72,6 @@ int main(int argc, char** argv) {
           ->Arg(8192);
     };
     bm.operator()<std::vector<std::vector<int>>>("std::distance(join_view(vector<vector<int>>))", std_distance, 256);
-    bm.operator()<std::vector<std::vector<int>>>(
-        "rng::distance(join_view(vector<vector<int>>)", std::ranges::distance, 256);
   }
 
   benchmark::Initialize(&argc, argv);


### PR DESCRIPTION
We're currently running all the algorithms benchmarks for the `std` and `ranges` variants, even though almost all the algorithms share the same code. This makes running the benchmarks on a large set of commits very slow and costly. This reduced running the `algorithm/` subdirectory from ~4 hours to roughtly 2.5 hours.

Fixes #175973
