### PR TITLE
[CI] Make premerge jobs support GHA postcommit

### DIFF
--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -37,11 +37,15 @@ function at-exit {
     python "${MONOREPO_ROOT}"/.ci/generate_test_report_github.py \
       $retcode "${BUILD_DIR}"/test-results.*.xml "${MONOREPO_ROOT}"/ninja*.log \
       >> $GITHUB_STEP_SUMMARY
-    (python "${MONOREPO_ROOT}"/.ci/premerge_advisor_explain.py \
-      $(git rev-parse HEAD~1) $retcode "${GITHUB_TOKEN}" \
-      $GITHUB_PR_NUMBER "${BUILD_DIR}"/test-results.*.xml \
-      "${MONOREPO_ROOT}"/ninja*.log)
-    advisor_retcode=$?
+    if [[ -n "$GITHUB_PR_NUMBER" ]]; then
+      (python "${MONOREPO_ROOT}"/.ci/premerge_advisor_explain.py \
+        $(git rev-parse HEAD~1) $retcode "${GITHUB_TOKEN}" \
+        $GITHUB_PR_NUMBER "${BUILD_DIR}"/test-results.*.xml \
+        "${MONOREPO_ROOT}"/ninja*.log)
+      advisor_retcode=$?
+    else
+      advisor_retcode=$retcode
+    fi
   fi
 
   if [[ "$retcode" != "0" ]]; then


### PR DESCRIPTION
This was causing failures in the release branch as the premerge jobs there are also run postcommit through GHA. We were expecting a PR number to always be present when it was not.