### PR TITLE
[LLVM][Utils] Do not error with dirty dir for untracked files

### DIFF
--- a/llvm/utils/git-llvm-push
+++ b/llvm/utils/git-llvm-push
@@ -365,10 +365,11 @@ class LLVMPRAutomator:
             text=True,
             read_only=True,
         )
-        if result.stdout.strip():
-            raise LlvmPrError(
-                "Your working tree is dirty. Please stash or commit your changes."
-            )
+        for file_path in [line.strip() for line in result.stdout.split("\n")[:-1]]:
+            if not file_path.startswith("?"):
+                raise LlvmPrError(
+                    "Your working tree is dirty. Please stash or commit your changes."
+                )
 
     def _rebase_current_branch(self) -> None:
         self._check_work_tree()


### PR DESCRIPTION
If someone has untracked files in their tree and they attempt to use the script, it will error out after processing the first commit complaining about a dirty working tree. This patch fixes that by making _check_work_tree look at the git status --porcelain output to ensure it finds entries are not prefixed with a ?, which corresponds to an untracked file.

Fixes #174592