### PR TITLE
InstCombine: Improve single-use fneg(fabs(x)) SimplifyDemandedFPClass handling

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2298,8 +2298,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
       FPClassTest ThisDemandedMask =
           adjustDemandedMaskFromFlags(DemandedMask, FabsFMF);
 
-      bool IsNSZ = FMF.noSignedZeros() ||
-                   (FabsFMF.noSignedZeros() && FNegSrc->hasOneUse());
+      bool IsNSZ = FMF.noSignedZeros() || FabsFMF.noSignedZeros();
       if (Value *Simplified = simplifyDemandedFPClassFnegFabs(
               Known, FNegFAbsSrc, ThisDemandedMask, KnownSrc, IsNSZ))
         return Simplified;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2118,6 +2118,31 @@ static Value *simplifyDemandedFPClassResult(Instruction *FPOp,
   return nullptr;
 }
 
+/// Perform multiple-use aware simplfications for fneg(fabs(\p Src)). Returns a
+/// replacement value if it's simplified, otherwise nullptr. Updates \p Known
+/// with the known fpclass if not simplified.
+static Value *simplifyDemandedFPClassFnegFabs(KnownFPClass &Known, Value *Src,
+                                              FPClassTest DemandedMask,
+                                              KnownFPClass KnownSrc, bool NSZ) {
+  if ((DemandedMask & fcNan) == fcNone)
+    KnownSrc.knownNot(fcNan);
+  if ((DemandedMask & fcInf) == fcNone)
+    KnownSrc.knownNot(fcInf);
+
+  // If the source value is known negative, we can directly fold to it.
+  if (KnownSrc.SignBit == true)
+    return Src;
+
+  // If the only sign bit difference is for 0, ignore it with nsz.
+  if (NSZ &&
+      KnownSrc.isKnownNever(KnownFPClass::OrderedGreaterThanZeroMask | fcNan))
+    return Src;
+
+  Known = KnownFPClass::fneg(KnownFPClass::fabs(KnownSrc));
+  Known.knownNot(~DemandedMask);
+  return nullptr;
+}
+
 static Value *
 simplifyDemandedFPClassMinMax(KnownFPClass &Known, Intrinsic::ID IID,
                               const CallInst *CI, FPClassTest DemandedMask,
@@ -2258,6 +2283,44 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
 
   switch (I->getOpcode()) {
   case Instruction::FNeg: {
+    // Special case fneg(fabs(x))
+
+    Value *FNegSrc = I->getOperand(0);
+    Value *FNegFAbsSrc;
+    if (match(FNegSrc, m_FAbs(m_Value(FNegFAbsSrc)))) {
+      KnownFPClass KnownSrc;
+      if (SimplifyDemandedFPClass(cast<Instruction>(FNegSrc), 0,
+                                  llvm::unknown_sign(DemandedMask), KnownSrc,
+                                  Depth + 1))
+        return I;
+
+      FastMathFlags FabsFMF = cast<FPMathOperator>(FNegSrc)->getFastMathFlags();
+      FPClassTest ThisDemandedMask =
+          adjustDemandedMaskFromFlags(DemandedMask, FabsFMF);
+
+      bool IsNSZ = FMF.noSignedZeros() ||
+                   (FabsFMF.noSignedZeros() && FNegSrc->hasOneUse());
+      if (Value *Simplified = simplifyDemandedFPClassFnegFabs(
+              Known, FNegFAbsSrc, ThisDemandedMask, KnownSrc, IsNSZ))
+        return Simplified;
+
+      if ((ThisDemandedMask & fcNan) == fcNone)
+        KnownSrc.knownNot(fcNan);
+      if ((ThisDemandedMask & fcInf) == fcNone)
+        KnownSrc.knownNot(fcInf);
+
+      // fneg(fabs(x)) => fneg(x)
+      if (KnownSrc.SignBit == false)
+        return replaceOperand(*I, 0, FNegFAbsSrc);
+
+      // fneg(fabs(x)) => fneg(x), ignoring -0 if nsz.
+      if (IsNSZ &&
+          KnownSrc.isKnownNever(KnownFPClass::OrderedLessThanZeroMask | fcNan))
+        return replaceOperand(*I, 0, FNegFAbsSrc);
+
+      break;
+    }
+
     if (SimplifyDemandedFPClass(I, 0, llvm::fneg(DemandedMask), Known,
                                 Depth + 1))
       return I;
@@ -3309,29 +3372,18 @@ Value *InstCombinerImpl::SimplifyMultipleUseDemandedFPClass(
       break;
     }
 
+    KnownFPClass KnownSrc =
+        computeKnownFPClass(Src, fcAllFlags, CxtI, Depth + 1);
+
     FastMathFlags FabsFMF = cast<FPMathOperator>(FNegSrc)->getFastMathFlags();
     FPClassTest ThisDemandedMask =
         adjustDemandedMaskFromFlags(DemandedMask, FabsFMF);
 
-    KnownFPClass KnownSrc =
-        computeKnownFPClass(Src, fcAllFlags, CxtI, Depth + 1);
-
-    if ((ThisDemandedMask & fcNan) == fcNone)
-      KnownSrc.knownNot(fcNan);
-    if ((ThisDemandedMask & fcInf) == fcNone)
-      KnownSrc.knownNot(fcInf);
-
-    // If the source value is known negative, we can directly fold to it.
-    if (KnownSrc.SignBit == true)
-      return Src;
-
-    // If the only sign bit difference is for 0, ignore it with nsz.
-    if ((FMF.noSignedZeros() || FabsFMF.noSignedZeros()) &&
-        KnownSrc.isKnownNever(KnownFPClass::OrderedGreaterThanZeroMask | fcNan))
-      return Src;
-
-    Known = KnownFPClass::fneg(KnownFPClass::fabs(KnownSrc));
-    Known.knownNot(~DemandedMask);
+    // We cannot apply the NSZ logic with multiple uses. We can apply it if the
+    // inner fabs has it and this is the only use.
+    if (Value *Simplified = simplifyDemandedFPClassFnegFabs(
+            Known, Src, ThisDemandedMask, KnownSrc, /*NSZ=*/false))
+      return Simplified;
     break;
   }
   case Instruction::Call: {
@@ -3343,9 +3395,11 @@ Value *InstCombinerImpl::SimplifyMultipleUseDemandedFPClass(
       KnownFPClass KnownSrc =
           computeKnownFPClass(Src, fcAllFlags, CxtI, Depth + 1);
 
+      // NSZ cannot be applied in multiple use case (maybe it could if all uses
+      // were known nsz)
       if (Value *Simplified = simplifyDemandedFPClassFabs(
               Known, CI->getArgOperand(0), DemandedMask, KnownSrc,
-              FMF.noSignedZeros()))
+              /*NSZ=*/false))
         return Simplified;
       break;
     }

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2287,7 +2287,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
 
     Value *FNegSrc = I->getOperand(0);
     Value *FNegFAbsSrc;
-    if (match(FNegSrc, m_FAbs(m_Value(FNegFAbsSrc)))) {
+    if (match(FNegSrc, m_OneUse(m_FAbs(m_Value(FNegFAbsSrc))))) {
       KnownFPClass KnownSrc;
       if (SimplifyDemandedFPClass(cast<Instruction>(FNegSrc), 0,
                                   llvm::unknown_sign(DemandedMask), KnownSrc,

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
@@ -814,9 +814,7 @@ define nofpclass(snan) float @fneg_fabs_src_known_negative_or_poszero_multiple_u
 define nofpclass(snan) float @fneg_fabs_nsz_src_known_negative_or_poszero(float nofpclass(nan pinf pnorm psub) %always.negative.or.pzero) {
 ; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_nsz_src_known_negative_or_poszero
 ; CHECK-SAME: (float nofpclass(nan pinf psub pnorm) [[ALWAYS_NEGATIVE_OR_PZERO:%.*]]) {
-; CHECK-NEXT:    [[FABS:%.*]] = call nsz float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE_OR_PZERO]])
-; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg float [[FABS]]
-; CHECK-NEXT:    ret float [[FNEG_FABS]]
+; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE_OR_PZERO]]
 ;
   %fabs = call nsz float @llvm.fabs.f32(float %always.negative.or.pzero)
   %fneg.fabs = fneg float %fabs
@@ -829,7 +827,7 @@ define nofpclass(snan) float @fneg_fabs_nsz_src_known_negative_or_poszero_multip
 ; CHECK-NEXT:    [[FABS:%.*]] = call nsz float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE_OR_PZERO]])
 ; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg float [[FABS]]
 ; CHECK-NEXT:    store float [[FNEG_FABS]], ptr [[PTR]], align 4
-; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE_OR_PZERO]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
 ;
   %fabs = call nsz float @llvm.fabs.f32(float %always.negative.or.pzero)
   %fneg.fabs = fneg float %fabs
@@ -837,12 +835,37 @@ define nofpclass(snan) float @fneg_fabs_nsz_src_known_negative_or_poszero_multip
   ret float %fneg.fabs
 }
 
+define nofpclass(snan) float @fneg_fabs_nsz_src_known_negative_or_poszero_multiple_uses_fabs(float nofpclass(nan pinf pnorm psub) %always.negative.or.pzero, ptr %ptr) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_nsz_src_known_negative_or_poszero_multiple_uses_fabs
+; CHECK-SAME: (float nofpclass(nan pinf psub pnorm) [[ALWAYS_NEGATIVE_OR_PZERO:%.*]], ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[FABS:%.*]] = call nsz float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE_OR_PZERO]])
+; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg float [[FABS]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
+;
+  %fabs = call nsz float @llvm.fabs.f32(float %always.negative.or.pzero)
+  store float %fabs, ptr %ptr
+  %fneg.fabs = fneg float %fabs
+  ret float %fneg.fabs
+}
+
+define nofpclass(snan) float @fneg_nsz_fabs_src_known_negative_or_poszero_multiple_uses_fabs(float nofpclass(nan pinf pnorm psub) %always.negative.or.pzero, ptr %ptr) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_nsz_fabs_src_known_negative_or_poszero_multiple_uses_fabs
+; CHECK-SAME: (float nofpclass(nan pinf psub pnorm) [[ALWAYS_NEGATIVE_OR_PZERO:%.*]], ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE_OR_PZERO]])
+; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE_OR_PZERO]]
+;
+  %fabs = call float @llvm.fabs.f32(float %always.negative.or.pzero)
+  store float %fabs, ptr %ptr
+  %fneg.fabs = fneg nsz float %fabs
+  ret float %fneg.fabs
+}
+
 define nofpclass(snan) float @fneg_nsz_fabs_src_known_negative_or_poszero(float nofpclass(nan pinf pnorm psub) %always.negative.or.pzero) {
 ; CHECK-LABEL: define nofpclass(snan) float @fneg_nsz_fabs_src_known_negative_or_poszero
 ; CHECK-SAME: (float nofpclass(nan pinf psub pnorm) [[ALWAYS_NEGATIVE_OR_PZERO:%.*]]) {
-; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE_OR_PZERO]])
-; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nsz float [[FABS]]
-; CHECK-NEXT:    ret float [[FNEG_FABS]]
+; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE_OR_PZERO]]
 ;
   %fabs = call float @llvm.fabs.f32(float %always.negative.or.pzero)
   %fneg.fabs = fneg nsz float %fabs
@@ -855,12 +878,224 @@ define nofpclass(snan) float @fneg_nsz_fabs_src_known_negative_or_poszero_multip
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE_OR_PZERO]])
 ; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nsz float [[FABS]]
 ; CHECK-NEXT:    store float [[FNEG_FABS]], ptr [[PTR]], align 4
-; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE_OR_PZERO]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
 ;
   %fabs = call float @llvm.fabs.f32(float %always.negative.or.pzero)
   %fneg.fabs = fneg nsz float %fabs
   store float %fneg.fabs, ptr %ptr
   ret float %fneg.fabs
+}
+
+define nofpclass(snan) float @fneg_fabs_src_known_negative_multiple_uses_fabs(float nofpclass(nan pinf pnorm psub pzero) %always.negative, ptr %ptr) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_src_known_negative_multiple_uses_fabs
+; CHECK-SAME: (float nofpclass(nan pinf pzero psub pnorm) [[ALWAYS_NEGATIVE:%.*]], ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE]])
+; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE]]
+;
+  %fabs = call float @llvm.fabs.f32(float %always.negative)
+  store float %fabs, ptr %ptr
+  %fneg.fabs = fneg float %fabs
+  ret float %fneg.fabs
+}
+
+define nofpclass(snan) float @fneg_fabs_src_known_positive_multiple_uses_fabs(float nofpclass(nan ninf nnorm nsub nzero) %always.positive, ptr %ptr) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_src_known_positive_multiple_uses_fabs
+; CHECK-SAME: (float nofpclass(nan ninf nzero nsub nnorm) [[ALWAYS_POSITIVE:%.*]], ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    store float [[ALWAYS_POSITIVE]], ptr [[PTR]], align 4
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg float [[ALWAYS_POSITIVE]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
+;
+  %fabs = call float @llvm.fabs.f32(float %always.positive)
+  store float %fabs, ptr %ptr
+  %fneg.fabs = fneg float %fabs
+  ret float %fneg.fabs
+}
+
+define nofpclass(snan) float @fneg_fabs_nnan__known_positive__sign_known_negative_or_nan(float nofpclass(ninf nzero nsub nnorm) %known.positive) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_nnan__known_positive__sign_known_negative_or_nan
+; CHECK-SAME: (float nofpclass(ninf nzero nsub nnorm) [[KNOWN_POSITIVE:%.*]]) {
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nnan float [[KNOWN_POSITIVE]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
+;
+  %fabs = call nnan float @llvm.fabs.f32(float %known.positive)
+  %fneg.fabs = fneg nnan float %fabs
+  ret float %fneg.fabs
+}
+
+define nofpclass(snan) float @fneg_fabs_nnan__known_positive__sign_known_positive_or_negzero_or_nan(float nofpclass(ninf nsub nnorm) %known.positive.or.neg.zero) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_nnan__known_positive__sign_known_positive_or_negzero_or_nan
+; CHECK-SAME: (float nofpclass(ninf nsub nnorm) [[KNOWN_POSITIVE_OR_NEG_ZERO:%.*]]) {
+; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[KNOWN_POSITIVE_OR_NEG_ZERO]])
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nnan float [[FABS]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
+;
+  %fabs = call float @llvm.fabs.f32(float %known.positive.or.neg.zero)
+  %fneg.fabs = fneg nnan float %fabs
+  ret float %fneg.fabs
+}
+
+define nofpclass(snan) float @fneg_fabs__known_positive__sign_known_positive_or_negzero_or_nan(float nofpclass(nan ninf nsub nnorm) %known.positive.or.neg.zero) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs__known_positive__sign_known_positive_or_negzero_or_nan
+; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[KNOWN_POSITIVE_OR_NEG_ZERO:%.*]]) {
+; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[KNOWN_POSITIVE_OR_NEG_ZERO]])
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg float [[FABS]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
+;
+  %fabs = call float @llvm.fabs.f32(float %known.positive.or.neg.zero)
+  %fneg.fabs = fneg float %fabs
+  ret float %fneg.fabs
+}
+
+define nofpclass(snan) float @fneg_nsz_fabs__known_positive__sign_known_positive_or_negzero_or_nan(float nofpclass(nan ninf nsub nnorm) %known.positive.or.neg.zero) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_nsz_fabs__known_positive__sign_known_positive_or_negzero_or_nan
+; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[KNOWN_POSITIVE_OR_NEG_ZERO:%.*]]) {
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nsz float [[KNOWN_POSITIVE_OR_NEG_ZERO]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
+;
+  %fabs = call float @llvm.fabs.f32(float %known.positive.or.neg.zero)
+  %fneg.fabs = fneg nsz float %fabs
+  ret float %fneg.fabs
+}
+
+define nofpclass(snan) float @fneg_nsz_fabs__known_positive__sign_known_positive_or_negzero_or_nan_multiple_use_fabs(float nofpclass(nan ninf nsub nnorm) %known.positive.or.neg.zero, ptr %ptr) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_nsz_fabs__known_positive__sign_known_positive_or_negzero_or_nan_multiple_use_fabs
+; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[KNOWN_POSITIVE_OR_NEG_ZERO:%.*]], ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[KNOWN_POSITIVE_OR_NEG_ZERO]])
+; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nsz float [[KNOWN_POSITIVE_OR_NEG_ZERO]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
+;
+  %fabs = call float @llvm.fabs.f32(float %known.positive.or.neg.zero)
+  store float %fabs, ptr %ptr
+  %fneg.fabs = fneg nsz float %fabs
+  ret float %fneg.fabs
+}
+
+define nofpclass(snan) float @fneg_nsz_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan_multiple_use_fabs(float nofpclass(nan ninf nsub nnorm) %known.positive.or.neg.zero, ptr %ptr) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_nsz_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan_multiple_use_fabs
+; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[KNOWN_POSITIVE_OR_NEG_ZERO:%.*]], ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    store float [[KNOWN_POSITIVE_OR_NEG_ZERO]], ptr [[PTR]], align 4
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nsz float [[KNOWN_POSITIVE_OR_NEG_ZERO]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
+;
+  %fabs = call nsz float @llvm.fabs.f32(float %known.positive.or.neg.zero)
+  store float %fabs, ptr %ptr
+  %fneg.fabs = fneg nsz float %fabs
+  ret float %fneg.fabs
+}
+
+define nofpclass(snan) float @fneg_nsz_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan_multiple_use_fneg(float nofpclass(nan ninf nsub nnorm) %known.positive.or.neg.zero, ptr %ptr) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_nsz_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan_multiple_use_fneg
+; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[KNOWN_POSITIVE_OR_NEG_ZERO:%.*]], ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nsz float [[KNOWN_POSITIVE_OR_NEG_ZERO]]
+; CHECK-NEXT:    store float [[FNEG_FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
+;
+  %fabs = call nsz float @llvm.fabs.f32(float %known.positive.or.neg.zero)
+  %fneg.fabs = fneg nsz float %fabs
+  store float %fneg.fabs, ptr %ptr
+  ret float %fneg.fabs
+}
+
+define nofpclass(snan) float @fneg_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan(float nofpclass(nan ninf nsub nnorm) %known.positive.or.neg.zero) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan
+; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[KNOWN_POSITIVE_OR_NEG_ZERO:%.*]]) {
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg float [[KNOWN_POSITIVE_OR_NEG_ZERO]]
+; CHECK-NEXT:    ret float [[COPYSIGN]]
+;
+  %fabs = call nsz float @llvm.fabs.f32(float %known.positive.or.neg.zero)
+  %copysign = fneg float %fabs
+  ret float %copysign
+}
+
+define nofpclass(snan) float @fneg_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan__multi_use_fabs(float nofpclass(nan ninf nsub nnorm) %known.positive.or.neg.zero, ptr %ptr) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_nsz__known_positive__sign_known_positive_or_negzero_or_nan__multi_use_fabs
+; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[KNOWN_POSITIVE_OR_NEG_ZERO:%.*]], ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    store float [[KNOWN_POSITIVE_OR_NEG_ZERO]], ptr [[PTR]], align 4
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg float [[KNOWN_POSITIVE_OR_NEG_ZERO]]
+; CHECK-NEXT:    ret float [[COPYSIGN]]
+;
+  %fabs = call nsz float @llvm.fabs.f32(float %known.positive.or.neg.zero)
+  store float %fabs, ptr %ptr
+  %copysign = fneg float %fabs
+  ret float %copysign
+}
+
+define nofpclass(snan) float @fneg_fabs_nnan__known_positive__sign_known_negative_or_nan_multi_use_fabs(float nofpclass(ninf nzero nsub nnorm) %known.positive, ptr %ptr) {
+; CHECK-LABEL: define nofpclass(snan) float @fneg_fabs_nnan__known_positive__sign_known_negative_or_nan_multi_use_fabs
+; CHECK-SAME: (float nofpclass(ninf nzero nsub nnorm) [[KNOWN_POSITIVE:%.*]], ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[FABS:%.*]] = call nnan float @llvm.fabs.f32(float [[KNOWN_POSITIVE]])
+; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg nnan float [[KNOWN_POSITIVE]]
+; CHECK-NEXT:    ret float [[COPYSIGN]]
+;
+  %fabs = call nnan float @llvm.fabs.f32(float %known.positive)
+  store float %fabs, ptr %ptr
+  %copysign = fneg nnan float %fabs
+  ret float %copysign
+}
+
+; Known fabs source is positive due to ninf flag
+define nofpclass(nan) float @no_nan__fneg_ninf_fabs__known_positive_or_ninf__sign_known_negative_or_nan(float nofpclass(nzero nsub nnorm) %known.positive.or.ninf) {
+; CHECK-LABEL: define nofpclass(nan) float @no_nan__fneg_ninf_fabs__known_positive_or_ninf__sign_known_negative_or_nan
+; CHECK-SAME: (float nofpclass(nzero nsub nnorm) [[KNOWN_POSITIVE_OR_NINF:%.*]]) {
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg ninf float [[KNOWN_POSITIVE_OR_NINF]]
+; CHECK-NEXT:    ret float [[COPYSIGN]]
+;
+  %fabs = call float @llvm.fabs.f32(float %known.positive.or.ninf)
+  %copysign = fneg ninf float %fabs
+  ret float %copysign
+}
+
+; Known fabs source is positive due to ninf flag
+define nofpclass(nan) float @no_nan__fneg_fabs_ninf__known_positive_or_ninf__sign_known_negative_or_nan(float nofpclass(nzero nsub nnorm) %known.positive.or.ninf) {
+; CHECK-LABEL: define nofpclass(nan) float @no_nan__fneg_fabs_ninf__known_positive_or_ninf__sign_known_negative_or_nan
+; CHECK-SAME: (float nofpclass(nzero nsub nnorm) [[KNOWN_POSITIVE_OR_NINF:%.*]]) {
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg float [[KNOWN_POSITIVE_OR_NINF]]
+; CHECK-NEXT:    ret float [[COPYSIGN]]
+;
+  %fabs = call ninf float @llvm.fabs.f32(float %known.positive.or.ninf)
+  %copysign = fneg float %fabs
+  ret float %copysign
+}
+
+; Can't tell fabs source is positive with no-pinf return
+define nofpclass(nan pinf) float @no_nan_nopinf__fneg_ninf_fabs__known_positive_or_ninf__sign_known_negative_or_nan(float nofpclass(nzero nsub nnorm) %known.positive.or.ninf) {
+; CHECK-LABEL: define nofpclass(nan pinf) float @no_nan_nopinf__fneg_ninf_fabs__known_positive_or_ninf__sign_known_negative_or_nan
+; CHECK-SAME: (float nofpclass(nzero nsub nnorm) [[KNOWN_POSITIVE_OR_NINF:%.*]]) {
+; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[KNOWN_POSITIVE_OR_NINF]])
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg float [[FABS]]
+; CHECK-NEXT:    ret float [[COPYSIGN]]
+;
+  %fabs = call float @llvm.fabs.f32(float %known.positive.or.ninf)
+  %copysign = fneg float %fabs
+  ret float %copysign
+}
+
+; Can't tell fabs source is positive with ninf return
+define nofpclass(nan ninf) float @no_nan_noninf__fneg_ninf_fabs__known_positive_or_ninf__sign_known_negative_or_nan(float nofpclass(nzero nsub nnorm) %known.positive.or.ninf) {
+; CHECK-LABEL: define nofpclass(nan ninf) float @no_nan_noninf__fneg_ninf_fabs__known_positive_or_ninf__sign_known_negative_or_nan
+; CHECK-SAME: (float nofpclass(nzero nsub nnorm) [[KNOWN_POSITIVE_OR_NINF:%.*]]) {
+; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[KNOWN_POSITIVE_OR_NINF]])
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg float [[FABS]]
+; CHECK-NEXT:    ret float [[COPYSIGN]]
+;
+  %fabs = call float @llvm.fabs.f32(float %known.positive.or.ninf)
+  %copysign = fneg float %fabs
+  ret float %copysign
+}
+
+; Can tell fabs source is positive with no inf return
+define nofpclass(nan inf) float @no_nan_noinf__fneg_ninf_fabs__known_positive_or_ninf__sign_known_negative_or_nan(float nofpclass(nzero nsub nnorm) %known.positive.or.ninf) {
+; CHECK-LABEL: define nofpclass(nan inf) float @no_nan_noinf__fneg_ninf_fabs__known_positive_or_ninf__sign_known_negative_or_nan
+; CHECK-SAME: (float nofpclass(nzero nsub nnorm) [[KNOWN_POSITIVE_OR_NINF:%.*]]) {
+; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg float [[KNOWN_POSITIVE_OR_NINF]]
+; CHECK-NEXT:    ret float [[COPYSIGN]]
+;
+  %fabs = call float @llvm.fabs.f32(float %known.positive.or.ninf)
+  %copysign = fneg float %fabs
+  ret float %copysign
 }
 
 ; should fold to ret copysign(%x)
@@ -1123,9 +1358,7 @@ define nofpclass(snan) float @copysign_nnan__known_positive__sign_known_positive
 define nofpclass(snan) float @copysign_nnan__known_negative__sign_known_negative_or_nan(float nofpclass(pinf pnorm psub pzero) %known.negative, float nofpclass(pinf pnorm psub pzero) %always.negative.or.nan) {
 ; CHECK-LABEL: define nofpclass(snan) float @copysign_nnan__known_negative__sign_known_negative_or_nan
 ; CHECK-SAME: (float nofpclass(pinf pzero psub pnorm) [[KNOWN_NEGATIVE:%.*]], float nofpclass(pinf pzero psub pnorm) [[ALWAYS_NEGATIVE_OR_NAN:%.*]]) {
-; CHECK-NEXT:    [[TMP1:%.*]] = call nnan float @llvm.fabs.f32(float [[KNOWN_NEGATIVE]])
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = fneg nnan float [[TMP1]]
-; CHECK-NEXT:    ret float [[COPYSIGN]]
+; CHECK-NEXT:    ret float [[KNOWN_NEGATIVE]]
 ;
   %copysign = call nnan float @llvm.copysign.f32(float %known.negative, float %always.negative.or.nan)
   ret float %copysign

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
@@ -855,7 +855,8 @@ define nofpclass(snan) float @fneg_nsz_fabs_src_known_negative_or_poszero_multip
 ; CHECK-SAME: (float nofpclass(nan pinf psub pnorm) [[ALWAYS_NEGATIVE_OR_PZERO:%.*]], ptr [[PTR:%.*]]) {
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE_OR_PZERO]])
 ; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
-; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE_OR_PZERO]]
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nsz float [[FABS]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
 ;
   %fabs = call float @llvm.fabs.f32(float %always.negative.or.pzero)
   store float %fabs, ptr %ptr
@@ -892,7 +893,8 @@ define nofpclass(snan) float @fneg_fabs_src_known_negative_multiple_uses_fabs(fl
 ; CHECK-SAME: (float nofpclass(nan pinf pzero psub pnorm) [[ALWAYS_NEGATIVE:%.*]], ptr [[PTR:%.*]]) {
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[ALWAYS_NEGATIVE]])
 ; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
-; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE]]
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg float [[FABS]]
+; CHECK-NEXT:    ret float [[FNEG_FABS]]
 ;
   %fabs = call float @llvm.fabs.f32(float %always.negative)
   store float %fabs, ptr %ptr
@@ -964,7 +966,7 @@ define nofpclass(snan) float @fneg_nsz_fabs__known_positive__sign_known_positive
 ; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[KNOWN_POSITIVE_OR_NEG_ZERO:%.*]], ptr [[PTR:%.*]]) {
 ; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[KNOWN_POSITIVE_OR_NEG_ZERO]])
 ; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
-; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nsz float [[KNOWN_POSITIVE_OR_NEG_ZERO]]
+; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg nsz float [[FABS]]
 ; CHECK-NEXT:    ret float [[FNEG_FABS]]
 ;
   %fabs = call float @llvm.fabs.f32(float %known.positive.or.neg.zero)
@@ -1103,7 +1105,8 @@ define nofpclass(nan) float @fneg_fabs_multiple_uses_fabs(i1 %cond, float %x, pt
 ; CHECK-LABEL: define nofpclass(nan) float @fneg_fabs_multiple_uses_fabs
 ; CHECK-SAME: (i1 [[COND:%.*]], float [[X:%.*]], ptr [[PTR:%.*]]) {
 ; CHECK-NEXT:    [[NAN:%.*]] = call float @nan_only()
-; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[X]])
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND]], float [[X]], float [[NAN]]
+; CHECK-NEXT:    [[FABS:%.*]] = call float @llvm.fabs.f32(float [[SEL]])
 ; CHECK-NEXT:    [[FNEG_FABS:%.*]] = fneg float [[FABS]]
 ; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
 ; CHECK-NEXT:    ret float [[FNEG_FABS]]


### PR DESCRIPTION
Match the multi-use case's logic for understanding no-nan/no-inf context.
 Also only apply the nsz handling in the single use case. alive2 seems to treat
 nsz as nondeterministic for each use.