### PR TITLE
[libc++] Remove redundant code after static_assert(false)

### DIFF
--- a/libcxx/src/experimental/time_zone.cpp
+++ b/libcxx/src/experimental/time_zone.cpp
@@ -209,8 +209,6 @@ __format(const __tz::__continuation& __continuation, const string& __letters, se
                    return chrono::seconds{0};
                  else
                    static_assert(false);
-
-                 std::__libcpp_unreachable();
                },
                __continuation.__rules);
 
@@ -235,8 +233,6 @@ __format(const __tz::__continuation& __continuation, const string& __letters, se
           return __value(__year, __month);
         else
           static_assert(false);
-
-        std::__libcpp_unreachable();
       },
       __on);
 }
@@ -698,8 +694,6 @@ __get_sys_info(sys_seconds __time,
           return chrono::__get_sys_info_basic(__time, __continuation_begin, __continuation, __value.__time);
         else
           static_assert(false);
-
-        std::__libcpp_unreachable();
       },
       __continuation.__rules);
 }


### PR DESCRIPTION
Eliminate unreachable code after static_assert(false).