### PR TITLE
[X86][APX] Ignore the use of EFLAGS when ZU is enabled

### DIFF
--- a/llvm/lib/Target/X86/X86FixupSetCC.cpp
+++ b/llvm/lib/Target/X86/X86FixupSetCC.cpp
@@ -97,7 +97,8 @@ static bool fixupSetCC(MachineFunction &MF) {
       // it, itself, by definition, clobbers eflags. But it may happen that
       // FlagsDefMI also *uses* eflags, in which case the transformation is
       // invalid.
-      if (FlagsDefMI->readsRegister(X86::EFLAGS, /*TRI=*/nullptr))
+      if (!ST->hasZU() &&
+          FlagsDefMI->readsRegister(X86::EFLAGS, /*TRI=*/nullptr))
         continue;
 
       // On 32-bit, we need to be careful to force an ABCD register.

--- a/llvm/test/CodeGen/X86/apx/setzucc.ll
+++ b/llvm/test/CodeGen/X86/apx/setzucc.ll
@@ -109,3 +109,16 @@ bb1:
 bb2:
   ret i32 0
 }
+
+define i32 @def_use_eflag(i32 %a, i32 %b, i8 %c) {
+; CHECK-LABEL: def_use_eflag:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    addb $-1, %dl
+; CHECK-NEXT:    adcl %esi, %edi
+; CHECK-NEXT:    setzub %al
+; CHECK-NEXT:    retq
+  %1 = call { i8, i32 } @llvm.x86.addcarry.32(i8 %c, i32 %a, i32 %b)
+  %2 = extractvalue { i8, i32 } %1, 0
+  %3 = zext i8 %2 to i32
+  ret i32 %3
+}


### PR DESCRIPTION
Since we don't need to insert the XOR instruction.

Fixes redundant MOVXZ in https://godbolt.org/z/s9Kq6TPoW