### PR TITLE
[llvm][Support] Create llvm::formatv variant of llvm::createStringError

### DIFF
--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -1341,7 +1341,8 @@ inline Error createStringError(std::errc EC, char const *Fmt,
 template <typename... Ts>
 inline Error createStringErrorV(std::error_code EC, char const *Fmt,
                                 Ts &&...Vals) {
-  return make_error<StringError>(formatv(Fmt, std::forward<Ts>(Vals)...).str(), EC, true);
+  return make_error<StringError>(formatv(Fmt, std::forward<Ts>(Vals)...).str(),
+                                 EC, true);
 }
 
 template <typename... Ts>

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -21,6 +21,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <cstdint>
@@ -1333,6 +1334,22 @@ template <typename... Ts>
 inline Error createStringError(std::errc EC, char const *Fmt,
                                const Ts &... Vals) {
   return createStringError(std::make_error_code(EC), Fmt, Vals...);
+}
+
+// LLVM formatv versions of llvm::createStringError
+
+template <typename... Ts>
+inline Error createStringErrorV(std::error_code EC, char const *Fmt,
+                                Ts &&...Vals) {
+  std::string Buffer;
+  raw_string_ostream(Buffer) << formatv(Fmt, std::forward<Ts>(Vals)...);
+  return make_error<StringError>(std::move(Buffer), EC, true);
+}
+
+template <typename... Ts>
+inline Error createStringErrorV(char const *Fmt, Ts &&...Vals) {
+  return createStringErrorV(llvm::inconvertibleErrorCode(), Fmt,
+                            std::forward<Ts>(Vals)...);
 }
 
 /// This class wraps a filename and another Error.

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -1341,9 +1341,7 @@ inline Error createStringError(std::errc EC, char const *Fmt,
 template <typename... Ts>
 inline Error createStringErrorV(std::error_code EC, char const *Fmt,
                                 Ts &&...Vals) {
-  std::string Buffer;
-  raw_string_ostream(Buffer) << formatv(Fmt, std::forward<Ts>(Vals)...);
-  return make_error<StringError>(std::move(Buffer), EC, true);
+  return make_error<StringError>(formatv(Fmt, std::forward<Ts>(Vals)...).str(), EC, true);
 }
 
 template <typename... Ts>

--- a/llvm/unittests/Support/ErrorTest.cpp
+++ b/llvm/unittests/Support/ErrorTest.cpp
@@ -471,6 +471,27 @@ TEST(Error, createStringError) {
     << "Failed to convert createStringError() result to error_code.";
 }
 
+TEST(Error, createStringErrorV) {
+  static const char *Bar = "bar";
+  static const std::error_code EC = errc::invalid_argument;
+  std::string Msg;
+  raw_string_ostream S(Msg);
+  logAllUnhandledErrors(createStringErrorV(EC, "foo{0}{1}{2:x}", Bar, 1, 0xff),
+                        S);
+  EXPECT_EQ(Msg, "foobar10xff\n")
+      << "Unexpected createStringError() log result";
+
+  Msg.clear();
+  auto Res = errorToErrorCode(createStringError(EC, "foo{0}", Bar));
+  EXPECT_EQ(Res, EC)
+      << "Failed to convert createStringError() result to error_code.";
+
+  Msg.clear();
+  logAllUnhandledErrors(createStringErrorV("foo{0}{1}{2:x}", Bar, 1, 0xff), S);
+  EXPECT_EQ(Msg, "foobar10xff\n")
+      << "Unexpected createStringError() (no EC overload) log result";
+}
+
 // Test that the ExitOnError utility works as expected.
 TEST(ErrorDeathTest, ExitOnError) {
   ExitOnError ExitOnErr;


### PR DESCRIPTION
Currently `llvm::createStringError` only supports printf format specifiers because it forwards to `llvm::format`.

In LLDB we've been using `llvm::createStringError(llvm::formatv(...), ...` to work around this. It would be convenient to have a version of the API that takes LLVM format specifiers, so we benefit from the advantages that come with those.

This patch adds a new `llvm::createStringErrorV` which forwards to `llvm::formatv` (hence the `V` suffix in the name). I only implemented `V` variants for the `llvm::createStringError` APIs that take a format string argument.

As a side-note, `llvm/lib/Frontend/Offloading/PropertySet.cpp` implements it's own variant of this function (and also calls it `createStringErrorV`). This patch would allow us to clean that up as well.