### PR TITLE
[libc] Stop passing `--version` to compiler when detecting target

### DIFF
--- a/libc/cmake/modules/LLVMLibCArchitectures.cmake
+++ b/libc/cmake/modules/LLVMLibCArchitectures.cmake
@@ -78,7 +78,7 @@ function(get_arch_and_system_from_triple triple arch_var sys_var)
   set(${sys_var} ${target_sys} PARENT_SCOPE)
 endfunction(get_arch_and_system_from_triple)
 
-execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version -v
+execute_process(COMMAND ${CMAKE_CXX_COMPILER} -v
                 RESULT_VARIABLE libc_compiler_info_result
                 OUTPUT_VARIABLE libc_compiler_info
                 ERROR_VARIABLE libc_compiler_info)


### PR DESCRIPTION
This reverts c267501c155f9, and also adds a `-c` flag.

Both gcc and clang print the `Target:` line that we're trying to find just find with just `-v`.

When passing `--version`, gcc passes `--version` to the system linker, and when using gcc on macOS, the system linker does not understand `--version`. Since `--version` does not seem to be necessary, drop it.

Also, passing `-c` lets gcc not print linker details, so add that too, as a belt-and-suspenders fix.

---

Makes `cmake` succeed for me on my mac with `/Applications/CMake.app/Contents/bin/cmake ../llvm-project/llvm -G Ninja -DLLVM_ENABLE_PROJECTS="libc" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12` (with gcc-12 from homebrew).