### PR TITLE
[libc++] Forward calls to ranges::swap_ranges to the 3-leg implementation if possible

### DIFF
--- a/libcxx/include/__algorithm/ranges_swap_ranges.h
+++ b/libcxx/include/__algorithm/ranges_swap_ranges.h
@@ -11,6 +11,7 @@
 
 #include <__algorithm/in_in_result.h>
 #include <__algorithm/iterator_operations.h>
+#include <__algorithm/min.h>
 #include <__algorithm/swap_ranges.h>
 #include <__config>
 #include <__iterator/concepts.h>
@@ -18,7 +19,9 @@
 #include <__ranges/access.h>
 #include <__ranges/concepts.h>
 #include <__ranges/dangling.h>
+#include <__type_traits/is_same.h>
 #include <__utility/move.h>
+#include <__utility/pair.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -41,9 +44,33 @@ struct __swap_ranges {
     requires indirectly_swappable<_I1, _I2>
   _LIBCPP_HIDE_FROM_ABI constexpr swap_ranges_result<_I1, _I2>
   operator()(_I1 __first1, _S1 __last1, _I2 __first2, _S2 __last2) const {
-    auto __ret = std::__swap_ranges<_RangeAlgPolicy>(
-        std::move(__first1), std::move(__last1), std::move(__first2), std::move(__last2));
-    return {std::move(__ret.first), std::move(__ret.second)};
+    if constexpr (sized_sentinel_for<_I1, _S1> && sized_sentinel_for<_I2, _S2> &&
+                  (random_access_iterator<_I1> || random_access_iterator<_I2> ||
+                   (is_same_v<_I1, _S1> && is_same_v<_I2, _S2>))) {
+      auto __offset = std::min(__last1 - __first1, __last2 - __first2);
+
+      auto __ret = [&] {
+        if constexpr (random_access_iterator<_I1>)
+          return std::__swap_ranges<_RangeAlgPolicy>(__first1, __first1 + __offset, std::move(__first2));
+        else if constexpr (random_access_iterator<_I2>)
+          return std::__swap_ranges<_RangeAlgPolicy>(__first2, __first2 + __offset, std::move(__first1));
+        else if (__last2 - __first2 < __last1 - __first1) {
+          auto __reversed =
+              std::__swap_ranges<_RangeAlgPolicy>(std::move(__first2), std::move(__last2), std::move(__first1));
+          return std::pair<_I1, _I2>(std::move(__reversed.second), std::move(__reversed.first));
+        } else
+          return std::__swap_ranges<_RangeAlgPolicy>(std::move(__first1), std::move(__last1), std::move(__first2));
+      }();
+      return {std::move(__ret.first), std::move(__ret.second)};
+    } else {
+      while (__first1 != __last1 && __first2 != __last2) {
+        ranges::iter_swap(__first1, __first2);
+        ++__first1;
+        ++__first2;
+      }
+
+      return {std::move(__first1), std::move(__first2)};
+    }
   }
 
   template <input_range _R1, input_range _R2>

--- a/libcxx/include/__algorithm/swap_ranges.h
+++ b/libcxx/include/__algorithm/swap_ranges.h
@@ -162,7 +162,6 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __bit_iterator<_Cr, false> _
   return __result;
 }
 
-// 2+1 iterators: size2 >= size1; used by std::swap_ranges.
 template <class, class _Cl, class _Cr>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<__bit_iterator<_Cl, false>, __bit_iterator<_Cr, false> >
 __swap_ranges(__bit_iterator<_Cl, false> __first1,
@@ -173,32 +172,6 @@ __swap_ranges(__bit_iterator<_Cl, false> __first1,
   return std::make_pair(__last1, std::__swap_ranges_unaligned(__first1, __last1, __first2));
 }
 
-// 2+2 iterators: used by std::ranges::swap_ranges.
-template <class _AlgPolicy, class _Cl, class _Cr>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<__bit_iterator<_Cl, false>, __bit_iterator<_Cr, false> >
-__swap_ranges(__bit_iterator<_Cl, false> __first1,
-              __bit_iterator<_Cl, false> __last1,
-              __bit_iterator<_Cr, false> __first2,
-              __bit_iterator<_Cr, false> __last2) {
-  if (__last1 - __first1 < __last2 - __first2)
-    return std::make_pair(__last1, std::__swap_ranges<_AlgPolicy>(__first1, __last1, __first2).second);
-  return std::make_pair(std::__swap_ranges<_AlgPolicy>(__first2, __last2, __first1).second, __last2);
-}
-
-// 2+2 iterators: the shorter size will be used.
-template <class _AlgPolicy, class _ForwardIterator1, class _Sentinel1, class _ForwardIterator2, class _Sentinel2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_ForwardIterator1, _ForwardIterator2>
-__swap_ranges(_ForwardIterator1 __first1, _Sentinel1 __last1, _ForwardIterator2 __first2, _Sentinel2 __last2) {
-  while (__first1 != __last1 && __first2 != __last2) {
-    _IterOps<_AlgPolicy>::iter_swap(__first1, __first2);
-    ++__first1;
-    ++__first2;
-  }
-
-  return pair<_ForwardIterator1, _ForwardIterator2>(std::move(__first1), std::move(__first2));
-}
-
-// 2+1 iterators: size2 >= size1.
 template <class _AlgPolicy, class _ForwardIterator1, class _Sentinel1, class _ForwardIterator2>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_ForwardIterator1, _ForwardIterator2>
 __swap_ranges(_ForwardIterator1 __first1, _Sentinel1 __last1, _ForwardIterator2 __first2) {


### PR DESCRIPTION
This allows us to make use of any optimizations to `std::swap_ranges` in `ranges::swap_ranges`.

This patch also moves some code specific to `ranges::swap_ranges` into `ranges_swap_ranges.h`.
