### PR TITLE
[MLIR] Remove leftover field from Variadic, NFC

### DIFF
--- a/mlir/include/mlir/IR/CommonTypeConstraints.td
+++ b/mlir/include/mlir/IR/CommonTypeConstraints.td
@@ -127,7 +127,6 @@ class Variadic<Type type> : TypeConstraint<type.predicate,
                                            "variadic of " # type.summary,
                                            type.cppType> {
   Type baseType = type;
-  int minSize = 0;
 }
 
 // A nested variadic type constraint. It expands to zero or more variadic ranges


### PR DESCRIPTION
There appears to be an unused field in the `Variadic` TableGen class, introduced originally in commit
70b69c54fa8b24519cd549eec10e549471157bb8. It looks like, when removing the associated `VariadicAtLeast` class
(bf8049dc483131365aea3d3626a2d27b5dfa92de), this field still remained.