### PR TITLE
[VPlan] Strip VPWidenSelectSC from VPRecipeTy (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -410,7 +410,6 @@ public:
     VPWidenStoreEVLSC,
     VPWidenStoreSC,
     VPWidenSC,
-    VPWidenSelectSC,
     VPBlendSC,
     VPHistogramSC,
     // START: Phi-like recipes. Need to be kept together.


### PR DESCRIPTION
WidenSelect has been removed in 16830b2 ([VPlan] Remove VPWidenSelectRecipe, use VPWidenRecipe instead, #174234).