### PR TITLE
[OpenMP][Offload] Add a buffer layer to debug messaging

### DIFF
--- a/offload/include/Shared/Debug.h
+++ b/offload/include/Shared/Debug.h
@@ -174,10 +174,11 @@ private:
   bool ShouldEmitNewLineOnDestruction;
   bool NeedEndNewLine = false;
 
-  /// Small buffer to reduce interference between different threads
+  /// Buffer to reduce interference between different threads
   /// writing at the same time to the underlying stream.
   static constexpr size_t BufferSize = 256;
   llvm::SmallString<BufferSize> Buffer;
+
   // Stream to write into Buffer. Its flushed to Os upon destruction.
   llvm::raw_svector_ostream BufferStrm;
 


### PR DESCRIPTION
To reduce interference between threads, instead of writing the components of a debug message directly to the underlying stream, write them to a buffer and flush the buffer to the stream when its completed.