### PR TITLE
[runtimes] Share doxygen handling with LLVM

### DIFF
--- a/cmake/Modules/HandleDoxygen.cmake
+++ b/cmake/Modules/HandleDoxygen.cmake
@@ -1,4 +1,4 @@
-option(LLVM_ENABLE_DOXYGEN "Use doxygen to generate llvm API documentation." OFF)
+option(LLVM_ENABLE_DOXYGEN "Use Doxygen to generate API documentation." OFF)
 
 
 # available programs checks

--- a/cmake/Modules/HandleDoxygen.cmake
+++ b/cmake/Modules/HandleDoxygen.cmake
@@ -1,0 +1,41 @@
+option(LLVM_ENABLE_DOXYGEN "Use doxygen to generate llvm API documentation." OFF)
+
+
+# available programs checks
+function(llvm_find_program name)
+  string(TOUPPER ${name} NAME)
+  string(REGEX REPLACE "\\." "_" NAME ${NAME})
+
+  find_program(LLVM_PATH_${NAME} NAMES ${ARGV})
+  mark_as_advanced(LLVM_PATH_${NAME})
+  if(LLVM_PATH_${NAME})
+    set(HAVE_${NAME} 1 CACHE INTERNAL "Is ${name} available ?")
+    mark_as_advanced(HAVE_${NAME})
+  else(LLVM_PATH_${NAME})
+    set(HAVE_${NAME} "" CACHE INTERNAL "Is ${name} available ?")
+  endif(LLVM_PATH_${NAME})
+endfunction()
+
+if (LLVM_ENABLE_DOXYGEN)
+  message(STATUS "Doxygen enabled.")
+  llvm_find_program(dot)
+  find_package(Doxygen REQUIRED)
+
+  if (DOXYGEN_FOUND)
+    # If we find doxygen and we want to enable doxygen by default create a
+    # global aggregate doxygen target for generating llvm and any/all
+    # subprojects doxygen documentation.
+    if (LLVM_BUILD_DOCS)
+      add_custom_target(doxygen ALL)
+    endif()
+
+    option(LLVM_DOXYGEN_EXTERNAL_SEARCH "Enable doxygen external search." OFF)
+    if (LLVM_DOXYGEN_EXTERNAL_SEARCH)
+      set(LLVM_DOXYGEN_SEARCHENGINE_URL "" CACHE STRING "URL to use for external search.")
+      set(LLVM_DOXYGEN_SEARCH_MAPPINGS "" CACHE STRING "Doxygen Search Mappings")
+    endif()
+  endif()
+else()
+  message(STATUS "Doxygen disabled.")
+endif()
+

--- a/cmake/Modules/HandleDoxygen.cmake
+++ b/cmake/Modules/HandleDoxygen.cmake
@@ -38,4 +38,3 @@ if (LLVM_ENABLE_DOXYGEN)
 else()
   message(STATUS "Doxygen disabled.")
 endif()
-

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -857,11 +857,12 @@ option(LLVM_INCLUDE_BENCHMARKS "Generate benchmark targets. If OFF, benchmarks c
 
 option (LLVM_BUILD_DOCS "Build the llvm documentation." OFF)
 option (LLVM_INCLUDE_DOCS "Generate build targets for llvm documentation." ON)
-option (LLVM_ENABLE_DOXYGEN "Use doxygen to generate llvm API documentation." OFF)
 option (LLVM_ENABLE_SPHINX "Use Sphinx to generate llvm documentation." OFF)
 option (LLVM_ENABLE_OCAMLDOC "Build OCaml bindings documentation." ON)
 option (LLVM_ENABLE_BINDINGS "Build bindings." ON)
 option (LLVM_ENABLE_TELEMETRY "Enable the telemetry library. If set to OFF, library cannot be enabled after build (eg., at runtime)" ON)
+
+include(HandleDoxygen)
 
 set(LLVM_INSTALL_DOXYGEN_HTML_DIR "${CMAKE_INSTALL_DOCDIR}/llvm/doxygen-html"
     CACHE STRING "Doxygen-generated HTML documentation install directory")

--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -448,25 +448,6 @@ if (NOT WIN32)
   endif()
 endif()
 
-# available programs checks
-function(llvm_find_program name)
-  string(TOUPPER ${name} NAME)
-  string(REGEX REPLACE "\\." "_" NAME ${NAME})
-
-  find_program(LLVM_PATH_${NAME} NAMES ${ARGV})
-  mark_as_advanced(LLVM_PATH_${NAME})
-  if(LLVM_PATH_${NAME})
-    set(HAVE_${NAME} 1 CACHE INTERNAL "Is ${name} available ?")
-    mark_as_advanced(HAVE_${NAME})
-  else(LLVM_PATH_${NAME})
-    set(HAVE_${NAME} "" CACHE INTERNAL "Is ${name} available ?")
-  endif(LLVM_PATH_${NAME})
-endfunction()
-
-if (LLVM_ENABLE_DOXYGEN)
-  llvm_find_program(dot)
-endif ()
-
 if(LLVM_ENABLE_FFI)
   set(FFI_REQUIRE_INCLUDE On)
   if(LLVM_ENABLE_FFI STREQUAL FORCE_ON)
@@ -668,28 +649,6 @@ if( LLVM_ENABLE_THREADS )
   message(STATUS "Threads enabled.")
 else( LLVM_ENABLE_THREADS )
   message(STATUS "Threads disabled.")
-endif()
-
-if (LLVM_ENABLE_DOXYGEN)
-  message(STATUS "Doxygen enabled.")
-  find_package(Doxygen REQUIRED)
-
-  if (DOXYGEN_FOUND)
-    # If we find doxygen and we want to enable doxygen by default create a
-    # global aggregate doxygen target for generating llvm and any/all
-    # subprojects doxygen documentation.
-    if (LLVM_BUILD_DOCS)
-      add_custom_target(doxygen ALL)
-    endif()
-
-    option(LLVM_DOXYGEN_EXTERNAL_SEARCH "Enable doxygen external search." OFF)
-    if (LLVM_DOXYGEN_EXTERNAL_SEARCH)
-      set(LLVM_DOXYGEN_SEARCHENGINE_URL "" CACHE STRING "URL to use for external search.")
-      set(LLVM_DOXYGEN_SEARCH_MAPPINGS "" CACHE STRING "Doxygen Search Mappings")
-    endif()
-  endif()
-else()
-  message(STATUS "Doxygen disabled.")
 endif()
 
 find_program(GOLD_EXECUTABLE NAMES ${LLVM_DEFAULT_TARGET_TRIPLE}-ld.gold ld.gold ${LLVM_DEFAULT_TARGET_TRIPLE}-ld ld DOC "The gold linker")

--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -241,6 +241,8 @@ option(LLVM_INCLUDE_DOCS "Generate build targets for the runtimes documentation.
 option(LLVM_ENABLE_SPHINX "Use Sphinx to generate the runtimes documentation." OFF)
 option(RUNTIMES_EXECUTE_ONLY_CODE "Compile runtime libraries as execute-only." OFF)
 
+include(HandleDoxygen)
+
 if (RUNTIMES_EXECUTE_ONLY_CODE)
   # If a target doesn't support or recognise -mexecute-only, Clang will simply ignore the flag.
   # We can check for this case using -Werror=unused-command-line-argument.


### PR DESCRIPTION
Hoist handling of Doxygen into the top-level cmake/ directory so it can be shared between LLVM and RUNTIMES so a default/standalone runtimes build can support building Doxygen documentation as well.

The openmp subproject currently supports doxygen documentation using an `LLVM_ENABLE_PROJECTS=openmp` build, but not with `LLVM_ENABLE_RUNTIMES=openmp` because of this missing boilerplate code in the runtimes build. This is a step towards removing the `LLVM_ENABLE_PROJECTS=openmp` build mode which was deprecated (#124014) and already scheduled to be removed in LLVM 21 (#136314). Eventual removal is planned with #176950.

Hoisting CMake code for shared use with runtimes has been done before in e.g. #84641, https://github.com/llvm/llvm-project/commit/7017e6c9cfd2de3122ce9528f338a97d61e96373, https://github.com/llvm/llvm-project/commit/44e3365775101fec3fd355eda339282258d74415, https://github.com/llvm/llvm-project/commit/7017e6c9cfd2de3122ce9528f338a97d61e96373