### PR TITLE
[NFC][llvm][docs] Fix alphabetical order of commands

### DIFF
--- a/llvm/docs/CommandGuide/llvm-readelf.rst
+++ b/llvm/docs/CommandGuide/llvm-readelf.rst
@@ -38,6 +38,10 @@ OPTIONS
  Display the contents of the basic block address map section(s), which contain the
  address of each function, along with the relative offset of each basic block.
 
+.. option:: --cg-profile
+
+ Display the callgraph profile section.
+
 .. option:: --decompress, -z
 
   Dump decompressed section content when used with ``-x`` or ``-p``.
@@ -62,10 +66,6 @@ OPTIONS
 .. option:: --dynamic-table, --dynamic, -d
 
  Display the dynamic table.
-
-.. option:: --cg-profile
-
- Display the callgraph profile section.
 
 .. option:: --histogram, -I
 

--- a/llvm/docs/CommandGuide/llvm-readobj.rst
+++ b/llvm/docs/CommandGuide/llvm-readobj.rst
@@ -181,13 +181,9 @@ The following options are implemented only for the ELF file format.
  When pgo analysis maps are present, all analyses are printed as their raw
  value.
 
-.. option:: --pretty-pgo-analysis-map
+.. option:: --cg-profile
 
- When pgo analysis maps are present in the basic block address map section(s),
- analyses with special formats (i.e. BlockFrequency, BranchProbability, etc)
- are printed using the same format as their respective analysis pass.
-
- Requires :option:`--bb-addr-map` to have an effect.
+ Display the callgraph profile section.
 
 .. option:: --dependent-libraries
 
@@ -205,14 +201,6 @@ The following options are implemented only for the ELF file format.
 
  Display the dynamic table.
 
-.. option:: --cg-profile
-
- Display the callgraph profile section.
-
-.. option:: --histogram, -I
-
- Display a bucket list histogram for dynamic symbol hash tables.
-
 .. option:: --elf-linker-options
 
  Display the linker options section.
@@ -223,10 +211,6 @@ The following options are implemented only for the ELF file format.
  ``GNU``, and ``JSON``. ``LLVM`` output (the default) is an expanded and
  structured format. ``GNU`` output mimics the equivalent GNU :program:`readelf`
  output. ``JSON`` is JSON formatted output intended for machine consumption.
-
-.. option:: --section-groups, -g
-
- Display section groups.
 
 .. option:: --gnu-hash-table
 
@@ -240,6 +224,10 @@ The following options are implemented only for the ELF file format.
 
  Display the hash table for dynamic symbols.
 
+.. option:: --histogram, -I
+
+ Display a bucket list histogram for dynamic symbol hash tables.
+
 .. option:: --memtag
 
  Display information about memory tagging present in the binary. This includes
@@ -250,6 +238,14 @@ The following options are implemented only for the ELF file format.
 
  Display all notes.
 
+.. option:: --pretty-pgo-analysis-map
+
+ When pgo analysis maps are present in the basic block address map section(s),
+ analyses with special formats (i.e. BlockFrequency, BranchProbability, etc)
+ are printed using the same format as their respective analysis pass.
+
+ Requires :option:`--bb-addr-map` to have an effect.
+
 .. option:: --pretty-print
 
  When used with :option:`--elf-output-style`, JSON output will be formatted in
@@ -258,6 +254,10 @@ The following options are implemented only for the ELF file format.
 .. option:: --program-headers, --segments, -l
 
  Display the program headers.
+
+.. option:: --section-groups, -g
+
+ Display section groups.
 
 .. option:: --section-mapping
 


### PR DESCRIPTION
Fix the order of commands for llvm-readelf and llvm-readobj docs.
