### PR TITLE
[acc] Fix OpenACCUtilsTest to avoid leak in isDeviceValueNonMappableType

### DIFF
--- a/mlir/unittests/Dialect/OpenACC/OpenACCUtilsTest.cpp
+++ b/mlir/unittests/Dialect/OpenACC/OpenACCUtilsTest.cpp
@@ -1435,8 +1435,9 @@ TEST_F(OpenACCUtilsTest, isDeviceValueMemrefNoAddressSpace) {
 
 TEST_F(OpenACCUtilsTest, isDeviceValueNonMappableType) {
   // Test with a non-mappable type (i32 value)
-  auto constOp = arith::ConstantOp::create(b, loc, b.getI32IntegerAttr(42));
-  Value val = constOp.getResult();
+  OwningOpRef<arith::ConstantOp> constOp =
+      arith::ConstantOp::create(b, loc, b.getI32IntegerAttr(42));
+  Value val = constOp->getResult();
 
   // Should return false since i32 is not a MappableType or PointerLikeType
   EXPECT_FALSE(isDeviceValue(val));


### PR DESCRIPTION
The problem is that the operation is created without an owner, then there is no free. This is being caught in llvm buildbot that are testing sanitizers.