### PR TITLE
[OpenMP][omptest] Fix CMake target properties

### DIFF
--- a/openmp/tools/omptest/CMakeLists.txt
+++ b/openmp/tools/omptest/CMakeLists.txt
@@ -85,7 +85,7 @@ if ((NOT LIBOMPTEST_BUILD_STANDALONE) OR LIBOMPTEST_BUILD_UNITTESTS)
   # Link against the default GTest which at this point primarily pulls in the
   # include directories and compile definitions. It is important to make these
   # available to dependant targets, e.g. for unit tests.
-  target_link_libraries(omptest INTERFACE default_gtest)
+  target_link_libraries(omptest PUBLIC default_gtest)
 
   # Link against Threads (recommended for GTest).
   find_package(Threads REQUIRED)


### PR DESCRIPTION
Fix visibility of target properties:
 * INCLUDE_DIRECTORIES
 * COMPILE_DEFINITIONS

implicitly pulled in from `default_gtest`.

Fixes: https://github.com/llvm/llvm-project/pull/159416