### PR TITLE
InstCombine: Fix SimplifyDemandedFPClass for fadd with known-inf source


### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2252,12 +2252,12 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
     }
 
     // With nnan: X + {+/-}Inf --> {+/-}Inf
-    if (KnownRHS.isKnownAlways(fcInf | fcNan) &&
+    if (ResultNotNan && KnownRHS.isKnownAlways(fcInf | fcNan) &&
         KnownLHS.isKnownNever(fcNan))
       return I->getOperand(1);
 
     // With nnan: {+/-}Inf + X --> {+/-}Inf
-    if (KnownLHS.isKnownAlways(fcInf | fcNan) &&
+    if (ResultNotNan && KnownLHS.isKnownAlways(fcInf | fcNan) &&
         KnownRHS.isKnownNever(fcNan))
       return I->getOperand(0);
 

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fadd.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fadd.ll
@@ -2020,6 +2020,27 @@ define nofpclass(norm sub nzero) half @demand_pzero_select_nsub_source__fadd_sel
   ret half %result
 }
 
+define nofpclass(snan) half @not_nan__fadd__inf_or_nan(half nofpclass(nan) %not.nan) {
+; CHECK-LABEL: define nofpclass(snan) half @not_nan__fadd__inf_or_nan(
+; CHECK-SAME: half nofpclass(nan) [[NOT_NAN:%.*]]) {
+; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call half @returns_inf_or_nan()
+; CHECK-NEXT:    ret half [[INF_OR_NAN]]
+;
+  %inf.or.nan = call half @returns_inf_or_nan()
+  %result = fadd half %not.nan, %inf.or.nan
+  ret half %result
+}
+
+define nofpclass(snan) half @inf_or_nan__fadd__not_nan(half nofpclass(nan) %not.nan) {
+; CHECK-LABEL: define nofpclass(snan) half @inf_or_nan__fadd__not_nan(
+; CHECK-SAME: half nofpclass(nan) [[NOT_NAN:%.*]]) {
+; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call half @returns_inf_or_nan()
+; CHECK-NEXT:    ret half [[INF_OR_NAN]]
+;
+  %inf.or.nan = call half @returns_inf_or_nan()
+  %result = fadd half %inf.or.nan, %not.nan
+  ret half %result
+}
 
 attributes #0 = { "denormal-fp-math"="preserve-sign,preserve-sign" }
 attributes #1 = { "denormal-fp-math"="dynamic,dynamic" }

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fadd.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fadd.ll
@@ -2024,7 +2024,8 @@ define nofpclass(snan) half @not_nan__fadd__inf_or_nan(half nofpclass(nan) %not.
 ; CHECK-LABEL: define nofpclass(snan) half @not_nan__fadd__inf_or_nan(
 ; CHECK-SAME: half nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call half @returns_inf_or_nan()
-; CHECK-NEXT:    ret half [[INF_OR_NAN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[NOT_NAN]], [[INF_OR_NAN]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %inf.or.nan = call half @returns_inf_or_nan()
   %result = fadd half %not.nan, %inf.or.nan
@@ -2035,7 +2036,8 @@ define nofpclass(snan) half @inf_or_nan__fadd__not_nan(half nofpclass(nan) %not.
 ; CHECK-LABEL: define nofpclass(snan) half @inf_or_nan__fadd__not_nan(
 ; CHECK-SAME: half nofpclass(nan) [[NOT_NAN:%.*]]) {
 ; CHECK-NEXT:    [[INF_OR_NAN:%.*]] = call half @returns_inf_or_nan()
-; CHECK-NEXT:    ret half [[INF_OR_NAN]]
+; CHECK-NEXT:    [[RESULT:%.*]] = fadd half [[INF_OR_NAN]], [[NOT_NAN]]
+; CHECK-NEXT:    ret half [[RESULT]]
 ;
   %inf.or.nan = call half @returns_inf_or_nan()
   %result = fadd half %inf.or.nan, %not.nan


### PR DESCRIPTION
Ensure the result cannot be nan.

Split out from https://github.com/llvm/llvm-project/pull/175852