### PR TITLE
[clang] Don't assert on paren-less lambdas with dependent return type

### DIFF
--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1224,6 +1224,8 @@ ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
                                    Scope::FunctionPrototypeScope);
 
   Actions.PushLambdaScope();
+  SourceLocation DeclLoc = Tok.getLocation();
+
   Actions.ActOnLambdaExpressionAfterIntroducer(Intro, getCurScope());
 
   ParsedAttributes Attributes(AttrFactory);
@@ -1308,7 +1310,7 @@ ExprResult Parser::ParseLambdaExpressionAfterIntroducer(
   TypeResult TrailingReturnType;
   SourceLocation TrailingReturnTypeLoc;
   SourceLocation LParenLoc, RParenLoc;
-  SourceLocation DeclEndLoc;
+  SourceLocation DeclEndLoc = DeclLoc;
   bool HasParentheses = false;
   bool HasSpecifiers = false;
   SourceLocation MutableLoc;

--- a/clang/test/Parser/cxx2b-lambdas.cpp
+++ b/clang/test/Parser/cxx2b-lambdas.cpp
@@ -27,6 +27,10 @@ auto L6 = [s = 1] mutable {};
 auto L7 = [s = 1] constexpr mutable noexcept {}; // cxx11-error {{return type 'void' is not a literal type}}
 #endif
 auto L8 = [] -> bool { return true; };
+#if __cplusplus >= 201103L
+template <typename> struct PR176256 {};
+PR176256<void> token = [] -> decltype(token) { return {}; }();
+#endif
 auto L9 = []<typename T> { return true; };
 #if __cplusplus >= 201103L
 auto L10 = []<typename T> noexcept { return true; };


### PR DESCRIPTION
The initial implementation of C++23 style lambdas without parameter lists, 0620e6f4b76a9, removed `DeclLoc`, which was used to intitialize `DeclEndLoc`.

This code was then moved around a bit in behavior-preserving ways in https://reviews.llvm.org/D124351 and 2eb1e75f42d7e09e.

If a lambda has no parentheses, no exception-specification, attribute-specifier, *and* a decltype() return type (which leads to `ParseTrailingReturnType` returning a range where `Range.getEnd().isValid()` is false), then we no longer set a valid `DeclEndLoc`. Fix this by restoring `DeclLoc` and using it as it was used before 0620e6f4b76a9.

Fixes #176256.