### PR TITLE
[mlir] Add side-effect check to moveOperationDependencies

### DIFF
--- a/mlir/include/mlir/Transforms/RegionUtils.h
+++ b/mlir/include/mlir/Transforms/RegionUtils.h
@@ -75,6 +75,8 @@ SmallVector<Value> makeRegionIsolatedFromAbove(
 /// so that the operation itself (or its replacement) can be moved to
 /// the insertion point. Current support is only for movement of
 /// dependencies of `op` before `insertionPoint` in the same basic block.
+/// Any side-effecting operations in the dependency chain pessimistically
+/// blocks movement.
 LogicalResult moveOperationDependencies(RewriterBase &rewriter, Operation *op,
                                         Operation *insertionPoint,
                                         DominanceInfo &dominance);


### PR DESCRIPTION
This patch adds a side-effect check to `moveOperationDependencies` to match the behavior of `moveValueDefinitions`. Previously, `moveOperationDependencies` would move operations with side-effecting dependencies, which could change program semantics.

**Note** that the existing test changes are needed because unregistered operations (e.g., "moved_op"()) are treated as side-effecting. These tests were updated to use pure operations for operations in the moved slice, while keeping unregistered ops for operations that aren't moved (e.g., "before"(), "foo"()). This ensures that tests continue to exercise their intended functionality without being blocked by the new side-effect check.