### PR TITLE
[JITLink][CompactUnwind] Explicitly enumerate mergeable encodings. NFCI.

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/CompactUnwindSupport.h
+++ b/llvm/lib/ExecutionEngine/JITLink/CompactUnwindSupport.h
@@ -483,10 +483,9 @@ private:
       auto &Next = NonUniqued[I];
       auto &Last = Records.back();
 
-      bool NextNeedsDWARF = CURecTraits::encodingSpecifiesDWARF(Next.Encoding);
       bool CanBeMerged = CURecTraits::encodingCanBeMerged(Next.Encoding);
-      if (NextNeedsDWARF || (Next.Encoding != Last.Encoding) || !CanBeMerged ||
-          Next.LSDA || Last.LSDA)
+      if (!CanBeMerged || (Next.Encoding != Last.Encoding) || Next.LSDA ||
+          Last.LSDA)
         Records.push_back(Next);
     }
 

--- a/llvm/lib/ExecutionEngine/JITLink/MachO_arm64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/MachO_arm64.cpp
@@ -638,14 +638,26 @@ struct CompactUnwindTraits_MachO_arm64
   constexpr static uint32_t EncodingModeMask = 0x0f000000;
   constexpr static uint32_t DWARFSectionOffsetMask = 0x00ffffff;
 
+  constexpr static uint32_t FramelessMode = 0x02000000;
+  constexpr static uint32_t DWARFMode = 0x03000000;
+  constexpr static uint32_t FrameMode = 0x04000000;
+
   using GOTManager = aarch64::GOTTableManager;
 
   static bool encodingSpecifiesDWARF(uint32_t Encoding) {
-    constexpr uint32_t DWARFMode = 0x03000000;
     return (Encoding & EncodingModeMask) == DWARFMode;
   }
 
-  static bool encodingCanBeMerged(uint32_t Encoding) { return true; }
+  static bool encodingCanBeMerged(uint32_t Encoding) {
+    switch (Encoding & EncodingModeMask) {
+    case FramelessMode:
+    case FrameMode:
+      return true;
+    case DWARFMode:
+    default:
+      return false;
+    }
+  }
 };
 
 void link_MachO_arm64(std::unique_ptr<LinkGraph> G,

--- a/llvm/lib/ExecutionEngine/JITLink/MachO_x86_64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/MachO_x86_64.cpp
@@ -514,16 +514,27 @@ struct CompactUnwindTraits_MachO_x86_64
   constexpr static uint32_t EncodingModeMask = 0x0f000000;
   constexpr static uint32_t DWARFSectionOffsetMask = 0x00ffffff;
 
+  constexpr static uint32_t EBPFrameMode = 0x01000000;
+  constexpr static uint32_t StackImmediateMode = 0x02000000;
+  constexpr static uint32_t StackIndirectMode = 0x03000000;
+  constexpr static uint32_t DWARFMode = 0x04000000;
+
   using GOTManager = x86_64::GOTTableManager;
 
   static bool encodingSpecifiesDWARF(uint32_t Encoding) {
-    constexpr uint32_t DWARFMode = 0x04000000;
     return (Encoding & EncodingModeMask) == DWARFMode;
   }
 
   static bool encodingCanBeMerged(uint32_t Encoding) {
-    constexpr uint32_t StackIndirectMode = 0x03000000;
-    return (Encoding & EncodingModeMask) != StackIndirectMode;
+    switch (Encoding & EncodingModeMask) {
+    case EBPFrameMode:
+    case StackImmediateMode:
+      return true;
+    case StackIndirectMode:
+    case DWARFMode:
+    default:
+      return false;
+    }
   }
 };
 


### PR DESCRIPTION
Updates CompactUnwindTraits_MachO_arm64 and CompactUnwindTraits_MachO_x86_64 encodingCanBeMerged methods to use switch statements that clearly list mergeable encodings, and have a default "false" case.

Since the new scheme explicitly covers DWARF modes (always non-mergeable), this patch removes the separate DWARF mode check from mergeRecords in CompactUnwindSupport.h.