### PR TITLE
[lldb] Fix llvm_unreachable for invalid Wasm address

### DIFF
--- a/lldb/source/Plugins/Process/wasm/ProcessWasm.cpp
+++ b/lldb/source/Plugins/Process/wasm/ProcessWasm.cpp
@@ -93,12 +93,16 @@ size_t ProcessWasm::ReadMemory(lldb::addr_t vm_addr, void *buf, size_t size,
   case WasmAddressType::Memory:
   case WasmAddressType::Object:
     return ProcessGDBRemote::ReadMemory(vm_addr, buf, size, error);
-  case WasmAddressType::Invalid:
-    error.FromErrorStringWithFormat(
-        "Wasm read failed for invalid address 0x%" PRIx64, vm_addr);
-    return 0;
+  default:
+    break;
   }
-  llvm_unreachable("Fully covered switch above");
+
+  error.FromErrorStringWithFormatv(
+      "Wasm read failed for invalid address {0:x} (type = {1:x}, module = "
+      "{2:x}, offset = {3:x})",
+      vm_addr, wasm_addr.GetType(), wasm_addr.GetModuleID(),
+      wasm_addr.GetOffset());
+  return 0;
 }
 
 llvm::Expected<std::vector<lldb::addr_t>>

--- a/lldb/source/Plugins/Process/wasm/ProcessWasm.cpp
+++ b/lldb/source/Plugins/Process/wasm/ProcessWasm.cpp
@@ -93,7 +93,7 @@ size_t ProcessWasm::ReadMemory(lldb::addr_t vm_addr, void *buf, size_t size,
   case WasmAddressType::Memory:
   case WasmAddressType::Object:
     return ProcessGDBRemote::ReadMemory(vm_addr, buf, size, error);
-  default:
+  case WasmAddressType::Invalid:
     break;
   }
 

--- a/lldb/source/Plugins/Process/wasm/ProcessWasm.h
+++ b/lldb/source/Plugins/Process/wasm/ProcessWasm.h
@@ -35,7 +35,9 @@ struct wasm_addr_t {
   wasm_addr_t(WasmAddressType type, uint32_t module_id, uint32_t offset)
       : offset(offset), module_id(module_id), type(type) {}
 
-  WasmAddressType GetType() { return static_cast<WasmAddressType>(type); }
+  WasmAddressType GetType() const { return static_cast<WasmAddressType>(type); }
+  uint32_t GetModuleID() const { return module_id; }
+  uint32_t GetOffset() const { return offset; }
 
   operator lldb::addr_t() { return *(uint64_t *)this; }
 };


### PR DESCRIPTION
We had an llvm_unreachable following a switch on the WasmAddress's type. However, the type is encoded in a larger 64 bit address, and therefore it's possible to create an invalid value that doesn't map back on one of the enum types.

We could try to diagnose that in the wrapper, or treat all invalid types the same. I took the latter approach because it makes it easier to show the invalid type after the fact in an error message.

rdar://168314695