### PR TITLE
InstCombine: Handle nsz in copysign SimplifyDemandedFPClass

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -2152,11 +2152,11 @@ static Value *simplifyDemandedFPClassCopysignMag(Value *MagSrc,
     constexpr FPClassTest PosOrZero = fcPositive | fcNegZero;
 
     if ((DemandedMask & ~NegOrZero) == fcNone &&
-        KnownSrc.isKnownNever(KnownFPClass::OrderedGreaterThanZeroMask | fcNan))
+        KnownSrc.isKnownAlways(NegOrZero))
       return MagSrc;
 
     if ((DemandedMask & ~PosOrZero) == fcNone &&
-        KnownSrc.isKnownNever(KnownFPClass::OrderedLessThanZeroMask | fcNan))
+        KnownSrc.isKnownAlways(PosOrZero))
       return MagSrc;
   } else {
     if ((DemandedMask & ~fcNegative) == fcNone && KnownSrc.SignBit == true)
@@ -2775,7 +2775,7 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
     case Intrinsic::copysign: {
       // Flip on more potentially demanded classes
       const FPClassTest DemandedMaskAnySign = llvm::unknown_sign(DemandedMask);
-      if (SimplifyDemandedFPClass(CI, 0, DemandedMaskAnySign, Known, Depth + 1))
+      if (SimplifyDemandedFPClass(I, 0, DemandedMaskAnySign, Known, Depth + 1))
         return I;
 
       if ((DemandedMask & fcNegative) == DemandedMask) {

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
@@ -2318,8 +2318,7 @@ define nofpclass(nan ninf nnorm nsub) float @ret_only_positive_or_zero__copysign
 define nofpclass(nan ninf nnorm nsub) float @ret_only_positive_or_zero__copysign_nsz_src_known_positive__sign_unknown(float nofpclass(nan ninf nnorm nsub) %always.positive.or.zero, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nan ninf nsub nnorm) float @ret_only_positive_or_zero__copysign_nsz_src_known_positive__sign_unknown
 ; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[ALWAYS_POSITIVE_OR_ZERO:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = call nsz float @llvm.copysign.f32(float [[ALWAYS_POSITIVE_OR_ZERO]], float [[UNKNOWN]])
-; CHECK-NEXT:    ret float [[COPYSIGN]]
+; CHECK-NEXT:    ret float [[ALWAYS_POSITIVE_OR_ZERO]]
 ;
   %copysign = call nsz float @llvm.copysign.f32(float %always.positive.or.zero, float %unknown)
   ret float %copysign
@@ -2352,8 +2351,7 @@ define nofpclass(nan pinf pnorm psub) float @ret_only_negative_or_pzero__copysig
 define nofpclass(nan pinf pnorm psub) float @ret_only_negative_or_pzero__copysign_nsz_src_known_negative__sign_unknown(float nofpclass(nan pinf pnorm psub) %always.negative.or.zero, float %unknown) {
 ; CHECK-LABEL: define nofpclass(nan pinf psub pnorm) float @ret_only_negative_or_pzero__copysign_nsz_src_known_negative__sign_unknown
 ; CHECK-SAME: (float nofpclass(nan pinf psub pnorm) [[ALWAYS_NEGATIVE_OR_ZERO:%.*]], float [[UNKNOWN:%.*]]) {
-; CHECK-NEXT:    [[COPYSIGN:%.*]] = call nsz float @llvm.copysign.f32(float [[ALWAYS_NEGATIVE_OR_ZERO]], float [[UNKNOWN]])
-; CHECK-NEXT:    ret float [[COPYSIGN]]
+; CHECK-NEXT:    ret float [[ALWAYS_NEGATIVE_OR_ZERO]]
 ;
   %copysign = call nsz float @llvm.copysign.f32(float %always.negative.or.zero, float %unknown)
   ret float %copysign


### PR DESCRIPTION
If the only sign bit difference is for 0, fold through the source.