### PR TITLE
[libc] [math] Refactor fsqrtl to be header-only

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -66,6 +66,7 @@
 #include "math/frexpf16.h"
 #include "math/fsqrt.h"
 #include "math/fsqrtf128.h"
+#include "math/fsqrtl.h"
 #include "math/hypotf.h"
 #include "math/ilogbf.h"
 #include "math/ilogbf16.h"

--- a/libc/shared/math/fsqrtl.h
+++ b/libc/shared/math/fsqrtl.h
@@ -1,5 +1,4 @@
-//===-- Shared header for fsqrtl ---------------------------------*- C++
-//-*-===//
+//===-- Shared header for fsqrtl ---------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/shared/math/fsqrtl.h
+++ b/libc/shared/math/fsqrtl.h
@@ -1,4 +1,5 @@
-//===-- Shared header for fsqrtl ---------------------------------*- C++ -*-===//
+//===-- Shared header for fsqrtl ---------------------------------*- C++
+//-*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/shared/math/fsqrtl.h
+++ b/libc/shared/math/fsqrtl.h
@@ -1,4 +1,4 @@
-//===-- Implementation of fsqrtl function ---------------------------------===//
+//===-- Shared header for fsqrtl ---------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/fsqrtl.h"
+#ifndef LLVM_LIBC_SHARED_MATH_FSQRTL_H
+#define LLVM_LIBC_SHARED_MATH_FSQRTL_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/fsqrtl.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(float, fsqrtl, (long double x)) { return math::fsqrtl(x); }
+namespace shared {
 
+using math::fsqrtl;
+
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_FSQRTL_H

--- a/libc/shared/math/fsqrtl.h
+++ b/libc/shared/math/fsqrtl.h
@@ -1,4 +1,4 @@
-//===-- Shared header for fsqrtl ---------------------------------*- C++ -*-===//
+//===-- Shared header for fsqrtl --------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -611,6 +611,14 @@ add_header_library(
 )
 
 add_header_library(
+  fsqrtl
+  HDRS
+    fsqrtl.h
+  DEPENDS
+    libc.src.__support.FPUtil.generic.sqrt
+)
+
+add_header_library(
   inv_trigf_utils
   HDRS
     inv_trigf_utils.h

--- a/libc/src/__support/math/fsqrtl.h
+++ b/libc/src/__support/math/fsqrtl.h
@@ -15,7 +15,7 @@ namespace LIBC_NAMESPACE_DECL {
 
 namespace math {
 
-LIBC_INLINE static constexpr float fsqrt(long double x) {
+LIBC_INLINE static constexpr float fsqrtl(long double x) {
   return fputil::sqrt<float>(x);
 }
 

--- a/libc/src/__support/math/fsqrtl.h
+++ b/libc/src/__support/math/fsqrtl.h
@@ -1,0 +1,26 @@
+//===-- Implementation header for fsqrtl ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FSQRTL_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_FSQRTL_H
+
+#include "src/__support/FPUtil/generic/sqrt.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE static constexpr float fsqrt(long double x) {
+  return fputil::sqrt<float>(x);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_FSQRTL_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -5187,7 +5187,7 @@ add_entrypoint_object(
   HDRS
     ../fsqrtl.h
   DEPENDS
-    libc.src.__support.FPUtil.generic.sqrt
+    libc.src.__support.math.fsqrtl
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -62,6 +62,7 @@ add_fp_unittest(
     libc.src.__support.math.frexpf16
     libc.src.__support.math.fsqrt
     libc.src.__support.math.fsqrtf128
+    libc.src.__support.math.fsqrtl
     libc.src.__support.math.hypotf
     libc.src.__support.math.ilogbf
     libc.src.__support.math.ilogbf16

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -116,7 +116,7 @@ TEST(LlvmLibcSharedMathTest, AllDouble) {
 TEST(LlvmLibcSharedMathTest, AllLongDouble) {
   EXPECT_FP_EQ(0x0p+0L,
                LIBC_NAMESPACE::shared::dfmal(0x0.p+0L, 0x0.p+0L, 0x0.p+0L));
-  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::fsqrtl(0.0L));
+  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::fsqrtl(0.0L));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbl(0x1.p+0L));
 }
 

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -118,8 +118,6 @@ TEST(LlvmLibcSharedMathTest, AllLongDouble) {
                LIBC_NAMESPACE::shared::dfmal(0x0.p+0L, 0x0.p+0L, 0x0.p+0L));
   EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::fsqrtl(0.0L));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbl(0x1.p+0L));
-  
-
 }
 
 #ifdef LIBC_TYPES_HAS_FLOAT128

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -116,7 +116,10 @@ TEST(LlvmLibcSharedMathTest, AllDouble) {
 TEST(LlvmLibcSharedMathTest, AllLongDouble) {
   EXPECT_FP_EQ(0x0p+0L,
                LIBC_NAMESPACE::shared::dfmal(0x0.p+0L, 0x0.p+0L, 0x0.p+0L));
+  EXPECT_FP_EQ(0x0p+0L, LIBC_NAMESPACE::shared::fsqrtl(0.0L));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbl(0x1.p+0L));
+  
+
 }
 
 #ifdef LIBC_TYPES_HAS_FLOAT128

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2916,6 +2916,14 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_fsqrtl",
+    hdrs = ["src/__support/math/fsqrtl.h"],
+    deps = [
+        ":__support_fputil_sqrt",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_inv_trigf_utils",
     hdrs = ["src/__support/math/inv_trigf_utils.h"],
     deps = [
@@ -4553,7 +4561,7 @@ libc_math_function(
 libc_math_function(
     name = "fsqrtl",
     additional_deps = [
-        ":__support_fputil_sqrt",
+        ":__support_math_fsqrtl",
     ],
 )
 


### PR DESCRIPTION
This PR refactors fsqrtl to be header only as discussed. No functional change intended. Test and build files were updated as required by the refactor
Fixes #175335
