### PR TITLE
[CodeGen][LSR][NPM] Make LoopStrengthReduce pass preserve LCSSA

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -7137,6 +7137,10 @@ PreservedAnalyses LoopStrengthReducePass::run(Loop &L, LoopAnalysisManager &AM,
                           AR.DT, AR.LI, AR.TTI, AR.AC, AR.TLI, AR.MSSA))
     return PreservedAnalyses::all();
 
+  // TODO: Remove this once the LSR handles LCSSA preservation completely.
+  if (auto *OuterLoop = L.getOutermostLoop())
+    formLCSSARecursively(*OuterLoop, AR.DT, &AR.LI, &AR.SE);
+
   auto PA = getLoopPassPreservedAnalyses();
   if (AR.MSSA)
     PA.preserve<MemorySSAAnalysis>();


### PR DESCRIPTION
New pass manager mandates every loop pass to preserve LCSSA form. LSR doesn't to do it completely although there is some effort to preserve LCSSA currently. Ideal situation would be that LSR handles this as part of the pass (I did try attempting it by basically toggling "preserveSSA" flags in SCEVExpander, however I saw several test case differences which didn't pass alive2 checks, hence am not really confident about the approach).  
Any comments on how to go about this are welcome. I would think we can go with this approach until we have a proper solution since this is a blocker enabling backend NPM .