### PR TITLE
AArch64/GlobalISel: Use LibcallLoweringInfo in utils

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64GlobalISelUtils.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64GlobalISelUtils.cpp
@@ -65,10 +65,10 @@ bool AArch64GISelUtils::tryEmitBZero(MachineInstr &MI,
                                      const LibcallLoweringInfo &Libcalls,
                                      bool MinSize) {
   assert(MI.getOpcode() == TargetOpcode::G_MEMSET);
-  MachineRegisterInfo &MRI = *MIRBuilder.getMRI();
-  auto &TLI = *MIRBuilder.getMF().getSubtarget().getTargetLowering();
-  if (!TLI.getLibcallName(RTLIB::BZERO))
+  if (Libcalls.getLibcallImpl(RTLIB::BZERO) == RTLIB::Unsupported)
     return false;
+
+  MachineRegisterInfo &MRI = *MIRBuilder.getMRI();
   auto Zero =
       getIConstantVRegValWithLookThrough(MI.getOperand(1).getReg(), MRI);
   if (!Zero || Zero->Value.getSExtValue() != 0)

--- a/llvm/lib/Target/AArch64/GISel/AArch64GlobalISelUtils.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64GlobalISelUtils.cpp
@@ -62,6 +62,7 @@ bool AArch64GISelUtils::isCMN(const MachineInstr *MaybeSub,
 
 bool AArch64GISelUtils::tryEmitBZero(MachineInstr &MI,
                                      MachineIRBuilder &MIRBuilder,
+                                     const LibcallLoweringInfo &Libcalls,
                                      bool MinSize) {
   assert(MI.getOpcode() == TargetOpcode::G_MEMSET);
   MachineRegisterInfo &MRI = *MIRBuilder.getMRI();

--- a/llvm/lib/Target/AArch64/GISel/AArch64GlobalISelUtils.h
+++ b/llvm/lib/Target/AArch64/GISel/AArch64GlobalISelUtils.h
@@ -51,7 +51,8 @@ bool isCMN(const MachineInstr *MaybeSub, const CmpInst::Predicate &Pred,
 /// \note This only applies on Darwin.
 ///
 /// \returns true if \p MI was replaced with a G_BZERO.
-bool tryEmitBZero(MachineInstr &MI, MachineIRBuilder &MIRBuilder, bool MinSize);
+bool tryEmitBZero(MachineInstr &MI, MachineIRBuilder &MIRBuilder,
+                  const LibcallLoweringInfo &Libcalls, bool MinSize);
 
 /// Analyze a ptrauth discriminator value to try to find the constant integer
 /// and address parts, cracking a ptrauth_blend intrinsic if there is one.


### PR DESCRIPTION
Wire up the boilerplate to get the query for bzero from
LibcallLoweringInfo instead of TargetLowering.