### PR TITLE
[Clang] Ensure a lambda DeclContext in BuildLambdaExpr

### DIFF
--- a/clang/lib/Sema/SemaLambda.cpp
+++ b/clang/lib/Sema/SemaLambda.cpp
@@ -2166,7 +2166,7 @@ ExprResult Sema::BuildLambdaExpr(SourceLocation StartLoc,
   TemplateOrNonTemplateCallOperatorDecl->setLexicalDeclContext(Class);
 
   {
-    ContextRAII SaveContext(*this, CallOperator, /*NewThisContext=*/false);
+    ContextRAII SavedContext(*this, CallOperator, /*NewThisContext=*/false);
     PopExpressionEvaluationContext();
   }
 

--- a/clang/lib/Sema/SemaLambda.cpp
+++ b/clang/lib/Sema/SemaLambda.cpp
@@ -2165,7 +2165,10 @@ ExprResult Sema::BuildLambdaExpr(SourceLocation StartLoc,
   // set as CurContext seems more faithful to the source.
   TemplateOrNonTemplateCallOperatorDecl->setLexicalDeclContext(Class);
 
-  PopExpressionEvaluationContext();
+  {
+    ContextRAII SaveContext(*this, CallOperator, /*NewThisContext=*/false);
+    PopExpressionEvaluationContext();
+  }
 
   sema::AnalysisBasedWarnings::Policy WP =
       AnalysisWarnings.getPolicyInEffectAt(EndLoc);

--- a/clang/lib/Sema/SemaLambda.cpp
+++ b/clang/lib/Sema/SemaLambda.cpp
@@ -2166,6 +2166,8 @@ ExprResult Sema::BuildLambdaExpr(SourceLocation StartLoc,
   TemplateOrNonTemplateCallOperatorDecl->setLexicalDeclContext(Class);
 
   {
+    // TreeTransform of immediate functions may call getCurLambda, which
+    // requires both the paired LSI and the lambda DeclContext.
     ContextRAII SavedContext(*this, CallOperator, /*NewThisContext=*/false);
     PopExpressionEvaluationContext();
   }

--- a/clang/test/SemaCXX/cxx2b-consteval-propagate.cpp
+++ b/clang/test/SemaCXX/cxx2b-consteval-propagate.cpp
@@ -629,6 +629,20 @@ void fn() {
 
 }
 
+namespace GH176045 {
+
+template <int NumArgs> struct MessageFormat {
+  template <int N> consteval MessageFormat(const char (&)[N]) {}
+};
+template <typename... Ts> void format(MessageFormat<sizeof...(Ts)>, Ts ...args);
+
+auto message = [] {
+   format("");
+   format("");
+};
+
+}
+
 
 namespace GH109096 {
 consteval void undefined();


### PR DESCRIPTION
Since 5f9630b388, we only remove the LSI after the evaluation context is popped. The TreeTransform of immediate functions may call getCurLambda, which requires both the paired LSI and the lambda DeclContext. In TransformLambdaExpr, we already switched the context, but this is not the case when parsing a lambda expression.

No release note, as this is a regression from 22.

Fixes https://github.com/llvm/llvm-project/issues/176045