### PR TITLE
[clang-tidy] Fix modernize-use-using wrongly modifies typedef of parenthesized functions

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.cpp
@@ -140,10 +140,24 @@ void UseUsingCheck::check(const MatchFinder::MatchResult &Result) {
     // without the identifier.
     if (TypeRange.fullyContains(MatchedDecl->getLocation())) {
       FunctionPointerCase = true;
-      const auto RangeLeftOfIdentifier = CharSourceRange::getCharRange(
-          TypeRange.getBegin(), MatchedDecl->getLocation());
+      SourceLocation StartLoc = MatchedDecl->getLocation();
+      SourceLocation EndLoc = MatchedDecl->getLocation();
+
+      while (true) {
+        Token Prev = utils::lexer::getPreviousToken(StartLoc, SM, LO);
+        const std::optional<Token> Next =
+            utils::lexer::findNextTokenSkippingComments(EndLoc, SM, LO);
+        if (Prev.isNot(tok::l_paren) || !Next || Next->isNot(tok::r_paren))
+          break;
+
+        StartLoc = Prev.getLocation();
+        EndLoc = Next->getLocation();
+      }
+
+      const auto RangeLeftOfIdentifier =
+          CharSourceRange::getCharRange(TypeRange.getBegin(), StartLoc);
       const auto RangeRightOfIdentifier = CharSourceRange::getCharRange(
-          Lexer::getLocForEndOfToken(MatchedDecl->getLocation(), 0, SM, LO),
+          Lexer::getLocForEndOfToken(EndLoc, 0, SM, LO),
           Lexer::getLocForEndOfToken(TypeRange.getEnd(), 0, SM, LO));
       const std::string VerbatimType =
           (Lexer::getSourceText(RangeLeftOfIdentifier, SM, LO) +

--- a/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.cpp
@@ -144,7 +144,7 @@ void UseUsingCheck::check(const MatchFinder::MatchResult &Result) {
       SourceLocation EndLoc = MatchedDecl->getLocation();
 
       while (true) {
-        Token Prev = utils::lexer::getPreviousToken(StartLoc, SM, LO);
+        const Token Prev = utils::lexer::getPreviousToken(StartLoc, SM, LO);
         const std::optional<Token> Next =
             utils::lexer::findNextTokenSkippingComments(EndLoc, SM, LO);
         if (Prev.isNot(tok::l_paren) || !Next || Next->isNot(tok::r_paren))

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -109,6 +109,10 @@ Changes in existing checks
   - Added support for analyzing function parameters with the `AnalyzeParameters`
     option.
 
+- Improved :doc:`modernize-use-using
+  <clang-tidy/checks/modernize/use-using>` check by avoiding the generation
+  of invalid code for function types with redundant parentheses.
+
 - Improved :doc:`performance-move-const-arg
   <clang-tidy/checks/performance/move-const-arg>` check by avoiding false
   positives on trivially copyable types with a non-public copy constructor.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
@@ -344,7 +344,7 @@ typedef int InExternCPP;
 }
 
 namespace ISSUE_72179
-{  
+{
   void foo()
   {
     typedef int a;
@@ -460,4 +460,30 @@ namespace GH173732 {
   typedef char (&refArray)[2], (*ptrArray)[2];
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
   // CHECK-MESSAGES: :[[@LINE-2]]:29: warning: use 'using' instead of 'typedef' [modernize-use-using]
+}
+
+namespace GH176267 {
+  typedef int(f1)(double);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
+  // CHECK-FIXES: using f1 = int(double);
+
+  typedef int(f2)(double);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
+  // CHECK-FIXES: using f2 = int(double);
+
+  typedef int f3(double);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
+  // CHECK-FIXES: using f3 = int (double);
+
+  typedef int (*f4)(double);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
+  // CHECK-FIXES: using f4 = int (*)(double);
+
+  typedef int ((f5))(double);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
+  // CHECK-FIXES: using f5 = int (double);
+
+  typedef int ( /* comment */ f6 ) (double);
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use 'using' instead of 'typedef' [modernize-use-using]
+  // CHECK-FIXES: using f6 = int  (double);
 }


### PR DESCRIPTION
Closes [#176267](https://github.com/llvm/llvm-project/issues/176267)