### PR TITLE
[Support][NFC] Use default move constr/assign for DomTree

### DIFF
--- a/llvm/include/llvm/Support/GenericDomTree.h
+++ b/llvm/include/llvm/Support/GenericDomTree.h
@@ -277,31 +277,11 @@ protected:
  public:
   DominatorTreeBase() = default;
 
-  DominatorTreeBase(DominatorTreeBase &&Arg)
-      : Roots(std::move(Arg.Roots)), DomTreeNodes(std::move(Arg.DomTreeNodes)),
-        NodeNumberMap(std::move(Arg.NodeNumberMap)), RootNode(Arg.RootNode),
-        Parent(Arg.Parent), DFSInfoValid(Arg.DFSInfoValid),
-        SlowQueries(Arg.SlowQueries), BlockNumberEpoch(Arg.BlockNumberEpoch) {
-    Arg.wipe();
-  }
-
-  DominatorTreeBase &operator=(DominatorTreeBase &&RHS) {
-    if (this == &RHS)
-      return *this;
-    Roots = std::move(RHS.Roots);
-    DomTreeNodes = std::move(RHS.DomTreeNodes);
-    NodeNumberMap = std::move(RHS.NodeNumberMap);
-    RootNode = RHS.RootNode;
-    Parent = RHS.Parent;
-    DFSInfoValid = RHS.DFSInfoValid;
-    SlowQueries = RHS.SlowQueries;
-    BlockNumberEpoch = RHS.BlockNumberEpoch;
-    RHS.wipe();
-    return *this;
-  }
-
   DominatorTreeBase(const DominatorTreeBase &) = delete;
   DominatorTreeBase &operator=(const DominatorTreeBase &) = delete;
+
+  DominatorTreeBase(DominatorTreeBase &&Arg) = default;
+  DominatorTreeBase &operator=(DominatorTreeBase &&RHS) = default;
 
   /// Iteration over roots.
   ///
@@ -1000,18 +980,6 @@ protected:
       B = IDom;  // Walk up the tree
 
     return B == A;
-  }
-
-  /// Wipe this tree's state without releasing any resources.
-  ///
-  /// This is essentially a post-move helper only. It leaves the object in an
-  /// assignable and destroyable state, but otherwise invalid.
-  void wipe() {
-    DomTreeNodes.clear();
-    if constexpr (!GraphHasNodeNumbers<NodeT *>)
-      NodeNumberMap.clear();
-    RootNode = nullptr;
-    Parent = nullptr;
   }
 };
 


### PR DESCRIPTION
Added in 5e10e21d28496ba40ccd385740d7d1b4bb1368e4, hopefully MSVC can generate the correct code 11 years later? (If not, we probably have other problems, too? Unfortunately, I couldn't find information on what the actual problem was.)

The explicit move constructor/assignment are error-prone to modifications, because it is easy to forget updating them when modifying members.