### PR TITLE
[LLDB] Close previously opened handles in `PseudoConsole`

### DIFF
--- a/lldb/include/lldb/Host/windows/PseudoConsole.h
+++ b/lldb/include/lldb/Host/windows/PseudoConsole.h
@@ -21,6 +21,14 @@ namespace lldb_private {
 class PseudoConsole {
 
 public:
+  PseudoConsole() = default;
+  ~PseudoConsole();
+
+  PseudoConsole(const PseudoConsole &) = delete;
+  PseudoConsole(PseudoConsole &&) = delete;
+  PseudoConsole &operator=(const PseudoConsole &) = delete;
+  PseudoConsole &operator=(PseudoConsole &&) = delete;
+
   llvm::Error OpenPseudoConsole();
 
   /// Close the ConPTY, its read/write handles and invalidate them.


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/175837#issuecomment-3749408432 I mentioned that any handles that were previously opened and haven't been closed since, won't be closed in the destructor nor in `OpenPseudoConsole`. 

In this PR, I added `Close` calls to these methods. Calling `Close()` is a no-op if the handles are invalid.