### PR TITLE
[offload][lit] XFAIL failing non-contiguous update tests on Intel

### DIFF
--- a/offload/test/offloading/strided_multiple_update_to.c
+++ b/offload/test/offloading/strided_multiple_update_to.c
@@ -3,6 +3,8 @@
 // from the host to the device.
 
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
+
 #include <omp.h>
 #include <stdio.h>
 

--- a/offload/test/offloading/strided_partial_update_to.c
+++ b/offload/test/offloading/strided_partial_update_to.c
@@ -3,6 +3,8 @@
 // across the array
 
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
+
 #include <omp.h>
 #include <stdio.h>
 

--- a/offload/test/offloading/strided_update_to.c
+++ b/offload/test/offloading/strided_update_to.c
@@ -4,6 +4,8 @@
 // other element (stride 2) from the host to the device
 
 // RUN: %libomptarget-compile-run-and-check-generic
+// XFAIL: intelgpu
+
 #include <omp.h>
 #include <stdio.h>
 


### PR DESCRIPTION
The new tests added in https://github.com/llvm/llvm-project/pull/169623 are [failing](https://lab.llvm.org/buildbot/#/builders/225/builds/544) on the Intel GPU runner, so XFAIL them as with the other tests.
