### PR TITLE
[libc][CMake] Add dependency on ELF headers for elf_proxy target

### DIFF
--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -274,6 +274,7 @@ add_gen_header(
     elf_proxy.h
   DEPENDS
     libc.include.llvm_libc_common_h
+    libc.include.elf
   PROXY
 )
 

--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -274,7 +274,48 @@ add_gen_header(
     elf_proxy.h
   DEPENDS
     libc.include.llvm_libc_common_h
-    libc.include.elf
+    libc.include.llvm-libc-types.Elf32_Addr
+    libc.include.llvm-libc-types.Elf32_Chdr
+    libc.include.llvm-libc-types.Elf32_Dyn
+    libc.include.llvm-libc-types.Elf32_Ehdr
+    libc.include.llvm-libc-types.Elf32_Half
+    libc.include.llvm-libc-types.Elf32_Lword
+    libc.include.llvm-libc-types.Elf32_Nhdr
+    libc.include.llvm-libc-types.Elf32_Off
+    libc.include.llvm-libc-types.Elf32_Phdr
+    libc.include.llvm-libc-types.Elf32_Rel
+    libc.include.llvm-libc-types.Elf32_Rela
+    libc.include.llvm-libc-types.Elf32_Shdr
+    libc.include.llvm-libc-types.Elf32_Sword
+    libc.include.llvm-libc-types.Elf32_Sym
+    libc.include.llvm-libc-types.Elf32_Verdaux
+    libc.include.llvm-libc-types.Elf32_Verdef
+    libc.include.llvm-libc-types.Elf32_Vernaux
+    libc.include.llvm-libc-types.Elf32_Verneed
+    libc.include.llvm-libc-types.Elf32_Versym
+    libc.include.llvm-libc-types.Elf32_Word
+    libc.include.llvm-libc-types.Elf64_Addr
+    libc.include.llvm-libc-types.Elf64_Chdr
+    libc.include.llvm-libc-types.Elf64_Dyn
+    libc.include.llvm-libc-types.Elf64_Ehdr
+    libc.include.llvm-libc-types.Elf64_Half
+    libc.include.llvm-libc-types.Elf64_Lword
+    libc.include.llvm-libc-types.Elf64_Nhdr
+    libc.include.llvm-libc-types.Elf64_Off
+    libc.include.llvm-libc-types.Elf64_Phdr
+    libc.include.llvm-libc-types.Elf64_Rel
+    libc.include.llvm-libc-types.Elf64_Rela
+    libc.include.llvm-libc-types.Elf64_Shdr
+    libc.include.llvm-libc-types.Elf64_Sword
+    libc.include.llvm-libc-types.Elf64_Sxword
+    libc.include.llvm-libc-types.Elf64_Sym
+    libc.include.llvm-libc-types.Elf64_Verdaux
+    libc.include.llvm-libc-types.Elf64_Verdef
+    libc.include.llvm-libc-types.Elf64_Vernaux
+    libc.include.llvm-libc-types.Elf64_Verneed
+    libc.include.llvm-libc-types.Elf64_Versym
+    libc.include.llvm-libc-types.Elf64_Word
+    libc.include.llvm-libc-types.Elf64_Xword
   PROXY
 )
 


### PR DESCRIPTION
Fixes parallel build problem for check-libc target where headers are generated after they are needed.  I think this was likely caused by https://github.com/llvm/llvm-project/pull/172766.