### PR TITLE
[clang] Set end loc on declspec()

### DIFF
--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -1123,6 +1123,7 @@ SourceLocation Parser::ParseDecltypeSpecifier(DeclSpec &DS) {
     Diag(StartLoc, DiagID) << PrevSpec;
     DS.SetTypeSpecError();
   }
+  DS.SetRangeEnd(EndLoc);
   return EndLoc;
 }
 

--- a/clang/test/AST/ast-dump-decl-stmts.cpp
+++ b/clang/test/AST/ast-dump-decl-stmts.cpp
@@ -36,3 +36,6 @@ void d(), e(int);
 int f;
 // CHECK: VarDecl 0x{{[^ ]*}} <line:[[@LINE-1]]:1, col:5> col:5 f 'int'
 
+int decltype_fn_int;
+auto decltype_fn() -> decltype(decltype_fn_int);
+// CHECK: FunctionDecl {{.*}} <line:[[@LINE-1]]:1, col:47> col:6 decltype_fn 'auto () -> decltype(decltype_fn_int)'


### PR DESCRIPTION
Follow-up to #176296 where the root problem was declspec() not having a valid range.

I don't if this is the right fix! It _is_ a progression on the included test file though, and it's similar to what Parser::ParsePackIndexingType() in the same file does.