### PR TITLE
AutoUpgrade: don't crash on unexpected AVX512 masked intrinsic

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -2490,7 +2490,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512)
       IID = Intrinsic::x86_avx512_packssdw_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("packuswb.")) {
     if (VecWidth == 128)
       IID = Intrinsic::x86_sse2_packuswb_128;
@@ -4906,6 +4906,10 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
     } else {
       llvm_unreachable("Unknown function for CallBase upgrade.");
     }
+
+    // If we could not upgrade and the call has uses, leave it alone.
+    if (!Rep && !CI->use_empty())
+      return;
 
     if (Rep)
       CI->replaceAllUsesWith(Rep);

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -2407,7 +2407,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 256 && EltWidth == 64)
       IID = Intrinsic::x86_avx_max_pd_256;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("min.p")) {
     if (VecWidth == 128 && EltWidth == 32)
       IID = Intrinsic::x86_sse_min_ps;
@@ -2418,7 +2418,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 256 && EltWidth == 64)
       IID = Intrinsic::x86_avx_min_pd_256;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("pshuf.b.")) {
     if (VecWidth == 128)
       IID = Intrinsic::x86_ssse3_pshuf_b_128;
@@ -2427,7 +2427,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512)
       IID = Intrinsic::x86_avx512_pshuf_b_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("pmul.hr.sw.")) {
     if (VecWidth == 128)
       IID = Intrinsic::x86_ssse3_pmul_hr_sw_128;
@@ -2436,7 +2436,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512)
       IID = Intrinsic::x86_avx512_pmul_hr_sw_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("pmulh.w.")) {
     if (VecWidth == 128)
       IID = Intrinsic::x86_sse2_pmulh_w;
@@ -2445,7 +2445,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512)
       IID = Intrinsic::x86_avx512_pmulh_w_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("pmulhu.w.")) {
     if (VecWidth == 128)
       IID = Intrinsic::x86_sse2_pmulhu_w;
@@ -2454,7 +2454,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512)
       IID = Intrinsic::x86_avx512_pmulhu_w_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("pmaddw.d.")) {
     if (VecWidth == 128)
       IID = Intrinsic::x86_sse2_pmadd_wd;
@@ -2463,7 +2463,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512)
       IID = Intrinsic::x86_avx512_pmaddw_d_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("pmaddubs.w.")) {
     if (VecWidth == 128)
       IID = Intrinsic::x86_ssse3_pmadd_ub_sw_128;
@@ -2472,7 +2472,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512)
       IID = Intrinsic::x86_avx512_pmaddubs_w_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("packsswb.")) {
     if (VecWidth == 128)
       IID = Intrinsic::x86_sse2_packsswb_128;
@@ -2481,7 +2481,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512)
       IID = Intrinsic::x86_avx512_packsswb_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("packssdw.")) {
     if (VecWidth == 128)
       IID = Intrinsic::x86_sse2_packssdw_128;
@@ -2499,7 +2499,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512)
       IID = Intrinsic::x86_avx512_packuswb_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("packusdw.")) {
     if (VecWidth == 128)
       IID = Intrinsic::x86_sse41_packusdw;
@@ -2508,7 +2508,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512)
       IID = Intrinsic::x86_avx512_packusdw_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("vpermilvar.")) {
     if (VecWidth == 128 && EltWidth == 32)
       IID = Intrinsic::x86_avx_vpermilvar_ps;
@@ -2523,7 +2523,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512 && EltWidth == 64)
       IID = Intrinsic::x86_avx512_vpermilvar_pd_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name == "cvtpd2dq.256") {
     IID = Intrinsic::x86_avx_cvt_pd2dq_256;
   } else if (Name == "cvtpd2ps.256") {
@@ -2565,7 +2565,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512 && EltWidth == 8)
       IID = Intrinsic::x86_avx512_permvar_qi_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("dbpsadbw.")) {
     if (VecWidth == 128)
       IID = Intrinsic::x86_avx512_dbpsadbw_128;
@@ -2574,7 +2574,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512)
       IID = Intrinsic::x86_avx512_dbpsadbw_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("pmultishift.qb.")) {
     if (VecWidth == 128)
       IID = Intrinsic::x86_avx512_pmultishift_qb_128;
@@ -2583,7 +2583,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (VecWidth == 512)
       IID = Intrinsic::x86_avx512_pmultishift_qb_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("conflict.")) {
     if (Name[9] == 'd' && VecWidth == 128)
       IID = Intrinsic::x86_avx512_conflict_d_128;
@@ -2598,7 +2598,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (Name[9] == 'q' && VecWidth == 512)
       IID = Intrinsic::x86_avx512_conflict_q_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else if (Name.starts_with("pavg.")) {
     if (Name[5] == 'b' && VecWidth == 128)
       IID = Intrinsic::x86_sse2_pavg_b;
@@ -2613,7 +2613,7 @@ static bool upgradeAVX512MaskToSelect(StringRef Name, IRBuilder<> &Builder,
     else if (Name[5] == 'w' && VecWidth == 512)
       IID = Intrinsic::x86_avx512_pavg_w_512;
     else
-      llvm_unreachable("Unexpected intrinsic");
+      return false;
   } else
     return false;
 
@@ -5640,7 +5640,7 @@ void llvm::UpgradeCallsToIntrinsic(Function *F) {
         UpgradeIntrinsicCall(CB, NewFn);
 
     // Remove old function, no longer used, from the module.
-    if (F != NewFn)
+    if (F != NewFn && F->use_empty())
       F->eraseFromParent();
   }
 }

--- a/llvm/test/Verifier/avx512-mask-packssdw-invalid-types-no-crash.ll
+++ b/llvm/test/Verifier/avx512-mask-packssdw-invalid-types-no-crash.ll
@@ -1,6 +1,6 @@
 ; NOTE: This test uses intentionally invalid IR (wrong intrinsic return type)
 ; to ensure the auto-upgrade logic does not crash.
-;
+
 ; RUN: opt -passes=verify -S %s 2>&1 | FileCheck %s
 
 define <4 x ptr> @test() {
@@ -9,4 +9,3 @@ define <4 x ptr> @test() {
 }
 
 ; CHECK: Unknown intrinsic
-; CHECK-NEXT: declare <4 x ptr> @llvm.x86.avx512.mask.packssdw.512(<4 x i32>, <4 x i32>, <4 x i32>)

--- a/llvm/test/Verifier/avx512-mask-packssdw-invalid-types-no-crash.ll
+++ b/llvm/test/Verifier/avx512-mask-packssdw-invalid-types-no-crash.ll
@@ -1,0 +1,12 @@
+; NOTE: This test uses intentionally invalid IR (wrong intrinsic return type)
+; to ensure the auto-upgrade logic does not crash.
+;
+; RUN: opt -passes=verify -S %s 2>&1 | FileCheck %s
+
+define <4 x ptr> @test() {
+  %v = call <4 x ptr> @llvm.x86.avx512.mask.packssdw.512(<4 x i32> zeroinitializer, <4 x i32> zeroinitializer, <4 x i32> zeroinitializer)
+  ret <4 x ptr> %v
+}
+
+; CHECK: Unknown intrinsic
+; CHECK-NEXT: declare <4 x ptr> @llvm.x86.avx512.mask.packssdw.512(<4 x i32>, <4 x i32>, <4 x i32>)


### PR DESCRIPTION
Prevent a crash in the LLVM auto-upgrade path when encountering malformed AVX-512 masked intrinsics.

The auto-upgrade logic for avx512.mask.* intrinsics previously assumed all variants were well-formed and would llvm_unreachable on unexpected cases. This could cause verifier crashes when handling invalid IR (e.g., wrong intrinsic return types).

This change makes the upgrade logic fail gracefully by declining to upgrade unknown or malformed AVX-512 masked intrinsics instead of crashing.

fixes #176675