### PR TITLE
[M68k][MC] Add support for the two remaining 68000 JSR addr modes

### DIFF
--- a/llvm/lib/Target/M68k/M68kInstrControl.td
+++ b/llvm/lib/Target/M68k/M68kInstrControl.td
@@ -293,6 +293,8 @@ class MxCall<MxOperand LOCOp, MxEncMemOp DST_ENC>
 
 def CALLk : MxCall<MxPCI32, MxEncAddrMode_k<"dst">>;
 def CALLq : MxCall<MxPCD32, MxEncAddrMode_q<"dst">>;
+def CALLf : MxCall<MxARII32, MxEncAddrMode_f<"dst">>;
+def CALLp : MxCall<MxARID32, MxEncAddrMode_p<"dst">>;
 def CALLb : MxCall<MxAL32,  MxEncAddrMode_abs<"dst", true>>;
 def CALLj : MxCall<MxARI32, MxEncAddrMode_j<"dst">>;
 

--- a/llvm/test/MC/M68k/Control/Classes/MxCALL.s
+++ b/llvm/test/MC/M68k/Control/Classes/MxCALL.s
@@ -33,3 +33,17 @@ jsr	(%a1)
 ; CHECK:      jsr  (%a2)
 ; CHECK-SAME: encoding: [0x4e,0x92]
 jsr	(%a2)
+
+; CHECK:      jsr  (0,%a0)
+; CHECK-SAME: encoding: [0x4e,0xa8,0x00,0x00]
+jsr	(0,%a0)
+; CHECK:      jsr  (-1,%a1)
+; CHECK-SAME: encoding: [0x4e,0xa9,0xff,0xff]
+jsr	(-1,%a1)
+
+; CHECK:      jsr  (0,%a0,%d0)
+; CHECK-SAME: encoding: [0x4e,0xb0,0x08,0x00]
+jsr	(0,%a0,%d0)
+; CHECK:      jsr  (-1,%sp,%sp)
+; CHECK-SAME: encoding: [0x4e,0xb7,0xf8,0xff]
+jsr	(-1,%sp,%sp)


### PR DESCRIPTION
These are (d16,An) and (d8,An,Xn).