### PR TITLE
[RISCV][llvm] Correct code generation of fma on zvfbfa

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVSDPatterns.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVSDPatterns.td
@@ -1233,10 +1233,11 @@ foreach fvti = AllFloatAndBF16Vectors in {
   // NOTE: We choose VFMADD because it has the most commuting freedom. So it
   // works best with how TwoAddressInstructionPass tries commuting.
   defvar suffix = fvti.LMul.MX # "_E" # fvti.SEW;
+  defvar alt = !if(!eq(fvti.Scalar, bf16), "_ALT", "");
   let Predicates = GetVTypePredicates<fvti>.Predicates in {
     def : Pat<(fvti.Vector (any_fma fvti.RegClass:$rs1, fvti.RegClass:$rd,
                                     fvti.RegClass:$rs2)),
-              (!cast<Instruction>("PseudoVFMADD_VV_"# suffix)
+              (!cast<Instruction>("PseudoVFMADD" # alt # "_VV_"# suffix)
                    fvti.RegClass:$rd, fvti.RegClass:$rs1, fvti.RegClass:$rs2,
                    // Value to indicate no rounding mode change in
                    // RISCVInsertReadWriteCSR
@@ -1244,7 +1245,7 @@ foreach fvti = AllFloatAndBF16Vectors in {
                    fvti.AVL, fvti.Log2SEW, TAIL_AGNOSTIC)>;
     def : Pat<(fvti.Vector (any_fma fvti.RegClass:$rs1, fvti.RegClass:$rd,
                                     (fneg fvti.RegClass:$rs2))),
-              (!cast<Instruction>("PseudoVFMSUB_VV_"# suffix)
+              (!cast<Instruction>("PseudoVFMSUB" # alt # "_VV_"# suffix)
                    fvti.RegClass:$rd, fvti.RegClass:$rs1, fvti.RegClass:$rs2,
                    // Value to indicate no rounding mode change in
                    // RISCVInsertReadWriteCSR
@@ -1252,7 +1253,7 @@ foreach fvti = AllFloatAndBF16Vectors in {
                    fvti.AVL, fvti.Log2SEW, TAIL_AGNOSTIC)>;
     def : Pat<(fvti.Vector (any_fma (fneg fvti.RegClass:$rs1), fvti.RegClass:$rd,
                                     (fneg fvti.RegClass:$rs2))),
-              (!cast<Instruction>("PseudoVFNMADD_VV_"# suffix)
+              (!cast<Instruction>("PseudoVFNMADD" # alt # "_VV_"# suffix)
                    fvti.RegClass:$rd, fvti.RegClass:$rs1, fvti.RegClass:$rs2,
                    // Value to indicate no rounding mode change in
                    // RISCVInsertReadWriteCSR
@@ -1260,7 +1261,7 @@ foreach fvti = AllFloatAndBF16Vectors in {
                    fvti.AVL, fvti.Log2SEW, TAIL_AGNOSTIC)>;
     def : Pat<(fvti.Vector (any_fma (fneg fvti.RegClass:$rs1), fvti.RegClass:$rd,
                                     fvti.RegClass:$rs2)),
-              (!cast<Instruction>("PseudoVFNMSUB_VV_"# suffix)
+              (!cast<Instruction>("PseudoVFNMSUB" # alt # "_VV_"# suffix)
                    fvti.RegClass:$rd, fvti.RegClass:$rs1, fvti.RegClass:$rs2,
                    // Value to indicate no rounding mode change in
                    // RISCVInsertReadWriteCSR
@@ -1271,7 +1272,7 @@ foreach fvti = AllFloatAndBF16Vectors in {
     // commutable.
     def : Pat<(fvti.Vector (any_fma (SplatFPOp fvti.ScalarRegClass:$rs1),
                                     fvti.RegClass:$rd, fvti.RegClass:$rs2)),
-              (!cast<Instruction>("PseudoVFMADD_V" # fvti.ScalarSuffix # "_" # suffix)
+              (!cast<Instruction>("PseudoVFMADD" # alt # "_V" # fvti.ScalarSuffix # "_" # suffix)
                    fvti.RegClass:$rd, fvti.ScalarRegClass:$rs1, fvti.RegClass:$rs2,
                    // Value to indicate no rounding mode change in
                    // RISCVInsertReadWriteCSR
@@ -1279,7 +1280,7 @@ foreach fvti = AllFloatAndBF16Vectors in {
                    fvti.AVL, fvti.Log2SEW, TAIL_AGNOSTIC)>;
     def : Pat<(fvti.Vector (any_fma (SplatFPOp fvti.ScalarRegClass:$rs1),
                                     fvti.RegClass:$rd, (fneg fvti.RegClass:$rs2))),
-              (!cast<Instruction>("PseudoVFMSUB_V" # fvti.ScalarSuffix # "_" # suffix)
+              (!cast<Instruction>("PseudoVFMSUB" # alt # "_V" # fvti.ScalarSuffix # "_" # suffix)
                    fvti.RegClass:$rd, fvti.ScalarRegClass:$rs1, fvti.RegClass:$rs2,
                    // Value to indicate no rounding mode change in
                    // RISCVInsertReadWriteCSR
@@ -1288,7 +1289,7 @@ foreach fvti = AllFloatAndBF16Vectors in {
 
     def : Pat<(fvti.Vector (any_fma (SplatFPOp fvti.ScalarRegClass:$rs1),
                                     (fneg fvti.RegClass:$rd), (fneg fvti.RegClass:$rs2))),
-              (!cast<Instruction>("PseudoVFNMADD_V" # fvti.ScalarSuffix # "_" # suffix)
+              (!cast<Instruction>("PseudoVFNMADD" # alt # "_V" # fvti.ScalarSuffix # "_" # suffix)
                    fvti.RegClass:$rd, fvti.ScalarRegClass:$rs1, fvti.RegClass:$rs2,
                    // Value to indicate no rounding mode change in
                    // RISCVInsertReadWriteCSR
@@ -1296,7 +1297,7 @@ foreach fvti = AllFloatAndBF16Vectors in {
                    fvti.AVL, fvti.Log2SEW, TAIL_AGNOSTIC)>;
     def : Pat<(fvti.Vector (any_fma (SplatFPOp fvti.ScalarRegClass:$rs1),
                                     (fneg fvti.RegClass:$rd), fvti.RegClass:$rs2)),
-              (!cast<Instruction>("PseudoVFNMSUB_V" # fvti.ScalarSuffix # "_" # suffix)
+              (!cast<Instruction>("PseudoVFNMSUB" # alt # "_V" # fvti.ScalarSuffix # "_" # suffix)
                    fvti.RegClass:$rd, fvti.ScalarRegClass:$rs1, fvti.RegClass:$rs2,
                    // Value to indicate no rounding mode change in
                    // RISCVInsertReadWriteCSR
@@ -1306,7 +1307,7 @@ foreach fvti = AllFloatAndBF16Vectors in {
     // The splat might be negated.
     def : Pat<(fvti.Vector (any_fma (fneg (SplatFPOp fvti.ScalarRegClass:$rs1)),
                                     fvti.RegClass:$rd, (fneg fvti.RegClass:$rs2))),
-              (!cast<Instruction>("PseudoVFNMADD_V" # fvti.ScalarSuffix # "_" # suffix)
+              (!cast<Instruction>("PseudoVFNMADD" # alt # "_V" # fvti.ScalarSuffix # "_" # suffix)
                    fvti.RegClass:$rd, fvti.ScalarRegClass:$rs1, fvti.RegClass:$rs2,
                    // Value to indicate no rounding mode change in
                    // RISCVInsertReadWriteCSR
@@ -1314,7 +1315,7 @@ foreach fvti = AllFloatAndBF16Vectors in {
                    fvti.AVL, fvti.Log2SEW, TAIL_AGNOSTIC)>;
     def : Pat<(fvti.Vector (any_fma (fneg (SplatFPOp fvti.ScalarRegClass:$rs1)),
                                     fvti.RegClass:$rd, fvti.RegClass:$rs2)),
-              (!cast<Instruction>("PseudoVFNMSUB_V" # fvti.ScalarSuffix # "_" # suffix)
+              (!cast<Instruction>("PseudoVFNMSUB" # alt # "_V" # fvti.ScalarSuffix # "_" # suffix)
                    fvti.RegClass:$rd, fvti.ScalarRegClass:$rs1, fvti.RegClass:$rs2,
                    // Value to indicate no rounding mode change in
                    // RISCVInsertReadWriteCSR

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVVLPatterns.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVVLPatterns.td
@@ -1814,11 +1814,12 @@ multiclass VPatFPMulAddVL_VV_VF<SDPatternOperator vop, string instruction_name> 
 multiclass VPatFPMulAddVL_VV_VF_RM<SDPatternOperator vop, string instruction_name> {
   foreach vti = AllFloatAndBF16Vectors in {
   defvar suffix = vti.LMul.MX # "_E" # vti.SEW;
+  defvar alt = !if(!eq(vti.Scalar, bf16), "_ALT", "");
   let Predicates = GetVTypePredicates<vti>.Predicates in {
     def : Pat<(vti.Vector (vop vti.RegClass:$rs1, vti.RegClass:$rd,
                                vti.RegClass:$rs2, (vti.Mask VMV0:$vm),
                                VLOpFrag)),
-              (!cast<Instruction>(instruction_name#"_VV_"# suffix #"_MASK")
+              (!cast<Instruction>(instruction_name # alt # "_VV_"# suffix #"_MASK")
                    vti.RegClass:$rd, vti.RegClass:$rs1, vti.RegClass:$rs2,
                    (vti.Mask VMV0:$vm),
                    // Value to indicate no rounding mode change in
@@ -1830,7 +1831,7 @@ multiclass VPatFPMulAddVL_VV_VF_RM<SDPatternOperator vop, string instruction_nam
                                vti.RegClass:$rd, vti.RegClass:$rs2,
                                (vti.Mask VMV0:$vm),
                                VLOpFrag)),
-              (!cast<Instruction>(instruction_name#"_V" # vti.ScalarSuffix # "_" # suffix # "_MASK")
+              (!cast<Instruction>(instruction_name # alt # "_V" # vti.ScalarSuffix # "_" # suffix # "_MASK")
                    vti.RegClass:$rd, vti.ScalarRegClass:$rs1, vti.RegClass:$rs2,
                    (vti.Mask VMV0:$vm),
                    // Value to indicate no rounding mode change in

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfmadd-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfmadd-sdnode.ll
@@ -7,7 +7,7 @@
 define <1 x bfloat> @vfmadd_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x bfloat> %vc) {
 ; CHECK-LABEL: vfmadd_vv_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmadd.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %vd = call <1 x bfloat> @llvm.fma.v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x bfloat> %vc)
@@ -17,7 +17,7 @@ define <1 x bfloat> @vfmadd_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x b
 define <1 x bfloat> @vfmadd_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmadd_vf_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmadd.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <1 x bfloat> poison, bfloat %c, i32 0
@@ -29,7 +29,7 @@ define <1 x bfloat> @vfmadd_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloat
 define <2 x bfloat> @vfmadd_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x bfloat> %vc) {
 ; CHECK-LABEL: vfmadd_vv_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmadd.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %vd = call <2 x bfloat> @llvm.fma.v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x bfloat> %vc)
@@ -39,7 +39,7 @@ define <2 x bfloat> @vfmadd_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x b
 define <2 x bfloat> @vfmadd_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmadd_vf_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmadd.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <2 x bfloat> poison, bfloat %c, i32 0
@@ -51,7 +51,7 @@ define <2 x bfloat> @vfmadd_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloat
 define <4 x bfloat> @vfmadd_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x bfloat> %vc) {
 ; CHECK-LABEL: vfmadd_vv_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfmadd.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %vd = call <4 x bfloat> @llvm.fma.v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x bfloat> %vc)
@@ -61,7 +61,7 @@ define <4 x bfloat> @vfmadd_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x b
 define <4 x bfloat> @vfmadd_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmadd_vf_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfmadd.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <4 x bfloat> poison, bfloat %c, i32 0
@@ -73,7 +73,7 @@ define <4 x bfloat> @vfmadd_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloat
 define <8 x bfloat> @vfmadd_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x bfloat> %vc) {
 ; CHECK-LABEL: vfmadd_vv_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfmadd.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %vd = call <8 x bfloat> @llvm.fma.v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x bfloat> %vc)
@@ -83,7 +83,7 @@ define <8 x bfloat> @vfmadd_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x b
 define <8 x bfloat> @vfmadd_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmadd_vf_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfmadd.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <8 x bfloat> poison, bfloat %c, i32 0
@@ -95,7 +95,7 @@ define <8 x bfloat> @vfmadd_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloat
 define <16 x bfloat> @vfmadd_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <16 x bfloat> %vc) {
 ; CHECK-LABEL: vfmadd_vv_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfmadd.vv v8, v10, v12
 ; CHECK-NEXT:    ret
   %vd = call <16 x bfloat> @llvm.fma.v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <16 x bfloat> %vc)
@@ -105,7 +105,7 @@ define <16 x bfloat> @vfmadd_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <1
 define <16 x bfloat> @vfmadd_vf_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmadd_vf_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfmadd.vf v8, fa0, v10
 ; CHECK-NEXT:    ret
   %head = insertelement <16 x bfloat> poison, bfloat %c, i32 0
@@ -117,7 +117,7 @@ define <16 x bfloat> @vfmadd_vf_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, bf
 define <1 x bfloat> @vfmacc_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x bfloat> %vc) {
 ; CHECK-LABEL: vfmacc_vv_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmacc.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %vd = call <1 x bfloat> @llvm.fma.v1bf16(<1 x bfloat> %vb, <1 x bfloat> %vc, <1 x bfloat> %va)
@@ -127,7 +127,7 @@ define <1 x bfloat> @vfmacc_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x b
 define <1 x bfloat> @vfmacc_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmacc_vf_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmacc.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <1 x bfloat> poison, bfloat %c, i32 0
@@ -139,7 +139,7 @@ define <1 x bfloat> @vfmacc_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloat
 define <2 x bfloat> @vfmacc_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x bfloat> %vc) {
 ; CHECK-LABEL: vfmacc_vv_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmacc.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %vd = call <2 x bfloat> @llvm.fma.v2bf16(<2 x bfloat> %vb, <2 x bfloat> %vc, <2 x bfloat> %va)
@@ -149,7 +149,7 @@ define <2 x bfloat> @vfmacc_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x b
 define <2 x bfloat> @vfmacc_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmacc_vf_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmacc.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <2 x bfloat> poison, bfloat %c, i32 0
@@ -161,7 +161,7 @@ define <2 x bfloat> @vfmacc_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloat
 define <4 x bfloat> @vfmacc_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x bfloat> %vc) {
 ; CHECK-LABEL: vfmacc_vv_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfmacc.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %vd = call <4 x bfloat> @llvm.fma.v4bf16(<4 x bfloat> %vb, <4 x bfloat> %vc, <4 x bfloat> %va)
@@ -171,7 +171,7 @@ define <4 x bfloat> @vfmacc_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x b
 define <4 x bfloat> @vfmacc_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmacc_vf_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfmacc.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <4 x bfloat> poison, bfloat %c, i32 0
@@ -183,7 +183,7 @@ define <4 x bfloat> @vfmacc_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloat
 define <8 x bfloat> @vfmacc_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x bfloat> %vc) {
 ; CHECK-LABEL: vfmacc_vv_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfmacc.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %vd = call <8 x bfloat> @llvm.fma.v8bf16(<8 x bfloat> %vb, <8 x bfloat> %vc, <8 x bfloat> %va)
@@ -193,7 +193,7 @@ define <8 x bfloat> @vfmacc_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x b
 define <8 x bfloat> @vfmacc_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmacc_vf_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfmacc.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <8 x bfloat> poison, bfloat %c, i32 0
@@ -205,7 +205,7 @@ define <8 x bfloat> @vfmacc_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloat
 define <16 x bfloat> @vfmacc_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <16 x bfloat> %vc) {
 ; CHECK-LABEL: vfmacc_vv_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfmacc.vv v8, v12, v10
 ; CHECK-NEXT:    ret
   %vd = call <16 x bfloat> @llvm.fma.v16bf16(<16 x bfloat> %vb, <16 x bfloat> %vc, <16 x bfloat> %va)
@@ -215,7 +215,7 @@ define <16 x bfloat> @vfmacc_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <1
 define <16 x bfloat> @vfmacc_vf_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmacc_vf_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfmacc.vf v8, fa0, v10
 ; CHECK-NEXT:    ret
   %head = insertelement <16 x bfloat> poison, bfloat %c, i32 0

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfmsub-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfmsub-sdnode.ll
@@ -7,7 +7,7 @@
 define <1 x bfloat> @vfmsub_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x bfloat> %vc) {
 ; CHECK-LABEL: vfmsub_vv_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmsub.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <1 x bfloat> %vc
@@ -18,7 +18,7 @@ define <1 x bfloat> @vfmsub_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x b
 define <1 x bfloat> @vfmsub_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmsub_vf_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmsub.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <1 x bfloat> poison, bfloat %c, i32 0
@@ -31,7 +31,7 @@ define <1 x bfloat> @vfmsub_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloat
 define <2 x bfloat> @vfmsub_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x bfloat> %vc) {
 ; CHECK-LABEL: vfmsub_vv_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmsub.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <2 x bfloat> %vc
@@ -42,7 +42,7 @@ define <2 x bfloat> @vfmsub_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x b
 define <2 x bfloat> @vfmsub_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmsub_vf_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmsub.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <2 x bfloat> poison, bfloat %c, i32 0
@@ -55,7 +55,7 @@ define <2 x bfloat> @vfmsub_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloat
 define <4 x bfloat> @vfmsub_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x bfloat> %vc) {
 ; CHECK-LABEL: vfmsub_vv_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfmsub.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <4 x bfloat> %vc
@@ -66,7 +66,7 @@ define <4 x bfloat> @vfmsub_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x b
 define <4 x bfloat> @vfmsub_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmsub_vf_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfmsub.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <4 x bfloat> poison, bfloat %c, i32 0
@@ -79,7 +79,7 @@ define <4 x bfloat> @vfmsub_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloat
 define <8 x bfloat> @vfmsub_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x bfloat> %vc) {
 ; CHECK-LABEL: vfmsub_vv_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfmsub.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <8 x bfloat> %vc
@@ -90,7 +90,7 @@ define <8 x bfloat> @vfmsub_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x b
 define <8 x bfloat> @vfmsub_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmsub_vf_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfmsub.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <8 x bfloat> poison, bfloat %c, i32 0
@@ -103,7 +103,7 @@ define <8 x bfloat> @vfmsub_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloat
 define <16 x bfloat> @vfmsub_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <16 x bfloat> %vc) {
 ; CHECK-LABEL: vfmsub_vv_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfmsub.vv v8, v10, v12
 ; CHECK-NEXT:    ret
   %neg = fneg <16 x bfloat> %vc
@@ -114,7 +114,7 @@ define <16 x bfloat> @vfmsub_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <1
 define <16 x bfloat> @vfmsub_vf_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmsub_vf_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfmsub.vf v8, fa0, v10
 ; CHECK-NEXT:    ret
   %head = insertelement <16 x bfloat> poison, bfloat %c, i32 0
@@ -127,7 +127,7 @@ define <16 x bfloat> @vfmsub_vf_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, bf
 define <1 x bfloat> @vfmsac_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x bfloat> %vc) {
 ; CHECK-LABEL: vfmsac_vv_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmsac.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %neg = fneg <1 x bfloat> %va
@@ -138,7 +138,7 @@ define <1 x bfloat> @vfmsac_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x b
 define <1 x bfloat> @vfmsac_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmsac_vf_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmsac.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <1 x bfloat> poison, bfloat %c, i32 0
@@ -151,7 +151,7 @@ define <1 x bfloat> @vfmsac_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloat
 define <2 x bfloat> @vfmsac_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x bfloat> %vc) {
 ; CHECK-LABEL: vfmsac_vv_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmsac.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %neg = fneg <2 x bfloat> %va
@@ -162,7 +162,7 @@ define <2 x bfloat> @vfmsac_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x b
 define <2 x bfloat> @vfmsac_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmsac_vf_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfmsac.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <2 x bfloat> poison, bfloat %c, i32 0
@@ -175,7 +175,7 @@ define <2 x bfloat> @vfmsac_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloat
 define <4 x bfloat> @vfmsac_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x bfloat> %vc) {
 ; CHECK-LABEL: vfmsac_vv_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfmsac.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %neg = fneg <4 x bfloat> %va
@@ -186,7 +186,7 @@ define <4 x bfloat> @vfmsac_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x b
 define <4 x bfloat> @vfmsac_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmsac_vf_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfmsac.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <4 x bfloat> poison, bfloat %c, i32 0
@@ -199,7 +199,7 @@ define <4 x bfloat> @vfmsac_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloat
 define <8 x bfloat> @vfmsac_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x bfloat> %vc) {
 ; CHECK-LABEL: vfmsac_vv_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfmsac.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %neg = fneg <8 x bfloat> %va
@@ -210,7 +210,7 @@ define <8 x bfloat> @vfmsac_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x b
 define <8 x bfloat> @vfmsac_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmsac_vf_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfmsac.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <8 x bfloat> poison, bfloat %c, i32 0
@@ -223,7 +223,7 @@ define <8 x bfloat> @vfmsac_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloat
 define <16 x bfloat> @vfmsac_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <16 x bfloat> %vc) {
 ; CHECK-LABEL: vfmsac_vv_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfmsac.vv v8, v12, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <16 x bfloat> %va
@@ -234,7 +234,7 @@ define <16 x bfloat> @vfmsac_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <1
 define <16 x bfloat> @vfmsac_vf_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfmsac_vf_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfmsac.vf v8, fa0, v10
 ; CHECK-NEXT:    ret
   %head = insertelement <16 x bfloat> poison, bfloat %c, i32 0

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfnmadd-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfnmadd-sdnode.ll
@@ -7,7 +7,7 @@
 define <1 x bfloat> @vfnmadd_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmadd_vv_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmadd.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <1 x bfloat> %va
@@ -19,7 +19,7 @@ define <1 x bfloat> @vfnmadd_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x 
 define <1 x bfloat> @vfnmadd_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmadd_vf_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmadd.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <1 x bfloat> poison, bfloat %c, i32 0
@@ -33,7 +33,7 @@ define <1 x bfloat> @vfnmadd_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloa
 define <2 x bfloat> @vfnmadd_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmadd_vv_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmadd.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <2 x bfloat> %va
@@ -45,7 +45,7 @@ define <2 x bfloat> @vfnmadd_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x 
 define <2 x bfloat> @vfnmadd_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmadd_vf_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmadd.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <2 x bfloat> poison, bfloat %c, i32 0
@@ -59,7 +59,7 @@ define <2 x bfloat> @vfnmadd_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloa
 define <4 x bfloat> @vfnmadd_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmadd_vv_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfnmadd.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <4 x bfloat> %va
@@ -71,7 +71,7 @@ define <4 x bfloat> @vfnmadd_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x 
 define <4 x bfloat> @vfnmadd_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmadd_vf_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfnmadd.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <4 x bfloat> poison, bfloat %c, i32 0
@@ -85,7 +85,7 @@ define <4 x bfloat> @vfnmadd_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloa
 define <8 x bfloat> @vfnmadd_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmadd_vv_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfnmadd.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <8 x bfloat> %va
@@ -97,7 +97,7 @@ define <8 x bfloat> @vfnmadd_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x 
 define <8 x bfloat> @vfnmadd_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmadd_vf_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfnmadd.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <8 x bfloat> poison, bfloat %c, i32 0
@@ -111,7 +111,7 @@ define <8 x bfloat> @vfnmadd_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloa
 define <16 x bfloat> @vfnmadd_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <16 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmadd_vv_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfnmadd.vv v8, v10, v12
 ; CHECK-NEXT:    ret
   %neg = fneg <16 x bfloat> %va
@@ -123,7 +123,7 @@ define <16 x bfloat> @vfnmadd_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <
 define <16 x bfloat> @vfnmadd_vf_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmadd_vf_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfnmadd.vf v8, fa0, v10
 ; CHECK-NEXT:    ret
   %head = insertelement <16 x bfloat> poison, bfloat %c, i32 0
@@ -137,7 +137,7 @@ define <16 x bfloat> @vfnmadd_vf_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, b
 define <1 x bfloat> @vfnmacc_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmacc_vv_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmacc.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %neg = fneg <1 x bfloat> %vb
@@ -149,7 +149,7 @@ define <1 x bfloat> @vfnmacc_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x 
 define <1 x bfloat> @vfnmacc_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmacc_vf_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmacc.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <1 x bfloat> poison, bfloat %c, i32 0
@@ -163,7 +163,7 @@ define <1 x bfloat> @vfnmacc_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloa
 define <2 x bfloat> @vfnmacc_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmacc_vv_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmacc.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %neg = fneg <2 x bfloat> %vb
@@ -175,7 +175,7 @@ define <2 x bfloat> @vfnmacc_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x 
 define <2 x bfloat> @vfnmacc_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmacc_vf_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmacc.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <2 x bfloat> poison, bfloat %c, i32 0
@@ -189,7 +189,7 @@ define <2 x bfloat> @vfnmacc_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloa
 define <4 x bfloat> @vfnmacc_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmacc_vv_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfnmacc.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %neg = fneg <4 x bfloat> %vb
@@ -201,7 +201,7 @@ define <4 x bfloat> @vfnmacc_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x 
 define <4 x bfloat> @vfnmacc_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmacc_vf_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfnmacc.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <4 x bfloat> poison, bfloat %c, i32 0
@@ -215,7 +215,7 @@ define <4 x bfloat> @vfnmacc_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloa
 define <8 x bfloat> @vfnmacc_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmacc_vv_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfnmacc.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %neg = fneg <8 x bfloat> %vb
@@ -227,7 +227,7 @@ define <8 x bfloat> @vfnmacc_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x 
 define <8 x bfloat> @vfnmacc_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmacc_vf_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfnmacc.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <8 x bfloat> poison, bfloat %c, i32 0
@@ -241,7 +241,7 @@ define <8 x bfloat> @vfnmacc_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloa
 define <16 x bfloat> @vfnmacc_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <16 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmacc_vv_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfnmacc.vv v8, v12, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <16 x bfloat> %vb
@@ -253,7 +253,7 @@ define <16 x bfloat> @vfnmacc_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <
 define <16 x bfloat> @vfnmacc_vf_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmacc_vf_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfnmacc.vf v8, fa0, v10
 ; CHECK-NEXT:    ret
   %head = insertelement <16 x bfloat> poison, bfloat %c, i32 0

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfnmsub-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-vfnmsub-sdnode.ll
@@ -7,7 +7,7 @@
 define <1 x bfloat> @vfnmsub_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmsub_vv_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmsub.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <1 x bfloat> %va
@@ -18,7 +18,7 @@ define <1 x bfloat> @vfnmsub_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x 
 define <1 x bfloat> @vfnmsub_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmsub_vf_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmsub.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <1 x bfloat> poison, bfloat %c, i32 0
@@ -31,7 +31,7 @@ define <1 x bfloat> @vfnmsub_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloa
 define <2 x bfloat> @vfnmsub_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmsub_vv_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmsub.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <2 x bfloat> %va
@@ -42,7 +42,7 @@ define <2 x bfloat> @vfnmsub_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x 
 define <2 x bfloat> @vfnmsub_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmsub_vf_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmsub.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <2 x bfloat> poison, bfloat %c, i32 0
@@ -55,7 +55,7 @@ define <2 x bfloat> @vfnmsub_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloa
 define <4 x bfloat> @vfnmsub_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmsub_vv_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfnmsub.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <4 x bfloat> %va
@@ -66,7 +66,7 @@ define <4 x bfloat> @vfnmsub_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x 
 define <4 x bfloat> @vfnmsub_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmsub_vf_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfnmsub.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <4 x bfloat> poison, bfloat %c, i32 0
@@ -79,7 +79,7 @@ define <4 x bfloat> @vfnmsub_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloa
 define <8 x bfloat> @vfnmsub_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmsub_vv_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfnmsub.vv v8, v9, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <8 x bfloat> %va
@@ -90,7 +90,7 @@ define <8 x bfloat> @vfnmsub_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x 
 define <8 x bfloat> @vfnmsub_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmsub_vf_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfnmsub.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <8 x bfloat> poison, bfloat %c, i32 0
@@ -103,7 +103,7 @@ define <8 x bfloat> @vfnmsub_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloa
 define <16 x bfloat> @vfnmsub_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <16 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmsub_vv_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfnmsub.vv v8, v10, v12
 ; CHECK-NEXT:    ret
   %neg = fneg <16 x bfloat> %va
@@ -114,7 +114,7 @@ define <16 x bfloat> @vfnmsub_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <
 define <16 x bfloat> @vfnmsub_vf_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmsub_vf_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfnmsub.vf v8, fa0, v10
 ; CHECK-NEXT:    ret
   %head = insertelement <16 x bfloat> poison, bfloat %c, i32 0
@@ -127,7 +127,7 @@ define <16 x bfloat> @vfnmsub_vf_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, b
 define <1 x bfloat> @vfnmsac_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmsac_vv_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmsac.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %neg = fneg <1 x bfloat> %vb
@@ -138,7 +138,7 @@ define <1 x bfloat> @vfnmsac_vv_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, <1 x 
 define <1 x bfloat> @vfnmsac_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmsac_vf_v1bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmsac.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <1 x bfloat> poison, bfloat %c, i32 0
@@ -151,7 +151,7 @@ define <1 x bfloat> @vfnmsac_vf_v1bf16(<1 x bfloat> %va, <1 x bfloat> %vb, bfloa
 define <2 x bfloat> @vfnmsac_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmsac_vv_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmsac.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %neg = fneg <2 x bfloat> %vb
@@ -162,7 +162,7 @@ define <2 x bfloat> @vfnmsac_vv_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, <2 x 
 define <2 x bfloat> @vfnmsac_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmsac_vf_v2bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 2, e16, mf4, ta, ma
+; CHECK-NEXT:    vsetivli zero, 2, e16alt, mf4, ta, ma
 ; CHECK-NEXT:    vfnmsac.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <2 x bfloat> poison, bfloat %c, i32 0
@@ -175,7 +175,7 @@ define <2 x bfloat> @vfnmsac_vf_v2bf16(<2 x bfloat> %va, <2 x bfloat> %vb, bfloa
 define <4 x bfloat> @vfnmsac_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmsac_vv_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfnmsac.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %neg = fneg <4 x bfloat> %vb
@@ -186,7 +186,7 @@ define <4 x bfloat> @vfnmsac_vv_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, <4 x 
 define <4 x bfloat> @vfnmsac_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmsac_vf_v4bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 4, e16, mf2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 4, e16alt, mf2, ta, ma
 ; CHECK-NEXT:    vfnmsac.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <4 x bfloat> poison, bfloat %c, i32 0
@@ -199,7 +199,7 @@ define <4 x bfloat> @vfnmsac_vf_v4bf16(<4 x bfloat> %va, <4 x bfloat> %vb, bfloa
 define <8 x bfloat> @vfnmsac_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmsac_vv_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfnmsac.vv v8, v10, v9
 ; CHECK-NEXT:    ret
   %neg = fneg <8 x bfloat> %vb
@@ -210,7 +210,7 @@ define <8 x bfloat> @vfnmsac_vv_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, <8 x 
 define <8 x bfloat> @vfnmsac_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmsac_vf_v8bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 8, e16, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 8, e16alt, m1, ta, ma
 ; CHECK-NEXT:    vfnmsac.vf v8, fa0, v9
 ; CHECK-NEXT:    ret
   %head = insertelement <8 x bfloat> poison, bfloat %c, i32 0
@@ -223,7 +223,7 @@ define <8 x bfloat> @vfnmsac_vf_v8bf16(<8 x bfloat> %va, <8 x bfloat> %vb, bfloa
 define <16 x bfloat> @vfnmsac_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <16 x bfloat> %vc) {
 ; CHECK-LABEL: vfnmsac_vv_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfnmsac.vv v8, v12, v10
 ; CHECK-NEXT:    ret
   %neg = fneg <16 x bfloat> %vb
@@ -234,7 +234,7 @@ define <16 x bfloat> @vfnmsac_vv_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, <
 define <16 x bfloat> @vfnmsac_vf_v16bf16(<16 x bfloat> %va, <16 x bfloat> %vb, bfloat %c) {
 ; CHECK-LABEL: vfnmsac_vf_v16bf16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 16, e16, m2, ta, ma
+; CHECK-NEXT:    vsetivli zero, 16, e16alt, m2, ta, ma
 ; CHECK-NEXT:    vfnmsac.vf v8, fa0, v10
 ; CHECK-NEXT:    ret
   %head = insertelement <16 x bfloat> poison, bfloat %c, i32 0

--- a/llvm/test/CodeGen/RISCV/rvv/vfmadd-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vfmadd-sdnode.ll
@@ -34,7 +34,7 @@ define <vscale x 1 x bfloat> @vfmadd_vv_nxv1bf16(<vscale x 1 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmadd_vv_nxv1bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf4, ta, ma
 ; ZVFBFA-NEXT:    vfmadd.vv v8, v9, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -64,7 +64,7 @@ define <vscale x 1 x bfloat> @vfmadd_vv_nxv1bf16_commuted(<vscale x 1 x bfloat> 
 ;
 ; ZVFBFA-LABEL: vfmadd_vv_nxv1bf16_commuted:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf4, ta, ma
 ; ZVFBFA-NEXT:    vfmacc.vv v8, v10, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -94,7 +94,7 @@ define <vscale x 1 x bfloat> @vfmadd_vf_nxv1bf16(<vscale x 1 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmadd_vf_nxv1bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf4, ta, ma
 ; ZVFBFA-NEXT:    vfmadd.vf v8, fa0, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -126,7 +126,7 @@ define <vscale x 2 x bfloat> @vfmadd_vv_nxv2bf16(<vscale x 2 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmadd_vv_nxv2bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf2, ta, ma
 ; ZVFBFA-NEXT:    vfmadd.vv v8, v10, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -156,7 +156,7 @@ define <vscale x 2 x bfloat> @vfmadd_vf_nxv2bf16(<vscale x 2 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmadd_vf_nxv2bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf2, ta, ma
 ; ZVFBFA-NEXT:    vfmacc.vf v8, fa0, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -188,7 +188,7 @@ define <vscale x 4 x bfloat> @vfmadd_vv_nxv4bf16(<vscale x 4 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmadd_vv_nxv4bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m1, ta, ma
 ; ZVFBFA-NEXT:    vfmadd.vv v8, v9, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -218,7 +218,7 @@ define <vscale x 4 x bfloat> @vfmadd_vf_nxv4bf16(<vscale x 4 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmadd_vf_nxv4bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m1, ta, ma
 ; ZVFBFA-NEXT:    vfmadd.vf v8, fa0, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -250,7 +250,7 @@ define <vscale x 8 x bfloat> @vfmadd_vv_nxv8bf16(<vscale x 8 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmadd_vv_nxv8bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m2, ta, ma
 ; ZVFBFA-NEXT:    vfmacc.vv v8, v12, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -280,7 +280,7 @@ define <vscale x 8 x bfloat> @vfmadd_vf_nxv8bf16(<vscale x 8 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmadd_vf_nxv8bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m2, ta, ma
 ; ZVFBFA-NEXT:    vfmacc.vf v8, fa0, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -312,7 +312,7 @@ define <vscale x 16 x bfloat> @vfmadd_vv_nxv16bf16(<vscale x 16 x bfloat> %va, <
 ;
 ; ZVFBFA-LABEL: vfmadd_vv_nxv16bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m4, ta, ma
 ; ZVFBFA-NEXT:    vfmadd.vv v8, v16, v12
 ; ZVFBFA-NEXT:    ret
 ;
@@ -342,7 +342,7 @@ define <vscale x 16 x bfloat> @vfmadd_vf_nxv16bf16(<vscale x 16 x bfloat> %va, <
 ;
 ; ZVFBFA-LABEL: vfmadd_vf_nxv16bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m4, ta, ma
 ; ZVFBFA-NEXT:    vfmadd.vf v8, fa0, v12
 ; ZVFBFA-NEXT:    ret
 ;
@@ -448,7 +448,7 @@ define <vscale x 32 x bfloat> @vfmadd_vv_nxv32bf16(<vscale x 32 x bfloat> %va, <
 ; ZVFBFA-LABEL: vfmadd_vv_nxv32bf16:
 ; ZVFBFA:       # %bb.0:
 ; ZVFBFA-NEXT:    vl8re16.v v24, (a0)
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m8, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m8, ta, ma
 ; ZVFBFA-NEXT:    vfmacc.vv v8, v16, v24
 ; ZVFBFA-NEXT:    ret
 ;
@@ -574,7 +574,7 @@ define <vscale x 32 x bfloat> @vfmadd_vf_nxv32bf16(<vscale x 32 x bfloat> %va, <
 ;
 ; ZVFBFA-LABEL: vfmadd_vf_nxv32bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m8, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m8, ta, ma
 ; ZVFBFA-NEXT:    vfmacc.vf v8, fa0, v16
 ; ZVFBFA-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/RISCV/rvv/vfmsub-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vfmsub-sdnode.ll
@@ -36,7 +36,7 @@ define <vscale x 1 x bfloat> @vfmsub_vv_nxv1bf16(<vscale x 1 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmsub_vv_nxv1bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf4, ta, ma
 ; ZVFBFA-NEXT:    vfmsub.vv v8, v9, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -71,7 +71,7 @@ define <vscale x 1 x bfloat> @vfmsub_vf_nxv1bf16(<vscale x 1 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmsub_vf_nxv1bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf4, ta, ma
 ; ZVFBFA-NEXT:    vfmsub.vf v8, fa0, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -108,7 +108,7 @@ define <vscale x 2 x bfloat> @vfmsub_vv_nxv2bf16(<vscale x 2 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmsub_vv_nxv2bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf2, ta, ma
 ; ZVFBFA-NEXT:    vfmsub.vv v8, v10, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -143,7 +143,7 @@ define <vscale x 2 x bfloat> @vfmsub_vf_nxv2bf16(<vscale x 2 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmsub_vf_nxv2bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf2, ta, ma
 ; ZVFBFA-NEXT:    vfmsac.vf v8, fa0, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -180,7 +180,7 @@ define <vscale x 4 x bfloat> @vfmsub_vv_nxv4bf16(<vscale x 4 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmsub_vv_nxv4bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m1, ta, ma
 ; ZVFBFA-NEXT:    vfmsub.vv v8, v9, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -215,7 +215,7 @@ define <vscale x 4 x bfloat> @vfmsub_vf_nxv4bf16(<vscale x 4 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmsub_vf_nxv4bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m1, ta, ma
 ; ZVFBFA-NEXT:    vfmsub.vf v8, fa0, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -252,7 +252,7 @@ define <vscale x 8 x bfloat> @vfmsub_vv_nxv8bf16(<vscale x 8 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmsub_vv_nxv8bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m2, ta, ma
 ; ZVFBFA-NEXT:    vfmsac.vv v8, v12, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -287,7 +287,7 @@ define <vscale x 8 x bfloat> @vfmsub_vf_nxv8bf16(<vscale x 8 x bfloat> %va, <vsc
 ;
 ; ZVFBFA-LABEL: vfmsub_vf_nxv8bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m2, ta, ma
 ; ZVFBFA-NEXT:    vfmsac.vf v8, fa0, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -324,7 +324,7 @@ define <vscale x 16 x bfloat> @vfmsub_vv_nxv16bf16(<vscale x 16 x bfloat> %va, <
 ;
 ; ZVFBFA-LABEL: vfmsub_vv_nxv16bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m4, ta, ma
 ; ZVFBFA-NEXT:    vfmsub.vv v8, v16, v12
 ; ZVFBFA-NEXT:    ret
 ;
@@ -359,7 +359,7 @@ define <vscale x 16 x bfloat> @vfmsub_vf_nxv16bf16(<vscale x 16 x bfloat> %va, <
 ;
 ; ZVFBFA-LABEL: vfmsub_vf_nxv16bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m4, ta, ma
 ; ZVFBFA-NEXT:    vfmsub.vf v8, fa0, v12
 ; ZVFBFA-NEXT:    ret
 ;
@@ -458,7 +458,7 @@ define <vscale x 32 x bfloat> @vfmsub_vv_nxv32bf16(<vscale x 32 x bfloat> %va, <
 ; ZVFBFA-LABEL: vfmsub_vv_nxv32bf16:
 ; ZVFBFA:       # %bb.0:
 ; ZVFBFA-NEXT:    vl8re16.v v24, (a0)
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m8, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m8, ta, ma
 ; ZVFBFA-NEXT:    vfmsac.vv v8, v16, v24
 ; ZVFBFA-NEXT:    ret
 ;
@@ -580,7 +580,7 @@ define <vscale x 32 x bfloat> @vfmsub_vf_nxv32bf16(<vscale x 32 x bfloat> %va, <
 ;
 ; ZVFBFA-LABEL: vfmsub_vf_nxv32bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m8, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m8, ta, ma
 ; ZVFBFA-NEXT:    vfmsac.vf v8, fa0, v16
 ; ZVFBFA-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/RISCV/rvv/vfnmadd-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vfnmadd-sdnode.ll
@@ -33,7 +33,7 @@ define <vscale x 1 x bfloat> @vfnmsub_vv_nxv1bf16(<vscale x 1 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vv_nxv1bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf4, ta, ma
 ; ZVFBFA-NEXT:    vfnmadd.vv v8, v9, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -71,7 +71,7 @@ define <vscale x 1 x bfloat> @vfnmsub_vf_nxv1bf16(<vscale x 1 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vf_nxv1bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf4, ta, ma
 ; ZVFBFA-NEXT:    vfnmadd.vf v8, fa0, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -111,7 +111,7 @@ define <vscale x 2 x bfloat> @vfnmsub_vv_nxv2bf16(<vscale x 2 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vv_nxv2bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf2, ta, ma
 ; ZVFBFA-NEXT:    vfnmadd.vv v8, v10, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -149,7 +149,7 @@ define <vscale x 2 x bfloat> @vfnmsub_vf_nxv2bf16(<vscale x 2 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vf_nxv2bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf2, ta, ma
 ; ZVFBFA-NEXT:    vfnmadd.vf v8, fa0, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -189,7 +189,7 @@ define <vscale x 4 x bfloat> @vfnmsub_vv_nxv4bf16(<vscale x 4 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vv_nxv4bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m1, ta, ma
 ; ZVFBFA-NEXT:    vfnmadd.vv v8, v9, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -229,7 +229,7 @@ define <vscale x 4 x bfloat> @vfnmsub_vf_nxv4bf16(<vscale x 4 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vf_nxv4bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m1, ta, ma
 ; ZVFBFA-NEXT:    vfnmadd.vf v8, fa0, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -271,7 +271,7 @@ define <vscale x 8 x bfloat> @vfnmsub_vv_nxv8bf16(<vscale x 8 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vv_nxv8bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m2, ta, ma
 ; ZVFBFA-NEXT:    vfnmacc.vv v8, v12, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -311,7 +311,7 @@ define <vscale x 8 x bfloat> @vfnmsub_vf_nxv8bf16(<vscale x 8 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vf_nxv8bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m2, ta, ma
 ; ZVFBFA-NEXT:    vfnmacc.vf v8, fa0, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -353,7 +353,7 @@ define <vscale x 16 x bfloat> @vfnmsub_vv_nxv16bf16(<vscale x 16 x bfloat> %va, 
 ;
 ; ZVFBFA-LABEL: vfnmsub_vv_nxv16bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m4, ta, ma
 ; ZVFBFA-NEXT:    vfnmadd.vv v8, v16, v12
 ; ZVFBFA-NEXT:    ret
 ;
@@ -393,7 +393,7 @@ define <vscale x 16 x bfloat> @vfnmsub_vf_nxv16bf16(<vscale x 16 x bfloat> %va, 
 ;
 ; ZVFBFA-LABEL: vfnmsub_vf_nxv16bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m4, ta, ma
 ; ZVFBFA-NEXT:    vfnmadd.vf v8, fa0, v12
 ; ZVFBFA-NEXT:    ret
 ;
@@ -515,7 +515,7 @@ define <vscale x 32 x bfloat> @vfnmsub_vv_nxv32bf16(<vscale x 32 x bfloat> %va, 
 ; ZVFBFA-LABEL: vfnmsub_vv_nxv32bf16:
 ; ZVFBFA:       # %bb.0:
 ; ZVFBFA-NEXT:    vl8re16.v v24, (a0)
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m8, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m8, ta, ma
 ; ZVFBFA-NEXT:    vfnmadd.vv v8, v24, v16
 ; ZVFBFA-NEXT:    ret
 ;
@@ -640,7 +640,7 @@ define <vscale x 32 x bfloat> @vfnmsub_vf_nxv32bf16(<vscale x 32 x bfloat> %va, 
 ;
 ; ZVFBFA-LABEL: vfnmsub_vf_nxv32bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m8, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m8, ta, ma
 ; ZVFBFA-NEXT:    vfnmacc.vf v8, fa0, v16
 ; ZVFBFA-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/RISCV/rvv/vfnmsub-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vfnmsub-sdnode.ll
@@ -32,7 +32,7 @@ define <vscale x 1 x bfloat> @vfnmsub_vv_nxv1bf16(<vscale x 1 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vv_nxv1bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf4, ta, ma
 ; ZVFBFA-NEXT:    vfnmsub.vv v8, v9, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -67,7 +67,7 @@ define <vscale x 1 x bfloat> @vfnmsub_vf_nxv1bf16(<vscale x 1 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vf_nxv1bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf4, ta, ma
 ; ZVFBFA-NEXT:    vfnmsub.vf v8, fa0, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -104,7 +104,7 @@ define <vscale x 2 x bfloat> @vfnmsub_vv_nxv2bf16(<vscale x 2 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vv_nxv2bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf2, ta, ma
 ; ZVFBFA-NEXT:    vfnmsub.vv v8, v10, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -139,7 +139,7 @@ define <vscale x 2 x bfloat> @vfnmsub_vf_nxv2bf16(<vscale x 2 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vf_nxv2bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, mf2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, mf2, ta, ma
 ; ZVFBFA-NEXT:    vfnmsub.vf v8, fa0, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -176,7 +176,7 @@ define <vscale x 4 x bfloat> @vfnmsub_vv_nxv4bf16(<vscale x 4 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vv_nxv4bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m1, ta, ma
 ; ZVFBFA-NEXT:    vfnmsub.vv v8, v9, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -213,7 +213,7 @@ define <vscale x 4 x bfloat> @vfnmsub_vf_nxv4bf16(<vscale x 4 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vf_nxv4bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m1, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m1, ta, ma
 ; ZVFBFA-NEXT:    vfnmsub.vf v8, fa0, v9
 ; ZVFBFA-NEXT:    ret
 ;
@@ -252,7 +252,7 @@ define <vscale x 8 x bfloat> @vfnmsub_vv_nxv8bf16(<vscale x 8 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vv_nxv8bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m2, ta, ma
 ; ZVFBFA-NEXT:    vfnmsac.vv v8, v12, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -289,7 +289,7 @@ define <vscale x 8 x bfloat> @vfnmsub_vf_nxv8bf16(<vscale x 8 x bfloat> %va, <vs
 ;
 ; ZVFBFA-LABEL: vfnmsub_vf_nxv8bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m2, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m2, ta, ma
 ; ZVFBFA-NEXT:    vfnmsac.vf v8, fa0, v10
 ; ZVFBFA-NEXT:    ret
 ;
@@ -328,7 +328,7 @@ define <vscale x 16 x bfloat> @vfnmsub_vv_nxv16bf16(<vscale x 16 x bfloat> %va, 
 ;
 ; ZVFBFA-LABEL: vfnmsub_vv_nxv16bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m4, ta, ma
 ; ZVFBFA-NEXT:    vfnmsub.vv v8, v16, v12
 ; ZVFBFA-NEXT:    ret
 ;
@@ -365,7 +365,7 @@ define <vscale x 16 x bfloat> @vfnmsub_vf_nxv16bf16(<vscale x 16 x bfloat> %va, 
 ;
 ; ZVFBFA-LABEL: vfnmsub_vf_nxv16bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m4, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m4, ta, ma
 ; ZVFBFA-NEXT:    vfnmsub.vf v8, fa0, v12
 ; ZVFBFA-NEXT:    ret
 ;
@@ -458,7 +458,7 @@ define <vscale x 32 x bfloat> @vfnmsub_vv_nxv32bf16(<vscale x 32 x bfloat> %va, 
 ; ZVFBFA-LABEL: vfnmsub_vv_nxv32bf16:
 ; ZVFBFA:       # %bb.0:
 ; ZVFBFA-NEXT:    vl8re16.v v24, (a0)
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m8, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m8, ta, ma
 ; ZVFBFA-NEXT:    vfnmsub.vv v8, v24, v16
 ; ZVFBFA-NEXT:    ret
 ;
@@ -571,7 +571,7 @@ define <vscale x 32 x bfloat> @vfnmsub_vf_nxv32bf16(<vscale x 32 x bfloat> %va, 
 ;
 ; ZVFBFA-LABEL: vfnmsub_vf_nxv32bf16:
 ; ZVFBFA:       # %bb.0:
-; ZVFBFA-NEXT:    vsetvli a0, zero, e16, m8, ta, ma
+; ZVFBFA-NEXT:    vsetvli a0, zero, e16alt, m8, ta, ma
 ; ZVFBFA-NEXT:    vfnmsac.vf v8, fa0, v16
 ; ZVFBFA-NEXT:    ret
 ;


### PR DESCRIPTION
Currently it's mapped to normal float16 instructions.
