### PR TITLE
Replace Erich Keane as Attributes maintainer

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -261,8 +261,8 @@ compiler.
 
 Attributes
 ~~~~~~~~~~
-| Erich Keane
-| ekeane\@nvidia.com (email), ErichKeane (Phabricator), erichkeane (GitHub)
+| Aaron Ballman
+| aaron\@aaronballman.com (email), aaron.ballman (Phabricator), AaronBallman (GitHub), AaronBallman (Discourse), aaronballman (Discord)
 
 
 Plugins


### PR DESCRIPTION
During the Clang maintainers list refresh, Erich mentioned he would like me to resume ownership of Clang attributes due to time constraints. He'll continue to help out as he can but this frees him up for other efforts. Thank you for your help in this role!