### PR TITLE
Make BreakpointName::SetEnable() changes propagate to breakpoints

### DIFF
--- a/lldb/source/API/SBBreakpointName.cpp
+++ b/lldb/source/API/SBBreakpointName.cpp
@@ -213,6 +213,7 @@ void SBBreakpointName::SetEnabled(bool enable) {
         m_impl_up->GetTarget()->GetAPIMutex());
 
   bp_name->GetOptions().SetEnabled(enable);
+  UpdateName(*bp_name);
 }
 
 void SBBreakpointName::UpdateName(BreakpointName &bp_name) {


### PR DESCRIPTION
This commit adds a missing "UpdateName()" call to the `BreakpointName::SetEnabled` method, to make sure changes are synced.

I don't know if this was left out on purpose, if so, feel free to close this, though I think it should be documented in that case, that the this behavior does not act like the others.