### PR TITLE
[AArch64][NFC] Extract a `LowerNTStore()` method

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -7335,9 +7335,7 @@ SDValue AArch64TargetLowering::LowerSTORE(SDValue Op,
   EVT VT = Value.getValueType();
   EVT MemVT = StoreNode->getMemoryVT();
 
-  // Currently, STNP lowering can only either keep or increase code size, thus
-  // we predicate it to not apply when optimizing for code size.
-  if (StoreNode->isNonTemporal() && !DAG.shouldOptForSize()) {
+  if (StoreNode->isNonTemporal()) {
     if (auto MaybeSTNP = LowerNTStore(StoreNode, VT, MemVT, Dl, DAG))
       return MaybeSTNP;
   }
@@ -7388,6 +7386,11 @@ static SDValue LowerNTStore(StoreSDNode *StoreNode, EVT VT, EVT MemVT,
                             const SDLoc &DL, SelectionDAG &DAG) {
   assert(StoreNode && "Expected a store operation");
   assert(StoreNode->isNonTemporal() && "Expected a non-temporal store");
+
+  // Currently, STNP lowering can only either keep or increase code size, thus
+  // we predicate it to not apply when optimizing for code size.
+  if (DAG.shouldOptForSize())
+    return SDValue();
 
   // Currently we only support NT stores lowering for little-endian targets.
   if (!DAG.getDataLayout().isLittleEndian())

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -7384,14 +7384,13 @@ SDValue AArch64TargetLowering::LowerSTORE(SDValue Op,
 }
 
 // Lower non-temporal stores that would otherwise be broken by legalization.
-SDValue AArch64TargetLowering::LowerNTStore(StoreSDNode *StoreNode, EVT VT,
-                                            EVT MemVT, const SDLoc &DL,
-                                            SelectionDAG &DAG) const {
+static SDValue LowerNTStore(StoreSDNode *StoreNode, EVT VT, EVT MemVT,
+                            const SDLoc &DL, SelectionDAG &DAG) {
   assert(StoreNode && "Expected a store operation");
   assert(StoreNode->isNonTemporal() && "Expected a non-temporal store");
 
   // Currently we only support NT stores lowering for little-endian targets.
-  if (!Subtarget->isLittleEndian())
+  if (!DAG.getDataLayout().isLittleEndian())
     return SDValue();
 
   if (VT.isVector()) {

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -614,6 +614,8 @@ private:
 
   SDValue LowerLOAD(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSTORE(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerNTStore(StoreSDNode *, EVT VT, EVT MemVT, const SDLoc &DL,
+                       SelectionDAG &DAG) const;
   SDValue LowerStore128(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerABS(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFMUL(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -614,8 +614,6 @@ private:
 
   SDValue LowerLOAD(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSTORE(SDValue Op, SelectionDAG &DAG) const;
-  SDValue LowerNTStore(StoreSDNode *, EVT VT, EVT MemVT, const SDLoc &DL,
-                       SelectionDAG &DAG) const;
   SDValue LowerStore128(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerABS(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFMUL(SDValue Op, SelectionDAG &DAG) const;


### PR DESCRIPTION
Extracts nontermporal store lowering from `LowerSTORE` into its own private method `LowerNTStore`. The refactoring improves overall code structure (and prepares for later scaling of custom STNP lowering logic).