### PR TITLE
[LLVM] Disable clang-format for TableGen files

### DIFF
--- a/llvm/.clang-format
+++ b/llvm/.clang-format
@@ -1,2 +1,8 @@
 BasedOnStyle: LLVM
 LineEnding: LF
+---
+# Don't format .td files
+Language: TableGen
+DisableFormat: true
+SortIncludes: false
+---

--- a/llvm/lib/Target/RISCV/.clang-format
+++ b/llvm/lib/Target/RISCV/.clang-format
@@ -1,6 +1,0 @@
----
-# Don't format .td files
-Language: TableGen
-DisableFormat: true
-SortIncludes: false
----

--- a/llvm/lib/Target/RISCV/.clang-format
+++ b/llvm/lib/Target/RISCV/.clang-format
@@ -1,0 +1,6 @@
+---
+# Don't format .td files
+Language: TableGen
+DisableFormat: true
+SortIncludes: false
+---


### PR DESCRIPTION
Clang-format is not very maintained for TableGen, and seems to make odd choices that differ significantly from how humans write and read the backend's tablegen.

For the moment, disable clang-format for TableGen files. This should also apply when using `git clang-format`, which should help with newer contributors who sometimes end up formatting td files by accident.