### PR TITLE
[libc][math] Refactor logbf16 to Header Only.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -68,6 +68,7 @@
 #include "math/ldexpf16.h"
 #include "math/log.h"
 #include "math/logbf128.h"
+#include "math/logbf16.h"
 #include "math/rsqrtf.h"
 #include "math/rsqrtf16.h"
 #include "math/sin.h"

--- a/libc/shared/math/logbf16.h
+++ b/libc/shared/math/logbf16.h
@@ -1,4 +1,4 @@
-//===-- Shared logbf16 function-------------------------------- -*- C++ -*-===//
+//===-- Shared logbf16 function ---------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/shared/math/logbf16.h
+++ b/libc/shared/math/logbf16.h
@@ -1,0 +1,29 @@
+//===-- Shared logbf16 function-------------------------------- -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_MATH_LOGBF16_H
+#define LLVM_LIBC_SHARED_MATH_LOGBF16_H
+
+#include "include/llvm-libc-macros/float16-macros.h"
+#include "shared/libc_common.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+
+#include "src/__support/math/logbf16.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace shared {
+
+using math::logbf16;
+
+} // namespace shared
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+#endif // LLVM_LIBC_SHARED_MATH_LOGBF16_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1071,6 +1071,15 @@ add_header_library(
 )
 
 add_header_library(
+  logbf16
+  HDRS
+    logbf16.h
+  DEPENDS
+    libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.macros.properties.types
+)
+
+add_header_library(
   log_range_reduction
   HDRS
     log_range_reduction.h
@@ -1105,3 +1114,4 @@ add_header_library(
     libc.src.__support.common
     libc.src.__support.macros.config
 )
+

--- a/libc/src/__support/math/logbf16.h
+++ b/libc/src/__support/math/logbf16.h
@@ -12,6 +12,7 @@
 #include "include/llvm-libc-macros/float16-macros.h"
 
 #ifdef LIBC_TYPES_HAS_FLOAT16
+
 #include "src/__support/FPUtil/ManipulationFunctions.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"

--- a/libc/src/__support/math/logbf16.h
+++ b/libc/src/__support/math/logbf16.h
@@ -1,0 +1,34 @@
+//===-- Implementation header for logbf16----------------------- -*- C++
+//-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_LOGBF16_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_LOGBF16_H
+
+#include "include/llvm-libc-macros/float16-macros.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+#include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE static constexpr float16 logbf16(float16 x) {
+  return fputil::logb(x);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_LOGBF16_H

--- a/libc/src/__support/math/logbf16.h
+++ b/libc/src/__support/math/logbf16.h
@@ -1,5 +1,4 @@
-//===-- Implementation header for logbf16----------------------- -*- C++
-//-*-===//
+//===-- Implementation header for logbf16 -----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -2193,8 +2193,8 @@ add_entrypoint_object(
   HDRS
     ../logbf16.h
   DEPENDS
-    libc.src.__support.macros.properties.types
-    libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.math.logbf16
+    libc.src.errno.errno
 )
 
 add_entrypoint_object(

--- a/libc/src/math/generic/logbf16.cpp
+++ b/libc/src/math/generic/logbf16.cpp
@@ -8,6 +8,7 @@
 
 #include "src/math/logbf16.h"
 #include "src/__support/math/logbf16.h"
+
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(float16, logbf16, (float16 x)) { return math::logbf16(x); }

--- a/libc/src/math/generic/logbf16.cpp
+++ b/libc/src/math/generic/logbf16.cpp
@@ -7,12 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/logbf16.h"
-#include "src/__support/FPUtil/ManipulationFunctions.h"
-#include "src/__support/common.h"
-#include "src/__support/macros/config.h"
-
+#include "src/__support/math/logbf16.h"
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(float16, logbf16, (float16 x)) { return fputil::logb(x); }
+LLVM_LIBC_FUNCTION(float16, logbf16, (float16 x)) { return math::logbf16(x); }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -67,4 +67,5 @@ add_fp_unittest(
     libc.src.__support.math.rsqrtf
     libc.src.__support.math.rsqrtf16
     libc.src.__support.math.sin
+    libc.src.__support.math.logbf16
 )

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -61,11 +61,11 @@ add_fp_unittest(
     libc.src.__support.math.ilogbf16
     libc.src.__support.math.log
     libc.src.__support.math.logbf128
+    libc.src.__support.math.logbf16
     libc.src.__support.math.ldexpf
     libc.src.__support.math.ldexpf128
     libc.src.__support.math.ldexpf16
     libc.src.__support.math.rsqrtf
     libc.src.__support.math.rsqrtf16
     libc.src.__support.math.sin
-    libc.src.__support.math.logbf16
 )

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -42,10 +42,9 @@ TEST(LlvmLibcSharedMathTest, AllFloat16) {
   EXPECT_EQ(exponent, 5);
 
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbf16(1.0f16));
+  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::logbf16(1.0f16));
 
   EXPECT_FP_EQ(0x1.921fb6p+0f16, LIBC_NAMESPACE::shared::acosf16(0.0f16));
-
-  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::logbf16(1.0f16));
 }
 
 #endif // LIBC_TYPES_HAS_FLOAT16

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -44,6 +44,8 @@ TEST(LlvmLibcSharedMathTest, AllFloat16) {
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbf16(1.0f16));
 
   EXPECT_FP_EQ(0x1.921fb6p+0f16, LIBC_NAMESPACE::shared::acosf16(0.0f16));
+
+  EXPECT_FP_EQ(0x0p+0f16, LIBC_NAMESPACE::shared::logbf16(1.0f16));
 }
 
 #endif // LIBC_TYPES_HAS_FLOAT16

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2915,6 +2915,14 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_logbf16",
+    hdrs = ["src/__support/math/logbf16.h"],
+    deps = [
+        ":__support_fputil_manipulation_functions",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_exp_constants",
     hdrs = ["src/__support/math/exp_constants.h"],
     deps = [
@@ -7892,13 +7900,5 @@ libc_function(
         ":__support_common",
         ":types_size_t",
         ":types_wchar_t",
-    ],
-)
-
-libc_support_library(
-    name = "__support_math_logbf16",
-    hdrs = ["src/__support/math/logbf16.h"],
-    deps = [
-        ":__support_fputil_manipulation_functions",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4559,7 +4559,12 @@ libc_math_function(
     additional_deps = [":__support_math_logbf128"],
 )
 
-libc_math_function(name = "logbf16")
+libc_math_function(
+    name = "logbf16",
+    additional_deps = [
+        ":__support_math_logbf16",
+    ],
+)
 
 libc_math_function(name = "lrint")
 
@@ -7887,5 +7892,13 @@ libc_function(
         ":__support_common",
         ":types_size_t",
         ":types_wchar_t",
+    ],
+)
+
+libc_support_library(
+    name = "__support_math_logbf16",
+    hdrs = ["src/__support/math/logbf16.h"],
+    deps = [
+        ":__support_fputil_manipulation_functions",
     ],
 )


### PR DESCRIPTION
builds with both Clang and GCC 12.2.

Closes https://github.com/llvm/llvm-project/issues/175363.

CC @bassiounix