### PR TITLE
Fix build breakage caused by #176061

### DIFF
--- a/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
@@ -27,7 +27,7 @@
 
 using namespace llvm;
 
-extern cl::opt<bool> EnableMachineCombinerPassX86;
+extern cl::opt<bool> X86EnableMachineCombinerPass;
 
 namespace {
 
@@ -117,7 +117,7 @@ Error X86CodeGenPassBuilder::addInstSelector(PassManagerWrapper &PMW) const {
 
 void X86CodeGenPassBuilder::addILPOpts(PassManagerWrapper &PMW) const {
   addMachineFunctionPass(EarlyIfConverterPass(), PMW);
-  if (EnableMachineCombinerPassX86) {
+  if (X86EnableMachineCombinerPass) {
     // TODO(boomanaiden154): Add the MachineCombinerPass here once it has been
     // ported to the new pass manager.
   }

--- a/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
+++ b/llvm/lib/Target/X86/X86CodeGenPassBuilder.cpp
@@ -27,7 +27,7 @@
 
 using namespace llvm;
 
-extern cl::opt<bool> EnableMachineCombinerPass;
+extern cl::opt<bool> EnableMachineCombinerPassX86;
 
 namespace {
 
@@ -117,7 +117,7 @@ Error X86CodeGenPassBuilder::addInstSelector(PassManagerWrapper &PMW) const {
 
 void X86CodeGenPassBuilder::addILPOpts(PassManagerWrapper &PMW) const {
   addMachineFunctionPass(EarlyIfConverterPass(), PMW);
-  if (EnableMachineCombinerPass) {
+  if (EnableMachineCombinerPassX86) {
     // TODO(boomanaiden154): Add the MachineCombinerPass here once it has been
     // ported to the new pass manager.
   }

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -53,9 +53,10 @@
 
 using namespace llvm;
 
-cl::opt<bool> EnableMachineCombinerPassX86("x86-machine-combiner",
-                               cl::desc("Enable the machine combiner pass"),
-                               cl::init(true), cl::Hidden);
+cl::opt<bool>
+    EnableMachineCombinerPassX86("x86-machine-combiner",
+                                 cl::desc("Enable the machine combiner pass"),
+                                 cl::init(true), cl::Hidden);
 
 static cl::opt<bool>
     EnableTileRAPass("x86-tile-ra",

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -54,7 +54,7 @@
 using namespace llvm;
 
 cl::opt<bool>
-    EnableMachineCombinerPassX86("x86-machine-combiner",
+    X86EnableMachineCombinerPass("x86-machine-combiner",
                                  cl::desc("Enable the machine combiner pass"),
                                  cl::init(true), cl::Hidden);
 
@@ -498,7 +498,7 @@ void X86PassConfig::addPreLegalizeMachineIR() {
 
 bool X86PassConfig::addILPOpts() {
   addPass(&EarlyIfConverterLegacyID);
-  if (EnableMachineCombinerPassX86)
+  if (X86EnableMachineCombinerPass)
     addPass(&MachineCombinerID);
   addPass(createX86CmovConversionLegacyPass());
   return true;

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -53,7 +53,7 @@
 
 using namespace llvm;
 
-static cl::opt<bool> EnableMachineCombinerPass("x86-machine-combiner",
+cl::opt<bool> EnableMachineCombinerPassX86("x86-machine-combiner",
                                cl::desc("Enable the machine combiner pass"),
                                cl::init(true), cl::Hidden);
 
@@ -497,7 +497,7 @@ void X86PassConfig::addPreLegalizeMachineIR() {
 
 bool X86PassConfig::addILPOpts() {
   addPass(&EarlyIfConverterLegacyID);
-  if (EnableMachineCombinerPass)
+  if (EnableMachineCombinerPassX86)
     addPass(&MachineCombinerID);
   addPass(createX86CmovConversionLegacyPass());
   return true;


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/176061 added an extern declaration of `EnableMachineCombinerPass`, which is `static`, causing missing symbol errors in the debug build. This PR fixes this by making that symbol non-static. Furthermore, this PR renames that symbol to `X86EnableMachineCombinerPass` as `EnableMachineCombinerPass` exists in other places.