### PR TITLE
[IR][NFC] Inline Value::getContext()

### DIFF
--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -256,7 +256,7 @@ public:
   Type *getType() const { return VTy; }
 
   /// All values hold a context through their type.
-  LLVM_ABI LLVMContext &getContext() const { return VTy->getContext(); }
+  LLVMContext &getContext() const { return VTy->getContext(); }
 
   // All values can potentially be named.
   bool hasName() const { return HasName; }

--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -17,6 +17,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
+#include "llvm/IR/Type.h"
 #include "llvm/IR/Use.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/CBindingWrapping.h"
@@ -50,7 +51,6 @@ class ModuleSlotTracker;
 class raw_ostream;
 template<typename ValueTy> class StringMapEntry;
 class Twine;
-class Type;
 class User;
 
 using ValueName = StringMapEntry<Value *>;
@@ -256,7 +256,7 @@ public:
   Type *getType() const { return VTy; }
 
   /// All values hold a context through their type.
-  LLVM_ABI LLVMContext &getContext() const;
+  LLVM_ABI LLVMContext &getContext() const { return VTy->getContext(); }
 
   // All values can potentially be named.
   bool hasName() const { return HasName; }

--- a/llvm/lib/IR/Value.cpp
+++ b/llvm/lib/IR/Value.cpp
@@ -1103,8 +1103,6 @@ const Value *Value::DoPHITranslation(const BasicBlock *CurBB,
   return this;
 }
 
-LLVMContext &Value::getContext() const { return VTy->getContext(); }
-
 void Value::reverseUseList() {
   if (!UseList || !UseList->Next)
     // No need to reverse 0 or 1 uses.

--- a/mlir/unittests/IR/RemarkTest.cpp
+++ b/mlir/unittests/IR/RemarkTest.cpp
@@ -23,7 +23,6 @@
 #include "gtest/gtest.h"
 #include <optional>
 
-using namespace llvm;
 using namespace mlir;
 using namespace testing;
 namespace {
@@ -35,9 +34,9 @@ TEST(Remark, TestOutputOptimizationRemark) {
   std::string categoryInliner("Inliner");
   std::string categoryReroller("Reroller");
   std::string myPassname1("myPass1");
-  SmallString<64> tmpPathStorage;
-  sys::fs::createUniquePath("remarks-%%%%%%.yaml", tmpPathStorage,
-                            /*MakeAbsolute=*/true);
+  llvm::SmallString<64> tmpPathStorage;
+  llvm::sys::fs::createUniquePath("remarks-%%%%%%.yaml", tmpPathStorage,
+                                  /*MakeAbsolute=*/true);
   std::string yamlFile =
       std::string(tmpPathStorage.data(), tmpPathStorage.size());
   ASSERT_FALSE(yamlFile.empty());
@@ -96,7 +95,7 @@ TEST(Remark, TestOutputOptimizationRemark) {
   }
 
   // Read the file
-  auto bufferOrErr = MemoryBuffer::getFile(yamlFile);
+  auto bufferOrErr = llvm::MemoryBuffer::getFile(yamlFile);
   ASSERT_TRUE(static_cast<bool>(bufferOrErr)) << "Failed to open remarks file";
   std::string content = bufferOrErr.get()->getBuffer().str();
 
@@ -154,8 +153,8 @@ TEST(Remark, TestNoOutputOptimizationRemark) {
   std::string categoryFailName("myImportantCategory");
   std::string myPassname1("myPass1");
   SmallString<64> tmpPathStorage;
-  sys::fs::createUniquePath("remarks-%%%%%%.yaml", tmpPathStorage,
-                            /*MakeAbsolute=*/true);
+  llvm::sys::fs::createUniquePath("remarks-%%%%%%.yaml", tmpPathStorage,
+                                  /*MakeAbsolute=*/true);
   std::string yamlFile =
       std::string(tmpPathStorage.data(), tmpPathStorage.size());
   ASSERT_FALSE(yamlFile.empty());
@@ -383,7 +382,7 @@ TEST(Remark, TestRemarkFinal) {
 TEST(Remark, TestArgWithAttribute) {
   MLIRContext context;
 
-  SmallVector<Attribute> elements;
+  llvm::SmallVector<Attribute> elements;
   elements.push_back(IntegerAttr::get(IntegerType::get(&context, 32), 1));
   elements.push_back(IntegerAttr::get(IntegerType::get(&context, 32), 2));
   elements.push_back(IntegerAttr::get(IntegerType::get(&context, 32), 3));


### PR DESCRIPTION
For non-LTO builds, this is a frequently called function consisting of just two instructions. Most files that include Value.h also include Type.h, so the added compile time cost is very low.

http://llvm-compile-time-tracker.com/compare.php?from=7b6751916cf74692df9c331ecdc731c42addafdf&to=65f91bbcba46afcec31554b1719b7b8c6bc2411c&stat=instructions:u