### PR TITLE
[lldb][test] fix sporadic failures with NumberAllocatedModules assert

### DIFF
--- a/lldb/source/API/SBModule.cpp
+++ b/lldb/source/API/SBModule.cpp
@@ -668,7 +668,7 @@ uint32_t SBModule::GetNumberAllocatedModules() {
 void SBModule::GarbageCollectAllocatedModules() {
   LLDB_INSTRUMENT();
 
-  const bool mandatory = false;
+  const bool mandatory = true;
   ModuleList::RemoveOrphanSharedModules(mandatory);
 }
 


### PR DESCRIPTION
Recent test executions exhibited sporadic failures due to the assert GetNumberAllocatedModules() != 0 in the tearDown phase. The underlying cause was identified as the invocation of GarbageCollectAllocatedModules() with the parameter mandatory=false. In this mode, the function attempts to acquire a lock using try_lock() and, if unsuccessful, silently returns without removing orphaned modules. Consequently, this behavior introduced a race condition, as background threads could retain the lock during test teardown.

To address this issue, the parameter was changed to mandatory=true, thereby enforcing a blocking lock. This modification guarantees that orphaned modules are consistently removed during test cleanup.