### PR TITLE
workflows/release-binaries: Fix attestation artifact name

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -62,6 +62,7 @@ jobs:
       release-binary-filename: ${{ steps.vars.outputs.release-binary-filename }}
       build-runs-on: ${{ steps.vars.outputs.build-runs-on }}
       test-runs-on: ${{ steps.vars.outputs.build-runs-on }}
+      attestation-name: ${{ steps.vars.outptus.attestation-name }}
 
     steps:
     # It's good practice to use setup-python, but this is also required on macos-14
@@ -199,6 +200,7 @@ jobs:
         echo "target-cmake-flags=$target_cmake_flags" >> $GITHUB_OUTPUT
         echo "build-runs-on=$build_runs_on" >> $GITHUB_OUTPUT
         echo "test-runs-on=$test_runs_on" >> $GITHUB_OUTPUT
+        echo "attestation-name=$RUNNER_OS-$RUNNER_ARCH-release-binary-attestation" >> $GITHUB_OUTPUT
 
   build-release-package:
     name: "Build Release Package"
@@ -334,6 +336,6 @@ jobs:
         uses: ./.github/workflows/upload-release-artifact
         with:
           artifact-id: ${{ needs.build-release-package.outputs.artifact-id }}
-          attestation-name: ${{ runner.os }}-${{ runner.arch }}-release-binary-attestation
+          attestation-name: ${{ needs.prepare.outputs.attestation-name }}
           digest: ${{ needs.build-release-package.outputs.digest }}
           upload: ${{ needs.prepare.outputs.upload }}


### PR DESCRIPTION
We were contructing the attestation artifact name using the arch and the OS of the current runner instead of using the runner that the builds were done on.  This led to a conflict in artifact names between all the release binary jobs.