### PR TITLE
[flang][OpenMP] Allow assumed-size arrays on USE_DEVICE_ADDR clause

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -4863,11 +4863,6 @@ void OmpStructureChecker::Enter(const parser::OmpClause::UseDeviceAddr &x) {
           useDeviceAddrNameList.push_back(*name);
         }
       }
-      if (version < 60 && IsWholeAssumedSizeArray(ompObject)) {
-        auto maybeSource{GetObjectSource(ompObject)};
-        context_.Say(maybeSource.value_or(clause->source),
-            "Whole assumed-size arrays are not allowed on USE_DEVICE_ADDR clause"_err_en_US);
-      }
     }
     CheckMultipleOccurrence(
         listVars, useDeviceAddrNameList, clause->source, "USE_DEVICE_ADDR");

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -4849,7 +4849,6 @@ void OmpStructureChecker::Enter(const parser::OmpClause::UseDeviceAddr &x) {
   SymbolSourceMap currSymbols;
   GetSymbolsInObjectList(x.v, currSymbols);
   semantics::UnorderedSymbolSet listVars;
-  unsigned version{context_.langOptions().OpenMPVersion};
 
   for (auto [_, clause] :
       FindClauses(llvm::omp::Clause::OMPC_use_device_addr)) {

--- a/flang/test/Semantics/OpenMP/use_device_addr1.f90
+++ b/flang/test/Semantics/OpenMP/use_device_addr1.f90
@@ -31,7 +31,7 @@ subroutine omp_target_data(asa)
       b = a
    !$omp end target data
 
-   !ERROR: Whole assumed-size arrays are not allowed on USE_DEVICE_ADDR clause
+   !No diagnostic expected, assumed-size arrays are ok
    !$omp target data use_device_addr(asa)
    !$omp end target data
 end subroutine omp_target_data


### PR DESCRIPTION
Assumed-size arrays do not present any issues here as they need to be either already mapped into the device data environment, or otherwise accessible on the target device.