### PR TITLE
InstCombine: Clean up SimplifyDemandedFPClass use context application

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2209,9 +2209,9 @@ static Value *simplifyDemandedUseFPClassFPTrunc(InstCombinerImpl &IC,
     return &I;
 
   Known = KnownFPClass::fptrunc(KnownSrc);
+  Known.knownNot(~DemandedMask);
 
-  FPClassTest ValidResults = DemandedMask & Known.KnownFPClasses;
-  return getFPClassConstant(I.getType(), ValidResults,
+  return getFPClassConstant(I.getType(), Known.KnownFPClasses,
                             /*IsCanonicalizing=*/true);
 }
 


### PR DESCRIPTION
Clean up some now redundant propagation of known-result to known-source
cases. Also move the application of the demanded mask to individual
cases, since the intermediate results are often used.