### PR TITLE
[LifetimeSafety] Detect dangling references to field members

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
@@ -37,6 +37,7 @@ public:
   void VisitDeclRefExpr(const DeclRefExpr *DRE);
   void VisitCXXConstructExpr(const CXXConstructExpr *CCE);
   void VisitCXXMemberCallExpr(const CXXMemberCallExpr *MCE);
+  void VisitMemberExpr(const MemberExpr *ME);
   void VisitCallExpr(const CallExpr *CE);
   void VisitCXXNullPtrLiteralExpr(const CXXNullPtrLiteralExpr *N);
   void VisitImplicitCastExpr(const ImplicitCastExpr *ICE);

--- a/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
+++ b/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
@@ -1009,15 +1009,12 @@ void operator_star_arrow_of_iterators_false_positive_no_cfg_analysis() {
   const char* q = (*v.begin()).second.data();
   const std::string& r = (*v.begin()).second;
 
-  // FIXME: Detect this using the CFG-based lifetime analysis.
-  //        Detect dangling references to struct field.
-  //        https://github.com/llvm/llvm-project/issues/176144
   auto temporary = []() { return std::vector<std::pair<int, std::string>>{{1, "1"}}; };
-  const char* x = temporary().begin()->second.data();
-  const char* y = (*temporary().begin()).second.data();
-  const std::string& z = (*temporary().begin()).second;
+  const char* x = temporary().begin()->second.data();   // cfg-warning {{object whose reference is captured does not live long enough}} cfg-note {{destroyed here}}
+  const char* y = (*temporary().begin()).second.data(); // cfg-warning {{object whose reference is captured does not live long enough}} cfg-note {{destroyed here}}
+  const std::string& z = (*temporary().begin()).second; // cfg-warning {{object whose reference is captured does not live long enough}} cfg-note {{destroyed here}}
 
-  use(p, q, r, x, y, z);
+  use(p, q, r, x, y, z); // cfg-note 3 {{later used here}}
 }
 } // namespace iterator_arrow
 
@@ -1057,24 +1054,27 @@ struct S {
 };
 struct Q {
   const S* get() const [[clang::lifetimebound]];
+  ~Q();
 };
 
 std::string_view foo(std::string_view sv [[clang::lifetimebound]]);
 
-// FIXME: Detect this using the CFG-based lifetime analysis.
-//        Detect dangling references to struct field.
-//        https://github.com/llvm/llvm-project/issues/176144
 void test1() {
   std::string_view k1 = S().sv; // OK
-  std::string_view k2 = S().s; // expected-warning {{object backing the pointer will}}
+  std::string_view k2 = S().s; // expected-warning {{object backing the pointer will}} \
+                               // cfg-warning {{object whose reference is captured does not live long enough}} cfg-note {{destroyed here}}
 
   std::string_view k3 = Q().get()->sv; // OK
-  std::string_view k4  = Q().get()->s; // expected-warning {{object backing the pointer will}}
+  std::string_view k4  = Q().get()->s; // expected-warning {{object backing the pointer will}} \
+                                       // cfg-warning {{object whose reference is captured does not live long enough}} cfg-note {{destroyed here}}
 
-  std::string_view lb1 = foo(S().s); // expected-warning {{object backing the pointer will}}
-  std::string_view lb2 = foo(Q().get()->s); // expected-warning {{object backing the pointer will}}
 
-  use(k1, k2, k3, k4, lb1, lb2);
+  std::string_view lb1 = foo(S().s); // expected-warning {{object backing the pointer will}} \
+                                     // cfg-warning {{object whose reference is captured does not live long enough}} cfg-note {{destroyed here}}
+  std::string_view lb2 = foo(Q().get()->s); // expected-warning {{object backing the pointer will}} \
+                                            // cfg-warning {{object whose reference is captured does not live long enough}} cfg-note {{destroyed here}}
+
+  use(k1, k2, k3, k4, lb1, lb2);  // cfg-note 4 {{later used here}}
 }
 
 struct Bar {};

--- a/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-suggestions.cpp
@@ -110,9 +110,9 @@ struct Container {
   MyObj data;
   const MyObj& getData() [[clang::lifetimebound]] { return data; }
 };
-// FIXME: c.data does not forward loans
-View return_struct_field(const Container& c) {
-  return c.data;
+
+View return_struct_field(const Container& c) { // expected-warning {{parameter in intra-TU function should be marked [[clang::lifetimebound]]}}
+  return c.data; // expected-note {{param returned here}}
 }
 View return_struct_lifetimebound_getter(Container& c) {  // expected-warning {{parameter in intra-TU function should be marked [[clang::lifetimebound]]}}
   return c.getData().getView();  // expected-note {{param returned here}}


### PR DESCRIPTION
Add support for detecting dangling references to struct fields in the CFG-based lifetime analysis.
The tests now include cases where accessing fields of temporary objects leads to dangling references, which are properly detected.


- Added `VisitMemberExpr` method to the `FactsGenerator` class to handle field member expressions
- Implemented the method to create origin flow facts for field member expressions
- Updated tests to include CFG-based warnings for dangling references to struct fields
- Fixed previously disabled tests that can now detect these issues

Fixes https://github.com/llvm/llvm-project/issues/176144