### PR TITLE
[MLIR][GPU][NVVM] Add verify-target-arch option to nvvm-attach-target pass

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/GPU/Transforms/Passes.td
@@ -162,6 +162,9 @@ def GpuNVVMAttachTarget: Pass<"nvvm-attach-target", ""> {
     Option<"cmdOptions", "ptxas-cmd-options", "std::string",
            /*default=*/ [{""}],
            "Command line options passed to downstream compiler">,
+    Option<"verifyTarget", "verify-target-arch", "bool",
+           /*default=*/"true",
+           "Enable verification of the target architecture">,
   ];
 }
 

--- a/mlir/lib/Dialect/GPU/Transforms/NVVMAttachTarget.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/NVVMAttachTarget.cpp
@@ -80,7 +80,8 @@ void NVVMAttachTarget::runOnOperation() {
   SmallVector<StringRef> filesToLink(libs);
   auto target = builder.getAttr<NVVMTargetAttr>(
       optLevel, triple, chip, features, getFlags(builder),
-      filesToLink.empty() ? nullptr : builder.getStrArrayAttr(filesToLink));
+      filesToLink.empty() ? nullptr : builder.getStrArrayAttr(filesToLink),
+      verifyTarget);
   llvm::Regex matcher(moduleMatcher);
   for (Region &region : getOperation()->getRegions())
     for (Block &block : region.getBlocks())

--- a/mlir/test/Dialect/GPU/nvvm-attach-target.mlir
+++ b/mlir/test/Dialect/GPU/nvvm-attach-target.mlir
@@ -1,10 +1,12 @@
 // RUN: mlir-opt %s --nvvm-attach-target="" | FileCheck %s
 // RUN: mlir-opt %s --nvvm-attach-target="ptxas-cmd-options=--register-usage-level=8" | FileCheck %s -check-prefix=CHECK-OPTIONS
+// RUN: mlir-opt %s --nvvm-attach-target="verify-target-arch=false" | FileCheck %s -check-prefix=CHECK-DISABLE-VERIFYTARGET
 
 module attributes {gpu.container_module} {
     // CHECK-LABEL:gpu.module @kernel_module1
     // CHECK: [#nvvm.target]
     // CHECK-OPTIONS: [#nvvm.target<flags = {"ptxas-cmd-options" = ["--register-usage-level=8"]}>]
+    // CHECK-DISABLE-VERIFYTARGET: [#nvvm.target<verifyTarget = false>]
     gpu.module @kernel_module1 {
     llvm.func @kernel(%arg0: i32, %arg1: !llvm.ptr,
         %arg2: !llvm.ptr, %arg3: i64, %arg4: i64,


### PR DESCRIPTION
This change adds the `verify-target-arch` option to the `nvvm-attach-target` to control the `verifyTarget` parameter in the attached `NVVMTargetAttr` which is used to enable/disable the verification of the target architecture with respect to the NVVM Ops.