### PR TITLE
[AArch64][SDAG] Combine vecreduce.add(ZExt(predicate)) into cntp(predicate)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -19409,19 +19409,44 @@ performActiveLaneMaskCombine(SDNode *N, TargetLowering::DAGCombinerInfo &DCI,
   return DAG.getNode(ISD::CONCAT_VECTORS, DL, N->getValueType(0), Concats);
 }
 
-// Turn a v8i8/v16i8 extended vecreduce into a udot/sdot and vecreduce
-//   vecreduce.add(ext(A)) to vecreduce.add(DOT(zero, A, one))
-//   vecreduce.add(mul(ext(A), ext(B))) to vecreduce.add(DOT(zero, A, B))
-// If we have vectors larger than v16i8 we extract v16i8 vectors,
-// Follow the same steps above to get DOT instructions concatenate them
-// and generate vecreduce.add(concat_vector(DOT, DOT2, ..)).
+// Turn vecreduce.add(ZExt(predicate)) into cntp(predicate).
+static SDValue performVecReduceAddCntpCombine(SDNode *N, SelectionDAG &DAG,
+                                              const AArch64Subtarget *ST) {
+  SDValue Op = N->getOperand(0);
+  if (Op->getOpcode() != ISD::ZERO_EXTEND)
+    return SDValue();
+
+  SDValue ZExtOp = Op->getOperand(0);
+  EVT VT = ZExtOp.getValueType();
+  if (!VT.isScalableVector() || VT.getVectorElementType() != MVT::i1 ||
+      !DAG.getTargetLoweringInfo().isTypeLegal(VT))
+    return SDValue();
+
+  SDLoc DL(N);
+  SDValue Cntp = DAG.getNode(
+      ISD::INTRINSIC_WO_CHAIN, DL, MVT::i64,
+      DAG.getTargetConstant(Intrinsic::aarch64_sve_cntp, DL, MVT::i64), ZExtOp,
+      ZExtOp);
+  return DAG.getZExtOrTrunc(Cntp, DL, N->getValueType(0));
+}
+
 static SDValue performVecReduceAddCombine(SDNode *N, SelectionDAG &DAG,
                                           const AArch64Subtarget *ST) {
+  if (SDValue Result = performVecReduceAddCntpCombine(N, DAG, ST))
+    return Result;
+
   if (!ST->isNeonAvailable())
     return SDValue();
 
   if (!ST->hasDotProd())
     return performVecReduceAddCombineWithUADDLP(N, DAG);
+
+  // Turn a v8i8/v16i8 extended vecreduce into a udot/sdot and vecreduce
+  //   vecreduce.add(ext(A)) to vecreduce.add(DOT(zero, A, one))
+  //   vecreduce.add(mul(ext(A), ext(B))) to vecreduce.add(DOT(zero, A, B))
+  // If we have vectors larger than v16i8 we extract v16i8 vectors,
+  // Follow the same steps above to get DOT instructions concatenate them
+  // and generate vecreduce.add(concat_vector(DOT, DOT2, ..)).
 
   SDValue Op0 = N->getOperand(0);
   if (N->getValueType(0) != MVT::i32 || Op0.getValueType().isScalableVT() ||

--- a/llvm/test/CodeGen/AArch64/sve-i1-add-reduce.ll
+++ b/llvm/test/CodeGen/AArch64/sve-i1-add-reduce.ll
@@ -16,21 +16,8 @@ entry:
 define i32 @uaddv_zexti8_nxv16i32(<vscale x 16 x i1> %v) {
 ; CHECK-LABEL: uaddv_zexti8_nxv16i32:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    punpklo p1.h, p0.b
-; CHECK-NEXT:    mov z0.s, #1 // =0x1
-; CHECK-NEXT:    punpkhi p0.h, p0.b
-; CHECK-NEXT:    punpklo p2.h, p1.b
-; CHECK-NEXT:    punpkhi p1.h, p1.b
-; CHECK-NEXT:    mov z1.s, p2/z, #1 // =0x1
-; CHECK-NEXT:    punpklo p3.h, p0.b
-; CHECK-NEXT:    mov z2.s, p1/z, #1 // =0x1
-; CHECK-NEXT:    punpkhi p0.h, p0.b
-; CHECK-NEXT:    add z1.s, p3/m, z1.s, z0.s
-; CHECK-NEXT:    add z2.s, p0/m, z2.s, z0.s
-; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    add z0.s, z1.s, z2.s
-; CHECK-NEXT:    uaddv d0, p0, z0.s
-; CHECK-NEXT:    fmov w0, s0
+; CHECK-NEXT:    cntp x0, p0, p0.b
+; CHECK-NEXT:    // kill: def $w0 killed $w0 killed $x0
 ; CHECK-NEXT:    ret
 entry:
   %3 = zext <vscale x 16 x i1> %v to <vscale x 16 x i32>
@@ -65,14 +52,8 @@ entry:
 define i32 @uaddv_zexti32_nxv8i1(<vscale x 8 x i1> %v) {
 ; CHECK-LABEL: uaddv_zexti32_nxv8i1:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    punpklo p1.h, p0.b
-; CHECK-NEXT:    mov z0.s, #1 // =0x1
-; CHECK-NEXT:    punpkhi p0.h, p0.b
-; CHECK-NEXT:    mov z1.s, p1/z, #1 // =0x1
-; CHECK-NEXT:    add z1.s, p0/m, z1.s, z0.s
-; CHECK-NEXT:    ptrue p0.s
-; CHECK-NEXT:    uaddv d0, p0, z1.s
-; CHECK-NEXT:    fmov w0, s0
+; CHECK-NEXT:    cntp x0, p0, p0.h
+; CHECK-NEXT:    // kill: def $w0 killed $w0 killed $x0
 ; CHECK-NEXT:    ret
 entry:
   %3 = zext <vscale x 8 x i1> %v to <vscale x 8 x i32>

--- a/llvm/test/CodeGen/AArch64/sve-i1-add-reduce.ll
+++ b/llvm/test/CodeGen/AArch64/sve-i1-add-reduce.ll
@@ -13,6 +13,31 @@ entry:
   ret i8 %4
 }
 
+define i32 @uaddv_zexti8_nxv16i32(<vscale x 16 x i1> %v) {
+; CHECK-LABEL: uaddv_zexti8_nxv16i32:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    punpklo p1.h, p0.b
+; CHECK-NEXT:    mov z0.s, #1 // =0x1
+; CHECK-NEXT:    punpkhi p0.h, p0.b
+; CHECK-NEXT:    punpklo p2.h, p1.b
+; CHECK-NEXT:    punpkhi p1.h, p1.b
+; CHECK-NEXT:    mov z1.s, p2/z, #1 // =0x1
+; CHECK-NEXT:    punpklo p3.h, p0.b
+; CHECK-NEXT:    mov z2.s, p1/z, #1 // =0x1
+; CHECK-NEXT:    punpkhi p0.h, p0.b
+; CHECK-NEXT:    add z1.s, p3/m, z1.s, z0.s
+; CHECK-NEXT:    add z2.s, p0/m, z2.s, z0.s
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    add z0.s, z1.s, z2.s
+; CHECK-NEXT:    uaddv d0, p0, z0.s
+; CHECK-NEXT:    fmov w0, s0
+; CHECK-NEXT:    ret
+entry:
+  %3 = zext <vscale x 16 x i1> %v to <vscale x 16 x i32>
+  %4 = tail call i32 @llvm.vector.reduce.add.nxv16i32(<vscale x 16 x i32> %3)
+  ret i32 %4
+}
+
 define i8 @uaddv_zexti8_nxv8i1(<vscale x 8 x i1> %v) {
 ; CHECK-LABEL: uaddv_zexti8_nxv8i1:
 ; CHECK:       // %bb.0: // %entry
@@ -35,6 +60,24 @@ entry:
   %3 = zext <vscale x 8 x i1> %v to <vscale x 8 x i16>
   %4 = tail call i16 @llvm.vector.reduce.add.nxv8i16(<vscale x 8 x i16> %3)
   ret i16 %4
+}
+
+define i32 @uaddv_zexti32_nxv8i1(<vscale x 8 x i1> %v) {
+; CHECK-LABEL: uaddv_zexti32_nxv8i1:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    punpklo p1.h, p0.b
+; CHECK-NEXT:    mov z0.s, #1 // =0x1
+; CHECK-NEXT:    punpkhi p0.h, p0.b
+; CHECK-NEXT:    mov z1.s, p1/z, #1 // =0x1
+; CHECK-NEXT:    add z1.s, p0/m, z1.s, z0.s
+; CHECK-NEXT:    ptrue p0.s
+; CHECK-NEXT:    uaddv d0, p0, z1.s
+; CHECK-NEXT:    fmov w0, s0
+; CHECK-NEXT:    ret
+entry:
+  %3 = zext <vscale x 8 x i1> %v to <vscale x 8 x i32>
+  %4 = tail call i32 @llvm.vector.reduce.add.nxv8i32(<vscale x 8 x i32> %3)
+  ret i32 %4
 }
 
 define i8 @uaddv_zexti8_nxv4i1(<vscale x 4 x i1> %v) {


### PR DESCRIPTION
This folds `vecreduce.add(ZExt(predicate))` into `cntp(predicate)` before type legalization expands the "ZExt" for illegal types.
