### PR TITLE
[CodeGen][NPM] Add a target option to control machine verifier enablement at end of default pipelines

### DIFF
--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -596,9 +596,6 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::buildPipeline(
   if (auto Err = derived().addMachinePasses(PMW))
     return std::move(Err);
 
-  if (!Opt.DisableVerify)
-    addMachineFunctionPass(MachineVerifierPass(), PMW);
-
   if (PrintAsm) {
     derived().addAsmPrinter(
         PMW, [this, &Out, DwoOut, FileType](MCContext &Ctx) {

--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -596,6 +596,9 @@ Error CodeGenPassBuilder<Derived, TargetMachineT>::buildPipeline(
   if (auto Err = derived().addMachinePasses(PMW))
     return std::move(Err);
 
+  if (!Opt.DisableVerify && TM.Options.EnableDefaultMachineVerifier)
+    addMachineFunctionPass(MachineVerifierPass(), PMW);
+
   if (PrintAsm) {
     derived().addAsmPrinter(
         PMW, [this, &Out, DwoOut, FileType](MCContext &Ctx) {

--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -307,6 +307,9 @@ public:
   void setSupportsDebugEntryValues(bool Enable) {
     Options.SupportsDebugEntryValues = Enable;
   }
+  void setEnableDefaultMachineVerifier(bool Enable) {
+    Options.EnableDefaultMachineVerifier = Enable;
+  }
 
   void setCFIFixup(bool Enable) { Options.EnableCFIFixup = Enable; }
 

--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -133,11 +133,11 @@ public:
         EmitStackSizeSection(false), EnableMachineOutliner(false),
         EnableMachineFunctionSplitter(false),
         EnableStaticDataPartitioning(false), SupportsDefaultOutlining(false),
-        EmitAddrsig(false), BBAddrMap(false), EmitCallGraphSection(false),
-        EmitCallSiteInfo(false), SupportsDebugEntryValues(false),
-        EnableDebugEntryValues(false), ValueTrackingVariableLocations(false),
-        ForceDwarfFrameSection(false), XRayFunctionIndex(true),
-        DebugStrictDwarf(false), Hotpatch(false),
+        EnableDefaultMachineVerifier(true), EmitAddrsig(false),
+        BBAddrMap(false), EmitCallGraphSection(false), EmitCallSiteInfo(false),
+        SupportsDebugEntryValues(false), EnableDebugEntryValues(false),
+        ValueTrackingVariableLocations(false), ForceDwarfFrameSection(false),
+        XRayFunctionIndex(true), DebugStrictDwarf(false), Hotpatch(false),
         PPCGenScalarMASSEntries(false), JMCInstrument(false),
         EnableCFIFixup(false), MisExpect(false), XCOFFReadOnlyPointers(false),
         VerifyArgABICompliance(true) {}
@@ -285,6 +285,10 @@ public:
 
   /// Set if the target supports default outlining behaviour.
   unsigned SupportsDefaultOutlining : 1;
+
+  /// Enable Machine verifier at the end of default codegen pipelines. (Only
+  /// used with NPM)
+  unsigned EnableDefaultMachineVerifier : 1;
 
   /// Emit address-significance table.
   unsigned EmitAddrsig : 1;

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -1197,7 +1197,9 @@ GCNTargetMachine::GCNTargetMachine(const Target &T, const Triple &TT,
                                    std::optional<Reloc::Model> RM,
                                    std::optional<CodeModel::Model> CM,
                                    CodeGenOptLevel OL, bool JIT)
-    : AMDGPUTargetMachine(T, TT, CPU, FS, Options, RM, CM, OL) {}
+    : AMDGPUTargetMachine(T, TT, CPU, FS, Options, RM, CM, OL) {
+  setEnableDefaultMachineVerifier(false);
+}
 
 const TargetSubtargetInfo *
 GCNTargetMachine::getSubtargetImpl(const Function &F) const {

--- a/llvm/test/CodeGen/AMDGPU/llc-pipeline-npm.ll
+++ b/llvm/test/CodeGen/AMDGPU/llc-pipeline-npm.ll
@@ -91,8 +91,7 @@
 ; GCN-O0-NEXT: live-debug-values
 ; GCN-O0-NEXT: machine-sanmd
 ; GCN-O0-NEXT: amdgpu-preload-kern-arg-prolog
-; GCN-O0-NEXT: stack-frame-layout
-; GCN-O0-NEXT: verify)
+; GCN-O0-NEXT: stack-frame-layout)
 ; GCN-O0-NEXT: free-machine-function))
 
 ; GCN-O2: require<MachineModuleAnalysis>
@@ -263,8 +262,7 @@
 ; GCN-O2-NEXT: live-debug-values
 ; GCN-O2-NEXT: machine-sanmd
 ; GCN-O2-NEXT: amdgpu-preload-kern-arg-prolog
-; GCN-O2-NEXT: stack-frame-layout
-; GCN-O2-NEXT: verify)
+; GCN-O2-NEXT: stack-frame-layout)
 ; GCN-O2-NEXT: free-machine-function))
 
 ; GCN-O3: require<MachineModuleAnalysis>
@@ -435,8 +433,7 @@
 ; GCN-O3-NEXT: live-debug-values
 ; GCN-O3-NEXT: machine-sanmd
 ; GCN-O3-NEXT: amdgpu-preload-kern-arg-prolog
-; GCN-O3-NEXT: stack-frame-layout
-; GCN-O3-NEXT: verify)
+; GCN-O3-NEXT: stack-frame-layout)
 ; GCN-O3-NEXT: free-machine-function))
 
 define void @empty() {

--- a/llvm/test/CodeGen/X86/llc-pipeline-npm.ll
+++ b/llvm/test/CodeGen/X86/llc-pipeline-npm.ll
@@ -65,8 +65,7 @@
 ; O0-NEXT: stack-frame-layout
 ; O0-NEXT: x86-seses
 ; O0-NEXT: x86-return-thunks
-; O0-NEXT: x86-lvi-ret
-; O0-NEXT: verify)
+; O0-NEXT: x86-lvi-ret)
 ; O0-NEXT: free-machine-function)
 
 ; O2: require<MachineModuleAnalysis>
@@ -179,8 +178,7 @@
 ; O2-NEXT: stack-frame-layout
 ; O2-NEXT: x86-seses
 ; O2-NEXT: x86-return-thunks
-; O2-NEXT: x86-lvi-ret
-; O2-NEXT: verify)
+; O2-NEXT: x86-lvi-ret)
 ; O2-NEXT: free-machine-function)
 
 ; O0-WINDOWS: require<MachineModuleAnalysis>
@@ -242,8 +240,7 @@
 ; O0-WINDOWS-NEXT: x86-return-thunks
 ; O0-WINDOWS-NEXT: x86-avoid-trailing-call
 ; O0-WINDOWS-NEXT: x86-lvi-ret
-; O0-WINDOWS-NEXT: x86-wineh-unwindv2
-; O0-WINDOWS-NEXT: verify)
+; O0-WINDOWS-NEXT: x86-wineh-unwindv2)
 ; O0-WINDOWS-NEXT: free-machine-function)
 
 ; O3-WINDOWS: require<MachineModuleAnalysis>
@@ -359,6 +356,5 @@
 ; O3-WINDOWS-NEXT: x86-return-thunks
 ; O3-WINDOWS-NEXT: x86-avoid-trailing-call
 ; O3-WINDOWS-NEXT: x86-lvi-ret
-; O3-WINDOWS-NEXT: x86-wineh-unwindv2
-; O3-WINDOWS-NEXT: verify)
+; O3-WINDOWS-NEXT: x86-wineh-unwindv2)
 ; O3-WINDOWS-NEXT: free-machine-function)

--- a/llvm/test/CodeGen/X86/llc-pipeline-npm.ll
+++ b/llvm/test/CodeGen/X86/llc-pipeline-npm.ll
@@ -65,7 +65,8 @@
 ; O0-NEXT: stack-frame-layout
 ; O0-NEXT: x86-seses
 ; O0-NEXT: x86-return-thunks
-; O0-NEXT: x86-lvi-ret)
+; O0-NEXT: x86-lvi-ret
+; O0-NEXT: verify)
 ; O0-NEXT: free-machine-function)
 
 ; O2: require<MachineModuleAnalysis>
@@ -178,7 +179,8 @@
 ; O2-NEXT: stack-frame-layout
 ; O2-NEXT: x86-seses
 ; O2-NEXT: x86-return-thunks
-; O2-NEXT: x86-lvi-ret)
+; O2-NEXT: x86-lvi-ret
+; O2-NEXT: verify)
 ; O2-NEXT: free-machine-function)
 
 ; O0-WINDOWS: require<MachineModuleAnalysis>
@@ -240,7 +242,8 @@
 ; O0-WINDOWS-NEXT: x86-return-thunks
 ; O0-WINDOWS-NEXT: x86-avoid-trailing-call
 ; O0-WINDOWS-NEXT: x86-lvi-ret
-; O0-WINDOWS-NEXT: x86-wineh-unwindv2)
+; O0-WINDOWS-NEXT: x86-wineh-unwindv2
+; O0-WINDOWS-NEXT: verify)
 ; O0-WINDOWS-NEXT: free-machine-function)
 
 ; O3-WINDOWS: require<MachineModuleAnalysis>
@@ -356,5 +359,6 @@
 ; O3-WINDOWS-NEXT: x86-return-thunks
 ; O3-WINDOWS-NEXT: x86-avoid-trailing-call
 ; O3-WINDOWS-NEXT: x86-lvi-ret
-; O3-WINDOWS-NEXT: x86-wineh-unwindv2)
+; O3-WINDOWS-NEXT: x86-wineh-unwindv2
+; O3-WINDOWS-NEXT: verify)
 ; O3-WINDOWS-NEXT: free-machine-function)


### PR DESCRIPTION
Adds a target option that lets the targets decide if they are ready to enable machine verifier at end of default NPM pipelines