### PR TITLE
[libunwind] Fix EH frame handling on illumos.

### DIFF
--- a/libunwind/src/AddressSpace.hpp
+++ b/libunwind/src/AddressSpace.hpp
@@ -424,7 +424,13 @@ static bool checkAddrInSegment(const Elf_Phdr *phdr, size_t image_base,
 static bool checkForUnwindInfoSegment(const Elf_Phdr *phdr, size_t image_base,
                                       dl_iterate_cb_data *cbdata) {
 #if defined(_LIBUNWIND_SUPPORT_DWARF_INDEX)
+#if defined(PT_SUNW_UNWIND)
+  // illumos uses both PT_GNU_EH_FRAME and PT_SUNW_UNWIND to access EH state;
+  // check both if PT_SUNW_UNWIND is defined.
+  if (phdr->p_type == PT_GNU_EH_FRAME || phdr->p_type == PT_SUNW_UNWIND) {
+#else
   if (phdr->p_type == PT_GNU_EH_FRAME) {
+#endif
     EHHeaderParser<LocalAddressSpace>::EHHeaderInfo hdrInfo;
     uintptr_t eh_frame_hdr_start = image_base + phdr->p_vaddr;
     cbdata->sects->dwarf_index_section = eh_frame_hdr_start;


### PR DESCRIPTION
Illumos uses PT_SUNW_EH_FRAME and PT_SUNW_UNWIND program header types instead of PT_GNU_EH_FRAME for exception handling frames. This patch checks if the illumos headers are defined, and checks the appropriate fields in the ELF header if so.

FreeBSD defines PT_SUNW_UNWIND but not PT_SUNW_EH_FRAME for compatibility, so we check for both headers to avoid breaking FreeBSD builds.

Note: this is motivated by a project to [add support for illumos](https://github.com/ClickHouse/ClickHouse/issues/23777) to clickhouse. We initially sent this patch to [clickhouse's fork of llvm](https://github.com/ClickHouse/llvm-project/pull/63), but would like to upstream the change first to prevent clickhouse's fork from further diverging from this repo.

cc @rschu1ze