### PR TITLE
[lldb] Check multiword command in `UserCommandExists`

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1544,7 +1544,8 @@ bool CommandInterpreter::AliasExists(llvm::StringRef cmd) const {
 }
 
 bool CommandInterpreter::UserCommandExists(llvm::StringRef cmd) const {
-  return m_user_dict.find(cmd) != m_user_dict.end();
+  return llvm::is_contained(m_user_dict, cmd) ||
+         llvm::is_contained(m_user_mw_dict, cmd);
 }
 
 bool CommandInterpreter::UserMultiwordCommandExists(llvm::StringRef cmd) const {

--- a/lldb/test/API/functionalities/plugins/command_plugin/TestPluginCommands.py
+++ b/lldb/test/API/functionalities/plugins/command_plugin/TestPluginCommands.py
@@ -31,10 +31,12 @@ class PluginCommandTestCase(TestBase):
 
         retobj = lldb.SBCommandReturnObject()
 
-        retval = self.dbg.GetCommandInterpreter().HandleCommand(
+        cinterpreter = self.dbg.GetCommandInterpreter()
+        retval = cinterpreter.HandleCommand(
             "plugin load %s" % self.getBuildArtifact(plugin_lib_name), retobj
         )
 
+        self.assertTrue(cinterpreter.UserCommandExists("plugin_loaded_command"))
         retobj.Clear()
 
         retval = self.dbg.GetCommandInterpreter().HandleCommand(


### PR DESCRIPTION
User created multiword command is not reported when querying `SBCommandInterpreter::UserCommandExists`