### PR TITLE
[clang][analyzer]Add TaintPropagation:EnableDefaultConfig config parameter

### DIFF
--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -1371,12 +1371,12 @@ For a more detailed description of configuration options, please see the
 
 **Configuration**
 
-* `optin.taint.TaintPropagation:Config`  Specifies the name of the YAML configuration file. The user can
-  define their own taint sources and sinks.
-* `optin.taint.TaintPropagation:EnableDefaultConfig` If set to true,
-   the default source, sink and propagation rules are loaded. Consider
-   setting it to false, if you want a fully custom taint configuration
-   without the defaults.
+* ``optin.taint.TaintPropagation:Config``  Specifies the name of the YAML
+  configuration file. The user can define their own taint sources and sinks.
+* ``optin.taint.TaintPropagation:EnableDefaultConfig`` If set to false,
+   the default source, sink and propagation rules are not loaded. This way,
+   advanced users can fully customize their taint configuration model.
+   Default: ``true``.
 
 **Related Guidelines**
 

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -1371,8 +1371,12 @@ For a more detailed description of configuration options, please see the
 
 **Configuration**
 
-* `Config`  Specifies the name of the YAML configuration file. The user can
+* `optin.taint.TaintPropagation:Config`  Specifies the name of the YAML configuration file. The user can
   define their own taint sources and sinks.
+* `optin.taint.TaintPropagation:EnableDefaultConfig` If set to true,
+   the default source, sink and propagation rules are loaded. Consider
+   setting it to false, if you want a fully custom taint configuration
+   without the defaults.
 
 **Related Guidelines**
 

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1624,10 +1624,10 @@ def TaintPropagationChecker : Checker<"TaintPropagation">, // Modelling checker
                   Released>,
     CmdLineOption<Boolean,
                   "EnableDefaultConfig",
-                  "If set to true, the default source, sink and "
-                  "propagation rules are added. Consider setting "
-                  "it to false if you want to use a fully custom "
-                  "taint configuration.",
+                  "If set to false, the default source, "
+                  "sink and propagation rules are not loaded."
+                  "This way, advanced users can fully customize "
+                  "their taint configuration model.",
                   "true",
                   Released>
   ]>,

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1621,6 +1621,14 @@ def TaintPropagationChecker : Checker<"TaintPropagation">, // Modelling checker
                   "Config",
                   "Specifies the name of the configuration file.",
                   "",
+                  Released>,
+    CmdLineOption<Boolean,
+                  "EnableDefaultConfig",
+                  "If set to true, the default source, sink and "
+                  "propagation rules are added. Consider setting "
+                  "it to false if you want to use a fully custom "
+                  "taint configuration.",
+                  "true",
                   Released>
   ]>,
   Documentation<NotDocumented>,

--- a/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
@@ -802,14 +802,11 @@ void GenericTaintChecker::initTaintRules(CheckerContext &C) const {
         {{CDM::CLibrary, {"getenv"}}, TR::Source({{ReturnValueIndex}})});
   }
   CheckerManager *Mgr = C.getAnalysisManager().getCheckerManager();
-  assert(Mgr);
 
-
+  StaticTaintRules = RuleLookupTy{};
   if (Mgr->getAnalyzerOptions().getCheckerBooleanOption(this, "EnableDefaultConfig"))
     StaticTaintRules.emplace(std::make_move_iterator(GlobalCRules.begin()),
                             std::make_move_iterator(GlobalCRules.end()));
-  else
-    StaticTaintRules = RuleLookupTy{};
 
   // User-provided taint configuration.
   const GenericTaintRuleParser ConfigParser{*Mgr};

--- a/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
@@ -804,9 +804,10 @@ void GenericTaintChecker::initTaintRules(CheckerContext &C) const {
   CheckerManager *Mgr = C.getAnalysisManager().getCheckerManager();
 
   StaticTaintRules = RuleLookupTy{};
-  if (Mgr->getAnalyzerOptions().getCheckerBooleanOption(this, "EnableDefaultConfig"))
+  if (Mgr->getAnalyzerOptions().getCheckerBooleanOption(this,
+                                                        "EnableDefaultConfig"))
     StaticTaintRules.emplace(std::make_move_iterator(GlobalCRules.begin()),
-                            std::make_move_iterator(GlobalCRules.end()));
+                             std::make_move_iterator(GlobalCRules.end()));
 
   // User-provided taint configuration.
   const GenericTaintRuleParser ConfigParser{*Mgr};

--- a/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
@@ -801,14 +801,18 @@ void GenericTaintChecker::initTaintRules(CheckerContext &C) const {
     GlobalCRules.push_back(
         {{CDM::CLibrary, {"getenv"}}, TR::Source({{ReturnValueIndex}})});
   }
-
-  StaticTaintRules.emplace(std::make_move_iterator(GlobalCRules.begin()),
-                           std::make_move_iterator(GlobalCRules.end()));
-
-  // User-provided taint configuration.
   CheckerManager *Mgr = C.getAnalysisManager().getCheckerManager();
   assert(Mgr);
-  GenericTaintRuleParser ConfigParser{*Mgr};
+
+
+  if (Mgr->getAnalyzerOptions().getCheckerBooleanOption(this, "EnableDefaultConfig"))
+    StaticTaintRules.emplace(std::make_move_iterator(GlobalCRules.begin()),
+                            std::make_move_iterator(GlobalCRules.end()));
+  else
+    StaticTaintRules = RuleLookupTy{};
+
+  // User-provided taint configuration.
+  const GenericTaintRuleParser ConfigParser{*Mgr};
   std::string Option{"Config"};
   StringRef ConfigFile =
       Mgr->getAnalyzerOptions().getCheckerStringOption(this, Option);

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -114,6 +114,7 @@
 // CHECK-NEXT: optin.osx.cocoa.localizability.NonLocalizedStringChecker:AggressiveReport = false
 // CHECK-NEXT: optin.performance.Padding:AllowedPad = 24
 // CHECK-NEXT: optin.taint.TaintPropagation:Config = ""
+// CHECK-NEXT: optin.taint.TaintPropagation:EnableDefaultConfig = true
 // CHECK-NEXT: osx.NumberObjectConversion:Pedantic = false
 // CHECK-NEXT: osx.cocoa.RetainCount:TrackNSCFStartParam = false
 // CHECK-NEXT: prune-paths = true


### PR DESCRIPTION
The new optin.taint.TaintPropagation:EnableDefaultConfig checker configuration parameter makes it possible for the users to disable the built-in taint configuration and use a full custom configuration instead.