### PR TITLE
[libsycl][NFC] Assign lead maintainers for the project

### DIFF
--- a/libsycl/Maintainers.md
+++ b/libsycl/Maintainers.md
@@ -4,7 +4,7 @@ This file is a list of the
 [maintainers](https://llvm.org/docs/DeveloperPolicy.html#maintainers) for
 the SYCL Runtime library.
 
-# Current Maintainers
+# Lead Maintainers
 
 Alexey Bader \
 | alexey.bader@intel.com (email), bader (GitHub, Discord, Discourse)


### PR DESCRIPTION
To align with https://llvm.org/docs/DeveloperPolicy.html#maintainers
libsycl project must explicitly list lead maintainers.