### PR TITLE
[libc] Never consider an fd being 0 as an error when opening

### DIFF
--- a/libc/src/spawn/linux/posix_spawn.cpp
+++ b/libc/src/spawn/linux/posix_spawn.cpp
@@ -44,7 +44,7 @@ cpp::optional<int> open(const char *path, int oflags, mode_t mode) {
   int fd = LIBC_NAMESPACE::syscall_impl<int>(SYS_openat, AT_FDCWD, path, oflags,
                                              mode);
 #endif
-  if (fd > 0)
+  if (fd >= 0)
     return fd;
   // The open function is called as part of the child process' preparatory
   // steps. If an open fails, the child process just exits. So, unlike


### PR DESCRIPTION
This is not semantically correct, as we can get 0 when calling open.