### PR TITLE
[libc++] Fix gdb pretty printer for strings

### DIFF
--- a/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
+++ b/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
@@ -231,6 +231,14 @@ void string_view_test() {
 }
 }
 
+std::u16string return_short_u16string() {
+  return u"a";
+}
+
+std::u16string return_long_u16string() {
+  return u"this is a string that is too long to fit in the string object";
+}
+
 void u16string_test() {
   std::u16string test0 = u"Hello World";
   ComparePrettyPrintToChars(test0, "u\"Hello World\"");
@@ -241,6 +249,20 @@ void u16string_test() {
   std::u16string test3 = u"mehmet bizim dostumuz agzi kirik testimiz";
   ComparePrettyPrintToChars(test3,
                             ("u\"mehmet bizim dostumuz agzi kirik testimiz\""));
+  // GDB handles strings that are returned from a debugger called function or
+  // when stepping out of a function differently from string variables. These
+  // two tests check that pretty printing works also for this case.
+  CompareExpressionPrettyPrintToChars("return_short_u16string()", "u\"a\"");
+  CompareExpressionPrettyPrintToChars("return_long_u16string()",
+      "u\"this is a string that is too long to fit in the string object\"");
+}
+
+std::u32string return_short_u32string() {
+  return U"a";
+}
+
+std::u32string return_long_u32string() {
+  return U"this is a string that is too long to fit in the string object";
 }
 
 void u32string_test() {
@@ -255,6 +277,12 @@ void u32string_test() {
   ComparePrettyPrintToChars(test2, ("U\"\U00004f60\U0000597d\""));
   std::u32string test3 = U"mehmet bizim dostumuz agzi kirik testimiz";
   ComparePrettyPrintToChars(test3, ("U\"mehmet bizim dostumuz agzi kirik testimiz\""));
+  // GDB handles strings that are returned from a debugger called function or
+  // when stepping out of a function differently from string variables. These
+  // two tests check that pretty printing works also for this case.
+  CompareExpressionPrettyPrintToChars("return_short_u32string()", "U\"a\"");
+  CompareExpressionPrettyPrintToChars("return_long_u32string()",
+      "U\"this is a string that is too long to fit in the string object\"");
 }
 
 void tuple_test() {

--- a/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
+++ b/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
@@ -172,6 +172,19 @@ template <typename T> class UncompressibleAllocator : public std::allocator<T> {
   };
 };
 
+// Helper function to check pretty printing of short strings returned by
+// debugger-called functions.
+std::string return_short_string() {
+  return "abc";
+}
+
+// Helper function to check pretty printing of long strings returned by
+// debugger-called functions.
+std::basic_string<char, std::char_traits<char>, UncompressibleAllocator<char>>
+return_long_string() {
+  return "this is a string that is too long to fit in the string object";
+}
+
 void string_test() {
   std::string short_string("kdjflskdjf");
   // The display_hint "string" adds quotes the printed result.
@@ -181,7 +194,14 @@ void string_test() {
       long_string("mehmet bizim dostumuz agzi kirik testimiz");
   ComparePrettyPrintToChars(long_string,
                             "\"mehmet bizim dostumuz agzi kirik testimiz\"");
-}
+
+  // GDB handles strings that are returned from a debugger called function or
+  // when stepping out of a function differently from string variables. These
+  // two tests check that pretty printing works also for this case.
+  CompareExpressionPrettyPrintToChars("return_short_string()", "\"abc\"");
+  CompareExpressionPrettyPrintToChars("return_long_string()",
+      "\"this is a string that is too long to fit in the string object\"");
+  }
 
 namespace a_namespace {
 // To test name-lookup in the presence of using inside a namespace. Inside this

--- a/libcxx/utils/gdb/libcxx/printers.py
+++ b/libcxx/utils/gdb/libcxx/printers.py
@@ -198,8 +198,9 @@ class StdStringPrinter(object):
             data = long_field["__data_"]
             size = long_field["__size_"]
         else:
-            char_ptr = gdb.lookup_type("char").pointer()
-            data = short_field["__data_"].cast(char_ptr)
+            data = short_field["__data_"]
+            ptr_type = data.type.target().pointer()
+            data = data.cast(ptr_type)
             size = short_field["__size_"]
         return data.lazy_string(length=size)
 

--- a/libcxx/utils/gdb/libcxx/printers.py
+++ b/libcxx/utils/gdb/libcxx/printers.py
@@ -198,7 +198,8 @@ class StdStringPrinter(object):
             data = long_field["__data_"]
             size = long_field["__size_"]
         else:
-            data = short_field["__data_"]
+            char_ptr = gdb.lookup_type("char").pointer()
+            data = short_field["__data_"].cast(char_ptr)
             size = short_field["__size_"]
         return data.lazy_string(length=size)
 


### PR DESCRIPTION
The gdb pretty printer for strings reports an error when printing a string that is small enough to fit inline in the string object. The problem is that the lazy_string method can't be applied directly to an array value. The fix is to cast the array to a pointer and apply lazy_string to that value.