### PR TITLE
[CodeGen] Set pseudo probe desc comdat symbol to external for COFF

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -1924,8 +1924,11 @@ void TargetLoweringObjectFileCOFF::emitModuleMetadata(MCStreamer &Streamer,
     if (MCSymbol *Sym =
             static_cast<MCSectionCOFF *>(Streamer.getCurrentSectionOnly())
                 ->getCOMDATSymbol())
-      if (Sym->isUndefined())
+      if (Sym->isUndefined()) {
+        // COMDAT symbol must be external to perform deduplication.
+        Streamer.emitSymbolAttribute(Sym, MCSA_Global);
         Streamer.emitLabel(Sym);
+      }
   });
 }
 

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-emit-inline.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-emit-inline.ll
@@ -80,19 +80,22 @@ define dso_local i32 @entry() !dbg !14 {
 ; CHECK-ASM-ELF-NEXT: .byte	5
 ; CHECK-ASM-ELF-NEXT: .ascii "entry"
 ; CHECK-ASM-COFF:      .section	.pseudo_probe_desc,"drD",same_contents,.pseudo_probe_desc_foo2
+; CHECK-ASM-COFF-NEXT: .globl .pseudo_probe_desc_foo2
 ; CHECK-ASM-COFF-NEXT: .pseudo_probe_desc_foo2:
 ; CHECK-ASM-COFF-NEXT: .quad	[[#GUID1]]
 ; CHECK-ASM-COFF-NEXT: .quad	[[#HASH1:]]
 ; CHECK-ASM-COFF-NEXT: .byte	4
 ; CHECK-ASM-COFF-NEXT: .ascii	"foo2"
 ; CHECK-ASM-COFF-NEXT: .section	.pseudo_probe_desc,"drD",same_contents,.pseudo_probe_desc_foo
-; CHECK-ASM-COFF:      .pseudo_probe_desc_foo:
+; CHECK-ASM-COFF-NEXT: .globl .pseudo_probe_desc_foo
+; CHECK-ASM-COFF-NEXT: .pseudo_probe_desc_foo:
 ; CHECK-ASM-COFF-NEXT: .quad	[[#GUID2]]
 ; CHECK-ASM-COFF-NEXT: .quad	[[#HASH2:]]
 ; CHECK-ASM-COFF-NEXT: .byte	3
 ; CHECK-ASM-COFF-NEXT: .ascii	"foo"
 ; CHECK-ASM-COFF-NEXT: .section	.pseudo_probe_desc,"drD",same_contents,.pseudo_probe_desc_entry
-; CHECK-ASM-COFF:      .pseudo_probe_desc_entry:
+; CHECK-ASM-COFF-NEXT: .globl .pseudo_probe_desc_entry
+; CHECK-ASM-COFF-NEXT: .pseudo_probe_desc_entry:
 ; CHECK-ASM-COFF-NEXT: .quad	[[#GUID3]]
 ; CHECK-ASM-COFF-NEXT: .quad	[[#HASH3:]]
 ; CHECK-ASM-COFF-NEXT: .byte	5

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-emit.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-emit.ll
@@ -112,12 +112,14 @@ entry:
 ; CHECK-ASM-ELF-NEXT: .byte 4
 ; CHECK-ASM-ELF-NEXT: .ascii	"foo2"
 ; CHECK-ASM-COFF: .section	.pseudo_probe_desc,"drD",same_contents,.pseudo_probe_desc_foo
+; CHECK-ASM-COFF-NEXT: .globl .pseudo_probe_desc_foo
 ; CHECK-ASM-COFF-NEXT: .pseudo_probe_desc_foo:
 ; CHECK-ASM-COFF-NEXT: .quad	[[#GUID]]
 ; CHECK-ASM-COFF-NEXT: .quad	[[#HASH:]]
 ; CHECK-ASM-COFF-NEXT: .byte	3
 ; CHECK-ASM-COFF-NEXT: .ascii	"foo"
 ; CHECK-ASM-COFF-NEXT: .section	.pseudo_probe_desc,"drD",same_contents,.pseudo_probe_desc_foo2
+; CHECK-ASM-COFF-NEXT: .globl .pseudo_probe_desc_foo2
 ; CHECK-ASM-COFF-NEXT: .pseudo_probe_desc_foo2:
 ; CHECK-ASM-COFF-NEXT: .quad	[[#GUID2]]
 ; CHECK-ASM-COFF-NEXT: .quad	[[#HASH2:]]


### PR DESCRIPTION
lld-link performs COMDAT sections deduplication only when COMDAT symbol
is external.