### PR TITLE
[clang][ssaf] Fix instantiations of `Registry<TUSummaryExtractor, TUSummaryBuilder &>`

### DIFF
--- a/clang/include/clang/Analysis/Scalable/TUSummary/ExtractorRegistry.h
+++ b/clang/include/clang/Analysis/Scalable/TUSummary/ExtractorRegistry.h
@@ -42,7 +42,7 @@ using TUSummaryExtractorRegistry =
 
 namespace llvm {
 extern template class CLANG_TEMPLATE_ABI
-    Registry<clang::ssaf::TUSummaryExtractorRegistry>;
+    Registry<clang::ssaf::TUSummaryExtractor, clang::ssaf::TUSummaryBuilder &>;
 } // namespace llvm
 
 #endif // LLVM_CLANG_ANALYSIS_SCALABLE_TUSUMMARY_EXTRACTORREGISTRY_H

--- a/clang/lib/Analysis/Scalable/TUSummary/ExtractorRegistry.cpp
+++ b/clang/lib/Analysis/Scalable/TUSummary/ExtractorRegistry.cpp
@@ -12,7 +12,10 @@
 using namespace clang;
 using namespace ssaf;
 
-LLVM_INSTANTIATE_REGISTRY(TUSummaryExtractorRegistry)
+// FIXME: LLVM_INSTANTIATE_REGISTRY can't be used here because it drops extra
+// type parameters.
+template class CLANG_EXPORT_TEMPLATE
+    llvm::Registry<TUSummaryExtractor, TUSummaryBuilder &>;
 
 bool ssaf::isTUSummaryExtractorRegistered(llvm::StringRef SummaryName) {
   for (const auto &Entry : TUSummaryExtractorRegistry::entries())

--- a/llvm/include/llvm/Support/Registry.h
+++ b/llvm/include/llvm/Support/Registry.h
@@ -40,13 +40,25 @@ public:
   }
 };
 
+template <typename T, typename... CtorParamTypes> class Registry;
+namespace detail {
+template <typename R> struct IsRegistryType : std::false_type {};
+template <typename T, typename... CtorParamTypes>
+struct IsRegistryType<Registry<T, CtorParamTypes...>> : std::true_type {};
+} // namespace detail
+
 /// A global registry used in conjunction with static constructors to make
 /// pluggable components (like targets or garbage collectors) "just work" when
 /// linked with an executable.
 template <typename T, typename... CtorParamTypes> class Registry {
+  static_assert(
+      !detail::IsRegistryType<T>::value,
+      "Trying to instantiate a wrong specialization 'Registry<Registry<...>>'");
+
 public:
   using type = T;
   using entry = SimpleRegistryEntry<T, CtorParamTypes...>;
+  static constexpr bool HasCtorParamTypes = sizeof...(CtorParamTypes) != 0;
 
   class node;
   class iterator;
@@ -147,11 +159,17 @@ public:
 #define LLVM_INSTANTIATE_REGISTRY(REGISTRY_CLASS)                              \
   namespace llvm {                                                             \
   template class LLVM_ABI_EXPORT Registry<REGISTRY_CLASS::type>;               \
+  static_assert(!REGISTRY_CLASS::HasCtorParamTypes,                            \
+                "LLVM_INSTANTIATE_REGISTRY can't be used with extra "          \
+                "constructor parameter types");                                \
   }
 #else
 #define LLVM_INSTANTIATE_REGISTRY(REGISTRY_CLASS)                              \
   namespace llvm {                                                             \
   template class Registry<REGISTRY_CLASS::type>;                               \
+  static_assert(!REGISTRY_CLASS::HasCtorParamTypes,                            \
+                "LLVM_INSTANTIATE_REGISTRY can't be used with extra "          \
+                "constructor parameter types");                                \
   }
 #endif
 


### PR DESCRIPTION
This patch fixes the incorrect explicit instantiation declaration/definition added in #173290, and adds checks to prevent similar errors.

MinGW/Cygwin with `-DCLANG_LINK_CLANG_DYLIB=ON` require proper declarations of the template instantiations to share data symbols across DLL boundaries.