### PR TITLE
Hexagon: Avoid using getLibcallName for special memcpy

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonSelectionDAGInfo.cpp
@@ -83,14 +83,17 @@ SDValue HexagonSelectionDAGInfo::EmitTargetCodeForMemcpy(
   Args.emplace_back(Src, ArgTy);
   Args.emplace_back(Size, ArgTy);
 
-  const char *SpecialMemcpyName = DAG.getLibcalls().getLibcallName(
+  RTLIB::LibcallImpl SpecialMemcpyImpl = DAG.getLibcalls().getLibcallImpl(
       RTLIB::HEXAGON_MEMCPY_LIKELY_ALIGNED_MIN32BYTES_MULT8BYTES);
+  if (SpecialMemcpyImpl == RTLIB::Unsupported)
+    return SDValue();
+
   const MachineFunction &MF = DAG.getMachineFunction();
   bool LongCalls = MF.getSubtarget<HexagonSubtarget>().useLongCalls();
   unsigned Flags = LongCalls ? HexagonII::HMOTF_ConstExtended : 0;
 
-  CallingConv::ID CC = DAG.getLibcalls().getLibcallCallingConv(
-      RTLIB::HEXAGON_MEMCPY_LIKELY_ALIGNED_MIN32BYTES_MULT8BYTES);
+  CallingConv::ID CC =
+      DAG.getLibcalls().getLibcallImplCallingConv(SpecialMemcpyImpl);
 
   TargetLowering::CallLoweringInfo CLI(DAG);
   CLI.setDebugLoc(dl)
@@ -98,7 +101,7 @@ SDValue HexagonSelectionDAGInfo::EmitTargetCodeForMemcpy(
       .setLibCallee(
           CC, Type::getVoidTy(*DAG.getContext()),
           DAG.getTargetExternalSymbol(
-              SpecialMemcpyName, TLI.getPointerTy(DAG.getDataLayout()), Flags),
+              SpecialMemcpyImpl, TLI.getPointerTy(DAG.getDataLayout()), Flags),
           std::move(Args))
       .setDiscardResult();
 


### PR DESCRIPTION
Create the symbol through the RTLIB::LibcallImpl enum.