### PR TITLE
[AMDGPU] Reduce number of emitted S_SET_VGPR_MSB instructions

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerVGPREncoding.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerVGPREncoding.cpp
@@ -164,6 +164,7 @@ private:
 bool AMDGPULowerVGPREncoding::setMode(ModeTy NewMode, ModeTy Mask,
                                       MachineBasicBlock::instr_iterator I) {
   assert((NewMode.raw_bits() & ~Mask.raw_bits()).none());
+  assert((CurrentMode.raw_bits() & ~CurrentMask.raw_bits()).none());
 
   auto Delta = NewMode.raw_bits() ^ CurrentMode.raw_bits();
 
@@ -172,7 +173,8 @@ bool AMDGPULowerVGPREncoding::setMode(ModeTy NewMode, ModeTy Mask,
     return false;
   }
 
-  if (MostRecentModeSet && (Delta & CurrentMask.raw_bits()).none()) {
+  if (MostRecentModeSet &&
+      ((Delta & Mask.raw_bits()) & CurrentMask.raw_bits()).none()) {
     CurrentMode |= NewMode;
     CurrentMask |= Mask;
 

--- a/llvm/test/CodeGen/AMDGPU/vgpr-lowering-gfx1250.mir
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-lowering-gfx1250.mir
@@ -526,7 +526,14 @@ body:             |
     $vgpr1 = V_ADD_U32_e32 undef $vgpr257, undef $vgpr1, implicit $exec
     $vgpr2 = V_ADD_U32_e32 undef $vgpr258, undef $vgpr258, implicit $exec
 
-    ; ASM: NumVgprs: 263
+    ; GCN-NEXT: s_set_vgpr_msb 0x50a
+    ; ASM-SAME:                                         ;  msbs: dst=0 src0=2 src1=2 src2=0
+    ; GCN-NEXT: v_mov_b32_e32 v8, v18 /*v530*/
+    ; GCN-NEXT: v_add_nc_u32_e32 v9, 0x1234, v19 /*v531*/
+    $vgpr8 = V_MOV_B32_e32 undef $vgpr530, implicit $exec
+    $vgpr9 = V_ADD_U32_e32 4660, undef $vgpr531, implicit $exec
+
+    ; ASM: NumVgprs: 532
 
 ...
 


### PR DESCRIPTION
Given a `S_SET_VGPR_MSB` instruction with `CurrentMode` and `CurrentMask` where `CurrentMask` is a bit mask with 1 for every bit position we set to 0 or 1 in `CurrentMode`.

We also have a new mode bitset `Mode` and  a `Mask` with the bit position we want set.

Currently we check if the difference between `Mode` and `CurrentMode` (`Delta = Mode ^ CurrentMode`) overlaps with the bit positions we previously set (`Delta & CurrentMask .== 0`). We then update `CurrentMode` and `CurrentMask` accordingly.

However if bit positions differ in `Mode` and `CurrentMode` but we do not care about these bit positions for our next instruction `(Delta & Mask) & CurrentMask .== 0`) we can still update the previous `S_SET_VGPR_MSB`, since we don't interfere with any of the bit positions in `CurrentMask`


```mir
     S_SET_VGPR_MSB 0x0002
     $vgpr0 = V_MOV_B32_e32 $vgpr530          ; mode: 0b0000_0010   mask:  0b0000_0011
->   $vgpr1 = V_ADD_U32_e32 0x1234, $vgpr531  ; mode: 0b0000_1000   mask:  0b0000_1100
                                              ; src0 is imm so we don't care about it.
```

|   | dst  |  src2 | src1  | src0  |
|---|---|---|---|---|
|  CurrentMode | 00  | 00  | 00  | 10  |
| CurrentMask  |  00  | 00  | 00  | 11  |
|  Mode | 00  | 00  |  10  |  00  |
|  Mask | 00  |  00  |  11  | 00  |
|  Delta |  00 | 00  | 10   | 10  |
| Delta & CurrentMask  | 00  | 00  | 00  | 10  |
| Delta & Mask & CurrentMask  |  00 | 00  | 00  | 00  |