### PR TITLE
[lldb][NFC] Replace createStringError/llvm::formatv pairs with createStringErrorV

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -702,9 +702,9 @@ static llvm::Error Evaluate_DW_OP_entry_value(DWARFExpression::Stack &stack,
     // produced by an ambiguous tail call. In this case, refuse to proceed.
     call_edge = parent_func->GetCallEdgeForReturnAddress(return_pc, target);
     if (!call_edge) {
-      return llvm::createStringError(
-          llvm::formatv("no call edge for retn-pc = {0:x} in parent frame {1}",
-                        return_pc, parent_func->GetName()));
+      return llvm::createStringErrorV(
+          "no call edge for retn-pc = {0:x} in parent frame {1}", return_pc,
+          parent_func->GetName());
     }
     Function *callee_func = call_edge->GetCallee(modlist, parent_exe_ctx);
     if (callee_func != current_func) {
@@ -1521,9 +1521,9 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
       if (new_offset <= opcodes.GetByteSize())
         offset = new_offset;
       else {
-        return llvm::createStringError(llvm::formatv(
+        return llvm::createStringErrorV(
             "Invalid opcode offset in DW_OP_skip: {0}+({1}) > {2}", offset,
-            skip_offset, opcodes.GetByteSize()));
+            skip_offset, opcodes.GetByteSize());
       }
     } break;
 
@@ -1547,9 +1547,9 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
         if (new_offset <= opcodes.GetByteSize())
           offset = new_offset;
         else {
-          return llvm::createStringError(llvm::formatv(
+          return llvm::createStringErrorV(
               "Invalid opcode offset in DW_OP_bra: {0}+({1}) > {2}", offset,
-              bra_offset, opcodes.GetByteSize()));
+              bra_offset, opcodes.GetByteSize());
         }
       }
     } break;
@@ -2268,8 +2268,8 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
           break;
         }
       }
-      return llvm::createStringError(llvm::formatv(
-          "Unhandled opcode {0} in DWARFExpression", LocationAtom(op)));
+      return llvm::createStringErrorV("Unhandled opcode {0} in DWARFExpression",
+                                      LocationAtom(op));
     }
   }
 

--- a/lldb/source/Expression/Expression.cpp
+++ b/lldb/source/Expression/Expression.cpp
@@ -53,7 +53,7 @@ lldb_private::FunctionCallLabel::fromString(llvm::StringRef label) {
   lldb::user_id_t module_id = 0;
   if (!llvm::to_integer(module_label, module_id))
     return llvm::createStringErrorV("failed to parse module ID from '{0}'.",
-                                   module_label);
+                                    module_label);
 
   lldb::user_id_t die_id;
   if (!llvm::to_integer(die_label, die_id))

--- a/lldb/source/Expression/Expression.cpp
+++ b/lldb/source/Expression/Expression.cpp
@@ -41,9 +41,9 @@ lldb_private::FunctionCallLabel::fromString(llvm::StringRef label) {
     return llvm::createStringError("malformed function call label.");
 
   if (components[0] != FunctionCallLabelPrefix)
-    return llvm::createStringError(llvm::formatv(
+    return llvm::createStringErrorV(
         "expected function call label prefix '{0}' but found '{1}' instead.",
-        FunctionCallLabelPrefix, components[0]));
+        FunctionCallLabelPrefix, components[0]);
 
   llvm::StringRef discriminator = components[1];
   llvm::StringRef module_label = components[2];
@@ -52,13 +52,13 @@ lldb_private::FunctionCallLabel::fromString(llvm::StringRef label) {
 
   lldb::user_id_t module_id = 0;
   if (!llvm::to_integer(module_label, module_id))
-    return llvm::createStringError(
-        llvm::formatv("failed to parse module ID from '{0}'.", module_label));
+    return llvm::createStringError("failed to parse module ID from '{0}'.",
+                                   module_label);
 
   lldb::user_id_t die_id;
   if (!llvm::to_integer(die_label, die_id))
-    return llvm::createStringError(
-        llvm::formatv("failed to parse symbol ID from '{0}'.", die_label));
+    return llvm::createStringErrorV("failed to parse symbol ID from '{0}'.",
+                                    die_label);
 
   return FunctionCallLabel{/*.discriminator=*/discriminator,
                            /*.module_id=*/module_id,

--- a/lldb/source/Expression/Expression.cpp
+++ b/lldb/source/Expression/Expression.cpp
@@ -52,7 +52,7 @@ lldb_private::FunctionCallLabel::fromString(llvm::StringRef label) {
 
   lldb::user_id_t module_id = 0;
   if (!llvm::to_integer(module_label, module_id))
-    return llvm::createStringError("failed to parse module ID from '{0}'.",
+    return llvm::createStringErrorV("failed to parse module ID from '{0}'.",
                                    module_label);
 
   lldb::user_id_t die_id;

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -366,9 +366,9 @@ ClangModulesDeclVendorImpl::AddModule(const SourceModule &module,
     lldb_private::StreamString error_stream;
     diagnostic_consumer->DumpDiagnostics(error_stream);
 
-    return llvm::createStringError(llvm::formatv(
-        "couldn't load top-level module {0}:\n{1}",
-        module.path.front().GetStringRef(), error_stream.GetString()));
+    return llvm::createStringErrorV("couldn't load top-level module {0}:\n{1}",
+                                    module.path.front().GetStringRef(),
+                                    error_stream.GetString());
   }
 
   clang::Module *submodule = top_level_module;
@@ -379,10 +379,10 @@ ClangModulesDeclVendorImpl::AddModule(const SourceModule &module,
       lldb_private::StreamString error_stream;
       diagnostic_consumer->DumpDiagnostics(error_stream);
 
-      return llvm::createStringError(llvm::formatv(
+      return llvm::createStringErrorV(
           "couldn't load submodule '{0}' of module '{1}':\n{2}",
           component.GetStringRef(), submodule->getFullModuleName(),
-          error_stream.GetString()));
+          error_stream.GetString());
     }
 
     submodule = found;
@@ -408,9 +408,8 @@ ClangModulesDeclVendorImpl::AddModule(const SourceModule &module,
     return llvm::Error::success();
   }
 
-  return llvm::createStringError(
-      llvm::formatv("unknown error while loading module {0}\n",
-                    module.path.front().GetStringRef()));
+  return llvm::createStringErrorV("unknown error while loading module {0}\n",
+                                  module.path.front().GetStringRef());
 }
 
 bool ClangModulesDeclVendor::LanguageSupportsClangModules(

--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
@@ -213,8 +213,8 @@ lldb::ProcessSP PlatformWasm::DebugProcess(ProcessLaunchInfo &launch_info,
     // failing to connect.
     if (*exit_code)
       error = Status::FromError(llvm::joinErrors(
-          llvm::createStringError(llvm::formatv(
-              "WebAssembly runtime exited with exit code {0}", **exit_code)),
+          llvm::createStringError(
+              "WebAssembly runtime exited with exit code {0}", **exit_code),
           error.takeError()));
 
     return nullptr;

--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
@@ -213,7 +213,7 @@ lldb::ProcessSP PlatformWasm::DebugProcess(ProcessLaunchInfo &launch_info,
     // failing to connect.
     if (*exit_code)
       error = Status::FromError(llvm::joinErrors(
-          llvm::createStringError(
+          llvm::createStringErrorV(
               "WebAssembly runtime exited with exit code {0}", **exit_code),
           error.takeError()));
 

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -2892,7 +2892,7 @@ llvm::Error ProcessGDBRemote::ParseMultiMemReadPacket(
   // The sizes and the data are separated by a `;`.
   auto [sizes_str, memory_data] = response_str.split(';');
   if (sizes_str.size() == response_str.size())
-    return llvm::createStringError(
+    return llvm::createStringErrorV(
         "MultiMemRead response missing field separator ';' in: '{0}'",
         response_str);
 
@@ -2900,14 +2900,13 @@ llvm::Error ProcessGDBRemote::ParseMultiMemReadPacket(
   for (llvm::StringRef size_str : llvm::split(sizes_str, ',')) {
     uint64_t read_size;
     if (size_str.getAsInteger(16, read_size))
-      return llvm::createStringError(
+      return llvm::createStringErrorV(
           "MultiMemRead response has invalid size string: {0}", size_str);
 
     if (memory_data.size() < read_size)
-      return llvm::createStringError(
-          "MultiMemRead response did not have enough data, "
-          "requested sizes: {0}",
-          sizes_str);
+      return llvm::createStringErrorV("MultiMemRead response did not have "
+                                      "enough data, requested sizes: {0}",
+                                      sizes_str);
 
     llvm::StringRef region_to_read = memory_data.take_front(read_size);
     memory_data = memory_data.drop_front(read_size);

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -2871,16 +2871,16 @@ ProcessGDBRemote::SendMultiMemReadPacket(
       m_gdb_comm.SendPacketAndWaitForResponse(packet_str.data(), response,
                                               GetInterruptTimeout());
   if (packet_result != GDBRemoteCommunication::PacketResult::Success)
-    return llvm::createStringError(
-        llvm::formatv("MultiMemRead failed to send packet: '{0}'", packet_str));
+    return llvm::createStringErrorV("MultiMemRead failed to send packet: '{0}'",
+                                    packet_str);
 
   if (response.IsErrorResponse())
-    return llvm::createStringError(
-        llvm::formatv("MultiMemRead failed: '{0}'", response.GetStringRef()));
+    return llvm::createStringErrorV("MultiMemRead failed: '{0}'",
+                                    response.GetStringRef());
 
   if (!response.IsNormalResponse())
-    return llvm::createStringError(llvm::formatv(
-        "MultiMemRead unexpected response: '{0}'", response.GetStringRef()));
+    return llvm::createStringErrorV("MultiMemRead unexpected response: '{0}'",
+                                    response.GetStringRef());
 
   return response;
 }
@@ -2892,22 +2892,22 @@ llvm::Error ProcessGDBRemote::ParseMultiMemReadPacket(
   // The sizes and the data are separated by a `;`.
   auto [sizes_str, memory_data] = response_str.split(';');
   if (sizes_str.size() == response_str.size())
-    return llvm::createStringError(llvm::formatv(
+    return llvm::createStringError(
         "MultiMemRead response missing field separator ';' in: '{0}'",
-        response_str));
+        response_str);
 
   // Sizes are separated by a `,`.
   for (llvm::StringRef size_str : llvm::split(sizes_str, ',')) {
     uint64_t read_size;
     if (size_str.getAsInteger(16, read_size))
-      return llvm::createStringError(llvm::formatv(
-          "MultiMemRead response has invalid size string: {0}", size_str));
+      return llvm::createStringError(
+          "MultiMemRead response has invalid size string: {0}", size_str);
 
     if (memory_data.size() < read_size)
       return llvm::createStringError(
-          llvm::formatv("MultiMemRead response did not have enough data, "
-                        "requested sizes: {0}",
-                        sizes_str));
+          "MultiMemRead response did not have enough data, "
+          "requested sizes: {0}",
+          sizes_str);
 
     llvm::StringRef region_to_read = memory_data.take_front(read_size);
     memory_data = memory_data.drop_front(read_size);
@@ -5674,9 +5674,8 @@ llvm::Expected<bool> ProcessGDBRemote::SaveCore(llvm::StringRef outfile) {
     // TODO: grab error message from the packet?  StringExtractor seems to
     // be missing a method for that
     if (response.IsErrorResponse())
-      return llvm::createStringError(
-          llvm::inconvertibleErrorCode(),
-          llvm::formatv("qSaveCore returned an error"));
+      return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                     "qSaveCore returned an error");
 
     std::string path;
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2619,24 +2619,24 @@ SymbolFileDWARF::ResolveFunctionCallLabel(FunctionCallLabel &label) {
         label.lookup_name, from, variant);
     if (!subst_or_err)
       return llvm::joinErrors(
-          llvm::createStringError(llvm::formatv(
+          llvm::createStringErrorV(
               "failed to substitute {0} for {1} in mangled name {2}:", from,
-              variant, label.lookup_name)),
+              variant, label.lookup_name),
           subst_or_err.takeError());
 
     if (!*subst_or_err)
       return llvm::createStringError(
-          llvm::formatv("got invalid substituted mangled named (substituted "
-                        "{0} for {1} in mangled name {2})",
-                        from, variant, label.lookup_name));
+          "got invalid substituted mangled named (substituted "
+          "{0} for {1} in mangled name {2})",
+          from, variant, label.lookup_name);
 
     label.lookup_name = subst_or_err->GetStringRef();
   }
 
   DWARFDIE die = GetDIE(label.symbol_id);
   if (!die.IsValid())
-    return llvm::createStringError(
-        llvm::formatv("invalid DIE ID in {0}", label));
+    return llvm::createStringErrorV(
+        llvm::formatv("invalid DIE ID in {0}", label);
 
   // Label was created using a declaration DIE. Need to fetch the definition
   // to resolve the function call.

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2625,7 +2625,7 @@ SymbolFileDWARF::ResolveFunctionCallLabel(FunctionCallLabel &label) {
           subst_or_err.takeError());
 
     if (!*subst_or_err)
-      return llvm::createStringError(
+      return llvm::createStringErrorV(
           "got invalid substituted mangled named (substituted "
           "{0} for {1} in mangled name {2})",
           from, variant, label.lookup_name);

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2635,8 +2635,7 @@ SymbolFileDWARF::ResolveFunctionCallLabel(FunctionCallLabel &label) {
 
   DWARFDIE die = GetDIE(label.symbol_id);
   if (!die.IsValid())
-    return llvm::createStringErrorV(
-        llvm::formatv("invalid DIE ID in {0}", label);
+    return llvm::createStringErrorV("invalid DIE ID in {0}", label);
 
   // Label was created using a declaration DIE. Need to fetch the definition
   // to resolve the function call.

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -1609,8 +1609,8 @@ SymbolFileDWARFDebugMap::ResolveFunctionCallLabel(FunctionCallLabel &label) {
   const uint64_t oso_idx = GetOSOIndexFromUserID(label.symbol_id);
   SymbolFileDWARF *oso_dwarf = GetSymbolFileByOSOIndex(oso_idx);
   if (!oso_dwarf)
-    return llvm::createStringError(llvm::formatv(
-        "couldn't find symbol file for {0} in debug-map.", label));
+    return llvm::createStringErrorV(
+        "couldn't find symbol file for {0} in debug-map.", label);
 
   return oso_dwarf->ResolveFunctionCallLabel(label);
 }

--- a/lldb/source/Protocol/MCP/Server.cpp
+++ b/lldb/source/Protocol/MCP/Server.cpp
@@ -190,7 +190,7 @@ Server::ToolsCallHandler(const CallToolParams &params) {
 
   auto it = m_tools.find(tool_name);
   if (it == m_tools.end())
-    return llvm::createStringError(llvm::formatv("no tool \"{0}\"", tool_name));
+    return llvm::createStringErrorV("no tool \"{0}\"", tool_name);
 
   ToolArguments tool_args;
   if (params.arguments)

--- a/lldb/source/Symbol/Function.cpp
+++ b/lldb/source/Symbol/Function.cpp
@@ -307,8 +307,8 @@ Function::GetSourceInfo() {
   GetStartLineSourceInfo(source_file_sp, start_line);
   LineTable *line_table = m_comp_unit->GetLineTable();
   if (start_line == 0 || !line_table) {
-    return llvm::createStringError(llvm::formatv(
-        "Could not find line information for function \"{0}\".", GetName()));
+    return llvm::createStringErrorV(
+        "Could not find line information for function \"{0}\".", GetName());
   }
 
   uint32_t end_line = start_line;


### PR DESCRIPTION
Makes use of the recently introduced `llvm::createStringErrorV` API. It's designed exactly for this use-case.