### PR TITLE
[Maintainers] Fix broken clang-tools-extra link (NFC)

### DIFF
--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -499,7 +499,7 @@ Some subprojects maintain their own list of per-component maintainers.
 
 [Clang maintainers](https://github.com/llvm/llvm-project/blob/main/clang/Maintainers.rst)
 
-[Clang-tools-extra maintainers](https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/Maintainers.txt)
+[Clang-tools-extra maintainers](https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/Maintainers.rst)
 
 [Compiler-rt maintainers](https://github.com/llvm/llvm-project/blob/main/compiler-rt/Maintainers.md)
 


### PR DESCRIPTION
Was converted to .rst in #165171