### PR TITLE
[AMDGPU] Fix expensive checks in fmaak/fmamk f16 folding

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -3816,12 +3816,31 @@ bool SIInstrInfo::foldImmediate(MachineInstr &UseMI, MachineInstr &DefMI,
 
       if (NewOpc == AMDGPU::V_FMAMK_F16_t16 ||
           NewOpc == AMDGPU::V_FMAMK_F16_fake16) {
-        auto Tmp = MRI->createVirtualRegister(getRegClass(get(NewOpc), 0));
+        const TargetRegisterClass *NewRC = getRegClass(get(NewOpc), 0);
+        auto Tmp = MRI->createVirtualRegister(NewRC);
         BuildMI(*UseMI.getParent(), std::next(UseMI.getIterator()),
                 UseMI.getDebugLoc(), get(AMDGPU::COPY),
                 UseMI.getOperand(0).getReg())
             .addReg(Tmp, RegState::Kill);
         UseMI.getOperand(0).setReg(Tmp);
+        if (UseMI.getOperand(1).isReg() &&
+            RI.isVGPR(*MRI, UseMI.getOperand(1).getReg())) {
+          auto Tmp = MRI->createVirtualRegister(NewRC);
+          BuildMI(*UseMI.getParent(), UseMI.getIterator(), UseMI.getDebugLoc(),
+                  get(AMDGPU::COPY), Tmp)
+              .addReg(UseMI.getOperand(1).getReg());
+          UseMI.getOperand(1).setReg(Tmp);
+          UseMI.getOperand(1).setIsKill();
+        }
+        if (UseMI.getOperand(3).isReg() &&
+            RI.isVGPR(*MRI, UseMI.getOperand(3).getReg())) {
+          auto Tmp = MRI->createVirtualRegister(NewRC);
+          BuildMI(*UseMI.getParent(), UseMI.getIterator(), UseMI.getDebugLoc(),
+                  get(AMDGPU::COPY), Tmp)
+              .addReg(UseMI.getOperand(3).getReg());
+          UseMI.getOperand(3).setReg(Tmp);
+          UseMI.getOperand(3).setIsKill();
+        }
       }
 
       bool DeleteDef = MRI->use_nodbg_empty(Reg);
@@ -3893,12 +3912,31 @@ bool SIInstrInfo::foldImmediate(MachineInstr &UseMI, MachineInstr &DefMI,
 
       if (NewOpc == AMDGPU::V_FMAAK_F16_t16 ||
           NewOpc == AMDGPU::V_FMAAK_F16_fake16) {
-        auto Tmp = MRI->createVirtualRegister(getRegClass(get(NewOpc), 0));
+        const TargetRegisterClass *NewRC = getRegClass(get(NewOpc), 0);
+        auto Tmp = MRI->createVirtualRegister(NewRC);
         BuildMI(*UseMI.getParent(), std::next(UseMI.getIterator()),
                 UseMI.getDebugLoc(), get(AMDGPU::COPY),
                 UseMI.getOperand(0).getReg())
             .addReg(Tmp, RegState::Kill);
         UseMI.getOperand(0).setReg(Tmp);
+        if (UseMI.getOperand(1).isReg() &&
+            RI.isVGPR(*MRI, UseMI.getOperand(1).getReg())) {
+          auto Tmp = MRI->createVirtualRegister(NewRC);
+          BuildMI(*UseMI.getParent(), UseMI.getIterator(), UseMI.getDebugLoc(),
+                  get(AMDGPU::COPY), Tmp)
+              .addReg(UseMI.getOperand(1).getReg());
+          UseMI.getOperand(1).setReg(Tmp);
+          UseMI.getOperand(1).setIsKill();
+        }
+        if (UseMI.getOperand(2).isReg() &&
+            RI.isVGPR(*MRI, UseMI.getOperand(2).getReg())) {
+          auto Tmp = MRI->createVirtualRegister(NewRC);
+          BuildMI(*UseMI.getParent(), UseMI.getIterator(), UseMI.getDebugLoc(),
+                  get(AMDGPU::COPY), Tmp)
+              .addReg(UseMI.getOperand(2).getReg());
+          UseMI.getOperand(2).setReg(Tmp);
+          UseMI.getOperand(2).setIsKill();
+        }
       }
 
       // It might happen that UseMI was commuted

--- a/llvm/test/CodeGen/AMDGPU/fma.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fma.f16.ll
@@ -205,7 +205,9 @@ define half @test_fmaak(half %x, half %y, half %z) {
 ; GFX11-SDAG-TRUE16-LABEL: test_fmaak:
 ; GFX11-SDAG-TRUE16:       ; %bb.0:
 ; GFX11-SDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-TRUE16-NEXT:    v_fmaak_f16 v0.l, v0.l, v1.l, 0x4200
+; GFX11-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
+; GFX11-SDAG-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-SDAG-TRUE16-NEXT:    v_fmaak_f16 v0.l, v0.l, v0.h, 0x4200
 ; GFX11-SDAG-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-SDAG-FAKE16-LABEL: test_fmaak:
@@ -233,7 +235,9 @@ define half @test_fmaak(half %x, half %y, half %z) {
 ; GFX12-SDAG-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-SDAG-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-SDAG-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-SDAG-TRUE16-NEXT:    v_fmaak_f16 v0.l, v0.l, v1.l, 0x4200
+; GFX12-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
+; GFX12-SDAG-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-SDAG-TRUE16-NEXT:    v_fmaak_f16 v0.l, v0.l, v0.h, 0x4200
 ; GFX12-SDAG-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-FAKE16-LABEL: test_fmaak:
@@ -294,7 +298,9 @@ define half @test_fmamk(half %x, half %y, half %z) {
 ; GFX11-SDAG-TRUE16-LABEL: test_fmamk:
 ; GFX11-SDAG-TRUE16:       ; %bb.0:
 ; GFX11-SDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-TRUE16-NEXT:    v_fmamk_f16 v0.l, v0.l, 0x4200, v2.l
+; GFX11-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v2.l
+; GFX11-SDAG-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-SDAG-TRUE16-NEXT:    v_fmamk_f16 v0.l, v0.l, 0x4200, v0.h
 ; GFX11-SDAG-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-SDAG-FAKE16-LABEL: test_fmamk:
@@ -324,7 +330,9 @@ define half @test_fmamk(half %x, half %y, half %z) {
 ; GFX12-SDAG-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-SDAG-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-SDAG-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-SDAG-TRUE16-NEXT:    v_fmamk_f16 v0.l, v0.l, 0x4200, v2.l
+; GFX12-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v2.l
+; GFX12-SDAG-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-SDAG-TRUE16-NEXT:    v_fmamk_f16 v0.l, v0.l, 0x4200, v0.h
 ; GFX12-SDAG-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-SDAG-FAKE16-LABEL: test_fmamk:
@@ -415,12 +423,13 @@ define i32 @test_D139469_f16(half %arg) {
 ; GFX11-SDAG-TRUE16-LABEL: test_D139469_f16:
 ; GFX11-SDAG-TRUE16:       ; %bb.0: ; %bb
 ; GFX11-SDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 0x291e
-; GFX11-SDAG-TRUE16-NEXT:    v_mul_f16_e32 v1.l, 0x291e, v0.l
-; GFX11-SDAG-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX11-SDAG-TRUE16-NEXT:    v_fmaak_f16 v0.l, v0.l, v0.h, 0x211e
-; GFX11-SDAG-TRUE16-NEXT:    v_min_f16_e32 v0.l, v1.l, v0.l
-; GFX11-SDAG-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 0x291e
+; GFX11-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v1.h, v0.l
+; GFX11-SDAG-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX11-SDAG-TRUE16-NEXT:    v_fmaak_f16 v0.l, v0.l, v1.l, 0x211e
+; GFX11-SDAG-TRUE16-NEXT:    v_mul_f16_e32 v0.h, 0x291e, v1.h
+; GFX11-SDAG-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX11-SDAG-TRUE16-NEXT:    v_min_f16_e32 v0.l, v0.h, v0.l
 ; GFX11-SDAG-TRUE16-NEXT:    v_cmp_gt_f16_e32 vcc_lo, 0, v0.l
 ; GFX11-SDAG-TRUE16-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc_lo
 ; GFX11-SDAG-TRUE16-NEXT:    s_setpc_b64 s[30:31]
@@ -472,12 +481,13 @@ define i32 @test_D139469_f16(half %arg) {
 ; GFX12-SDAG-TRUE16-NEXT:    s_wait_samplecnt 0x0
 ; GFX12-SDAG-TRUE16-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-SDAG-TRUE16-NEXT:    s_wait_kmcnt 0x0
-; GFX12-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.h, 0x291e
-; GFX12-SDAG-TRUE16-NEXT:    v_mul_f16_e32 v1.l, 0x291e, v0.l
-; GFX12-SDAG-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX12-SDAG-TRUE16-NEXT:    v_fmaak_f16 v0.l, v0.l, v0.h, 0x211e
-; GFX12-SDAG-TRUE16-NEXT:    v_min_num_f16_e32 v0.l, v1.l, v0.l
-; GFX12-SDAG-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v1.l, 0x291e
+; GFX12-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v1.h, v0.l
+; GFX12-SDAG-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
+; GFX12-SDAG-TRUE16-NEXT:    v_fmaak_f16 v0.l, v0.l, v1.l, 0x211e
+; GFX12-SDAG-TRUE16-NEXT:    v_mul_f16_e32 v0.h, 0x291e, v1.h
+; GFX12-SDAG-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_1)
+; GFX12-SDAG-TRUE16-NEXT:    v_min_num_f16_e32 v0.l, v0.h, v0.l
 ; GFX12-SDAG-TRUE16-NEXT:    v_cmp_gt_f16_e32 vcc_lo, 0, v0.l
 ; GFX12-SDAG-TRUE16-NEXT:    s_wait_alu depctr_va_vcc(0)
 ; GFX12-SDAG-TRUE16-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc_lo

--- a/llvm/test/CodeGen/AMDGPU/fmul-to-ldexp.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmul-to-ldexp.ll
@@ -3815,7 +3815,8 @@ define half @v_fma_mul_add_32_f16(half %x, half %y) {
 ; GFX11-SDAG-TRUE16-LABEL: v_fma_mul_add_32_f16:
 ; GFX11-SDAG-TRUE16:       ; %bb.0:
 ; GFX11-SDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-TRUE16-NEXT:    v_fmamk_f16 v0.l, v0.l, 0x5000, v1.l
+; GFX11-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
+; GFX11-SDAG-TRUE16-NEXT:    v_fmamk_f16 v0.l, v0.l, 0x5000, v0.h
 ; GFX11-SDAG-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-SDAG-FAKE16-LABEL: v_fma_mul_add_32_f16:
@@ -3914,7 +3915,8 @@ define half @v_fma_mul_add_neg32_f16(half %x, half %y) {
 ; GFX11-SDAG-TRUE16-LABEL: v_fma_mul_add_neg32_f16:
 ; GFX11-SDAG-TRUE16:       ; %bb.0:
 ; GFX11-SDAG-TRUE16-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-TRUE16-NEXT:    v_fmamk_f16 v0.l, v0.l, 0xd000, v1.l
+; GFX11-SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
+; GFX11-SDAG-TRUE16-NEXT:    v_fmamk_f16 v0.l, v0.l, 0xd000, v0.h
 ; GFX11-SDAG-TRUE16-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-SDAG-FAKE16-LABEL: v_fma_mul_add_neg32_f16:

--- a/llvm/test/CodeGen/AMDGPU/llvm.fmuladd.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.fmuladd.f16.ll
@@ -485,7 +485,9 @@ define amdgpu_kernel void @fmuladd_f16_imm_a(
 ; GFX11-DENORM-TRUE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-DENORM-TRUE16-NEXT:    s_mov_b32 s8, s0
 ; GFX11-DENORM-TRUE16-NEXT:    s_mov_b32 s9, s1
-; GFX11-DENORM-TRUE16-NEXT:    v_fmamk_f16 v0.l, v0.l, 0x4200, v1.l
+; GFX11-DENORM-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
+; GFX11-DENORM-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-DENORM-TRUE16-NEXT:    v_fmamk_f16 v0.l, v0.l, 0x4200, v0.h
 ; GFX11-DENORM-TRUE16-NEXT:    buffer_store_b16 v0, off, s[8:11], 0
 ; GFX11-DENORM-TRUE16-NEXT:    s_endpgm
 ;
@@ -717,7 +719,9 @@ define amdgpu_kernel void @fmuladd_f16_imm_b(
 ; GFX11-DENORM-TRUE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-DENORM-TRUE16-NEXT:    s_mov_b32 s8, s0
 ; GFX11-DENORM-TRUE16-NEXT:    s_mov_b32 s9, s1
-; GFX11-DENORM-TRUE16-NEXT:    v_fmamk_f16 v0.l, v0.l, 0x4200, v1.l
+; GFX11-DENORM-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
+; GFX11-DENORM-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-DENORM-TRUE16-NEXT:    v_fmamk_f16 v0.l, v0.l, 0x4200, v0.h
 ; GFX11-DENORM-TRUE16-NEXT:    buffer_store_b16 v0, off, s[8:11], 0
 ; GFX11-DENORM-TRUE16-NEXT:    s_endpgm
 ;


### PR DESCRIPTION
Register classes of sources also has to be restrained to lo128.
There are few regression with register coalescing in true16 mode
though, but otherwise it fails verification.
