### PR TITLE
[Utils][vim] Fix number highlighting for negative literals

### DIFF
--- a/llvm/utils/vim/syntax/llvm.vim
+++ b/llvm/utils/vim/syntax/llvm.vim
@@ -218,8 +218,8 @@ syn keyword llvmError  getresult begin end
 
 " Misc syntax.
 syn match   llvmNoName /[%@!]\d\+\>/
-syn match   llvmNumber /-\?\<\d\+\>/
-syn match   llvmFloat  /-\?\<\d\+\.\d*\(e[+-]\d\+\)\?\>/
+syn match   llvmNumber /\<-\?\zs\d\+\>/
+syn match   llvmFloat  /\<-\?\zs\d\+\.\d*\(e[+-]\d\+\)\?\>/
 syn match   llvmFloat  /\<\(u\|s\)\?0x[KLMHR]\?\x\+\>/
 syn keyword llvmBoolean true false
 syn keyword llvmConstant zeroinitializer undef null none poison vscale


### PR DESCRIPTION
The current regex for llvmNumber and llvmFloat cannot properly match negatives due to the placement of the word boundary. This change includes the `-` symbol in the word boundary and uses `\zs` to exclude it from highlighting.