### PR TITLE
[TableGen] Remove temporary vector from FactorScope. NFC

### DIFF
--- a/llvm/utils/TableGen/DAGISelMatcher.h
+++ b/llvm/utils/TableGen/DAGISelMatcher.h
@@ -222,14 +222,7 @@ public:
     return Res;
   }
 
-  void setNumChildren(unsigned NC) {
-    if (NC < Children.size()) {
-      // delete any children we're about to lose pointers to.
-      for (unsigned i = NC, e = Children.size(); i != e; ++i)
-        delete Children[i];
-    }
-    Children.resize(NC);
-  }
+  SmallVectorImpl<Matcher *> &getChildren() { return Children; }
 
   static bool classof(const Matcher *N) { return N->getKind() == Scope; }
 

--- a/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
@@ -346,21 +346,24 @@ static void FactorNodes(std::unique_ptr<Matcher> &InputMatcherPtr);
 static void FactorScope(std::unique_ptr<Matcher> &MatcherPtr) {
   ScopeMatcher *Scope = cast<ScopeMatcher>(MatcherPtr.get());
 
-  // Okay, pull together the children of the scope node into a vector so we can
-  // inspect it more easily.
-  SmallVector<Matcher *, 32> OptionsToMatch;
+  SmallVectorImpl<Matcher *> &OptionsToMatch = Scope->getChildren();
 
-  for (unsigned i = 0, e = Scope->getNumChildren(); i != e; ++i) {
+  for (auto I = OptionsToMatch.begin(); I != OptionsToMatch.end();) {
+    // TODO: Store unique_ptr in ScopeMatcher.
     // Factor the subexpression.
-    std::unique_ptr<Matcher> Child(Scope->takeChild(i));
+    std::unique_ptr<Matcher> Child(*I);
     FactorNodes(Child);
 
     // If the child is a ScopeMatcher we can just merge its contents.
     if (auto *SM = dyn_cast<ScopeMatcher>(Child.get())) {
-      for (unsigned j = 0, e = SM->getNumChildren(); j != e; ++j)
-        OptionsToMatch.push_back(SM->takeChild(j));
+      SmallVectorImpl<Matcher *> &Children = SM->getChildren();
+      *I++ = *Children.begin();
+      I = OptionsToMatch.insert(I, Children.begin() + 1, Children.end());
+      I += Children.size() - 1;
+      Children.clear();
     } else {
-      OptionsToMatch.push_back(Child.release());
+      Child.release();
+      ++I;
     }
   }
 
@@ -487,7 +490,7 @@ static void FactorScope(std::unique_ptr<Matcher> &MatcherPtr) {
   // If we're down to a single pattern to match, then we don't need this scope
   // anymore.
   if (OptionsToMatch.size() == 1) {
-    MatcherPtr.reset(OptionsToMatch[0]);
+    MatcherPtr.reset(OptionsToMatch.pop_back_val());
     return;
   }
 
@@ -549,6 +552,7 @@ static void FactorScope(std::unique_ptr<Matcher> &MatcherPtr) {
       Cases.emplace_back(&COM->getOpcode(), COM->takeNext());
       delete COM;
     }
+    OptionsToMatch.clear();
 
     MatcherPtr.reset(new SwitchOpcodeMatcher(std::move(Cases)));
     return;
@@ -572,8 +576,7 @@ static void FactorScope(std::unique_ptr<Matcher> &MatcherPtr) {
         // If we have unfactored duplicate types, then we should factor them.
         Matcher *PrevMatcher = Cases[Entry - 1].second;
         if (ScopeMatcher *SM = dyn_cast<ScopeMatcher>(PrevMatcher)) {
-          SM->setNumChildren(SM->getNumChildren() + 1);
-          SM->resetChild(SM->getNumChildren() - 1, MatcherWithoutCTM);
+          SM->getChildren().push_back(MatcherWithoutCTM);
           continue;
         }
 
@@ -585,6 +588,7 @@ static void FactorScope(std::unique_ptr<Matcher> &MatcherPtr) {
       Entry = Cases.size() + 1;
       Cases.emplace_back(CTMTy, MatcherWithoutCTM);
     }
+    OptionsToMatch.clear();
 
     // Make sure we recursively factor any scopes we may have created.
     for (auto &M : Cases) {
@@ -605,11 +609,6 @@ static void FactorScope(std::unique_ptr<Matcher> &MatcherPtr) {
     }
     return;
   }
-
-  // Reassemble the Scope node with the adjusted children.
-  Scope->setNumChildren(OptionsToMatch.size());
-  for (unsigned i = 0, e = OptionsToMatch.size(); i != e; ++i)
-    Scope->resetChild(i, OptionsToMatch[i]);
 }
 
 /// Search a ScopeMatcher to factor with FactorScope.


### PR DESCRIPTION
Operate directly on the vector in the ScopeMatcher.