### PR TITLE
[mlir][Python] remove stray nb::cast

### DIFF
--- a/mlir/lib/Bindings/Python/TransformInterpreter.cpp
+++ b/mlir/lib/Bindings/Python/TransformInterpreter.cpp
@@ -71,12 +71,6 @@ static void populateTransformInterpreterSubmodule(nb::module_ &m) {
          PyOperationBase &transformModule, const PyTransformOptions &options) {
         mlir::python::CollectDiagnosticsToStringScope scope(
             mlirOperationGetContext(transformRoot.getOperation()));
-
-        // Calling back into Python to invalidate everything under the payload
-        // root. This is awkward, but we don't have access to PyMlirContext
-        // object here otherwise.
-        nb::object obj = nb::cast(payloadRoot);
-
         MlirLogicalResult result = mlirTransformApplyNamedSequence(
             payloadRoot.getOperation(), transformRoot.getOperation(),
             transformModule.getOperation(), options.options);


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/155114 we removed `liveOperations` but forgot this line which was being used to invalidate operations under a transform root, which currently isn't being used for anything. So remove. 

FYI this led to a subtle double free bug after https://github.com/llvm/llvm-project/pull/175405:

```python
@test_in_context
def check_builtin():
    module = builtin_d.ModuleOp()
    with module.context, ir.Location.unknown():
        transform_module = builtin_d.Module.create()
        transform_module.operation.attributes["transform.with_named_sequence"] = (
            ir.UnitAttr.get()
        )
        with ir.InsertionPoint(transform_module.body):
            named_sequence = NamedSequenceOp("__transform_main", [any_op_t()], [])
            with ir.InsertionPoint(named_sequence.body):
                YieldOp([])
        interp.apply_named_sequence(
            module,
            transform_module.body.operations[0],
            transform_module,
        )
```

with error 

```
python(7436,0x1f95a93c0) malloc: *** error for object 0x6000002b0000: pointer being freed was not allocated
python(7436,0x1f95a93c0) malloc: *** set a breakpoint in malloc_error_break to debug
```

This is because

```
nb::object obj = nb::cast(payloadRoot);
```
is actually equivalent to
```
nb::object obj = nb::cast(payloadRoot, nb::rv_policy::automatic);
```
which is actually equivalent to
```
nb::object obj = nb::cast(payloadRoot, nb::rv_policy::copy);
```
because I changed the API to `PyOperationBase &payloadRoot` i.e., an lvalue reference and `nb::rv_policy::automatic` decays to `nb::rv_policy::copy` for [lvalue refs](https://nanobind.readthedocs.io/en/latest/api_core.html#_CPPv4N8nanobind9rv_policy9automaticE). 

