### PR TITLE
[lldb-dap] Join the ProgressEventReporter thread if possible

### DIFF
--- a/lldb/tools/lldb-dap/ProgressEvent.cpp
+++ b/lldb/tools/lldb-dap/ProgressEvent.cpp
@@ -195,7 +195,8 @@ ProgressEventReporter::ProgressEventReporter(
 
 ProgressEventReporter::~ProgressEventReporter() {
   m_thread_should_exit = true;
-  m_thread.join();
+  if (m_thread.joinable())
+    m_thread.join();
 }
 
 void ProgressEventReporter::ReportStartEvents() {


### PR DESCRIPTION
It is not easily noticeable because it mostly happens when ending the debug session.