### PR TITLE
[FileCheck] Add %ProtectFileCheckOutput to backref-limit.txt test.

### DIFF
--- a/llvm/test/FileCheck/backref-limit.txt
+++ b/llvm/test/FileCheck/backref-limit.txt
@@ -1,4 +1,4 @@
-; RUN: not FileCheck -check-prefix=CHECK-BACKREF %s < /dev/null 2>&1 | FileCheck -check-prefix=ERR-CHECK-BACKREF %s
+; RUN: %ProtectFileCheckOutput not FileCheck -check-prefix=CHECK-BACKREF %s < /dev/null 2>&1 | FileCheck -check-prefix=ERR-CHECK-BACKREF %s
 
 ; ERR-CHECK-BACKREF: error: Can't back-reference more than 20 variables
 


### PR DESCRIPTION
This test passes locally and asserts as intended, but fails on BuildBot.