### PR TITLE
[Support][NFCI] Store DomTree children as linked list

### DIFF
--- a/llvm/include/llvm/Support/GenericDomTree.h
+++ b/llvm/include/llvm/Support/GenericDomTree.h
@@ -73,27 +73,29 @@ template <class NodeT> class DomTreeNodeBase {
   DomTreeNodeBase(const DomTreeNodeBase &) = delete;
   DomTreeNodeBase &operator=(const DomTreeNodeBase &) = delete;
 
-  class iterator
-      : public iterator_facade_base<iterator, std::forward_iterator_tag,
+  class const_iterator
+      : public iterator_facade_base<const_iterator, std::forward_iterator_tag,
                                     DomTreeNodeBase *> {
     DomTreeNodeBase *node;
 
   public:
-    iterator(DomTreeNodeBase *node = nullptr) : node(node) {}
-    bool operator==(const iterator &other) const { return other.node == node; }
+    const_iterator(DomTreeNodeBase *node = nullptr) : node(node) {}
+    bool operator==(const const_iterator &other) const {
+      return other.node == node;
+    }
     DomTreeNodeBase *operator*() const { return node; }
-    iterator &operator++() {
+    const_iterator &operator++() {
       node = node->Sibling;
       return *this;
     }
-    iterator operator++(int) {
-      iterator cp = *this;
+    const_iterator operator++(int) {
+      const_iterator cp = *this;
       ++*this;
       return cp;
     }
   };
   // We don't permit modifications through the iterator.
-  using const_iterator = iterator;
+  using iterator = const_iterator;
 
   iterator begin() const { return iterator{FirstChild}; }
   iterator end() const { return iterator{}; }

--- a/llvm/include/llvm/Support/GenericDomTree.h
+++ b/llvm/include/llvm/Support/GenericDomTree.h
@@ -76,16 +76,16 @@ template <class NodeT> class DomTreeNodeBase {
   class const_iterator
       : public iterator_facade_base<const_iterator, std::forward_iterator_tag,
                                     DomTreeNodeBase *> {
-    DomTreeNodeBase *node;
+    DomTreeNodeBase *Node;
 
   public:
-    const_iterator(DomTreeNodeBase *node = nullptr) : node(node) {}
-    bool operator==(const const_iterator &other) const {
-      return other.node == node;
+    const_iterator(DomTreeNodeBase *Node = nullptr) : Node(Node) {}
+    bool operator==(const const_iterator &Other) const {
+      return Other.Node == Node;
     }
-    DomTreeNodeBase *operator*() const { return node; }
+    DomTreeNodeBase *operator*() const { return Node; }
     const_iterator &operator++() {
-      node = node->Sibling;
+      Node = Node->Sibling;
       return *this;
     }
     const_iterator operator++(int) {

--- a/llvm/include/llvm/Support/GenericDomTree.h
+++ b/llvm/include/llvm/Support/GenericDomTree.h
@@ -60,7 +60,9 @@ template <class NodeT> class DomTreeNodeBase {
   NodeT *TheBB;
   DomTreeNodeBase *IDom;
   unsigned Level;
-  SmallVector<DomTreeNodeBase *, 4> Children;
+  DomTreeNodeBase *FirstChild = nullptr;
+  DomTreeNodeBase *Sibling = nullptr;
+  DomTreeNodeBase **AppendPtr = &FirstChild;
   mutable unsigned DFSNumIn = ~0;
   mutable unsigned DFSNumOut = ~0;
 
@@ -68,17 +70,33 @@ template <class NodeT> class DomTreeNodeBase {
   DomTreeNodeBase(NodeT *BB, DomTreeNodeBase *iDom)
       : TheBB(BB), IDom(iDom), Level(IDom ? IDom->Level + 1 : 0) {}
 
-  using iterator = typename SmallVector<DomTreeNodeBase *, 4>::iterator;
-  using const_iterator =
-      typename SmallVector<DomTreeNodeBase *, 4>::const_iterator;
+  DomTreeNodeBase(const DomTreeNodeBase &) = delete;
+  DomTreeNodeBase &operator=(const DomTreeNodeBase &) = delete;
 
-  iterator begin() { return Children.begin(); }
-  iterator end() { return Children.end(); }
-  const_iterator begin() const { return Children.begin(); }
-  const_iterator end() const { return Children.end(); }
+  class iterator
+      : public iterator_facade_base<iterator, std::forward_iterator_tag,
+                                    DomTreeNodeBase *> {
+    DomTreeNodeBase *node;
 
-  DomTreeNodeBase *const &back() const { return Children.back(); }
-  DomTreeNodeBase *&back() { return Children.back(); }
+  public:
+    iterator(DomTreeNodeBase *node = nullptr) : node(node) {}
+    bool operator==(const iterator &other) const { return other.node == node; }
+    DomTreeNodeBase *operator*() const { return node; }
+    iterator &operator++() {
+      node = node->Sibling;
+      return *this;
+    }
+    iterator operator++(int) {
+      iterator cp = *this;
+      ++*this;
+      return cp;
+    }
+  };
+  // We don't permit modifications through the iterator.
+  using const_iterator = iterator;
+
+  iterator begin() const { return iterator{FirstChild}; }
+  iterator end() const { return iterator{}; }
 
   iterator_range<iterator> children() { return make_range(begin(), end()); }
   iterator_range<const_iterator> children() const {
@@ -89,17 +107,33 @@ template <class NodeT> class DomTreeNodeBase {
   DomTreeNodeBase *getIDom() const { return IDom; }
   unsigned getLevel() const { return Level; }
 
-  void addChild(DomTreeNodeBase *C) { Children.push_back(C); }
+  // TODO: make these private once NewGVN doesn't require these anymore.
+  void addChild(DomTreeNodeBase *C) {
+    assert(!C->Sibling && "cannot add child that already has siblings");
+    assert(!*AppendPtr && "sibling of last child must be nullptr");
+    *AppendPtr = C;
+    AppendPtr = &C->Sibling;
+  }
 
-  bool isLeaf() const { return Children.empty(); }
-  size_t getNumChildren() const { return Children.size(); }
+  // TODO: make these private once NewGVN doesn't require these anymore.
+  void removeChild(DomTreeNodeBase *C) {
+    DomTreeNodeBase **It = &FirstChild;
+    while (*It != C) {
+      assert(*It != nullptr && "Not in immediate dominator children list!");
+      It = &(*It)->Sibling;
+    }
+    assert(!*AppendPtr && "sibling of last child must be nullptr");
+    assert(C->Sibling || AppendPtr == &C->Sibling);
+    *It = C->Sibling;
+    if (C->Sibling)
+      C->Sibling = nullptr;
+    else
+      AppendPtr = It;
+  }
 
-  void clearAllChildren() { Children.clear(); }
+  bool isLeaf() const { return FirstChild == nullptr; }
 
   bool compare(const DomTreeNodeBase *Other) const {
-    if (getNumChildren() != Other->getNumChildren())
-      return true;
-
     if (Level != Other->Level) return true;
 
     SmallPtrSet<const NodeT *, 4> OtherChildren;
@@ -108,27 +142,24 @@ template <class NodeT> class DomTreeNodeBase {
       OtherChildren.insert(Nd);
     }
 
+    size_t OwnCount = 0;
     for (const DomTreeNodeBase *I : *this) {
       const NodeT *N = I->getBlock();
       if (OtherChildren.count(N) == 0)
         return true;
+      ++OwnCount;
     }
-    return false;
+    return OwnCount != OtherChildren.size();
   }
 
   void setIDom(DomTreeNodeBase *NewIDom) {
     assert(IDom && "No immediate dominator?");
     if (IDom == NewIDom) return;
-
-    auto I = find(IDom->Children, this);
-    assert(I != IDom->Children.end() &&
-           "Not in immediate dominator children set!");
-    // I am no longer your child...
-    IDom->Children.erase(I);
+    IDom->removeChild(this);
 
     // Switch to new dominator
     IDom = NewIDom;
-    IDom->Children.push_back(this);
+    IDom->addChild(this);
 
     UpdateLevel();
   }
@@ -743,15 +774,8 @@ public:
     DFSInfoValid = false;
 
     // Remove node from immediate dominator's children list.
-    DomTreeNodeBase<NodeT> *IDom = Node->getIDom();
-    if (IDom) {
-      const auto I = find(IDom->Children, Node);
-      assert(I != IDom->Children.end() &&
-             "Not in immediate dominator children set!");
-      // I am no longer your child...
-      std::swap(*I, IDom->Children.back());
-      IDom->Children.pop_back();
-    }
+    if (DomTreeNodeBase<NodeT> *IDom = Node->getIDom())
+      IDom->removeChild(Node);
 
     DomTreeNodes[*IdxOpt] = nullptr;
     if constexpr (!GraphHasNodeNumbers<NodeT *>)

--- a/llvm/lib/CodeGen/EarlyIfConversion.cpp
+++ b/llvm/lib/CodeGen/EarlyIfConversion.cpp
@@ -868,9 +868,9 @@ void updateDomTree(MachineDominatorTree *DomTree, const SSAIfConv &IfConv,
   for (auto *B : Removed) {
     MachineDomTreeNode *Node = DomTree->getNode(B);
     assert(Node != HeadNode && "Cannot erase the head node");
-    while (Node->getNumChildren()) {
+    while (!Node->isLeaf()) {
       assert(Node->getBlock() == IfConv.Tail && "Unexpected children");
-      DomTree->changeImmediateDominator(Node->back(), HeadNode);
+      DomTree->changeImmediateDominator(*Node->begin(), HeadNode);
     }
     DomTree->eraseNode(B);
   }

--- a/llvm/lib/CodeGen/MachineCSE.cpp
+++ b/llvm/lib/CodeGen/MachineCSE.cpp
@@ -777,8 +777,9 @@ bool MachineCSEImpl::PerformCSE(MachineDomTreeNode *Node) {
   do {
     Node = WorkList.pop_back_val();
     Scopes.push_back(Node);
-    OpenChildren[Node] = Node->getNumChildren();
+    size_t WorkListSize = WorkList.size();
     append_range(WorkList, Node->children());
+    OpenChildren[Node] = WorkList.size() - WorkListSize; // Number of children.
   } while (!WorkList.empty());
 
   // Now perform CSE.

--- a/llvm/lib/Target/AArch64/AArch64ConditionalCompares.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ConditionalCompares.cpp
@@ -820,8 +820,8 @@ void AArch64ConditionalCompares::updateDomTree(
     MachineDomTreeNode *Node = DomTree->getNode(RemovedMBB);
     assert(Node != HeadNode && "Cannot erase the head node");
     assert(Node->getIDom() == HeadNode && "CmpBB should be dominated by Head");
-    while (Node->getNumChildren())
-      DomTree->changeImmediateDominator(Node->back(), HeadNode);
+    while (!Node->isLeaf())
+      DomTree->changeImmediateDominator(*Node->begin(), HeadNode);
     DomTree->eraseNode(RemovedMBB);
   }
 }

--- a/llvm/lib/Target/SystemZ/SystemZLDCleanup.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZLDCleanup.cpp
@@ -103,8 +103,8 @@ bool SystemZLDCleanup::VisitNode(MachineDomTreeNode *Node,
   }
 
   // Visit the children of this block in the dominator tree.
-  for (auto &N : *Node)
-    Changed |= VisitNode(N, TLSBaseAddrReg);
+  for (MachineDomTreeNode *Child : *Node)
+    Changed |= VisitNode(Child, TLSBaseAddrReg);
 
   return Changed;
 }

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -10562,9 +10562,8 @@ struct LDTLSCleanup : public MachineFunctionPass {
     }
 
     // Visit the children of this block in the dominator tree.
-    for (auto &I : *Node) {
+    for (MachineDomTreeNode *I : Node->children())
       Changed |= VisitNode(I, TLSBaseAddrReg);
-    }
 
     return Changed;
   }

--- a/llvm/lib/Transforms/Utils/LoopSimplify.cpp
+++ b/llvm/lib/Transforms/Utils/LoopSimplify.cpp
@@ -669,10 +669,8 @@ ReprocessLoop:
       LI->removeBlock(ExitingBlock);
 
       DomTreeNode *Node = DT->getNode(ExitingBlock);
-      while (!Node->isLeaf()) {
-        DomTreeNode *Child = Node->back();
-        DT->changeImmediateDominator(Child, Node->getIDom());
-      }
+      while (!Node->isLeaf())
+        DT->changeImmediateDominator(*Node->begin(), Node->getIDom());
       DT->eraseNode(ExitingBlock);
       if (MSSAU) {
         SmallSetVector<BasicBlock *, 8> ExitBlockSet;

--- a/llvm/test/Transforms/JumpThreading/domtree-updates.ll
+++ b/llvm/test/Transforms/JumpThreading/domtree-updates.ll
@@ -18,17 +18,17 @@
 ; CHECK:      Inorder Dominator Tree: DFSNumbers invalid: 0 slow queries.
 ; CHECK-NEXT:   [1] %entry {4294967295,4294967295} [0]
 ; CHECK-NEXT:     [2] %for.cond1 {4294967295,4294967295} [1]
-; CHECK-NEXT:       [3] %for.inc19 {4294967295,4294967295} [2]
 ; CHECK-NEXT:       [3] %if.then {4294967295,4294967295} [2]
 ; CHECK-NEXT:         [4] %for.cond5.preheader {4294967295,4294967295} [3]
+; CHECK-NEXT:           [5] %for.body7 {4294967295,4294967295} [4]
+; CHECK-NEXT:             [6] %for.inc {4294967295,4294967295} [5]
 ; CHECK-NEXT:           [5] %cleanup {4294967295,4294967295} [4]
 ; CHECK-NEXT:             [6] %cleanup16 {4294967295,4294967295} [5]
 ; CHECK-NEXT:               [7] %unreachable {4294967295,4294967295} [6]
 ; CHECK-NEXT:               [7] %for.end21 {4294967295,4294967295} [6]
-; CHECK-NEXT:           [5] %for.body7 {4294967295,4294967295} [4]
-; CHECK-NEXT:             [6] %for.inc {4294967295,4294967295} [5]
 ; CHECK-NEXT:           [5] %return {4294967295,4294967295} [4]
 ; CHECK-NEXT:       [3] %cleanup16.thread {4294967295,4294967295} [2]
+; CHECK-NEXT:       [3] %for.inc19 {4294967295,4294967295} [2]
 ; CHECK-NEXT:     [2] %infinite.loop {4294967295,4294967295} [1]
 ; CHECK-NEXT: Roots: %entry
 


### PR DESCRIPTION
Reduce the size of a DomTreeNodeBase from 80 to 56 bytes by not storing the children in a SmallVector. Instead, store children as forward-linked list. This also avoids extra allocations for nodes with many children. Additionally, DomTreeNodeBase is now trivially destructible.

A lot of code depends on the order of nodes in the dominator tree, so make sure that the order is the same when inserting nodes. (Not having to do this would save 8 bytes per node.)

NewGVN uses the order of nodes in the dominator tree in a way that is not entirely clear to me (https://reviews.llvm.org/D28129). I kept the semantics as, but now this is the only external user of addChild/removeChild, which actually should be private.

https://llvm-compile-time-tracker.com/compare.php?from=263802c56b4db3fc9b6ed9fd313499cb03ca44da&to=43e0c0c5b663b3a4067252fc0addbaccefd0014d&stat=instructions:u