### PR TITLE
[TargetParser] Fix fp16 feature name for ARM64 Windows feature detection

### DIFF
--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -2388,7 +2388,7 @@ StringMap<bool> sys::getHostCPUFeatures() {
       IsProcessorFeaturePresent(PF_ARM_SVE_F64MM_INSTRUCTIONS_AVAILABLE);
   Features["i8mm"] =
       IsProcessorFeaturePresent(PF_ARM_V82_I8MM_INSTRUCTIONS_AVAILABLE);
-  Features["fp16"] =
+  Features["fullfp16"] =
       IsProcessorFeaturePresent(PF_ARM_V82_FP16_INSTRUCTIONS_AVAILABLE);
   Features["bf16"] =
       IsProcessorFeaturePresent(PF_ARM_V86_BF16_INSTRUCTIONS_AVAILABLE);


### PR DESCRIPTION
The feature is called fullfp16, not fp16, see: https://github.com/llvm/llvm-project/blob/979db00b9a2401b65725f44de8172aba79cacd38/llvm/lib/Target/AArch64/AArch64Features.td#L142