### PR TITLE
[libcxx] Bump release runner image version

### DIFF
--- a/libcxx/utils/ci/images/libcxx_release_runners.txt
+++ b/libcxx/utils/ci/images/libcxx_release_runners.txt
@@ -1,1 +1,1 @@
-ghcr.io/llvm/libcxx-linux-builder:05b5090e961f6b45ba9144d4d846e0f174d0aedf
+ghcr.io/llvm/libcxx-linux-builder:e8753c0de90d3aaa60361b5354588fa29fef9228


### PR DESCRIPTION
Now that v22 has branched, we need to update the release runner version so we get appropriate testing on the release branch.