### PR TITLE
Reland "[STLExtras] Add a template for detecting whether a type has an equality comparison operator"

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -2682,6 +2682,17 @@ template <typename T> using has_sizeof = decltype(sizeof(T));
 template <typename T>
 constexpr bool is_incomplete_v = !is_detected<detail::has_sizeof, T>::value;
 
+// Detect types with equality comparison operators.
+namespace detail {
+template <typename T>
+using has_equality_comparison =
+    decltype(std::declval<const T &>() == std::declval<const T &>());
+} // namespace detail
+
+/// Detects when type `const T` can be compared for equality with itself.
+template <typename T>
+constexpr bool has_equality_comparison_v =
+    is_detected<detail::has_equality_comparison, T>::value;
 } // end namespace llvm
 
 namespace std {

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -2684,15 +2684,15 @@ constexpr bool is_incomplete_v = !is_detected<detail::has_sizeof, T>::value;
 
 // Detect types with equality comparison operators.
 namespace detail {
-template <typename T>
+template <typename T, typename U>
 using has_equality_comparison =
-    decltype(std::declval<const T &>() == std::declval<const T &>());
+    decltype(std::declval<const T &>() == std::declval<const U &>());
 } // namespace detail
 
-/// Detects when type `const T` can be compared for equality with itself.
-template <typename T>
+/// Detects when type `const T` can be compared for equality with `const U`.
+template <typename T, typename U = T>
 constexpr bool has_equality_comparison_v =
-    is_detected<detail::has_equality_comparison, T>::value;
+    is_detected<detail::has_equality_comparison, T, U>::value;
 } // end namespace llvm
 
 namespace std {

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1802,6 +1802,13 @@ struct PublicEqualityComparison {
 };
 static_assert(has_equality_comparison_v<PublicEqualityComparison>);
 
+struct StructA {};
+struct StructB {
+  bool operator==(const StructA &Other) const { return false; }
+};
+static_assert(!has_equality_comparison_v<StructA, StructB>);
+static_assert(has_equality_comparison_v<StructB, StructA>);
+
 TEST(STLExtrasTest, Search) {
   // Test finding a subsequence in the middle.
   std::vector<int> Haystack = {1, 2, 3, 4, 5, 6, 7, 8};

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1780,6 +1780,28 @@ struct Bar {};
 static_assert(is_incomplete_v<Foo>, "Foo is incomplete");
 static_assert(!is_incomplete_v<Bar>, "Bar is defined");
 
+struct NoEqualityComparison {};
+static_assert(!has_equality_comparison_v<NoEqualityComparison>);
+
+// Mutating equality comparison doesn't count.
+struct MutatingEqualityComparison {
+  bool operator==(MutatingEqualityComparison &Other) { return false; }
+};
+static_assert(!has_equality_comparison_v<MutatingEqualityComparison>);
+
+struct PrivateEqualityComparison {
+private:
+  bool operator==(const PrivateEqualityComparison &Other) const {
+    return false;
+  }
+};
+static_assert(!has_equality_comparison_v<PrivateEqualityComparison>);
+
+struct PublicEqualityComparison {
+  bool operator==(const PublicEqualityComparison &Other) const { return false; }
+};
+static_assert(has_equality_comparison_v<PublicEqualityComparison>);
+
 TEST(STLExtrasTest, Search) {
   // Test finding a subsequence in the middle.
   std::vector<int> Haystack = {1, 2, 3, 4, 5, 6, 7, 8};

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1777,37 +1777,43 @@ TEST(STLExtrasTest, ReverseConditionally) {
 struct Foo;
 struct Bar {};
 
-static_assert(is_incomplete_v<Foo>, "Foo is incomplete");
-static_assert(!is_incomplete_v<Bar>, "Bar is defined");
+TEST(STLExtrasTest, HasEqualityComparison) {
+  static_assert(is_incomplete_v<Foo>, "Foo is incomplete");
+  static_assert(!is_incomplete_v<Bar>, "Bar is defined");
 
-struct NoEqualityComparison {};
-static_assert(!has_equality_comparison_v<NoEqualityComparison>);
+  struct NoEqualityComparison {};
+  static_assert(!has_equality_comparison_v<NoEqualityComparison>);
 
-// Mutating equality comparison doesn't count.
-struct MutatingEqualityComparison {
-  bool operator==(MutatingEqualityComparison &Other) { return false; }
-};
-static_assert(!has_equality_comparison_v<MutatingEqualityComparison>);
+  // Mutating equality comparison doesn't count.
+  struct MutatingEqualityComparison {
+    bool operator==(MutatingEqualityComparison &Other) { return false; }
+  };
+  static_assert(!has_equality_comparison_v<MutatingEqualityComparison>);
 
-struct PrivateEqualityComparison {
-private:
-  bool operator==(const PrivateEqualityComparison &Other) const {
-    return false;
-  }
-};
-static_assert(!has_equality_comparison_v<PrivateEqualityComparison>);
+  struct PrivateEqualityComparison {
+  private:
+    bool operator==(const PrivateEqualityComparison &Other) const {
+      return false;
+    }
+  };
+  static_assert(!has_equality_comparison_v<PrivateEqualityComparison>);
 
-struct PublicEqualityComparison {
-  bool operator==(const PublicEqualityComparison &Other) const { return false; }
-};
-static_assert(has_equality_comparison_v<PublicEqualityComparison>);
+  struct PublicEqualityComparison {
+    bool operator==(const PublicEqualityComparison &Other) const {
+      return false;
+    }
+  };
+  static_assert(has_equality_comparison_v<PublicEqualityComparison>);
 
-struct StructA {};
-struct StructB {
-  bool operator==(const StructA &Other) const { return false; }
-};
-static_assert(!has_equality_comparison_v<StructA, StructB>);
-static_assert(has_equality_comparison_v<StructB, StructA>);
+  struct StructA {};
+  struct StructB {
+    bool operator==(const StructA &Other) const { return false; }
+  };
+  static_assert(!has_equality_comparison_v<StructA, StructB>);
+  static_assert(has_equality_comparison_v<StructB, StructA>);
+
+  SUCCEED();
+}
 
 TEST(STLExtrasTest, Search) {
   // Test finding a subsequence in the middle.

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1777,10 +1777,10 @@ TEST(STLExtrasTest, ReverseConditionally) {
 struct Foo;
 struct Bar {};
 
-TEST(STLExtrasTest, HasEqualityComparison) {
-  static_assert(is_incomplete_v<Foo>, "Foo is incomplete");
-  static_assert(!is_incomplete_v<Bar>, "Bar is defined");
+static_assert(is_incomplete_v<Foo>, "Foo is incomplete");
+static_assert(!is_incomplete_v<Bar>, "Bar is defined");
 
+TEST(STLExtrasTest, HasEqualityComparison) {
   struct NoEqualityComparison {};
   static_assert(!has_equality_comparison_v<NoEqualityComparison>);
 

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1790,14 +1790,6 @@ TEST(STLExtrasTest, HasEqualityComparison) {
   };
   static_assert(!has_equality_comparison_v<MutatingEqualityComparison>);
 
-  struct PrivateEqualityComparison {
-  private:
-    bool operator==(const PrivateEqualityComparison &Other) const {
-      return false;
-    }
-  };
-  static_assert(!has_equality_comparison_v<PrivateEqualityComparison>);
-
   struct PublicEqualityComparison {
     bool operator==(const PublicEqualityComparison &Other) const {
       return false;


### PR DESCRIPTION
This PR is an attempt to reland https://github.com/llvm/llvm-project/pull/176429.

It seems there's a difference between Clang and MSVC's template handling, resulting in a difference in the behaviour of is_detected with private class members. [This](https://godbolt.org/z/x61YdEz44) Godbolt link demonstrates the difference. This was causing one of the test cases I made, which was checking that it didn't pick up a private equality comparison operator, to fail when compiled using MSVC.

In this PR I have just removed that test case.