### PR TITLE
[libc++] Document that backported language features should be used

### DIFF
--- a/libcxx/docs/CodingGuidelines.rst
+++ b/libcxx/docs/CodingGuidelines.rst
@@ -104,12 +104,22 @@ provide alternative spellings for their attributes, so these should be avoided i
 
 This is enforced by the clang-tidy check ``libcpp-uglify-attributes``.
 
-Use C++11 extensions in C++03 code if they simplify the code
-============================================================
+Use extensions if they simplify the code
+========================================
 
-libc++ supports the C++98/03 mode only with the Clang compiler. Clang provides many C++11 features
-in C++03, making it possible to write a lot of code in a simpler way than if we were restricted to C++03 features.
-Some use of extensions is even mandatory, since libc++ supports move semantics in C++03.
+libc++ only supports recent versions Clang and GCC, which allows us to make use of extensions in the code base if both
+compilers support them. Only  features backported from future language versions should be used liberally throughout the
+library. For example, some of the most useful extensions are lambdas and ``if constexpr``, since they almost always
+significantly improve readability when used as intended.
+
+libc++ supports the C++98/03 mode only with the Clang compiler. Clang provides many C++11 features in C++03, making it
+possible to write a lot of code in a simpler way than if we were restricted to C++03 features. Some use of extensions is
+even mandatory, since libc++ supports move semantics in C++03. Details on which features have been backported can be
+found
+`here <https://clang.llvm.org/docs/LanguageExtensions.html#language-extensions-back-ported-to-previous-standards>`__.
+
+GCC is only supported from C++11 onwards. Unfortunately, GCC doesn't document which features are backported to older
+language versions, so you just have to try whether GCC accepts the features you want to use.
 
 Use ``using`` aliases instead of ``typedef``
 ============================================


### PR DESCRIPTION
We've been using language extensions from newer language modes quite liberally throughout the code base for a while now and didn't encounter major problems. This patch documents that practice in the coding guidelines.
