### PR TITLE
[AArch64] Improve Cortex-A57 EXTR modelling

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SchedA57.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedA57.td
@@ -160,8 +160,11 @@ def : InstRW<[A57Write_6cyc_1M], (instrs SMULHrr, UMULHrr)>;
 // Miscellaneous Data-Processing Instructions
 // -----------------------------------------------------------------------------
 
-def : InstRW<[A57Write_1cyc_1I],    (instrs EXTRWrri)>;
-def : InstRW<[A57Write_3cyc_1I_1M], (instrs EXTRXrri)>;
+def A57WriteExtr : SchedWriteVariant<[
+       SchedVar<IsRORImmIdiomPred, [A57Write_1cyc_1I]>,
+       SchedVar<NoSchedPred, [A57Write_3cyc_1I_1M]>]>;
+
+def : InstRW<[A57WriteExtr],    (instrs EXTRWrri, EXTRXrri)>;
 def : InstRW<[A57Write_2cyc_1M],    (instregex "BFM")>;
 
 

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A57-basic-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A57-basic-instructions.s
@@ -498,12 +498,12 @@
 # CHECK-NEXT:  1      3     1.00                        umull	x11, w13, w17
 # CHECK-NEXT:  1      3     1.00                        smnegl	x11, w13, w17
 # CHECK-NEXT:  1      3     1.00                        umnegl	x11, w13, w17
-# CHECK-NEXT:  1      1     0.50                        extr	w3, w5, w7, #0
-# CHECK-NEXT:  1      1     0.50                        extr	w11, w13, w17, #31
+# CHECK-NEXT:  2      3     1.00                        extr	w3, w5, w7, #0
+# CHECK-NEXT:  2      3     1.00                        extr	w11, w13, w17, #31
 # CHECK-NEXT:  2      3     1.00                        extr	x3, x5, x7, #15
 # CHECK-NEXT:  2      3     1.00                        extr	x11, x13, x17, #63
-# CHECK-NEXT:  2      3     1.00                        ror	x19, x23, #24
-# CHECK-NEXT:  2      3     1.00                        ror	x29, xzr, #63
+# CHECK-NEXT:  1      1     0.50                        ror	x19, x23, #24
+# CHECK-NEXT:  1      1     0.50                        ror	x29, xzr, #63
 # CHECK-NEXT:  1      1     0.50                        ror	w9, w13, #31
 # CHECK-NEXT:  1      3     0.50                        fcmp	s3, s5
 # CHECK-NEXT:  1      3     0.50                        fcmp	s31, #0.0
@@ -1672,12 +1672,12 @@
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -     umull	x11, w13, w17
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -     smnegl	x11, w13, w17
 # CHECK-NEXT:  -      -      -      -     1.00    -      -      -     umnegl	x11, w13, w17
-# CHECK-NEXT:  -     0.50   0.50    -      -      -      -      -     extr	w3, w5, w7, #0
-# CHECK-NEXT:  -     0.50   0.50    -      -      -      -      -     extr	w11, w13, w17, #31
+# CHECK-NEXT:  -     0.50   0.50    -     1.00    -      -      -     extr	w3, w5, w7, #0
+# CHECK-NEXT:  -     0.50   0.50    -     1.00    -      -      -     extr	w11, w13, w17, #31
 # CHECK-NEXT:  -     0.50   0.50    -     1.00    -      -      -     extr	x3, x5, x7, #15
 # CHECK-NEXT:  -     0.50   0.50    -     1.00    -      -      -     extr	x11, x13, x17, #63
-# CHECK-NEXT:  -     0.50   0.50    -     1.00    -      -      -     ror	x19, x23, #24
-# CHECK-NEXT:  -     0.50   0.50    -     1.00    -      -      -     ror	x29, xzr, #63
+# CHECK-NEXT:  -     0.50   0.50    -      -      -      -      -     ror	x19, x23, #24
+# CHECK-NEXT:  -     0.50   0.50    -      -      -      -      -     ror	x29, xzr, #63
 # CHECK-NEXT:  -     0.50   0.50    -      -      -      -      -     ror	w9, w13, #31
 # CHECK-NEXT:  -      -      -      -      -      -     0.50   0.50   fcmp	s3, s5
 # CHECK-NEXT:  -      -      -      -      -      -     0.50   0.50   fcmp	s31, #0.0


### PR DESCRIPTION
The extr instruction operating on one reg is performed faster (1 cycle instead of 3) and is utilizing only I pipeline.