### PR TITLE
[AMDGPU] Remove redundant s_cmp_* after add X, 1

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -10963,6 +10963,34 @@ static bool foldableSelect(const MachineInstr &Def) {
   return true;
 }
 
+static bool setsSCCifResultIsZero(const MachineInstr &Def, bool &NeedInversion,
+                                  unsigned &NewDefOpc) {
+  // S_ADD_U32 X, 1 sets SCC on carryout which can only happen if result==0.
+  // S_ADD_I32 X, 1 can be converted to S_ADD_U32 X, 1 if SCC is dead.
+  if (Def.getOpcode() != AMDGPU::S_ADD_I32 &&
+      Def.getOpcode() != AMDGPU::S_ADD_U32)
+    return false;
+  MachineOperand AddSrc1 = Def.getOperand(1);
+  MachineOperand AddSrc2 = Def.getOperand(2);
+  int64_t addend;
+  if (!(AddSrc1.isImm() && AddSrc1.getImm() == 1) &&
+      !(AddSrc2.isImm() && AddSrc2.getImm() == 1) &&
+      !(getFoldableImm(&AddSrc1, addend) && addend == 1) &&
+      !(getFoldableImm(&AddSrc2, addend) && addend == 1))
+    return false;
+
+  if (Def.getOpcode() == AMDGPU::S_ADD_I32) {
+    const MachineOperand *SccDef =
+        Def.findRegisterDefOperand(AMDGPU::SCC, /*TRI=*/nullptr);
+    if (!SccDef->isDead())
+      return false;
+    NewDefOpc = AMDGPU::S_ADD_U32;
+  }
+
+  NeedInversion = !NeedInversion;
+  return true;
+}
+
 bool SIInstrInfo::optimizeCompareInstr(MachineInstr &CmpInstr, Register SrcReg,
                                        Register SrcReg2, int64_t CmpMask,
                                        int64_t CmpValue,
@@ -10984,19 +11012,31 @@ bool SIInstrInfo::optimizeCompareInstr(MachineInstr &CmpInstr, Register SrcReg,
 
     // For S_OP that set SCC = DST!=0, do the transformation
     //
-    //   s_cmp_lg_* (S_OP ...), 0 => (S_OP ...)
-
+    //   s_cmp_[lg|eq]_* (S_OP ...), 0 => (S_OP ...)
+    //
+    // For (S_OP ...) that set SCC = DST==0, invert NeedInversion and
+    // do the transformation:
+    //
+    //   s_cmp_[lg|eq]_* (S_OP ...), 0 => (S_OP ...)
+    //
     // If foldableSelect, s_cmp_lg_* is redundant because the SCC input value
     // for S_CSELECT* already has the same value that will be calculated by
     // s_cmp_lg_*
     //
-    //   s_cmp_lg_* (S_CSELECT* (non-zero imm), 0), 0 => (S_CSELECT* (non-zero
-    //   imm), 0)
-    if (!setsSCCifResultIsNonZero(*Def) && !foldableSelect(*Def))
+    //   s_cmp_[lg|eq]_* (S_CSELECT* (non-zero imm), 0), 0 => (S_CSELECT*
+    //   (non-zero imm), 0)
+
+    unsigned NewDefOpc = Def->getOpcode();
+    if (!setsSCCifResultIsNonZero(*Def) &&
+        !setsSCCifResultIsZero(*Def, NeedInversion, NewDefOpc) &&
+        !foldableSelect(*Def))
       return false;
 
     if (!optimizeSCC(Def, &CmpInstr, NeedInversion))
       return false;
+
+    if (NewDefOpc != Def->getOpcode())
+      Def->setDesc(get(NewDefOpc));
 
     // If s_or_b32 result, sY, is unused (i.e. it is effectively a 64-bit
     // s_cmp_lg of a register pair) and the inputs are the hi and lo-halves of a
@@ -11020,7 +11060,7 @@ bool SIInstrInfo::optimizeCompareInstr(MachineInstr &CmpInstr, Register SrcReg,
             Def1->getOperand(1).getReg() == Def2->getOperand(1).getReg()) {
           MachineInstr *Select = MRI->getVRegDef(Def1->getOperand(1).getReg());
           if (Select && foldableSelect(*Select))
-            optimizeSCC(Select, Def, false);
+            optimizeSCC(Select, Def, /*NeedInversion=*/false);
         }
       }
     }
@@ -11101,7 +11141,7 @@ bool SIInstrInfo::optimizeCompareInstr(MachineInstr &CmpInstr, Register SrcReg,
     if (IsReversedCC && !MRI->hasOneNonDBGUse(DefReg))
       return false;
 
-    if (!optimizeSCC(Def, &CmpInstr, false))
+    if (!optimizeSCC(Def, &CmpInstr, /*NeedInversion=*/false))
       return false;
 
     if (!MRI->use_nodbg_empty(DefReg)) {

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -728,7 +728,7 @@ public:
     }
   }
 
-  static bool setsSCCifResultIsNonZero(const MachineInstr &MI) {
+  static bool setsSCCIfResultIsNonZero(const MachineInstr &MI) {
     switch (MI.getOpcode()) {
     case AMDGPU::S_ABSDIFF_I32:
     case AMDGPU::S_ABS_I32:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/insertelement.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/insertelement.ll
@@ -2024,31 +2024,30 @@ entry:
 define amdgpu_ps <8 x float> @dyn_insertelement_v8f32_s_s_s_add_1(<8 x float> inreg %vec, float inreg %val, i32 inreg %idx) {
 ; GPRIDX-LABEL: dyn_insertelement_v8f32_s_s_s_add_1:
 ; GPRIDX:       ; %bb.0: ; %entry
-; GPRIDX-NEXT:    s_add_i32 s11, s11, 1
-; GPRIDX-NEXT:    s_cmp_eq_u32 s11, 0
-; GPRIDX-NEXT:    s_cselect_b32 s0, s10, s2
-; GPRIDX-NEXT:    s_cmp_eq_u32 s11, 1
-; GPRIDX-NEXT:    s_cselect_b32 s1, s10, s3
-; GPRIDX-NEXT:    s_cmp_eq_u32 s11, 2
-; GPRIDX-NEXT:    s_cselect_b32 s2, s10, s4
-; GPRIDX-NEXT:    s_cmp_eq_u32 s11, 3
-; GPRIDX-NEXT:    s_cselect_b32 s3, s10, s5
-; GPRIDX-NEXT:    s_cmp_eq_u32 s11, 4
-; GPRIDX-NEXT:    s_cselect_b32 s4, s10, s6
-; GPRIDX-NEXT:    s_cmp_eq_u32 s11, 5
-; GPRIDX-NEXT:    s_cselect_b32 s5, s10, s7
-; GPRIDX-NEXT:    s_cmp_eq_u32 s11, 6
-; GPRIDX-NEXT:    s_cselect_b32 s6, s10, s8
-; GPRIDX-NEXT:    s_cmp_eq_u32 s11, 7
-; GPRIDX-NEXT:    s_cselect_b32 s7, s10, s9
-; GPRIDX-NEXT:    v_mov_b32_e32 v0, s0
-; GPRIDX-NEXT:    v_mov_b32_e32 v1, s1
-; GPRIDX-NEXT:    v_mov_b32_e32 v2, s2
-; GPRIDX-NEXT:    v_mov_b32_e32 v3, s3
-; GPRIDX-NEXT:    v_mov_b32_e32 v4, s4
-; GPRIDX-NEXT:    v_mov_b32_e32 v5, s5
-; GPRIDX-NEXT:    v_mov_b32_e32 v6, s6
-; GPRIDX-NEXT:    v_mov_b32_e32 v7, s7
+; GPRIDX-NEXT:    s_add_u32 s0, s11, 1
+; GPRIDX-NEXT:    s_cselect_b32 s1, s10, s2
+; GPRIDX-NEXT:    s_cmp_eq_u32 s0, 1
+; GPRIDX-NEXT:    s_cselect_b32 s2, s10, s3
+; GPRIDX-NEXT:    s_cmp_eq_u32 s0, 2
+; GPRIDX-NEXT:    s_cselect_b32 s3, s10, s4
+; GPRIDX-NEXT:    s_cmp_eq_u32 s0, 3
+; GPRIDX-NEXT:    s_cselect_b32 s4, s10, s5
+; GPRIDX-NEXT:    s_cmp_eq_u32 s0, 4
+; GPRIDX-NEXT:    s_cselect_b32 s5, s10, s6
+; GPRIDX-NEXT:    s_cmp_eq_u32 s0, 5
+; GPRIDX-NEXT:    s_cselect_b32 s6, s10, s7
+; GPRIDX-NEXT:    s_cmp_eq_u32 s0, 6
+; GPRIDX-NEXT:    s_cselect_b32 s7, s10, s8
+; GPRIDX-NEXT:    s_cmp_eq_u32 s0, 7
+; GPRIDX-NEXT:    s_cselect_b32 s0, s10, s9
+; GPRIDX-NEXT:    v_mov_b32_e32 v0, s1
+; GPRIDX-NEXT:    v_mov_b32_e32 v1, s2
+; GPRIDX-NEXT:    v_mov_b32_e32 v2, s3
+; GPRIDX-NEXT:    v_mov_b32_e32 v3, s4
+; GPRIDX-NEXT:    v_mov_b32_e32 v4, s5
+; GPRIDX-NEXT:    v_mov_b32_e32 v5, s6
+; GPRIDX-NEXT:    v_mov_b32_e32 v6, s7
+; GPRIDX-NEXT:    v_mov_b32_e32 v7, s0
 ; GPRIDX-NEXT:    ; return to shader part epilog
 ;
 ; GFX10-LABEL: dyn_insertelement_v8f32_s_s_s_add_1:

--- a/llvm/test/CodeGen/AMDGPU/optimize-compare.mir
+++ b/llvm/test/CodeGen/AMDGPU/optimize-compare.mir
@@ -2447,306 +2447,152 @@ body:             |
 
 ...
 
+# STARTT
 ---
 # Delete s_cmp after s_add_u32 X, 1
-name:            s_add_u32_1_s_cmp_eq_u32_0x00000000
+name:            s_add_u32_X_1
 body:             |
-  ; GCN-LABEL: name: s_add_u32_1_s_cmp_eq_u32_0x00000000
-  ; GCN: bb.0:
-  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
-  ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], 1, implicit-def $scc
-  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
-  ; GCN-NEXT:   S_BRANCH %bb.1
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.1:
-  ; GCN-NEXT:   successors: %bb.2(0x80000000)
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.2:
-  ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1, %bb.2
     liveins: $sgpr0
-    %2:sreg_32 = COPY $sgpr0
-    %3:sreg_32 = S_ADD_U32 %2, 1, implicit-def $scc
-    S_CMP_EQ_U32 killed %3, 0, implicit-def $scc
-    S_CBRANCH_SCC0 %bb.2, implicit $scc
-    S_BRANCH %bb.1
-
-  bb.1:
-    successors: %bb.2
-
-  bb.2:
+    ; GCN-LABEL: name: s_add_u32_X_1
+    ; GCN: liveins: $sgpr0
+    ; GCN-NEXT: {{  $}}
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+    ; GCN-NEXT: [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], 1, implicit-def $scc
+    ; GCN-NEXT: S_ENDPGM 0
+    %0:sreg_32 = COPY $sgpr0
+    %1:sreg_32 = S_ADD_U32 %0, 1, implicit-def $scc
+    S_CMP_EQ_U32 killed %1, 0, implicit-def $scc
     S_ENDPGM 0
-
 ...
-
 ---
 # Delete s_cmp after s_add_u32 X, Y, where Y==1
-name:            s_add_u32_X_s_cmp_eq_u32_0x00000000
+name:            s_add_u32_X_R1
 body:             |
-  ; GCN-LABEL: name: s_add_u32_X_s_cmp_eq_u32_0x00000000
-  ; GCN: bb.0:
-  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
-  ; GCN-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 1
-  ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], [[S_MOV_B32_]], implicit-def $scc
-  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
-  ; GCN-NEXT:   S_BRANCH %bb.1
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.1:
-  ; GCN-NEXT:   successors: %bb.2(0x80000000)
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.2:
-  ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1, %bb.2
     liveins: $sgpr0
-    %2:sreg_32 = COPY $sgpr0
-    %3:sreg_32 = S_MOV_B32 1
-    %4:sreg_32 = S_ADD_U32 %2, %3, implicit-def $scc
-    S_CMP_EQ_U32 killed %4, 0, implicit-def $scc
-    S_CBRANCH_SCC0 %bb.2, implicit $scc
-    S_BRANCH %bb.1
-
-  bb.1:
-    successors: %bb.2
-
-  bb.2:
+    ; GCN-LABEL: name: s_add_u32_X_R1
+    ; GCN: liveins: $sgpr0
+    ; GCN-NEXT: {{  $}}
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+    ; GCN-NEXT: [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 1
+    ; GCN-NEXT: [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], [[S_MOV_B32_]], implicit-def $scc
+    ; GCN-NEXT: S_ENDPGM 0
+    %0:sreg_32 = COPY $sgpr0
+    %1:sreg_32 = S_MOV_B32 1
+    %2:sreg_32 = S_ADD_U32 %0, %1, implicit-def $scc
+    S_CMP_EQ_U32 killed %2, 0, implicit-def $scc
     S_ENDPGM 0
-
 ...
-
 ---
-# Delete s_cmp after s_add_i32 1, X
-name:            s_add_i32_1_s_cmp_eq_u32_0x00000000
+# Delete s_cmp after s_add_u32 1, X
+name:            s_add_u32_1_X
 body:             |
-  ; GCN-LABEL: name: s_add_i32_1_s_cmp_eq_u32_0x00000000
-  ; GCN: bb.0:
-  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
-  ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 1, [[COPY]], implicit-def $scc
-  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
-  ; GCN-NEXT:   S_BRANCH %bb.1
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.1:
-  ; GCN-NEXT:   successors: %bb.2(0x80000000)
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.2:
-  ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1, %bb.2
-    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
-    %0:vgpr_32 = IMPLICIT_DEF
-    %2:sreg_32 = COPY %0
-    %3:sreg_32 = S_ADD_I32 1, %2, implicit-def dead $scc
-    S_CMP_EQ_U32 killed %3, 0, implicit-def $scc
-    S_CBRANCH_SCC0 %bb.2, implicit $scc
-    S_BRANCH %bb.1
-
-  bb.1:
-    successors: %bb.2
-
-  bb.2:
-    S_ENDPGM 0
-
-...
-
----
-# Delete s_cmp after s_add_i32 X, Y, where X==1
-name:            s_add_i32_X_s_cmp_eq_u32_0x00000000
-body:             |
-  ; GCN-LABEL: name: s_add_i32_X_s_cmp_eq_u32_0x00000000
-  ; GCN: bb.0:
-  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
-  ; GCN-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 1
-  ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[S_MOV_B32_]], [[COPY]], implicit-def $scc
-  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
-  ; GCN-NEXT:   S_BRANCH %bb.1
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.1:
-  ; GCN-NEXT:   successors: %bb.2(0x80000000)
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.2:
-  ; GCN-NEXT:   S_ENDPGM 0
-  bb.0:
-    successors: %bb.1, %bb.2
     liveins: $sgpr0
-    %2:sreg_32 = COPY $sgpr0
-    %3:sreg_32 = S_MOV_B32 1
-    %4:sreg_32 = S_ADD_I32 %3, %2, implicit-def dead $scc
-    S_CMP_EQ_U32 killed %4, 0, implicit-def $scc
-    S_CBRANCH_SCC0 %bb.2, implicit $scc
-    S_BRANCH %bb.1
-
-  bb.1:
-    successors: %bb.2
-
-  bb.2:
+    ; GCN-LABEL: name: s_add_u32_1_X
+    ; GCN: liveins: $sgpr0
+    ; GCN-NEXT: {{  $}}
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+    ; GCN-NEXT: [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 1, [[COPY]], implicit-def $scc
+    ; GCN-NEXT: S_ENDPGM 0
+    %0:sreg_32 = COPY $sgpr0
+    %1:sreg_32 = S_ADD_U32 1, %0, implicit-def $scc
+    S_CMP_EQ_U32 killed %1, 0, implicit-def $scc
     S_ENDPGM 0
-
 ...
-
+---
+# Delete s_cmp after s_add_u32 X, Y, where X==1
+name:            s_add_u32_R1_Y
+body:             |
+  bb.0:
+    liveins: $sgpr0
+    ; GCN-LABEL: name: s_add_u32_R1_Y
+    ; GCN: liveins: $sgpr0
+    ; GCN-NEXT: {{  $}}
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+    ; GCN-NEXT: [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 1
+    ; GCN-NEXT: [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[S_MOV_B32_]], [[COPY]], implicit-def $scc
+    ; GCN-NEXT: S_ENDPGM 0
+    %0:sreg_32 = COPY $sgpr0
+    %1:sreg_32 = S_MOV_B32 1
+    %2:sreg_32 = S_ADD_U32 %1, %0, implicit-def $scc
+    S_CMP_EQ_U32 killed %2, 0, implicit-def $scc
+    S_ENDPGM 0
+...
 ---
 # Do not delete s_cmp after s_add_u32 X, 2
-name:            s_add_u32_non1_s_cmp_eq_u32_0x00000000
+name:            s_add_u32_X_2
 body:             |
-  ; GCN-LABEL: name: s_add_u32_non1_s_cmp_eq_u32_0x00000000
-  ; GCN: bb.0:
-  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
-  ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], 2, implicit-def $scc
-  ; GCN-NEXT:   S_CMP_EQ_U32 killed [[S_ADD_U32_]], 0, implicit-def $scc
-  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
-  ; GCN-NEXT:   S_BRANCH %bb.1
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.1:
-  ; GCN-NEXT:   successors: %bb.2(0x80000000)
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.2:
-  ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1, %bb.2
     liveins: $sgpr0
-    %2:sreg_32 = COPY $sgpr0
-    %3:sreg_32 = S_ADD_U32 %2, 2, implicit-def $scc
-    S_CMP_EQ_U32 killed %3, 0, implicit-def $scc
-    S_CBRANCH_SCC0 %bb.2, implicit $scc
-    S_BRANCH %bb.1
-
-  bb.1:
-    successors: %bb.2
-
-  bb.2:
+    ; GCN-LABEL: name: s_add_u32_X_2
+    ; GCN: liveins: $sgpr0
+    ; GCN-NEXT: {{  $}}
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+    ; GCN-NEXT: [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], 2, implicit-def $scc
+    ; GCN-NEXT: S_CMP_EQ_U32 killed [[S_ADD_U32_]], 0, implicit-def $scc
+    ; GCN-NEXT: S_ENDPGM 0
+    %0:sreg_32 = COPY $sgpr0
+    %1:sreg_32 = S_ADD_U32 %0, 2, implicit-def $scc
+    S_CMP_EQ_U32 killed %1, 0, implicit-def $scc
     S_ENDPGM 0
-
 ...
-
 ---
 # Do not delete s_cmp after s_add_u32 X, Y, where Y!=1
-name:            s_add_u32_non1X_s_cmp_eq_u32_0x00000000
+name:            s_add_u32_X_Rnon1
 body:             |
-  ; GCN-LABEL: name: s_add_u32_non1X_s_cmp_eq_u32_0x00000000
-  ; GCN: bb.0:
-  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
-  ; GCN-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 3
-  ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], [[S_MOV_B32_]], implicit-def $scc
-  ; GCN-NEXT:   S_CMP_EQ_U32 killed [[S_ADD_U32_]], 0, implicit-def $scc
-  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
-  ; GCN-NEXT:   S_BRANCH %bb.1
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.1:
-  ; GCN-NEXT:   successors: %bb.2(0x80000000)
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.2:
-  ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1, %bb.2
     liveins: $sgpr0
-    %2:sreg_32 = COPY $sgpr0
-    %3:sreg_32 = S_MOV_B32 3
-    %4:sreg_32 = S_ADD_U32 %2, %3, implicit-def $scc
-    S_CMP_EQ_U32 killed %4, 0, implicit-def $scc
-    S_CBRANCH_SCC0 %bb.2, implicit $scc
-    S_BRANCH %bb.1
-
-  bb.1:
-    successors: %bb.2
-
-  bb.2:
+    ; GCN-LABEL: name: s_add_u32_X_Rnon1
+    ; GCN: liveins: $sgpr0
+    ; GCN-NEXT: {{  $}}
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+    ; GCN-NEXT: [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 3
+    ; GCN-NEXT: [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], [[S_MOV_B32_]], implicit-def $scc
+    ; GCN-NEXT: S_CMP_EQ_U32 killed [[S_ADD_U32_]], 0, implicit-def $scc
+    ; GCN-NEXT: S_ENDPGM 0
+    %0:sreg_32 = COPY $sgpr0
+    %1:sreg_32 = S_MOV_B32 3
+    %2:sreg_32 = S_ADD_U32 %0, %1, implicit-def $scc
+    S_CMP_EQ_U32 killed %2, 0, implicit-def $scc
     S_ENDPGM 0
-
 ...
-
 ---
-# Do not delete s_cmp after s_add_i32 2, X
-name:            s_add_i32_non1_s_cmp_eq_u32_0x00000000
+# Do not delete s_cmp after s_add_u32 3, X
+name:            s_add_u32_3_X
 body:             |
-  ; GCN-LABEL: name: s_add_i32_non1_s_cmp_eq_u32_0x00000000
-  ; GCN: bb.0:
-  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
-  ; GCN-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 2, [[COPY]], implicit-def dead $scc
-  ; GCN-NEXT:   S_CMP_EQ_U32 killed [[S_ADD_I32_]], 0, implicit-def $scc
-  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
-  ; GCN-NEXT:   S_BRANCH %bb.1
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.1:
-  ; GCN-NEXT:   successors: %bb.2(0x80000000)
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.2:
-  ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1, %bb.2
-    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
-    %0:vgpr_32 = IMPLICIT_DEF
-    %2:sreg_32 = COPY %0
-    %3:sreg_32 = S_ADD_I32 2, %2, implicit-def dead $scc
-    S_CMP_EQ_U32 killed %3, 0, implicit-def $scc
-    S_CBRANCH_SCC0 %bb.2, implicit $scc
-    S_BRANCH %bb.1
-
-  bb.1:
-    successors: %bb.2
-
-  bb.2:
-    S_ENDPGM 0
-
-...
-
----
-# Do not delete s_cmp after s_add_i32 X, Y, where X!=1
-name:            s_add_i32_non1X_s_cmp_eq_u32_0x00000000
-body:             |
-  ; GCN-LABEL: name: s_add_i32_non1X_s_cmp_eq_u32_0x00000000
-  ; GCN: bb.0:
-  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
-  ; GCN-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 5
-  ; GCN-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 [[S_MOV_B32_]], [[COPY]], implicit-def dead $scc
-  ; GCN-NEXT:   S_CMP_EQ_U32 killed [[S_ADD_I32_]], 0, implicit-def $scc
-  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
-  ; GCN-NEXT:   S_BRANCH %bb.1
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.1:
-  ; GCN-NEXT:   successors: %bb.2(0x80000000)
-  ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT: bb.2:
-  ; GCN-NEXT:   S_ENDPGM 0
-  bb.0:
-    successors: %bb.1, %bb.2
     liveins: $sgpr0
-    %2:sreg_32 = COPY $sgpr0
-    %3:sreg_32 = S_MOV_B32 5
-    %4:sreg_32 = S_ADD_I32 %3, %2, implicit-def dead $scc
-    S_CMP_EQ_U32 killed %4, 0, implicit-def $scc
-    S_CBRANCH_SCC0 %bb.2, implicit $scc
-    S_BRANCH %bb.1
-
-  bb.1:
-    successors: %bb.2
-
-  bb.2:
+    ; GCN-LABEL: name: s_add_u32_3_X
+    ; GCN: liveins: $sgpr0
+    ; GCN-NEXT: {{  $}}
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+    ; GCN-NEXT: [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 3, [[COPY]], implicit-def $scc
+    ; GCN-NEXT: S_CMP_EQ_U32 killed [[S_ADD_U32_]], 0, implicit-def $scc
+    ; GCN-NEXT: S_ENDPGM 0
+    %0:sreg_32 = COPY $sgpr0
+    %1:sreg_32 = S_ADD_U32 3, %0, implicit-def $scc
+    S_CMP_EQ_U32 killed %1, 0, implicit-def $scc
     S_ENDPGM 0
-
+...
+---
+# Do not delete s_cmp after s_add_u32 X, Y, where X!=1
+name:            s_add_u32_Rnon1_Y
+body:             |
+  bb.0:
+    liveins: $sgpr0
+    ; GCN-LABEL: name: s_add_u32_Rnon1_Y
+    ; GCN: liveins: $sgpr0
+    ; GCN-NEXT: {{  $}}
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+    ; GCN-NEXT: [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 4
+    ; GCN-NEXT: [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[S_MOV_B32_]], [[COPY]], implicit-def $scc
+    ; GCN-NEXT: S_CMP_EQ_U32 killed [[S_ADD_U32_]], 0, implicit-def $scc
+    ; GCN-NEXT: S_ENDPGM 0
+    %0:sreg_32 = COPY $sgpr0
+    %1:sreg_32 = S_MOV_B32 4
+    %2:sreg_32 = S_ADD_U32 %1, %0, implicit-def $scc
+    S_CMP_EQ_U32 killed %2, 0, implicit-def $scc
+    S_ENDPGM 0
 ...

--- a/llvm/test/CodeGen/AMDGPU/optimize-compare.mir
+++ b/llvm/test/CodeGen/AMDGPU/optimize-compare.mir
@@ -20,7 +20,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -30,7 +30,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -57,7 +57,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -68,7 +68,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -94,7 +94,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -104,7 +104,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -131,7 +131,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -141,7 +141,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -173,20 +173,20 @@ body:             |
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
     liveins: $sgpr0, $vgpr0_vgpr1
-    successors: %bb.1(0x80000000)
+    successors: %bb.1
 
     %0:sreg_32 = COPY $sgpr0
     %1:sreg_32 = S_AND_B32 1, killed %0, implicit-def dead $scc
 
   bb.1:
-    successors: %bb.2(0x40000000), %bb.1(0x40000000)
+    successors: %bb.2, %bb.1
 
     S_CMP_EQ_I32 %1:sreg_32, 1, implicit-def $scc
     S_CBRANCH_SCC0 %bb.2, implicit $scc
     S_BRANCH %bb.1
 
   bb.2:
-    successors: %bb.3(0x80000000)
+    successors: %bb.3
 
   bb.3:
     S_ENDPGM 0
@@ -213,7 +213,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -223,7 +223,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -249,7 +249,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -259,7 +259,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -285,7 +285,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -294,7 +294,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -322,7 +322,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -333,7 +333,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -361,7 +361,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $sgpr1, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -372,7 +372,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -399,7 +399,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -410,7 +410,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -436,7 +436,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -447,7 +447,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -473,7 +473,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -484,7 +484,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -512,7 +512,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -523,7 +523,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -550,7 +550,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -560,7 +560,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -587,7 +587,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -597,7 +597,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -623,7 +623,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -633,7 +633,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -659,7 +659,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -669,7 +669,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -695,7 +695,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -705,7 +705,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -731,7 +731,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -741,7 +741,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -768,7 +768,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -778,7 +778,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -804,7 +804,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -814,7 +814,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -840,7 +840,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -850,7 +850,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -876,7 +876,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
 
     %0:sreg_64 = COPY $sgpr0_sgpr1
@@ -886,7 +886,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -912,7 +912,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
 
     %0:sreg_64 = COPY $sgpr0_sgpr1
@@ -922,7 +922,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -948,7 +948,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -958,7 +958,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -984,7 +984,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -994,7 +994,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1020,7 +1020,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1030,7 +1030,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1056,7 +1056,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1066,7 +1066,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1092,7 +1092,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1102,7 +1102,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1128,7 +1128,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1138,7 +1138,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1164,7 +1164,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1174,7 +1174,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1200,7 +1200,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1210,7 +1210,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1235,7 +1235,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = S_AND_B32 1, 11, implicit-def dead $scc
@@ -1244,7 +1244,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1270,7 +1270,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1280,7 +1280,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1306,7 +1306,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1316,7 +1316,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1342,7 +1342,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
 
     %0:sreg_64 = COPY $sgpr0_sgpr1
@@ -1352,7 +1352,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1378,7 +1378,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1388,7 +1388,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1414,7 +1414,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1424,7 +1424,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1450,7 +1450,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
 
     %0:sreg_64 = COPY $sgpr0_sgpr1
@@ -1460,7 +1460,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1488,7 +1488,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1498,7 +1498,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
     S_NOP 0, implicit %1
   bb.2:
@@ -1526,7 +1526,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1536,7 +1536,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1563,7 +1563,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1573,7 +1573,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1600,7 +1600,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1611,7 +1611,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1638,7 +1638,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1649,7 +1649,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1676,7 +1676,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
 
     %0:sreg_64 = COPY $sgpr0_sgpr1
@@ -1687,7 +1687,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1713,7 +1713,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1723,7 +1723,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1749,7 +1749,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1759,7 +1759,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1785,7 +1785,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1795,7 +1795,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1822,7 +1822,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1832,7 +1832,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1858,7 +1858,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1868,7 +1868,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1894,7 +1894,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1904,7 +1904,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1931,7 +1931,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1941,7 +1941,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -1967,7 +1967,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -1977,7 +1977,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2003,7 +2003,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
 
     %0:sreg_64 = COPY $sgpr0_sgpr1
@@ -2013,7 +2013,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2039,7 +2039,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
 
     %0:sreg_64 = COPY $sgpr0_sgpr1
@@ -2049,7 +2049,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2077,7 +2077,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -2087,7 +2087,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
     S_NOP 0, implicit %1
 
@@ -2116,7 +2116,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -2126,7 +2126,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2152,7 +2152,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -2162,7 +2162,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2188,7 +2188,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -2198,7 +2198,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2224,7 +2224,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0, $vgpr0_vgpr1
 
     %0:sreg_32 = COPY $sgpr0
@@ -2234,7 +2234,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2260,7 +2260,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
 
     %0:sreg_64 = COPY $sgpr0_sgpr1
@@ -2270,7 +2270,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2299,7 +2299,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0
     %2:sreg_32 = COPY $sgpr0
     S_CMP_LG_U32 %2, 0, implicit-def $scc
@@ -2312,7 +2312,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2343,7 +2343,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0
     %2:sreg_32 = COPY $sgpr0
     S_CMP_LG_U32 %2, 0, implicit-def $scc
@@ -2357,7 +2357,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2388,7 +2388,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0
     %2:sreg_32 = COPY $sgpr0
     S_CMP_LG_U32 %2, 0, implicit-def $scc
@@ -2401,7 +2401,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2429,7 +2429,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0
     %2:sreg_32 = COPY $sgpr0
     S_CMP_LG_U32 %2, 0, implicit-def $scc
@@ -2440,7 +2440,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2468,7 +2468,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0
     %2:sreg_32 = COPY $sgpr0
     %3:sreg_32 = S_ADD_U32 %2, 1, implicit-def $scc
@@ -2477,7 +2477,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2505,7 +2505,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0
     %2:sreg_32 = COPY $sgpr0
     %3:sreg_32 = S_MOV_B32 1
@@ -2515,7 +2515,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2543,7 +2543,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
     %0:vgpr_32 = IMPLICIT_DEF
     %2:sreg_32 = COPY %0
@@ -2553,7 +2553,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0
@@ -2581,7 +2581,7 @@ body:             |
   ; GCN-NEXT: bb.2:
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
-    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    successors: %bb.1, %bb.2
     liveins: $sgpr0
     %2:sreg_32 = COPY $sgpr0
     %3:sreg_32 = S_MOV_B32 1
@@ -2591,7 +2591,7 @@ body:             |
     S_BRANCH %bb.1
 
   bb.1:
-    successors: %bb.2(0x80000000)
+    successors: %bb.2
 
   bb.2:
     S_ENDPGM 0

--- a/llvm/test/CodeGen/AMDGPU/optimize-compare.mir
+++ b/llvm/test/CodeGen/AMDGPU/optimize-compare.mir
@@ -2454,3 +2454,160 @@ body:             |
     S_ENDPGM 0
 
 ...
+
+
+---
+# Delete s_cmp after s_add_u32 X, 1
+name:            s_add_u32_1_s_cmp_eq_u32_0x00000000
+body:             |
+  ; GCN-LABEL: name: s_add_u32_1_s_cmp_eq_u32_0x00000000
+  ; GCN: bb.0:
+  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
+  ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], 1, implicit-def $scc
+  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
+  ; GCN-NEXT:   S_BRANCH %bb.1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.1:
+  ; GCN-NEXT:   successors: %bb.2(0x80000000)
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.2:
+  ; GCN-NEXT:   S_ENDPGM 0
+  bb.0:
+    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+    %0:vgpr_32 = IMPLICIT_DEF
+    %2:sreg_32 = COPY %0
+    %3:sreg_32 = S_ADD_U32 %2, 1, implicit-def $scc
+    S_CMP_EQ_U32 killed %3, 0, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.2, implicit $scc
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2(0x80000000)
+
+  bb.2:
+    S_ENDPGM 0
+
+...
+
+---
+# Delete s_cmp after s_add_u32 X, Y, where Y==1
+name:            s_add_u32_X_s_cmp_eq_u32_0x00000000
+body:             |
+  ; GCN-LABEL: name: s_add_u32_X_s_cmp_eq_u32_0x00000000
+  ; GCN: bb.0:
+  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
+  ; GCN-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 1
+  ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], [[S_MOV_B32_]], implicit-def $scc
+  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
+  ; GCN-NEXT:   S_BRANCH %bb.1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.1:
+  ; GCN-NEXT:   successors: %bb.2(0x80000000)
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.2:
+  ; GCN-NEXT:   S_ENDPGM 0
+  bb.0:
+    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+    %0:vgpr_32 = IMPLICIT_DEF
+    %2:sreg_32 = COPY %0
+    %3:sreg_32 = S_MOV_B32 1
+    %4:sreg_32 = S_ADD_U32 %2, %3, implicit-def $scc
+    S_CMP_EQ_U32 killed %4, 0, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.2, implicit $scc
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2(0x80000000)
+
+  bb.2:
+    S_ENDPGM 0
+
+...
+
+---
+# Delete s_cmp after s_add_i32 1, X
+name:            s_add_i32_1_s_cmp_eq_u32_0x00000000
+body:             |
+  ; GCN-LABEL: name: s_add_i32_1_s_cmp_eq_u32_0x00000000
+  ; GCN: bb.0:
+  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
+  ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 1, [[COPY]], implicit-def $scc
+  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
+  ; GCN-NEXT:   S_BRANCH %bb.1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.1:
+  ; GCN-NEXT:   successors: %bb.2(0x80000000)
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.2:
+  ; GCN-NEXT:   S_ENDPGM 0
+  bb.0:
+    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+    %0:vgpr_32 = IMPLICIT_DEF
+    %2:sreg_32 = COPY %0
+    %3:sreg_32 = S_ADD_I32 1, %2, implicit-def dead $scc
+    S_CMP_EQ_U32 killed %3, 0, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.2, implicit $scc
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2(0x80000000)
+
+  bb.2:
+    S_ENDPGM 0
+
+...
+
+---
+# Delete s_cmp after s_add_i32 X, Y, where X==1
+name:            s_add_i32_X_s_cmp_eq_u32_0x00000000
+body:             |
+  ; GCN-LABEL: name: s_add_i32_X_s_cmp_eq_u32_0x00000000
+  ; GCN: bb.0:
+  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
+  ; GCN-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 1
+  ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[S_MOV_B32_]], [[COPY]], implicit-def $scc
+  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
+  ; GCN-NEXT:   S_BRANCH %bb.1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.1:
+  ; GCN-NEXT:   successors: %bb.2(0x80000000)
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.2:
+  ; GCN-NEXT:   S_ENDPGM 0
+  bb.0:
+    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+    %0:vgpr_32 = IMPLICIT_DEF
+    %2:sreg_32 = COPY %0
+    %3:sreg_32 = S_MOV_B32 1
+    %4:sreg_32 = S_ADD_I32 %3, %2, implicit-def dead $scc
+    S_CMP_EQ_U32 killed %4, 0, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.2, implicit $scc
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2(0x80000000)
+
+  bb.2:
+    S_ENDPGM 0
+
+...

--- a/llvm/test/CodeGen/AMDGPU/optimize-compare.mir
+++ b/llvm/test/CodeGen/AMDGPU/optimize-compare.mir
@@ -2447,7 +2447,6 @@ body:             |
 
 ...
 
-
 ---
 # Delete s_cmp after s_add_u32 X, 1
 name:            s_add_u32_1_s_cmp_eq_u32_0x00000000
@@ -2585,6 +2584,160 @@ body:             |
     liveins: $sgpr0
     %2:sreg_32 = COPY $sgpr0
     %3:sreg_32 = S_MOV_B32 1
+    %4:sreg_32 = S_ADD_I32 %3, %2, implicit-def dead $scc
+    S_CMP_EQ_U32 killed %4, 0, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.2, implicit $scc
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+
+...
+
+---
+# Do not delete s_cmp after s_add_u32 X, 2
+name:            s_add_u32_non1_s_cmp_eq_u32_0x00000000
+body:             |
+  ; GCN-LABEL: name: s_add_u32_non1_s_cmp_eq_u32_0x00000000
+  ; GCN: bb.0:
+  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; GCN-NEXT:   liveins: $sgpr0
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+  ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], 2, implicit-def $scc
+  ; GCN-NEXT:   S_CMP_EQ_U32 killed [[S_ADD_U32_]], 0, implicit-def $scc
+  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
+  ; GCN-NEXT:   S_BRANCH %bb.1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.1:
+  ; GCN-NEXT:   successors: %bb.2(0x80000000)
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.2:
+  ; GCN-NEXT:   S_ENDPGM 0
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $sgpr0
+    %2:sreg_32 = COPY $sgpr0
+    %3:sreg_32 = S_ADD_U32 %2, 2, implicit-def $scc
+    S_CMP_EQ_U32 killed %3, 0, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.2, implicit $scc
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+
+...
+
+---
+# Do not delete s_cmp after s_add_u32 X, Y, where Y!=1
+name:            s_add_u32_non1X_s_cmp_eq_u32_0x00000000
+body:             |
+  ; GCN-LABEL: name: s_add_u32_non1X_s_cmp_eq_u32_0x00000000
+  ; GCN: bb.0:
+  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; GCN-NEXT:   liveins: $sgpr0
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+  ; GCN-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 3
+  ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], [[S_MOV_B32_]], implicit-def $scc
+  ; GCN-NEXT:   S_CMP_EQ_U32 killed [[S_ADD_U32_]], 0, implicit-def $scc
+  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
+  ; GCN-NEXT:   S_BRANCH %bb.1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.1:
+  ; GCN-NEXT:   successors: %bb.2(0x80000000)
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.2:
+  ; GCN-NEXT:   S_ENDPGM 0
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $sgpr0
+    %2:sreg_32 = COPY $sgpr0
+    %3:sreg_32 = S_MOV_B32 3
+    %4:sreg_32 = S_ADD_U32 %2, %3, implicit-def $scc
+    S_CMP_EQ_U32 killed %4, 0, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.2, implicit $scc
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+
+...
+
+---
+# Do not delete s_cmp after s_add_i32 2, X
+name:            s_add_i32_non1_s_cmp_eq_u32_0x00000000
+body:             |
+  ; GCN-LABEL: name: s_add_i32_non1_s_cmp_eq_u32_0x00000000
+  ; GCN: bb.0:
+  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
+  ; GCN-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 2, [[COPY]], implicit-def dead $scc
+  ; GCN-NEXT:   S_CMP_EQ_U32 killed [[S_ADD_I32_]], 0, implicit-def $scc
+  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
+  ; GCN-NEXT:   S_BRANCH %bb.1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.1:
+  ; GCN-NEXT:   successors: %bb.2(0x80000000)
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.2:
+  ; GCN-NEXT:   S_ENDPGM 0
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+    %0:vgpr_32 = IMPLICIT_DEF
+    %2:sreg_32 = COPY %0
+    %3:sreg_32 = S_ADD_I32 2, %2, implicit-def dead $scc
+    S_CMP_EQ_U32 killed %3, 0, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.2, implicit $scc
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+
+...
+
+---
+# Do not delete s_cmp after s_add_i32 X, Y, where X!=1
+name:            s_add_i32_non1X_s_cmp_eq_u32_0x00000000
+body:             |
+  ; GCN-LABEL: name: s_add_i32_non1X_s_cmp_eq_u32_0x00000000
+  ; GCN: bb.0:
+  ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; GCN-NEXT:   liveins: $sgpr0
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
+  ; GCN-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 5
+  ; GCN-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 [[S_MOV_B32_]], [[COPY]], implicit-def dead $scc
+  ; GCN-NEXT:   S_CMP_EQ_U32 killed [[S_ADD_I32_]], 0, implicit-def $scc
+  ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
+  ; GCN-NEXT:   S_BRANCH %bb.1
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.1:
+  ; GCN-NEXT:   successors: %bb.2(0x80000000)
+  ; GCN-NEXT: {{  $}}
+  ; GCN-NEXT: bb.2:
+  ; GCN-NEXT:   S_ENDPGM 0
+  bb.0:
+    successors: %bb.1, %bb.2
+    liveins: $sgpr0
+    %2:sreg_32 = COPY $sgpr0
+    %3:sreg_32 = S_MOV_B32 5
     %4:sreg_32 = S_ADD_I32 %3, %2, implicit-def dead $scc
     S_CMP_EQ_U32 killed %4, 0, implicit-def $scc
     S_CBRANCH_SCC0 %bb.2, implicit $scc

--- a/llvm/test/CodeGen/AMDGPU/optimize-compare.mir
+++ b/llvm/test/CodeGen/AMDGPU/optimize-compare.mir
@@ -2283,10 +2283,9 @@ body:             |
   ; GCN-LABEL: name: s_cselect_b64_s_or_b32_s_cmp_lg_u32_0x00000000
   ; GCN: bb.0:
   ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+  ; GCN-NEXT:   liveins: $sgpr0
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
   ; GCN-NEXT:   S_CMP_LG_U32 [[COPY]], 0, implicit-def $scc
   ; GCN-NEXT:   [[S_CSELECT_B64_:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
   ; GCN-NEXT:   [[COPY1:%[0-9]+]]:sreg_32_xm0_xexec = COPY [[S_CSELECT_B64_]].sub0
@@ -2301,9 +2300,8 @@ body:             |
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
     successors: %bb.1(0x40000000), %bb.2(0x40000000)
-    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
-    %0:vgpr_32 = IMPLICIT_DEF
-    %2:sreg_32 = COPY %0
+    liveins: $sgpr0
+    %2:sreg_32 = COPY $sgpr0
     S_CMP_LG_U32 %2, 0, implicit-def $scc
     %31:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
     %40:sreg_32_xm0_xexec = COPY %31.sub0:sreg_64_xexec
@@ -2327,10 +2325,9 @@ body:             |
   ; GCN-LABEL: name: s_cselect_b64_s_or_b32_s_cmp_lg_u32_0x00000000_cant_optimize_intervening
   ; GCN: bb.0:
   ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+  ; GCN-NEXT:   liveins: $sgpr0
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
   ; GCN-NEXT:   S_CMP_LG_U32 [[COPY]], 0, implicit-def $scc
   ; GCN-NEXT:   [[S_CSELECT_B64_:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
   ; GCN-NEXT:   S_CMP_LG_U32 [[COPY]], 0, implicit-def $scc
@@ -2347,9 +2344,8 @@ body:             |
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
     successors: %bb.1(0x40000000), %bb.2(0x40000000)
-    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
-    %0:vgpr_32 = IMPLICIT_DEF
-    %2:sreg_32 = COPY %0
+    liveins: $sgpr0
+    %2:sreg_32 = COPY $sgpr0
     S_CMP_LG_U32 %2, 0, implicit-def $scc
     %31:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
     S_CMP_LG_U32 %2, 0, implicit-def $scc
@@ -2375,10 +2371,9 @@ body:             |
   ; GCN-LABEL: name: s_cselect_b64_s_or_b32_s_cmp_lg_u32_0x00000000_cant_optimize
   ; GCN: bb.0:
   ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+  ; GCN-NEXT:   liveins: $sgpr0
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
   ; GCN-NEXT:   S_CMP_LG_U32 [[COPY]], 0, implicit-def $scc
   ; GCN-NEXT:   [[S_CSELECT_B64_:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 1, 0, implicit $scc
   ; GCN-NEXT:   [[COPY1:%[0-9]+]]:sreg_32_xm0_xexec = COPY [[S_CSELECT_B64_]].sub1
@@ -2394,9 +2389,8 @@ body:             |
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
     successors: %bb.1(0x40000000), %bb.2(0x40000000)
-    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
-    %0:vgpr_32 = IMPLICIT_DEF
-    %2:sreg_32 = COPY %0
+    liveins: $sgpr0
+    %2:sreg_32 = COPY $sgpr0
     S_CMP_LG_U32 %2, 0, implicit-def $scc
     %31:sreg_64_xexec = S_CSELECT_B64 1, 0, implicit $scc
     %40:sreg_32_xm0_xexec = COPY %31.sub1:sreg_64_xexec
@@ -2420,13 +2414,12 @@ body:             |
   ; GCN-LABEL: name: s_cselect_b64_undef_s_or_b32_s_cmp_lg_u32_0x00000000
   ; GCN: bb.0:
   ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+  ; GCN-NEXT:   liveins: $sgpr0
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
   ; GCN-NEXT:   S_CMP_LG_U32 [[COPY]], 0, implicit-def $scc
   ; GCN-NEXT:   [[S_CSELECT_B64_:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
-  ; GCN-NEXT:   %sgpr4:sreg_32 = S_OR_B32 undef %4:sreg_32_xm0_xexec, undef %5:sreg_32_xm0_xexec, implicit-def $scc
+  ; GCN-NEXT:   %sgpr4:sreg_32 = S_OR_B32 undef %3:sreg_32_xm0_xexec, undef %4:sreg_32_xm0_xexec, implicit-def $scc
   ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
   ; GCN-NEXT:   S_BRANCH %bb.1
   ; GCN-NEXT: {{  $}}
@@ -2437,9 +2430,8 @@ body:             |
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
     successors: %bb.1(0x40000000), %bb.2(0x40000000)
-    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
-    %0:vgpr_32 = IMPLICIT_DEF
-    %2:sreg_32 = COPY %0
+    liveins: $sgpr0
+    %2:sreg_32 = COPY $sgpr0
     S_CMP_LG_U32 %2, 0, implicit-def $scc
     %31:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
     %sgpr4:sreg_32 = S_OR_B32 undef %40:sreg_32_xm0_xexec, undef %41:sreg_32_xm0_xexec, implicit-def $scc
@@ -2463,10 +2455,9 @@ body:             |
   ; GCN-LABEL: name: s_add_u32_1_s_cmp_eq_u32_0x00000000
   ; GCN: bb.0:
   ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+  ; GCN-NEXT:   liveins: $sgpr0
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
   ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], 1, implicit-def $scc
   ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
   ; GCN-NEXT:   S_BRANCH %bb.1
@@ -2478,9 +2469,8 @@ body:             |
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
     successors: %bb.1(0x40000000), %bb.2(0x40000000)
-    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
-    %0:vgpr_32 = IMPLICIT_DEF
-    %2:sreg_32 = COPY %0
+    liveins: $sgpr0
+    %2:sreg_32 = COPY $sgpr0
     %3:sreg_32 = S_ADD_U32 %2, 1, implicit-def $scc
     S_CMP_EQ_U32 killed %3, 0, implicit-def $scc
     S_CBRANCH_SCC0 %bb.2, implicit $scc
@@ -2501,10 +2491,9 @@ body:             |
   ; GCN-LABEL: name: s_add_u32_X_s_cmp_eq_u32_0x00000000
   ; GCN: bb.0:
   ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+  ; GCN-NEXT:   liveins: $sgpr0
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
   ; GCN-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 1
   ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY]], [[S_MOV_B32_]], implicit-def $scc
   ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
@@ -2517,9 +2506,8 @@ body:             |
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
     successors: %bb.1(0x40000000), %bb.2(0x40000000)
-    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
-    %0:vgpr_32 = IMPLICIT_DEF
-    %2:sreg_32 = COPY %0
+    liveins: $sgpr0
+    %2:sreg_32 = COPY $sgpr0
     %3:sreg_32 = S_MOV_B32 1
     %4:sreg_32 = S_ADD_U32 %2, %3, implicit-def $scc
     S_CMP_EQ_U32 killed %4, 0, implicit-def $scc
@@ -2579,10 +2567,9 @@ body:             |
   ; GCN-LABEL: name: s_add_i32_X_s_cmp_eq_u32_0x00000000
   ; GCN: bb.0:
   ; GCN-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; GCN-NEXT:   liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
+  ; GCN-NEXT:   liveins: $sgpr0
   ; GCN-NEXT: {{  $}}
-  ; GCN-NEXT:   [[DEF:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY [[DEF]]
+  ; GCN-NEXT:   [[COPY:%[0-9]+]]:sreg_32 = COPY $sgpr0
   ; GCN-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 1
   ; GCN-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[S_MOV_B32_]], [[COPY]], implicit-def $scc
   ; GCN-NEXT:   S_CBRANCH_SCC0 %bb.2, implicit $scc
@@ -2595,9 +2582,8 @@ body:             |
   ; GCN-NEXT:   S_ENDPGM 0
   bb.0:
     successors: %bb.1(0x40000000), %bb.2(0x40000000)
-    liveins: $sgpr0_sgpr1, $vgpr0_vgpr1
-    %0:vgpr_32 = IMPLICIT_DEF
-    %2:sreg_32 = COPY %0
+    liveins: $sgpr0
+    %2:sreg_32 = COPY $sgpr0
     %3:sreg_32 = S_MOV_B32 1
     %4:sreg_32 = S_ADD_I32 %3, %2, implicit-def dead $scc
     S_CMP_EQ_U32 killed %4, 0, implicit-def $scc

--- a/llvm/test/CodeGen/AMDGPU/s_cmp_0.ll
+++ b/llvm/test/CodeGen/AMDGPU/s_cmp_0.ll
@@ -7,6 +7,24 @@ declare i64 @llvm.ctpop.i64(i64)
 declare i32 @llvm.amdgcn.s.quadmask.i32(i32)
 declare i64 @llvm.amdgcn.s.quadmask.i64(i64)
 
+define amdgpu_ps i32 @add32(i32 inreg %val0) {
+; CHECK-LABEL: add32:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_add_u32 s0, s0, 1
+; CHECK-NEXT:    ;;#ASMSTART
+; CHECK-NEXT:    ; use s0
+; CHECK-NEXT:    ;;#ASMEND
+; CHECK-NEXT:    s_cselect_b64 s[0:1], 0, -1
+; CHECK-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s[0:1]
+; CHECK-NEXT:    v_readfirstlane_b32 s0, v0
+; CHECK-NEXT:    ; return to shader part epilog
+  %result = add i32 %val0, 1
+  call void asm "; use $0", "s"(i32 %result)
+  %cmp = icmp ne i32 %result, 0
+  %zext = zext i1 %cmp to i32
+  ret i32 %zext
+}
+
 define amdgpu_ps i32 @shl32(i32 inreg %val0, i32 inreg %val1) {
 ; CHECK-LABEL: shl32:
 ; CHECK:       ; %bb.0:
@@ -691,14 +709,14 @@ define amdgpu_ps i32 @si_pc_add_rel_offset_must_not_optimize() {
 ; CHECK-NEXT:    s_add_u32 s0, s0, __unnamed_1@rel32@lo+4
 ; CHECK-NEXT:    s_addc_u32 s1, s1, __unnamed_1@rel32@hi+12
 ; CHECK-NEXT:    s_cmp_lg_u64 s[0:1], 0
-; CHECK-NEXT:    s_cbranch_scc0 .LBB40_2
+; CHECK-NEXT:    s_cbranch_scc0 .LBB41_2
 ; CHECK-NEXT:  ; %bb.1: ; %endif
 ; CHECK-NEXT:    s_mov_b32 s0, 1
-; CHECK-NEXT:    s_branch .LBB40_3
-; CHECK-NEXT:  .LBB40_2: ; %if
+; CHECK-NEXT:    s_branch .LBB41_3
+; CHECK-NEXT:  .LBB41_2: ; %if
 ; CHECK-NEXT:    s_mov_b32 s0, 0
-; CHECK-NEXT:    s_branch .LBB40_3
-; CHECK-NEXT:  .LBB40_3:
+; CHECK-NEXT:    s_branch .LBB41_3
+; CHECK-NEXT:  .LBB41_3:
   %cmp = icmp ne ptr addrspace(4) @1, null
   br i1 %cmp, label %endif, label %if
 


### PR DESCRIPTION
Convert:

```
s_add_u32 X, Y, 1
s_cmp_lg_i32 X, 0

```
to:

```
s_add_u32 X, Y, 1
<invert scc uses>
```
Also delete with s_cmp_eq_i32 X, 0, but inverting scc uses is not necessary.