### PR TITLE
[clang-repl] Skip out-of-process execution due to compiler-rt path mismatch

### DIFF
--- a/clang/lib/Interpreter/IncrementalExecutor.cpp
+++ b/clang/lib/Interpreter/IncrementalExecutor.cpp
@@ -501,15 +501,15 @@ llvm::Error IncrementalExecutorBuilder::UpdateOrcRuntimePath(
   std::string Joined;
   for (size_t i = 0; i < triedPaths.size(); ++i) {
     if (i > 0)
-      Joined += "\n  "; // Use newlines for better readability
+      Joined += "\n  ";
     Joined += triedPaths[i];
   }
 
   return llvm::make_error<llvm::StringError>(
-      llvm::formatv("OrcRuntime library not found. Checked:\n  {0}",
+      llvm::formatv("OrcRuntime library not found. Checked:  {0}",
                     Joined.empty() ? "<none>" : Joined)
           .str(),
-      llvm::inconvertibleErrorCode());
+      std::make_error_code(std::errc::no_such_file_or_directory));
 }
 
 } // end namespace clang


### PR DESCRIPTION
On some setups (Solaris), clang-repl attempts to enable out-of-process execution,
but fails to locate the ORC runtime due to a mismatch between the toolchain’s
expected compiler-rt path and the actual on-disk layout.

Specifically, ToolChain::getCompilerRT() relies on getArchNameForCompilerRTLib(),
which returns an architecture name that does not match the Solaris compiler-rt
directory naming. As a result, the ORC runtime (orc_rt) is not detected at the
correct path, even though it exists under lib/clang/<version>/lib/sunos/.

As an initial workaround, special-case Solaris in
getArchNameForCompilerRTLib() to return "sunos", aligning the expected path with
the system layout and preventing clang-repl from attempting out-of-process
execution on Solaris.

Note that compiler-rt libraries on Solaris are suffixed with -<arch> (e.g.
liborc_rt-x86_64.a) to support multilib configurations, which is not yet fully
handled by the current lookup logic. A more complete solution will require
revisiting compiler-rt path resolution for Solaris.

The discussion is available here: https://github.com/llvm/llvm-project/pull/175322