### PR TITLE
GlobalISel: Use LibcallLowering to get libcall calling conventions

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -639,10 +639,8 @@ LegalizerHelper::LegalizeResult LegalizerHelper::createLibcall(
   if (LibcallImpl == RTLIB::Unsupported)
     return LegalizerHelper::UnableToLegalize;
 
-  auto &TLI = *MIRBuilder.getMF().getSubtarget().getTargetLowering();
-
   StringRef Name = RTLIB::RuntimeLibcallsInfo::getLibcallImplName(LibcallImpl);
-  const CallingConv::ID CC = TLI.getLibcallImplCallingConv(LibcallImpl);
+  const CallingConv::ID CC = Libcalls->getLibcallImplCallingConv(LibcallImpl);
   return createLibcall(Name.data(), Result, Args, CC, LocObserver, MI);
 }
 
@@ -807,7 +805,6 @@ LegalizerHelper::createMemLibcall(MachineRegisterInfo &MRI, MachineInstr &MI,
   }
 
   auto &CLI = *MIRBuilder.getMF().getSubtarget().getCallLowering();
-  auto &TLI = *MIRBuilder.getMF().getSubtarget().getTargetLowering();
   RTLIB::Libcall RTLibcall;
   unsigned Opc = MI.getOpcode();
   switch (Opc) {
@@ -843,7 +840,7 @@ LegalizerHelper::createMemLibcall(MachineRegisterInfo &MRI, MachineInstr &MI,
   }
 
   CallLowering::CallLoweringInfo Info;
-  Info.CallConv = TLI.getLibcallImplCallingConv(RTLibcallImpl);
+  Info.CallConv = Libcalls->getLibcallImplCallingConv(RTLibcallImpl);
 
   StringRef LibcallName =
       RTLIB::RuntimeLibcallsInfo::getLibcallImplName(RTLibcallImpl);
@@ -987,7 +984,6 @@ LegalizerHelper::createAtomicLibcall(MachineInstr &MI) const {
     return LegalizerHelper::UnableToLegalize;
 
   auto &CLI = *MIRBuilder.getMF().getSubtarget().getCallLowering();
-  auto &TLI = *MIRBuilder.getMF().getSubtarget().getTargetLowering();
   RTLIB::Libcall RTLibcall = getOutlineAtomicLibcall(MI);
   RTLIB::LibcallImpl RTLibcallImpl = Libcalls->getLibcallImpl(RTLibcall);
 
@@ -999,7 +995,7 @@ LegalizerHelper::createAtomicLibcall(MachineInstr &MI) const {
   }
 
   CallLowering::CallLoweringInfo Info;
-  Info.CallConv = TLI.getLibcallImplCallingConv(RTLibcallImpl);
+  Info.CallConv = Libcalls->getLibcallImplCallingConv(RTLibcallImpl);
 
   StringRef LibcallName =
       RTLIB::RuntimeLibcallsInfo::getLibcallImplName(RTLibcallImpl);


### PR DESCRIPTION
0e304e6d9f306ead81fc5177b8a497af0d416a73 converted the name queries,
but missed some of the calling conventions.