### PR TITLE
added option `llvm-header-guard.HeaderDirs`

### DIFF
--- a/clang-tools-extra/clang-tidy/llvm/HeaderGuardCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/HeaderGuardCheck.h
@@ -21,7 +21,11 @@ public:
   LLVMHeaderGuardCheck(StringRef Name, ClangTidyContext *Context);
 
   bool shouldSuggestEndifComment(StringRef Filename) override { return false; }
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
   std::string getHeaderGuard(StringRef Filename, StringRef OldGuard) override;
+
+private:
+  const std::vector<StringRef> HeaderDirs;
 };
 
 } // namespace clang::tidy::llvm_check

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -131,6 +131,9 @@ Changes in existing checks
   now uses separate note diagnostics for each uninitialized enumerator, making
   it easier to see which specific enumerators need explicit initialization.
 
+- Improved :doc:`llvm-header-guard <clang-tidy/checks/llvm/header-guard>` check
+  by adding the option `HeaderDirs` to configure header directory names.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/header-guard.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/header-guard.rst
@@ -4,3 +4,11 @@ llvm-header-guard
 =================
 
 Finds and fixes header guards that do not adhere to LLVM style.
+
+Options
+-------
+
+.. option:: HeaderDirs
+
+   A list of directories where the include guard string will start.
+   defaults to `include`.

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard.cpp
@@ -1,0 +1,115 @@
+#include "header-guard/include/correct.hpp"
+#include "header-guard/include/missing.hpp"
+#include "header-guard/include/wrong.hpp"
+
+#include "header-guard/other/correct.hpp"
+#include "header-guard/other/missing.hpp"
+#include "header-guard/other/wrong.hpp"
+
+// ---------------------------------------
+// TEST 1: Use no config options (default)
+// ---------------------------------------
+// RUN: %check_clang_tidy %s llvm-header-guard %t -export-fixes=%t.1.yaml --header-filter=.* -- -I%S > %t.1.msg 2>&1
+// RUN: FileCheck -input-file=%t.1.msg -check-prefix=CHECK-MESSAGES1 %s
+// RUN: FileCheck -input-file=%t.1.yaml -check-prefix=CHECK-YAML1 %s
+
+// CHECK-MESSAGES1: header-guard/include/missing.hpp:1:1: warning: header is missing header guard [llvm-header-guard]
+// CHECK-MESSAGES1: header-guard/other/missing.hpp:1:1: warning: header is missing header guard [llvm-header-guard]
+// CHECK-MESSAGES1: header-guard/include/wrong.hpp:1:9: warning: header guard does not follow preferred style [llvm-header-guard]
+// CHECK-MESSAGES1: header-guard/other/wrong.hpp:1:9: warning: header guard does not follow preferred style [llvm-header-guard]
+
+// CHECK-YAML1: Message:         header is missing header guard
+// CHECK-YAML1: FilePath:        '{{.*}}/header-guard/include/missing.hpp'
+// CHECK-YAML1: ReplacementText: "#ifndef MISSING_HPP\n#define MISSING_HPP\n\n"
+// CHECK-YAML1: ReplacementText: "\n#endif\n"
+
+// CHECK-YAML1: Message:         header guard does not follow preferred style
+// CHECK-YAML1: FilePath:        '{{.*}}/header-guard/include/wrong.hpp'
+// CHECK-YAML1: ReplacementText: WRONG_HPP
+
+// CHECK-YAML1: Message:         header is missing header guard
+// CHECK-YAML1: FilePath:        '{{.*}}/header-guard/other/missing.hpp'
+// CHECK-YAML1: ReplacementText: "#ifndef LLVM_HEADER_GUARD_OTHER_MISSING_HPP\n#define LLVM_HEADER_GUARD_OTHER_MISSING_HPP\n\n"
+// CHECK-YAML1: ReplacementText: "\n#endif\n"
+// CHECK-YAML1: Message:         header guard does not follow preferred style
+// CHECK-YAML1: FilePath:        '{{.*}}/header-guard/other/wrong.hpp'
+// CHECK-YAML1: ReplacementText: LLVM_HEADER_GUARD_OTHER_WRONG_HPP
+
+// ---------------------------------------
+// TEST 2: Set option HeaderDirs=other
+// ---------------------------------------
+// RUN: %check_clang_tidy %s llvm-header-guard %t -export-fixes=%t.2.yaml --header-filter=.* \
+// RUN:   --config='{CheckOptions: { \
+// RUN:     llvm-header-guard.HeaderDirs: other, \
+// RUN:   }}' -- -I%S > %t.2.msg 2>&1
+// RUN: FileCheck -input-file=%t.2.msg -check-prefix=CHECK-MESSAGES2 %s
+// RUN: FileCheck -input-file=%t.2.yaml -check-prefix=CHECK-YAML2 %s
+
+// CHECK-MESSAGES2: header-guard/include/correct.hpp:1:9: warning: header guard does not follow preferred style [llvm-header-guard]
+// CHECK-MESSAGES2: header-guard/other/correct.hpp:1:9: warning: header guard does not follow preferred style [llvm-header-guard]
+// CHECK-MESSAGES2: header-guard/include/missing.hpp:1:1: warning: header is missing header guard [llvm-header-guard]
+// CHECK-MESSAGES2: header-guard/other/missing.hpp:1:1: warning: header is missing header guard [llvm-header-guard]
+// CHECK-MESSAGES2: header-guard/include/wrong.hpp:1:9: warning: header guard does not follow preferred style [llvm-header-guard]
+// CHECK-MESSAGES2: header-guard/other/wrong.hpp:1:9: warning: header guard does not follow preferred style [llvm-header-guard]
+
+// CHECK-YAML2: Message:         header guard does not follow preferred style
+// CHECK-YAML2: FilePath:        '{{.*}}/header-guard/include/correct.hpp'
+// CHECK-YAML2: ReplacementText: LLVM_HEADER_GUARD_INCLUDE_CORRECT_HPP
+// CHECK-YAML2: Message:         header is missing header guard
+// CHECK-YAML2: FilePath:        '{{.*}}/header-guard/include/missing.hpp'
+// CHECK-YAML2: ReplacementText: "#ifndef LLVM_HEADER_GUARD_INCLUDE_MISSING_HPP\n#define LLVM_HEADER_GUARD_INCLUDE_MISSING_HPP\n\n"
+// CHECK-YAML2: ReplacementText: "\n#endif\n"
+// CHECK-YAML2: Message:         header guard does not follow preferred style
+// CHECK-YAML2: FilePath:        '{{.*}}/header-guard/include/wrong.hpp'
+// CHECK-YAML2: ReplacementText: LLVM_HEADER_GUARD_INCLUDE_WRONG_HPP
+
+// CHECK-YAML2: Message:         header guard does not follow preferred style
+// CHECK-YAML2: FilePath:        '{{.*}}/header-guard/other/correct.hpp'
+// CHECK-YAML2: ReplacementText: CORRECT_HPP
+// CHECK-YAML2: Message:         header is missing header guard
+// CHECK-YAML2: FilePath:        '{{.*}}/header-guard/other/missing.hpp'
+// CHECK-YAML2: ReplacementText: "#ifndef MISSING_HPP\n#define MISSING_HPP\n\n"
+// CHECK-YAML2: ReplacementText: "\n#endif\n"
+// CHECK-YAML2: Message:         header guard does not follow preferred style
+// CHECK-YAML2: FilePath:        '{{.*}}/header-guard/other/wrong.hpp'
+// CHECK-YAML2: ReplacementText: WRONG_HPP
+
+
+// ---------------------------------------
+// TEST 3: Set option HeaderDirs=include;other
+// ---------------------------------------
+// RUN: %check_clang_tidy %s llvm-header-guard %t -export-fixes=%t.3.yaml --header-filter=.* \
+// RUN:   --config='{CheckOptions: { \
+// RUN:     llvm-header-guard.HeaderDirs: include;other, \
+// RUN:   }}' -- -I%S > %t.3.msg 2>&1
+// RUN: FileCheck -input-file=%t.3.msg -check-prefix=CHECK-MESSAGES3 %s
+// RUN: FileCheck -input-file=%t.3.yaml -check-prefix=CHECK-YAML3 %s
+
+// CHECK-MESSAGES2: header-guard/include/correct.hpp:1:9: warning: header guard does not follow preferred style [llvm-header-guard]
+// CHECK-MESSAGES2: header-guard/other/correct.hpp:1:9: warning: header guard does not follow preferred style [llvm-header-guard]
+// CHECK-MESSAGES3: header-guard/include/missing.hpp:1:1: warning: header is missing header guard [llvm-header-guard]
+// CHECK-MESSAGES3: header-guard/other/missing.hpp:1:1: warning: header is missing header guard [llvm-header-guard]
+// CHECK-MESSAGES3: header-guard/include/wrong.hpp:1:9: warning: header guard does not follow preferred style [llvm-header-guard]
+// CHECK-MESSAGES3: header-guard/other/wrong.hpp:1:9: warning: header guard does not follow preferred style [llvm-header-guard]
+
+// CHECK-YAML3: Message:         header is missing header guard
+// CHECK-YAML3: FilePath:        '{{.*}}/header-guard/include/missing.hpp'
+// CHECK-YAML3: ReplacementText: "#ifndef MISSING_HPP\n#define MISSING_HPP\n\n"
+// CHECK-YAML3: ReplacementText: "\n#endif\n"
+// CHECK-YAML3: Message:         header guard does not follow preferred style
+// CHECK-YAML3: FilePath:        '{{.*}}/header-guard/include/wrong.hpp'
+// CHECK-YAML3: ReplacementText: WRONG_HPP
+
+// CHECK-YAML3: Message:         header guard does not follow preferred style
+// CHECK-YAML3: FilePath:        '{{.*}}/header-guard/other/correct.hpp'
+// CHECK-YAML3: ReplacementText: CORRECT_HPP
+// CHECK-YAML3: Message:         header is missing header guard
+// CHECK-YAML3: FilePath:        '{{.*}}/header-guard/other/missing.hpp'
+// CHECK-YAML3: ReplacementText: "#ifndef MISSING_HPP\n#define MISSING_HPP\n\n"
+// CHECK-YAML3: ReplacementText: "\n#endif\n"
+// CHECK-YAML3: Message:         header guard does not follow preferred style
+// CHECK-YAML3: FilePath:        '{{.*}}/header-guard/other/wrong.hpp'
+// CHECK-YAML3: ReplacementText: WRONG_HPP
+
+
+

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard/include/correct.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard/include/correct.hpp
@@ -1,0 +1,7 @@
+#ifndef CORRECT_HPP
+#define CORRECT_HPP
+#endif
+
+// RUN: %check_clang_tidy %s llvm-header-guard correct -export-fixes=%t.yaml > %t.msg 2>&1
+// RUN: FileCheck -input-file=%t.msg -check-prefix=CHECK-MSG %s
+// CHECK-MSG: warning: code/includes outside of area guarded by header guard; consider moving it [llvm-header-guard]

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard/include/missing.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard/include/missing.hpp
@@ -1,0 +1,5 @@
+
+
+// RUN: %check_clang_tidy %s llvm-header-guard missing -export-fixes=%t.yaml > %t.msg 2>&1
+// RUN: FileCheck -input-file=%t.msg -check-prefix=CHECK-MSG %s
+// CHECK-MSG: :1:1: warning: header is missing header guard [llvm-header-guard]

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard/include/wrong.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard/include/wrong.hpp
@@ -1,0 +1,7 @@
+#ifndef HERE_IS_SOMETHING_WRONG_HPP
+#define HERE_IS_SOMETHING_WRONG_HPP
+#endif
+
+// RUN: %check_clang_tidy %s llvm-header-guard wrong -export-fixes=%t.yaml > %t.msg 2>&1
+// RUN: FileCheck -input-file=%t.msg -check-prefix=CHECK-MSG %s
+// CHECK-MSG: warning: header guard does not follow preferred style [llvm-header-guard]

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard/other/correct.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard/other/correct.hpp
@@ -1,0 +1,7 @@
+#ifndef LLVM_HEADER_GUARD_OTHER_CORRECT_HPP
+#define LLVM_HEADER_GUARD_OTHER_CORRECT_HPP
+#endif
+
+// RUN: %check_clang_tidy %s llvm-header-guard correct -export-fixes=%t.yaml > %t.msg 2>&1
+// RUN: FileCheck -input-file=%t.msg -check-prefix=CHECK-MSG %s
+// CHECK-MSG: warning: code/includes outside of area guarded by header guard; consider moving it [llvm-header-guard]

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard/other/missing.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard/other/missing.hpp
@@ -1,0 +1,5 @@
+
+
+// RUN: %check_clang_tidy %s llvm-header-guard missing -export-fixes=%t.yaml > %t.msg 2>&1
+// RUN: FileCheck -input-file=%t.msg -check-prefix=CHECK-MSG %s
+// CHECK-MSG: :1:1: warning: header is missing header guard [llvm-header-guard]

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard/other/wrong.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/header-guard/other/wrong.hpp
@@ -1,0 +1,7 @@
+#ifndef SOME_WRONG_HEADER_GUARD_HPP
+#define SOME_WRONG_HEADER_GUARD_HPP
+#endif
+
+// RUN: %check_clang_tidy %s llvm-header-guard wrong -export-fixes=%t.yaml > %t.msg 2>&1
+// RUN: FileCheck -input-file=%t.msg -check-prefix=CHECK-MSG %s
+// CHECK-MSG: warning: header guard does not follow preferred style [llvm-header-guard]


### PR DESCRIPTION
new option `HeaderDirs` for `llvm-header-guard` is added.

Defaults to `include`. When checking header guards, the header file path is searched for the first matching directory in this `HeaderDirs` list. All parent path components preceding that directory are discarded, so the generated header guard starts at the matched include directory.

Ref: #71732