### PR TITLE
[libclc][NFC] Don't include 'clc/internal/clc.h' in OpenCL library

### DIFF
--- a/libclc/opencl/include/clc/opencl/synchronization/utils.h
+++ b/libclc/opencl/include/clc/opencl/synchronization/utils.h
@@ -9,7 +9,7 @@
 #ifndef __CLC_OPENCL_SYNCHRONIZATION_UTILS_H__
 #define __CLC_OPENCL_SYNCHRONIZATION_UTILS_H__
 
-#include <clc/internal/clc.h>
+#include <clc/opencl/opencl-base.h>
 #include <clc/mem_fence/clc_mem_semantic.h>
 
 static _CLC_INLINE int __opencl_get_memory_scope(cl_mem_fence_flags flag) {

--- a/libclc/opencl/include/clc/opencl/synchronization/utils.h
+++ b/libclc/opencl/include/clc/opencl/synchronization/utils.h
@@ -9,8 +9,8 @@
 #ifndef __CLC_OPENCL_SYNCHRONIZATION_UTILS_H__
 #define __CLC_OPENCL_SYNCHRONIZATION_UTILS_H__
 
-#include <clc/opencl/opencl-base.h>
 #include <clc/mem_fence/clc_mem_semantic.h>
+#include <clc/opencl/opencl-base.h>
 
 static _CLC_INLINE int __opencl_get_memory_scope(cl_mem_fence_flags flag) {
   if (flag & CLK_GLOBAL_MEM_FENCE)

--- a/libclc/opencl/include/clc/opencl/utils.h
+++ b/libclc/opencl/include/clc/opencl/utils.h
@@ -9,7 +9,7 @@
 #ifndef __CLC_OPENCL_UTILS_H__
 #define __CLC_OPENCL_UTILS_H__
 
-#include <clc/internal/clc.h>
+#include <clc/opencl/opencl-base.h>
 
 static _CLC_INLINE int __opencl_get_clang_memory_scope(memory_scope scope) {
   switch (scope) {


### PR DESCRIPTION
The file is meant for internal use within the CLC library.