### PR TITLE
InstCombine: Filter reported classes from SimplifyDemandedFPClass

### DIFF
--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-canonicalize.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-canonicalize.ll
@@ -58,8 +58,7 @@ define nofpclass(nan zero) float @ret_nofpclass_nan_zero__canonicalize_select_su
 ; CHECK-SAME: float [[X:%.*]], i1 [[COND:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call float @returns_sub_norm()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[X]], float [[SUB]]
-; CHECK-NEXT:    [[CANON:%.*]] = call float @llvm.canonicalize.f32(float [[SELECT]])
-; CHECK-NEXT:    ret float [[CANON]]
+; CHECK-NEXT:    ret float [[SELECT]]
 ;
   %sub = call float @returns_sub_norm()
   %select = select i1 %cond, float %x, float %sub
@@ -97,8 +96,7 @@ define nofpclass(nan zero) float @ret_nofpclass_nan_zero__canonicalize_select_su
 ; CHECK-LABEL: define nofpclass(nan zero) float @ret_nofpclass_nan_zero__canonicalize_select_sub_daz(
 ; CHECK-SAME: float [[X:%.*]], i1 [[COND:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[SUB:%.*]] = call float @returns_sub()
-; CHECK-NEXT:    [[CANON:%.*]] = call float @llvm.canonicalize.f32(float [[X]])
-; CHECK-NEXT:    ret float [[CANON]]
+; CHECK-NEXT:    ret float [[X]]
 ;
   %sub = call float @returns_sub()
   %select = select i1 %cond, float %x, float %sub
@@ -353,8 +351,7 @@ define nofpclass(zero) float @ret_nofpclass_zero__canonicalize_nnan_src_ieee(flo
 define nofpclass(zero) float @ret_nofpclass_zero__canonicalize_nnan_src_daz(float nofpclass(nan) %x, i1 %cond) #0 {
 ; CHECK-LABEL: define nofpclass(zero) float @ret_nofpclass_zero__canonicalize_nnan_src_daz(
 ; CHECK-SAME: float nofpclass(nan) [[X:%.*]], i1 [[COND:%.*]]) #[[ATTR0]] {
-; CHECK-NEXT:    [[CANON:%.*]] = call float @llvm.canonicalize.f32(float [[X]])
-; CHECK-NEXT:    ret float [[CANON]]
+; CHECK-NEXT:    ret float [[X]]
 ;
   %canon = call float @llvm.canonicalize.f32(float %x)
   ret float %canon

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fadd.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fadd.ll
@@ -63,7 +63,7 @@ define nofpclass(qnan inf zero sub norm) half @ret_only_snan(half %x, half %y) {
 define nofpclass(nan inf sub norm) half @ret_only_zero(half %x, half %y) {
 ; CHECK-LABEL: define nofpclass(nan inf sub norm) half @ret_only_zero(
 ; CHECK-SAME: half [[X:%.*]], half [[Y:%.*]]) {
-; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan ninf half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %add = fadd half %x, %y
@@ -215,7 +215,7 @@ define nofpclass(nan inf) half @ret_nofpclass_inf_nan__fadd_select_unknown_or_in
 ; CHECK-SAME: i1 [[COND:%.*]], half [[X:%.*]], half [[Y:%.*]]) {
 ; CHECK-NEXT:    [[INF0:%.*]] = call half @returns_inf()
 ; CHECK-NEXT:    [[INF1:%.*]] = call half @returns_inf()
-; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan half [[X]], [[Y]]
+; CHECK-NEXT:    [[ADD:%.*]] = fadd nnan ninf half [[X]], [[Y]]
 ; CHECK-NEXT:    ret half [[ADD]]
 ;
   %inf0 = call half @returns_inf()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fmul.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fmul.ll
@@ -448,7 +448,7 @@ define nofpclass(pinf nan) float @ret_no_pinf_or_nan_results__lhs_known_non_inf(
 define nofpclass(inf nan) float @ret_no_inf_or_nan_results__lhs_known_non_inf(i1 %cond, float %x, float nofpclass(inf) %y) {
 ; CHECK-LABEL: define nofpclass(nan inf) float @ret_no_inf_or_nan_results__lhs_known_non_inf(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[X:%.*]], float nofpclass(inf) [[Y:%.*]]) {
-; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[X]], [[Y]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf float [[X]], [[Y]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %x.or.pinf = select i1 %cond, float %x, float 0x7FF0000000000000
@@ -460,7 +460,7 @@ define nofpclass(inf nan) float @ret_no_inf_or_nan_results__lhs_known_non_inf(i1
 define nofpclass(inf nan) float @ret_no_inf_or_nan_results__rhs_known_non_inf(i1 %cond, float %x, float nofpclass(inf) %y) {
 ; CHECK-LABEL: define nofpclass(nan inf) float @ret_no_inf_or_nan_results__rhs_known_non_inf(
 ; CHECK-SAME: i1 [[COND:%.*]], float [[X:%.*]], float nofpclass(inf) [[Y:%.*]]) {
-; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[X]], [[Y]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf float [[X]], [[Y]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %y.or.pinf = select i1 %cond, float %y, float 0x7FF0000000000000
@@ -1297,7 +1297,7 @@ define nofpclass(nan inf norm sub) float @zero_result_demands_sub_source_lhs(i1 
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SUB:%.*]] = call float @returns_sub()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SUB]], float [[UNKNOWN0]]
-; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[SELECT]], [[UNKNOWN1]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf float [[SELECT]], [[UNKNOWN1]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %sub = call float @returns_sub()
@@ -1311,7 +1311,7 @@ define nofpclass(nan inf norm sub) float @zero_result_demands_sub_source_rhs(i1 
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SUB:%.*]] = call float @returns_sub()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SUB]], float [[UNKNOWN0]]
-; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[UNKNOWN1]], [[SELECT]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf float [[UNKNOWN1]], [[SELECT]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %sub = call float @returns_sub()
@@ -1325,7 +1325,7 @@ define nofpclass(nan inf norm sub) float @zero_result_demands_norm_source_lhs(i1
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[NORM:%.*]] = call float @returns_norm()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[NORM]], float [[UNKNOWN0]]
-; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[SELECT]], [[UNKNOWN1]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf float [[SELECT]], [[UNKNOWN1]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %norm = call float @returns_norm()
@@ -1339,7 +1339,7 @@ define nofpclass(nan inf norm sub) float @zero_result_demands_norm_source_rhs(i1
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[NORM:%.*]] = call float @returns_norm()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[NORM]], float [[UNKNOWN0]]
-; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[UNKNOWN1]], [[SELECT]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf float [[UNKNOWN1]], [[SELECT]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %norm = call float @returns_norm()
@@ -1353,7 +1353,7 @@ define nofpclass(nan inf norm zero) float @sub_result_demands_norm_source_lhs(i1
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[NORM:%.*]] = call float @returns_norm()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[NORM]], float [[UNKNOWN0]]
-; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[SELECT]], [[UNKNOWN1]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf float [[SELECT]], [[UNKNOWN1]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %norm = call float @returns_norm()
@@ -1367,7 +1367,7 @@ define nofpclass(nan inf norm zero) float @sub_result_demands_norm_source_rhs(i1
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[NORM:%.*]] = call float @returns_norm()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[NORM]], float [[UNKNOWN0]]
-; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[UNKNOWN1]], [[SELECT]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf float [[UNKNOWN1]], [[SELECT]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %norm = call float @returns_norm()
@@ -1381,7 +1381,7 @@ define nofpclass(nan inf sub zero) float @norm_result_demands_sub_source_lhs(i1 
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SUB:%.*]] = call float @returns_sub()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SUB]], float [[UNKNOWN0]]
-; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[SELECT]], [[UNKNOWN1]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf float [[SELECT]], [[UNKNOWN1]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %sub = call float @returns_sub()
@@ -1395,7 +1395,7 @@ define nofpclass(nan inf sub zero) float @norm_result_demands_sub_source_rhs(i1 
 ; CHECK-SAME: i1 [[COND:%.*]], float [[UNKNOWN0:%.*]], float [[UNKNOWN1:%.*]]) {
 ; CHECK-NEXT:    [[SUB:%.*]] = call float @returns_sub()
 ; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[COND]], float [[SUB]], float [[UNKNOWN0]]
-; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[UNKNOWN1]], [[SELECT]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf float [[UNKNOWN1]], [[SELECT]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %sub = call float @returns_sub()

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-rounding-intrinsics.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-rounding-intrinsics.ll
@@ -14,7 +14,7 @@ define nofpclass(snan) float @ret_no_snan__floor_no_snan(float nofpclass(nan) %x
 define nofpclass(inf norm sub zero) float @ret_only_nan__floor(float %x) {
 ; CHECK-LABEL: define nofpclass(inf zero sub norm) float @ret_only_nan__floor(
 ; CHECK-SAME: float [[X:%.*]]) {
-; CHECK-NEXT:    ret float 0x7FF8000000000000
+; CHECK-NEXT:    ret float [[X]]
 ;
   %result = call float @llvm.floor.f32(float %x)
   ret float %result
@@ -23,7 +23,7 @@ define nofpclass(inf norm sub zero) float @ret_only_nan__floor(float %x) {
 define nofpclass(inf norm sub zero) <2 x float> @ret_only_nan__floor_vec(<2 x float> %x) {
 ; CHECK-LABEL: define nofpclass(inf zero sub norm) <2 x float> @ret_only_nan__floor_vec(
 ; CHECK-SAME: <2 x float> [[X:%.*]]) {
-; CHECK-NEXT:    ret <2 x float> splat (float 0x7FF8000000000000)
+; CHECK-NEXT:    ret <2 x float> [[X]]
 ;
   %result = call <2 x float> @llvm.floor.v2f32(<2 x float> %x)
   ret <2 x float> %result
@@ -32,8 +32,7 @@ define nofpclass(inf norm sub zero) <2 x float> @ret_only_nan__floor_vec(<2 x fl
 define nofpclass(inf norm sub zero qnan) float @ret_only_snan__floor(float %x) {
 ; CHECK-LABEL: define nofpclass(qnan inf zero sub norm) float @ret_only_snan__floor(
 ; CHECK-SAME: float [[X:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.floor.f32(float [[X]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[X]]
 ;
   %result = call float @llvm.floor.f32(float %x)
   ret float %result
@@ -42,8 +41,7 @@ define nofpclass(inf norm sub zero qnan) float @ret_only_snan__floor(float %x) {
 define nofpclass(inf norm sub zero snan) float @ret_only_qnan__floor(float %x) {
 ; CHECK-LABEL: define nofpclass(snan inf zero sub norm) float @ret_only_qnan__floor(
 ; CHECK-SAME: float [[X:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.floor.f32(float [[X]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[X]]
 ;
   %result = call float @llvm.floor.f32(float %x)
   ret float %result
@@ -52,8 +50,7 @@ define nofpclass(inf norm sub zero snan) float @ret_only_qnan__floor(float %x) {
 define nofpclass(nan norm sub zero) float @ret_only_inf__floor(float %x) {
 ; CHECK-LABEL: define nofpclass(nan zero sub norm) float @ret_only_inf__floor(
 ; CHECK-SAME: float [[X:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call float @llvm.floor.f32(float [[X]])
-; CHECK-NEXT:    ret float [[RESULT]]
+; CHECK-NEXT:    ret float [[X]]
 ;
   %result = call float @llvm.floor.f32(float %x)
   ret float %result


### PR DESCRIPTION
When reporting the known class result, apply the demanded mask to
filter out rejected cases. This can simplify known-source checks
further up the call stack. There are a few improved test diffs. This
does not yet try to clean up now redundant result checks.

Do an initial brute-force scope_exit to ensure these are cleared.
Later we can do a better job by pushing this into the individual
instruction cases.