### PR TITLE
[OFFLOAD] Add a check before calling dataExchange

### DIFF
--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1014,13 +1014,18 @@ Error olMemcpy_impl(ol_queue_handle_t Queue, void *DstPtr,
       return Res;
   } else {
     if (Queue)
-      olSyncQueue(Queue);
+      if (auto Res = olSyncQueue_impl(Queue))
+        return Res;
 
     void *Buffer = malloc(Size);
+    if (!Buffer)
+      return createOffloadError(
+          ErrorCode::OUT_OF_RESOURCES,
+          "Couldn't allocate a buffer for transfer");
     Error Res = SrcDevice->Device->dataRetrieve(Buffer, SrcPtr, Size, nullptr);
-    if (!Res) {
+    if (!Res)
       Res = DstDevice->Device->dataSubmit(DstPtr, Buffer, Size, nullptr);
-    }
+
     free(Buffer);
     return Res;
   }

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1019,9 +1019,8 @@ Error olMemcpy_impl(ol_queue_handle_t Queue, void *DstPtr,
 
     void *Buffer = malloc(Size);
     if (!Buffer)
-      return createOffloadError(
-          ErrorCode::OUT_OF_RESOURCES,
-          "Couldn't allocate a buffer for transfer");
+      return createOffloadError(ErrorCode::OUT_OF_RESOURCES,
+                                "Couldn't allocate a buffer for transfer");
     Error Res = SrcDevice->Device->dataRetrieve(Buffer, SrcPtr, Size, nullptr);
     if (!Res)
       Res = DstDevice->Device->dataSubmit(DstPtr, Buffer, Size, nullptr);

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1007,23 +1007,25 @@ Error olMemcpy_impl(ol_queue_handle_t Queue, void *DstPtr,
       return Res;
   } else {
     if (SrcDevice->Platform.Plugin == DstDevice->Platform.Plugin &&
-      SrcDevice->Platform.Plugin->isDataExchangable(
-        SrcDevice->Device->getDeviceId(), DstDevice->Device->getDeviceId())) {
-      if (auto Res = SrcDevice->Device->dataExchange(SrcPtr, 
-                                                  *DstDevice->Device,
-                                                  DstPtr, Size, QueueImpl))
+        SrcDevice->Platform.Plugin->isDataExchangable(
+            SrcDevice->Device->getDeviceId(),
+            DstDevice->Device->getDeviceId())) {
+      if (auto Res = SrcDevice->Device->dataExchange(SrcPtr, *DstDevice->Device,
+                                                     DstPtr, Size, QueueImpl))
         return Res;
     } else {
       void *Buffer = malloc(Size);
       ol_queue_handle_t Queue;
       olCreateQueue(SrcDevice, &Queue);
-      Error Res = SrcDevice->Device->dataRetrieve(Buffer, SrcPtr, Size, Queue->AsyncInfo);
+      Error Res = SrcDevice->Device->dataRetrieve(Buffer, SrcPtr, Size,
+                                                  Queue->AsyncInfo);
       olDestroyQueue(Queue);
 
       if (!Res) {
         ol_queue_handle_t Queue;
         olCreateQueue(DstDevice, &Queue);
-        Res = DstDevice->Device->dataSubmit(DstPtr, Buffer, Size, Queue->AsyncInfo);
+        Res = DstDevice->Device->dataSubmit(DstPtr, Buffer, Size,
+                                            Queue->AsyncInfo);
         olDestroyQueue(Queue);
       }
       free(Buffer);

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1007,8 +1007,8 @@ Error olMemcpy_impl(ol_queue_handle_t Queue, void *DstPtr,
       return Res;
   } else if (SrcDevice->Platform.Plugin == DstDevice->Platform.Plugin &&
              SrcDevice->Platform.Plugin->isDataExchangable(
-                SrcDevice->Device->getDeviceId(),
-                DstDevice->Device->getDeviceId())) {
+                 SrcDevice->Device->getDeviceId(),
+                 DstDevice->Device->getDeviceId())) {
     if (auto Res = SrcDevice->Device->dataExchange(SrcPtr, *DstDevice->Device,
                                                    DstPtr, Size, QueueImpl))
       return Res;
@@ -1017,11 +1017,9 @@ Error olMemcpy_impl(ol_queue_handle_t Queue, void *DstPtr,
       olSyncQueue(Queue);
 
     void *Buffer = malloc(Size);
-    Error Res = SrcDevice->Device->dataRetrieve(Buffer, SrcPtr, Size,
-                                                nullptr);
+    Error Res = SrcDevice->Device->dataRetrieve(Buffer, SrcPtr, Size, nullptr);
     if (!Res) {
-      Res = DstDevice->Device->dataSubmit(DstPtr, Buffer, Size,
-                                         nullptr);
+      Res = DstDevice->Device->dataSubmit(DstPtr, Buffer, Size, nullptr);
     }
     free(Buffer);
     return Res;

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1005,32 +1005,26 @@ Error olMemcpy_impl(ol_queue_handle_t Queue, void *DstPtr,
     if (auto Res =
             DstDevice->Device->dataSubmit(DstPtr, SrcPtr, Size, QueueImpl))
       return Res;
-  } else {
-    if (SrcDevice->Platform.Plugin == DstDevice->Platform.Plugin &&
-        SrcDevice->Platform.Plugin->isDataExchangable(
-            SrcDevice->Device->getDeviceId(),
-            DstDevice->Device->getDeviceId())) {
-      if (auto Res = SrcDevice->Device->dataExchange(SrcPtr, *DstDevice->Device,
-                                                     DstPtr, Size, QueueImpl))
-        return Res;
-    } else {
-      void *Buffer = malloc(Size);
-      ol_queue_handle_t Queue;
-      olCreateQueue(SrcDevice, &Queue);
-      Error Res = SrcDevice->Device->dataRetrieve(Buffer, SrcPtr, Size,
-                                                  Queue->AsyncInfo);
-      olDestroyQueue(Queue);
-
-      if (!Res) {
-        ol_queue_handle_t Queue;
-        olCreateQueue(DstDevice, &Queue);
-        Res = DstDevice->Device->dataSubmit(DstPtr, Buffer, Size,
-                                            Queue->AsyncInfo);
-        olDestroyQueue(Queue);
-      }
-      free(Buffer);
+  } else if (SrcDevice->Platform.Plugin == DstDevice->Platform.Plugin &&
+             SrcDevice->Platform.Plugin->isDataExchangable(
+                SrcDevice->Device->getDeviceId(),
+                DstDevice->Device->getDeviceId())) {
+    if (auto Res = SrcDevice->Device->dataExchange(SrcPtr, *DstDevice->Device,
+                                                   DstPtr, Size, QueueImpl))
       return Res;
+  } else {
+    if (Queue)
+      olSyncQueue(Queue);
+
+    void *Buffer = malloc(Size);
+    Error Res = SrcDevice->Device->dataRetrieve(Buffer, SrcPtr, Size,
+                                                nullptr);
+    if (!Res) {
+      Res = DstDevice->Device->dataSubmit(DstPtr, Buffer, Size,
+                                         nullptr);
     }
+    free(Buffer);
+    return Res;
   }
 
   return Error::success();

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -1007,7 +1007,7 @@ Error olMemcpy_impl(ol_queue_handle_t Queue, void *DstPtr,
       return Res;
   } else {
     if (SrcDevice->Platform.Plugin == DstDevice->Platform.Plugin &&
-      SrcDevice->Platform.Plugin->is_data_exchangable(
+      SrcDevice->Platform.Plugin->isDataExchangable(
         SrcDevice->Device->getDeviceId(), DstDevice->Device->getDeviceId())) {
       if (auto Res = SrcDevice->Device->dataExchange(SrcPtr, 
                                                   *DstDevice->Device,


### PR DESCRIPTION
Per documentation the call to dataExchange API (move memory block between different devices) is permitted only if isDataExchangable() call returned true. While almost all platforms support memory transfer between different devices, in the case when the transfer is attempted  between devices belonging to different platforms if they are present on the same machine which can lead to unexpected results. This PR adds a check if dataExchange can be called and if not uses a workaround by initiating memory transfer through host.