### PR TITLE
[IR][Verifier] Reject GEP into vector with non-byte-addressable element type

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -81,6 +81,7 @@
 #include "llvm/IR/EHPersonalities.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/GCStrategy.h"
+#include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/GlobalAlias.h"
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/GlobalVariable.h"
@@ -4443,6 +4444,17 @@ void Verifier::visitGetElementPtrInst(GetElementPtrInst &GEP) {
       }
       Check(IndexTy->isIntOrIntVectorTy(),
             "All GEP indices should be of integer type");
+    }
+  }
+
+  // Check that GEP does not index into a vector with non-byte-addressable
+  // elements.
+  for (gep_type_iterator GTI = gep_type_begin(GEP), GTE = gep_type_end(GEP);
+       GTI != GTE; ++GTI) {
+    if (GTI.isVector()) {
+      Type *ElemTy = GTI.getIndexedType();
+      Check(DL.typeSizeEqualsStoreSize(ElemTy),
+            "GEP into vector with non-byte-addressable element type", &GEP);
     }
   }
 

--- a/llvm/test/Verifier/gep-vector-non-byte-element.ll
+++ b/llvm/test/Verifier/gep-vector-non-byte-element.ll
@@ -4,12 +4,6 @@
 ; This testcase is invalid because we are indexing into a vector
 ; with non-byte-addressable element type (i1).
 
-define <2 x i1> @test(<2 x i1> %a) {
-  %a.priv = alloca <2 x i1>, align 2
-  store <2 x i1> %a, ptr %a.priv, align 2
-  %a.priv.0.1 = getelementptr <2 x i1>, ptr %a.priv, i64 0, i64 1
-  store <2 x i1> %a, ptr %a.priv.0.1, align 2
-  ret <2 x i1> zeroinitializer
 define ptr @test(ptr %p) {
   %gep = getelementptr <2 x i1>, ptr %p, i64 0, i64 1
   ret ptr %gep

--- a/llvm/test/Verifier/gep-vector-non-byte-element.ll
+++ b/llvm/test/Verifier/gep-vector-non-byte-element.ll
@@ -1,0 +1,13 @@
+; RUN: not llvm-as < %s 2>&1 | FileCheck %s
+; CHECK: GEP into vector with non-byte-addressable element type
+
+; This testcase is invalid because we are indexing into a vector
+; with non-byte-addressable element type (i1).
+
+define <2 x i1> @test(<2 x i1> %a) {
+  %a.priv = alloca <2 x i1>, align 2
+  store <2 x i1> %a, ptr %a.priv, align 2
+  %a.priv.0.1 = getelementptr <2 x i1>, ptr %a.priv, i64 0, i64 1
+  store <2 x i1> %a, ptr %a.priv.0.1, align 2
+  ret <2 x i1> zeroinitializer
+}

--- a/llvm/test/Verifier/gep-vector-non-byte-element.ll
+++ b/llvm/test/Verifier/gep-vector-non-byte-element.ll
@@ -10,4 +10,7 @@ define <2 x i1> @test(<2 x i1> %a) {
   %a.priv.0.1 = getelementptr <2 x i1>, ptr %a.priv, i64 0, i64 1
   store <2 x i1> %a, ptr %a.priv.0.1, align 2
   ret <2 x i1> zeroinitializer
+define ptr @test(ptr %p) {
+  %gep = getelementptr <2 x i1>, ptr %p, i64 0, i64 1
+  ret ptr %gep
 }


### PR DESCRIPTION
Add a verifier check to reject GEP instructions that index into vectors with non-byte-addressable element types (e.g., <2 x i1>). Such GEPs cannot have their offset computed in bytes, causing assertions in passes like SROA that try to compute byte offsets.

Fixes #176628