### PR TITLE
[clang][modulemap] Don't call translateFile

### DIFF
--- a/clang/include/clang/Lex/ModuleMap.h
+++ b/clang/include/clang/Lex/ModuleMap.h
@@ -266,6 +266,10 @@ private:
   llvm::DenseMap<const FileEntry *, const modulemap::ModuleMapFile *>
       ParsedModuleMap;
 
+  /// Each CompilerInstance needs its own FileID for each module map, but there
+  /// should only ever be one for each.
+  llvm::DenseMap<const FileEntry *, FileID> ModuleMapLocalFileID;
+
   std::vector<std::unique_ptr<modulemap::ModuleMapFile>> ParsedModuleMaps;
 
   /// Map from top level module name to a list of ModuleDecls in the order they

--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -1332,12 +1332,13 @@ bool ModuleMap::parseModuleMapFile(FileEntryRef File, bool IsSystem,
 
   // If the module map file wasn't already entered, do so now.
   if (ID.isInvalid()) {
-    ID = SourceMgr.translateFile(File);
-    if (ID.isInvalid() || SourceMgr.isLoadedFileID(ID)) {
+    FileID &LocalFID = ModuleMapLocalFileID[File];
+    if (LocalFID.isInvalid()) {
       auto FileCharacter =
           IsSystem ? SrcMgr::C_System_ModuleMap : SrcMgr::C_User_ModuleMap;
-      ID = SourceMgr.createFileID(File, ExternModuleLoc, FileCharacter);
+      LocalFID = SourceMgr.createFileID(File, ExternModuleLoc, FileCharacter);
     }
+    ID = LocalFID;
   }
 
   std::optional<llvm::MemoryBufferRef> Buffer = SourceMgr.getBufferOrNone(ID);
@@ -2247,16 +2248,17 @@ bool ModuleMap::parseAndLoadModuleMapFile(FileEntryRef File, bool IsSystem,
 
   // If the module map file wasn't already entered, do so now.
   if (ID.isInvalid()) {
-    ID = SourceMgr.translateFile(File);
     // TODO: The way we compute affecting module maps requires this to be a
     //       local FileID. This should be changed to reuse loaded FileIDs when
     //       available, and change the way that affecting module maps are
     //       computed to not require this.
-    if (ID.isInvalid() || SourceMgr.isLoadedFileID(ID)) {
+    FileID &LocalFID = ModuleMapLocalFileID[File];
+    if (LocalFID.isInvalid()) {
       auto FileCharacter =
           IsSystem ? SrcMgr::C_System_ModuleMap : SrcMgr::C_User_ModuleMap;
-      ID = SourceMgr.createFileID(File, ExternModuleLoc, FileCharacter);
+      LocalFID = SourceMgr.createFileID(File, ExternModuleLoc, FileCharacter);
     }
+    ID = LocalFID;
   }
 
   assert(Target && "Missing target information");


### PR DESCRIPTION
In some cases `SourceManager::translateFile` ends up spending a lot of time loading source locations from PCMs, significantly slowing down module scanning. The actual requirements are that we use local FileIDs for module maps so that we can compute affecting module maps, and that there is only one FileID per module map per compiler instance. This patch simply records the FileEntry to FileID mapping and reuses it when needed.