### PR TITLE
[lldb] Mark Symbol::GetPrologueByteSize as const

### DIFF
--- a/lldb/include/lldb/Symbol/Symbol.h
+++ b/lldb/include/lldb/Symbol/Symbol.h
@@ -221,7 +221,7 @@ public:
 
   // If m_type is "Code" or "Function" then this will return the prologue size
   // in bytes, else it will return zero.
-  uint32_t GetPrologueByteSize();
+  uint32_t GetPrologueByteSize() const;
 
   bool GetDemangledNameIsSynthesized() const {
     return m_demangled_is_synthesized;
@@ -320,9 +320,9 @@ protected:
 
   uint32_t m_uid = LLDB_INVALID_SYMBOL_ID; // User ID (usually the original
                                            // symbol table index)
-  uint16_t m_type_data = 0; // data specific to m_type
-  uint16_t m_type_data_resolved : 1, // True if the data in m_type_data has
-                                     // already been calculated
+  mutable uint16_t m_type_data = 0;        // data specific to m_type
+  mutable uint16_t m_type_data_resolved : 1, // True if the data in m_type_data
+                                             // has already been calculated
       m_is_synthetic : 1, // non-zero if this symbol is not actually in the
                           // symbol table, but synthesized from other info in
                           // the object file.

--- a/lldb/source/Symbol/Symbol.cpp
+++ b/lldb/source/Symbol/Symbol.cpp
@@ -310,7 +310,7 @@ void Symbol::Dump(Stream *s, Target *target, uint32_t index,
   }
 }
 
-uint32_t Symbol::GetPrologueByteSize() {
+uint32_t Symbol::GetPrologueByteSize() const {
   if (m_type == eSymbolTypeCode || m_type == eSymbolTypeResolver) {
     if (!m_type_data_resolved) {
       m_type_data_resolved = true;


### PR DESCRIPTION
This method is only non-const because it lazily computes the information and caches it. This means users of Symbol must otherwise carry around a pointer or reference to a mutable Symbol. I would like to minimize the places that need a mutable pointer/reference to Symbols if possible.