### PR TITLE
[NFC] Adding intrinsics_gen dependency to address emb_utils buildbot fixup

### DIFF
--- a/llvm/tools/llvm-ir2vec/utils/CMakeLists.txt
+++ b/llvm/tools/llvm-ir2vec/utils/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_llvm_library(emb_utils STATIC
   utils.cpp
 
+  DEPENDS
+  intrinsics_gen
+
   LINK_COMPONENTS
   Analysis
   CodeGen


### PR DESCRIPTION
Addressing build_bot failure https://lab.llvm.org/buildbot/#/builders/10/builds/20789