### PR TITLE
[llvm][utils][release] Remove mention of sub-project source archives

### DIFF
--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -175,8 +175,8 @@ Each platform has one binary release package. The file name starts with either `
 Except for Windows. Where `LLVM-*.exe` is an installer intended for using LLVM as a toolchain and the archive `clang+llvm-` contains the contents of the installer, plus libraries and tools not normally used in a toolchain. You most likely want the `LLVM-` installer, unless you are developing software which itself uses LLVM, in which case choose `clang+llvm-`.
 
 In addition, source archives are available:
-* `<sub-project>-{release}.src.tar.xz` are archives of the sources of specific sub-projects of `llvm-project` (except for `test-suite` which is an archive of the [LLVM Test Suite](https://github.com/llvm/llvm-test-suite)).
 * To get all the `llvm-project` source code for this release, choose `llvm-project-{release}.src.tar.xz`.
+* `test-suite-{release}.src.tar.xz` is an archive of the [LLVM Test Suite](https://github.com/llvm/llvm-test-suite)) for this release.
 
 ## Verifying Packages
 


### PR DESCRIPTION
These are no longer provided as of llvm 22:
https://discourse.llvm.org/t/llvm-22-1-0-rc1-released/89479

> Please note: since the last release the subproject tarballs have been
> removed and are no longer provided. See RFC: Do "something" with the
> subproject tarballs in the release page for more details.

There are now only llvm-project and llvm-test-suite archives.