### PR TITLE
llvm: Add LLVM_ABI_FOR_TEST annotations in VPlanValue

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -239,9 +239,9 @@ class VPRecipeValue : public VPValue {
   VPDef *Def;
 
 public:
-  VPRecipeValue(VPDef *Def, Value *UV = nullptr);
+  LLVM_ABI_FOR_TEST VPRecipeValue(VPDef *Def, Value *UV = nullptr);
 
-  virtual ~VPRecipeValue();
+  LLVM_ABI_FOR_TEST virtual ~VPRecipeValue();
 
   static bool classof(const VPValue *V) {
     return V->getVPValueID() == VPVRecipeValueSC;


### PR DESCRIPTION
This is needed to build LLVM as a DLL on Windows.

This effort is tracked in #109483.