### PR TITLE
release/22.x: [clang-tidy] Fix performance-move-const-arg for trivially copyable types with private copy constructor (#175449)

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/MoveConstArgCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/MoveConstArgCheck.cpp
@@ -136,7 +136,8 @@ void MoveConstArgCheck::check(const MatchFinder::MatchResult &Result) {
         return;
       // Don't warn when the type is not copyable.
       for (const auto *Ctor : R->ctors())
-        if (Ctor->isCopyConstructor() && Ctor->isDeleted())
+        if (Ctor->isCopyConstructor() &&
+            (Ctor->isDeleted() || Ctor->getAccess() != AS_public))
           return;
     }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -664,6 +664,10 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-using>` check to correctly provide fix-its
   for typedefs of pointers or references to array types.
 
+- Improved :doc:`performance-move-const-arg
+  <clang-tidy/checks/performance/move-const-arg>` check by avoiding false
+  positives on trivially copyable types with a non-public copy constructor.
+
 - Improved :doc:`performance-unnecessary-copy-initialization
   <clang-tidy/checks/performance/unnecessary-copy-initialization>` by printing
   the type of the diagnosed variable.

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/move-const-arg.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/move-const-arg.cpp
@@ -583,3 +583,37 @@ void testTernaryMove() {
 
 };
 } // namespace GH126515
+
+namespace GH174826 {
+
+struct PrivateCopy {
+  PrivateCopy() = default;
+  PrivateCopy(PrivateCopy &&) = default;
+
+private:
+  PrivateCopy(const PrivateCopy &) = default;
+};
+
+void receive(PrivateCopy) {}
+
+void testPrivate() {
+  PrivateCopy v;
+  receive(std::move(v));
+}
+
+struct PublicCopy {
+  PublicCopy() = default;
+  PublicCopy(const PublicCopy &) = default;
+  PublicCopy(PublicCopy &&) = default;
+};
+
+void receive(PublicCopy) {}
+
+void testPublic() {
+  PublicCopy v;
+  receive(std::move(v));
+  // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: std::move of the variable 'v' of the trivially-copyable type 'PublicCopy' has no effect; remove std::move() [performance-move-const-arg]
+  // CHECK-FIXES: receive(v);
+}
+
+} // namespace GH174826


### PR DESCRIPTION
Backport 513062dd583dc65e29987f3716f5b6fa9c1b4fe9