### PR TITLE
[asan] Add readability guard for %s in printf interceptor

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_format.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_format.inc
@@ -551,15 +551,11 @@ static void printf_common(void *ctx, const char *format, va_list aq) {
       continue;
     } else if (size == FSS_STRLEN) {
       if (void *argp = va_arg(aq, void *)) {
-        // Skip strlen/strnlen checking if the first byte is not readable.
+        // Check whether the first byte of the %s argument is readable.
         if (!IsAccessibleMemoryRange((uptr)argp, 1)) {
-          static int ReportedOnce;
-          if (!ReportedOnce++)
-            Report(
-                "%s: WARNING: unreadable pointer %p for %%s format specifier "
-                "(reported once per process)\n",
-                SanitizerToolName, argp);
-          continue;
+          Report("%s: ERROR: unreadable pointer %p for %%s format specifier\n",
+                 SanitizerToolName, argp);
+          Die();
         }
         uptr len;
         if (dir.starredPrecision) {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_format.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_format.inc
@@ -551,6 +551,16 @@ static void printf_common(void *ctx, const char *format, va_list aq) {
       continue;
     } else if (size == FSS_STRLEN) {
       if (void *argp = va_arg(aq, void *)) {
+        // Skip strlen/strnlen checking if the first byte is not readable.
+        if (!IsAccessibleMemoryRange((uptr)argp, 1)) {
+          static int ReportedOnce;
+          if (!ReportedOnce++)
+            Report(
+                "%s: WARNING: unreadable pointer %p for %%s format specifier "
+                "(reported once per process)\n",
+                SanitizerToolName, argp);
+          continue;
+        }
         uptr len;
         if (dir.starredPrecision) {
           // FIXME: properly support starred precision for strings.


### PR DESCRIPTION
## Description
The printf interceptor may crash when checking %s arguments that point to unreadable memory. Add a minimal readability check for the first byte and skip the strlen/strnlen-based checking in that case, emitting a warning once per process.

This is a minimal guard and does not attempt to validate full string readability.

## Before
ASan crashes in the interceptor’s format-checking path (internal_strlen in printf_common).
```
Exit code 1
AddressSanitizer:DEADLYSIGNAL
=================================================================
==24312==ERROR: AddressSanitizer: SEGV on unknown address 0x00000000002a (pc 0x7f5a83644422 bp 0x7ffe0f9e4a40 sp 0x7ffe0f9e4168 T0)
==24312==The signal is caused by a READ memory access.
==24312==Hint: address points to the zero page.
    #0 0x7f5a83644422 in __sanitizer::internal_strlen(char const*) /home/rokuhatsuke/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_libc.cpp:176:13
    #1 0x7f5a837039a4 in printf_common(void*, char const*, __va_list_tag*) /home/rokuhatsuke/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors_format.inc:565:32
    #2 0x7f5a8373fffe in vsnprintf /home/rokuhatsuke/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:1739:1
    #3 0x7f5a8374257c in snprintf /home/rokuhatsuke/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:1812:1
    #4 0x5b95131a527e in main /home/rokuhatsuke/llvm-project/test_printf_fix.c:14:3
    #5 0x7f5a83343ca7 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #6 0x7f5a83343d64 in __libc_start_main csu/../csu/libc-start.c:360:3
    #7 0x5b95131a5080 in _start (/home/rokuhatsuke/llvm-project/test_before+0x1080)

==24312==Register values:
rax = 0x0000000000000000  rbx = 0x00005b95131a6069  rcx = 0x0000000000000000  rdx = 0x00007ffe0f9e5318  
rdi = 0x000000000000002a  rsi = 0x0000000000000073  rbp = 0x00007ffe0f9e4a40  rsp = 0x00007ffe0f9e4168  
 r8 = 0x00007ffe0f9e41f8   r9 = 0x00005b95131a606b  r10 = 0x0000000000000007  r11 = 0x00007f5a8373fed0  
r12 = 0x00007f5a837988c7  r13 = 0x000000000000002a  r14 = 0x00007ffe0f9e4a78  r15 = 0x00007ffe0f9e41d0  
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/rokuhatsuke/llvm-project/test_printf_fix.c:14:3 in main
==24312==ABORTING
```

## After
ASan emits a warning and avoids crashing in the interceptor. The program may still crash later in libc (expected for undefined behavior in the application), but the crash is no longer attributed to the interceptor itself.

```
Exit code 1
==76617==AddressSanitizer: WARNING: unreadable pointer 0x00000000002a for %s format specifier (reported once per process)
AddressSanitizer:DEADLYSIGNAL
=================================================================
==76617==ERROR: AddressSanitizer: SEGV on unknown address 0x00000000002a (pc 0x7e80da771119 bp 0x00000000002a sp 0x7ffebc8ba048 T0)
==76617==The signal is caused by a READ memory access.
==76617==Hint: address points to the zero page.
    #0 0x7e80da771119 in __strlen_avx2 string/../sysdeps/x86_64/multiarch/strlen-avx2.S:76
    #1 0x7e80da66e2ff in __printf_buffer stdio-common/vfprintf-process-arg.c:435:17
    #2 0x7e80da691e5d in __vsnprintf_internal libio/vsnprintf.c:96:3
    #3 0x7e80da691e5d in vsnprintf libio/vsnprintf.c:103:10
    #4 0x7e80da93ffd3 in vsnprintf /home/rokuhatsuke/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:1739:1
    #5 0x7e80da9425dc in snprintf /home/rokuhatsuke/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:1812:1
    #6 0x58f6e1a727de in main /home/rokuhatsuke/llvm-project/test_printf_fix.c:14:3
    #7 0x7e80da633ca7 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #8 0x7e80da633d64 in __libc_start_main csu/../csu/libc-start.c:360:3
    #9 0x58f6e1a711a0 in _start (/home/rokuhatsuke/llvm-project/test_printf_fix+0x11a0)

==76617==Register values:
rax = 0x000000000000002a  rbx = 0x00007ffebc8ba580  rcx = 0x0000000000000002  rdx = 0x000000000000002a  
rdi = 0x000000000000002a  rsi = 0x737373737373730a  rbp = 0x000000000000002a  rsp = 0x00007ffebc8ba048  
 r8 = 0x0000000000000073   r9 = 0x00000000ffffffff  r10 = 0x0000000000000000  r11 = 0x0000000000000000  
r12 = 0x0000000000000000  r13 = 0x0000000000000000  r14 = 0x00007ffebc8baed8  r15 = 0x000058f6e1a730ab  
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV string/../sysdeps/x86_64/multiarch/strlen-avx2.S:76 in __strlen_avx2
==76617==ABORTING
```