### PR TITLE
Early exit llvm-bolt when coming across empty data files

### DIFF
--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -354,7 +354,7 @@ std::error_code DataReader::parseInput() {
     return EC;
 
   Diag << "WARNING: invalid profile data detected at line " << Line
-      << ". Possibly corrupted profile.\n";
+       << ". Possibly corrupted profile.\n";
 
   buildLTONameMaps();
 

--- a/bolt/lib/Profile/DataReader.cpp
+++ b/bolt/lib/Profile/DataReader.cpp
@@ -344,11 +344,17 @@ std::error_code DataReader::parseInput() {
   }
   FileBuf = std::move(MB.get());
   ParsingBuf = FileBuf->getBuffer();
+
+  if (ParsingBuf.empty()) {
+    Diag << "WARNING: empty profile data file: " << Filename << "\n";
+    return make_error_code(llvm::errc::io_error);
+  }
+
   if (std::error_code EC = parse())
     return EC;
-  if (!ParsingBuf.empty())
-    Diag << "WARNING: invalid profile data detected at line " << Line
-         << ". Possibly corrupted profile.\n";
+
+  Diag << "WARNING: invalid profile data detected at line " << Line
+      << ". Possibly corrupted profile.\n";
 
   buildLTONameMaps();
 

--- a/bolt/test/empty-fdata-file.test
+++ b/bolt/test/empty-fdata-file.test
@@ -1,0 +1,12 @@
+## Check that llvm-bolt detects bad profile data and aborts
+
+## This test uses the clang driver without target flags and will only succeed
+## on Linux systems where the host triple matches the target.
+REQUIRES: system-linux
+
+RUN: %clang %S/Inputs/hello.c -o %t
+RUN: touch %t.empty.fdata
+RUN: not llvm-bolt %t -o %t.bolt --data %t.empty.fdata 2>&1 | FileCheck %s
+
+CHECK: WARNING: empty profile data file
+CHECK-NEXT: BOLT-ERROR: {{.*}}Input/output error

--- a/bolt/test/empty-fdata-file.test
+++ b/bolt/test/empty-fdata-file.test
@@ -4,7 +4,7 @@
 ## on Linux systems where the host triple matches the target.
 REQUIRES: system-linux
 
-RUN: %clang %S/Inputs/hello.c -o %t
+RUN: %clang %cflags %S/Inputs/hello.c -o %t
 RUN: touch %t.empty.fdata
 RUN: not llvm-bolt %t -o %t.bolt --data %t.empty.fdata 2>&1 | FileCheck %s
 


### PR DESCRIPTION
perf2bolt generates empty fdata files for small binaries and right now BOLT does this check while parsing by calling `((!hasBranchData() && !hasMemData()))`. Instead, early exit as soon as the buffer finishes reading the data file and exit with error message.