### PR TITLE
[lldb-dap] separate the --stdio flag in 3 separate flags

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1155,7 +1155,9 @@ class DebugCommunication(object):
         disableSTDIO=False,
         shellExpandArguments=False,
         console: Optional[str] = None,
-        stdio: Optional[list[str]] = None,
+        stdin_path: Optional[str] = None,
+        stdout_path: Optional[str] = None,
+        stderr_path: Optional[str] = None,
         enableAutoVariableSummaries=False,
         displayExtendedBacktrace=False,
         enableSyntheticChildDebugging=False,
@@ -1207,8 +1209,12 @@ class DebugCommunication(object):
             args_dict["sourceMap"] = sourceMap
         if console:
             args_dict["console"] = console
-        if stdio:
-            args_dict["stdio"] = stdio
+        if stdin_path:
+            args_dict["stdin_path"] = stdin_path
+        if stdout_path:
+            args_dict["stdout_path"] = stdout_path
+        if stderr_path:
+            args_dict["stderr_path"] = stderr_path
         if postRunCommands:
             args_dict["postRunCommands"] = postRunCommands
         if customFrameFormat:

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -2,6 +2,7 @@
 Test lldb-dap setBreakpoints request
 """
 
+from sys import stderr
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 import lldbdap_testcase
@@ -634,7 +635,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
 
         with tempfile.NamedTemporaryFile("rt") as f:
-            self.launch(program, stdio=[None, f.name])
+            self.launch(program, stdout_path=f.name)
             self.continue_to_exit()
             lines = f.readlines()
             self.assertIn(
@@ -654,7 +655,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
 
         with tempfile.NamedTemporaryFile("rt") as f:
             self.launch(
-                program, console="integratedTerminal", stdio=[None, f.name, None]
+                program, console="integratedTerminal", stdout_path=f.name, stderr_path=f.name
             )
             self.continue_to_exit()
             lines = f.readlines()

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -655,7 +655,10 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
 
         with tempfile.NamedTemporaryFile("rt") as f:
             self.launch(
-                program, console="integratedTerminal", stdout_path=f.name, stderr_path=f.name
+                program,
+                console="integratedTerminal",
+                stdout_path=f.name,
+                stderr_path=f.name,
             )
             self.continue_to_exit()
             lines = f.readlines()

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -654,12 +654,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
 
         with tempfile.NamedTemporaryFile("rt") as f:
-            self.launch(
-                program,
-                console="integratedTerminal",
-                stdout_path=f.name,
-                stderr_path=f.name,
-            )
+            self.launch(program, console="integratedTerminal", stdout_path=f.name)
             self.continue_to_exit()
             lines = f.readlines()
             self.assertIn(

--- a/lldb/test/API/tools/lldb-dap/launch/io/TestDAP_launch_io.py
+++ b/lldb/test/API/tools/lldb-dap/launch/io/TestDAP_launch_io.py
@@ -47,7 +47,9 @@ class DAP_launchIO(lldbdap_testcase.DAPTestCaseBase):
             stdin.flush()
             self.launch(
                 program,
-                stdio=[stdin.name, stdout.name, stderr.name],
+                stdin_path=stdin.name,
+                stdout_path=stdout.name,
+                stderr_path=stderr.name,
                 console=console,
                 args=program_args,
             )
@@ -81,7 +83,7 @@ class DAP_launchIO(lldbdap_testcase.DAPTestCaseBase):
         with NamedTemporaryFile("w+t") as stdin:
             stdin.write(input_text)
             stdin.flush()
-            self.launch(program, stdio=[stdin.name], console=console, args=program_args)
+            self.launch(program, stdin_path=stdin.name, console=console, args=program_args)
             self.continue_to_exit()
 
             stdout_text = self._get_debuggee_stdout()
@@ -112,7 +114,7 @@ class DAP_launchIO(lldbdap_testcase.DAPTestCaseBase):
         with NamedTemporaryFile("rt") as stdout:
             self.launch(
                 program,
-                stdio=[None, stdout.name],
+                stdout_path=stdout.name,
                 console=console,
                 args=program_args,
                 env=env,
@@ -173,7 +175,7 @@ class DAP_launchIO(lldbdap_testcase.DAPTestCaseBase):
         with NamedTemporaryFile("rt") as stderr:
             self.launch(
                 program,
-                stdio=[None, None, stderr.name],
+                stderr_path=stderr.name,
                 console=console,
                 args=program_args,
                 env=env,

--- a/lldb/test/API/tools/lldb-dap/launch/io/TestDAP_launch_io.py
+++ b/lldb/test/API/tools/lldb-dap/launch/io/TestDAP_launch_io.py
@@ -83,7 +83,9 @@ class DAP_launchIO(lldbdap_testcase.DAPTestCaseBase):
         with NamedTemporaryFile("w+t") as stdin:
             stdin.write(input_text)
             stdin.flush()
-            self.launch(program, stdin_path=stdin.name, console=console, args=program_args)
+            self.launch(
+                program, stdin_path=stdin.name, console=console, args=program_args
+            )
             self.continue_to_exit()
 
             stdout_text = self._get_debuggee_stdout()

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -200,7 +200,8 @@ llvm::Error BaseRequestHandler::LaunchProcess(
     launch_info.SetEnvironment(env, true);
   }
 
-  if ((arguments.stdin_path || arguments.stdout_path || arguments.stderr_path) &&
+  if ((arguments.stdin_path || arguments.stdout_path ||
+       arguments.stderr_path) &&
       !arguments.disableSTDIO)
     SetupIORedirection(arguments.stdin_path, arguments.stdout_path,
                        arguments.stderr_path, launch_info);

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -200,7 +200,7 @@ llvm::Error BaseRequestHandler::LaunchProcess(
     launch_info.SetEnvironment(env, true);
   }
 
-  if ((arguments.stdin_path || arguments.stdout_path || arguments.stdin_path) &&
+  if ((arguments.stdin_path || arguments.stdout_path || arguments.stderr_path) &&
       !arguments.disableSTDIO)
     SetupIORedirection(arguments.stdin_path, arguments.stdout_path,
                        arguments.stderr_path, launch_info);

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -707,7 +707,9 @@ llvm::json::Object CreateRunInTerminalReverseRequest(
     llvm::StringRef program, const std::vector<std::string> &args,
     const llvm::StringMap<std::string> &env, llvm::StringRef cwd,
     llvm::StringRef comm_file, lldb::pid_t debugger_pid,
-    const std::vector<std::optional<std::string>> &stdio, bool external) {
+    const std::optional<std::string> &stdin_path,
+    const std::optional<std::string> &stdout_path,
+    const std::optional<std::string> &stderr_path, bool external) {
   llvm::json::Object run_in_terminal_args;
   if (external) {
     // This indicates the IDE to open an external terminal window.
@@ -725,17 +727,17 @@ llvm::json::Object CreateRunInTerminalReverseRequest(
     req_args.push_back(std::to_string(debugger_pid));
   }
 
-  if (!stdio.empty()) {
-    req_args.emplace_back("--stdio");
-
-    std::stringstream ss;
-    std::string_view delimiter;
-    for (const std::optional<std::string> &file : stdio) {
-      ss << std::exchange(delimiter, ":");
-      if (file)
-        ss << *file;
-    }
-    req_args.push_back(ss.str());
+  if (stdin_path) {
+    req_args.push_back("--stdin-path");
+    req_args.push_back(*stdin_path);
+  }
+  if (stdout_path) {
+    req_args.push_back("--stdout-path");
+    req_args.push_back(*stdout_path);
+  }
+  if (stderr_path) {
+    req_args.push_back("--stderr-path");
+    req_args.push_back(*stderr_path);
   }
 
   // WARNING: Any argument added after `launch-target` is passed to to the

--- a/lldb/tools/lldb-dap/JSONUtils.h
+++ b/lldb/tools/lldb-dap/JSONUtils.h
@@ -340,9 +340,14 @@ std::pair<int64_t, bool> UnpackLocation(int64_t location_id);
 ///     launcher uses it on Linux tell the kernel that it should allow the
 ///     debugger process to attach.
 ///
-/// \param[in] stdio
-///     An array of file paths for redirecting the program's standard IO
-///     streams.
+/// \param[in] stdin_path
+///     A file path for redirecting the program's stdout stream.
+///
+/// \param[in] stdout_path
+///     A file path for redirecting the program's stdin stream.
+///
+/// \param[in] stderr_path
+///     A file path for redirecting the program's stderr stream.
 ///
 /// \param[in] external
 ///     If set to true, the program will run in an external terminal window
@@ -355,7 +360,9 @@ llvm::json::Object CreateRunInTerminalReverseRequest(
     llvm::StringRef program, const std::vector<std::string> &args,
     const llvm::StringMap<std::string> &env, llvm::StringRef cwd,
     llvm::StringRef comm_file, lldb::pid_t debugger_pid,
-    const std::vector<std::optional<std::string>> &stdio, bool external);
+    const std::optional<std::string> &stdin_path,
+    const std::optional<std::string> &stdout_path,
+    const std::optional<std::string> &stderr_path, bool external);
 
 /// Create a "Terminated" JSON object that contains statistics
 ///

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.cpp
@@ -307,15 +307,20 @@ bool fromJSON(const json::Value &Params, LaunchRequestArguments &LRA,
       O.mapOptional("shellExpandArguments", LRA.shellExpandArguments) &&
       O.mapOptional("runInTerminal", LRA.console) &&
       O.mapOptional("console", LRA.console) &&
-      O.mapOptional("stdio", LRA.stdio) && parseEnv(Params, LRA.env, P);
+      O.mapOptional("stdin_path", LRA.stdin_path) &&
+      O.mapOptional("stdout_path", LRA.stdout_path) &&
+      O.mapOptional("stderr_path", LRA.stderr_path) &&
+      parseEnv(Params, LRA.env, P);
   if (!success)
     return false;
 
-  for (std::optional<std::string> &io_path : LRA.stdio) {
-    // set empty paths to null.
-    if (io_path && llvm::StringRef(*io_path).trim().empty())
-      io_path.reset();
-  }
+  // set empty paths to null.
+  if (LRA.stdin_path && llvm::StringRef(*LRA.stdin_path).trim().empty())
+    LRA.stdin_path.reset();
+  if (LRA.stdout_path && llvm::StringRef(*LRA.stdout_path).trim().empty())
+    LRA.stdout_path.reset();
+  if (LRA.stderr_path && llvm::StringRef(*LRA.stderr_path).trim().empty())
+    LRA.stderr_path.reset();
 
   // Validate that we have a well formed launch request.
   if (!LRA.launchCommands.empty() &&

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -301,8 +301,14 @@ struct LaunchRequestArguments {
   /// terminal or external terminal.
   Console console = eConsoleInternal;
 
-  /// An array of file paths for redirecting the program's standard IO streams.
-  std::vector<std::optional<std::string>> stdio;
+  /// A file path for redirecting the program's stdin stream.
+  std::optional<std::string> stdin_path;
+
+  /// A file path for redirecting the program's stdout stream.
+  std::optional<std::string> stdout_path;
+
+  /// A file path for redirecting the program's stderr stream.
+  std::optional<std::string> stderr_path;
 
   /// @}
 };

--- a/lldb/tools/lldb-dap/README.md
+++ b/lldb/tools/lldb-dap/README.md
@@ -68,7 +68,8 @@ This will launch process and connect `stdin` to `in.txt`, both of `stdout` and `
   "request": "launch",
   "name": "Debug",
   "program": "/tmp/a.out",
-  "stdio": ["in.txt", "out.txt"]
+  "stdin-path": "in.txt",
+  "stdout-path": "out.txt"
 }
 ```
 
@@ -265,7 +266,9 @@ contain the following key/value pairs:
 | **stopOnEntry**                   | boolean     |     | Whether to stop program immediately after launching.
 | **runInTerminal** (deprecated)    | boolean     |     | Launch the program inside an integrated terminal in the IDE. Useful for debugging interactive command line programs.
 | **console**                       | string      |     | Specify where to launch the program: internal console (`internalConsole`), integrated terminal (`integratedTerminal`) or external terminal (`externalTerminal`). Supported from lldb-dap 21.0 version.
-| **stdio**                         | [string]    |     | Redirects the debuggee's standard I/O (stdin, stdout, stderr) to a file path, named pipe, or TTY device.<br/>Use null to redirect a stream to the default debug terminal.<br/>The first three values map to stdin, stdout, and stderr respectively, Additional values create extra file descriptors (4, 5, etc.).<br/><br/>Example: `stdio: [null, "./output_file"]`, the debuggee uses the default terminal for `stdin` and `stderr`, but writes `stdout` to `./output_file`.<br/>Added in version 22.0.
+| **stdin-path**                    | [string]    |     | Redirects the debuggee's standard input (stdin) to a file path, named pipe, or TTY device.<br/>Use null to redirect the stream to the default debug terminal.
+| **stdout-path**                   | [string]    |     | Redirects the debuggee's standard output (stdout) to a file path, named pipe, or TTY device.<br/>Use null to redirect the stream to the default debug terminal.
+| **stderr-path**                   | [string]    |     | Redirects the debuggee's standard error (stderr) to a file path, named pipe, or TTY device.<br/>Use null to redirect the stream to the default debug terminal.
 | **launchCommands**                | [string]    |     | LLDB commands executed to launch the program.
 
 For JSON configurations of `"type": "attach"`, the JSON configuration can contain

--- a/lldb/tools/lldb-dap/tool/Options.td
+++ b/lldb/tools/lldb-dap/tool/Options.td
@@ -47,11 +47,20 @@ def debugger_pid: S<"debugger-pid">,
   HelpText<"The PID of the lldb-dap instance that sent the launchInTerminal "
     "request when using --launch-target.">;
 
-def stdio: S<"stdio">,
-  MetaVarName<"<stdin:stdout:stderr:...>">,
-  HelpText<"An array of file paths for redirecting the program's standard IO "
-    "streams. A colon-separated list of entries. Empty value means no "
-    "redirection.">;
+def stdin_path: S<"stdin-path">,
+  MetaVarName<"<stdin>">,
+  HelpText<"A file path for redirecting the program's stdin stream. Empty "
+    "value means no redirection.">;
+
+def stdout_path: S<"stdout-path">,
+  MetaVarName<"<stdout>">,
+  HelpText<"A file path for redirecting the program's stdout stream. Empty "
+    "value means no redirection.">;
+
+def stderr_path: S<"stderr-path">,
+  MetaVarName<"<stderr>">,
+  HelpText<"A file path for redirecting the program's stderr stream. Empty "
+    "value means no redirection.">;
 
 def repl_mode
     : S<"repl-mode">,

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -265,12 +265,9 @@ LaunchRunInTerminalTarget(llvm::opt::Arg &target_arg, llvm::StringRef comm_file,
 #endif
 
   lldb_private::FileSystem::Initialize();
-  if (!stdio.empty()) {
-    constexpr size_t num_of_stdio = 3;
-    llvm::SmallVector<llvm::StringRef, num_of_stdio> stdio_files;
-    stdio.split(stdio_files, ':');
-    stdio_files.resize(std::max(num_of_stdio, stdio_files.size()));
-    if (llvm::Error err = SetupIORedirection(stdio_files))
+  if (!stdin_path.empty() || !stdout_path.empty() || !stderr_path.empty()) {
+    if (llvm::Error err =
+            SetupIORedirection(stdin_path, stdout_path, stderr_path))
       return err;
   } else if ((isatty(STDIN_FILENO) != 0) &&
              llvm::StringRef(getenv("TERM")).starts_with_insensitive("xterm")) {


### PR DESCRIPTION
This patch separates the `--stdio` flag in three separate flags: `--stdin-path`, `--stdout-path` and `--stderr-path`.

The original option was inspired by CodeLLDB, with `--stdio` being a list of `:` separated file paths, with additional paths (flags with an index >= 3) being inherited to the `stderr` flag. The `:` separator was incompatible with Windows, which accepts `:` in file paths (`C:\`).