### PR TITLE
[lldb][DWARFASTParserClang] RequireCompleteType for ObjC types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -9702,7 +9702,8 @@ TypeSystemClang::DeclContextGetTypeSystemClang(const CompilerDeclContext &dc) {
 void TypeSystemClang::RequireCompleteType(CompilerType type) {
   // Technically, enums can be incomplete too, but we don't handle those as they
   // are emitted even under -flimit-debug-info.
-  if (!TypeSystemClang::IsCXXClassType(type))
+  if (!TypeSystemClang::IsCXXClassType(type) &&
+      !TypeSystemClang::IsObjCObjectOrInterfaceType(type))
     return;
 
   if (type.GetCompleteType())

--- a/lldb/test/Shell/Expr/TestObjCIncompleteSuperclass.test
+++ b/lldb/test/Shell/Expr/TestObjCIncompleteSuperclass.test
@@ -3,7 +3,6 @@
 # it will fail to do so. LLDB should handle this situation gracefully.
 # A super-class definition is required when laying out Obj-C types.
 #
-# XFAIL: *
 # REQUIRES: system-darwin
 #
 # RUN: split-file %s %t


### PR DESCRIPTION
Currently we forcefully complete C++ types if we can't find their definition for layout purposes. This ensures that we at least don't crash in Clang when laying out the type. The definition is required for types of members/array elements/base classes for the purposes of calculating their layout. This is also true for Obj-C types, but we haven't been forcefully completing those.

The test-case that's being un-XFAILed in this patch demonstrates a case where not completing the super-class forcefully causes a clang crash.

rdar://168440264