### PR TITLE
[ci][ids] Fix pattern prefix check

### DIFF
--- a/llvm/utils/git/ids-check-helper.py
+++ b/llvm/utils/git/ids-check-helper.py
@@ -167,8 +167,8 @@ View the diff from {self.name} here.
             # Check if file matches any pattern
             matches_pattern = False
             for pattern in category["patterns"]:
-                # Simple pattern matching for /**/*.h style patterns
-                pattern_prefix = pattern.replace("/**/*.h", "")
+                # Simple pattern matching for **/*.h style patterns
+                pattern_prefix = pattern.replace("**/*.h", "")
                 if path.startswith(pattern_prefix) and path.endswith(".h"):
                     matches_pattern = True
                     break


### PR DESCRIPTION
The prefix check did not include the trailing /, so llvm-c headers were treated like llvm headers, resulting in incorrect suggestions to use LLVM_ABI where LLVM_C_ABI was already present.

See https://github.com/llvm/llvm-project/pull/176309#issuecomment-3757987748 for an example.