### PR TITLE
Nominate Endilll as Python bindings maintainer

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -210,6 +210,12 @@ Code Coverage
 | a-phipps\@ti.com (email), evodius96 (GitHub), evodius96 (Discourse)
 
 
+Python Bindings
+~~~~~~~~~~~~~~~
+| Vlad Serebrennikov
+| serebrennikov.vladislav\@gmail.com (email), Endilll (GitHub), Endill (Discord), Endill (Discourse)
+
+
 Tools
 -----
 These maintainers are responsible for user-facing tools under the Clang


### PR DESCRIPTION
We have the python library bindings in Clang and Vlad has been doing all of the work of a maintainer in terms of code reviews and answering questions about the python bindings.