### PR TITLE
[CoroFrame] Save frame ptr in entry funclets

### DIFF
--- a/llvm/test/Transforms/Coroutines/declare-value.ll
+++ b/llvm/test/Transforms/Coroutines/declare-value.ll
@@ -1,9 +1,13 @@
 ;RUN: opt -mtriple='arm64-' %s -S -passes='module(coro-early),cgscc(coro-split,simplifycfg)' -o - | FileCheck %s
 
+; CHECK-LABEL: define swifttailcc void @coroutineA
+; CHECK-SAME:    (ptr swiftasync %[[frame_ptr:.*]],
 ; CHECK:  %.debug = alloca double, align 8
 ; CHECK-NEXT:    #dbg_declare(ptr %{{.*}}, !{{[0-9]+}}, !DIExpression(DW_OP_deref), !{{[0-9]+}})
 ; CHECK-NEXT:  store double %{{[0-9]+}}, ptr %{{.*}}, align 8
-; CHECK-NEXT:    #dbg_declare(ptr %arg, !{{[0-9]+}}, !DIExpression(DW_OP_plus_uconst, 24), !{{[0-9]+}})
+; CHECK:       %[[frame_ptr_alloca:.*]] = alloca ptr,
+; CHECK-NEXT:  #dbg_declare(ptr %[[frame_ptr_alloca]], !{{[0-9]+}}, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24), !{{[0-9]+}})
+; CHECK-NEXT:  store ptr %[[frame_ptr]], ptr %[[frame_ptr_alloca]]
 
 ; ModuleID = '/Users/srastogi/Development/llvm-project-2/llvm/test/Transforms/Coroutines/declare-value.ll'
 source_filename = "/Users/srastogi/Development/llvm-project-2/llvm/test/Transforms/Coroutines/declare-value.ll"

--- a/llvm/test/Transforms/Coroutines/swift-async-dbg.ll
+++ b/llvm/test/Transforms/Coroutines/swift-async-dbg.ll
@@ -23,10 +23,12 @@ define swifttailcc void @coroutineA(ptr swiftasync %arg) !dbg !48 {
   %i3 = call ptr @llvm.coro.begin(token %i2, ptr null)
 ; CHECK-LABEL: define {{.*}} @coroutineA(
 ; CHECK-SAME:    ptr swiftasync %[[frame_ptr:.*]])
-; CHECK:      #dbg_declare(ptr %[[frame_ptr]], {{.*}} !DIExpression(
-; CHECK-SAME:                   DW_OP_plus_uconst, 24)
-; CHECK:      #dbg_value(ptr %[[frame_ptr]], {{.*}} !DIExpression(
-; CHECK-SAME:                 DW_OP_plus_uconst, 16, DW_OP_deref)
+; CHECK:      %[[frame_ptr_alloca:.*]] = alloca ptr
+; CHECK:      #dbg_declare(ptr %[[frame_ptr_alloca]], {{.*}} !DIExpression(
+; CHECK-SAME:                   DW_OP_deref, DW_OP_plus_uconst, 24)
+; CHECK:      store ptr %[[frame_ptr]], ptr %[[frame_ptr_alloca]]
+; CHECK:      #dbg_value(ptr %[[frame_ptr_alloca]], {{.*}} !DIExpression(
+; CHECK-SAME:                 DW_OP_deref, DW_OP_plus_uconst, 16, DW_OP_deref)
 ; CHECK:      call {{.*}} @swift_task_switch
 
   %i7 = call ptr @llvm.coro.async.resume(), !dbg !54


### PR DESCRIPTION
The logic deciding whether to save the frame pointer using an Alloca was flawed: it must be the opposite of deciding whether to use EntryValue, since those are the only methods allowing debuggers to find the frame pointer (and therefore variables) reliably. This commit fixes the logic.