### PR TITLE
[mlir][memref]: Fold ExpandShape into TransferRead

### DIFF
--- a/mlir/test/Dialect/MemRef/fold-memref-alias-ops.mlir
+++ b/mlir/test/Dialect/MemRef/fold-memref-alias-ops.mlir
@@ -820,6 +820,42 @@ func.func @fold_vector_transfer_read_expand_shape(
 
 // -----
 
+func.func @fold_vector_transfer_read_expand_shape_non_identity(
+  %arg0 : memref<32x32xf32>, %arg1 : index, %arg2 : index) -> vector<8x8xf32> {
+  %c0 = arith.constant 0 : index
+  %pad = ub.poison : f32
+  %0 = memref.expand_shape %arg0 [[0, 1], [2, 3]] output_shape [4, 8, 4, 8] : memref<32x32xf32> into memref<4x8x4x8xf32>
+  %1 = vector.transfer_read %0[%arg1, %c0, %arg2, %c0], %pad {in_bounds = [true, true], permutation_map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>} : memref<4x8x4x8xf32>, vector<8x8xf32>
+  return %1 : vector<8x8xf32>
+}
+
+// CHECK-LABEL: func @fold_vector_transfer_read_expand_shape_non_identity
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<32x32xf32>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:   %[[ARG2:[a-zA-Z0-9_]+]]: index
+//       CHECK:   %[[C0:.*]] = arith.constant 0
+//       CHECK:   %[[PAD:.*]] = ub.poison : f32
+//       CHECK:   %[[IDX1:.*]] = affine.linearize_index [%[[ARG1]], %[[C0]]] by (4, 8)
+//       CHECK:   %[[IDX2:.*]] = affine.linearize_index [%[[ARG2]], %[[C0]]] by (4, 8)
+//       CHECK:   vector.transfer_read %[[ARG0]][%[[IDX1]], %[[IDX2]]], %[[PAD]] {in_bounds = [true, true]}
+
+// -----
+
+func.func @fold_vector_transfer_read_expand_shape_non_identity_non_contiguous(
+  %arg0 : memref<32x32xf32>, %arg1 : index, %arg2 : index) -> vector<8x8xf32> {
+  %c0 = arith.constant 0 : index
+  %pad = ub.poison : f32
+  %0 = memref.expand_shape %arg0 [[0, 1], [2, 3]] output_shape [4, 8, 4, 8] : memref<32x32xf32> into memref<4x8x4x8xf32>
+  %1 = vector.transfer_read %0[%arg1, %c0, %arg2, %c0], %pad {in_bounds = [true, true], permutation_map = affine_map<(d0, d1, d2, d3) -> (d0, d3)>} : memref<4x8x4x8xf32>, vector<8x8xf32>
+  return %1 : vector<8x8xf32>
+}
+
+// CHECK-LABEL: func @fold_vector_transfer_read_expand_shape_non_identity_non_contiguous
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<32x32xf32>
+//       CHECK:   memref.expand_shape %[[ARG0]] {{\[}}[0, 1], [2, 3]] output_shape [4, 8, 4, 8] : memref<32x32xf32> into memref<4x8x4x8xf32>
+
+// -----
+
 func.func @fold_vector_transfer_read_with_perm_map(
   %arg0 : memref<32xf32>, %arg1 : index) -> vector<4x4xf32> {
   %c0 = arith.constant 0 : index


### PR DESCRIPTION
Add support for folding `memref.expand_shape` ops into `vector.transfer_read` ops when the permutation map is a non-minor-identity.

In the case that the permutation map indexes into expanded dimensions that would be contiguous within the original source shape then it is safe to make this transformation.