### PR TITLE
[github] Fix release parameter to uncomment download links step

### DIFF
--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -112,6 +112,7 @@ jobs:
       contents: write # For updating the release message.
     if: '!cancelled()'
     needs:
+      - validate-tag
       - release-binaries
 
     steps:


### PR DESCRIPTION
I thought I could remove validate-tag from the "needs" because release-binaries also "needs" validate-tag. Turns out that we get the release version from an output of validate-tag and if it isn't in the "needs" section we get an empty string when substitution happens. Leading to this error:

./llvm/utils/release/./github-upload-release.py --token "$GITHUB_TOKEN" --release  uncomment_download_links
github-upload-release.py: error: the following arguments are required: command

Put back validate-tag.

Fixes 822a45f4b4909289f84d119f1e5891b486d74f5e.