### PR TITLE
[update_mc_test_checks.py] Fix python 3.8 compatibility

### DIFF
--- a/llvm/utils/update_mc_test_checks.py
+++ b/llvm/utils/update_mc_test_checks.py
@@ -3,7 +3,7 @@
 A test update script.  This script is a utility to update LLVM 'llvm-mc' based test cases with new FileCheck patterns.
 """
 
-from __future__ import print_function
+from __future__ import annotations, print_function
 
 from sys import stderr
 from traceback import print_exc


### PR DESCRIPTION
Add `from __future__ import annotations` which is needed since
https://github.com/llvm/llvm-project/pull/174011 landed.
