### PR TITLE
[clang][analyzer] Add 'Strict' option to 'core.DivideZero' checker

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -214,6 +214,14 @@ def VLASizeChecker : Checker<"VLASize">,
 
 def DivZeroChecker : Checker<"DivideZero">,
   HelpText<"Check for division by zero">,
+  CheckerOptions<[
+    CmdLineOption<Boolean,
+                  "Strict",
+                  "Warn on all potential divisions by zero i.e., if zero "
+                  "falls within the range of possible divisor values.",
+                  "false",
+                  InAlpha>,
+  ]>,
   Documentation<HasDocumentation>;
 
 def UndefResultChecker : Checker<"UndefinedBinaryOperatorResult">,

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -38,6 +38,7 @@
 // CHECK-NEXT: core.CallAndMessage:NilReceiver = true
 // CHECK-NEXT: core.CallAndMessage:ParameterCount = true
 // CHECK-NEXT: core.CallAndMessage:UndefReceiver = true
+// CHECK-NEXT: core.DivideZero:Strict = false
 // CHECK-NEXT: cplusplus.Move:WarnOn = KnownsAndLocals
 // CHECK-NEXT: cplusplus.SmartPtrModeling:ModelSmartPtrDereference = false
 // CHECK-NEXT: crosscheck-with-z3 = false


### PR DESCRIPTION
With the option 'Strict' the checker warns every time the denominator of a division is potentially zero. For example:

```c
void foo() {
  int x = 1 / rand(); // Warns!
}

void bar() {
  int x;
  int n = rand();
  if (n != 0)
    x = 1 / n; // Ok
}

int main(int argc, char **argv) {
  return 1 / (argc - 1); // Warns!
}
```

Does this make sense? If so, I will add tests and update the documentation.