### PR TITLE
Implement MIR serialization support for prefetch targets.

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -722,8 +722,8 @@ public:
     return PrefetchTargetCallsiteIndexes;
   }
 
-  void setPrefetchTargetCallsiteIndexes(const SmallVector<unsigned> &V) {
-    PrefetchTargetCallsiteIndexes = V;
+  void setPrefetchTargetCallsiteIndexes(ArrayRef<unsigned> V) {
+    PrefetchTargetCallsiteIndexes.assign(V.begin(), V.end());
   }
 
   /// Returns the section ID of this basic block.

--- a/llvm/lib/CodeGen/MIRParser/MILexer.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MILexer.cpp
@@ -275,6 +275,7 @@ static MIToken::TokenKind getIdentifierKind(StringRef Identifier) {
       .Case("ehfunclet-entry", MIToken::kw_ehfunclet_entry)
       .Case("liveins", MIToken::kw_liveins)
       .Case("successors", MIToken::kw_successors)
+      .Case("prefetch-targets", MIToken::kw_prefetch_targets)
       .Case("floatpred", MIToken::kw_floatpred)
       .Case("intpred", MIToken::kw_intpred)
       .Case("shufflemask", MIToken::kw_shufflemask)

--- a/llvm/lib/CodeGen/MIRParser/MILexer.h
+++ b/llvm/lib/CodeGen/MIRParser/MILexer.h
@@ -130,6 +130,7 @@ struct MIToken {
     kw_ehfunclet_entry,
     kw_liveins,
     kw_successors,
+    kw_prefetch_targets,
     kw_floatpred,
     kw_intpred,
     kw_shufflemask,

--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -447,6 +447,7 @@ public:
                        MachineBasicBlock *&AddFalthroughFrom);
   bool parseBasicBlockLiveins(MachineBasicBlock &MBB);
   bool parseBasicBlockSuccessors(MachineBasicBlock &MBB);
+  bool parseBasicBlockPrefetchTargets(MachineBasicBlock &MBB);
 
   bool parseNamedRegister(Register &Reg);
   bool parseVirtualRegister(VRegInfo *&Info);
@@ -927,6 +928,27 @@ bool MIParser::parseBasicBlockSuccessors(MachineBasicBlock &MBB) {
   return false;
 }
 
+bool MIParser::parseBasicBlockPrefetchTargets(MachineBasicBlock &MBB) {
+  assert(Token.is(MIToken::kw_prefetch_targets));
+  lex();
+  if (expectAndConsume(MIToken::colon))
+    return true;
+  if (Token.isNewlineOrEOF()) // Allow an empty list.
+    return false;
+  SmallVector<unsigned> PrefetchTargets;
+  do {
+    if (Token.isNot(MIToken::IntegerLiteral))
+      return error("expected an integer literal");
+    unsigned Index;
+    if (getUnsigned(Index))
+      return true;
+    PrefetchTargets.push_back(Index);
+    lex();
+  } while (consumeIfPresent(MIToken::comma));
+  MBB.setPrefetchTargetCallsiteIndexes(PrefetchTargets);
+  return false;
+}
+
 bool MIParser::parseBasicBlock(MachineBasicBlock &MBB,
                                MachineBasicBlock *&AddFalthroughFrom) {
   // Skip the definition.
@@ -956,6 +978,9 @@ bool MIParser::parseBasicBlock(MachineBasicBlock &MBB,
       ExplicitSuccessors = true;
     } else if (Token.is(MIToken::kw_liveins)) {
       if (parseBasicBlockLiveins(MBB))
+        return true;
+    } else if (Token.is(MIToken::kw_prefetch_targets)) {
+      if (parseBasicBlockPrefetchTargets(MBB))
         return true;
     } else if (consumeIfPresent(MIToken::Newline)) {
       continue;

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -776,7 +776,7 @@ void printMBB(raw_ostream &OS, MFPrintState &State,
     OS.indent(2) << "prefetch-targets: ";
     ListSeparator LS;
     for (unsigned I : MBB.getPrefetchTargetCallsiteIndexes()) {
-        OS << LS << I;
+      OS << LS << I;
     }
     OS << "\n";
     HasLineAttributes = true;

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -771,6 +771,17 @@ void printMBB(raw_ostream &OS, MFPrintState &State,
     HasLineAttributes = true;
   }
 
+  // Print prefetch targets
+  if (!MBB.getPrefetchTargetCallsiteIndexes().empty()) {
+    OS.indent(2) << "prefetch-targets: ";
+    ListSeparator LS;
+    for (unsigned I : MBB.getPrefetchTargetCallsiteIndexes()) {
+        OS << LS << I;
+    }
+    OS << "\n";
+    HasLineAttributes = true;
+  }
+
   if (HasLineAttributes && !MBB.empty())
     OS << "\n";
   bool IsInBundle = false;

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -778,7 +778,7 @@ void printMBB(raw_ostream &OS, MFPrintState &State,
     for (unsigned I : MBB.getPrefetchTargetCallsiteIndexes()) {
       OS << LS << I;
     }
-    OS << "\n";
+    OS << '\n';
     HasLineAttributes = true;
   }
 

--- a/llvm/test/CodeGen/MIR/Generic/prefetch-targets-err1.mir
+++ b/llvm/test/CodeGen/MIR/Generic/prefetch-targets-err1.mir
@@ -1,0 +1,8 @@
+# RUN: not llc -run-pass=none -o - %s 2>&1 | FileCheck %s
+
+name: prefetch
+body: |
+  bb.0:
+  ; CHECK: [[@LINE+1]]:22: expected ':'
+    prefetch-targets 0, 1, 2
+...

--- a/llvm/test/CodeGen/MIR/Generic/prefetch-targets-err2.mir
+++ b/llvm/test/CodeGen/MIR/Generic/prefetch-targets-err2.mir
@@ -1,0 +1,8 @@
+# RUN: not llc -run-pass=none -o - %s 2>&1 | FileCheck %s
+
+name: prefetch
+body: |
+  bb.0:
+  ; CHECK: [[@LINE+1]]:26: expected an integer literal
+    prefetch-targets: 0, a, 2
+...

--- a/llvm/test/CodeGen/MIR/Generic/prefetch-targets.mir
+++ b/llvm/test/CodeGen/MIR/Generic/prefetch-targets.mir
@@ -1,0 +1,23 @@
+# RUN: llc -run-pass none -o - %s | FileCheck %s
+# This test ensures that the MIR parser parses the prefetch-targets attribute
+# correctly.
+
+--- |
+
+  define void @prefetch() {
+  entry:
+    ret void
+  }
+
+...
+---
+# CHECK-LABEL: name: prefetch
+# CHECK:       bb.0.entry:
+# CHECK-NEXT:    liveins: $edi
+# CHECK-NEXT:    prefetch-targets: 0, 1, 2
+name: prefetch
+body: |
+  bb.0.entry:
+    prefetch-targets: 0, 1, 2
+    liveins: $edi
+...

--- a/llvm/test/CodeGen/MIR/Generic/prefetch-targets.mir
+++ b/llvm/test/CodeGen/MIR/Generic/prefetch-targets.mir
@@ -1,23 +1,14 @@
-# RUN: llc -run-pass none -o - %s | FileCheck %s
+# RUN: llc -run-pass=none -o - %s | FileCheck %s
 # This test ensures that the MIR parser parses the prefetch-targets attribute
 # correctly.
 
---- |
-
-  define void @prefetch() {
-  entry:
-    ret void
-  }
-
-...
----
 # CHECK-LABEL: name: prefetch
 # CHECK:       bb.0.entry:
 # CHECK-NEXT:    liveins: $edi
 # CHECK-NEXT:    prefetch-targets: 0, 1, 2
 name: prefetch
 body: |
-  bb.0.entry:
+  bb.0:
     prefetch-targets: 0, 1, 2
     liveins: $edi
 ...

--- a/llvm/test/CodeGen/MIR/Generic/prefetch-targets.mir
+++ b/llvm/test/CodeGen/MIR/Generic/prefetch-targets.mir
@@ -3,12 +3,11 @@
 # correctly.
 
 # CHECK-LABEL: name: prefetch
-# CHECK:       bb.0.entry:
-# CHECK-NEXT:    liveins: $edi
+# CHECK:       bb.0:
 # CHECK-NEXT:    prefetch-targets: 0, 1, 2
+
 name: prefetch
 body: |
   bb.0:
     prefetch-targets: 0, 1, 2
-    liveins: $edi
 ...


### PR DESCRIPTION
The implementation includes:
    - A new  token in the MIR lexer.
    - Parsing logic to handle the  attribute.
    - Serialization logic to write the  attribute.
    - A new test case to verify the correct serialization and parsing of this attribute.
