### PR TITLE
workflows/release-binaries: Pass user-token to upload-release-artifact

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -337,3 +337,4 @@ jobs:
           attestation-name: ${{ runner.os }}-${{ runner.arch }}-release-binary-attestation
           digest: ${{ needs.build-release-package.outputs.digest }}
           upload: ${{ needs.prepare.outputs.upload }}
+          user-token: ${{ secrets.RELEASE_TASKS_USER_TOKEN }}


### PR DESCRIPTION
This is necessary in order to be ablet to upload the artifact and was omitted from a8ccd42ab23af6848929a638cd6b099953c7e491.