### PR TITLE
[HWASAN] [RISC-V] Update EnableTaggingAbi for RISC-V linux.

### DIFF
--- a/compiler-rt/lib/hwasan/hwasan.h
+++ b/compiler-rt/lib/hwasan/hwasan.h
@@ -57,11 +57,18 @@ constexpr unsigned kTaggableRegionCheckShift =
 // Tags are done in upper bits using Intel LAM.
 constexpr unsigned kAddressTagShift = 57;
 constexpr unsigned kTagBits = 6;
-#else
+#elif defined(__aarch64__)
 // TBI (Top Byte Ignore) feature of AArch64: bits [63:56] are ignored in address
 // translation and can be used to store a tag.
 constexpr unsigned kAddressTagShift = 56;
 constexpr unsigned kTagBits = 8;
+#elif SANITIZER_RISCV64
+// Pointer Masking extension for RISC-V: Top PMLEN (16 or 7) bits are ignored in
+// address translation and can be used to store a tag.
+constexpr unsigned kAddressTagShift = 56;
+constexpr unsigned kTagBits = 8;
+#else
+#  error Architecture not supported
 #endif  // defined(HWASAN_ALIASING_MODE)
 
 // Mask for extracting tag bits from the lower 8 bits.


### PR DESCRIPTION
Enabling pointer tagging in the userspace ABI for RISC-V kernels differs to that of Aarch64. It requires requesting a particular number of masked pointer bits, an error is returned if the platform could not accommodate the request:
https://docs.kernel.org/arch/riscv/uabi.html#pointer-masking

While experimenting with enabling RISC-V HWASAN on GCC I was hitting the error

> HWAddressSanitizer failed to enable tagged address syscall ABI

when attempting to run instrumented programs in the spike simulator running kernel release 6.18. This patch successfully allows the tagged address syscall ABI to be enabled by the support runtime.
