### PR TITLE
[Darwin] CMake warning when building sanitized libLTO on Darwin with system sanitizer library

### DIFF
--- a/llvm/tools/lto/CMakeLists.txt
+++ b/llvm/tools/lto/CMakeLists.txt
@@ -48,6 +48,15 @@ if(LLVM_ENABLE_PIC)
     set_property(TARGET LTO APPEND_STRING PROPERTY
                 LINK_FLAGS
                 " -compatibility_version 1 -current_version ${LTO_VERSION}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
+    if(LLVM_USE_SANITIZER)
+      execute_process(COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=lib
+                      OUTPUT_VARIABLE clang_lib_dir)
+      string(STRIP ${clang_lib_dir} clang_lib_dir)
+      if (clang_lib_dir MATCHES ".*xctoolchain.*")
+        message(WARNING "Sanitized libLTO (with LLVM_USE_SANITIZER) is unsupported on Darwin when compiling "
+                        "with a system sanitizer library. Please use just-built sanitizers.")
+      endif()
+    endif()
   endif()
 
 endif()


### PR DESCRIPTION
Due to a system security policy, libLTO built with `LLVM_USE_SANITIZER` and a toolchain (i.e. Xcode) sanitizer library cannot be loaded into the toolchain `ld`. This only affects Darwin.

This adds a warning when users try to do this, and suggests a workaround (use just-built sanitizer libraries). 

This affected the lldb-cmake-sanitized job: https://github.com/llvm/llvm-zorg/commits/main/zorg/jenkins/jobs/jobs/lldb-cmake-sanitized

rdar://168502870