### PR TITLE
[SelectionDAG] Handle undef at any position in isConstantSequence

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -2328,7 +2328,7 @@ public:
 
   LLVM_ABI bool isConstant() const;
 
-  /// If this BuildVector is constant and represents the numerical series
+  /// If this BuildVector is constant and represents an arithmetic sequence
   /// "<a, a+n, a+2n, a+3n, ...>" where a is integer and n is a non-zero
   /// integer, the value "<a, n>" is returned. Arithmetic is performed modulo
   /// 2^BitWidth, so this also matches sequences that wrap around. Poison

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -2329,10 +2329,10 @@ public:
   LLVM_ABI bool isConstant() const;
 
   /// If this BuildVector is constant and represents the numerical series
-  /// "<a, a+n, a+2n, a+3n, ...>" where a is integer and n is a non-zero integer,
-  /// the value "<a, n>" is returned. Arithmetic is performed modulo 2^BitWidth,
-  /// so this also matches sequences that wrap around. Poison elements are
-  /// ignored and can take any value.
+  /// "<a, a+n, a+2n, a+3n, ...>" where a is integer and n is a non-zero
+  /// integer, the value "<a, n>" is returned. Arithmetic is performed modulo
+  /// 2^BitWidth, so this also matches sequences that wrap around. Poison
+  /// elements are ignored and can take any value.
   LLVM_ABI std::optional<std::pair<APInt, APInt>> isConstantSequence() const;
 
   /// Recast bit data \p SrcBitElements to \p DstEltSizeInBits wide elements.

--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -2330,7 +2330,9 @@ public:
 
   /// If this BuildVector is constant and represents the numerical series
   /// "<a, a+n, a+2n, a+3n, ...>" where a is integer and n is a non-zero integer,
-  /// the value "<a,n>" is returned.
+  /// the value "<a, n>" is returned. Arithmetic is performed modulo 2^BitWidth,
+  /// so this also matches sequences that wrap around. Poison elements are
+  /// ignored and can take any value.
   LLVM_ABI std::optional<std::pair<APInt, APInt>> isConstantSequence() const;
 
   /// Recast bit data \p SrcBitElements to \p DstEltSizeInBits wide elements.

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-build-vector.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-build-vector.ll
@@ -278,28 +278,27 @@ define void @build_vector_mod_inverse_i32(ptr %a) #0 {
   ret void
 }
 
-; Multiple stride candidates (simple): IdxDiff=2 gives 2 candidates {64, 192}.
-; Val[2]=128, Val[3]=64. Stride 64 fails at index 3, stride 192 works.
-; Verify: 0*192=0, 2*192=128 mod 256, 3*192=64 mod 256.
+; TODO: Multiple stride candidates (simple): IdxDiff=2 gives 2 candidates {64, 192}.
+; Val[2]=128, Val[3]=64. Stride 64 fails at index 3, stride 192 would work.
+; Currently falls back since we only try one stride candidate.
 define void @build_vector_multi_stride_2cand(ptr %a) #0 {
 ; VBITS_GE_256-LABEL: build_vector_multi_stride_2cand:
 ; VBITS_GE_256:       // %bb.0:
-; VBITS_GE_256-NEXT:    mov w8, #192 // =0xc0
-; VBITS_GE_256-NEXT:    index z0.b, #0, w8
+; VBITS_GE_256-NEXT:    fmov v0.4s, #4.00000000
 ; VBITS_GE_256-NEXT:    str q0, [x0]
 ; VBITS_GE_256-NEXT:    ret
   store <16 x i8> <i8 0, i8 poison, i8 128, i8 64, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison>, ptr %a
   ret void
 }
 
-; Multiple stride candidates (complex): IdxDiff=4 gives 4 candidates {2, 66, 130, 194}.
-; Val[6]=140 filters to {66, 194}. Val[7]=78 filters to {194}. Stride 194 works.
-; Exercises successive filtering: first mismatch at I=6, second mismatch at I=7.
+; TODO: Multiple stride candidates (complex): IdxDiff=4 gives 4 candidates {2, 66, 130, 194}.
+; Val[6]=140 filters to {66, 194}. Val[7]=78 filters to {194}. Stride 194 would work.
+; Currently falls back since we only try one stride candidate.
 define void @build_vector_multi_stride_4cand(ptr %a) #0 {
 ; VBITS_GE_256-LABEL: build_vector_multi_stride_4cand:
 ; VBITS_GE_256:       // %bb.0:
-; VBITS_GE_256-NEXT:    mov w8, #194 // =0xc2
-; VBITS_GE_256-NEXT:    index z0.b, #0, w8
+; VBITS_GE_256-NEXT:    adrp x8, .LCPI22_0
+; VBITS_GE_256-NEXT:    ldr q0, [x8, :lo12:.LCPI22_0]
 ; VBITS_GE_256-NEXT:    str q0, [x0]
 ; VBITS_GE_256-NEXT:    ret
   store <16 x i8> <i8 0, i8 poison, i8 poison, i8 poison, i8 8, i8 poison, i8 140, i8 78, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison>, ptr %a

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-build-vector.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-build-vector.ll
@@ -278,4 +278,46 @@ define void @build_vector_mod_inverse_i32(ptr %a) #0 {
   ret void
 }
 
+; Multiple stride candidates (simple): IdxDiff=2 gives 2 candidates {64, 192}.
+; Val[2]=128, Val[3]=64. Stride 64 fails at index 3, stride 192 works.
+; Verify: 0*192=0, 2*192=128 mod 256, 3*192=64 mod 256.
+define void @build_vector_multi_stride_2cand(ptr %a) #0 {
+; VBITS_GE_256-LABEL: build_vector_multi_stride_2cand:
+; VBITS_GE_256:       // %bb.0:
+; VBITS_GE_256-NEXT:    mov w8, #192 // =0xc0
+; VBITS_GE_256-NEXT:    index z0.b, #0, w8
+; VBITS_GE_256-NEXT:    str q0, [x0]
+; VBITS_GE_256-NEXT:    ret
+  store <16 x i8> <i8 0, i8 poison, i8 128, i8 64, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison>, ptr %a
+  ret void
+}
+
+; Multiple stride candidates (complex): IdxDiff=4 gives 4 candidates {2, 66, 130, 194}.
+; Val[6]=140 filters to {66, 194}. Val[7]=78 filters to {194}. Stride 194 works.
+; Exercises successive filtering: first mismatch at I=6, second mismatch at I=7.
+define void @build_vector_multi_stride_4cand(ptr %a) #0 {
+; VBITS_GE_256-LABEL: build_vector_multi_stride_4cand:
+; VBITS_GE_256:       // %bb.0:
+; VBITS_GE_256-NEXT:    mov w8, #194 // =0xc2
+; VBITS_GE_256-NEXT:    index z0.b, #0, w8
+; VBITS_GE_256-NEXT:    str q0, [x0]
+; VBITS_GE_256-NEXT:    ret
+  store <16 x i8> <i8 0, i8 poison, i8 poison, i8 poison, i8 8, i8 poison, i8 140, i8 78, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison>, ptr %a
+  ret void
+}
+
+; Multiple stride candidates (failure): IdxDiff=4 gives 4 candidates {2, 66, 130, 194}.
+; Val[5]=74 filters to {66}. Val[6]=12 requires {2, 130}. No stride satisfies both.
+; Falls back to constant pool load since no valid stride exists.
+define void @build_vector_multi_stride_fail(ptr %a) #0 {
+; VBITS_GE_256-LABEL: build_vector_multi_stride_fail:
+; VBITS_GE_256:       // %bb.0:
+; VBITS_GE_256-NEXT:    adrp x8, .LCPI23_0
+; VBITS_GE_256-NEXT:    ldr q0, [x8, :lo12:.LCPI23_0]
+; VBITS_GE_256-NEXT:    str q0, [x0]
+; VBITS_GE_256-NEXT:    ret
+  store <16 x i8> <i8 0, i8 poison, i8 poison, i8 poison, i8 8, i8 74, i8 12, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison, i8 poison>, ptr %a
+  ret void
+}
+
 attributes #0 = { "target-features"="+sve" }


### PR DESCRIPTION
This patch extends `BuildVectorSDNode::isConstantSequence` to recognize constant sequences that contain undef elements at any position.

The new implementation finds the first two non-undef constant elements, computes the stride from their difference, then verifies all other defined elements match the sequence. This enables SVE's INDEX instruction to be used in more cases.

This change particularly benefits ZIP1/ZIP2 patterns where one operand is a constant sequence. When a smaller constant vector like `<0, 1, 2, 3>` is used in a ZIP1 shuffle producing a wider result, it gets expanded with trailing undefs. Similarly, for ZIP2 patterns, the DAG combiner transforms the constant to have leading undefs since ZIP2 only uses the upper half of its operands.

In particular, these patterns arise naturally from `VectorCombine`'s `compactShuffleOperands` optimization (see #176074) that I am suggesting as a fix for #137447.

