### PR TITLE
[TSan][Darwin] Fix error message for invalid lock_during_write flag

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_flags.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_flags.cpp
@@ -37,7 +37,7 @@ inline bool FlagHandler<LockDuringWriteSetting>::Parse(const char *value) {
     *t_ = kNoLockDuringWritesAllProcesses;
     return true;
   }
-  Printf("ERROR: Invalid value for signal handler option: '%s'\n", value);
+  Printf("ERROR: Invalid value for lock_during_write option: '%s'\n", value);
   return false;
 }
 


### PR DESCRIPTION
Currently giving an invalid value for this flag logs the error message "Invalid value for signal handler option" - which is misleading.

This patch fixes that error message.

rdar://157565672