### PR TITLE
[lldb-dap] Bump vscode version

### DIFF
--- a/lldb/tools/lldb-dap/extension/package-lock.json
+++ b/lldb/tools/lldb-dap/extension/package-lock.json
@@ -15,7 +15,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^18.19.41",
         "@types/tabulator-tables": "^6.2.10",
-        "@types/vscode": "1.75.0",
+        "@types/vscode": "1.90.0",
         "@types/vscode-webview": "^1.57.5",
         "@vscode/debugprotocol": "^1.68.0",
         "@vscode/test-cli": "^0.0.12",
@@ -31,7 +31,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "vscode": "^1.75.0"
+        "vscode": "^1.90.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -1231,9 +1231,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
-      "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
+      "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/lldb/tools/lldb-dap/extension/package.json
+++ b/lldb/tools/lldb-dap/extension/package.json
@@ -22,7 +22,7 @@
     "LLDB"
   ],
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.90.0"
   },
   "categories": [
     "Debuggers"
@@ -34,7 +34,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^18.19.41",
     "@types/tabulator-tables": "^6.2.10",
-    "@types/vscode": "1.75.0",
+    "@types/vscode": "1.90.0",
     "@types/vscode-webview": "^1.57.5",
     "@vscode/debugprotocol": "^1.68.0",
     "@vscode/test-cli": "^0.0.12",


### PR DESCRIPTION
VS Code and node versions should be synchronized. We use node >= 18.19, so expected VS Code version is 1.90.0. I checked it using this [info](https://github.com/ewanharris/vscode-versions).