### PR TITLE
[libFuzzer] Stop fuzzing if no new corpus were found within a specified period

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
@@ -697,6 +697,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
   Options.IgnoreOOMs = Flags.ignore_ooms;
   Options.IgnoreCrashes = Flags.ignore_crashes;
   Options.MaxTotalTimeSec = Flags.max_total_time;
+  Options.ExitOnTimeSec = Flags.exit_on_time;
   Options.DoCrossOver = Flags.cross_over;
   Options.CrossOverUniformDist = Flags.cross_over_uniform_dist;
   Options.MutateDepth = Flags.mutate_depth;
@@ -923,8 +924,9 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
   F->Loop(CorporaFiles);
 
   if (Flags.verbosity)
-    Printf("Done %zd runs in %zd second(s)\n", F->getTotalNumberOfRuns(),
-           F->secondsSinceProcessStartUp());
+    Printf("Done %zd runs in %zd second(s), %zd second(s) without new corpus\n",
+           F->getTotalNumberOfRuns(), F->secondsSinceProcessStartUp(),
+           F->secondsSinceLastNewCorpus());
   F->PrintFinalStats();
 
   exit(0);  // Don't let F destroy itself.

--- a/compiler-rt/lib/fuzzer/FuzzerFlags.def
+++ b/compiler-rt/lib/fuzzer/FuzzerFlags.def
@@ -56,6 +56,9 @@ FUZZER_FLAG_INT(timeout_exitcode, 70, "When libFuzzer reports a timeout "
   "this exit code will be used.")
 FUZZER_FLAG_INT(max_total_time, 0, "If positive, indicates the maximal total "
                                    "time in seconds to run the fuzzer.")
+FUZZER_FLAG_INT(exit_on_time, 0,
+                "If positive, indicates the maximum time in seconds to run the "
+                "fuzzer after new input is added to the corpus.")
 FUZZER_FLAG_INT(help, 0, "Print help.")
 FUZZER_FLAG_INT(fork, 0, "Experimental mode where fuzzing happens "
                 "in a subprocess")

--- a/compiler-rt/lib/fuzzer/FuzzerInternal.h
+++ b/compiler-rt/lib/fuzzer/FuzzerInternal.h
@@ -44,10 +44,18 @@ public:
         .count();
   }
 
+  size_t secondsSinceLastNewCorpus() {
+    return duration_cast<seconds>(system_clock::now() - LastNewCorpusTime)
+        .count();
+  }
+
   bool TimedOut() {
-    return Options.MaxTotalTimeSec > 0 &&
-           secondsSinceProcessStartUp() >
-               static_cast<size_t>(Options.MaxTotalTimeSec);
+    return (Options.MaxTotalTimeSec > 0 &&
+            secondsSinceProcessStartUp() >
+                static_cast<size_t>(Options.MaxTotalTimeSec)) ||
+           (Options.ExitOnTimeSec > 0 &&
+            secondsSinceLastNewCorpus() >
+                static_cast<size_t>(Options.ExitOnTimeSec));
   }
 
   size_t execPerSec() {
@@ -137,6 +145,7 @@ private:
   DataFlowTrace DFT;
 
   system_clock::time_point ProcessStartTime = system_clock::now();
+  system_clock::time_point LastNewCorpusTime = system_clock::now();
   system_clock::time_point UnitStartTime, UnitStopTime;
   long TimeOfLongestUnitInSeconds = 0;
   long EpochOfLastReadOfOutputCorpus = 0;

--- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
@@ -332,6 +332,8 @@ void Fuzzer::PrintStats(const char *Where, const char *End, size_t Units,
     Printf(" cov: %zd", N);
   if (size_t N = Features ? Features : Corpus.NumFeatures())
     Printf(" ft: %zd", N);
+  if (Options.ExitOnTimeSec > 0)
+    Printf(" wo_finds: %zd", secondsSinceLastNewCorpus());
   if (!Corpus.empty()) {
     Printf(" corp: %zd", Corpus.NumActiveUnits());
     if (size_t N = Corpus.SizeInBytes()) {
@@ -535,6 +537,7 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
   size_t NumNewFeatures = Corpus.NumFeatureUpdates() - NumUpdatesBefore;
   if (NumNewFeatures || ForceAddToCorpus) {
     TPC.UpdateObservedPCs();
+    LastNewCorpusTime = UnitStopTime;
     auto NewII =
         Corpus.AddToCorpus({Data, Data + Size}, NumNewFeatures, MayDeleteFile,
                            TPC.ObservedFocusFunction(), ForceAddToCorpus,

--- a/compiler-rt/lib/fuzzer/FuzzerOptions.h
+++ b/compiler-rt/lib/fuzzer/FuzzerOptions.h
@@ -28,6 +28,7 @@ struct FuzzingOptions {
   bool IgnoreOOMs = true;
   bool IgnoreCrashes = false;
   int MaxTotalTimeSec = 0;
+  int ExitOnTimeSec = 0;
   int RssLimitMb = 0;
   int MallocLimitMb = 0;
   bool DoCrossOver = true;

--- a/compiler-rt/test/fuzzer/exit_on_time-reload-fork.test
+++ b/compiler-rt/test/fuzzer/exit_on_time-reload-fork.test
@@ -1,0 +1,26 @@
+# FIXME: -fork currently doesn't reload the main corpus with -reload=1
+XFAIL: *
+
+RUN: %cpp_compiler %S/CleanseTest.cpp -o %t-CleanseTest
+
+# total time - double digits
+EXIT_ON_TIME_FORK: INFO: no new corpus for {{[0-9]}} seconds, wrapping up soon
+EXIT_ON_TIME_FORK-NEXT: INFO: exiting: 0 time: {{[0-9][0-9]}}s
+
+# is timer updated with a new input?
+RUN: rm -rf %t-1
+RUN: mkdir -p %t-1
+RUN: setsid %run %t-CleanseTest -seed=1 -exit_on_time=7 -mutate_depth=0 -fork=1 %t-1 2>%t-1-log & export PID=$!
+RUN: sleep 3
+RUN: echo -n ' 1   5    A         ' > %t-1/new
+RUN: wait $PID
+RUN: cat %t-1-log | FileCheck %s --check-prefix=EXIT_ON_TIME_FORK
+
+# max_total_time may be triggered first
+RUN: rm -rf %t-2
+RUN: mkdir -p %t-2
+RUN: setsid %run %t-CleanseTest -seed=1 -exit_on_time=10 -max_total_time=10 -mutate_depth=0 %t-2 2>%t-2-log & export PID=$!
+RUN: sleep 4
+RUN: echo -n ' 1   5    A         ' > %t-2/new
+RUN: wait $PID
+RUN: cat %t-2-log | FileCheck %s --check-prefix=EXIT_ON_TIME_FORK

--- a/compiler-rt/test/fuzzer/exit_on_time-reload.test
+++ b/compiler-rt/test/fuzzer/exit_on_time-reload.test
@@ -1,0 +1,22 @@
+RUN: %cpp_compiler %S/CleanseTest.cpp -o %t-CleanseTest
+
+# total time - double digits, without new corpus - one digit
+EXIT_ON_TIME: Done {{.*}} runs in {{[0-9][0-9]}} second(s), {{[0-9]}} second(s)
+
+# is timer updated with a new input?
+RUN: rm -rf %t-1
+RUN: mkdir -p %t-1
+RUN: setsid %run %t-CleanseTest -seed=1 -exit_on_time=7 -mutate_depth=0 %t-1 2>%t-1-log & export PID=$!
+RUN: sleep 4
+RUN: echo -n ' 1   5    A         ' > %t-1/new
+RUN: wait $PID
+RUN: cat %t-1-log | FileCheck %s --check-prefix=EXIT_ON_TIME
+
+# max_total_time may be triggered first
+RUN: rm -rf %t-2
+RUN: mkdir -p %t-2
+RUN: setsid %run %t-CleanseTest -seed=1 -exit_on_time=10 -max_total_time=10 -mutate_depth=0 %t-2 2>%t-2-log & export PID=$!
+RUN: sleep 4
+RUN: echo -n ' 1   5    A         ' > %t-2/new
+RUN: wait $PID
+RUN: cat %t-2-log | FileCheck %s --check-prefix=EXIT_ON_TIME

--- a/compiler-rt/test/fuzzer/exit_on_time.test
+++ b/compiler-rt/test/fuzzer/exit_on_time.test
@@ -1,0 +1,15 @@
+RUN: %cpp_compiler %S/SingleMemcmpTest.cpp -o %t-SingleMemcmpTest
+
+EXIT_ON_TIME-NOT: Done 100000000 runs
+EXIT_ON_TIME: Done {{[0-9]+}} runs in {{[0-9]}} second(s), {{[0-9]}} second(s) without new corpus
+
+# does it work?
+RUN: %run %t-SingleMemcmpTest -seed=1 -runs=100000000 -exit_on_time=2 -use_cmp=0 2>&1 | FileCheck %s --check-prefix=EXIT_ON_TIME
+
+# same for -fork
+
+EXIT_ON_TIME_FORK-NOT: INFO: fuzzed for {{[0-9]+}} iterations
+EXIT_ON_TIME_FORK: INFO: no new corpus for {{[0-9]+}} seconds
+
+# does it work?
+RUN: %run %t-SingleMemcmpTest -runs=100000000 -exit_on_time=2 -use_cmp=0 -fork=1 2>&1 | FileCheck %s --check-prefix=EXIT_ON_TIME_FORK

--- a/llvm/docs/LibFuzzer.rst
+++ b/llvm/docs/LibFuzzer.rst
@@ -287,6 +287,9 @@ The most important command line options are:
 ``-max_total_time``
   If positive, indicates the maximum total time in seconds to run the fuzzer.
   If 0 (the default), run indefinitely.
+``-exit_on_time``
+  If positive, indicates the maximum time in seconds to run the fuzzer after new
+  input is added to the corpus.
 ``-merge``
   If set to 1, any corpus inputs from the 2nd, 3rd etc. corpus directories
   that trigger new code coverage will be merged into the first corpus


### PR DESCRIPTION
This patch adds a new command-line option `-exit_on_time=N` which allows you to specify that the fuzzer should exit if it hasn't found a new corpus within a certain amount of time. It also adds to stats how many seconds a new path has not been found. An analog of `AFL_EXIT_ON_TIME`.