### PR TITLE
[Flang][OpenMP] Permit EXTERNAL with DECLARE TARGET

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1322,7 +1322,8 @@ void OmpStructureChecker::CheckThreadprivateOrDeclareTargetVar(
             ContextDirectiveAsFortran());
       } else if (!IsSaved(*name->symbol) &&
           declScope.kind() != Scope::Kind::MainProgram &&
-          declScope.kind() != Scope::Kind::Module) {
+          declScope.kind() != Scope::Kind::Module &&
+          !name->symbol->attrs().test(Attr::EXTERNAL)) {
         context_.Say(name->source,
             "A variable that appears in a %s directive must be declared in the scope of a module or have the SAVE attribute, either explicitly or implicitly"_err_en_US,
             ContextDirectiveAsFortran());

--- a/flang/test/Semantics/OpenMP/declare-target08.f90
+++ b/flang/test/Semantics/OpenMP/declare-target08.f90
@@ -19,16 +19,22 @@ subroutine importer()
     external ext_function
     !$omp declare target(ext_routine)
     !$omp declare target(ext_function)
+    !CHECK: ext_function, EXTERNAL (Function, OmpDeclareTarget): ProcEntity {{.*}}
+    !CHECK: ext_routine, EXTERNAL (OmpDeclareTarget): ProcEntity
 end subroutine importer
 
 program main
 real a
 external ext_routine
+integer ext_function
+external ext_function
 !CHECK: bar (Subroutine, OmpDeclareTarget): HostAssoc
 !CHECK: baz (Function, OmpDeclareTarget): HostAssoc
+!CHECK: ext_function, EXTERNAL (Function, OmpDeclareTarget): ProcEntity {{.*}}
 !CHECK: ext_routine, EXTERNAL (OmpDeclareTarget): ProcEntity
 !$omp declare target(bar)
 !$omp declare target(baz)
+!$omp declare target(ext_function)
 !$omp declare target(ext_routine)
 
 a = baz(a)

--- a/flang/test/Semantics/OpenMP/declare-target08.f90
+++ b/flang/test/Semantics/OpenMP/declare-target08.f90
@@ -13,12 +13,23 @@ function baz(a)
     baz = a
 end function baz
 
+subroutine importer()
+    external ext_routine
+    integer ext_function
+    external ext_function
+    !$omp declare target(ext_routine)
+    !$omp declare target(ext_function)
+end subroutine importer
+
 program main
 real a
+external ext_routine
 !CHECK: bar (Subroutine, OmpDeclareTarget): HostAssoc
 !CHECK: baz (Function, OmpDeclareTarget): HostAssoc
+!CHECK: ext_routine, EXTERNAL (OmpDeclareTarget): ProcEntity
 !$omp declare target(bar)
 !$omp declare target(baz)
+!$omp declare target(ext_routine)
 
 a = baz(a)
 call bar(2,a)


### PR DESCRIPTION
When DECLARE TARGET was used with a symbol that has the EXTERNAL attribute, the Flang was rejecting the code as invalid.  This PR fixes this by allowing names with the EXTERNAL attribute to appear in DECLARE TARGET directives.