### PR TITLE
[MC] Fix quadratic runtime within alignment boundary fragment relaxation

### DIFF
--- a/llvm/include/llvm/MC/MCAssembler.h
+++ b/llvm/include/llvm/MC/MCAssembler.h
@@ -102,6 +102,7 @@ private:
   /// (increased in size, in order to hold its value correctly).
   bool fixupNeedsRelaxation(const MCFragment &, const MCFixup &) const;
 
+  void layoutBoundaryAlign(MCBoundaryAlignFragment &BF);
   void layoutSection(MCSection &Sec);
   /// Perform one layout iteration and return the index of the first stable
   /// section for subsequent optimization.
@@ -111,7 +112,6 @@ private:
   bool relaxFragment(MCFragment &F);
   void relaxInstruction(MCFragment &F);
   void relaxLEB(MCFragment &F);
-  void relaxBoundaryAlign(MCBoundaryAlignFragment &BF);
   void relaxDwarfLineAddr(MCFragment &F);
   void relaxDwarfCallFrameFragment(MCFragment &F);
   void relaxSFrameFragment(MCFragment &DF);

--- a/llvm/test/MC/X86/align-branch-relax-blowup.s
+++ b/llvm/test/MC/X86/align-branch-relax-blowup.s
@@ -1,0 +1,28 @@
+// REQUIRES: asserts
+// Test that sections containing large amounts of branches with alignment
+// constraints do not cause quadratic relaxation blowup.
+
+// RUN: llvm-mc -filetype=obj -triple x86_64 --stats -o %t \
+// RUN:   --x86-align-branch-boundary=8 --x86-align-branch=call %s 2>&1 \
+// RUN: | FileCheck %s
+// CHECK: 1 assembler         - Number of assembler layout and relaxation steps
+
+// RUN: llvm-objdump -d --no-show-raw-insn %t \
+// RUN: | FileCheck %s --check-prefix=DISASM
+// DISASM:  0: callq
+// DISASM:  8: callq
+// DISASM: 10: callq
+// DISASM: 18: callq
+// DISASM: 20: callq
+// DISASM: 28: callq
+
+  .text
+foo:
+  callq bar
+  callq bar
+  callq bar
+  callq bar
+  .p2align 3
+  callq bar
+  callq bar
+  ret


### PR DESCRIPTION
Relaxing an alignment boundary fragment does not consider size changes of previous fragments. This means that in some cases the padding inside such a fragment can only be determined once all sections preceeding it have reached a fix-point. If a function contains many alignment boundary fragments, this can lead to quadratic runtime: in each iteration over the entire fragment list of a section, only the first alignment boundary fragment can be correctly relaxed. The next alignment boundary fragment requires recomputing the layout. By tracking the accumulated offset during relaxation, the alignment fragment can be relaxed correctly within the same iteration.

To test this, adjust the `RelaxationSteps` statistic to be incremented by the largest number of repeated iterations over a section within each relaxation. This brings it back closer to its previous implementation, where each invocation of `relaxOnce` would iterate over each seaction exactly once.