### PR TITLE
[NFC][llvm-ir2vec] Addressing llvm standards around adding a lib object for an llvm tool

### DIFF
--- a/llvm/tools/llvm-ir2vec/CMakeLists.txt
+++ b/llvm/tools/llvm-ir2vec/CMakeLists.txt
@@ -20,7 +20,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 # Add the utils subdirectory for the library
-add_subdirectory(utils)
+add_subdirectory(lib)
 
 # Main executable
 add_llvm_tool(llvm-ir2vec
@@ -30,5 +30,5 @@ add_llvm_tool(llvm-ir2vec
   intrinsics_gen
 )
 
-target_include_directories(llvm-ir2vec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/utils)
-target_link_libraries(llvm-ir2vec PRIVATE emb_utils)
+target_include_directories(llvm-ir2vec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+target_link_libraries(llvm-ir2vec PRIVATE LLVMEmbUtils)

--- a/llvm/tools/llvm-ir2vec/lib/CMakeLists.txt
+++ b/llvm/tools/llvm-ir2vec/lib/CMakeLists.txt
@@ -1,5 +1,7 @@
-add_llvm_library(emb_utils STATIC
-  utils.cpp
+add_llvm_library(LLVMEmbUtils STATIC
+  Utils.cpp
+
+  BUILDTREE_ONLY
 
   DEPENDS
   intrinsics_gen

--- a/llvm/tools/llvm-ir2vec/lib/Utils.cpp
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.cpp
@@ -1,4 +1,4 @@
-//===- utils.cpp - IR2Vec/MIR2Vec Embedding Generation Tool -----------===//
+//===- Utils.cpp - IR2Vec/MIR2Vec Embedding Generation Tool -----------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,7 +12,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "utils.h"
+#include "Utils.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Analysis/IR2Vec.h"
 #include "llvm/IR/BasicBlock.h"

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -1,4 +1,4 @@
-//===- utils.h - IR2Vec/MIR2Vec Tool Classes ----------------------===//
+//===- Utils.h - IR2Vec/MIR2Vec Tool Classes ----------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
+++ b/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
@@ -54,7 +54,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "utils.h"
+#include "Utils.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Analysis/IR2Vec.h"
 #include "llvm/IR/BasicBlock.h"


### PR DESCRIPTION
The following changes have beem made to address the comments here at https://github.com/llvm/llvm-project/pull/174133#discussion_r2702525132 

- Moved`llvm-ir2vec/utils` to `llvm-ir2vec/lib` 
- Fixed up the naming convention ` utils.h -> Utils.h , utils.cpp -> Utils.cpp`
- Changed the lib object name from `emb-utils` to `LLVMEmbUtils` to reflect the standard naming conventions
- Added the BUILDTREE_ONLY keyword to the CMakeList.txt for the library object. The intent here is that the lib object is merely an implementation helper for the tool, and is not meant to be installed and used independently.

@svkeerthy @nikic 