### PR TITLE
[clang-format][doc] Add GNU style link in KeepFormFeed option

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -5012,13 +5012,11 @@ the configuration (without a prefix: ``Auto``).
 .. _KeepFormFeed:
 
 **KeepFormFeed** (``Boolean``) :versionbadge:`clang-format 20` :ref:`¶ <KeepFormFeed>`
-  Keep the form feed character (``\f``) if it's immediately preceded and
-  followed by a newline. Multiple form feeds and newlines within a
-  whitespace range are replaced with a single newline and form feed followed
-  by the remaining newlines. See
-  `GNU formfeed coding standard
-  <https://www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed>`_
-  for more information.
+  Keep the form feed character if it's immediately preceded and followed by
+  a newline. Multiple form feeds and newlines within a whitespace range are
+  replaced with a single newline and form feed followed by the remaining
+  newlines. (See
+  www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed.)
 
 .. _LambdaBodyIndentation:
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -5016,7 +5016,7 @@ the configuration (without a prefix: ``Auto``).
   followed by a newline. Multiple form feeds and newlines within a
   whitespace range are replaced with a single newline and form feed
   followed by the remaining newlines. See
-  `GNU coding standards <https://www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed>`_
+  `GNU formfeed coding standard <https://www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed>`_
   for more information.
 
 .. _LambdaBodyIndentation:

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -5012,10 +5012,18 @@ the configuration (without a prefix: ``Auto``).
 .. _KeepFormFeed:
 
 **KeepFormFeed** (``Boolean``) :versionbadge:`clang-format 20` :ref:`¶ <KeepFormFeed>`
-  Keep the form feed character if it's immediately preceded and followed by
-  a newline. Multiple form feeds and newlines within a whitespace range are
-  replaced with a single newline and form feed followed by the remaining
-  newlines.
+  Keep the form feed character (``\f``) if it's immediately preceded and
+  followed by a newline. Multiple form feeds and newlines within a
+  whitespace range are replaced with a single newline and form feed
+  followed by the remaining newlines.
+
+  .. code-block:: c++
+
+    false:          true:
+
+    "int i;\n"      "int i;\n"
+    "\n"            "\f\n"
+    "void f();"     "void f();"
 
 .. _LambdaBodyIndentation:
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -5018,7 +5018,7 @@ the configuration (without a prefix: ``Auto``).
   by the remaining newlines. See
   `GNU formfeed coding standard
   <https://www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed>`_
-   for more information.
+  for more information.
 
 .. _LambdaBodyIndentation:
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -5015,15 +5015,9 @@ the configuration (without a prefix: ``Auto``).
   Keep the form feed character (``\f``) if it's immediately preceded and
   followed by a newline. Multiple form feeds and newlines within a
   whitespace range are replaced with a single newline and form feed
-  followed by the remaining newlines.
-
-  .. code-block:: c++
-
-    false:          true:
-
-    "int i;\n"      "int i;\n"
-    "\n"            "\f\n"
-    "void f();"     "void f();"
+  followed by the remaining newlines. See
+  `GNU coding standards <https://www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed>`_
+  for more information.
 
 .. _LambdaBodyIndentation:
 

--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -5014,10 +5014,11 @@ the configuration (without a prefix: ``Auto``).
 **KeepFormFeed** (``Boolean``) :versionbadge:`clang-format 20` :ref:`¶ <KeepFormFeed>`
   Keep the form feed character (``\f``) if it's immediately preceded and
   followed by a newline. Multiple form feeds and newlines within a
-  whitespace range are replaced with a single newline and form feed
-  followed by the remaining newlines. See
-  `GNU formfeed coding standard <https://www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed>`_
-  for more information.
+  whitespace range are replaced with a single newline and form feed followed
+  by the remaining newlines. See
+  `GNU formfeed coding standard
+  <https://www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed>`_
+   for more information.
 
 .. _LambdaBodyIndentation:
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -3517,13 +3517,11 @@ struct FormatStyle {
   /// \version 3.7
   // bool KeepEmptyLinesAtTheStartOfBlocks;
 
-  /// Keep the form feed character (``\f``) if it's immediately preceded and
-  /// followed by a newline. Multiple form feeds and newlines within a
-  /// whitespace range are replaced with a single newline and form feed followed
-  /// by the remaining newlines. See
-  /// `GNU formfeed coding standard
-  /// <https://www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed>`_
-  /// for more information.
+  /// Keep the form feed character if it's immediately preceded and followed by
+  /// a newline. Multiple form feeds and newlines within a whitespace range are
+  /// replaced with a single newline and form feed followed by the remaining
+  /// newlines. (See
+  /// www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed.)
   /// \version 20
   bool KeepFormFeed;
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -3519,15 +3519,10 @@ struct FormatStyle {
 
   /// Keep the form feed character (``\f``) if it's immediately preceded and
   /// followed by a newline. Multiple form feeds and newlines within a
-  /// whitespace range are replaced with a single newline and form feed
-  /// followed by the remaining newlines.
-  /// \code
-  ///   false:          true:
-  ///
-  ///   "int i;\n"      "int i;\n"
-  ///   "\n"            "\f\n"
-  ///   "void f();"     "void f();"
-  /// \endcode
+  /// whitespace range are replaced with a single newline and form feed followed
+  /// by the remaining newlines. (See
+  /// https://www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed
+  /// for more information.)
   /// \version 20
   bool KeepFormFeed;
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -3517,10 +3517,17 @@ struct FormatStyle {
   /// \version 3.7
   // bool KeepEmptyLinesAtTheStartOfBlocks;
 
-  /// Keep the form feed character if it's immediately preceded and followed by
-  /// a newline. Multiple form feeds and newlines within a whitespace range are
-  /// replaced with a single newline and form feed followed by the remaining
-  /// newlines.
+  /// Keep the form feed character (``\f``) if it's immediately preceded and
+  /// followed by a newline. Multiple form feeds and newlines within a
+  /// whitespace range are replaced with a single newline and form feed
+  /// followed by the remaining newlines.
+  /// \code
+  ///   false:          true:
+  ///
+  ///   "int i;\n"      "int i;\n"
+  ///   "\n"            "\f\n"
+  ///   "void f();"     "void f();"
+  /// \endcode
   /// \version 20
   bool KeepFormFeed;
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -3523,7 +3523,7 @@ struct FormatStyle {
   /// by the remaining newlines. See
   /// `GNU formfeed coding standard
   /// <https://www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed>`_
-  ///  for more information.
+  /// for more information.
   /// \version 20
   bool KeepFormFeed;
 

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -3520,9 +3520,10 @@ struct FormatStyle {
   /// Keep the form feed character (``\f``) if it's immediately preceded and
   /// followed by a newline. Multiple form feeds and newlines within a
   /// whitespace range are replaced with a single newline and form feed followed
-  /// by the remaining newlines. (See
-  /// https://www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed
-  /// for more information.)
+  /// by the remaining newlines. See
+  /// `GNU formfeed coding standard
+  /// <https://www.gnu.org/prep/standards/html_node/Formatting.html#:~:text=formfeed>`_
+  ///  for more information.
   /// \version 20
   bool KeepFormFeed;
 


### PR DESCRIPTION
It was not clear from the description what this option does.
Added small example to demostrate its behavior.