### PR TITLE
llc: Construct RuntimeLibraryInfoWrapper with correct triple

### DIFF
--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -752,9 +752,9 @@ static int compileModule(char **argv, SmallVectorImpl<PassPlugin> &PluginList,
   legacy::PassManager PM;
   PM.add(new TargetLibraryInfoWrapperPass(TLII));
   PM.add(new RuntimeLibraryInfoWrapper(
-      M->getTargetTriple(), Target->Options.ExceptionModel,
-      Target->Options.FloatABIType, Target->Options.EABIVersion,
-      Options.MCOptions.ABIName, Target->Options.VecLib));
+      TheTriple, Target->Options.ExceptionModel, Target->Options.FloatABIType,
+      Target->Options.EABIVersion, Options.MCOptions.ABIName,
+      Target->Options.VecLib));
 
   {
     raw_pwrite_stream *OS = &Out->os();


### PR DESCRIPTION
The target option processing here is unnecessarily confusing
and buggy. Depending on the combination of -march, -mtriple, and
an explicit module in the triple, the triple won't be set in the
IR module. "TheTriple" should be the one consistent with the
constructed TargetMachine.

This avoids a behavior change when SelectionDAG is switched to
using LibcallLoweringInfo.