### PR TITLE
[VPlan] Fix register usage of VPExpressionRecipe

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -3215,6 +3215,8 @@ public:
     return PR ? PR->getVFScaleFactor() : 1;
   }
 
+  unsigned getMinVFScaleFactor() const;
+
   /// Method for generating code, must not be called as this recipe is abstract.
   void execute(VPTransformState &State) override {
     llvm_unreachable("recipe must be removed before execute");

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -2949,6 +2949,14 @@ void VPExpressionRecipe::decompose() {
   ExpressionRecipes.clear();
 }
 
+unsigned VPExpressionRecipe::getMinVFScaleFactor() const {
+  unsigned Min = UINT_MAX;
+  for (auto *R : ExpressionRecipes) {
+    Min = std::min(Min, vputils::getVFScaleFactor(R));
+  }
+  return Min;
+}
+
 InstructionCost VPExpressionRecipe::computeCost(ElementCount VF,
                                                 VPCostContext &Ctx) const {
   Type *RedTy = Ctx.Types.inferScalarType(this);

--- a/llvm/test/Transforms/LoopVectorize/AArch64/reg-usage.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/reg-usage.ll
@@ -192,7 +192,7 @@ define i32 @dotp_unrolled(i32 %num_out, i64 %num_in, ptr %a, ptr %b) {
 ; CHECK:       LV(REG): VF = 16
 ; CHECK-NEXT:  LV(REG): Found max usage: 2 item
 ; CHECK-NEXT:  LV(REG): RegisterClass: Generic::ScalarRC, 9 registers
-; CHECK-NEXT:  LV(REG): RegisterClass: Generic::VectorRC, 6 registers
+; CHECK-NEXT:  LV(REG): RegisterClass: Generic::VectorRC, 16 registers
 ; CHECK-NEXT:  LV(REG): Found invariant usage: 1 item
 entry:
   br label %for.body


### PR DESCRIPTION
In calculateRegisterUsageForPlan the VF is scaled when the recipe has a scaling factor. For VPExpressionRecipe this is based on the output of the recipe, but for calculating the register usage we're intrested in the largest VF used in all of the subexpressions, which means we should be using the minimum scaling factor from all of the subexpressions.