### PR TITLE
[libc][math] Refactor ilogbl to Header Only.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -64,6 +64,7 @@
 #include "math/fsqrt.h"
 #include "math/hypotf.h"
 #include "math/ilogbf16.h"
+#include "math/ilogbl.h"
 #include "math/ldexpf.h"
 #include "math/ldexpf128.h"
 #include "math/ldexpf16.h"

--- a/libc/shared/math/ilogbl.h
+++ b/libc/shared/math/ilogbl.h
@@ -1,4 +1,4 @@
-//===-- Implementation of ilogbl function ---------------------------------===//
+//===-- Shared ilogbl function ----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/ilogbl.h"
+#ifndef LLVM_LIBC_SHARED_MATH_ILOGBL_H
+#define LLVM_LIBC_SHARED_MATH_ILOGBL_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/ilogbl.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(int, ilogbl, (long double x)) { return math::ilogbl(x); }
+using math::ilogbl;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_ILOGBL_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -957,6 +957,16 @@ add_header_library(
 )
 
 add_header_library(
+  ilogbl
+  HDRS
+    ilogbl.h
+  DEPENDS
+    libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.common
+    libc.src.__support.macros.config
+)
+
+add_header_library(
   range_reduction_double
   HDRS
     range_reduction_double_common.h

--- a/libc/src/__support/math/ilogbl.h
+++ b/libc/src/__support/math/ilogbl.h
@@ -1,0 +1,28 @@
+//===-- Implementation header for ilogbl ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBL_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBL_H
+
+#include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE static constexpr int ilogbl(long double x) {
+  return fputil::intlogb<int>(x);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_ILOGBL_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1782,7 +1782,8 @@ add_entrypoint_object(
   HDRS
     ../ilogbl.h
   DEPENDS
-    libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.math.ilogbl
+    libc.src.errno.errno
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -60,6 +60,7 @@ add_fp_unittest(
     libc.src.__support.math.fsqrt
     libc.src.__support.math.hypotf
     libc.src.__support.math.ilogbf16
+    libc.src.__support.math.ilogbl
     libc.src.__support.math.log
     libc.src.__support.math.logbf
     libc.src.__support.math.logbf128
@@ -70,5 +71,4 @@ add_fp_unittest(
     libc.src.__support.math.rsqrtf
     libc.src.__support.math.rsqrtf16
     libc.src.__support.math.sin
-    libc.src.__support.math.ilogbl
 )

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -70,4 +70,5 @@ add_fp_unittest(
     libc.src.__support.math.rsqrtf
     libc.src.__support.math.rsqrtf16
     libc.src.__support.math.sin
+    libc.src.__support.math.ilogbl
 )

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -102,6 +102,7 @@ TEST(LlvmLibcSharedMathTest, AllDouble) {
 TEST(LlvmLibcSharedMathTest, AllLongDouble) {
   EXPECT_FP_EQ(0x0p+0L,
                LIBC_NAMESPACE::shared::dfmal(0x0.p+0L, 0x0.p+0L, 0x0.p+0L));
+  EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbl(0x1.p+0L));
 }
 #ifdef LIBC_TYPES_HAS_FLOAT128
 

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -99,11 +99,13 @@ TEST(LlvmLibcSharedMathTest, AllDouble) {
   EXPECT_FP_EQ(0x0p+0, LIBC_NAMESPACE::shared::log(1.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::sin(0.0));
 }
+
 TEST(LlvmLibcSharedMathTest, AllLongDouble) {
   EXPECT_FP_EQ(0x0p+0L,
                LIBC_NAMESPACE::shared::dfmal(0x0.p+0L, 0x0.p+0L, 0x0.p+0L));
   EXPECT_EQ(0, LIBC_NAMESPACE::shared::ilogbl(0x1.p+0L));
 }
+
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
 TEST(LlvmLibcSharedMathTest, AllFloat128) {

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4392,7 +4392,10 @@ libc_math_function(name = "ilogb")
 
 libc_math_function(name = "ilogbf")
 
-libc_math_function(name = "ilogbl")
+libc_math_function(
+    name = "ilogbl",
+    additional_deps = ["__support_math_ilogbl"],
+)
 
 libc_math_function(name = "ilogbf128")
 
@@ -7929,5 +7932,13 @@ libc_function(
         ":__support_common",
         ":types_size_t",
         ":types_wchar_t",
+    ],
+)
+
+libc_support_library(
+    name = "__support_math_ilogbl",
+    hdrs = ["src/__support/math/ilogbl.h"],
+    deps = [
+        ":__support_fputil_manipulation_functions",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2862,6 +2862,14 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_ilogbl",
+    hdrs = ["src/__support/math/ilogbl.h"],
+    deps = [
+        ":__support_fputil_manipulation_functions",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_ldexpf128",
     hdrs = ["src/__support/math/ldexpf128.h"],
     deps = [
@@ -7932,13 +7940,5 @@ libc_function(
         ":__support_common",
         ":types_size_t",
         ":types_wchar_t",
-    ],
-)
-
-libc_support_library(
-    name = "__support_math_ilogbl",
-    hdrs = ["src/__support/math/ilogbl.h"],
-    deps = [
-        ":__support_fputil_manipulation_functions",
     ],
 )


### PR DESCRIPTION
builds with both Clang and GCC 12.2.

Closes https://github.com/llvm/llvm-project/issues/175349.

CC @bassiounix 