### PR TITLE
[mlir][Interfaces][NFC] Improve return type of `getTerminatorPredecessorOrNull`

### DIFF
--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
@@ -313,7 +313,7 @@ def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
             predecessorValues.push_back($_op.getEntrySuccessorOperands(successor)[index]);
             continue;
           }
-          auto terminator = cast<RegionBranchTerminatorOpInterface>(predecessor.getTerminatorPredecessorOrNull());
+          auto terminator = predecessor.getTerminatorPredecessorOrNull();
           predecessorValues.push_back(terminator.getSuccessorOperands(successor)[index]);
         }
       }]>,

--- a/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
@@ -639,8 +639,6 @@ void AbstractSparseBackwardDataFlowAnalysis::
     visitRegionSuccessorsFromTerminator(
         RegionBranchTerminatorOpInterface terminator,
         RegionBranchOpInterface branch) {
-  assert(isa<RegionBranchTerminatorOpInterface>(terminator) &&
-         "expected a `RegionBranchTerminatorOpInterface` op");
   assert(terminator->getParentOp() == branch.getOperation() &&
          "expected `branch` to be the parent op of `terminator`");
 

--- a/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
+++ b/mlir/lib/Interfaces/ControlFlowInterfaces.cpp
@@ -439,9 +439,7 @@ RegionBranchOpInterface::getSuccessorOperands(RegionBranchPoint src,
                                               RegionSuccessor dest) {
   if (src.isParent())
     return getEntrySuccessorOperands(dest);
-  auto terminator = cast<RegionBranchTerminatorOpInterface>(
-      src.getTerminatorPredecessorOrNull());
-  return terminator.getSuccessorOperands(dest);
+  return src.getTerminatorPredecessorOrNull().getSuccessorOperands(dest);
 }
 
 static MutableArrayRef<OpOperand> operandsToOpOperands(OperandRange &operands) {


### PR DESCRIPTION
The terminator is always a `RegionBranchTerminatorOpInterface` (or "null"). There is no other way to construct a `RegionBranchPoint`.

Note: `RegionBranchPoint::predecessor` is still a `Operation *` due to layering constraints. Storing a `RegionBranchTerminatorOpInterface` would require a full definition of `RegionBranchTerminatorOpInterface`, but `RegionBranchTerminatorOpInterface` cannot be defined before `RegionBranchPoint` because it has default interface implementations that construct a `RegionBranchPoint`.
