### PR TITLE
[flang][acc] Disallow duplicate variables in use_device clause

### DIFF
--- a/flang/docs/OpenACC.md
+++ b/flang/docs/OpenACC.md
@@ -30,10 +30,10 @@ local:
 * The OpenACC specification disallows a variable appearing multiple times in
   clauses of `!$acc declare` directives for a function, subroutine, program,
   or module, but it is allowed with a warning when same clause is used.
-* The OpenACC specification does not disallow the same variable from appearing
+* The OpenACC specification does not prohibit the same variable from appearing
   in multiple data clauses, but this is disallowed for variables appearing in
   `private`, `firstprivate`, or `reduction` clauses.
-* The OpenACC specification does not disallow the same variable from appearing
+* The OpenACC specification does not prohibit the same variable from appearing
   multiple times in a `use_device` clause on a `host_data` construct, but this
   is disallowed.
 

--- a/flang/docs/OpenACC.md
+++ b/flang/docs/OpenACC.md
@@ -30,6 +30,12 @@ local:
 * The OpenACC specification disallows a variable appearing multiple times in
   clauses of `!$acc declare` directives for a function, subroutine, program,
   or module, but it is allowed with a warning when same clause is used.
+* The OpenACC specification does not disallow the same variable from appearing
+  in multiple data clauses, but this is disallowed for variables appearing in
+  `private`, `firstprivate`, or `reduction` clauses.
+* The OpenACC specification does not disallow the same variable from appearing
+  multiple times in a `use_device` clause on a `host_data` construct, but this
+  is disallowed.
 
 ## Remarks about incompatibilities with other implementations
 * Array element references in the data clauses are equivalent to array sections

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -396,15 +396,7 @@ private:
 
   // Track use_device variables and check for duplicates.
   // Emits an error if the object was already added.
-  void AddUseDeviceObject(const Symbol &object, const parser::Name &name) {
-    auto result = useDeviceObjects_.insert(object);
-    if (!result.second) {
-      context_.Say(name.source,
-          "'%s' appears in more than one USE_DEVICE clause "
-          "on the same HOST_DATA directive"_err_en_US,
-          name.ToString());
-    }
-  }
+  void AddUseDeviceObject(const Symbol &, const parser::Name &);
   void ClearUseDeviceObjects() { useDeviceObjects_.clear(); }
   UnorderedSymbolSet useDeviceObjects_;
 
@@ -1794,6 +1786,17 @@ Symbol *AccAttributeVisitor::ResolveAccCommonBlockName(
     }
   }
   return nullptr;
+}
+
+void AccAttributeVisitor::AddUseDeviceObject(
+    const Symbol &object, const parser::Name &name) {
+  auto result = useDeviceObjects_.insert(object);
+  if (!result.second) {
+    context_.Say(name.source,
+        "'%s' appears in more than one USE_DEVICE clause "
+        "on the same HOST_DATA directive"_err_en_US,
+        name.ToString());
+  }
 }
 
 void AccAttributeVisitor::ResolveAccObjectList(

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1790,8 +1790,7 @@ Symbol *AccAttributeVisitor::ResolveAccCommonBlockName(
 
 void AccAttributeVisitor::AddUseDeviceObject(
     const Symbol &object, const parser::Name &name) {
-  auto result = useDeviceObjects_.insert(object);
-  if (!result.second) {
+  if (!useDeviceObjects_.insert(object).second) {
     context_.Say(name.source,
         "'%s' appears in more than one USE_DEVICE clause "
         "on the same HOST_DATA directive"_err_en_US,

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -341,8 +341,7 @@ public:
     for (const auto &accObject : x.v.v) {
       if (const auto *designator{
               std::get_if<parser::Designator>(&accObject.u)}) {
-        if (const auto *name{
-                parser::GetDesignatorNameIfDataRef(*designator)}) {
+        if (const auto *name{parser::GetDesignatorNameIfDataRef(*designator)}) {
           if (name->symbol) {
             if (HasUseDeviceObject(*name->symbol)) {
               context_.Say(name->source,
@@ -403,7 +402,9 @@ private:
       Symbol &, const parser::OpenACCRoutineConstruct &);
 
   // Track use_device variables
-  void AddUseDeviceObject(SymbolRef object) { useDeviceObjects_.insert(object); }
+  void AddUseDeviceObject(SymbolRef object) {
+    useDeviceObjects_.insert(object);
+  }
   void ClearUseDeviceObjects() { useDeviceObjects_.clear(); }
   bool HasUseDeviceObject(const Symbol &object) {
     return useDeviceObjects_.find(object) != useDeviceObjects_.end();

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1792,8 +1792,7 @@ void AccAttributeVisitor::AddUseDeviceObject(
     const Symbol &object, const parser::Name &name) {
   if (!useDeviceObjects_.insert(object).second) {
     context_.Say(name.source,
-        "'%s' appears in more than one USE_DEVICE clause "
-        "on the same HOST_DATA directive"_err_en_US,
+        "'%s' appears in more than one USE_DEVICE clause on the same HOST_DATA directive"_err_en_US,
         name.ToString());
   }
 }

--- a/flang/test/Semantics/OpenACC/acc-host-data.f90
+++ b/flang/test/Semantics/OpenACC/acc-host-data.f90
@@ -38,4 +38,12 @@ program openacc_host_data_validity
   !$acc host_data use_device(aa, bb) if(.true.) if(ifCondition)
   !$acc end host_data
 
+  !ERROR: 'aa' appears in more than one USE_DEVICE clause on the same HOST_DATA directive
+  !$acc host_data use_device(aa) use_device(aa)
+  !$acc end host_data
+
+  !ERROR: 'bb' appears in more than one USE_DEVICE clause on the same HOST_DATA directive
+  !$acc host_data use_device(bb, bb)
+  !$acc end host_data
+
 end program openacc_host_data_validity


### PR DESCRIPTION
Add a semantic check to detect when the same variable appears multiple times in `use_device` clauses on the same `host_data` directive. While the OpenACC specification does not explicitly prohibit this, allowing duplicates is likely a user error and provides no additional semantics.

A similar restriction was already in place for `private`, `firstprivate`, and `reduction` clauses on compute constructs. This change extends that behavior to `use_device` on `host_data`.

Error message:
  `'<var>' appears in more than one USE_DEVICE clause on the same HOST_DATA directive`