### PR TITLE
InstSimplify: Handle nsz in fabs of known positive fold

### DIFF
--- a/llvm/test/Transforms/InstCombine/fabs.ll
+++ b/llvm/test/Transforms/InstCombine/fabs.ll
@@ -204,8 +204,30 @@ define float @square_fma_fabs_intrinsic_f32(float noundef %x) {
 
 ; The fabs cannot be eliminated because %x may be a NaN
 
-define float @square_nnan_fma_fabs_intrinsic_f32(float noundef %x) {
+define float @square_nnan_fma_fabs_intrinsic_f32(float noundef %x, float %y) {
 ; CHECK-LABEL: @square_nnan_fma_fabs_intrinsic_f32(
+; CHECK-NEXT:    [[FMA:%.*]] = call nnan float @llvm.fma.f32(float [[X:%.*]], float [[X]], float [[Y:%.*]])
+; CHECK-NEXT:    [[FABSF:%.*]] = call float @llvm.fabs.f32(float [[FMA]])
+; CHECK-NEXT:    ret float [[FABSF]]
+;
+  %fma = call nnan float @llvm.fma.f32(float %x, float %x, float %y)
+  %fabsf = call float @llvm.fabs.f32(float %fma)
+  ret float %fabsf
+}
+
+define float @square_nnan_fma_fabs_nsz_intrinsic_f32(float noundef %x, float %y) {
+; CHECK-LABEL: @square_nnan_fma_fabs_nsz_intrinsic_f32(
+; CHECK-NEXT:    [[FMA:%.*]] = call nnan float @llvm.fma.f32(float [[X:%.*]], float [[X]], float [[Y:%.*]])
+; CHECK-NEXT:    [[FABSF:%.*]] = call nsz float @llvm.fabs.f32(float [[FMA]])
+; CHECK-NEXT:    ret float [[FABSF]]
+;
+  %fma = call nnan float @llvm.fma.f32(float %x, float %x, float %y)
+  %fabsf = call nsz float @llvm.fabs.f32(float %fma)
+  ret float %fabsf
+}
+
+define float @square_nnan_fma_fabs_intrinsic_f32_add_const(float noundef %x) {
+; CHECK-LABEL: @square_nnan_fma_fabs_intrinsic_f32_add_const(
 ; CHECK-NEXT:    [[FMA:%.*]] = call nnan float @llvm.fma.f32(float [[X:%.*]], float [[X]], float 1.000000e+00)
 ; CHECK-NEXT:    ret float [[FMA]]
 ;
@@ -222,6 +244,28 @@ define float @square_fmuladd_fabs_intrinsic_f32(float noundef %x) {
 ;
   %fmuladd = call float @llvm.fmuladd.f32(float %x, float %x, float 1.0)
   %fabsf = call float @llvm.fabs.f32(float %fmuladd)
+  ret float %fabsf
+}
+
+define float @square_nnan_nsz_fma_fabs_intrinsic_f32(float noundef %x, float %y) {
+; CHECK-LABEL: @square_nnan_nsz_fma_fabs_intrinsic_f32(
+; CHECK-NEXT:    [[FMA1:%.*]] = call nnan float @llvm.fma.f32(float [[X:%.*]], float [[X]], float [[Y:%.*]])
+; CHECK-NEXT:    [[FMA:%.*]] = call nsz float @llvm.fabs.f32(float [[FMA1]])
+; CHECK-NEXT:    ret float [[FMA]]
+;
+  %fma = call nnan float @llvm.fma.f32(float %x, float %x, float %y)
+  %fabsf = call nsz float @llvm.fabs.f32(float %fma)
+  ret float %fabsf
+}
+
+define float @square_nnan_nsz_fmuladd_fabs_intrinsic_f32(float noundef %x, float %y) {
+; CHECK-LABEL: @square_nnan_nsz_fmuladd_fabs_intrinsic_f32(
+; CHECK-NEXT:    [[FMULADD1:%.*]] = call nnan float @llvm.fmuladd.f32(float [[X:%.*]], float [[X]], float [[Y:%.*]])
+; CHECK-NEXT:    [[FMULADD:%.*]] = call nsz float @llvm.fabs.f32(float [[FMULADD1]])
+; CHECK-NEXT:    ret float [[FMULADD]]
+;
+  %fmuladd = call nnan float @llvm.fmuladd.f32(float %x, float %x, float %y)
+  %fabsf = call nsz float @llvm.fabs.f32(float %fmuladd)
   ret float %fabsf
 }
 

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
@@ -585,8 +585,7 @@ define nofpclass(snan) float @fabs_nsz_src_known_positive_except_negzero(float n
 define nofpclass(snan) float @fabs_nsz_src_known_positive_except_negzero_multiple_uses(float nofpclass(nan ninf nnorm nsub) %always.positive.or.nzero, ptr %ptr) {
 ; CHECK-LABEL: define nofpclass(snan) float @fabs_nsz_src_known_positive_except_negzero_multiple_uses
 ; CHECK-SAME: (float nofpclass(nan ninf nsub nnorm) [[ALWAYS_POSITIVE_OR_NZERO:%.*]], ptr [[PTR:%.*]]) {
-; CHECK-NEXT:    [[FABS:%.*]] = call nsz float @llvm.fabs.f32(float [[ALWAYS_POSITIVE_OR_NZERO]])
-; CHECK-NEXT:    store float [[FABS]], ptr [[PTR]], align 4
+; CHECK-NEXT:    store float [[ALWAYS_POSITIVE_OR_NZERO]], ptr [[PTR]], align 4
 ; CHECK-NEXT:    ret float [[ALWAYS_POSITIVE_OR_NZERO]]
 ;
   %fabs = call nsz float @llvm.fabs.f32(float %always.positive.or.nzero)


### PR DESCRIPTION
The current tests for the fold use fma with a squared input.
This isn't entirely correct because fma can return -0 in this case.

Extend the fold to perform it with nsz. Also extend the tests to
test with an unknown value for the addend. The known normal constant is
almost special case that disproves a -0 result.

Split out from https://github.com/llvm/llvm-project/pull/175614