### PR TITLE
[libc++][NFC] Use forward declarations in {in,}out_ptr.h

### DIFF
--- a/libcxx/include/__memory/inout_ptr.h
+++ b/libcxx/include/__memory/inout_ptr.h
@@ -11,10 +11,9 @@
 #define _LIBCPP___INOUT_PTR_H
 
 #include <__config>
+#include <__fwd/memory.h>
 #include <__memory/addressof.h>
 #include <__memory/pointer_traits.h>
-#include <__memory/shared_ptr.h>
-#include <__memory/unique_ptr.h>
 #include <__type_traits/is_pointer.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/is_specialization.h>

--- a/libcxx/include/__memory/out_ptr.h
+++ b/libcxx/include/__memory/out_ptr.h
@@ -11,10 +11,9 @@
 #define _LIBCPP___OUT_PTR_H
 
 #include <__config>
+#include <__fwd/memory.h>
 #include <__memory/addressof.h>
 #include <__memory/pointer_traits.h>
-#include <__memory/shared_ptr.h>
-#include <__memory/unique_ptr.h>
 #include <__type_traits/is_pointer.h>
 #include <__type_traits/is_specialization.h>
 #include <__type_traits/is_void.h>


### PR DESCRIPTION
This doesn't improve compile times currently, but it does make it clear that we don't need the definition of `shared_ptr` or `unique_ptr` for `{in,}out_ptr`. It also reduces compile times quite a bit if we ever use these utilities in another header.
