### PR TITLE
[AMDGPU] Fix hoist location for s_set_vgpr_msb past SALU program state instructions

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerVGPREncoding.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerVGPREncoding.cpp
@@ -319,9 +319,9 @@ AMDGPULowerVGPREncoding::handleCoissue(MachineBasicBlock::instr_iterator I) {
     return I;
 
   auto isProgramStateSALU = [this](MachineInstr *MI) {
-    return TII->isBarrier(MI->getOpcode()) || TII->isWaitcnt(MI->getOpcode()) ||
-           (SIInstrInfo::isProgramStateSALU(*MI) &&
-            MI->getOpcode() != AMDGPU::S_SET_VGPR_MSB);
+    return TII->isBarrier(MI->getOpcode()) ||
+           TII->isWaitcnt(MI || (SIInstrInfo::isProgramStateSALU(*MI) &&
+                                 MI->getOpcode() != AMDGPU::S_SET_VGPR_MSB));
   };
 
   while (!I.isEnd() && I != I->getParent()->begin()) {

--- a/llvm/test/CodeGen/AMDGPU/vgpr-set-msb-coissue.mir
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-set-msb-coissue.mir
@@ -11,8 +11,8 @@ body:             |
     ; CHECK: liveins: $vgpr10, $vgpr11, $vgpr900, $vgpr901
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: $vgpr11 = nofpexcept V_EXP_F32_e32 killed $vgpr10, implicit $mode, implicit $exec
-    ; CHECK-NEXT: S_SET_VGPR_MSB 65, implicit-def $mode
     ; CHECK-NEXT: S_WAIT_DSCNT 0
+    ; CHECK-NEXT: S_SET_VGPR_MSB 65, implicit-def $mode
     ; CHECK-NEXT: S_BARRIER_SIGNAL_IMM -1
     ; CHECK-NEXT: S_BARRIER_WAIT -1
     ; CHECK-NEXT: $vgpr256 = nofpexcept V_EXP_F32_e32 killed $vgpr257, implicit $mode, implicit $exec
@@ -64,22 +64,23 @@ body:             |
 ...
 
 ---
-name:            past_waitcnt
+name:            triple
 tracksRegLiveness: true
 body:             |
   bb.0:
   liveins: $vgpr4, $vgpr515
-    ; CHECK-LABEL: name: barrier_blocks_coissue
+    ; CHECK-LABEL: name: triple
     ; CHECK: liveins: $vgpr4, $vgpr515
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: S_SET_VGPR_MSB 68, implicit-def $mode
     ; CHECK-NEXT: $vgpr260 = V_AND_B32_e32 496, $vgpr260, implicit $exec
     ; CHECK-NEXT: S_SET_VGPR_MSB 17544, implicit-def $mode
-    ; CHECK-NEXT: S_BARRIER_WAIT -1
     ; CHECK-NEXT: $vgpr514 = V_LSHRREV_B32_e32 4, $vgpr515, implicit $exec
+    ; CHECK-NEXT: S_SET_VGPR_MSB 34884, implicit-def $mode
+    ; CHECK-NEXT: $vgpr260 = V_AND_B32_e32 496, $vgpr260, implicit $exec
     ; CHECK-NEXT: S_ENDPGM 0
     $vgpr260 = V_AND_B32_e32 496, $vgpr260, implicit $exec
-    S_WAIT_DSCNT 0
     $vgpr514 = V_LSHRREV_B32_e32 4, $vgpr515, implicit $exec
+    $vgpr260 = V_AND_B32_e32 496, $vgpr260, implicit $exec
     S_ENDPGM 0
 ...

--- a/llvm/test/CodeGen/AMDGPU/vgpr-set-msb-coissue.mir
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-set-msb-coissue.mir
@@ -62,3 +62,24 @@ body:             |
   $vgpr256 = nofpexcept V_EXP_F32_e32 killed $vgpr257, implicit $mode, implicit $exec
   S_ENDPGM 0
 ...
+
+---
+name:            past_waitcnt
+tracksRegLiveness: true
+body:             |
+  bb.0:
+  liveins: $vgpr4, $vgpr515
+    ; CHECK-LABEL: name: barrier_blocks_coissue
+    ; CHECK: liveins: $vgpr4, $vgpr515
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: S_SET_VGPR_MSB 68, implicit-def $mode
+    ; CHECK-NEXT: $vgpr260 = V_AND_B32_e32 496, $vgpr260, implicit $exec
+    ; CHECK-NEXT: S_SET_VGPR_MSB 17544, implicit-def $mode
+    ; CHECK-NEXT: S_BARRIER_WAIT -1
+    ; CHECK-NEXT: $vgpr514 = V_LSHRREV_B32_e32 4, $vgpr515, implicit $exec
+    ; CHECK-NEXT: S_ENDPGM 0
+    $vgpr260 = V_AND_B32_e32 496, $vgpr260, implicit $exec
+    S_WAIT_DSCNT 0
+    $vgpr514 = V_LSHRREV_B32_e32 4, $vgpr515, implicit $exec
+    S_ENDPGM 0
+...


### PR DESCRIPTION
If we exit the loop at a non SALU state instruction we have to return the next instruction because we will insert before the instruction we return. The check before the loop already did this for cases we start on a non SALU state instruction by returning `I`. This is now done afterwards.