### PR TITLE
[Clang][WebAssembly] Fix crash when using __funcref in C++ code

### DIFF
--- a/clang/lib/Basic/Targets/WebAssembly.h
+++ b/clang/lib/Basic/Targets/WebAssembly.h
@@ -81,6 +81,7 @@ public:
   explicit WebAssemblyTargetInfo(const llvm::Triple &T, const TargetOptions &)
       : TargetInfo(T) {
     AddrSpaceMap = &WebAssemblyAddrSpaceMap;
+    UseAddrSpaceMapMangling = true;
     NoAsmVariants = true;
     SuitableAlign = 128;
     LargeArrayMinWidth = 128;

--- a/clang/test/CodeGenCXX/wasm-reftypes-mangle.cpp
+++ b/clang/test/CodeGenCXX/wasm-reftypes-mangle.cpp
@@ -2,5 +2,19 @@
 // RUN: %clang_cc1 %s -triple wasm32-unknown-unknown -target-feature +reference-types -emit-llvm -o - -std=c++11 | FileCheck %s
 // RUN: %clang_cc1 %s -triple wasm64-unknown-unknown -target-feature +reference-types -emit-llvm -o - -std=c++11 | FileCheck %s
 
-// CHECK: _Z2f1u11externref_t
+// Test that funcref can be used in C++ without crashing during codegen.
+// See https://github.com/llvm/llvm-project/issues/176154
+typedef void (*__funcref funcref_t)();
+
+// Global funcref variables - test that codegen doesn't crash.
+// CHECK-DAG: @fptr = global ptr addrspace(20) null
+funcref_t fptr;
+
+// CHECK-DAG: @fpt2 = global ptr addrspace(20) null
+void (*__funcref fpt2)();
+
+// CHECK-DAG: _Z2f1u11externref_t
 void f1(__externref_t) {}
+
+// CHECK-DAG: _Z2f2PU4AS20FvvE
+void f2(funcref_t) {}


### PR DESCRIPTION
Enable address space map mangling for the WebAssembly target. This fixes a crash in the Itanium name mangler when trying to mangle types with the wasm_funcref address space qualifier in C++ mode.

Fixes #176154