### PR TITLE
[flang-rt] Fix system_clock scaling on MacOS

### DIFF
--- a/flang-rt/lib/runtime/time-intrinsic.cpp
+++ b/flang-rt/lib/runtime/time-intrinsic.cpp
@@ -193,7 +193,7 @@ count_t ConvertTimeSpecToCount(int kind, const struct timespec &tspec) {
 #ifndef _AIX
 // More accurate version with nanosecond accuracy
 template <typename Unused = void>
-staitic count_t GetSystemClockCount(int kind, fallback_implementation) {
+static count_t GetSystemClockCount(int kind, fallback_implementation) {
   struct timespec tspec;
 
   if (timespec_get(&tspec, TIME_UTC) < 0) {

--- a/flang-rt/lib/runtime/time-intrinsic.cpp
+++ b/flang-rt/lib/runtime/time-intrinsic.cpp
@@ -130,7 +130,6 @@ using unsigned_count_t = std::uint64_t;
 //  - nanoseconds for kinds 8, 16
 constexpr unsigned_count_t DS_PER_SEC{10u};
 constexpr unsigned_count_t MS_PER_SEC{1'000u};
-[[maybe_unused]] constexpr unsigned_count_t US_PER_SEC{1'000'000u};
 constexpr unsigned_count_t NS_PER_SEC{1'000'000'000u};
 
 // Computes HUGE(INT(0,kind)) as an unsigned integer value.

--- a/flang-rt/lib/runtime/time-intrinsic.cpp
+++ b/flang-rt/lib/runtime/time-intrinsic.cpp
@@ -159,14 +159,14 @@ count_t ConvertSecondsNanosecondsToCount(
 // Function converts a struct timeval into the desired count to
 // be returned by the timing functions in accordance with the requested
 // kind at the call site.
-count_t ConvertTimevalToCount(int kind, const struct timeval &tval) {
+static count_t ConvertTimevalToCount(int kind, const struct timeval &tval) {
   unsigned_count_t sec{static_cast<unsigned_count_t>(tval.tv_sec)};
   unsigned_count_t nsec{static_cast<unsigned_count_t>(tval.tv_usec) * 1000};
   return ConvertSecondsNanosecondsToCount(kind, sec, nsec);
 }
 
 template <typename Unused = void>
-count_t GetSystemClockCount(int kind, fallback_implementation) {
+static count_t GetSystemClockCount(int kind, fallback_implementation) {
   struct timeval tval;
 
   if (gettimeofday(&tval, /*timezone=*/nullptr) != 0) {
@@ -193,7 +193,7 @@ count_t ConvertTimeSpecToCount(int kind, const struct timespec &tspec) {
 #ifndef _AIX
 // More accurate version with nanosecond accuracy
 template <typename Unused = void>
-count_t GetSystemClockCount(int kind, fallback_implementation) {
+staitic count_t GetSystemClockCount(int kind, fallback_implementation) {
   struct timespec tspec;
 
   if (timespec_get(&tspec, TIME_UTC) < 0) {
@@ -209,16 +209,12 @@ count_t GetSystemClockCount(int kind, fallback_implementation) {
 #endif // !NO_TIMESPEC
 
 template <typename Unused = void>
-count_t GetSystemClockCountRate(int kind, fallback_implementation) {
-#ifdef NO_TIMESPEC
-  return kind >= 8 ? US_PER_SEC : kind >= 2 ? MS_PER_SEC : DS_PER_SEC;
-#else
+static count_t GetSystemClockCountRate(int kind, fallback_implementation) {
   return kind >= 8 ? NS_PER_SEC : kind >= 2 ? MS_PER_SEC : DS_PER_SEC;
-#endif
 }
 
 template <typename Unused = void>
-count_t GetSystemClockCountMax(int kind, fallback_implementation) {
+static count_t GetSystemClockCountMax(int kind, fallback_implementation) {
   unsigned_count_t maxCount{GetHUGE(kind)};
   return maxCount;
 }
@@ -226,7 +222,7 @@ count_t GetSystemClockCountMax(int kind, fallback_implementation) {
 #ifndef NO_TIMESPEC
 #ifdef CLOCKID_ELAPSED_TIME
 template <typename T = int, typename U = struct timespec>
-count_t GetSystemClockCount(int kind, preferred_implementation,
+static count_t GetSystemClockCount(int kind, preferred_implementation,
     // We need some dummy parameters to pass to decltype(clock_gettime).
     T ClockId = 0, U *Timespec = nullptr,
     decltype(clock_gettime(ClockId, Timespec)) *Enabled = nullptr) {
@@ -243,7 +239,7 @@ count_t GetSystemClockCount(int kind, preferred_implementation,
 #endif // CLOCKID_ELAPSED_TIME
 
 template <typename T = int, typename U = struct timespec>
-count_t GetSystemClockCountRate(int kind, preferred_implementation,
+static count_t GetSystemClockCountRate(int kind, preferred_implementation,
     // We need some dummy parameters to pass to decltype(clock_gettime).
     T ClockId = 0, U *Timespec = nullptr,
     decltype(clock_gettime(ClockId, Timespec)) *Enabled = nullptr) {
@@ -251,7 +247,7 @@ count_t GetSystemClockCountRate(int kind, preferred_implementation,
 }
 
 template <typename T = int, typename U = struct timespec>
-count_t GetSystemClockCountMax(int kind, preferred_implementation,
+static count_t GetSystemClockCountMax(int kind, preferred_implementation,
     // We need some dummy parameters to pass to decltype(clock_gettime).
     T ClockId = 0, U *Timespec = nullptr,
     decltype(clock_gettime(ClockId, Timespec)) *Enabled = nullptr) {


### PR DESCRIPTION
The less accurate clock was being adjusted for twice: once in `GetSystemClockCountRate` and again in `ConvertTimevalToCount`.

Also adding missing `static` specifiers I noticed whilst reading the file. I don't know of a way of meaningfully testing this in the repository, but the code in the ticket now produces the correct result.

Fixes #176505