### PR TITLE
MCAssembler: Write object only if there is no layout error

### DIFF
--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -733,8 +733,11 @@ void MCAssembler::layout() {
 void MCAssembler::Finish() {
   layout();
 
-  // Write the object file.
-  stats::ObjectBytes += getWriter().writeObject();
+  // Write the object file if there is no error. The output would be discarded
+  // anyway, and this avoids wasting time writing large files (e.g. when testing
+  // fixup overflow with `.space 0x80000000`).
+  if (!getContext().hadError())
+    stats::ObjectBytes += getWriter().writeObject();
 
   HasLayout = false;
   assert(PendingErrors.empty());

--- a/llvm/test/MC/Mips/set-sym-recursive.s
+++ b/llvm/test/MC/Mips/set-sym-recursive.s
@@ -1,11 +1,15 @@
-# RUN: not llvm-mc -filetype=obj -triple=mips64 %s -o /dev/null 2>&1 | FileCheck %s --implicit-check-not=error:
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: not llvm-mc -filetype=obj -triple=mips64 1.s -o /dev/null 2>&1 | FileCheck 1.s --implicit-check-not=error:
+# RUN: not llvm-mc -filetype=obj -triple=mips64 2.s -o /dev/null 2>&1 | FileCheck 2.s --check-prefix=CHECK2 --implicit-check-not=error:
 
+#--- 1.s
 # CHECK: :[[@LINE+1]]:11: error: cyclic dependency detected for symbol 'A'
 .set A, A + 1
 # CHECK: :[[@LINE+1]]:7: error: expected relocatable expression
 .word A
 .word A
 
-# CHECK: :[[@LINE+2]]:11: error: cyclic dependency detected for symbol 'B'
-# CHECK: :[[@LINE+1]]:11: error: expression could not be evaluated
+#--- 2.s
+# CHECK2: :[[@LINE+2]]:11: error: cyclic dependency detected for symbol 'B'
+# CHECK2: :[[@LINE+1]]:11: error: expression could not be evaluated
 .set B, B + 1


### PR DESCRIPTION
Currently, parsing phase errors suppress `writeObject` while layout
errors don't. This patch suppresses `writeObject` for layout errors.
The output file would be discarded anyway.

This change allows us to test fixup value overflow using large fill
fragments (e.g. `.space 0x80000000`) without wasting time on the unused
temporary object file.