### PR TITLE
[lldb-dap] Fix Completions Request crash

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1405,7 +1405,6 @@ class DebugCommunication(object):
         return response
 
     def request_completions(self, text, frameId=None):
-
         def code_units(input: str) -> int:
             utf16_bytes = input.encode("utf-16-le")
             # one UTF16 codeunit = 2 bytes.

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1405,7 +1405,13 @@ class DebugCommunication(object):
         return response
 
     def request_completions(self, text, frameId=None):
-        args_dict = {"text": text, "column": len(text) + 1}
+
+        def code_units(input: str) -> int:
+            utf16_bytes = input.encode("utf-16-le")
+            # one UTF16 codeunit = 2 bytes.
+            return len(utf16_bytes) // 2
+
+        args_dict = {"text": text, "column": code_units(text) + 1}
         if frameId:
             args_dict["frameId"] = frameId
         command_dict = {

--- a/lldb/test/API/tools/lldb-dap/completions/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/completions/main.cpp
@@ -29,6 +29,7 @@ int main(int argc, char const *argv[]) {
   fun(vec);
   bar bar1 = {2};
   bar *bar2 = &bar1;
+  int ƒake_f = 200;
   foo foo1 = {3, &bar1, bar1, NULL};
   return 0; // breakpoint 2
 }

--- a/lldb/tools/lldb-dap/Handler/CompletionsHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/CompletionsHandler.cpp
@@ -21,9 +21,9 @@ using namespace lldb_dap::protocol;
 
 namespace lldb_dap {
 /// Gets the position in the UTF8 string where the specified line started.
-static size_t GetLineStartPos(llvm::StringRef text, uint32_t line) {
+static size_t GetLineStartPos(StringRef text, uint32_t line) {
   if (line == 0) // Invalid line.
-    return llvm::StringRef::npos;
+    return StringRef::npos;
 
   if (line == 1)
     return 0;
@@ -34,14 +34,13 @@ static size_t GetLineStartPos(llvm::StringRef text, uint32_t line) {
   while (cur_line < line) {
     const size_t new_line_pos = text.find('\n', pos);
 
-    if (new_line_pos == llvm::StringRef::npos) {
+    if (new_line_pos == StringRef::npos)
       return new_line_pos;
-    }
 
     pos = new_line_pos + 1;
     // text may end with a new line
     if (pos >= text.size())
-      return llvm::StringRef::npos;
+      return StringRef::npos;
 
     cur_line++;
   }
@@ -50,16 +49,16 @@ static size_t GetLineStartPos(llvm::StringRef text, uint32_t line) {
   return pos;
 }
 
-static std::optional<size_t> GetCursorPos(llvm::StringRef text, uint32_t line,
+static std::optional<size_t> GetCursorPos(StringRef text, uint32_t line,
                                           uint32_t utf16_codeunits) {
   if (text.empty())
     return std::nullopt;
 
   const size_t line_start_pos = GetLineStartPos(text, line);
-  if (line_start_pos == llvm::StringRef::npos)
+  if (line_start_pos == StringRef::npos)
     return std::nullopt;
 
-  const llvm::StringRef completion_line =
+  const StringRef completion_line =
       text.substr(line_start_pos, text.find('\n', line_start_pos));
   if (completion_line.empty())
     return std::nullopt;
@@ -98,7 +97,7 @@ CompletionsRequestHandler::Run(const CompletionsArguments &args) const {
     frame_thread.SetSelectedFrame(frame.GetFrameID());
   }
 
-  const llvm::StringRef escape_prefix = dap.configuration.commandEscapePrefix;
+  const StringRef escape_prefix = dap.configuration.commandEscapePrefix;
   const bool had_escape_prefix = StringRef(text).starts_with(escape_prefix);
   const ReplMode repl_mode = dap.DetectReplMode(frame, text, true);
   // Handle the cursor_pos change introduced by stripping out the
@@ -136,13 +135,13 @@ CompletionsRequestHandler::Run(const CompletionsArguments &args) const {
     // all the matches. The rest of the elements are the matches so ignore the
     // first result.
     for (uint32_t i = 1; i < matches.GetSize(); i++) {
-      const llvm::StringRef match = matches.GetStringAtIndex(i);
-      const llvm::StringRef description = descriptions.GetStringAtIndex(i);
+      const StringRef match = matches.GetStringAtIndex(i);
+      const StringRef description = descriptions.GetStringAtIndex(i);
 
       StringRef match_ref = match;
       for (const StringRef commit_point : {".", "->"}) {
         if (const size_t pos = match_ref.rfind(commit_point);
-            pos != llvm::StringRef::npos) {
+            pos != StringRef::npos) {
           match_ref = match_ref.substr(pos + commit_point.size());
         }
       }

--- a/lldb/tools/lldb-dap/Handler/CompletionsHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/CompletionsHandler.cpp
@@ -7,17 +7,71 @@
 //===----------------------------------------------------------------------===//
 
 #include "DAP.h"
-#include "JSONUtils.h"
+#include "LLDBUtils.h"
 #include "Protocol/ProtocolRequests.h"
 #include "Protocol/ProtocolTypes.h"
 #include "RequestHandler.h"
 #include "lldb/API/SBStringList.h"
+#include "llvm/Support/ConvertUTF.h"
 
 using namespace llvm;
 using namespace lldb_dap;
+using namespace lldb;
 using namespace lldb_dap::protocol;
 
 namespace lldb_dap {
+/// Gets the position in the UTF8 string where the specified line started.
+static size_t GetLineStartPos(llvm::StringRef text, uint32_t line) {
+  if (line == 0) // Invalid line.
+    return llvm::StringRef::npos;
+
+  if (line == 1)
+    return 0;
+
+  uint32_t cur_line = 1;
+  size_t pos = 0;
+
+  while (cur_line < line) {
+    const size_t new_line_pos = text.find('\n', pos);
+
+    if (new_line_pos == llvm::StringRef::npos) {
+      return new_line_pos;
+    }
+
+    pos = new_line_pos + 1;
+    // text may end with a new line
+    if (pos >= text.size())
+      return llvm::StringRef::npos;
+
+    cur_line++;
+  }
+
+  assert(pos < text.size());
+  return pos;
+}
+
+static std::optional<size_t> GetCursorPos(llvm::StringRef text, uint32_t line,
+                                          uint32_t utf16_codeunits) {
+  if (text.empty())
+    return std::nullopt;
+
+  const size_t line_start_pos = GetLineStartPos(text, line);
+  if (line_start_pos == llvm::StringRef::npos)
+    return std::nullopt;
+
+  const llvm::StringRef completion_line =
+      text.substr(line_start_pos, text.find('\n', line_start_pos));
+  if (completion_line.empty())
+    return std::nullopt;
+
+  const std::optional<size_t> cursor_pos_opt =
+      UTF16CodeunitToBytes(completion_line, utf16_codeunits);
+  if (!cursor_pos_opt)
+    return std::nullopt;
+
+  const size_t cursor_pos = line_start_pos + *cursor_pos_opt;
+  return cursor_pos;
+}
 
 /// Returns a list of possible completions for a given caret position and text.
 ///
@@ -25,85 +79,85 @@ namespace lldb_dap {
 /// `supportsCompletionsRequest` is true.
 Expected<CompletionsResponseBody>
 CompletionsRequestHandler::Run(const CompletionsArguments &args) const {
+  std::string text = args.text;
+  const uint32_t line = args.line;
+  // column starts at 1.
+  const uint32_t utf16_codeunits = args.column - 1;
+
+  const auto cursor_pos_opt = GetCursorPos(text, line, utf16_codeunits);
+  if (!cursor_pos_opt)
+    return CompletionsResponseBody{};
+
+  size_t cursor_pos = *cursor_pos_opt;
+
   // If we have a frame, try to set the context for variable completions.
   lldb::SBFrame frame = dap.GetLLDBFrame(args.frameId);
   if (frame.IsValid()) {
-    frame.GetThread().GetProcess().SetSelectedThread(frame.GetThread());
-    frame.GetThread().SetSelectedFrame(frame.GetFrameID());
+    lldb::SBThread frame_thread = frame.GetThread();
+    frame_thread.GetProcess().SetSelectedThread(frame_thread);
+    frame_thread.SetSelectedFrame(frame.GetFrameID());
   }
 
-  std::string text = args.text;
-  auto original_column = args.column;
-  auto original_line = args.line;
-  auto offset = original_column - 1;
-  if (original_line > 1) {
-    SmallVector<StringRef, 2> lines;
-    StringRef(text).split(lines, '\n');
-    for (int i = 0; i < original_line - 1; i++) {
-      offset += lines[i].size();
-    }
-  }
-
-  std::vector<CompletionItem> targets;
-
-  bool had_escape_prefix =
-      StringRef(text).starts_with(dap.configuration.commandEscapePrefix);
-  ReplMode completion_mode = dap.DetectReplMode(frame, text, true);
-
-  // Handle the offset change introduced by stripping out the
+  const llvm::StringRef escape_prefix = dap.configuration.commandEscapePrefix;
+  const bool had_escape_prefix = StringRef(text).starts_with(escape_prefix);
+  const ReplMode repl_mode = dap.DetectReplMode(frame, text, true);
+  // Handle the cursor_pos change introduced by stripping out the
   // `command_escape_prefix`.
   if (had_escape_prefix) {
-    if (offset <
-        static_cast<int64_t>(dap.configuration.commandEscapePrefix.size())) {
-      return CompletionsResponseBody{std::move(targets)};
-    }
-    offset -= dap.configuration.commandEscapePrefix.size();
+    if (cursor_pos < escape_prefix.size())
+      return CompletionsResponseBody{};
+
+    cursor_pos -= escape_prefix.size();
   }
 
   // While the user is typing then we likely have an incomplete input and cannot
   // reliably determine the precise intent (command vs variable), try completing
   // the text as both a command and variable expression, if applicable.
   const std::string expr_prefix = "expression -- ";
-  std::array<std::tuple<ReplMode, std::string, uint64_t>, 2> exprs = {
-      {std::make_tuple(ReplMode::Command, text, offset),
+  const std::array<std::tuple<ReplMode, std::string, uint64_t>, 2> exprs = {
+      {std::make_tuple(ReplMode::Command, text, cursor_pos),
        std::make_tuple(ReplMode::Variable, expr_prefix + text,
-                       offset + expr_prefix.size())}};
+                       cursor_pos + expr_prefix.size())}};
+
+  CompletionsResponseBody response;
+  std::vector<CompletionItem> &targets = response.targets;
+  lldb::SBCommandInterpreter interpreter = dap.debugger.GetCommandInterpreter();
   for (const auto &[mode, line, cursor] : exprs) {
-    if (completion_mode != ReplMode::Auto && completion_mode != mode)
+    if (repl_mode != ReplMode::Auto && repl_mode != mode)
       continue;
 
     lldb::SBStringList matches;
     lldb::SBStringList descriptions;
-    if (!dap.debugger.GetCommandInterpreter().HandleCompletionWithDescriptions(
-            line.c_str(), cursor, 0, 100, matches, descriptions))
+    if (!interpreter.HandleCompletionWithDescriptions(
+            line.c_str(), cursor, 0, 50, matches, descriptions))
       continue;
 
     // The first element is the common substring after the cursor position for
     // all the matches. The rest of the elements are the matches so ignore the
     // first result.
-    for (size_t i = 1; i < matches.GetSize(); i++) {
-      std::string match = matches.GetStringAtIndex(i);
-      std::string description = descriptions.GetStringAtIndex(i);
+    for (uint32_t i = 1; i < matches.GetSize(); i++) {
+      const llvm::StringRef match = matches.GetStringAtIndex(i);
+      const llvm::StringRef description = descriptions.GetStringAtIndex(i);
 
-      CompletionItem item;
       StringRef match_ref = match;
-      for (StringRef commit_point : {".", "->"}) {
-        if (match_ref.contains(commit_point)) {
-          match_ref = match_ref.rsplit(commit_point).second;
+      for (const StringRef commit_point : {".", "->"}) {
+        if (const size_t pos = match_ref.rfind(commit_point);
+            pos != llvm::StringRef::npos) {
+          match_ref = match_ref.substr(pos + commit_point.size());
         }
       }
-      item.text = match_ref;
 
-      if (description.empty())
-        item.label = match;
-      else
-        item.label = match + " -- " + description;
+      CompletionItem item;
+      item.text = match_ref;
+      item.label = match;
+      if (!description.empty())
+        item.detail = description;
 
       targets.emplace_back(std::move(item));
     }
   }
 
-  return CompletionsResponseBody{std::move(targets)};
+  return response;
 }
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/LLDBUtils.h
+++ b/lldb/tools/lldb-dap/LLDBUtils.h
@@ -248,6 +248,24 @@ llvm::Error ToError(const lldb::SBError &error, bool show_user = true);
 /// Provides the string value if this data structure is a string type.
 std::string GetStringValue(const lldb::SBStructuredData &data);
 
+/// Converts UTF16 column codeunits to bytes.
+/// we are recieving utf8 from the specification.
+/// UTF16 codunit size => 2 bytes.
+/// UTF8 codunit size => 1 byte.
+/// Example
+/// | info     | info  | utf16_cu | size in bytes |
+/// | fake f   | ƒ     | 1        | 2             |
+/// | fake c   | ç     | 1        | 3             |
+/// | poop char| 💩    | 2        | 4             |
+///
+/// so with inputs string of
+/// (`ƒ💩`, 3) we have 3 utf16_u and ( 2 + 4 ) bytes.
+/// (`ƒ💩`, 2) we have 3 utf16_u and ( 2 + 4 ) bytes but the position is in
+///  between the 💩 char so we return null since the codepoint is not complete.
+///
+/// see https://utf8everywhere.org/#characters for more info.
+std::optional<size_t> UTF16CodeunitToBytes(llvm::StringRef line,
+                                           uint32_t utf16_codeunits);
 } // namespace lldb_dap
 
 #endif

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -313,7 +313,7 @@ bool fromJSON(const llvm::json::Value &, LaunchRequestArguments &,
 /// field is required.
 using LaunchResponse = VoidResponse;
 
-#define LLDB_DAP_INVALID_PORT -1
+#define LLDB_DAP_INVALID_PORT (-1)
 /// An invalid 'frameId' default value.
 #define LLDB_DAP_INVALID_FRAME_ID UINT64_MAX
 
@@ -401,11 +401,11 @@ struct CompletionsArguments {
   /// The position within `text` for which to determine the completion
   /// proposals. It is measured in UTF-16 code units and the client capability
   /// `columnsStartAt1` determines whether it is 0- or 1-based.
-  int64_t column = 0;
+  uint32_t column = LLDB_INVALID_COLUMN_NUMBER;
 
   /// A line for which to determine the completion proposals. If missing the
   /// first line of the text is assumed.
-  int64_t line = 0;
+  uint32_t line = 1;
 };
 bool fromJSON(const llvm::json::Value &, CompletionsArguments &,
               llvm::json::Path);

--- a/lldb/unittests/DAP/LLDBUtilsTest.cpp
+++ b/lldb/unittests/DAP/LLDBUtilsTest.cpp
@@ -9,6 +9,7 @@
 #include "LLDBUtils.h"
 #include "lldb/API/SBError.h"
 #include "lldb/API/SBStructuredData.h"
+#include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Error.h"
 #include "gtest/gtest.h"
 
@@ -62,4 +63,31 @@ TEST(LLDBUtilsTest, ToError) {
 
   std::string error_message = toString(std::move(llvm_error));
   EXPECT_EQ(error_message, "Test error message");
+}
+
+TEST(LLDBUtilsTest, UTF16Codeunits) {
+  using Expect = std::optional<size_t>;
+
+  EXPECT_EQ(UTF16CodeunitToBytes("a", 0), Expect{0});
+  EXPECT_EQ(UTF16CodeunitToBytes("some word", 4), Expect{4});
+  EXPECT_EQ(UTF16CodeunitToBytes("fake", 4), Expect{4});
+  EXPECT_EQ(UTF16CodeunitToBytes("ƒake", 4), Expect{5});
+  EXPECT_EQ(UTF16CodeunitToBytes("b", 1), Expect{1});
+  EXPECT_EQ(UTF16CodeunitToBytes("💩", 0), Expect{0});
+  EXPECT_EQ(UTF16CodeunitToBytes("ƒ", 1), Expect{2});
+  EXPECT_EQ(UTF16CodeunitToBytes("💩ƒ", 2), Expect{4});
+  EXPECT_EQ(UTF16CodeunitToBytes("√", 2), Expect{3});
+  EXPECT_EQ(UTF16CodeunitToBytes("√ƒ", 4), Expect{5});
+  EXPECT_EQ(UTF16CodeunitToBytes("√💩", 4), Expect{7});
+  EXPECT_EQ(UTF16CodeunitToBytes("√", 1), Expect{3});
+
+  // Index
+  EXPECT_EQ(UTF16CodeunitToBytes("ƒake extra", 4), Expect{5});
+  EXPECT_EQ(UTF16CodeunitToBytes("3çç ", 3), Expect{5});
+  EXPECT_EQ(UTF16CodeunitToBytes("20𒂷 ", 3), std::nullopt);
+
+  // Failures
+  EXPECT_EQ(UTF16CodeunitToBytes("💩ƒ", 1), std::nullopt);
+  EXPECT_NE(UTF16CodeunitToBytes("20𒂷 ", 3), Expect{5});
+  EXPECT_NE(UTF16CodeunitToBytes("w💩ƒ", 2), Expect{6});
 }

--- a/lldb/unittests/DAP/ProtocolTypesTest.cpp
+++ b/lldb/unittests/DAP/ProtocolTypesTest.cpp
@@ -1042,10 +1042,10 @@ TEST(ProtocolTypesTest, CompletionsArguments) {
     "text": "abc"
   })");
   ASSERT_THAT_EXPECTED(expected, llvm::Succeeded());
-  EXPECT_EQ(expected->frameId, 7u);
+  EXPECT_EQ(expected->frameId, 7U);
   EXPECT_EQ(expected->text, "abc");
-  EXPECT_EQ(expected->column, 8);
-  EXPECT_EQ(expected->line, 9);
+  EXPECT_EQ(expected->column, 8U);
+  EXPECT_EQ(expected->line, 9U);
 
   // Check required keys.
   EXPECT_THAT_EXPECTED(parse<CompletionsArguments>(R"({})"),


### PR DESCRIPTION
lldb-dap currently crashes when the first character is non ascii. This is because we assume that the request column is ascii based instead of UTF16 code units,
and end up in the middle of a character code point. causing an assertion since we cannot not send invalid UTF-8 values.

This also handles the case in multilines and the column is outside the range of the text.

Move completion description to the `CompletionItem.detail` property.