### PR TITLE
[libc++][test] Fix `constexpr` stdver. for tests for `find_if(_not)`

### DIFF
--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find_if.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find_if.pass.cpp
@@ -8,10 +8,8 @@
 
 // <algorithm>
 
-// template<InputIterator Iter, Predicate<auto, Iter::value_type> Pred>
-//   requires CopyConstructible<Pred>
-//   constexpr Iter   // constexpr after C++17
-//   find_if(Iter first, Iter last, Pred pred);
+// template<class InputIterator, class Predicate>
+//   constexpr InputIterator find_if(InputIterator first, InputIterator last, Predicate pred); // constexpr since C++20
 
 #include <algorithm>
 #include <functional>
@@ -27,7 +25,7 @@ struct EqualTo {
 };
 
 template <class Iter>
-TEST_CONSTEXPR_CXX17 void test_iter() {
+TEST_CONSTEXPR_CXX20 void test_iter() {
   int range[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   // We don't find what we're looking for in the range
@@ -51,7 +49,7 @@ TEST_CONSTEXPR_CXX17 void test_iter() {
   }
 }
 
-TEST_CONSTEXPR_CXX17 bool test() {
+TEST_CONSTEXPR_CXX20 bool test() {
   test_iter<cpp17_input_iterator<int*> >();
   test_iter<forward_iterator<int*> >();
   test_iter<bidirectional_iterator<int*> >();

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find_if_not.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find_if_not.pass.cpp
@@ -8,10 +8,9 @@
 
 // <algorithm>
 
-// template<InputIterator Iter, Predicate<auto, Iter::value_type> Pred>
-//   requires CopyConstructible<Pred>
-//   constexpr Iter   // constexpr after C++17
-//   find_if_not(Iter first, Iter last, Pred pred);
+// template<class InputIterator, class Predicate>
+//  constexpr InputIterator find_if_not(InputIterator first, InputIterator last, // constexpr since C++20
+//                                      Predicate pred);
 
 #include <algorithm>
 #include <functional>
@@ -27,7 +26,7 @@ struct DifferentFrom {
 };
 
 template <class Iter>
-TEST_CONSTEXPR_CXX17 void test_iter() {
+TEST_CONSTEXPR_CXX20 void test_iter() {
   int range[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   // We don't find what we're looking for in the range
@@ -51,7 +50,7 @@ TEST_CONSTEXPR_CXX17 void test_iter() {
   }
 }
 
-TEST_CONSTEXPR_CXX17 bool test() {
+TEST_CONSTEXPR_CXX20 bool test() {
   test_iter<cpp17_input_iterator<int*> >();
   test_iter<forward_iterator<int*> >();
   test_iter<bidirectional_iterator<int*> >();


### PR DESCRIPTION
Until C++20, `std::find_if(_not)` were not `constexpr`, so uses of `TEST_CONSTEXPR_CXX17` make the test functions ill-formed, no diagnostic required in C++17 mode.

The uses were introduced in 2b4b26ea84fd9c95d0ff25ce338c15ea5e74a4e4, while the transformation looked incorrect - `TEST_CONSTEXPR_CXX20` should be used instead.

Drive-by changes: Fix comments in both changed test files to match the actually standardized wording.