### PR TITLE
[libc++][ranges] Updated `[[nodiscard]]` implementation for `subrange` and `join_with_view`

### DIFF
--- a/libcxx/include/__ranges/join_with_view.h
+++ b/libcxx/include/__ranges/join_with_view.h
@@ -372,7 +372,7 @@ public:
     return __tmp;
   }
 
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, const __iterator& __y)
+  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator& __x, const __iterator& __y)
     requires __ref_is_glvalue && forward_range<_Base> && equality_comparable<_InnerIter>
   {
     return __x.__outer_it_ == __y.__outer_it_ && __x.__inner_it_ == __y.__inner_it_;
@@ -420,8 +420,7 @@ public:
 
   template <bool _OtherConst>
     requires sentinel_for<sentinel_t<_Base>, iterator_t<__maybe_const<_OtherConst, _View>>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI friend constexpr bool
-  operator==(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
+  _LIBCPP_HIDE_FROM_ABI friend constexpr bool operator==(const __iterator<_OtherConst>& __x, const __sentinel& __y) {
     return __get_outer_of(__x) == __y.__end_;
   }
 };

--- a/libcxx/include/__ranges/subrange.h
+++ b/libcxx/include/__ranges/subrange.h
@@ -131,7 +131,7 @@ public:
     return _Pair(__begin_, __end_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Iter begin() const
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Iter begin() const
     requires copyable<_Iter>
   {
     return __begin_;
@@ -143,11 +143,11 @@ public:
     return std::move(__begin_);
   }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr _Sent end() const { return __end_; }
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr _Sent end() const { return __end_; }
 
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr bool empty() const { return __begin_ == __end_; }
 
-  _LIBCPP_HIDE_FROM_ABI constexpr make_unsigned_t<iter_difference_t<_Iter>> size() const
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr make_unsigned_t<iter_difference_t<_Iter>> size() const
     requires(_Kind == subrange_kind::sized)
   {
     if constexpr (_StoreSize)
@@ -214,7 +214,7 @@ subrange(_Range&&, make_unsigned_t<range_difference_t<_Range>>)
 
 template <size_t _Index, class _Iter, class _Sent, subrange_kind _Kind>
   requires((_Index == 0 && copyable<_Iter>) || _Index == 1)
-_LIBCPP_HIDE_FROM_ABI constexpr auto get(const subrange<_Iter, _Sent, _Kind>& __subrange) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto get(const subrange<_Iter, _Sent, _Kind>& __subrange) {
   if constexpr (_Index == 0)
     return __subrange.begin();
   else
@@ -223,7 +223,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto get(const subrange<_Iter, _Sent, _Kind>& __
 
 template <size_t _Index, class _Iter, class _Sent, subrange_kind _Kind>
   requires(_Index < 2)
-_LIBCPP_HIDE_FROM_ABI constexpr auto get(subrange<_Iter, _Sent, _Kind>&& __subrange) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto get(subrange<_Iter, _Sent, _Kind>&& __subrange) {
   if constexpr (_Index == 0)
     return __subrange.begin();
   else

--- a/libcxx/include/__ranges/subrange.h
+++ b/libcxx/include/__ranges/subrange.h
@@ -201,7 +201,8 @@ template <input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent>
 subrange(_Iter, _Sent, make_unsigned_t<iter_difference_t<_Iter>>) -> subrange<_Iter, _Sent, subrange_kind::sized>;
 
 template <borrowed_range _Range>
-subrange(_Range&&) -> subrange<iterator_t<_Range>,
+subrange(_Range&&)
+    -> subrange<iterator_t<_Range>,
                 sentinel_t<_Range>,
                 (sized_range<_Range> || sized_sentinel_for<sentinel_t<_Range>, iterator_t<_Range>>)
                     ? subrange_kind::sized

--- a/libcxx/include/__ranges/subrange.h
+++ b/libcxx/include/__ranges/subrange.h
@@ -201,8 +201,7 @@ template <input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent>
 subrange(_Iter, _Sent, make_unsigned_t<iter_difference_t<_Iter>>) -> subrange<_Iter, _Sent, subrange_kind::sized>;
 
 template <borrowed_range _Range>
-subrange(_Range&&)
-    -> subrange<iterator_t<_Range>,
+subrange(_Range&&) -> subrange<iterator_t<_Range>,
                 sentinel_t<_Range>,
                 (sized_range<_Range> || sized_sentinel_for<sentinel_t<_Range>, iterator_t<_Range>>)
                     ? subrange_kind::sized

--- a/libcxx/test/libcxx/ranges/range.adaptors/range.join.with/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/ranges/range.adaptors/range.join.with/nodiscard.verify.cpp
@@ -22,12 +22,10 @@ void test() {
 
   std::ranges::join_with_view view(range, pattern);
 
-  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  view.base();
+  // [range.join.with.view]
+
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::as_const(view).base();
-  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::move(std::as_const(view)).base();
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::move(view).base();
 
@@ -41,38 +39,20 @@ void test() {
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::as_const(view).end();
 
-  // }
+  // [range.join.with.iterator]
 
-  // void test_iterator() {
-  //   char range[3][2] = {{'x', 'x'}, {'y', 'y'}, {'z', 'z'}};
-  //   char pattern[2]  = {',', ' '};
-
-  //   std::ranges::join_with_view view(range, pattern);
+  auto cIt = std::as_const(view).begin();
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  *view.begin();
-  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  *std::as_const(view).begin();
+  *cIt;
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  iter_move(view.begin());
-  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  iter_move(std::as_const(view).begin());
+  iter_move(cIt);
 
-  // }
+  // [range.join.with.overview]
 
-  // void test_overview() {
-  //   int range[3][3]     = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
-  //   int pattern_base[2] = {-1, -1};
-  //   auto pattern        = std::views::all(pattern_base);
-
-  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::views::join_with(pattern);
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
   std::views::join_with(range, pattern);
-
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::views::join_with(0);
-  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::views::join_with(range, 0);
+  std::views::join_with(pattern);
 }

--- a/libcxx/test/libcxx/ranges/range.utility/range.subrange/nodiscard.verify.cpp
+++ b/libcxx/test/libcxx/ranges/range.utility/range.subrange/nodiscard.verify.cpp
@@ -6,73 +6,45 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: std-at-least-c++23
+// REQUIRES: std-at-least-c++20
 
 // Test that functions are marked [[nodiscard]].
 
 #include <ranges>
 #include <utility>
+#include <vector>
 
-#include "test_iterators.h"
 #include "test_range.h"
 
 void test() {
-  int range[3][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
-  int pattern[2]  = {-1, -1};
-
-  std::ranges::join_with_view view(range, pattern);
+  std::vector<int> range;
+  std::ranges::subrange subrange{range.begin(), range.end()};
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  view.base();
+  std::as_const(subrange).begin();
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::as_const(view).base();
-  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::move(std::as_const(view)).base();
-  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::move(view).base();
+  subrange.begin();
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  view.begin();
-  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::as_const(view).begin();
+  std::as_const(subrange).end();
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  view.end();
+  std::as_const(subrange).empty();
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::as_const(view).end();
-
-  // }
-
-  // void test_iterator() {
-  //   char range[3][2] = {{'x', 'x'}, {'y', 'y'}, {'z', 'z'}};
-  //   char pattern[2]  = {',', ' '};
-
-  //   std::ranges::join_with_view view(range, pattern);
+  std::as_const(subrange).size();
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  *view.begin();
+  std::as_const(subrange).next();
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  *std::as_const(view).begin();
+  std::move(subrange).next();
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  iter_move(view.begin());
+  std::as_const(subrange).prev();
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  iter_move(std::as_const(view).begin());
-
-  // }
-
-  // void test_overview() {
-  //   int range[3][3]     = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
-  //   int pattern_base[2] = {-1, -1};
-  //   auto pattern        = std::views::all(pattern_base);
+  std::move(subrange).prev();
 
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::views::join_with(pattern);
+  std::get<0>(std::as_const(subrange));
   // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::views::join_with(range, pattern);
-
-  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::views::join_with(0);
-  // expected-warning@+1 {{ignoring return value of function declared with 'nodiscard' attribute}}
-  std::views::join_with(range, 0);
+  std::get<0>(std::move(subrange));
 }


### PR DESCRIPTION
Added or removed `[[nodiscard]]` according to the guidelines and updated the tests.

 - https://libcxx.llvm.org/CodingGuidelines.html
 - https://wg21.link/range.subrange
 -  https://wg21.link/range.join.with.view

Towards #172124