### PR TITLE
[clang-tidy][NFC] Enable RemoveSemicolon in clang-format config

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-format
+++ b/clang-tools-extra/clang-tidy/.clang-format
@@ -7,3 +7,4 @@ KeepEmptyLines:
 LineEnding: LF
 QualifierAlignment: Left
 RemoveBracesLLVM: true
+RemoveSemicolon: true

--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -339,7 +339,7 @@ private:
   std::unique_ptr<ClangTidyProfiling> Profiling;
   std::unique_ptr<ast_matchers::MatchFinder> Finder;
   std::vector<std::unique_ptr<ClangTidyCheck>> Checks;
-  void anchor() override {};
+  void anchor() override {}
 };
 
 } // namespace

--- a/clang-tools-extra/clang-tidy/GlobList.h
+++ b/clang-tools-extra/clang-tidy/GlobList.h
@@ -49,7 +49,7 @@ private:
   SmallVector<GlobListItem, 0> Items;
 
 public:
-  const SmallVectorImpl<GlobListItem> &getItems() const { return Items; };
+  const SmallVectorImpl<GlobListItem> &getItems() const { return Items; }
 };
 
 /// A \p GlobList that caches search results, so that search is performed only

--- a/clang-tools-extra/clang-tidy/bugprone/NotNullTerminatedResultCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NotNullTerminatedResultCheck.cpp
@@ -679,7 +679,7 @@ void NotNullTerminatedResultCheck::registerMatchers(MatchFinder *Finder) {
                 std::optional<unsigned> SourcePos, unsigned LengthPos,
                 bool WithIncrease)
         : Name(Name), DestinationPos(DestinationPos), SourcePos(SourcePos),
-          LengthPos(LengthPos), WithIncrease(WithIncrease) {};
+          LengthPos(LengthPos), WithIncrease(WithIncrease) {}
 
     StringRef Name;
     std::optional<unsigned> DestinationPos;

--- a/clang-tools-extra/clang-tidy/bugprone/StringIntegerAssignmentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/StringIntegerAssignmentCheck.cpp
@@ -104,7 +104,7 @@ private:
   // Returns true if `E` is an character constant.
   bool isCharConstant(const Expr *E) const {
     return isCharTyped(E) && isCharValuedConstant(E);
-  };
+  }
 
   // Returns true if `E` is an integer constant which fits in `CharType`.
   bool isCharValuedConstant(const Expr *E) const {
@@ -114,13 +114,13 @@ private:
     if (!E->EvaluateAsInt(EvalResult, Ctx, Expr::SE_AllowSideEffects))
       return false;
     return EvalResult.Val.getInt().getActiveBits() <= Ctx.getTypeSize(CharType);
-  };
+  }
 
   // Returns true if `E` has the right character type.
   bool isCharTyped(const Expr *E) const {
     return E->getType().getCanonicalType().getTypePtr() ==
            CharType.getTypePtr();
-  };
+  }
 
   const QualType CharType;
   const ASTContext &Ctx;

--- a/clang-tools-extra/clang-tidy/modernize/UseDesignatedInitializersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseDesignatedInitializersCheck.cpp
@@ -51,7 +51,7 @@ namespace {
 struct Designators {
   Designators(const InitListExpr *InitList) : InitList(InitList) {
     assert(InitList->isSyntacticForm());
-  };
+  }
 
   unsigned size() { return getCached().size(); }
 


### PR DESCRIPTION
Welcome everyone to YAFI (yet another format improvements) in 2026:)
Starting from `clang-format-16` we have quite useful option `RemoveSemicolon`.