### PR TITLE
[lldb] skip TestHiddenFrameMarkers test on Windows

### DIFF
--- a/lldb/test/API/terminal/hidden_frame_markers/TestHiddenFrameMarkers.py
+++ b/lldb/test/API/terminal/hidden_frame_markers/TestHiddenFrameMarkers.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 class HiddenFrameMarkerTest(TestBase):
+    @skipIfWindows
     @unicode_test
     def test_hidden_frame_markers(self):
         """Test that hidden frame markers are rendered in backtraces"""
@@ -51,7 +52,8 @@ class HiddenFrameMarkerTest(TestBase):
             ],
         )
 
-    def test_hidden_frame_markers(self):
+    @skipIfWindows
+    def test_hidden_frame_markers_setting_deactivation(self):
         """
         Test that hidden frame markers are not rendered in backtraces when
         mark-hidden-frames is set to false


### PR DESCRIPTION
This patch deactivates the `TestHiddenFrameMarkers` test on Windows.

https://github.com/llvm/llvm-project/pull/167550 introduced a new marker in front of hidden frames in the lldb backtrace printer. Hidden frames do not seem to be working on Windows.

https://github.com/llvm/llvm-project/issues/176738 is the tracking issue for the hidden frames on Windows.