### PR TITLE
[clang][bytecode] Handle corner condition for sign negation

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2888,7 +2888,9 @@ inline bool DoShift(InterpState &S, CodePtr OpPC, LT &LHS, RT &RHS,
     S.CCEDiag(Loc, diag::note_constexpr_negative_shift) << RHS.toAPSInt();
     if (!S.noteUndefinedBehavior())
       return false;
-    RHS = -RHS;
+
+    RHS = RHS.isMin() ? RT(APSInt::getMaxValue(RHS.bitWidth(), false)) : -RHS;
+
     return DoShift<LT, RT,
                    Dir == ShiftDir::Left ? ShiftDir::Right : ShiftDir::Left>(
         S, OpPC, LHS, RHS, Result);

--- a/clang/test/AST/ByteCode/shifts.cpp
+++ b/clang/test/AST/ByteCode/shifts.cpp
@@ -75,6 +75,8 @@ namespace shifts {
                           // ref-cxx17-warning {{shift count >= width of type}}
     (void)((long)c << __CHAR_BIT__);
 
+    c = 1 << (int)INT_MIN; // all-warning {{shift count is negative}}
+
     int i; // cxx17-warning {{uninitialized variable}} \
            // ref-cxx17-warning {{uninitialized variable}}
     i = 1 << (__INT_WIDTH__ - 2);


### PR DESCRIPTION
RHS = -RHS works for most cases, however, the behaviour when RHS is INTXX_MIN is undefined. In these particular case(s), we should use INTXX_MAX instead.

Fixes #176271.