### PR TITLE
[SamplePGO] Ignore Remapper when salvaging unused profile

### DIFF
--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -771,7 +771,7 @@ bool SampleProfileMatcher::functionMatchesProfileHelper(
   // this, we load the top-level profile candidate explicitly for the matching.
   if (!FSForMatching && LoadFuncProfileforCGMatching) {
     DenseSet<StringRef> TopLevelFunc({ProfFunc.stringRef()});
-    if (std::error_code EC = Reader.read(TopLevelFunc))
+    if (std::error_code EC = Reader.read(TopLevelFunc, /*IgnoreRemapper=*/true))
       return false;
     FSForMatching = Reader.getSamplesFor(ProfFunc.stringRef());
     LLVM_DEBUG({
@@ -879,7 +879,7 @@ void SampleProfileMatcher::UpdateWithSalvagedProfiles() {
   // based on current function names in the module, so we need to load top-level
   // profiles for functions with different profile name explicitly after
   // function-profile name map is established with stale profile matching.
-  Reader.read(ProfileSalvagedFuncs);
+  Reader.read(ProfileSalvagedFuncs, /*IgnoreRemapper=*/true);
   Reader.setFuncNameToProfNameMap(*FuncNameToProfNameMap);
 }
 


### PR DESCRIPTION
Currently `SampleProfileMatcher::functionMatchesProfileHelper` calls `Reader.read(TopLevelFunc))` for the function for which it was called. If a Remapper is configured, `Reader::read` will ultimately iterate over *all* functions in the profile (iteration over `FuncOffsetList` in `SampleProfileReaderExtBinaryBase::readFuncProfiles`). This means that `-fsalvage-unused-profile` has a quadratic time complexity.

We don't need the remapper at all when salvaging unused profile. The whole idea of salvaging unused profiles is to be resilient to function renames, so we don't need to support hand-crafted symbol renames there.