### PR TITLE
[llvm][Support] Move llvm::createStringErrorV to a new ErrorExtras.h header

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -38,6 +38,7 @@
 #include "lldb/Target/Thread.h"
 #include "llvm/DebugInfo/DWARF/DWARFExpressionPrinter.h"
 #include "llvm/DebugInfo/DWARF/LowLevel/DWARFExpression.h"
+#include "llvm/Support/ErrorExtras.h"
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/source/Expression/Expression.cpp
+++ b/lldb/source/Expression/Expression.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorExtras.h"
 
 using namespace lldb_private;
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -20,6 +20,7 @@
 #include "clang/Sema/Lookup.h"
 #include "clang/Serialization/ASTReader.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Threading.h"
 

--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWasm.cpp
@@ -20,6 +20,7 @@
 #include "lldb/Utility/Listener.h"
 #include "lldb/Utility/Log.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/ErrorExtras.h"
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -90,6 +90,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -15,6 +15,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFDebugLoc.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/Threading.h"

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -33,6 +33,7 @@
 #include "lldb/Symbol/VariableList.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/ScopedPrinter.h"
 
 #include "lldb/Target/StackFrame.h"

--- a/lldb/source/Protocol/MCP/Server.cpp
+++ b/lldb/source/Protocol/MCP/Server.cpp
@@ -14,6 +14,7 @@
 #include "lldb/Protocol/MCP/Protocol.h"
 #include "lldb/Protocol/MCP/Transport.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Support/ErrorExtras.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/Signals.h"

--- a/lldb/source/Symbol/Function.cpp
+++ b/lldb/source/Symbol/Function.cpp
@@ -22,6 +22,7 @@
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/ErrorExtras.h"
 
 using namespace lldb;
 using namespace lldb_private;

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -21,7 +21,6 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/Format.h"
-#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <cstdint>
@@ -1334,21 +1333,6 @@ template <typename... Ts>
 inline Error createStringError(std::errc EC, char const *Fmt,
                                const Ts &... Vals) {
   return createStringError(std::make_error_code(EC), Fmt, Vals...);
-}
-
-// LLVM formatv versions of llvm::createStringError
-
-template <typename... Ts>
-inline Error createStringErrorV(std::error_code EC, char const *Fmt,
-                                Ts &&...Vals) {
-  return make_error<StringError>(formatv(Fmt, std::forward<Ts>(Vals)...).str(),
-                                 EC, true);
-}
-
-template <typename... Ts>
-inline Error createStringErrorV(char const *Fmt, Ts &&...Vals) {
-  return createStringErrorV(llvm::inconvertibleErrorCode(), Fmt,
-                            std::forward<Ts>(Vals)...);
 }
 
 /// This class wraps a filename and another Error.

--- a/llvm/include/llvm/Support/ErrorExtras.h
+++ b/llvm/include/llvm/Support/ErrorExtras.h
@@ -1,4 +1,4 @@
-//===- llvm/Support/Error.h - Recoverable error handling --------*- C++ -*-===//
+//===- llvm/Support/ErrorExtras.h -------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/include/llvm/Support/ErrorExtras.h
+++ b/llvm/include/llvm/Support/ErrorExtras.h
@@ -1,0 +1,34 @@
+//===- llvm/Support/Error.h - Recoverable error handling --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_ERROREXTRAS_H
+#define LLVM_SUPPORT_ERROREXTRAS_H
+
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FormatVariadic.h"
+
+namespace llvm {
+
+// LLVM formatv versions of llvm::createStringError
+
+template <typename... Ts>
+inline Error createStringErrorV(std::error_code EC, char const *Fmt,
+                                Ts &&...Vals) {
+  return make_error<StringError>(formatv(Fmt, std::forward<Ts>(Vals)...).str(),
+                                 EC, true);
+}
+
+template <typename... Ts>
+inline Error createStringErrorV(char const *Fmt, Ts &&...Vals) {
+  return createStringErrorV(llvm::inconvertibleErrorCode(), Fmt,
+                            std::forward<Ts>(Vals)...);
+}
+
+} // namespace llvm
+
+#endif // LLVM_SUPPORT_ERROREXTRAS_H

--- a/llvm/unittests/Support/ErrorTest.cpp
+++ b/llvm/unittests/Support/ErrorTest.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/Support/Error.h"
 #include "llvm-c/Error.h"
+#include "llvm/Support/ErrorExtras.h"
 
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Errc.h"


### PR DESCRIPTION
Introducing `llvm::createStringErrorV` caused a `0.5%` compile-time regression because it's an inline function in a core header. This moves the API to a new header to prevent including this function in files that don't need it.

Also includes the header in the source files that have been using `createStringErrorV` (which currently is just LLDB).