### PR TITLE
[Clang][AArch64] Add ACLE macros to support Armv9.6

### DIFF
--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -565,6 +565,33 @@ void AArch64TargetInfo::getTargetDefines(const LangOptions &Opts,
   else if (HasRCPC)
     Builder.defineMacro("__ARM_FEATURE_RCPC", "1");
 
+  if (HasFPRCVT)
+    Builder.defineMacro("__ARM_FEATURE_FPRCVT", "1");
+
+  if (HasF8F16MM)
+    Builder.defineMacro("__ARM_FEATURE_F8F16MM", "1");
+
+  if (HasF8F32MM)
+    Builder.defineMacro("__ARM_FEATURE_F8F32MM", "1");
+
+  if (HasSVE_F16F32MM)
+    Builder.defineMacro("__ARM_FEATURE_SVE_F16F32MM", "1");
+
+  if (HasSVE_BFSCALE)
+    Builder.defineMacro("__ARM_FEATURE_SVE_BFSCALE", "1");
+
+  if (HasSVE_AES2)
+    Builder.defineMacro("__ARM_FEATURE_SVE_AES2", "1");
+
+  if (HasSSVE_AES)
+    Builder.defineMacro("__ARM_FEATURE_SSVE_AES", "1");
+
+  if (HasSVE2p2)
+    Builder.defineMacro("__ARM_FEATURE_SVE2p2", "1");
+
+  if (HasSME2p2)
+    Builder.defineMacro("__ARM_FEATURE_SME2p2", "1");
+
   if (HasFMV)
     Builder.defineMacro("__HAVE_FUNCTION_MULTI_VERSIONING", "1");
 
@@ -876,6 +903,15 @@ bool AArch64TargetInfo::hasFeature(StringRef Feature) const {
       .Case("ssve-fp8fma", HasSSVE_FP8FMA)
       .Case("sme-f8f32", HasSME_F8F32)
       .Case("sme-f8f16", HasSME_F8F16)
+      .Case("fprcvt", HasFPRCVT)
+      .Case("f8f16mm", HasF8F16MM)
+      .Case("f8f32mm", HasF8F32MM)
+      .Case("sve-f16f32mm", HasSVE_F16F32MM)
+      .Case("sve-bfscale", HasSVE_BFSCALE)
+      .Case("sve-aes2", HasSVE_AES2)
+      .Case("ssve-aes", HasSSVE_AES)
+      .Case("sve2p2", FPU & SveMode && HasSVE2p2)
+      .Case("sme2p2", HasSME2p2)
       .Default(false);
 }
 
@@ -1105,6 +1141,24 @@ bool AArch64TargetInfo::handleTargetFeatures(std::vector<std::string> &Features,
     }
     if (Feature == "+strict-align")
       HasUnalignedAccess = false;
+    if (Feature == "+fprcvt")
+      HasFPRCVT = true;
+    if (Feature == "+f8f16mm")
+      HasF8F16MM = true;
+    if (Feature == "+f8f32mm")
+      HasF8F32MM = true;
+    if (Feature == "+sve-f16f32mm")
+      HasSVE_F16F32MM = true;
+    if (Feature == "+sve-bfscale")
+      HasSVE_BFSCALE = true;
+    if (Feature == "+sve-aes2")
+      HasSVE_AES2 = true;
+    if (Feature == "+ssve-aes")
+      HasSSVE_AES = true;
+    if (Feature == "+sve2p2")
+      HasSVE2p2 = true;
+    if (Feature == "+sme2p2")
+      HasSME2p2 = true;
 
     // All predecessor archs are added but select the latest one for ArchKind.
     if (Feature == "+v8a" && ArchInfo->Version < llvm::AArch64::ARMV8A.Version)

--- a/clang/lib/Basic/Targets/AArch64.h
+++ b/clang/lib/Basic/Targets/AArch64.h
@@ -131,6 +131,15 @@ class LLVM_LIBRARY_VISIBILITY AArch64TargetInfo : public TargetInfo {
   bool HasRCPC3 = false;
   bool HasSMEFA64 = false;
   bool HasPAuthLR = false;
+  bool HasFPRCVT = false;
+  bool HasF8F16MM = false;
+  bool HasF8F32MM = false;
+  bool HasSVE_F16F32MM = false;
+  bool HasSVE_BFSCALE = false;
+  bool HasSVE_AES2 = false;
+  bool HasSSVE_AES = false;
+  bool HasSVE2p2 = false;
+  bool HasSME2p2 = false;
 
   const llvm::AArch64::ArchInfo *ArchInfo = &llvm::AArch64::ARMV8A;
 

--- a/clang/test/Preprocessor/aarch64-target-features.c
+++ b/clang/test/Preprocessor/aarch64-target-features.c
@@ -790,3 +790,46 @@
 // CHECK-SMEF8F16: __ARM_FEATURE_FP8 1
 // CHECK-SMEF8F16: __ARM_FEATURE_SME2 1
 // CHECK-SMEF8F16: __ARM_FEATURE_SME_F8F16 1
+
+//  RUN: %clang --target=aarch64 -march=armv9-a+fprcvt -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-FPRCVT %s
+// CHECK-FPRCVT: __ARM_FEATURE_FPRCVT 1
+
+//  RUN: %clang --target=aarch64 -march=armv9-a+f8f16mm -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-F8F16MM %s
+//  CHECK-F8F16MM: __ARM_FEATURE_F8F16MM 1
+//  CHECK-F8F16MM: __ARM_FEATURE_FP8 1
+
+//  RUN: %clang --target=aarch64 -march=armv9-a+f8f32mm -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-F8F32MM %s
+//  CHECK-F8F32MM: __ARM_FEATURE_F8F32MM 1
+//  CHECK-F8F32MM: __ARM_FEATURE_FP8 1
+
+//  RUN: %clang --target=aarch64 -march=armv9-a+sve-f16f32mm -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SVE-F16F32MM %s
+//  CHECK-SVE-F16F32MM: __ARM_FEATURE_SVE 1
+//  CHECK-SVE-F16F32MM: __ARM_FEATURE_SVE_F16F32MM 1
+
+//  RUN: %clang --target=aarch64 -march=armv9-a+sve-bfscale -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SVE-BFSCALE %s
+//  CHECK-SVE-BFSCALE: __ARM_FEATURE_SVE_BFSCALE 1
+
+//  RUN: %clang --target=aarch64 -march=armv9-a+sve-aes2 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SVE-AES2 %s
+//  CHECK-SVE-AES2: __ARM_FEATURE_SVE_AES2 1
+
+//  RUN: %clang --target=aarch64 -march=armv9-a+ssve-aes -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SSVE-AES %s
+//  CHECK-SSVE-AES: __ARM_FEATURE_SME2 1
+//  CHECK-SSVE-AES: __ARM_FEATURE_SSVE_AES
+//  CHECK-SSVE-AES: __ARM_FEATURE_SVE2_AES 1
+
+// RUN: %clang -target aarch64-none-linux-gnu -march=armv9-a+sve2p2 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SVE2p2 %s
+// CHECK-SVE2p2: __ARM_FEATURE_FP16_SCALAR_ARITHMETIC 1
+// CHECK-SVE2p2: __ARM_FEATURE_FP16_VECTOR_ARITHMETIC 1
+// CHECK-SVE2p2: __ARM_FEATURE_SVE2 1
+// CHECK-SVE2p2: __ARM_FEATURE_SVE2p1 1
+// CHECK-SVE2p2: __ARM_FEATURE_SVE2p2 1
+// CHECK-SVE2p2: __ARM_NEON 1
+// CHECK-SVE2p2: __ARM_NEON_FP 0xE
+// CHECK-SVE2p2: __ARM_NEON_SVE_BRIDGE 1
+//
+// RUN: %clang --target=aarch64 -march=armv9-a+sme2p2 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SME2p2 %s
+// CHECK-SME2p2: __ARM_FEATURE_LOCALLY_STREAMING 1
+// CHECK-SME2p2: __ARM_FEATURE_SME 1
+// CHECK-SME2p2: __ARM_FEATURE_SME2 1
+// CHECK-SME2p2: __ARM_FEATURE_SME2p1 1
+// CHECK-SME2p2: __ARM_FEATURE_SME2p2 1

--- a/clang/test/Preprocessor/aarch64-target-features.c
+++ b/clang/test/Preprocessor/aarch64-target-features.c
@@ -814,7 +814,7 @@
 
 //  RUN: %clang --target=aarch64 -march=armv9-a+ssve-aes -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SSVE-AES %s
 //  CHECK-SSVE-AES: __ARM_FEATURE_SME2 1
-//  CHECK-SSVE-AES: __ARM_FEATURE_SSVE_AES
+//  CHECK-SSVE-AES: __ARM_FEATURE_SSVE_AES 1
 //  CHECK-SSVE-AES: __ARM_FEATURE_SVE2_AES 1
 
 // RUN: %clang -target aarch64-none-linux-gnu -march=armv9-a+sve2p2 -x c -E -dM %s -o - | FileCheck --check-prefix=CHECK-SVE2p2 %s


### PR DESCRIPTION
This patch add the macros for Armv9.6 according to the ACLE[1]

 [1]https://github.com/ARM-software/acle/blob/main/main/acle.md