### PR TITLE
[clang][bytecode] Fix stack corruption in pointer arithmetic discard

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -1083,21 +1083,21 @@ bool Compiler<Emitter>::VisitPointerArithBinOp(const BinaryOperator *E) {
   if (Op == BO_Add) {
     if (!this->emitAddOffset(OffsetType, E))
       return false;
-
-    if (classifyPrim(E) != PT_Ptr)
-      return this->emitDecayPtr(PT_Ptr, classifyPrim(E), E);
-    return true;
-  }
-  if (Op == BO_Sub) {
+  } else if (Op == BO_Sub) {
     if (!this->emitSubOffset(OffsetType, E))
       return false;
-
-    if (classifyPrim(E) != PT_Ptr)
-      return this->emitDecayPtr(PT_Ptr, classifyPrim(E), E);
-    return true;
+  } else {
+    return false;
   }
 
-  return false;
+  if (classifyPrim(E) != PT_Ptr) {
+    if (!this->emitDecayPtr(PT_Ptr, classifyPrim(E), E))
+      return false;
+  }
+
+  if (DiscardResult)
+    return this->emitPop(classifyPrim(E), E);
+  return true;
 }
 
 template <class Emitter>

--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -1080,13 +1080,16 @@ bool Compiler<Emitter>::VisitPointerArithBinOp(const BinaryOperator *E) {
 
   // Do the operation and optionally transform to
   // result pointer type.
-  if (Op == BO_Add) {
+  switch (Op) {
+  case BO_Add:
     if (!this->emitAddOffset(OffsetType, E))
       return false;
-  } else if (Op == BO_Sub) {
+    break;
+  case BO_Sub:
     if (!this->emitSubOffset(OffsetType, E))
       return false;
-  } else {
+    break;
+  default:
     return false;
   }
 

--- a/clang/test/AST/ByteCode/gh176549.cpp
+++ b/clang/test/AST/ByteCode/gh176549.cpp
@@ -1,8 +1,7 @@
 // RUN: %clang_cc1 -fexperimental-new-constant-interpreter -verify %s
-// expected-no-diagnostics
 
 const char a[4] = "abc";
 void foo() {
   int i = 0;
-  i = 1 > (a + 1, sizeof(a));
+  i = 1 > (a + 1, sizeof(a)); // expected-warning {{left operand of comma operator has no effect}}
 }

--- a/clang/test/AST/ByteCode/gh176549.cpp
+++ b/clang/test/AST/ByteCode/gh176549.cpp
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -fexperimental-new-constant-interpreter -verify %s
+// expected-no-diagnostics
+
+const char a[4] = "abc";
+void foo() {
+  int i = 0;
+  i = 1 > (a + 1, sizeof(a));
+}


### PR DESCRIPTION
The bytecode compiler was ignoring the DiscardResult flag in 
VisitPointerArithBinOp
, causing pointer addition and subtraction results to persist on the stack when they should have been popped (e.g., in comma expressions). This led to stack corruption and assertion failures in subsequent operations that encountered an unexpected pointer on the stack.

This patch refactors the unified addition/subtraction logic to ensure the result is properly popped when DiscardResult is true.

Fixes #176549