### PR TITLE
[TableGen] Remove incorrect flag checking on patterns

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
@@ -1244,7 +1244,6 @@ private:
   void ExpandHwModeBasedTypes();
   void InferInstructionFlags();
   void GenerateVariants();
-  void VerifyInstructionFlags();
 
   void ParseOnePattern(const Record *TheDef, TreePattern &Pattern,
                        TreePattern &Result,


### PR DESCRIPTION
In `VerifyInstructionFlags`, TableGen will try to ensure that the flags on the input pattern are not more restrictive than those on the output pattern. However there are some cases where this check can falsely raise errors for a valid lowering. For example, an intrinsic which _may_ store could be lowered to an instruction which actually does not store based on an immediate flag or a sub-target feature. This if fine because the intrinsic attributes represent the maximum boundary of the intrinsic's behavior, not what it will necessarily do in all cases. 

This MR removes this checking as it is not rigorous and is more likely to prevent valid patterns from being expressed in TableGen, than to catch real bugs. 