### PR TITLE
[Clang] Warn on duplicate standard attributes

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2099,6 +2099,12 @@ static void handleStandardNoReturnAttr(Sema &S, Decl *D, const ParsedAttr &A) {
         S.getSourceManager().isInSystemMacro(A.getLoc())))
     S.Diag(A.getLoc(), diag::warn_deprecated_noreturn_spelling) << A.getRange();
 
+  // Check for duplicate attribute - warn if already applied.
+  if (D->hasAttr<CXX11NoReturnAttr>()) {
+    S.Diag(A.getLoc(), diag::warn_duplicate_attribute_exact) << A;
+    return;
+  }
+
   D->addAttr(::new (S.Context) CXX11NoReturnAttr(S.Context, A));
 }
 
@@ -2230,6 +2236,11 @@ static void handleUnusedAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (!S.getLangOpts().CPlusPlus17 && IsCXX17Attr)
     S.Diag(AL.getLoc(), diag::ext_cxx17_attr) << AL;
 
+  // Check for duplicate attribute - warn if already applied.
+  if (D->hasAttr<UnusedAttr>()) {
+    S.Diag(AL.getLoc(), diag::warn_duplicate_attribute_exact) << AL;
+    return;
+  }
   D->addAttr(::new (S.Context) UnusedAttr(S.Context, AL));
 }
 

--- a/clang/test/SemaCXX/cxx17-duplicate-attrs.cpp
+++ b/clang/test/SemaCXX/cxx17-duplicate-attrs.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++17 -verify %s
+
+int foo([[maybe_unused, maybe_unused]] int a) { // expected-warning {{attribute 'maybe_unused' is already applied}}
+    return 1;
+}
+
+[[noreturn, noreturn]] void g() { // expected-warning {{attribute 'noreturn' is already applied}}
+    __builtin_unreachable();
+}
+
+int h(int n) {
+    switch (n) {
+    case 1:
+        [[fallthrough, fallthrough]]; // expected-warning {{attribute 'fallthrough' is already applied}}
+    case 2:
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Diagnose duplicate [[maybe_unused]], [[noreturn]], and [[fallthrough]]
attributes as required by the C++17 standard (attribute shall appear at
most once in each attribute-list).

- [X] Tested locally

Fixes #176136 