### PR TITLE
[AArch64] Fix fmaxnm/fminnm SNAN handling

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -2522,7 +2522,12 @@ public:
       Action != TypeSplitVector;
   }
 
-  virtual bool isProfitableToCombineMinNumMaxNum(EVT VT) const { return true; }
+  virtual bool isProfitableToCombineMinNumMaxNum(EVT VT, SDValue LHS,
+                                                  SDValue RHS,
+                                                  const SDNodeFlags &Flags,
+                                                  SelectionDAG &DAG) const {
+    return true;
+  }
 
   /// Return true if a select of constants (select Cond, C1, C2) should be
   /// transformed into simple math ops with the condition value. For example:

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -12015,8 +12015,13 @@ static bool isLegalToCombineMinNumMaxNum(SelectionDAG &DAG, SDValue LHS,
   if (!VT.isFloatingPoint())
     return false;
 
-  return Flags.hasNoSignedZeros() &&
-         TLI.isProfitableToCombineMinNumMaxNum(VT) &&
+  const TargetOptions &Options = DAG.getTarget().Options;
+
+  // The target can decide whether to combine based on value types, operands,
+  // flags, and NaN analysis. This allows targets like Aarch64 to implement
+  // specific logic for handling NaN semantics of their min/max instructions.
+  return (Flags.hasNoSignedZeros() || Options.NoSignedZerosFPMath) &&
+         TLI.isProfitableToCombineMinNumMaxNum(VT, LHS, RHS, Flags, DAG) &&
          (Flags.hasNoNaNs() ||
           (DAG.isKnownNeverNaN(RHS) && DAG.isKnownNeverNaN(LHS)));
 }

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -220,6 +220,10 @@ public:
 
   bool isProfitableToHoist(Instruction *I) const override;
 
+  bool isProfitableToCombineMinNumMaxNum(EVT VT, SDValue LHS, SDValue RHS,
+                                          const SDNodeFlags &Flags,
+                                          SelectionDAG &DAG) const override;
+
   bool isZExtFree(Type *Ty1, Type *Ty2) const override;
   bool isZExtFree(EVT VT1, EVT VT2) const override;
   bool isZExtFree(SDValue Val, EVT VT2) const override;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -5515,9 +5515,10 @@ defm FADD   : TwoOperandFPData<0b0010, "fadd", any_fadd>;
 let SchedRW = [WriteFDiv] in {
 defm FDIV   : TwoOperandFPData<0b0001, "fdiv", any_fdiv>;
 }
-defm FMAXNM : TwoOperandFPData<0b0110, "fmaxnm", any_fmaxnum>;
+// No pattern - expanded to fcmp+select for SNAN correctness.
+defm FMAXNM : TwoOperandFPData<0b0110, "fmaxnm">;
 defm FMAX   : TwoOperandFPData<0b0100, "fmax", any_fmaximum>;
-defm FMINNM : TwoOperandFPData<0b0111, "fminnm", any_fminnum>;
+defm FMINNM : TwoOperandFPData<0b0111, "fminnm">;
 defm FMIN   : TwoOperandFPData<0b0101, "fmin", any_fminimum>;
 let SchedRW = [WriteFMul] in {
 defm FMUL   : TwoOperandFPData<0b0000, "fmul", any_fmul>;
@@ -5565,29 +5566,13 @@ def : Pat<(v1f64 (fmaximum (v1f64 FPR64:$Rn), (v1f64 FPR64:$Rm))),
           (FMAXDrr FPR64:$Rn, FPR64:$Rm)>;
 def : Pat<(v1f64 (fminimum (v1f64 FPR64:$Rn), (v1f64 FPR64:$Rm))),
           (FMINDrr FPR64:$Rn, FPR64:$Rm)>;
-def : Pat<(v1f64 (fmaxnum (v1f64 FPR64:$Rn), (v1f64 FPR64:$Rm))),
-          (FMAXNMDrr FPR64:$Rn, FPR64:$Rm)>;
-def : Pat<(v1f64 (fminnum (v1f64 FPR64:$Rn), (v1f64 FPR64:$Rm))),
-          (FMINNMDrr FPR64:$Rn, FPR64:$Rm)>;
 
-def : Pat<(fminnum_ieee (f64 FPR64:$a), (f64 FPR64:$b)),
-          (FMINNMDrr FPR64:$a, FPR64:$b)>;
-def : Pat<(fmaxnum_ieee (f64 FPR64:$a), (f64 FPR64:$b)),
-          (FMAXNMDrr FPR64:$a, FPR64:$b)>;
 def : Pat<(f64 (fcanonicalize f64:$a)),
           (FMINNMDrr   f64:$a, f64:$a)>;
-def : Pat<(fminnum_ieee (f32 FPR32:$a), (f32 FPR32:$b)),
-          (FMINNMSrr FPR32:$a, FPR32:$b)>;
-def : Pat<(fmaxnum_ieee (f32 FPR32:$a), (f32 FPR32:$b)),
-          (FMAXNMSrr FPR32:$a, FPR32:$b)>;
 def : Pat<(f32 (fcanonicalize f32:$a)),
           (FMINNMSrr   f32:$a, f32:$a)>;
 
 let Predicates = [HasFullFP16] in {
-def : Pat<(fminnum_ieee (f16 FPR16:$a), (f16 FPR16:$b)),
-          (FMINNMHrr FPR16:$a, FPR16:$b)>;
-def : Pat<(fmaxnum_ieee (f16 FPR16:$a), (f16 FPR16:$b)),
-          (FMAXNMHrr FPR16:$a, FPR16:$b)>;
 def : Pat<(f16 (fcanonicalize f16:$a)),
           (FMINNMHrr   f16:$a, f16:$a)>;
 }


### PR DESCRIPTION
Fix #176624

I’ve confirmed that this patch addresses the issue, but I’m very new to the LLVM project and I’m not at all confident that this is the correct fix. Please treat this patch only as a reference to help illustrate the issue in more detail.

If you’re willing to provide guidance on how it should be improved, I’d be more than happy to revise it accordingly.
