### PR TITLE
[InstCombine] Preserve multi-dimensional array structure in GEP optimization

### DIFF
--- a/clang/test/CodeGen/union-tbaa1.c
+++ b/clang/test/CodeGen/union-tbaa1.c
@@ -11,13 +11,13 @@ void bar(vect32 p[][2]);
 // CHECK-LABEL: define dso_local void @fred(
 // CHECK-SAME: i32 noundef [[NUM:%.*]], ptr noundef writeonly captures(none) initializes((0, 8)) [[VEC:%.*]], ptr noundef readonly captures(none) [[INDEX:%.*]], ptr noundef readonly captures(none) [[ARR:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[TMP:%.*]] = alloca [4 x [2 x %union.vect32]], align 8
+// CHECK-NEXT:    [[TMP:%.*]] = alloca [4 x [2 x [[UNION_VECT32:%.*]]]], align 8
 // CHECK-NEXT:    call void @llvm.lifetime.start.p0(ptr nonnull [[TMP]]) #[[ATTR3:[0-9]+]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[INDEX]], align 4, !tbaa [[TBAA2:![0-9]+]]
 // CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds [2 x i32], ptr [[ARR]], i32 [[TMP0]]
 // CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[ARRAYIDX]], align 4, !tbaa [[TBAA2]]
 // CHECK-NEXT:    [[MUL:%.*]] = mul i32 [[TMP1]], [[NUM]]
-// CHECK-NEXT:    [[ARRAYIDX2:%.*]] = getelementptr inbounds [2 x %union.vect32], ptr [[TMP]], i32 [[TMP0]]
+// CHECK-NEXT:    [[ARRAYIDX2:%.*]] = getelementptr inbounds [4 x [2 x [[UNION_VECT32]]]], ptr [[TMP]], i32 0, i32 [[TMP0]]
 // CHECK-NEXT:    store i32 [[MUL]], ptr [[ARRAYIDX2]], align 8, !tbaa [[TBAA6:![0-9]+]]
 // CHECK-NEXT:    [[ARRAYIDX5:%.*]] = getelementptr inbounds nuw i8, ptr [[ARRAYIDX]], i32 4
 // CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr [[ARRAYIDX5]], align 4, !tbaa [[TBAA2]]
@@ -27,7 +27,7 @@ void bar(vect32 p[][2]);
 // CHECK-NEXT:    [[TMP3:%.*]] = lshr i32 [[MUL]], 16
 // CHECK-NEXT:    store i32 [[TMP3]], ptr [[VEC]], align 4, !tbaa [[TBAA2]]
 // CHECK-NEXT:    [[TMP4:%.*]] = load i32, ptr [[INDEX]], align 4, !tbaa [[TBAA2]]
-// CHECK-NEXT:    [[ARRAYIDX13:%.*]] = getelementptr inbounds [2 x %union.vect32], ptr [[TMP]], i32 [[TMP4]]
+// CHECK-NEXT:    [[ARRAYIDX13:%.*]] = getelementptr inbounds [4 x [2 x [[UNION_VECT32]]]], ptr [[TMP]], i32 0, i32 [[TMP4]]
 // CHECK-NEXT:    [[ARRAYIDX15:%.*]] = getelementptr inbounds nuw i8, ptr [[ARRAYIDX13]], i32 6
 // CHECK-NEXT:    [[TMP5:%.*]] = load i16, ptr [[ARRAYIDX15]], align 2, !tbaa [[TBAA6]]
 // CHECK-NEXT:    [[CONV16:%.*]] = zext i16 [[TMP5]] to i32

--- a/llvm/test/Transforms/InstCombine/canonicalize-gep-constglob.ll
+++ b/llvm/test/Transforms/InstCombine/canonicalize-gep-constglob.ll
@@ -35,9 +35,7 @@ define ptr @xzy(i64 %x, i64 %y, i64 %z) {
 ; CHECK-LABEL: define ptr @xzy(
 ; CHECK-SAME: i64 [[X:%.*]], i64 [[Y:%.*]], i64 [[Z:%.*]]) {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[GEP_SPLIT:%.*]] = getelementptr inbounds [10 x [10 x i32]], ptr getelementptr inbounds nuw (i8, ptr @glob, i64 40), i64 [[X]]
-; CHECK-NEXT:    [[GEP_SPLIT1:%.*]] = getelementptr inbounds [10 x i32], ptr [[GEP_SPLIT]], i64 [[Z]]
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr inbounds i32, ptr [[GEP_SPLIT1]], i64 [[Y]]
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr inbounds [10 x [10 x [10 x i32]]], ptr getelementptr inbounds nuw (i8, ptr @glob, i64 40), i64 0, i64 [[X]], i64 [[Z]], i64 [[Y]]
 ; CHECK-NEXT:    ret ptr [[GEP]]
 ;
 entry:

--- a/llvm/test/Transforms/InstCombine/strcmp-3.ll
+++ b/llvm/test/Transforms/InstCombine/strcmp-3.ll
@@ -25,7 +25,7 @@ define i32 @fold_strcmp_a5i0_a5i1_to_0() {
 
 define i32 @call_strcmp_a5i0_a5iI(i64 %I) {
 ; CHECK-LABEL: @call_strcmp_a5i0_a5iI(
-; CHECK-NEXT:    [[Q:%.*]] = getelementptr [4 x i8], ptr @a5, i64 [[I:%.*]]
+; CHECK-NEXT:    [[Q:%.*]] = getelementptr [5 x [4 x i8]], ptr @a5, i64 0, i64 [[I:%.*]]
 ; CHECK-NEXT:    [[CMP:%.*]] = call i32 @strcmp(ptr noundef nonnull dereferenceable(4) @a5, ptr noundef nonnull dereferenceable(1) [[Q]])
 ; CHECK-NEXT:    ret i32 [[CMP]]
 ;
@@ -40,7 +40,7 @@ define i32 @call_strcmp_a5i0_a5iI(i64 %I) {
 
 define i32 @call_strcmp_a5iI_a5i0(i64 %I) {
 ; CHECK-LABEL: @call_strcmp_a5iI_a5i0(
-; CHECK-NEXT:    [[P:%.*]] = getelementptr [4 x i8], ptr @a5, i64 [[I:%.*]]
+; CHECK-NEXT:    [[P:%.*]] = getelementptr [5 x [4 x i8]], ptr @a5, i64 0, i64 [[I:%.*]]
 ; CHECK-NEXT:    [[CMP:%.*]] = call i32 @strcmp(ptr noundef nonnull dereferenceable(1) [[P]], ptr noundef nonnull dereferenceable(4) @a5)
 ; CHECK-NEXT:    ret i32 [[CMP]]
 ;
@@ -68,7 +68,7 @@ define i32 @fold_strcmp_a5i0_a5i1_p1_to_0() {
 
 define i32 @call_strcmp_a5i0_a5i1_pI(i64 %I) {
 ; CHECK-LABEL: @call_strcmp_a5i0_a5i1_pI(
-; CHECK-NEXT:    [[Q:%.*]] = getelementptr i8, ptr getelementptr inbounds nuw (i8, ptr @a5, i64 4), i64 [[I:%.*]]
+; CHECK-NEXT:    [[Q:%.*]] = getelementptr [5 x [4 x i8]], ptr @a5, i64 0, i64 1, i64 [[I:%.*]]
 ; CHECK-NEXT:    [[CMP:%.*]] = call i32 @strcmp(ptr noundef nonnull dereferenceable(4) @a5, ptr noundef nonnull dereferenceable(1) [[Q]])
 ; CHECK-NEXT:    ret i32 [[CMP]]
 ;

--- a/llvm/test/Transforms/InstCombine/strlen-8.ll
+++ b/llvm/test/Transforms/InstCombine/strlen-8.ll
@@ -16,7 +16,7 @@ declare i64 @strlen(ptr)
 
 define i64 @fold_a5_4_i0_pI(i64 %I) {
 ; CHECK-LABEL: @fold_a5_4_i0_pI(
-; CHECK-NEXT:    [[PTR:%.*]] = getelementptr i8, ptr @a5_4, i64 [[I:%.*]]
+; CHECK-NEXT:    [[PTR:%.*]] = getelementptr [5 x [4 x i8]], ptr @a5_4, i64 0, i64 0, i64 [[I:%.*]]
 ; CHECK-NEXT:    [[LEN:%.*]] = call i64 @strlen(ptr noundef nonnull dereferenceable(1) [[PTR]])
 ; CHECK-NEXT:    ret i64 [[LEN]]
 ;
@@ -30,7 +30,7 @@ define i64 @fold_a5_4_i0_pI(i64 %I) {
 
 define i64 @fold_a5_4_i1_pI(i64 %I) {
 ; CHECK-LABEL: @fold_a5_4_i1_pI(
-; CHECK-NEXT:    [[PTR:%.*]] = getelementptr i8, ptr getelementptr inbounds nuw (i8, ptr @a5_4, i64 4), i64 [[I:%.*]]
+; CHECK-NEXT:    [[PTR:%.*]] = getelementptr [5 x [4 x i8]], ptr @a5_4, i64 0, i64 1, i64 [[I:%.*]]
 ; CHECK-NEXT:    [[LEN:%.*]] = call i64 @strlen(ptr noundef nonnull dereferenceable(1) [[PTR]])
 ; CHECK-NEXT:    ret i64 [[LEN]]
 ;
@@ -44,7 +44,7 @@ define i64 @fold_a5_4_i1_pI(i64 %I) {
 
 define i64 @fold_a5_4_i2_pI(i64 %I) {
 ; CHECK-LABEL: @fold_a5_4_i2_pI(
-; CHECK-NEXT:    [[PTR:%.*]] = getelementptr i8, ptr getelementptr inbounds nuw (i8, ptr @a5_4, i64 8), i64 [[I:%.*]]
+; CHECK-NEXT:    [[PTR:%.*]] = getelementptr [5 x [4 x i8]], ptr @a5_4, i64 0, i64 2, i64 [[I:%.*]]
 ; CHECK-NEXT:    [[LEN:%.*]] = call i64 @strlen(ptr noundef nonnull dereferenceable(1) [[PTR]])
 ; CHECK-NEXT:    ret i64 [[LEN]]
 ;
@@ -58,7 +58,7 @@ define i64 @fold_a5_4_i2_pI(i64 %I) {
 
 define i64 @fold_a5_4_i3_pI_to_0(i64 %I) {
 ; CHECK-LABEL: @fold_a5_4_i3_pI_to_0(
-; CHECK-NEXT:    [[PTR:%.*]] = getelementptr i8, ptr getelementptr inbounds nuw (i8, ptr @a5_4, i64 12), i64 [[I:%.*]]
+; CHECK-NEXT:    [[PTR:%.*]] = getelementptr [5 x [4 x i8]], ptr @a5_4, i64 0, i64 3, i64 [[I:%.*]]
 ; CHECK-NEXT:    [[LEN:%.*]] = call i64 @strlen(ptr noundef nonnull dereferenceable(1) [[PTR]])
 ; CHECK-NEXT:    ret i64 [[LEN]]
 ;
@@ -72,7 +72,7 @@ define i64 @fold_a5_4_i3_pI_to_0(i64 %I) {
 
 define i64 @fold_a5_4_i4_pI_to_0(i64 %I) {
 ; CHECK-LABEL: @fold_a5_4_i4_pI_to_0(
-; CHECK-NEXT:    [[PTR:%.*]] = getelementptr i8, ptr getelementptr inbounds nuw (i8, ptr @a5_4, i64 16), i64 [[I:%.*]]
+; CHECK-NEXT:    [[PTR:%.*]] = getelementptr [5 x [4 x i8]], ptr @a5_4, i64 0, i64 4, i64 [[I:%.*]]
 ; CHECK-NEXT:    [[LEN:%.*]] = call i64 @strlen(ptr noundef nonnull dereferenceable(1) [[PTR]])
 ; CHECK-NEXT:    ret i64 [[LEN]]
 ;


### PR DESCRIPTION
These changes are needed to improve register pressure on AMDGPU backends.  Commits 055bfc0 and 8a09adc simplified multi-dimensional array GEP operations into chains of single-index GEPs and stripped leading zeros. It causes significant performance drop on AMDGPUs by removing semantic information that the backend relies on. For example, multi-dimensional GEPs allow coalesced LDS reads that reduces register pressure. 

If we use the example in https://github.com/llvm/llvm-project/issues/170477, flattened GEPs lead to a pattern of ds_read->spill to scratch. If we guard the GEP flattening for multi-dimensional arrays, it allows the backend to generate code such that ds_reads are immediately used.