### PR TITLE
[InferAlign] Eliminate trunc ptr to log2(align) pattern

### DIFF
--- a/llvm/lib/Transforms/Scalar/InferAlignment.cpp
+++ b/llvm/lib/Transforms/Scalar/InferAlignment.cpp
@@ -56,6 +56,13 @@ static bool tryToImproveAlign(
       return true;
     }
   }
+  if (match(I, m_Trunc(m_PtrToIntOrAddr(m_Value(PtrOp))))) {
+    Align ActualAlign = Fn(PtrOp, Align(1), Align(1));
+    if (Log2(ActualAlign) >= I->getType()->getScalarSizeInBits()) {
+      I->replaceAllUsesWith(Constant::getNullValue(I->getType()));
+      return true;
+    }
+  }
 
   IntrinsicInst *II = dyn_cast<IntrinsicInst>(I);
   if (!II)

--- a/llvm/test/Transforms/InferAlignment/ptrtoint.ll
+++ b/llvm/test/Transforms/InferAlignment/ptrtoint.ll
@@ -111,7 +111,7 @@ define i1 @trunc1_ptrtoint(ptr %ptr) {
 ; CHECK-NEXT:    [[LOAD:%.*]] = load i16, ptr [[PTR]], align 2
 ; CHECK-NEXT:    [[INT:%.*]] = ptrtoint ptr [[PTR]] to i64
 ; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[INT]] to i1
-; CHECK-NEXT:    ret i1 [[TRUNC]]
+; CHECK-NEXT:    ret i1 false
 ;
   %load = load i16, ptr %ptr, align 2
   %int = ptrtoint ptr %ptr to i64
@@ -139,7 +139,7 @@ define i4 @trunc4_ptrtoint(ptr %ptr) {
 ; CHECK-NEXT:    [[LOAD:%.*]] = load i32, ptr [[PTR]], align 16
 ; CHECK-NEXT:    [[INT:%.*]] = ptrtoint ptr [[PTR]] to i64
 ; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[INT]] to i4
-; CHECK-NEXT:    ret i4 [[TRUNC]]
+; CHECK-NEXT:    ret i4 0
 ;
   %load = load i32, ptr %ptr, align 16
   %int = ptrtoint ptr %ptr to i64
@@ -153,7 +153,7 @@ define i1 @trunc1_ptrtoaddr(ptr %ptr) {
 ; CHECK-NEXT:    [[LOAD:%.*]] = load i16, ptr [[PTR]], align 2
 ; CHECK-NEXT:    [[INT:%.*]] = ptrtoaddr ptr [[PTR]] to i64
 ; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[INT]] to i1
-; CHECK-NEXT:    ret i1 [[TRUNC]]
+; CHECK-NEXT:    ret i1 false
 ;
   %load = load i16, ptr %ptr, align 2
   %int = ptrtoaddr ptr %ptr to i64

--- a/llvm/test/Transforms/InferAlignment/ptrtoint.ll
+++ b/llvm/test/Transforms/InferAlignment/ptrtoint.ll
@@ -104,3 +104,59 @@ define i64 @not_redundant_mask(ptr %ptr) {
   %mask = and i64 %int, -5
   ret i64 %mask
 }
+
+define i1 @trunc1_ptrtoint(ptr %ptr) {
+; CHECK-LABEL: define i1 @trunc1_ptrtoint(
+; CHECK-SAME: ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[LOAD:%.*]] = load i16, ptr [[PTR]], align 2
+; CHECK-NEXT:    [[INT:%.*]] = ptrtoint ptr [[PTR]] to i64
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[INT]] to i1
+; CHECK-NEXT:    ret i1 [[TRUNC]]
+;
+  %load = load i16, ptr %ptr, align 2
+  %int = ptrtoint ptr %ptr to i64
+  %trunc = trunc i64 %int to i1
+  ret i1 %trunc
+}
+
+define i1 @neg_trunc1_ptrtoint(ptr %ptr) {
+; CHECK-LABEL: define i1 @neg_trunc1_ptrtoint(
+; CHECK-SAME: ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[LOAD:%.*]] = load i8, ptr [[PTR]], align 1
+; CHECK-NEXT:    [[INT:%.*]] = ptrtoint ptr [[PTR]] to i64
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[INT]] to i1
+; CHECK-NEXT:    ret i1 [[TRUNC]]
+;
+  %load = load i8, ptr %ptr, align 1
+  %int = ptrtoint ptr %ptr to i64
+  %trunc = trunc i64 %int to i1
+  ret i1 %trunc
+}
+
+define i4 @trunc4_ptrtoint(ptr %ptr) {
+; CHECK-LABEL: define i4 @trunc4_ptrtoint(
+; CHECK-SAME: ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[LOAD:%.*]] = load i32, ptr [[PTR]], align 16
+; CHECK-NEXT:    [[INT:%.*]] = ptrtoint ptr [[PTR]] to i64
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[INT]] to i4
+; CHECK-NEXT:    ret i4 [[TRUNC]]
+;
+  %load = load i32, ptr %ptr, align 16
+  %int = ptrtoint ptr %ptr to i64
+  %trunc = trunc i64 %int to i4
+  ret i4 %trunc
+}
+
+define i1 @trunc1_ptrtoaddr(ptr %ptr) {
+; CHECK-LABEL: define i1 @trunc1_ptrtoaddr(
+; CHECK-SAME: ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[LOAD:%.*]] = load i16, ptr [[PTR]], align 2
+; CHECK-NEXT:    [[INT:%.*]] = ptrtoaddr ptr [[PTR]] to i64
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i64 [[INT]] to i1
+; CHECK-NEXT:    ret i1 [[TRUNC]]
+;
+  %load = load i16, ptr %ptr, align 2
+  %int = ptrtoaddr ptr %ptr to i64
+  %trunc = trunc i64 %int to i1
+  ret i1 %trunc
+}


### PR DESCRIPTION
Fold trunc ptrtoint/ptrtoaddr to N -> 0 when all N bits are zero due to alignment.

To Avoid regression due to icmp_ne(and(x,1),0) -> trunc(x) fold https://github.com/llvm/llvm-project/issues/172888

Proof: https://alive2.llvm.org/ce/z/ZS-QJL