### PR TITLE
[lld][WebAssembly] Fix crash in debug info relocation against shared symbols

### DIFF
--- a/lld/test/wasm/debug-weak-unused.s
+++ b/lld/test/wasm/debug-weak-unused.s
@@ -1,0 +1,36 @@
+# Verify that we can handle R_WASM_FUNCTION_OFFSET relocations against weak
+# symbols that were defined in shared libraries.
+# Test that the .debug_info is generated without error and contains the
+# tombstone value.
+#
+# Based on debug-undefined-fs.s
+#
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t_ret32.o %p/Inputs/ret32.s
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
+# RUN: wasm-ld -shared -o %t_lib.so %t_ret32.o
+# RUN: wasm-ld -pie %t_lib.so %t.o -o %t.wasm
+# RUN: obj2yaml %t.wasm | FileCheck %s
+
+# ret32 is weakly defined here, but strongly defined in the shared library.
+# So we expect the tombstone to be written for relocations refering to it in
+# the debug section.
+.globl ret32
+.weak ret32
+ret32:
+    .functype ret32 (f32) -> (i32)
+    i32.const 0
+    end_function
+
+.globl _start
+_start:
+    .functype _start () -> ()
+    f32.const 0.0
+    call ret32
+    drop
+    end_function
+
+.section .debug_info,"",@
+    .int32 ret32
+
+# CHECK:          Name:            .debug_info
+# CHECK-NEXT:     Payload:         FFFFFFFF

--- a/lld/wasm/InputFiles.cpp
+++ b/lld/wasm/InputFiles.cpp
@@ -208,7 +208,7 @@ uint64_t ObjFile::calcNewValue(const WasmRelocation &reloc, uint64_t tombstone,
     return getTagSymbol(reloc.Index)->getTagIndex();
   case R_WASM_FUNCTION_OFFSET_I32:
   case R_WASM_FUNCTION_OFFSET_I64: {
-    if (isa<UndefinedFunction>(sym)) {
+    if (isa<UndefinedFunction>(sym) || sym->isShared()) {
       return tombstone ? tombstone : reloc.Addend;
     }
     auto *f = cast<DefinedFunction>(sym);


### PR DESCRIPTION
When a weakly defined function is not include because its defined in shared object we should use the tombstone value during relocation of debug info.

Fixes: https://github.com/emscripten-core/emscripten/issues/26044