### PR TITLE
[JITLink][CompactUnwind] Express mergeability via +ve predicate. NFCI.

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/CompactUnwindSupport.h
+++ b/llvm/lib/ExecutionEngine/JITLink/CompactUnwindSupport.h
@@ -465,9 +465,9 @@ private:
       auto &Last = Records.back();
 
       bool NextNeedsDWARF = CURecTraits::encodingSpecifiesDWARF(Next.Encoding);
-      bool CannotBeMerged = CURecTraits::encodingCannotBeMerged(Next.Encoding);
-      if (NextNeedsDWARF || (Next.Encoding != Last.Encoding) ||
-          CannotBeMerged || Next.LSDA || Last.LSDA)
+      bool CanBeMerged = CURecTraits::encodingCanBeMerged(Next.Encoding);
+      if (NextNeedsDWARF || (Next.Encoding != Last.Encoding) || !CanBeMerged ||
+          Next.LSDA || Last.LSDA)
         Records.push_back(Next);
     }
 

--- a/llvm/lib/ExecutionEngine/JITLink/MachO_arm64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/MachO_arm64.cpp
@@ -645,7 +645,7 @@ struct CompactUnwindTraits_MachO_arm64
     return (Encoding & EncodingModeMask) == DWARFMode;
   }
 
-  static bool encodingCannotBeMerged(uint32_t Encoding) { return false; }
+  static bool encodingCanBeMerged(uint32_t Encoding) { return true; }
 };
 
 void link_MachO_arm64(std::unique_ptr<LinkGraph> G,

--- a/llvm/lib/ExecutionEngine/JITLink/MachO_x86_64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/MachO_x86_64.cpp
@@ -521,9 +521,9 @@ struct CompactUnwindTraits_MachO_x86_64
     return (Encoding & EncodingModeMask) == DWARFMode;
   }
 
-  static bool encodingCannotBeMerged(uint32_t Encoding) {
+  static bool encodingCanBeMerged(uint32_t Encoding) {
     constexpr uint32_t StackIndirectMode = 0x03000000;
-    return (Encoding & EncodingModeMask) == StackIndirectMode;
+    return (Encoding & EncodingModeMask) != StackIndirectMode;
   }
 };
 


### PR DESCRIPTION
Compact unwind record merging is an optimization. Using a can-be-merged predicate is preferrable to a "cannot-be-merged" predicate as the former encourages conservatively correct implementations: "what is safe to merge" is easier to reason about than "what is safe to not not merge".