### PR TITLE
[InstCombine] Add combines for unsigned comparison of absolute value to constant

### DIFF
--- a/llvm/test/Transforms/InstCombine/abs-intrinsic.ll
+++ b/llvm/test/Transforms/InstCombine/abs-intrinsic.ll
@@ -1000,8 +1000,8 @@ define i8 @abs_diff_sle_y_x(i8 %x, i8 %y) {
 
 define i1 @abs_cmp_ule_no_poison(i32 %x) {
 ; CHECK-LABEL: @abs_cmp_ule_no_poison(
-; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], 63
+; CHECK-NEXT:    [[X_ABS:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 false)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS]], 32
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
@@ -1024,36 +1024,32 @@ define i1 @abs_cmp_ule_no_poison_multiuse(i32 %x) {
 
 define i1 @abs_cmp_ule_poison(i32 %x) {
 ; CHECK-LABEL: @abs_cmp_ule_poison(
-; CHECK-NEXT:    [[X_ABS_FREEZE:%.*]] = freeze i32 [[X:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X_ABS_FREEZE]], 31
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X:%.*]], 31
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], 63
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
-  %x.abs.freeze = freeze i32 %x.abs
-  %cmp = icmp ule i32 %x.abs.freeze, 31
+  %cmp = icmp ule i32 %x.abs, 31
   ret i1 %cmp
 }
 
 define i1 @abs_cmp_ule_poison_multiuse(i32 %x) {
 ; CHECK-LABEL: @abs_cmp_ule_poison_multiuse(
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
-; CHECK-NEXT:    [[X_ABS_FREEZE:%.*]] = call i32 @llvm.abs.i32(i32 [[X_FR]], i1 false)
-; CHECK-NEXT:    call void @use(i32 [[X_ABS_FREEZE]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS_FREEZE]], 32
+; CHECK-NEXT:    [[X_ABS:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 true)
+; CHECK-NEXT:    call void @use(i32 [[X_ABS]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ult i32 [[X_ABS]], 32
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
-  %x.abs.freeze = freeze i32 %x.abs
-  call void @use(i32 %x.abs.freeze)
-  %cmp = icmp ule i32 %x.abs.freeze, 31
+  call void @use(i32 %x.abs)
+  %cmp = icmp ule i32 %x.abs, 31
   ret i1 %cmp
 }
 
 define i1 @abs_cmp_ult_no_poison(i32 %x) {
 ; CHECK-LABEL: @abs_cmp_ult_no_poison(
-; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], 63
+; CHECK-NEXT:    [[X_ABS:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 false)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS]], 32
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
@@ -1076,29 +1072,25 @@ define i1 @abs_cmp_ult_no_poison_multiuse(i32 %x) {
 
 define i1 @abs_cmp_ult_poison(i32 %x) {
 ; CHECK-LABEL: @abs_cmp_ult_poison(
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X_FR]], 31
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X_FR:%.*]], 31
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], 63
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
-  %x.abs.freeze = freeze i32 %x.abs
-  %cmp = icmp ult i32 %x.abs.freeze, 32
+  %cmp = icmp ult i32 %x.abs, 32
   ret i1 %cmp
 }
 
 define i1 @abs_cmp_ult_poison_multiuse(i32 %x) {
 ; CHECK-LABEL: @abs_cmp_ult_poison_multiuse(
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
-; CHECK-NEXT:    [[X_ABS_FREEZE:%.*]] = call i32 @llvm.abs.i32(i32 [[X_FR]], i1 false)
-; CHECK-NEXT:    call void @use(i32 [[X_ABS_FREEZE]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS_FREEZE]], 32
+; CHECK-NEXT:    [[X_ABS:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 true)
+; CHECK-NEXT:    call void @use(i32 [[X_ABS]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ult i32 [[X_ABS]], 32
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
-  %x.abs.freeze = freeze i32 %x.abs
-  call void @use(i32 %x.abs.freeze)
-  %cmp = icmp ult i32 %x.abs.freeze, 32
+  call void @use(i32 %x.abs)
+  %cmp = icmp ult i32 %x.abs, 32
   ret i1 %cmp
 }
 
@@ -1128,29 +1120,25 @@ define i1 @abs_cmp_uge_no_poison_multiuse(i32 %x) {
 
 define i1 @abs_cmp_uge_poison(i32 %x) {
 ; CHECK-LABEL: @abs_cmp_uge_poison(
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X_FR]], -31
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X_FR:%.*]], -31
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], -61
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
-  %x.abs.freeze = freeze i32 %x.abs
-  %cmp = icmp ugt i32 %x.abs.freeze, 30
+  %cmp = icmp ugt i32 %x.abs, 30
   ret i1 %cmp
 }
 
 define i1 @abs_cmp_uge_poison_multiuse(i32 %x) {
 ; CHECK-LABEL: @abs_cmp_uge_poison_multiuse(
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
-; CHECK-NEXT:    [[X_ABS_FREEZE:%.*]] = call i32 @llvm.abs.i32(i32 [[X_FR]], i1 false)
-; CHECK-NEXT:    call void @use(i32 [[X_ABS_FREEZE]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[X_ABS_FREEZE]], 30
+; CHECK-NEXT:    [[X_ABS:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 true)
+; CHECK-NEXT:    call void @use(i32 [[X_ABS]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ugt i32 [[X_ABS]], 30
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
-  %x.abs.freeze = freeze i32 %x.abs
-  call void @use(i32 %x.abs.freeze)
-  %cmp = icmp ugt i32 %x.abs.freeze, 30
+  call void @use(i32 %x.abs)
+  %cmp = icmp ugt i32 %x.abs, 30
   ret i1 %cmp
 }
 
@@ -1180,28 +1168,24 @@ define i1 @abs_cmp_ugt_no_poison_multiuse(i32 %x) {
 
 define i1 @abs_cmp_ugt_poison(i32 %x) {
 ; CHECK-LABEL: @abs_cmp_ugt_poison(
-; CHECK-NEXT:    [[X:%.*]] = freeze i32 [[X1:%.*]]
-; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X]], -32
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X:%.*]], -32
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], -63
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
-  %x.abs.freeze = freeze i32 %x.abs
-  %cmp = icmp ugt i32 %x.abs.freeze, 31
+  %cmp = icmp ugt i32 %x.abs, 31
   ret i1 %cmp
 }
 
 define i1 @abs_cmp_ugt_poison_multiuse(i32 %x) {
 ; CHECK-LABEL: @abs_cmp_ugt_poison_multiuse(
-; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
-; CHECK-NEXT:    [[X_ABS_FREEZE:%.*]] = call i32 @llvm.abs.i32(i32 [[X_FR]], i1 false)
-; CHECK-NEXT:    call void @use(i32 [[X_ABS_FREEZE]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[X_ABS_FREEZE]], 31
+; CHECK-NEXT:    [[X_ABS:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 true)
+; CHECK-NEXT:    call void @use(i32 [[X_ABS]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ugt i32 [[X_ABS]], 31
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
-  %x.abs.freeze = freeze i32 %x.abs
-  call void @use(i32 %x.abs.freeze)
-  %cmp = icmp ugt i32 %x.abs.freeze, 31
+  call void @use(i32 %x.abs)
+  %cmp = icmp ugt i32 %x.abs, 31
   ret i1 %cmp
 }

--- a/llvm/test/Transforms/InstCombine/abs-intrinsic.ll
+++ b/llvm/test/Transforms/InstCombine/abs-intrinsic.ll
@@ -429,7 +429,7 @@ define i32 @abs_sext(i8 %x) {
 ; CHECK-NEXT:    ret i32 [[A]]
 ;
   %s = sext i8 %x to i32
-  %a = call i32 @llvm.abs.i32(i32 %s, i1 0)
+  %a = call i32 @llvm.abs.i32(i32 %s, i1 false)
   ret i32 %a
 }
 
@@ -440,7 +440,7 @@ define <3 x i82> @abs_nsw_sext(<3 x i7> %x) {
 ; CHECK-NEXT:    ret <3 x i82> [[A]]
 ;
   %s = sext <3 x i7> %x to <3 x i82>
-  %a = call <3 x i82> @llvm.abs.v3i82(<3 x i82> %s, i1 1)
+  %a = call <3 x i82> @llvm.abs.v3i82(<3 x i82> %s, i1 true)
   ret <3 x i82> %a
 }
 
@@ -453,7 +453,7 @@ define i32 @abs_sext_extra_use(i8 %x, ptr %p) {
 ;
   %s = sext i8 %x to i32
   store i32 %s, ptr %p
-  %a = call i32 @llvm.abs.i32(i32 %s, i1 0)
+  %a = call i32 @llvm.abs.i32(i32 %s, i1 false)
   ret i32 %a
 }
 
@@ -1004,7 +1004,7 @@ define i1 @abs_cmp_ule_no_poison(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS]], 32
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 false)
   %cmp = icmp ule i32 %x.abs, 31
   ret i1 %cmp
 }
@@ -1016,7 +1016,7 @@ define i1 @abs_cmp_ule_no_poison_multiuse(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS]], 32
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 false)
   call void @use(i32 %x.abs)
   %cmp = icmp ule i32 %x.abs, 31
   ret i1 %cmp
@@ -1028,7 +1028,7 @@ define i1 @abs_cmp_ule_poison(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], 63
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 true)
   %cmp = icmp ule i32 %x.abs, 31
   ret i1 %cmp
 }
@@ -1040,7 +1040,7 @@ define i1 @abs_cmp_ule_poison_multiuse(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ult i32 [[X_ABS]], 32
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 true)
   call void @use(i32 %x.abs)
   %cmp = icmp ule i32 %x.abs, 31
   ret i1 %cmp
@@ -1052,7 +1052,7 @@ define i1 @abs_cmp_ult_no_poison(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS]], 32
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 false)
   %cmp = icmp ult i32 %x.abs, 32
   ret i1 %cmp
 }
@@ -1064,7 +1064,7 @@ define i1 @abs_cmp_ult_no_poison_multiuse(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS]], 32
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 false)
   call void @use(i32 %x.abs)
   %cmp = icmp ult i32 %x.abs, 32
   ret i1 %cmp
@@ -1076,7 +1076,7 @@ define i1 @abs_cmp_ult_poison(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], 63
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 true)
   %cmp = icmp ult i32 %x.abs, 32
   ret i1 %cmp
 }
@@ -1088,7 +1088,7 @@ define i1 @abs_cmp_ult_poison_multiuse(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ult i32 [[X_ABS]], 32
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 true)
   call void @use(i32 %x.abs)
   %cmp = icmp ult i32 %x.abs, 32
   ret i1 %cmp
@@ -1100,7 +1100,7 @@ define i1 @abs_cmp_uge_no_poison(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], -61
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 false)
   %cmp = icmp ugt i32 %x.abs, 30
   ret i1 %cmp
 }
@@ -1112,7 +1112,7 @@ define i1 @abs_cmp_uge_no_poison_multiuse(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[X_ABS]], 30
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 false)
   call void @use(i32 %x.abs)
   %cmp = icmp ugt i32 %x.abs, 30
   ret i1 %cmp
@@ -1124,7 +1124,7 @@ define i1 @abs_cmp_uge_poison(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], -61
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 true)
   %cmp = icmp ugt i32 %x.abs, 30
   ret i1 %cmp
 }
@@ -1136,7 +1136,7 @@ define i1 @abs_cmp_uge_poison_multiuse(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ugt i32 [[X_ABS]], 30
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 true)
   call void @use(i32 %x.abs)
   %cmp = icmp ugt i32 %x.abs, 30
   ret i1 %cmp
@@ -1148,7 +1148,7 @@ define i1 @abs_cmp_ugt_no_poison(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], -63
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 false)
   %cmp = icmp ugt i32 %x.abs, 31
   ret i1 %cmp
 }
@@ -1160,7 +1160,7 @@ define i1 @abs_cmp_ugt_no_poison_multiuse(i32 %x) {
 ; CHECK-NEXT:    call void @use(i32 [[X_ABS]])
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 false)
   %cmp = icmp ugt i32 %x.abs, 31
   call void @use(i32 %x.abs)
   ret i1 %cmp
@@ -1172,7 +1172,7 @@ define i1 @abs_cmp_ugt_poison(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], -63
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 true)
   %cmp = icmp ugt i32 %x.abs, 31
   ret i1 %cmp
 }
@@ -1184,7 +1184,7 @@ define i1 @abs_cmp_ugt_poison_multiuse(i32 %x) {
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ugt i32 [[X_ABS]], 31
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 true)
   call void @use(i32 %x.abs)
   %cmp = icmp ugt i32 %x.abs, 31
   ret i1 %cmp

--- a/llvm/test/Transforms/InstCombine/abs-intrinsic.ll
+++ b/llvm/test/Transforms/InstCombine/abs-intrinsic.ll
@@ -997,3 +997,211 @@ define i8 @abs_diff_sle_y_x(i8 %x, i8 %y) {
   %cond = select i1 %cmp, i8 %sub, i8 %sub1
   ret i8 %cond
 }
+
+define i1 @abs_cmp_ule_no_poison(i32 %x) {
+; CHECK-LABEL: @abs_cmp_ule_no_poison(
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], 63
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %cmp = icmp ule i32 %x.abs, 31
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_ule_no_poison_multiuse(i32 %x) {
+; CHECK-LABEL: @abs_cmp_ule_no_poison_multiuse(
+; CHECK-NEXT:    [[X_ABS:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 false)
+; CHECK-NEXT:    call void @use(i32 [[X_ABS]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS]], 32
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  call void @use(i32 %x.abs)
+  %cmp = icmp ule i32 %x.abs, 31
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_ule_poison(i32 %x) {
+; CHECK-LABEL: @abs_cmp_ule_poison(
+; CHECK-NEXT:    [[X_ABS_FREEZE:%.*]] = freeze i32 [[X:%.*]]
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X_ABS_FREEZE]], 31
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], 63
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs.freeze = freeze i32 %x.abs
+  %cmp = icmp ule i32 %x.abs.freeze, 31
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_ule_poison_multiuse(i32 %x) {
+; CHECK-LABEL: @abs_cmp_ule_poison_multiuse(
+; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
+; CHECK-NEXT:    [[X_ABS_FREEZE:%.*]] = call i32 @llvm.abs.i32(i32 [[X_FR]], i1 false)
+; CHECK-NEXT:    call void @use(i32 [[X_ABS_FREEZE]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS_FREEZE]], 32
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs.freeze = freeze i32 %x.abs
+  call void @use(i32 %x.abs.freeze)
+  %cmp = icmp ule i32 %x.abs.freeze, 31
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_ult_no_poison(i32 %x) {
+; CHECK-LABEL: @abs_cmp_ult_no_poison(
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], 63
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %cmp = icmp ult i32 %x.abs, 32
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_ult_no_poison_multiuse(i32 %x) {
+; CHECK-LABEL: @abs_cmp_ult_no_poison_multiuse(
+; CHECK-NEXT:    [[X_ABS:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 false)
+; CHECK-NEXT:    call void @use(i32 [[X_ABS]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS]], 32
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  call void @use(i32 %x.abs)
+  %cmp = icmp ult i32 %x.abs, 32
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_ult_poison(i32 %x) {
+; CHECK-LABEL: @abs_cmp_ult_poison(
+; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X_FR]], 31
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], 63
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs.freeze = freeze i32 %x.abs
+  %cmp = icmp ult i32 %x.abs.freeze, 32
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_ult_poison_multiuse(i32 %x) {
+; CHECK-LABEL: @abs_cmp_ult_poison_multiuse(
+; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
+; CHECK-NEXT:    [[X_ABS_FREEZE:%.*]] = call i32 @llvm.abs.i32(i32 [[X_FR]], i1 false)
+; CHECK-NEXT:    call void @use(i32 [[X_ABS_FREEZE]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[X_ABS_FREEZE]], 32
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs.freeze = freeze i32 %x.abs
+  call void @use(i32 %x.abs.freeze)
+  %cmp = icmp ult i32 %x.abs.freeze, 32
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_uge_no_poison(i32 %x) {
+; CHECK-LABEL: @abs_cmp_uge_no_poison(
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X:%.*]], -31
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], -61
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %cmp = icmp ugt i32 %x.abs, 30
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_uge_no_poison_multiuse(i32 %x) {
+; CHECK-LABEL: @abs_cmp_uge_no_poison_multiuse(
+; CHECK-NEXT:    [[X_ABS:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 false)
+; CHECK-NEXT:    call void @use(i32 [[X_ABS]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[X_ABS]], 30
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  call void @use(i32 %x.abs)
+  %cmp = icmp ugt i32 %x.abs, 30
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_uge_poison(i32 %x) {
+; CHECK-LABEL: @abs_cmp_uge_poison(
+; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X_FR]], -31
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], -61
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs.freeze = freeze i32 %x.abs
+  %cmp = icmp ugt i32 %x.abs.freeze, 30
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_uge_poison_multiuse(i32 %x) {
+; CHECK-LABEL: @abs_cmp_uge_poison_multiuse(
+; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
+; CHECK-NEXT:    [[X_ABS_FREEZE:%.*]] = call i32 @llvm.abs.i32(i32 [[X_FR]], i1 false)
+; CHECK-NEXT:    call void @use(i32 [[X_ABS_FREEZE]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[X_ABS_FREEZE]], 30
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs.freeze = freeze i32 %x.abs
+  call void @use(i32 %x.abs.freeze)
+  %cmp = icmp ugt i32 %x.abs.freeze, 30
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_ugt_no_poison(i32 %x) {
+; CHECK-LABEL: @abs_cmp_ugt_no_poison(
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X:%.*]], -32
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], -63
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %cmp = icmp ugt i32 %x.abs, 31
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_ugt_no_poison_multiuse(i32 %x) {
+; CHECK-LABEL: @abs_cmp_ugt_no_poison_multiuse(
+; CHECK-NEXT:    [[X_ABS:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 false)
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[X_ABS]], 31
+; CHECK-NEXT:    call void @use(i32 [[X_ABS]])
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 0)
+  %cmp = icmp ugt i32 %x.abs, 31
+  call void @use(i32 %x.abs)
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_ugt_poison(i32 %x) {
+; CHECK-LABEL: @abs_cmp_ugt_poison(
+; CHECK-NEXT:    [[X:%.*]] = freeze i32 [[X1:%.*]]
+; CHECK-NEXT:    [[TMP1:%.*]] = add i32 [[X]], -32
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i32 [[TMP1]], -63
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs.freeze = freeze i32 %x.abs
+  %cmp = icmp ugt i32 %x.abs.freeze, 31
+  ret i1 %cmp
+}
+
+define i1 @abs_cmp_ugt_poison_multiuse(i32 %x) {
+; CHECK-LABEL: @abs_cmp_ugt_poison_multiuse(
+; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
+; CHECK-NEXT:    [[X_ABS_FREEZE:%.*]] = call i32 @llvm.abs.i32(i32 [[X_FR]], i1 false)
+; CHECK-NEXT:    call void @use(i32 [[X_ABS_FREEZE]])
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ugt i32 [[X_ABS_FREEZE]], 31
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %x.abs = call i32 @llvm.abs.i32(i32 %x, i1 1)
+  %x.abs.freeze = freeze i32 %x.abs
+  call void @use(i32 %x.abs.freeze)
+  %cmp = icmp ugt i32 %x.abs.freeze, 31
+  ret i1 %cmp
+}


### PR DESCRIPTION
This patch implements the following two peephole optimisations:
1. ``` abs(X) u> K --> K >= 0 ? `X + K u> 2 * K` : `false` ```;
2. If `abs(INT_MIN)` is `poison`, ```abs(X) u< K --> K >= 1 ? `X + (K - 1) u<= 2 * (K - 1)` : K != 0```.

See the following Alive2 proofs: [1](https://alive2.llvm.org/ce/z/J2SRSv) and [2](https://alive2.llvm.org/ce/z/tfxTrU).