### PR TITLE
[lldb] Fix the 'skipUnlessUndefinedBehaviorSanitizer' decorator.

### DIFF
--- a/lldb/packages/Python/lldbsuite/support/temp_file.py
+++ b/lldb/packages/Python/lldbsuite/support/temp_file.py
@@ -12,20 +12,12 @@ class OnDiskTempFile:
     def __init__(self, delete=True):
         self.path = None
 
-    def __del__(self):
-        if self.path and os.path.exists(self.path):
-            os.remove(self.path)
-
-    def _set_path(self):
-        if self.path:
-            return
+    def __enter__(self):
         fd, path = tempfile.mkstemp()
         os.close(fd)
         self.path = path
-
-    def __enter__(self):
-        self._set_path()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
+        if os.path.exists(self.path):
+            os.remove(self.path)

--- a/lldb/packages/Python/lldbsuite/support/temp_file.py
+++ b/lldb/packages/Python/lldbsuite/support/temp_file.py
@@ -12,12 +12,20 @@ class OnDiskTempFile:
     def __init__(self, delete=True):
         self.path = None
 
-    def __enter__(self):
+    def __del__(self):
+        if self.path and os.path.exists(self.path):
+            os.remove(self.path)
+
+    def _set_path(self):
+        if self.path:
+            return
         fd, path = tempfile.mkstemp()
         os.close(fd)
         self.path = path
+
+    def __enter__(self):
+        self._set_path()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if os.path.exists(self.path):
-            os.remove(self.path)
+        pass

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -103,10 +103,11 @@ def _match_decorator_property(expected, actual):
 
 def _compiler_supports(compiler, flag, source="int main() {}", output_file=None):
     """Test whether the compiler supports the given flag."""
-    with contextlib.nullcontext(
-        output_file if output_file else temp_file.OnDiskTempFile()
-    ) as ctx:
-        path = ctx.path
+    if output_file:
+        context = contextlib.nullcontext(output_file)
+    else:
+        context = temp_file.OnDiskTempFile()
+    with context as ctx:
         if platform.system() == "Darwin":
             compiler = "xcrun " + compiler
         try:
@@ -114,7 +115,7 @@ def _compiler_supports(compiler, flag, source="int main() {}", output_file=None)
                 source,
                 compiler,
                 flag,
-                path,
+                ctx.path,
             )
             subprocess.check_call(cmd, shell=True)
         except subprocess.CalledProcessError:

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1114,6 +1114,7 @@ def skipUnlessBoundsSafety(func):
 
     return skipTestIfFn(is_compiler_with_bounds_safety)(func)
 
+
 def skipIfAsan(func):
     """Skip this test if the environment is set up to run LLDB *itself* under ASAN."""
     return skipTestIfFn(is_running_under_asan)(func)

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import wraps
 from packaging import version
+import contextlib
 import ctypes
 import locale
 import os
@@ -100,11 +101,12 @@ def _match_decorator_property(expected, actual):
     return expected == actual
 
 
-def _compiler_supports(
-    compiler, flag, source="int main() {}", output_file=temp_file.OnDiskTempFile()
-):
+def _compiler_supports(compiler, flag, source="int main() {}", output_file=None):
     """Test whether the compiler supports the given flag."""
-    with output_file:
+    with contextlib.nullcontext(
+        output_file if output_file else temp_file.OnDiskTempFile()
+    ) as ctx:
+        path = ctx.path
         if platform.system() == "Darwin":
             compiler = "xcrun " + compiler
         try:
@@ -112,7 +114,7 @@ def _compiler_supports(
                 source,
                 compiler,
                 flag,
-                output_file.path,
+                path,
             )
             subprocess.check_call(cmd, shell=True)
         except subprocess.CalledProcessError:
@@ -1034,22 +1036,21 @@ def skipUnlessUndefinedBehaviorSanitizer(func):
             )
 
         # We need to write out the object into a named temp file for inspection.
-        outputf = temp_file.OnDiskTempFile()
+        with temp_file.OnDiskTempFile() as outputf:
+            # Try to compile with ubsan turned on.
+            if not _compiler_supports(
+                lldbplatformutil.getCompiler(),
+                "-fsanitize=undefined",
+                "int main() { int x = 0; return x / x; }",
+                outputf,
+            ):
+                return "Compiler cannot compile with -fsanitize=undefined"
 
-        # Try to compile with ubsan turned on.
-        if not _compiler_supports(
-            lldbplatformutil.getCompiler(),
-            "-fsanitize=undefined",
-            "int main() { int x = 0; return x / x; }",
-            outputf,
-        ):
-            return "Compiler cannot compile with -fsanitize=undefined"
-
-        # Check that we actually see ubsan instrumentation in the binary.
-        cmd = "nm %s" % outputf.path
-        with os.popen(cmd) as nm_output:
-            if "___ubsan_handle_divrem_overflow" not in nm_output.read():
-                return "Division by zero instrumentation is missing"
+            # Check that we actually see ubsan instrumentation in the binary.
+            cmd = "nm %s" % outputf.path
+            with os.popen(cmd) as nm_output:
+                if "___ubsan_handle_divrem_overflow" not in nm_output.read():
+                    return "Division by zero instrumentation is missing"
 
         # Find the ubsan dylib.
         # FIXME: This check should go away once compiler-rt gains support for __ubsan_on_report.


### PR DESCRIPTION
This decorator is trying to reference the file that is already deleted by the time the `nm` call is made.

Fix this by correcting how `_compiler_supports` the `output_file` argument.
