### PR TITLE
[bazel] Fix build failure caused by tools/llvm-ir2vec/*.h not found

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -6627,7 +6627,7 @@ cc_binary(
     testonly = True,
     srcs = glob([
         "tools/llvm-ir2vec/*.cpp",
-        "tools/llvm-ir2vec/*.h",
+        "tools/llvm-ir2vec/utils/*.h",
     ]),
     copts = llvm_copts,
     stamp = 0,


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/176572.

cc @nishant-sachdeva