### PR TITLE
[clang] Don't assert on perfect overload match with _Atomic

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -151,6 +151,7 @@ Miscellaneous Clang Crashes Fixed
 - Fixed a crash when attempting to jump over initialization of a variable with variably modified type. (#GH175540)
 - Fixed a crash when using loop hint with a value dependent argument inside a
   generic lambda. (#GH172289)
+- Fixed a crash in C++ overload resolution with ``_Atomic``-qualified argument types. (#GH170433)
 
 OpenACC Specific Changes
 ------------------------

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -444,7 +444,8 @@ class Sema;
           if (auto *N = T->getAs<MemberPointerType>();
               N && N->isMemberFunctionPointer())
             T = C.getDecayedType(N->getPointeeType());
-          return T;
+
+          return T.getAtomicUnqualifiedType();
         };
         // The types might differ if there is an array-to-pointer conversion
         // an function-to-pointer conversion, or lvalue-to-rvalue conversion.

--- a/clang/test/SemaCXX/crash-GH170433.cpp
+++ b/clang/test/SemaCXX/crash-GH170433.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -verify %s
+
+// https://github.com/llvm/llvm-project/issues/170433
+
+// expected-no-diagnostics
+
+void f(double);
+
+template <class = int>
+void f(double);
+
+_Atomic double atomic_value = 42.5;
+
+void test() {
+    f(atomic_value);
+}


### PR DESCRIPTION
An assertion incorrectly treated difference in _Atomic qualification as different types for the purpose of verifying a perfect match in overload resolution in C++.

Fixes #170433