### PR TITLE
[clang][modules] Erase PCMs not meeting expectations from in-memory cache

### DIFF
--- a/clang/include/clang/Serialization/InMemoryModuleCache.h
+++ b/clang/include/clang/Serialization/InMemoryModuleCache.h
@@ -74,6 +74,11 @@ public:
   llvm::MemoryBuffer &addBuiltPCM(llvm::StringRef Filename,
                                   std::unique_ptr<llvm::MemoryBuffer> Buffer);
 
+  /// Completely remove the PCM from the cache.
+  ///
+  /// \post state is Unknown
+  void erasePCM(llvm::StringRef Filename);
+
   /// Try to remove a buffer from the cache.  No effect if state is Final.
   ///
   /// \pre state is Tentative/Final.

--- a/clang/include/clang/Serialization/ModuleManager.h
+++ b/clang/include/clang/Serialization/ModuleManager.h
@@ -198,7 +198,10 @@ public:
     Missing,
 
     /// The module file is out-of-date.
-    OutOfDate
+    OutOfDate,
+
+    /// The module file has a different size/mtime/signature than expected.
+    ExpectationNotMet,
   };
 
   using ASTFileSignatureReader = ASTFileSignature (*)(StringRef);

--- a/clang/lib/Serialization/InMemoryModuleCache.cpp
+++ b/clang/lib/Serialization/InMemoryModuleCache.cpp
@@ -56,6 +56,10 @@ bool InMemoryModuleCache::shouldBuildPCM(llvm::StringRef Filename) const {
   return getPCMState(Filename) == ToBuild;
 }
 
+void InMemoryModuleCache::erasePCM(llvm::StringRef Filename) {
+  PCMs.erase(Filename);
+}
+
 bool InMemoryModuleCache::tryToDropPCM(llvm::StringRef Filename) {
   auto I = PCMs.find(Filename);
   assert(I != PCMs.end() && "PCM to remove is unknown...");

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -125,7 +125,7 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
     ErrorStr = IgnoreModTime ? "module file has a different size than expected"
                              : "module file has a different size or "
                                "modification time than expected";
-    return OutOfDate;
+    return ExpectationNotMet;
   }
 
   if (!Entry) {
@@ -159,7 +159,7 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
     if (implicitModuleNamesMatch(Type, ModuleEntry, *Entry)) {
       // Check the stored signature.
       if (checkSignature(ModuleEntry->Signature, ExpectedSignature, ErrorStr))
-        return OutOfDate;
+        return ExpectationNotMet;
 
       Module = ModuleEntry;
       updateModuleImports(*ModuleEntry, ImportedBy, ImportLoc);
@@ -226,7 +226,7 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
   // ReadSignature unless there's something to check though.
   if (ExpectedSignature && checkSignature(ReadSignature(NewModule->Data),
                                           ExpectedSignature, ErrorStr))
-    return OutOfDate;
+    return ExpectationNotMet;
 
   // We're keeping this module.  Store it everywhere.
   Module = Modules[*Entry] = NewModule.get();


### PR DESCRIPTION
There's a scenario in which the implicit build seemingly fails to recompile out-of-date PCM files.

Let's consider a project where TU1 imports module A, module A imports module B, and TU2 imports module B directly. After initial clean build, the module cache contains A.pcm and B.pcm. During the first incremental build, after compiling TU1, inputs to module B change, and TU2 recompiles B.pcm. At the start of the second incremental build, inputs to module B change, and therefore both TU1 and TU2 need to be recompiled. Note that now the module cache contains A.pcm from the clean build and B.pcm from the previous incremental build. This is what happens:

1. When compiling TU1, Clang tries to import A.pcm, and then transitively B.pcm. However, A.pcm expects B.pcm to have a different signature. This will trigger an attempt to recompile module A, but importantly the B.pcm from previous incremental build remains in the in-memory cache (added by `ModuleManager::add()` and never removed).

2. Concurrently Clang compiling TU2 tries to import B.pcm, but notices one of its input files changed. B.pcm is successfully rebuilt and the writer updates the validation timestamp beside B.pcm.

3. Now the instance compiling TU1 that is currently recompiling module A tries to import B.pcm. It find the validation timestamp that says B.pcm file was validated during this build session, skips input validation, and continues using the stale version of the PCM from previous incremental build that it loaded from the in-memory cache. Then, when compilation of module A triggers some deserialization from B.pcm, `ASTReader::getInputFile()` performs (redundant) on-demand file validation and figures out B.pcm is out-of-date. This is at a point where there's no going back, and the build fails with an "input file out-of-date" error.

AFAICT this bug existed for a long time, but it's now much easier to hit due to the writer of the PCM file also updates the validation timestamp (https://github.com/llvm/llvm-project/pull/112452 and subsequent bug fix https://github.com/llvm/llvm-project/pull/151774).

This PR fixes this issue by removing non-final PCM files from the in-memory module cache whenever they don't meet the importer's expectations. In the scenario described above, step 3 would've loaded the up-to-date B.pcm produced in step 2.

Credit for understanding what's going on goes to Volodymyr Sapsai.