### PR TITLE
[ci] ids-check: build tablegen headers for idt

### DIFF
--- a/.github/workflows/ids-check.yml
+++ b/.github/workflows/ids-check.yml
@@ -55,7 +55,7 @@ jobs:
                 -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
                 -G Ninja
           cd ${{ github.workspace }}/llvm-project/build/
-          ninja -t targets all | grep "CommonTableGen: phony$" | grep -v "/" | sed 's/:.*//'
+          ninja -t targets all | grep "CommonTableGen: phony$" | grep -v "/" | sed 's/:.*//' | xargs -r ninja
 
       - name: Configure ids
         run: |


### PR DESCRIPTION
This PR updates ids-check to build the CommonTableGen targets after LLVM
configuration, so generated headers like llvm/IR/Attributes.inc exist
before idt scans changed headers. It is needed because the current
workflow only lists those targets and never builds them, causing idt to
fail when a changed header includes a generated .inc file.