### PR TITLE
[orc-rt] Make WrapperFunctionResult constructor explicit.

### DIFF
--- a/orc-rt/include/orc-rt/AllocAction.h
+++ b/orc-rt/include/orc-rt/AllocAction.h
@@ -57,7 +57,7 @@ struct AllocActionFunction {
       return WrapperFunctionBuffer::createOutOfBandError(
           "Could not deserialize allocation action argument buffer");
 
-    return std::apply(std::forward<Handler>(H), std::move(Args)).release();
+    return std::apply(std::forward<Handler>(H), std::move(Args));
   }
 };
 
@@ -69,7 +69,7 @@ struct AllocAction {
 
   [[nodiscard]] WrapperFunctionBuffer operator()() {
     assert(Fn && "Attempt to call null action");
-    return Fn(ArgData.data(), ArgData.size());
+    return WrapperFunctionBuffer(Fn(ArgData.data(), ArgData.size()));
   }
 
   explicit operator bool() const noexcept { return !!Fn; }

--- a/orc-rt/include/orc-rt/SPSWrapperFunction.h
+++ b/orc-rt/include/orc-rt/SPSWrapperFunction.h
@@ -131,6 +131,16 @@ template <typename SPSSig> struct SPSWrapperFunction {
                             WrapperFunctionSPSSerializer<SPSSig>(),
                             std::forward<Handler>(H));
   }
+
+  /// Convenience override that takes ArgBytes as an
+  /// orc_rt_WrapperFunctionBuffer.
+  template <typename Handler>
+  static void handle(orc_rt_SessionRef S, uint64_t CallId,
+                     orc_rt_WrapperFunctionReturn Return,
+                     orc_rt_WrapperFunctionBuffer ArgBytes, Handler &&H) {
+    handle(S, CallId, Return, WrapperFunctionBuffer(ArgBytes),
+           std::forward<Handler>(H));
+  }
 };
 
 } // namespace orc_rt

--- a/orc-rt/include/orc-rt/Session.h
+++ b/orc-rt/include/orc-rt/Session.h
@@ -156,9 +156,8 @@ public:
     if (auto TmpCA = CA)
       CA->callController(std::move(OnComplete), T, std::move(ArgBytes));
     else
-      OnComplete(
-          WrapperFunctionBuffer::createOutOfBandError("no controller attached")
-              .release());
+      OnComplete(WrapperFunctionBuffer::createOutOfBandError(
+          "no controller attached"));
   }
 
 private:

--- a/orc-rt/include/orc-rt/WrapperFunction.h
+++ b/orc-rt/include/orc-rt/WrapperFunction.h
@@ -34,7 +34,7 @@ public:
   /// Create a WrapperFunctionBuffer from a WrapperFunctionBuffer. This
   /// instance takes ownership of the result object and will automatically
   /// call dispose on the result upon destruction.
-  WrapperFunctionBuffer(orc_rt_WrapperFunctionBuffer B) : B(B) {}
+  explicit WrapperFunctionBuffer(orc_rt_WrapperFunctionBuffer B) : B(B) {}
 
   WrapperFunctionBuffer(const WrapperFunctionBuffer &) = delete;
   WrapperFunctionBuffer &operator=(const WrapperFunctionBuffer &) = delete;
@@ -78,22 +78,25 @@ public:
   /// Create a WrapperFunctionBuffer with the given size and return a pointer
   /// to the underlying memory.
   static WrapperFunctionBuffer allocate(size_t Size) {
-    return orc_rt_WrapperFunctionBufferAllocate(Size);
+    return WrapperFunctionBuffer(orc_rt_WrapperFunctionBufferAllocate(Size));
   }
 
   /// Copy from the given char range.
   static WrapperFunctionBuffer copyFrom(const char *Source, size_t Size) {
-    return orc_rt_CreateWrapperFunctionBufferFromRange(Source, Size);
+    return WrapperFunctionBuffer(
+        orc_rt_CreateWrapperFunctionBufferFromRange(Source, Size));
   }
 
   /// Copy from the given null-terminated string (includes the null-terminator).
   static WrapperFunctionBuffer copyFrom(const char *Source) {
-    return orc_rt_CreateWrapperFunctionBufferFromString(Source);
+    return WrapperFunctionBuffer(
+        orc_rt_CreateWrapperFunctionBufferFromString(Source));
   }
 
   /// Create an out-of-band error by copying the given string.
   static WrapperFunctionBuffer createOutOfBandError(const char *Msg) {
-    return orc_rt_CreateWrapperFunctionBufferFromOutOfBandError(Msg);
+    return WrapperFunctionBuffer(
+        orc_rt_CreateWrapperFunctionBufferFromOutOfBandError(Msg));
   }
 
   /// If this value is an out-of-band error then this returns the error message,

--- a/orc-rt/lib/executor/Session.cpp
+++ b/orc-rt/lib/executor/Session.cpp
@@ -100,7 +100,7 @@ void Session::shutdownComplete() {
 
 void Session::wrapperReturn(orc_rt_SessionRef S, uint64_t CallId,
                             orc_rt_WrapperFunctionBuffer ResultBytes) {
-  unwrap(S)->sendWrapperResult(CallId, ResultBytes);
+  unwrap(S)->sendWrapperResult(CallId, WrapperFunctionBuffer(ResultBytes));
 }
 
 } // namespace orc_rt

--- a/orc-rt/unittests/DirectCaller.h
+++ b/orc-rt/unittests/DirectCaller.h
@@ -27,7 +27,7 @@ private:
       std::unique_ptr<DirectResultSender>(
           reinterpret_cast<DirectResultSender *>(
               static_cast<uintptr_t>(CallId)))
-          ->send(S, ResultBytes);
+          ->send(S, orc_rt::WrapperFunctionBuffer(ResultBytes));
     }
   };
 

--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -227,8 +227,8 @@ private:
                        orc_rt_WrapperFunctionBuffer ResultBytes) {
     // Abuse "session" to refer to the ControllerAccess object.
     // We can just re-use sendFunctionResult for this.
-    reinterpret_cast<MockControllerAccess *>(S)->sendWrapperResult(CallId,
-                                                                   ResultBytes);
+    reinterpret_cast<MockControllerAccess *>(S)->sendWrapperResult(
+        CallId, WrapperFunctionBuffer(ResultBytes));
   }
 
   Session &SS;


### PR DESCRIPTION
The WrapperFunctionBuffer(orc_rt_WrapperFunctionBuffer) constructor takes ownership of the underlying buffer (if one exists). Making the constructor explicit makes this clearer at the call site.

This mirrors a similar change to the LLVM-side API in dec5d663745.