### PR TITLE
[CIR] Upstream support for null and virtual method pointers

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -184,6 +184,10 @@ public:
     return cir::MethodAttr::get(ty, methodFuncSymbolRef);
   }
 
+  cir::MethodAttr getNullMethodAttr(cir::MethodType ty) {
+    return cir::MethodAttr::get(ty);
+  }
+
   cir::BoolAttr getCIRBoolAttr(bool state) {
     return cir::BoolAttr::get(getContext(), state);
   }

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -511,10 +511,13 @@ def CIR_MethodAttr : CIR_Attr<"Method", "method", [TypedAttrInterface]> {
     If the member function is a non-virtual function, the `symbol` parameter
     gives the global symbol for the non-virtual member function.
 
-    Virtual function handling is not yet implemented.
+    If the member function is a virtual function, the `vtable_offset` parameter
+    gives the offset of the vtable entry corresponding to the virtual member
+    function.
 
-    If `symbol` is not present, the attribute represents a null pointer
-    constant.
+    `symbol` and `vtable_offset` cannot be present at the same time. If both of
+    `symbol` and `vtable_offset` are not present, the attribute represents a
+    null pointer constant.
 
     Examples:
     ```
@@ -522,7 +525,7 @@ def CIR_MethodAttr : CIR_Attr<"Method", "method", [TypedAttrInterface]> {
     %0 = cir.const #cir.method<@_ZN1S2m1Ei> :
              !cir.method<!cir.func<(!s32i)> in !rec_S>
 
-    // Virtual method (not yet implemented)
+    // Virtual method
     %1 = cir.const #cir.method<vtable_offset = 8> :
              !cir.method<!cir.func<(!s32i)> in !rec_S>
 
@@ -534,23 +537,35 @@ def CIR_MethodAttr : CIR_Attr<"Method", "method", [TypedAttrInterface]> {
   let parameters = (ins AttributeSelfTypeParameter<
                             "", "cir::MethodType">:$type,
                         OptionalParameter<
-                            "std::optional<mlir::FlatSymbolRefAttr>">:$symbol);
+                            "std::optional<mlir::FlatSymbolRefAttr>">:$symbol,
+                        OptionalParameter<
+                            "std::optional<uint64_t>">:$vtable_offset);
 
   let builders = [
     AttrBuilderWithInferredContext<(ins "cir::MethodType":$type), [{
-      return $_get(type.getContext(), type, std::nullopt);
+      return $_get(type.getContext(), type, std::nullopt, std::nullopt);
     }]>,
     AttrBuilderWithInferredContext<(ins "cir::MethodType":$type,
                                         "mlir::FlatSymbolRefAttr":$symbol), [{
-      return $_get(type.getContext(), type, symbol);
+      return $_get(type.getContext(), type, symbol, std::nullopt);
+    }]>,
+    AttrBuilderWithInferredContext<(ins "cir::MethodType":$type,
+                                        "uint64_t":$vtable_offset), [{
+      return $_get(type.getContext(), type, std::nullopt, vtable_offset);
     }]>,
   ];
 
   let hasCustomAssemblyFormat = 1;
 
+  let genVerifyDecl = 1;
+
   let extraClassDeclaration = [{
     bool isNull() const {
-      return !getSymbol().has_value();
+      return !getSymbol().has_value() && !getVtableOffset().has_value();
+    }
+
+    bool isVirtual() const {
+      return getVtableOffset().has_value();
     }
   }];
 }

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -349,7 +349,6 @@ struct MissingFeatures {
   static bool useEHCleanupForArray() { return false; }
   static bool vaArgABILowering() { return false; }
   static bool vectorConstants() { return false; }
-  static bool virtualMethodAttr() { return false; }
   static bool vlas() { return false; }
   static bool vtableInitialization() { return false; }
   static bool vtableEmitMetadata() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -380,6 +380,10 @@ public:
     return cir::ConstantOp::create(*this, loc, getNullDataMemberAttr(ty));
   }
 
+  cir::ConstantOp getNullMethodPtr(cir::MethodType ty, mlir::Location loc) {
+    return cir::ConstantOp::create(*this, loc, getNullMethodAttr(ty));
+  }
+
   // TODO: split this to createFPExt/createFPTrunc when we have dedicated cast
   // operations.
   mlir::Value createFloatingCast(mlir::Value v, mlir::Type destType) {

--- a/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
@@ -61,6 +61,9 @@ public:
                                       cir::PointerType destCIRTy,
                                       bool isRefCast, Address src) = 0;
 
+  virtual cir::MethodAttr buildVirtualMethodAttr(cir::MethodType methodTy,
+                                                 const CXXMethodDecl *md) = 0;
+
 public:
   /// Similar to AddedStructorArgs, but only notes the number of additional
   /// arguments.

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2246,8 +2246,8 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
 
     const MemberPointerType *mpt = ce->getType()->getAs<MemberPointerType>();
     if (mpt->isMemberFunctionPointerType()) {
-      auto Ty = mlir::cast<cir::MethodType>(cgf.convertType(destTy));
-      return builder.getNullMethodPtr(Ty, cgf.getLoc(subExpr->getExprLoc()));
+      auto ty = mlir::cast<cir::MethodType>(cgf.convertType(destTy));
+      return builder.getNullMethodPtr(ty, cgf.getLoc(subExpr->getExprLoc()));
     }
 
     auto ty = mlir::cast<cir::DataMemberType>(cgf.convertType(destTy));

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2246,9 +2246,8 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
 
     const MemberPointerType *mpt = ce->getType()->getAs<MemberPointerType>();
     if (mpt->isMemberFunctionPointerType()) {
-      cgf.cgm.errorNYI(subExpr->getSourceRange(),
-                       "CK_NullToMemberPointer: member function pointer");
-      return {};
+      auto Ty = mlir::cast<cir::MethodType>(cgf.convertType(destTy));
+      return builder.getNullMethodPtr(Ty, cgf.getLoc(subExpr->getExprLoc()));
     }
 
     auto ty = mlir::cast<cir::DataMemberType>(cgf.convertType(destTy));

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1529,12 +1529,9 @@ mlir::Value CIRGenModule::emitMemberPointerConstant(const UnaryOperator *e) {
   // A member function pointer.
   if (const auto *methodDecl = dyn_cast<CXXMethodDecl>(decl)) {
     auto ty = mlir::cast<cir::MethodType>(convertType(e->getType()));
-    if (methodDecl->isVirtual()) {
-      assert(!cir::MissingFeatures::virtualMethodAttr());
-      errorNYI(e->getSourceRange(),
-               "emitMemberPointerConstant: virtual method pointer");
-      return {};
-    }
+    if (methodDecl->isVirtual())
+      return cir::ConstantOp::create(
+          builder, loc, getCXXABI().buildVirtualMethodAttr(ty, methodDecl));
 
     cir::FuncOp methodFuncOp = getAddrOfFunction(methodDecl);
     return cir::ConstantOp::create(builder, loc,

--- a/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-member-func.cpp
@@ -39,6 +39,60 @@ auto make_non_virtual() -> void (Foo::*)(int) {
 // OGCG: define {{.*}} { i64, i64 } @_Z16make_non_virtualv()
 // OGCG:   ret { i64, i64 } { i64 ptrtoint (ptr @_ZN3Foo2m1Ei to i64), i64 0 }
 
+auto make_virtual() -> void (Foo::*)(int) {
+  return &Foo::m3;
+}
+
+// CIR-BEFORE: cir.func {{.*}} @_Z12make_virtualv() -> !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CIR-BEFORE:   %[[RETVAL:.*]] = cir.alloca !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, ["__retval"]
+// CIR-BEFORE:   %[[METHOD_PTR:.*]] = cir.const #cir.method<vtable_offset = 8> : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CIR-BEFORE:   cir.store %[[METHOD_PTR]], %[[RETVAL]]
+// CIR-BEFORE:   %[[RET:.*]] = cir.load %[[RETVAL]] : !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CIR-BEFORE:   cir.return %[[RET]] : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+
+// CIR-AFTER: cir.func {{.*}} @_Z12make_virtualv() -> !rec_anon_struct
+// CIR-AFTER:   %[[RETVAL:.*]] = cir.alloca !rec_anon_struct, !cir.ptr<!rec_anon_struct>, ["__retval"]
+// CIR-AFTER:   %[[METHOD_PTR:.*]] = cir.const #cir.const_record<{#cir.int<9> : !s64i, #cir.int<0> : !s64i}> : !rec_anon_struct
+// CIR-AFTER:   cir.store %[[METHOD_PTR]], %[[RETVAL]]
+// CIR-AFTER:   %[[RET:.*]] = cir.load %[[RETVAL]]
+// CIR-AFTER:   cir.return %[[RET]] : !rec_anon_struct
+
+// LLVM: define {{.*}} @_Z12make_virtualv()
+// LLVM:   %[[RETVAL:.*]] = alloca { i64, i64 }
+// LLVM:   store { i64, i64 } { i64 9, i64 0 }, ptr %[[RETVAL]]
+// LLVM:   %[[RET:.*]] = load { i64, i64 }, ptr %[[RETVAL]]
+// LLVM:   ret { i64, i64 } %[[RET]]
+
+// OGCG: define {{.*}} @_Z12make_virtualv()
+// OGCG:   ret { i64, i64 } { i64 9, i64 0 }
+
+auto make_null() -> void (Foo::*)(int) {
+  return nullptr;
+}
+
+// CIR-BEFORE: cir.func {{.*}} @_Z9make_nullv() -> !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CIR-BEFORE:   %[[RETVAL:.*]] = cir.alloca !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, ["__retval"]
+// CIR-BEFORE:   %[[METHOD_PTR:.*]] = cir.const #cir.method<null> : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CIR-BEFORE:   cir.store %[[METHOD_PTR]], %[[RETVAL]]
+// CIR-BEFORE:   %[[RET:.*]] = cir.load %[[RETVAL]]
+// CIR-BEFORE:   cir.return %[[RET]] : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+
+// CIR-AFTER: cir.func {{.*}} @_Z9make_nullv() -> !rec_anon_struct
+// CIR-AFTER:   %[[RETVAL:.*]] = cir.alloca !rec_anon_struct, !cir.ptr<!rec_anon_struct>, ["__retval"]
+// CIR-AFTER:   %[[METHOD_PTR:.*]] = cir.const #cir.const_record<{#cir.int<0> : !s64i, #cir.int<0> : !s64i}> : !rec_anon_struct
+// CIR-AFTER:   cir.store %[[METHOD_PTR]], %[[RETVAL]]
+// CIR-AFTER:   %[[RET:.*]] = cir.load %[[RETVAL]]
+// CIR-AFTER:   cir.return %[[RET]] : !rec_anon_struct
+
+// LLVM: define {{.*}} @_Z9make_nullv()
+// LLVM:   %[[RETVAL:.*]] = alloca { i64, i64 }
+// LLVM:   store { i64, i64 } zeroinitializer, ptr %[[RETVAL]]
+// LLVM:   %[[RET:.*]] = load { i64, i64 }, ptr %[[RETVAL]]
+// LLVM:   ret { i64, i64 } %[[RET]]
+
+// OGCG: define {{.*}} @_Z9make_nullv()
+// OGCG:   ret { i64, i64 } zeroinitializer
+
 void call(Foo *obj, void (Foo::*func)(int), int arg) {
   (obj->*func)(arg);
 }

--- a/clang/test/CIR/IR/method-attr.cir
+++ b/clang/test/CIR/IR/method-attr.cir
@@ -22,6 +22,22 @@ module {
 // CHECK:    cir.return %2 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
 // CHECK:  }
 
+  cir.func no_inline dso_local @_Z12make_virtualv() -> !cir.method<!cir.func<(!s32i)> in !rec_Foo> {
+    %0 = cir.alloca !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, ["__retval"] {alignment = 8 : i64}
+    %1 = cir.const #cir.method<vtable_offset = 8> : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+    cir.store %1, %0 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>
+    %2 = cir.load %0 : !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+    cir.return %2 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+  }
+
+// CHECK:  cir.func no_inline dso_local @_Z12make_virtualv() -> !cir.method<!cir.func<(!s32i)> in !rec_Foo> {
+// CHECK:    %0 = cir.alloca !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, ["__retval"] {alignment = 8 : i64}
+// CHECK:    %1 = cir.const #cir.method<vtable_offset = 8> : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CHECK:    cir.store %1, %0 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>
+// CHECK:    %2 = cir.load %0 : !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CHECK:    cir.return %2 : !cir.method<!cir.func<(!s32i)> in !rec_Foo>
+// CHECK:  }
+
   cir.func no_inline dso_local @_Z9make_nullv() -> !cir.method<!cir.func<(!s32i)> in !rec_Foo> {
     %0 = cir.alloca !cir.method<!cir.func<(!s32i)> in !rec_Foo>, !cir.ptr<!cir.method<!cir.func<(!s32i)> in !rec_Foo>>, ["__retval"] {alignment = 8 : i64}
     %1 = cir.const #cir.method<null> : !cir.method<!cir.func<(!s32i)> in !rec_Foo>


### PR DESCRIPTION
This upstreams support for pointer-to-member value representations of null and virtual member pointers and the lowering of virtual member pointers.