### PR TITLE
[SemaHLSL] Verify assignment of local resources

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13431,6 +13431,9 @@ def err_hlsl_incomplete_resource_array_in_function_param: Error<
   "incomplete resource array in a function parameter">;
 def err_hlsl_assign_to_global_resource: Error<
   "assignment to global resource variable %0 is not allowed">;
+def err_hlsl_assigning_local_resource_is_not_unique
+    : Error<"assignment to local resource %0 is not to same unique global "
+            "resource">;
 
 def err_hlsl_push_constant_unique
     : Error<"cannot have more than one push constant block">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13432,7 +13432,8 @@ def err_hlsl_incomplete_resource_array_in_function_param: Error<
 def err_hlsl_assign_to_global_resource: Error<
   "assignment to global resource variable %0 is not allowed">;
 def err_hlsl_assigning_local_resource_is_not_unique
-    : Error<"assignment to local resource %0 is not to the same unique global "
+    : Error<"assignment of %0 to local resource %1 is not to the same unique "
+            "global "
             "resource">;
 
 def err_hlsl_push_constant_unique

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13432,7 +13432,7 @@ def err_hlsl_incomplete_resource_array_in_function_param: Error<
 def err_hlsl_assign_to_global_resource: Error<
   "assignment to global resource variable %0 is not allowed">;
 def err_hlsl_assigning_local_resource_is_not_unique
-    : Error<"assignment to local resource %0 is not to same unique global "
+    : Error<"assignment to local resource %0 is not to the same unique global "
             "resource">;
 
 def err_hlsl_push_constant_unique

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -113,14 +113,15 @@ class LocalResourceAssigns {
 public:
   struct Assign {
     const Expr *AssignExpr;
+    const Scope *AssignScope;
     const DeclBindingInfo *Info;
 
     bool Invalidated;
 
-    Assign(const Expr *AssignExpr, const DeclBindingInfo *Info);
+    Assign(const Expr *AssignExpr, const Scope *AssignScope, const DeclBindingInfo *Info);
   };
 
-  void trackAssign(const ValueDecl *VD, const Expr *AssignExpr,
+  void trackAssign(const ValueDecl *VD, const Scope *AssignScope, const Expr *AssignExpr,
                    const DeclBindingInfo *Info);
   std::optional<Assign> getAssign(const ValueDecl *VD);
 

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -116,6 +116,10 @@ public:
     const Scope *AssignScope;
     const DeclBindingInfo *Info;
 
+    // A new scope is not created for an else/else if it does not precede a
+    // compound stmt as per CXX specification. The CurMSManglingNumber at the
+    // time of parsing is used to differentiate the scope in this case.
+    uint32_t MSMangleNum;
     bool Invalidated;
 
     Assign(const Expr *AssignExpr, const Scope *AssignScope, const DeclBindingInfo *Info);

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -137,7 +137,7 @@ public:
   // std::nullopt if the expr refers to non-unique global bindings, returns
   // nullptr if it isn't refer to any global binding, otherwise it returns
   // a reference to the global binding info.
-  std::optional<const DeclBindingInfo *> GetGlobalBinding(Expr *E);
+  std::optional<const DeclBindingInfo *> getGlobalBinding(Expr *E);
 
   // Return true if everything is ok; returns false if there was an error.
   bool CheckResourceBinOp(BinaryOperatorKind Opc, Expr *LHSExpr, Expr *RHSExpr,

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -122,11 +122,12 @@ public:
     uint32_t MSMangleNum;
     bool Invalidated;
 
-    Assign(const Expr *AssignExpr, const Scope *AssignScope, const DeclBindingInfo *Info);
+    Assign(const Expr *AssignExpr, const Scope *AssignScope,
+           const DeclBindingInfo *Info);
   };
 
-  void trackAssign(const ValueDecl *VD, const Scope *AssignScope, const Expr *AssignExpr,
-                   const DeclBindingInfo *Info);
+  void trackAssign(const ValueDecl *VD, const Scope *AssignScope,
+                   const Expr *AssignExpr, const DeclBindingInfo *Info);
   std::optional<Assign> getAssign(const ValueDecl *VD);
 
 private:

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -240,8 +240,8 @@ private:
 
   // Map of local resource variables to their used global resource.
   //
-  // The Binding can be a nullptr, in which case, the variable has not be
-  // initialized or assigned to yet.
+  // The binding can be a nullptr, in which case, the variable has yet to be
+  // initialized or assigned to.
   llvm::DenseMap<const VarDecl *, const DeclBindingInfo *>
       LocalResourceBindings;
 

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -132,6 +132,14 @@ public:
   bool ActOnUninitializedVarDecl(VarDecl *D);
   void ActOnEndOfTranslationUnit(TranslationUnitDecl *TU);
   void CheckEntryPoint(FunctionDecl *FD);
+
+  // Return an info if the expr has common global binding info; returns
+  // std::nullopt if the expr refers to non-unique global bindings, returns
+  // nullptr if it isn't refer to any global binding, otherwise it returns
+  // a reference to the global binding info.
+  std::optional<const DeclBindingInfo *> GetGlobalBinding(Expr *E);
+
+  // Return true if everything is ok; returns false if there was an error.
   bool CheckResourceBinOp(BinaryOperatorKind Opc, Expr *LHSExpr, Expr *RHSExpr,
                           SourceLocation Loc);
 
@@ -229,6 +237,13 @@ private:
 
   // List of all resource bindings
   ResourceBindings Bindings;
+
+  // Map of local resource variables to their used global resource.
+  //
+  // The Binding can be a nullptr, in which case, the variable has not be
+  // initialized or assigned to yet.
+  llvm::DenseMap<const VarDecl *, const DeclBindingInfo *>
+      LocalResourceBindings;
 
   // Global declaration collected for the $Globals default constant
   // buffer which will be created at the end of the translation unit.

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -202,14 +202,15 @@ LocalResourceAssigns::Assign::Assign(const Expr *AssignExpr,
     : AssignExpr(AssignExpr), AssignScope(AssignScope), Info(Info),
       MSMangleNum(AssignScope->getMSCurManglingNumber()), Invalidated(false) {}
 
-static bool isEquivalentScope(LocalResourceAssigns::Assign Cur,
-                              LocalResourceAssigns::Assign Prev) {
+static bool isEquivalentAssignmentScope(LocalResourceAssigns::Assign Cur,
+                                        LocalResourceAssigns::Assign Prev) {
   const Scope *CurScope = Cur.AssignScope;
   const Scope *PrevScope = Prev.AssignScope;
   if (CurScope != PrevScope)
     return false;
 
-  // If these are not equivalent
+  // If these are not equivalent, then we are at a tailing single stmt else/
+  // else if, and should be denoted as different for assignment.
   if (Cur.MSMangleNum != Prev.MSMangleNum)
     return false;
 
@@ -245,7 +246,7 @@ void LocalResourceAssigns::trackAssign(const ValueDecl *VD,
 
   Assign &Prev = AssignIt->getSecond();
 
-  if (isEquivalentScope(Cur, Prev) ||
+  if (isEquivalentAssignmentScope(Cur, Prev) ||
       isAncestorScope(Cur.AssignScope, Prev.AssignScope->getParent())) {
     // If the current scope is equivalent or an ancestor of the previous scope,
     // we should ignore the previous access and overwrite it

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4398,10 +4398,10 @@ bool SemaHLSL::ActOnUninitializedVarDecl(VarDecl *VD) {
   return false;
 }
 
-std::optional<const DeclBindingInfo *> SemaHLSL::GetGlobalBinding(Expr *E) {
+std::optional<const DeclBindingInfo *> SemaHLSL::getGlobalBinding(Expr *E) {
   if (auto *Ternary = dyn_cast<ConditionalOperator>(E)) {
-    auto TrueInfo = GetGlobalBinding(Ternary->getTrueExpr());
-    auto FalseInfo = GetGlobalBinding(Ternary->getFalseExpr());
+    auto TrueInfo = getGlobalBinding(Ternary->getTrueExpr());
+    auto FalseInfo = getGlobalBinding(Ternary->getFalseExpr());
     if (!TrueInfo || !FalseInfo)
       return std::nullopt;
     if (*TrueInfo != *FalseInfo)
@@ -4450,7 +4450,7 @@ bool SemaHLSL::CheckResourceBinOp(BinaryOperatorKind Opc, Expr *LHSExpr,
           return false;
       }
 
-      auto RHSBinding = GetGlobalBinding(RHSExpr);
+      auto RHSBinding = getGlobalBinding(RHSExpr);
       if (!RHSBinding) {
         SemaRef.Diag(Loc,
                      diag::err_hlsl_assigning_local_resource_is_not_unique)
@@ -4851,7 +4851,7 @@ bool SemaHLSL::handleInitialization(VarDecl *VDecl, Expr *&Init) {
   // If initializing a local resource, register the binding it is using.
   if (VDecl->getType()->isHLSLResourceRecord() && !VDecl->hasGlobalStorage())
     if (auto *InitExpr = Init) {
-      if (auto Binding = GetGlobalBinding(InitExpr)) {
+      if (auto Binding = getGlobalBinding(InitExpr)) {
         LocalResourceBindings.insert({VDecl, *Binding});
       } else {
         SemaRef.Diag(Init->getBeginLoc(),

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -253,8 +253,11 @@ void LocalResourceAssigns::trackAssign(const ValueDecl *VD,
     return;
   }
 
-  Cur.Invalidated = Cur.Info != Prev.Info;
-  Prev = Cur;
+  // If it isn't equivalent, mark the assignment as invalid and updated the
+  // AssignExpr to the current. We should keep the previous scope to prevent
+  // overwriting an invalid access.
+  Prev.Invalidated = Cur.Info != Prev.Info;
+  Prev.AssignExpr = Cur.AssignExpr;
 }
 
 std::optional<LocalResourceAssigns::Assign>

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -201,6 +201,15 @@ LocalResourceAssigns::Assign::Assign(const Expr *AssignExpr,
                                      const DeclBindingInfo *Info)
     : AssignExpr(AssignExpr), AssignScope(AssignScope), Info(Info), Invalidated(false) {}
 
+static bool isAncestorScope(const Scope *Ancestor, const Scope *Cur) {
+  while (Cur != nullptr) {
+    if (Ancestor == Cur)
+      return true;
+    Cur = Cur->getParent();
+  }
+  return false;
+}
+
 void LocalResourceAssigns::trackAssign(const ValueDecl *VD,
                                        const Scope *AssignScope,
                                        const Expr *AssignExpr,
@@ -215,8 +224,9 @@ void LocalResourceAssigns::trackAssign(const ValueDecl *VD,
   }
 
   Assign &Prev = AssignIt->getSecond();
-  if (Cur.AssignScope == Prev.AssignScope) {
-    // If we are in the same scope, just overwrite it
+  if (isAncestorScope(Cur.AssignScope, Prev.AssignScope)) {
+    // If the current scope is an ancestor of the previous scope,
+    // we should ignore the previous access and overwrite it
     Prev = Cur;
     return;
   }

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4518,10 +4518,10 @@ bool SemaHLSL::CheckResourceBinOp(BinaryOperatorKind Opc, Expr *LHSExpr,
   if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(E->IgnoreParens())) {
     if (VarDecl *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
       if (VD->hasGlobalStorage() && VD->getStorageClass() != SC_Static) {
-          // Assignment to a global resource is not allowed.
-          SemaRef.Diag(Loc, diag::err_hlsl_assign_to_global_resource) << VD;
-          SemaRef.Diag(VD->getLocation(), diag::note_var_declared_here) << VD;
-          return false;
+        // Assignment to a global resource is not allowed.
+        SemaRef.Diag(Loc, diag::err_hlsl_assign_to_global_resource) << VD;
+        SemaRef.Diag(VD->getLocation(), diag::note_var_declared_here) << VD;
+        return false;
       }
 
       if (auto Binding = getGlobalBinding(RHSExpr)) {

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4462,7 +4462,8 @@ bool SemaHLSL::CheckResourceBinOp(BinaryOperatorKind Opc, Expr *LHSExpr,
         // with previous assignments to global resources
         const DeclBindingInfo *LHSBinding = LocalResourceBindings[VD];
         if (!LHSBinding) {
-          // LHSBinding is a nullptr when the local resource is instantiated without an expression.
+          // LHSBinding is a nullptr when the local resource is instantiated
+          // without an expression.
           LocalResourceBindings[VD] = *RHSBinding;
         } else if (LHSBinding != *RHSBinding) {
           SemaRef.Diag(Loc,

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -4452,7 +4452,7 @@ bool SemaHLSL::CheckResourceBinOp(BinaryOperatorKind Opc, Expr *LHSExpr,
     if (VarDecl *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
       if (VD->getStorageClass() != SC_Static) {
         if (VD->hasGlobalStorage()) {
-          // assignment to global resource is not allowed
+          // Assignment to a global resource is not allowed.
           SemaRef.Diag(Loc, diag::err_hlsl_assign_to_global_resource) << VD;
           SemaRef.Diag(VD->getLocation(), diag::note_var_declared_here) << VD;
           return false;
@@ -4462,7 +4462,7 @@ bool SemaHLSL::CheckResourceBinOp(BinaryOperatorKind Opc, Expr *LHSExpr,
         // with previous assignments to global resources
         const DeclBindingInfo *LHSBinding = LocalResourceBindings[VD];
         if (!LHSBinding) {
-          // occurs when local resource was instantiated without an expression
+          // LHSBinding is a nullptr when the local resource is instantiated without an expression.
           LocalResourceBindings[VD] = *RHSBinding;
         } else if (LHSBinding != *RHSBinding) {
           SemaRef.Diag(Loc,
@@ -4848,7 +4848,7 @@ bool SemaHLSL::transformInitList(const InitializedEntity &Entity,
 }
 
 bool SemaHLSL::handleInitialization(VarDecl *VDecl, Expr *&Init) {
-  // If initializing a local resource, register the binding it is using
+  // If initializing a local resource, register the binding it is using.
   if (VDecl->getType()->isHLSLResourceRecord() && !VDecl->hasGlobalStorage())
     if (auto *InitExpr = Init) {
       if (auto Binding = GetGlobalBinding(InitExpr)) {

--- a/clang/test/SemaHLSL/local_resource_binding.hlsl
+++ b/clang/test/SemaHLSL/local_resource_binding.hlsl
@@ -69,3 +69,16 @@ void unused_reassign(int idx) {
     Out = Out0;
     Out[idx] = In[idx];
 }
+
+void scoped_switch(int idx) {
+    RWStructuredBuffer<int> Out;
+    switch (idx) {
+    case 0: Out = Out0;
+    case 1: Out = Out0;
+    default: {
+        Out = Out1;
+        Out = Out0;
+    }
+	}
+    Out[idx] = In[idx];
+}

--- a/clang/test/SemaHLSL/local_resource_binding.hlsl
+++ b/clang/test/SemaHLSL/local_resource_binding.hlsl
@@ -11,6 +11,12 @@ cbuffer c {
     bool cond;
 };
 
+void overwrite(int idx) {
+	RWStructuredBuffer<int> Out = Out0;
+	Out = Out1;
+	Out[idx] = In[idx];
+}
+
 void no_initial_assignment(int idx) {
     RWStructuredBuffer<int> Out;
     if (cond) {

--- a/clang/test/SemaHLSL/local_resource_binding.hlsl
+++ b/clang/test/SemaHLSL/local_resource_binding.hlsl
@@ -60,3 +60,12 @@ void conditional_result_in_same(int idx) {
     RWStructuredBuffer<int> Out = cond ? Out0 : Out0;
 	Out[idx] = In[idx];
 }
+
+void unused_reassign(int idx) {
+    RWStructuredBuffer<int> Out = Out0;
+    if (cond) {
+        Out = Out1;
+    }
+    Out = Out0;
+    Out[idx] = In[idx];
+}

--- a/clang/test/SemaHLSL/local_resource_binding.hlsl
+++ b/clang/test/SemaHLSL/local_resource_binding.hlsl
@@ -1,0 +1,56 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -verify %s
+
+// expected-no-diagnostics
+
+RWBuffer<int> In : register(u0);
+RWStructuredBuffer<int> Out0 : register(u1);
+RWStructuredBuffer<int> Out1 : register(u2);
+RWStructuredBuffer<int> OutArr[];
+
+cbuffer c {
+    bool cond;
+};
+
+void no_initial_assignment(int idx) {
+    RWStructuredBuffer<int> Out;
+    if (cond) {
+        Out = Out1;
+    }
+    Out[idx] = In[idx];
+}
+
+void same_assignment(int idx) {
+    RWStructuredBuffer<int> Out = Out1;
+    if (cond) {
+        Out = Out1;
+    }
+    Out[idx] = In[idx];
+}
+
+void conditional_initialization_with_index(int idx) {
+    RWStructuredBuffer<int> Out = cond ? OutArr[0] : OutArr[1];
+    Out[idx] = In[idx];
+}
+
+void conditional_assignment_with_index(int idx) {
+    RWStructuredBuffer<int> Out;
+	if (cond) {
+		Out = OutArr[0];
+	} else {
+		Out = OutArr[1];
+	}
+    Out[idx] = In[idx];
+}
+
+void reassignment(int idx) {
+    RWStructuredBuffer<int> Out = Out0;
+	if (cond) {
+		Out = Out0;
+	}
+	Out[idx] = In[idx];
+}
+
+void conditional_result_in_same(int idx) {
+    RWStructuredBuffer<int> Out = cond ? Out0 : Out0;
+	Out[idx] = In[idx];
+}

--- a/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
+++ b/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
@@ -65,6 +65,7 @@ void scoped_switch(int idx) {
     case 0: Out = Out0;
     case 1: Out = Out0;
     default: {
+        Out = Out0;
         // expected-error@+1 {{assignment of 'Out1' to local resource 'Out' is not to the same unique global resource}}
         Out = Out1;
     }

--- a/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
+++ b/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
@@ -47,3 +47,27 @@ void static_conditional_assignment(int idx) {
     StaticOut = cond ? Out0 : Out1;
     StaticOut[idx] = In[idx];
 }
+
+void scoped_else(int idx) {
+    RWStructuredBuffer<int> Out; // expected-note {{variable 'Out' is declared here}}
+    if (cond) {
+        Out = Out0;
+    } else {
+        // expected-error@+1 {{assignment of 'Out1' to local resource 'Out' is not to the same unique global resource}}
+        Out = Out1;
+    }
+    Out[idx] = In[idx];
+}
+
+void scoped_switch(int idx) {
+    RWStructuredBuffer<int> Out; // expected-note {{variable 'Out' is declared here}}
+    switch (idx) {
+    case 0: Out = Out0;
+    case 1: Out = Out0;
+    default: {
+        // expected-error@+1 {{assignment of 'Out1' to local resource 'Out' is not to the same unique global resource}}
+        Out = Out1;
+    }
+    }
+    Out[idx] = In[idx];
+}

--- a/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
+++ b/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
@@ -39,3 +39,11 @@ void conditional_assignment(int idx) {
     Out = cond ? Out0 : Out1;
     Out[idx] = In[idx];
 }
+
+static RWStructuredBuffer<int> StaticOut;
+
+void static_conditional_assignment(int idx) {
+    // expected-error@+1 {{assignment of 'cond ? Out0 : Out1' to local resource 'StaticOut' is not to the same unique global resource}}
+    StaticOut = cond ? Out0 : Out1;
+    StaticOut[idx] = In[idx];
+}

--- a/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
+++ b/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -verify %s
+
+RWBuffer<int> In : register(u0);
+RWStructuredBuffer<int> Out0 : register(u1);
+RWStructuredBuffer<int> Out1 : register(u2);
+RWStructuredBuffer<int> OutArr[];
+
+cbuffer c {
+    bool cond;
+};
+
+void conditional_initialization(int idx) {
+    // expected-error@+1 {{assignment to local resource 'cond ? Out0 : Out1' is not to same unique global resource}}
+    RWStructuredBuffer<int> Out = cond ? Out0 : Out1;
+    Out[idx] = In[idx];
+}
+
+void branched_assignment(int idx) {
+    RWStructuredBuffer<int> Out = Out0; // expected-note {{variable 'Out' is declared here}}
+    if (cond) {
+        // expected-error@+1 {{assignment to local resource 'Out1' is not to same unique global resource}}
+        Out = Out1;
+    }
+    Out[idx] = In[idx];
+}
+
+void branched_assignment_with_array(int idx) {
+    RWStructuredBuffer<int> Out = Out0; // expected-note {{variable 'Out' is declared here}}
+    if (cond) {
+        // expected-error@+1 {{assignment to local resource 'OutArr[0]' is not to same unique global resource}}
+        Out = OutArr[0];
+    }
+    Out[idx] = In[idx];
+}
+
+void conditional_assignment(int idx) {
+    RWStructuredBuffer<int> Out;
+    // expected-error@+1 {{assignment to local resource 'cond ? Out0 : Out1' is not to same unique global resource}}
+    Out = cond ? Out0 : Out1;
+    Out[idx] = In[idx];
+}

--- a/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
+++ b/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
@@ -10,7 +10,7 @@ cbuffer c {
 };
 
 void conditional_initialization(int idx) {
-    // expected-error@+1 {{assignment to local resource 'cond ? Out0 : Out1' is not to the same unique global resource}}
+    // expected-error@+1 {{assignment of 'cond ? Out0 : Out1' to local resource 'Out' is not to the same unique global resource}}
     RWStructuredBuffer<int> Out = cond ? Out0 : Out1;
     Out[idx] = In[idx];
 }
@@ -18,7 +18,7 @@ void conditional_initialization(int idx) {
 void branched_assignment(int idx) {
     RWStructuredBuffer<int> Out = Out0; // expected-note {{variable 'Out' is declared here}}
     if (cond) {
-        // expected-error@+1 {{assignment to local resource 'Out1' is not to the same unique global resource}}
+        // expected-error@+1 {{assignment of 'Out1' to local resource 'Out' is not to the same unique global resource}}
         Out = Out1;
     }
     Out[idx] = In[idx];
@@ -27,7 +27,7 @@ void branched_assignment(int idx) {
 void branched_assignment_with_array(int idx) {
     RWStructuredBuffer<int> Out = Out0; // expected-note {{variable 'Out' is declared here}}
     if (cond) {
-        // expected-error@+1 {{assignment to local resource 'OutArr[0]' is not to the same unique global resource}}
+        // expected-error@+1 {{assignment of 'OutArr[0]' to local resource 'Out' is not to the same unique global resource}}
         Out = OutArr[0];
     }
     Out[idx] = In[idx];
@@ -35,7 +35,7 @@ void branched_assignment_with_array(int idx) {
 
 void conditional_assignment(int idx) {
     RWStructuredBuffer<int> Out;
-    // expected-error@+1 {{assignment to local resource 'cond ? Out0 : Out1' is not to the same unique global resource}}
+    // expected-error@+1 {{assignment of 'cond ? Out0 : Out1' to local resource 'Out' is not to the same unique global resource}}
     Out = cond ? Out0 : Out1;
     Out[idx] = In[idx];
 }

--- a/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
+++ b/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
@@ -18,7 +18,7 @@ void conditional_initialization(int idx) {
 void branched_assignment(int idx) {
     RWStructuredBuffer<int> Out = Out0; // expected-note {{variable 'Out' is declared here}}
     if (cond) {
-        // expected-error@+1 {{assignment to local resource 'Out1' is not to same the unique global resource}}
+        // expected-error@+1 {{assignment to local resource 'Out1' is not to the same unique global resource}}
         Out = Out1;
     }
     Out[idx] = In[idx];

--- a/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
+++ b/clang/test/SemaHLSL/local_resource_binding_errs.hlsl
@@ -10,7 +10,7 @@ cbuffer c {
 };
 
 void conditional_initialization(int idx) {
-    // expected-error@+1 {{assignment to local resource 'cond ? Out0 : Out1' is not to same unique global resource}}
+    // expected-error@+1 {{assignment to local resource 'cond ? Out0 : Out1' is not to the same unique global resource}}
     RWStructuredBuffer<int> Out = cond ? Out0 : Out1;
     Out[idx] = In[idx];
 }
@@ -18,7 +18,7 @@ void conditional_initialization(int idx) {
 void branched_assignment(int idx) {
     RWStructuredBuffer<int> Out = Out0; // expected-note {{variable 'Out' is declared here}}
     if (cond) {
-        // expected-error@+1 {{assignment to local resource 'Out1' is not to same unique global resource}}
+        // expected-error@+1 {{assignment to local resource 'Out1' is not to same the unique global resource}}
         Out = Out1;
     }
     Out[idx] = In[idx];
@@ -27,7 +27,7 @@ void branched_assignment(int idx) {
 void branched_assignment_with_array(int idx) {
     RWStructuredBuffer<int> Out = Out0; // expected-note {{variable 'Out' is declared here}}
     if (cond) {
-        // expected-error@+1 {{assignment to local resource 'OutArr[0]' is not to same unique global resource}}
+        // expected-error@+1 {{assignment to local resource 'OutArr[0]' is not to the same unique global resource}}
         Out = OutArr[0];
     }
     Out[idx] = In[idx];
@@ -35,7 +35,7 @@ void branched_assignment_with_array(int idx) {
 
 void conditional_assignment(int idx) {
     RWStructuredBuffer<int> Out;
-    // expected-error@+1 {{assignment to local resource 'cond ? Out0 : Out1' is not to same unique global resource}}
+    // expected-error@+1 {{assignment to local resource 'cond ? Out0 : Out1' is not to the same unique global resource}}
     Out = cond ? Out0 : Out1;
     Out[idx] = In[idx];
 }


### PR DESCRIPTION
This change adds the equivalent verification from DXC to ensure that a local resource is only assigned to a unique global resource.

It corresponds to the 'local resource not guaranteed to map to unique global resource' error demonstrated in cases B/C [here](https://godbolt.org/z/bhhqde77c).

This is orthogonal, but a pre-requisite, to resolving https://github.com/llvm/llvm-project/issues/165288. As it limits the kinds of ptr/handle usages are required to be handled during `dxil-resource-access`.