### PR TITLE
[NFC][win] Use an enum for the cfguard module flag

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1122,11 +1122,15 @@ void CodeGenModule::Release() {
     getModule().addModuleFlag(llvm::Module::Warning, "CodeViewGHash", 1);
   }
   if (CodeGenOpts.ControlFlowGuard) {
-    // Function ID tables and checks for Control Flow Guard (cfguard=2).
-    getModule().addModuleFlag(llvm::Module::Warning, "cfguard", 2);
+    // Function ID tables and checks for Control Flow Guard.
+    getModule().addModuleFlag(
+        llvm::Module::Warning, "cfguard",
+        static_cast<unsigned>(llvm::ControlFlowGuardMode::Enabled));
   } else if (CodeGenOpts.ControlFlowGuardNoChecks) {
-    // Function ID tables for Control Flow Guard (cfguard=1).
-    getModule().addModuleFlag(llvm::Module::Warning, "cfguard", 1);
+    // Function ID tables for Control Flow Guard.
+    getModule().addModuleFlag(
+        llvm::Module::Warning, "cfguard",
+        static_cast<unsigned>(llvm::ControlFlowGuardMode::TableOnly));
   }
   if (CodeGenOpts.EHContGuard) {
     // Function ID tables for EH Continuation Guard.

--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -1056,6 +1056,9 @@ public:
   /// Get how unwind v2 (epilog) information should be generated for x64
   /// Windows.
   WinX64EHUnwindV2Mode getWinX64EHUnwindV2Mode() const;
+
+  /// Gets the Control Flow Guard mode.
+  ControlFlowGuardMode getControlFlowGuardMode() const;
 };
 
 /// Given "llvm.used" or "llvm.compiler.used" as a global name, collect the

--- a/llvm/include/llvm/Support/CodeGen.h
+++ b/llvm/include/llvm/Support/CodeGen.h
@@ -173,6 +173,16 @@ namespace llvm {
     Required = 2,
   };
 
+  enum class ControlFlowGuardMode {
+    // Don't enable Control Flow Guard.
+    Disabled = 0,
+    // Emit the Control Flow Guard tables in the binary, but don't emit any
+    // checks.
+    TableOnly = 1,
+    // Enable Control Flow Guard checks and emit the tables.
+    Enabled = 2,
+  };
+
   } // namespace llvm
 
 #endif

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -664,8 +664,8 @@ bool AsmPrinter::doInitialization(Module &M) {
   if (ES)
     Handlers.push_back(std::unique_ptr<EHStreamer>(ES));
 
-  // Emit tables for any value of cfguard flag (i.e. cfguard=1 or cfguard=2).
-  if (mdconst::extract_or_null<ConstantInt>(M.getModuleFlag("cfguard")))
+  // All CFG modes required the tables emitted.
+  if (M.getControlFlowGuardMode() != ControlFlowGuardMode::Disabled)
     EHHandlers.push_back(std::make_unique<WinCFGuard>(this));
 
   for (auto &Handler : Handlers)
@@ -5088,7 +5088,7 @@ void AsmPrinter::emitCOFFFeatureSymbol(Module &M) {
     Feat00Value |= COFF::Feat00Flags::SafeSEH;
   }
 
-  if (M.getModuleFlag("cfguard")) {
+  if (M.getControlFlowGuardMode() != ControlFlowGuardMode::Disabled) {
     // Object is CFG-aware.
     Feat00Value |= COFF::Feat00Flags::GuardCF;
   }

--- a/llvm/lib/CodeGen/CFGuardLongjmp.cpp
+++ b/llvm/lib/CodeGen/CFGuardLongjmp.cpp
@@ -62,7 +62,8 @@ FunctionPass *llvm::createCFGuardLongjmpPass() { return new CFGuardLongjmp(); }
 bool CFGuardLongjmp::runOnMachineFunction(MachineFunction &MF) {
 
   // Skip modules for which the cfguard flag is not set.
-  if (!MF.getFunction().getParent()->getModuleFlag("cfguard"))
+  if (MF.getFunction().getParent()->getControlFlowGuardMode() ==
+      ControlFlowGuardMode::Disabled)
     return false;
 
   // Skip functions that do not have calls to _setjmp.

--- a/llvm/lib/IR/Module.cpp
+++ b/llvm/lib/IR/Module.cpp
@@ -940,3 +940,10 @@ WinX64EHUnwindV2Mode Module::getWinX64EHUnwindV2Mode() const {
     return static_cast<WinX64EHUnwindV2Mode>(CI->getZExtValue());
   return WinX64EHUnwindV2Mode::Disabled;
 }
+
+ControlFlowGuardMode Module::getControlFlowGuardMode() const {
+  Metadata *MD = getModuleFlag("cfguard");
+  if (auto *CI = mdconst::dyn_extract_or_null<ConstantInt>(MD))
+    return static_cast<ControlFlowGuardMode>(CI->getZExtValue());
+  return ControlFlowGuardMode::Disabled;
+}

--- a/llvm/lib/Transforms/CFGuard/CFGuard.cpp
+++ b/llvm/lib/Transforms/CFGuard/CFGuard.cpp
@@ -146,8 +146,8 @@ public:
   bool runOnFunction(Function &F);
 
 private:
-  // Only add checks if the module has the cfguard=2 flag.
-  int CFGuardModuleFlag = 0;
+  // Only add checks if the module has them enabled.
+  ControlFlowGuardMode CFGuardModuleFlag = ControlFlowGuardMode::Disabled;
   StringRef GuardFnName;
   Mechanism GuardMechanism = Mechanism::Check;
   FunctionType *GuardFnType = nullptr;
@@ -233,12 +233,10 @@ void CFGuardImpl::insertCFGuardDispatch(CallBase *CB) {
 
 bool CFGuardImpl::doInitialization(Module &M) {
   // Check if this module has the cfguard flag and read its value.
-  if (auto *MD =
-          mdconst::extract_or_null<ConstantInt>(M.getModuleFlag("cfguard")))
-    CFGuardModuleFlag = MD->getZExtValue();
+  CFGuardModuleFlag = M.getControlFlowGuardMode();
 
   // Skip modules for which CFGuard checks have been disabled.
-  if (CFGuardModuleFlag != 2)
+  if (CFGuardModuleFlag != ControlFlowGuardMode::Enabled)
     return false;
 
   // Set up prototypes for the guard check and dispatch functions.
@@ -260,7 +258,7 @@ bool CFGuardImpl::doInitialization(Module &M) {
 
 bool CFGuardImpl::runOnFunction(Function &F) {
   // Skip modules for which CFGuard checks have been disabled.
-  if (CFGuardModuleFlag != 2)
+  if (CFGuardModuleFlag != ControlFlowGuardMode::Enabled)
     return false;
 
   SmallVector<CallBase *, 8> IndirectCalls;


### PR DESCRIPTION
Currently the `cfguard` module flag can be set to 1 (emit tables only, no checks) or 2 (emit tables and checks).

This change formalizes that definition by moving these values into an enum, instead of just having them documented in comments.

Split out from #176276