### PR TITLE
Stop calling a constexpr function to evaluate the boolean condition of

### DIFF
--- a/clang/lib/AST/AttrImpl.cpp
+++ b/clang/lib/AST/AttrImpl.cpp
@@ -289,21 +289,20 @@ namespace {
 //  - DeclArgument
 //  - OMPTraitInfoArgument
 //  - VariadicOMPInteropInfoArgument
-template <class T> constexpr bool useDefaultEquality() {
-  return std::is_same_v<T, StringRef> || std::is_same_v<T, VersionTuple> ||
-         std::is_same_v<T, IdentifierInfo *> || std::is_same_v<T, ParamIdx> ||
-         std::is_same_v<T, Attr *> || std::is_same_v<T, char *> ||
-         std::is_enum_v<T> || std::is_integral_v<T>;
-}
+#define USE_DEFAULT_EQUALITY                                                   \
+  (std::is_same_v<T, StringRef> || std::is_same_v<T, VersionTuple> ||          \
+   std::is_same_v<T, IdentifierInfo *> || std::is_same_v<T, ParamIdx> ||       \
+   std::is_same_v<T, Attr *> || std::is_same_v<T, char *> ||                   \
+   std::is_enum_v<T> || std::is_integral_v<T>)
 
 template <class T>
-typename std::enable_if_t<!useDefaultEquality<T>(), bool>
+typename std::enable_if_t<!USE_DEFAULT_EQUALITY, bool>
 equalAttrArgs(T A, T B, StructuralEquivalenceContext &Context) {
   return false;
 }
 
 template <class T>
-typename std::enable_if_t<useDefaultEquality<T>(), bool>
+typename std::enable_if_t<USE_DEFAULT_EQUALITY, bool>
 equalAttrArgs(T A1, T A2, StructuralEquivalenceContext &Context) {
   return A1 == A2;
 }


### PR DESCRIPTION
std::enable_if

This is an attempt to fix a windows build failure after 6fac9b143252bec62c1a5ee9fc1b0f214e7f2f8e.