### PR TITLE
[mlir][gpu] Enforce async keyword when parsing gpu.launch with results

### DIFF
--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -1048,8 +1048,13 @@ ParseResult LaunchOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.resolveOperands(asyncDependencies, asyncTokenType,
                              result.operands))
     return failure();
-  if (parser.getNumResults() > 0)
+  if (parser.getNumResults() > 0) {
+    if (!asyncTokenType)
+      return parser.emitError(
+          parser.getNameLoc(),
+          "gpu.launch requires 'async' keyword to return a value");
     result.types.push_back(asyncTokenType);
+  }
 
   bool hasCluster = false;
   if (succeeded(

--- a/mlir/test/Dialect/GPU/invalid.mlir
+++ b/mlir/test/Dialect/GPU/invalid.mlir
@@ -35,6 +35,17 @@ func.func @launch_requires_gpu_return(%sz : index) {
 
 // -----
 
+func.func @launch_result_no_async() {
+  %c1 = arith.constant 1 : index
+  // expected-error@+1 {{gpu.launch requires 'async' keyword to return a value}}
+  %0 = gpu.launch blocks(%bx, %by, %bz) in (%gx = %c1, %gy = %c1, %gz = %c1) threads(%tx, %ty, %tz) in (%lx = %c1, %ly = %c1, %lz = %c1) {
+    gpu.terminator
+  }
+  return
+}
+
+// -----
+
 func.func @launch_func_too_few_operands(%sz : index) {
   // expected-error@+1 {{expected 6 or more operands}}
   "gpu.launch_func"(%sz, %sz, %sz, %sz, %sz)


### PR DESCRIPTION
The `gpu.launch` parser attempts to add a null `asyncTokenType` to the results list if a result is requested but the `async` keyword is missing, leading to an assertion failure.

Explicitly verify that `asyncTokenType` is valid when `parser.getNumResults() > 0`. Emit a diagnostic error if the `async` keyword is missing instead of crashing.

Add a regression test to `mlir/test/Dialect/GPU/invalid.mlir`.

Fix: https://github.com/llvm/llvm-project/issues/176530