### PR TITLE
[flang][OpenMP] Allow ALLOC/RELEASE in place of STORAGE in 6.0

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -4301,10 +4301,11 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Map &x) {
     static auto isValidForVersion{
         [](parser::OmpMapType::Value t, unsigned version) {
           switch (t) {
-          case parser::OmpMapType::Value::Alloc:
           case parser::OmpMapType::Value::Delete:
-          case parser::OmpMapType::Value::Release:
             return version < 60;
+          case parser::OmpMapType::Value::Alloc:
+          case parser::OmpMapType::Value::Release:
+            return version <= 60;
           case parser::OmpMapType::Value::Storage:
             return version >= 60;
           default:
@@ -4337,8 +4338,9 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Map &x) {
         llvm::is_contained(leafs, Directive::OMPD_target_data)) {
       if (version >= 60) {
         // Map types listed in the decay table. [6.0:276]
-        CheckAllowedMapTypes(
-            type->v, {Value::Storage, Value::From, Value::To, Value::Tofrom});
+        CheckAllowedMapTypes(type->v,
+            {Value::Alloc, Value::Release, Value::Storage, Value::From,
+                Value::To, Value::Tofrom});
       } else {
         CheckAllowedMapTypes(
             type->v, {Value::Alloc, Value::From, Value::To, Value::Tofrom});

--- a/flang/test/Semantics/OpenMP/map-clause-v60.f90
+++ b/flang/test/Semantics/OpenMP/map-clause-v60.f90
@@ -6,3 +6,30 @@ subroutine f00(a)
   !$omp target map(a)
   !$omp end target
 end
+
+subroutine f01
+  integer :: x
+  ! No diagnostic expected, alloc is allowed on map-entering constructs
+  !$omp target map(alloc: x)
+  !$omp end target
+end
+
+subroutine f02
+  integer :: x
+  ! No diagnostic expected, release is allowed on map-exiting constructs
+  !$omp target_data map(release: x)
+  !$omp end target_data
+end
+
+subroutine f03
+  integer :: x
+  ! No diagnostic expected, delete is its own modifier in 6.0+
+  !$omp target_data map(delete: x)
+  !$omp end target_data
+end
+
+subroutine f04
+  integer :: x
+  !ERROR: Only the FROM, RELEASE, STORAGE, TOFROM map types are permitted for MAP clauses on the TARGET_EXIT_DATA directive
+  !$omp target_exit_data map(alloc: x)
+end


### PR DESCRIPTION
As per the 6.0 spec

> The value alloc may be used on map-entering constructs and the value release may be used on map-exiting constructs with identical meaning to the value storage.