### PR TITLE
[RISCV][llvm] Remove outdated FIXME in calling convention. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVCallingConv.cpp
+++ b/llvm/lib/Target/RISCV/RISCVCallingConv.cpp
@@ -557,8 +557,6 @@ bool llvm::CC_RISCV(unsigned ValNo, MVT ValVT, MVT LocVT,
     } else {
       // For return values, the vector must be passed fully via registers or
       // via the stack.
-      // FIXME: The proposed vector ABI only mandates v8-v15 for return values,
-      // but we're using all of them.
       if (IsRet)
         return true;
       // Try using a GPR to pass the address


### PR DESCRIPTION
Vector calling convention spec is ratified a while ago and now return
value is also handled by v8-v23 same as arguments.
