### PR TITLE
Update sanitizer_coverage_allowlist_ignorelist.cpp to use POSIX-compliant regex

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_allowlist_ignorelist.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_allowlist_ignorelist.cpp
@@ -24,10 +24,10 @@
 
 // Check inline-8bit-counters
 // RUN: echo 'section "__sancov_cntrs"'                                                                             >  patterns.txt
-// RUN: echo '%[0-9]\+ = load i8, ptr @__sancov_gen_' >> patterns.txt
-// RUN: echo 'store i8 %[0-9]\+, ptr @__sancov_gen_'  >> patterns.txt
-// RUN: echo '%[0-9]\+ = load i8, ptr getelementptr (\[[0-9]\+ x i8\], ptr @__sancov_gen_' >> patterns.txt
-// RUN: echo 'store i8 %[0-9]\+, ptr getelementptr (\[[0-9]\+ x i8\], ptr @__sancov_gen_'  >> patterns.txt
+// RUN: echo '%[0-9][0-9]* = load i8, ptr @__sancov_gen_' >> patterns.txt
+// RUN: echo 'store i8 %[0-9][0-9]*, ptr @__sancov_gen_'  >> patterns.txt
+// RUN: echo '%[0-9][0-9]* = load i8, ptr getelementptr (\[[0-9][0-9]* x i8\], ptr @__sancov_gen_' >> patterns.txt
+// RUN: echo 'store i8 %[0-9][0-9]*, ptr getelementptr (\[[0-9][0-9]* x i8\], ptr @__sancov_gen_'  >> patterns.txt
 
 // Check indirect-calls
 // RUN: echo 'call void @__sanitizer_cov_trace_pc_indir'                                                            >> patterns.txt


### PR DESCRIPTION
As `\+` is a GNU extension, it is not supported by the system grep on AIX. This change replaces `%[0-9]\+` with `%[0-9][0-9]*`, which is POSIX-compliant and therefore compatible with AIX.