### PR TITLE
[Hexagon[ Optimize HVXVectorCombine:Limit Conversion for Unaligned Loads

### DIFF
--- a/llvm/test/CodeGen/Hexagon/autohvx/vector-align-addr.ll
+++ b/llvm/test/CodeGen/Hexagon/autohvx/vector-align-addr.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=hexagon -hexagon-hvx-widen=32 < %s | FileCheck %s
+; RUN: llc -march=hexagon -hexagon-hvx-widen=32 -hvc-ld-min-group-size-for-alignment=2 < %s | FileCheck %s
 
 ; Test that the Hexagon Vector Combine pass computes the address
 ; correctly when the loading objects that contain extra padding

--- a/llvm/test/CodeGen/Hexagon/autohvx/vector-align-bad-move.ll
+++ b/llvm/test/CodeGen/Hexagon/autohvx/vector-align-bad-move.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=hexagon < %s | FileCheck %s
+; RUN: llc -march=hexagon -hvc-ld-min-group-size-for-alignment=2 < %s | FileCheck %s
 ; REQUIRES: asserts
 
 ; Test that the HexagonVectorCombine pass does not move an instruction

--- a/llvm/test/CodeGen/Hexagon/autohvx/vector-align-base-type-mismatch.ll
+++ b/llvm/test/CodeGen/Hexagon/autohvx/vector-align-base-type-mismatch.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=hexagon < %s | FileCheck %s
+; RUN: llc -march=hexagon -hvc-ld-min-group-size-for-alignment=2 < %s | FileCheck %s
 
 ; The getelementptr's based on %a2, but with different base types caused
 ; a problem in vector alignment code.

--- a/llvm/test/CodeGen/Hexagon/autohvx/vector-align-basic.ll
+++ b/llvm/test/CodeGen/Hexagon/autohvx/vector-align-basic.ll
@@ -6,40 +6,37 @@ define <32 x i32> @f0(ptr %a0, i32 %a1) #0 {
 ; CHECK-LABEL: f0:
 ; CHECK:       // %bb.0: // %b0
 ; CHECK-NEXT:    {
-; CHECK-NEXT:     r0 = add(r1,r0)
+; CHECK-NEXT:     [[RADD:[r0-9]+]] = add([[R1:[r0-9]+]],[[R0:[r0-9]+]])
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
-; CHECK-NEXT:     r7 = #8
+; CHECK-NEXT:     [[RLCPI:[r0-9]+]] = ##.LCPI0_0
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
-; CHECK-NEXT:     r4 = ##.LCPI0_0
+; CHECK-NEXT:     [[RNEG:[r0-9]+]] = #-1
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
-; CHECK-NEXT:     r2 = #-1
+; CHECK-NEXT:     [[RADD136:[r0-9]+]] = add([[RADD]],#136)
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
-; CHECK-NEXT:     v0 = vmem(r0+#1)
+; CHECK-NEXT:     [[V1:[v0-9]+]] = vmem([[RLCPI]]+#0)
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
-; CHECK-NEXT:     v1 = vmem(r0+#2)
+; CHECK-NEXT:     [[RADD128:[r0-9]+]] = add([[RADD]],#128)
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
-; CHECK-NEXT:     r0 = add(r0,#128)
+; CHECK-NEXT:     [[Q0:[q0-9]+]] = vand([[V1]],[[RNEG]])
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
-; CHECK-NEXT:     v1 = valign(v1,v0,r7)
+; CHECK-NEXT:     [[V2:[v0-9]+]] = vmemu([[RADD136]]+#0)
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
-; CHECK-NEXT:     v2 = vmem(r4+#0)
+; CHECK-NEXT:     [[V3:[v0-9]+]] = vmem([[RADD]]+#1)
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
-; CHECK-NEXT:     q0 = vand(v2,r2)
+; CHECK-NEXT:     [[V0:[v0-9]+]].w = vadd([[V3]].w,[[V2]].w)
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
-; CHECK-NEXT:     v0.w = vadd(v0.w,v1.w)
-; CHECK-NEXT:    }
-; CHECK-NEXT:    {
-; CHECK-NEXT:     if (q0) vmem(r0+#0) = v0
+; CHECK-NEXT:     if ([[Q0]]) vmem([[RADD128]]+#0) = [[V0]]
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
 ; CHECK-NEXT:     jumpr r31

--- a/llvm/test/CodeGen/Hexagon/autohvx/vector-align-tbaa.ll
+++ b/llvm/test/CodeGen/Hexagon/autohvx/vector-align-tbaa.ll
@@ -14,23 +14,10 @@ define <64 x i16> @f0(ptr %a0, i32 %a1) #0 {
 ; CHECK-NEXT:  b0:
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i16, ptr [[A0:%.*]], i32 [[A1:%.*]]
 ; CHECK-NEXT:    [[V1:%.*]] = getelementptr i8, ptr [[TMP0]], i32 128
-; CHECK-NEXT:    [[PTI:%.*]] = ptrtoint ptr [[V1]] to i32
-; CHECK-NEXT:    [[AND:%.*]] = and i32 [[PTI]], -128
-; CHECK-NEXT:    [[ITP:%.*]] = inttoptr i32 [[AND]] to ptr
-; CHECK-NEXT:    [[PTI1:%.*]] = ptrtoint ptr [[V1]] to i32
-; CHECK-NEXT:    [[ALD14:%.*]] = load <32 x i32>, ptr [[ITP]], align 128, !tbaa [[TBAA0:![0-9]+]]
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr [[ITP]], i32 128
-; CHECK-NEXT:    [[ALD2:%.*]] = load <128 x i8>, ptr [[GEP]], align 128, !tbaa [[TBAA0]]
+; CHECK-NEXT:    [[CST12:%.*]] = load <64 x i16>, ptr [[V1]], align 2, !tbaa [[TBAA0:![0-9]+]]
+; CHECK-NEXT:    [[ITP:%.*]] = getelementptr i16, ptr [[A0]], i32 [[A1]]
 ; CHECK-NEXT:    [[GEP3:%.*]] = getelementptr i8, ptr [[ITP]], i32 256
-; CHECK-NEXT:    [[AND4:%.*]] = and i32 [[PTI1]], 127
-; CHECK-NEXT:    [[ISZ:%.*]] = icmp ne i32 [[AND4]], 0
-; CHECK-NEXT:    [[CUP:%.*]] = call <32 x i32> @llvm.hexagon.V6.vL32b.pred.ai.128B(i1 [[ISZ]], ptr [[GEP3]], i32 0), !tbaa [[TBAA0]]
-; CHECK-NEXT:    [[CST5:%.*]] = bitcast <128 x i8> [[ALD2]] to <32 x i32>
-; CHECK-NEXT:    [[CUP7:%.*]] = call <32 x i32> @llvm.hexagon.V6.valignb.128B(<32 x i32> [[CST5]], <32 x i32> [[ALD14]], i32 [[PTI1]])
-; CHECK-NEXT:    [[CST12:%.*]] = bitcast <32 x i32> [[CUP7]] to <64 x i16>
-; CHECK-NEXT:    [[CST9:%.*]] = bitcast <128 x i8> [[ALD2]] to <32 x i32>
-; CHECK-NEXT:    [[CUP10:%.*]] = call <32 x i32> @llvm.hexagon.V6.valignb.128B(<32 x i32> [[CUP]], <32 x i32> [[CST9]], i32 [[PTI1]])
-; CHECK-NEXT:    [[CST13:%.*]] = bitcast <32 x i32> [[CUP10]] to <64 x i16>
+; CHECK-NEXT:    [[CST13:%.*]] = load <64 x i16>, ptr [[GEP3]], align 2, !tbaa [[TBAA0]]
 ; CHECK-NEXT:    [[V8:%.*]] = add <64 x i16> [[CST12]], [[CST13]]
 ; CHECK-NEXT:    ret <64 x i16> [[V8]]
 ;
@@ -52,23 +39,10 @@ define <64 x i16> @f1(ptr %a0, i32 %a1) #0 {
 ; CHECK-NEXT:  b0:
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i16, ptr [[A0:%.*]], i32 [[A1:%.*]]
 ; CHECK-NEXT:    [[V1:%.*]] = getelementptr i8, ptr [[TMP0]], i32 128
-; CHECK-NEXT:    [[PTI:%.*]] = ptrtoint ptr [[V1]] to i32
-; CHECK-NEXT:    [[AND:%.*]] = and i32 [[PTI]], -128
-; CHECK-NEXT:    [[ITP:%.*]] = inttoptr i32 [[AND]] to ptr
-; CHECK-NEXT:    [[PTI1:%.*]] = ptrtoint ptr [[V1]] to i32
-; CHECK-NEXT:    [[ALD14:%.*]] = load <32 x i32>, ptr [[ITP]], align 128, !tbaa [[TBAA0]]
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr [[ITP]], i32 128
-; CHECK-NEXT:    [[ALD2:%.*]] = load <128 x i8>, ptr [[GEP]], align 128
+; CHECK-NEXT:    [[CST12:%.*]] = load <64 x i16>, ptr [[V1]], align 2, !tbaa [[TBAA0]]
+; CHECK-NEXT:    [[ITP:%.*]] = getelementptr i16, ptr [[A0]], i32 [[A1]]
 ; CHECK-NEXT:    [[GEP3:%.*]] = getelementptr i8, ptr [[ITP]], i32 256
-; CHECK-NEXT:    [[AND4:%.*]] = and i32 [[PTI1]], 127
-; CHECK-NEXT:    [[ISZ:%.*]] = icmp ne i32 [[AND4]], 0
-; CHECK-NEXT:    [[CUP:%.*]] = call <32 x i32> @llvm.hexagon.V6.vL32b.pred.ai.128B(i1 [[ISZ]], ptr [[GEP3]], i32 0)
-; CHECK-NEXT:    [[CST5:%.*]] = bitcast <128 x i8> [[ALD2]] to <32 x i32>
-; CHECK-NEXT:    [[CUP7:%.*]] = call <32 x i32> @llvm.hexagon.V6.valignb.128B(<32 x i32> [[CST5]], <32 x i32> [[ALD14]], i32 [[PTI1]])
-; CHECK-NEXT:    [[CST12:%.*]] = bitcast <32 x i32> [[CUP7]] to <64 x i16>
-; CHECK-NEXT:    [[CST9:%.*]] = bitcast <128 x i8> [[ALD2]] to <32 x i32>
-; CHECK-NEXT:    [[CUP10:%.*]] = call <32 x i32> @llvm.hexagon.V6.valignb.128B(<32 x i32> [[CUP]], <32 x i32> [[CST9]], i32 [[PTI1]])
-; CHECK-NEXT:    [[CST13:%.*]] = bitcast <32 x i32> [[CUP10]] to <64 x i16>
+; CHECK-NEXT:    [[CST13:%.*]] = load <64 x i16>, ptr [[GEP3]], align 2
 ; CHECK-NEXT:    [[V8:%.*]] = add <64 x i16> [[CST12]], [[CST13]]
 ; CHECK-NEXT:    ret <64 x i16> [[V8]]
 ;
@@ -90,23 +64,10 @@ define <64 x i16> @f2(ptr %a0, i32 %a1) #0 {
 ; CHECK-NEXT:  b0:
 ; CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i16, ptr [[A0:%.*]], i32 [[A1:%.*]]
 ; CHECK-NEXT:    [[V1:%.*]] = getelementptr i8, ptr [[TMP0]], i32 128
-; CHECK-NEXT:    [[PTI:%.*]] = ptrtoint ptr [[V1]] to i32
-; CHECK-NEXT:    [[AND:%.*]] = and i32 [[PTI]], -128
-; CHECK-NEXT:    [[ITP:%.*]] = inttoptr i32 [[AND]] to ptr
-; CHECK-NEXT:    [[PTI1:%.*]] = ptrtoint ptr [[V1]] to i32
-; CHECK-NEXT:    [[ALD14:%.*]] = load <32 x i32>, ptr [[ITP]], align 128, !tbaa [[TBAA0]]
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr [[ITP]], i32 128
-; CHECK-NEXT:    [[ALD2:%.*]] = load <128 x i8>, ptr [[GEP]], align 128
+; CHECK-NEXT:    [[CST12:%.*]] = load <64 x i16>, ptr [[V1]], align 2, !tbaa [[TBAA0]]
+; CHECK-NEXT:    [[ITP:%.*]] = getelementptr i16, ptr [[A0]], i32 [[A1]]
 ; CHECK-NEXT:    [[GEP3:%.*]] = getelementptr i8, ptr [[ITP]], i32 256
-; CHECK-NEXT:    [[AND4:%.*]] = and i32 [[PTI1]], 127
-; CHECK-NEXT:    [[ISZ:%.*]] = icmp ne i32 [[AND4]], 0
-; CHECK-NEXT:    [[CUP:%.*]] = call <32 x i32> @llvm.hexagon.V6.vL32b.pred.ai.128B(i1 [[ISZ]], ptr [[GEP3]], i32 0), !tbaa [[TBAA3:![0-9]+]]
-; CHECK-NEXT:    [[CST5:%.*]] = bitcast <128 x i8> [[ALD2]] to <32 x i32>
-; CHECK-NEXT:    [[CUP7:%.*]] = call <32 x i32> @llvm.hexagon.V6.valignb.128B(<32 x i32> [[CST5]], <32 x i32> [[ALD14]], i32 [[PTI1]])
-; CHECK-NEXT:    [[CST12:%.*]] = bitcast <32 x i32> [[CUP7]] to <64 x i16>
-; CHECK-NEXT:    [[CST9:%.*]] = bitcast <128 x i8> [[ALD2]] to <32 x i32>
-; CHECK-NEXT:    [[CUP10:%.*]] = call <32 x i32> @llvm.hexagon.V6.valignb.128B(<32 x i32> [[CUP]], <32 x i32> [[CST9]], i32 [[PTI1]])
-; CHECK-NEXT:    [[CST13:%.*]] = bitcast <32 x i32> [[CUP10]] to <64 x i16>
+; CHECK-NEXT:    [[CST13:%.*]] = load <64 x i16>, ptr [[GEP3]], align 2, !tbaa [[TBAA3:![0-9]+]]
 ; CHECK-NEXT:    [[V8:%.*]] = add <64 x i16> [[CST12]], [[CST13]]
 ; CHECK-NEXT:    ret <64 x i16> [[V8]]
 ;

--- a/llvm/test/CodeGen/Hexagon/vcombine_zero_diff_ptrs.ll
+++ b/llvm/test/CodeGen/Hexagon/vcombine_zero_diff_ptrs.ll
@@ -1,4 +1,4 @@
-; RUN: opt -hexagon-vc -S < %s | FileCheck %s
+; RUN: opt -march=hexagon -hexagon-vc -hvc-ld-min-group-size-for-alignment=2 -S < %s | FileCheck %s
 
 ; Test that the HexagonVectorCombine pass identifies instruction
 ; pairs whose difference in pointers is zero. This creates a vector

--- a/llvm/test/CodeGen/Hexagon/vector-load-group-min-threshold.ll
+++ b/llvm/test/CodeGen/Hexagon/vector-load-group-min-threshold.ll
@@ -1,0 +1,53 @@
+; RUN: llc -march=hexagon -mhvx < %s | FileCheck %s
+
+; Check that Hexagon Vector Combine do not create vmem for adjacent
+; loads less than 4.
+
+; Test 1: We have three adjacent loads. By default, we won't produce vmem
+; for loads less than 4.
+; CHECK-LABEL: @foo1
+; CHECK: vmemu(
+; CHECK-NOT: vmem(
+
+define <32 x i32> @foo1(ptr %iptr) #0 align 32 {
+entry:
+  %0 = load <32 x i32>, ptr %iptr, align 1
+  %add.ptr = getelementptr inbounds i8, ptr %iptr, i32 128
+  %1 = load <32 x i32>, ptr %add.ptr, align 1
+  %add.ptr2 = getelementptr inbounds i8, ptr %iptr, i32 256
+  %2 = load <32 x i32>, ptr %add.ptr2, align 1
+  %3 = tail call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %1, <32 x i32> %0)
+  %4 = tail call <32 x i32> @llvm.hexagon.V6.vconv.hf.qf32.128B(<64 x i32> %3)
+  %5 = tail call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %2, <32 x i32> %1)
+  %6 = tail call <32 x i32> @llvm.hexagon.V6.vconv.hf.qf32.128B(<64 x i32> %5)
+  %7 = tail call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %4, <32 x i32> %6)
+  %8 = tail call <32 x i32> @llvm.hexagon.V6.vconv.hf.qf32.128B(<64 x i32> %7)
+  ret <32 x i32> %8
+}
+
+; Test 2: We have four adjacent loads. Thus, we will produce vmem.
+; CHECK-LABEL: @foo2
+; CHECK: vmem(
+; CHECK-NOT: vmemu
+
+define <32 x i32> @foo2(ptr %iptr) #0 align 32 {
+entry:
+  %0 = load <32 x i32>, ptr %iptr, align 1
+  %add.ptr = getelementptr inbounds i8, ptr %iptr, i32 128
+  %1 = load <32 x i32>, ptr %add.ptr, align 1
+  %add.ptr2 = getelementptr inbounds i8, ptr %iptr, i32 256
+  %2 = load <32 x i32>, ptr %add.ptr2, align 1
+  %add.ptr4 = getelementptr inbounds i8, ptr %iptr, i32 512
+  %3 = load <32 x i32>, ptr %add.ptr4, align 1
+  %4 = tail call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %1, <32 x i32> %0)
+  %5 = tail call <32 x i32> @llvm.hexagon.V6.vconv.hf.qf32.128B(<64 x i32> %4)
+  %6 = tail call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %3, <32 x i32> %2)
+  %7 = tail call <32 x i32> @llvm.hexagon.V6.vconv.hf.qf32.128B(<64 x i32> %6)
+  %8 = tail call <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32> %5, <32 x i32> %7)
+  %9 = tail call <32 x i32> @llvm.hexagon.V6.vconv.hf.qf32.128B(<64 x i32> %8)
+  ret <32 x i32> %9
+}
+
+declare <32 x i32> @llvm.hexagon.V6.vconv.hf.qf32.128B(<64 x i32>) #1
+declare <64 x i32> @llvm.hexagon.V6.vcombine.128B(<32 x i32>, <32 x i32>) #1
+attributes #0 = {"target-features"="+hvx-length128b,+hvxv75" }


### PR DESCRIPTION
The current implementation of HVXVectorCombine converts unaligned loads to aligned ones if adjacency is proven. However, this does not account for the cost of extra loads whether it is amortized or not, leading to performance regressions in certain cases. This change prevents performance regressions by avoiding unnecessary conversions for few numbers of contiguous unaligned loads.

Patch By: Fateme Hosseini