### PR TITLE
[lldb][Module][NFC] Remove unused always_create parameter to GetSharedModule

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -477,8 +477,7 @@ public:
   static Status
   GetSharedModule(const ModuleSpec &module_spec, lldb::ModuleSP &module_sp,
                   llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
-                  bool *did_create_ptr, bool always_create = false,
-                  bool invoke_locate_callback = true);
+                  bool *did_create_ptr, bool invoke_locate_callback = true);
 
   static bool RemoveSharedModule(lldb::ModuleSP &module_sp);
 

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -1047,8 +1047,7 @@ size_t ModuleList::RemoveOrphanSharedModules(bool mandatory) {
 Status
 ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
                             llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
-                            bool *did_create_ptr, bool always_create,
-                            bool invoke_locate_callback) {
+                            bool *did_create_ptr, bool invoke_locate_callback) {
   SharedModuleList &shared_module_list = GetSharedModuleList();
   std::lock_guard<std::recursive_mutex> guard(shared_module_list.GetMutex());
   char path[PATH_MAX];
@@ -1067,7 +1066,7 @@ ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
   // Make sure no one else can try and get or create a module while this
   // function is actively working on it by doing an extra lock on the global
   // mutex list.
-  if (!always_create) {
+  {
     ModuleList matching_module_list;
     shared_module_list.FindModules(module_spec, matching_module_list);
     const size_t num_matching_modules = matching_module_list.GetSize();

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
@@ -433,9 +433,8 @@ Status PlatformAppleSimulator::GetSharedModule(
   if (error.Success()) {
     error = ResolveExecutable(platform_module_spec, module_sp);
   } else {
-    const bool always_create = false;
     error = ModuleList::GetSharedModule(module_spec, module_sp, old_modules,
-                                        did_create_ptr, always_create);
+                                        did_create_ptr);
   }
   if (module_sp)
     module_sp->SetPlatformFileSpec(platform_file);

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
@@ -274,7 +274,6 @@ Status PlatformRemoteDarwinDevice::GetSharedModule(
   if (error.Success())
     return error;
 
-  const bool always_create = false;
   error = ModuleList::GetSharedModule(module_spec, module_sp, old_modules,
                                       did_create_ptr);
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformRemoteDarwinDevice.cpp
@@ -276,7 +276,7 @@ Status PlatformRemoteDarwinDevice::GetSharedModule(
 
   const bool always_create = false;
   error = ModuleList::GetSharedModule(module_spec, module_sp, old_modules,
-                                      did_create_ptr, always_create);
+                                      did_create_ptr);
 
   if (module_sp)
     module_sp->SetPlatformFileSpec(platform_file);

--- a/lldb/source/Target/ModuleCache.cpp
+++ b/lldb/source/Target/ModuleCache.cpp
@@ -255,7 +255,7 @@ Status ModuleCache::Get(const FileSpec &root_dir_spec, const char *hostname,
   cached_module_spec.GetPlatformFileSpec() = module_spec.GetFileSpec();
 
   error = ModuleList::GetSharedModule(cached_module_spec, cached_module_sp,
-                                      nullptr, did_create_ptr, false);
+                                      nullptr, did_create_ptr);
   if (error.Fail())
     return error;
 

--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -169,7 +169,7 @@ Status Platform::GetSharedModule(
     // by getting target from module_spec and calling
     // target->GetExecutableSearchPaths()
     return ModuleList::GetSharedModule(module_spec, module_sp, old_modules,
-                                       did_create_ptr, false);
+                                       did_create_ptr);
 
   // Module resolver lambda.
   auto resolver = [&](const ModuleSpec &spec) {
@@ -182,14 +182,14 @@ Status Platform::GetSharedModule(
       resolved_spec.GetFileSpec().PrependPathComponent(m_sdk_sysroot);
       // Try to get shared module with resolved spec.
       error = ModuleList::GetSharedModule(resolved_spec, module_sp, old_modules,
-                                          did_create_ptr, false);
+                                          did_create_ptr);
     }
     // If we don't have sysroot or it didn't work then
     // try original module spec.
     if (!error.Success()) {
       resolved_spec = spec;
       error = ModuleList::GetSharedModule(resolved_spec, module_sp, old_modules,
-                                          did_create_ptr, false);
+                                          did_create_ptr);
     }
     if (error.Success() && module_sp)
       module_sp->SetPlatformFileSpec(resolved_spec.GetFileSpec());
@@ -1673,7 +1673,7 @@ void Platform::CallLocateModuleCallbackIfSet(const ModuleSpec &module_spec,
   cached_module_spec.SetObjectOffset(0);
 
   error = ModuleList::GetSharedModule(cached_module_spec, module_sp, nullptr,
-                                      did_create_ptr, false, false);
+                                      did_create_ptr, false);
   if (error.Success() && module_sp) {
     // Succeeded to load the module file.
     LLDB_LOGF(log, "%s: locate module callback succeeded: module=%s symbol=%s",

--- a/lldb/unittests/Core/ModuleListTest.cpp
+++ b/lldb/unittests/Core/ModuleListTest.cpp
@@ -49,16 +49,14 @@ Sections:
 
   ModuleSP first_module;
   bool first_did_create = false;
-  Status error_first =
-      ModuleList::GetSharedModule(ExpectedFile->moduleSpec(), first_module,
-                                  nullptr, &first_did_create, false);
+  Status error_first = ModuleList::GetSharedModule(
+      ExpectedFile->moduleSpec(), first_module, nullptr, &first_did_create);
 
   // Second call with the same spec
   ModuleSP second_module;
   bool second_did_create = false;
-  Status error_second =
-      ModuleList::GetSharedModule(ExpectedFile->moduleSpec(), second_module,
-                                  nullptr, &second_did_create, false);
+  Status error_second = ModuleList::GetSharedModule(
+      ExpectedFile->moduleSpec(), second_module, nullptr, &second_did_create);
 
   if (error_first.Success() && error_second.Success()) {
     // If both succeeded, verify they're the same module
@@ -94,7 +92,7 @@ Sections:
   ModuleSP created_module;
   bool did_create = false;
   Status error = ModuleList::GetSharedModule(
-      ExpectedFile->moduleSpec(), created_module, nullptr, &did_create, false);
+      ExpectedFile->moduleSpec(), created_module, nullptr, &did_create);
 
   if (error.Success() && created_module) {
     // Get the UUID of the created module
@@ -138,9 +136,8 @@ Sections:
   // Create and add a module to the shared module list
   ModuleSP first_module;
   bool first_did_create = false;
-  Status first_error =
-      ModuleList::GetSharedModule(ExpectedFile->moduleSpec(), first_module,
-                                  nullptr, &first_did_create, false);
+  Status first_error = ModuleList::GetSharedModule(
+      ExpectedFile->moduleSpec(), first_module, nullptr, &first_did_create);
 
   if (first_error.Success() && first_module) {
     UUID module_uuid = first_module->GetUUID();
@@ -155,7 +152,7 @@ Sections:
       ModuleSP second_module;
       bool second_did_create = false;
       Status second_error = ModuleList::GetSharedModule(
-          second_spec, second_module, nullptr, &second_did_create, false);
+          second_spec, second_module, nullptr, &second_did_create);
 
       if (second_error.Success() && second_module) {
         // If we got a module back, check if it's the same one


### PR DESCRIPTION
No caller sets this to `true`. Initially added for and set by `SymbolFileDWARFDebugMap` (see `616f490777a4f35269a23abee851680134050065`). This was then removed shortly after in:
```
commit 762f7135e290696595b6c7233245581f59eeb07c
Author: Greg Clayton <gclayton@apple.com>
Date:   Sun Sep 18 18:59:15 2011 +0000

    Don't put modules for .o files into the global shared module list. We
    used to do this because we needed to find the shared pointer for a .o
    file when the .o file's module was needed in a SymbolContext since the
    module in a symbol context was a shared pointer. Now that we are using
    intrusive pointers we don't have this limitation anymore since any
    instrusive shared pointer can be made from a pointer to an object
    all on its own.
```

At this point it's more of a foot-gun, because forcing it to true has potentially significant performance implications (e.g., https://github.com/swiftlang/llvm-project/pull/12126/changes/a5eaa05dce15231f7a1de360b4e6634145c7dfc9)