### PR TITLE
[ReachingDefAnalysis] Track function live-in registers.

### DIFF
--- a/llvm/lib/Target/ARM/ARMFixCortexA57AES1742098Pass.cpp
+++ b/llvm/lib/Target/ARM/ARMFixCortexA57AES1742098Pass.cpp
@@ -288,7 +288,8 @@ void ARMFixCortexA57AES1742098::analyzeMF(
       // Inspect all operands, choosing whether to insert a fixup.
       for (MachineOperand &MOp : MI.uses()) {
         SmallPtrSet<MachineInstr *, 1> AllDefs{};
-        RDI.getGlobalReachingDefs(&MI, MOp.getReg(), AllDefs);
+        bool HasLiveInPath = false;
+        RDI.getGlobalReachingDefs(&MI, MOp.getReg(), AllDefs, HasLiveInPath);
 
         // Planned Fixup: This should be added to FixupLocsForFn at most once.
         AESFixupLocation NewLoc{&MBB, &MI, &MOp};

--- a/llvm/test/CodeGen/RISCV/rda-entry-bb-is-a-loop.mir
+++ b/llvm/test/CodeGen/RISCV/rda-entry-bb-is-a-loop.mir
@@ -5,7 +5,7 @@ tracksRegLiveness: true
 body:             |
   ; CHECK-LABEL: Reaching definitions for for machine function: entry_bb_is_a_loop
   ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: $x10:{ 1 }
+  ; CHECK-NEXT: $x10:{ 1 livein }
   ; CHECK-NEXT: 0: $x10 = ADDI $x10, 1
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: $x10:{ 0 }

--- a/llvm/test/CodeGen/RISCV/rda-liveins.mir
+++ b/llvm/test/CodeGen/RISCV/rda-liveins.mir
@@ -6,7 +6,7 @@ tracksRegLiveness: true
 body:             |
   ; CHECK-LABEL: Reaching definitions for for machine function: test0
   ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: implicit $x10:{ }
+  ; CHECK-NEXT: implicit $x10:{ livein }
   ; CHECK-NEXT: 0: PseudoRET implicit $x10
 
   bb.0.entry:
@@ -21,7 +21,7 @@ tracksRegLiveness: true
 body:             |
   ; CHECK-LABEL: Reaching definitions for for machine function: test1
   ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: 0: $x10 = ADDI $x10, 1
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: implicit $x10:{ 0 }
@@ -39,19 +39,19 @@ tracksRegLiveness: true
 body:             |
   ; CHECK-LABEL: Reaching definitions for for machine function: test2
   ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: $x0:{ }
   ; CHECK-NEXT: 0: BEQ $x10, $x0, %bb.2
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %bb.1:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: 1: $x10 = ADDI $x10, 1
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: implicit $x10:{ 1 }
   ; CHECK-NEXT: 2: PseudoRET implicit $x10
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %bb.2
-  ; CHECK-NEXT: implicit $x10:{ }
+  ; CHECK-NEXT: implicit $x10:{ livein }
   ; CHECK-NEXT: 3: PseudoRET implicit $x10
   bb.0.entry:
     liveins: $x10
@@ -77,25 +77,25 @@ stack:
 body:             |
   ; CHECK-LABEL: Reaching definitions for for machine function: test3
   ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: $x0:{ }
   ; CHECK-NEXT: 0: BEQ $x10, $x0, %bb.2
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %bb.1:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: 1: $x10 = ADDI $x10, 1
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: 2: PseudoBR %bb.3
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %bb.2:
-  ; CHECK-NEXT: $x10:{ }
+  ; CHECK-NEXT: $x10:{ livein }
   ; CHECK-NEXT: %stack.0:{ }
   ; CHECK-NEXT: 3: SD $x10, %stack.0, 0 :: (store (s64))
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: 4: PseudoBR %bb.3
   ; CHECK-EMPTY: 
   ; CHECK-NEXT: %bb.3:
-  ; CHECK-NEXT: implicit $x10:{ 1 }
+  ; CHECK-NEXT: implicit $x10:{ 1 livein }
   ; CHECK-NEXT: 5: PseudoRET implicit $x10
   bb.0.entry:
     liveins: $x10
@@ -114,4 +114,29 @@ body:             |
   bb.3:
     liveins: $x10
     PseudoRET implicit $x10
+...
+
+---
+name:            test6
+tracksRegLiveness: true
+body:             |
+  ; CHECK-LABEL: Reaching definitions for for machine function: test6
+  ; CHECK-NEXT: %bb.0:
+  ; CHECK-NEXT: $x10:{ 0 livein }
+  ; CHECK-NEXT: 0: $x10 = ADDI $x10, 1
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: $x10:{ 0 }
+  ; CHECK-NEXT: $x0:{ }
+  ; CHECK-NEXT: 1: BNE $x10, $x0, %bb.0
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: %bb.1:
+  ; CHECK-NEXT: 2: PseudoRET
+  bb.0.entry:
+    liveins: $x10
+    $x10 = ADDI $x10, 1
+    BNE $x10, $x0, %bb.0
+
+  bb.1:
+    PseudoRET
+
 ...

--- a/llvm/test/CodeGen/RISCV/rda-stack.mir
+++ b/llvm/test/CodeGen/RISCV/rda-stack.mir
@@ -20,178 +20,178 @@ body:             |
     $x10 = LD %stack.0, 0 :: (load (s64))
     PseudoRET implicit $x10
 
-...
----
-name:            test1
-tracksRegLiveness: true
-stack:
-  - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
-      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-  - { id: 1, name: '', type: default, offset: 0, size: 4, alignment: 4,
-      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-body:             |
-  ; CHECK-LABEL: Reaching definitions for for machine function: test1
-  ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: %stack.0:{ }
-  ; CHECK-NEXT: 0: $x10 = LD %stack.0, 0 :: (load (s64))
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: %stack.1:{ }
-  ; CHECK-NEXT: 1: $x11 = LD %stack.1, 0 :: (load (s64))
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: $x10:{ 0 }
-  ; CHECK-NEXT: $x11:{ 1 }
-  ; CHECK-NEXT: 2: $x10 = ADD $x10, $x11
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: implicit $x10:{ 2 }
-  ; CHECK-NEXT: 3: PseudoRET implicit $x10
-
-  bb.0.entry:
-    $x10 = LD %stack.0, 0 :: (load (s64))
-    $x11 = LD %stack.1, 0 :: (load (s64))
-    $x10 = ADD $x10, $x11
-    PseudoRET implicit $x10
-
-...
----
-name:            test2
-tracksRegLiveness: true
-stack:
-  - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
-      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-  - { id: 1, name: '', type: default, offset: 0, size: 4, alignment: 4,
-      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-body:             |
-  ; CHECK-LABEL: Reaching definitions for for machine function: test2
-  ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: %stack.0:{ }
-  ; CHECK-NEXT: 0: $x10 = LD %stack.0, 0 :: (load (s64))
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: %stack.1:{ }
-  ; CHECK-NEXT: 1: $x11 = LD %stack.1, 0 :: (load (s64))
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: $x10:{ 0 }
-  ; CHECK-NEXT: $x11:{ 1 }
-  ; CHECK-NEXT: 2: $x10 = ADD $x10, $x11
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: $x10:{ 2 }
-  ; CHECK-NEXT: %stack.0:{ }
-  ; CHECK-NEXT: 3: SD $x10, %stack.0, 0 :: (store (s64))
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: %stack.0:{ 3 }
-  ; CHECK-NEXT: 4: $x10 = LD %stack.0, 0 :: (load (s64))
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: implicit $x10:{ 4 }
-  ; CHECK-NEXT: 5: PseudoRET implicit $x10
-
-  bb.0.entry:
-    $x10 = LD %stack.0, 0 :: (load (s64))
-    $x11 = LD %stack.1, 0 :: (load (s64))
-    $x10 = ADD $x10, $x11
-    SD $x10, %stack.0, 0 :: (store (s64))
-    $x10 = LD %stack.0, 0 :: (load (s64))
-    PseudoRET implicit $x10
-
-...
----
-name:            test3
-tracksRegLiveness: true
-stack:
-  - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
-      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-body:             |
-  ; CHECK-LABEL: Reaching definitions for for machine function: test3
-  ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: $x10:{ }
-  ; CHECK-NEXT: $x0:{ }
-  ; CHECK-NEXT: 0: BEQ $x10, $x0, %bb.2
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: %bb.1:
-  ; CHECK-NEXT: $x10:{ }
-  ; CHECK-NEXT: 1: $x10 = ADDI $x10, 1
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: $x10:{ 1 }
-  ; CHECK-NEXT: %stack.0:{ }
-  ; CHECK-NEXT: 2: SD $x10, %stack.0, 0 :: (store (s64))
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: 3: PseudoBR %bb.3
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: %bb.2:
-  ; CHECK-NEXT: $x10:{ }
-  ; CHECK-NEXT: 4: $x10 = ADDI $x10, 2
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: $x10:{ 4 }
-  ; CHECK-NEXT: %stack.0:{ }
-  ; CHECK-NEXT: 5: SD $x10, %stack.0, 0 :: (store (s64))
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: %bb.3:
-  ; CHECK-NEXT: %stack.0:{ 2 5 }
-  ; CHECK-NEXT: 6: $x10 = LD %stack.0, 0 :: (load (s64))
-  ; CHECK-EMPTY: 
-  ; CHECK-NEXT: implicit $x10:{ 6 }
-  ; CHECK-NEXT: 7: PseudoRET implicit $x10
-
-  bb.0.entry:
-    liveins: $x10
-    BEQ $x10, $x0, %bb.2
-
-  bb.1:
-    liveins: $x10
-    $x10 = ADDI $x10, 1
-    SD $x10, %stack.0, 0 :: (store (s64))
-    PseudoBR %bb.3
-
-  bb.2:
-    liveins: $x10
-    $x10 = ADDI $x10, 2
-    SD $x10, %stack.0, 0 :: (store (s64))
-
-  bb.3:
-    $x10 = LD %stack.0, 0 :: (load (s64))
-    PseudoRET implicit $x10
-...
----
-name:            test4
-tracksRegLiveness: true
-fixedStack:
-  - { id: 0, type: default, offset: 0, size: 4, alignment: 16,
-      isImmutable: true, isAliased: false }
-stack:
-  - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
-      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-  - { id: 1, name: '', type: default, offset: 0, size: 4, alignment: 4,
-      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-body:             |
-  ; CHECK-LABEL: Reaching definitions for for machine function: test4
-  ; CHECK-NEXT: %bb.0:
-  ; CHECK-NEXT: $x10:{ }
-  ; CHECK-NEXT: %stack.0:{ }
-  ; CHECK-NEXT: 0: SD $x10, %stack.0, 0 :: (store (s64))
-  ; CHECK-EMPTY:
-  ; CHECK-NEXT: $x11:{ }
-  ; CHECK-NEXT: %stack.0:{ 0 }
-  ; CHECK-NEXT: 1: SD $x11, %stack.0, 0 :: (store (s64))
-  ; CHECK-EMPTY:
-  ; CHECK-NEXT: $x10:{ }
-  ; CHECK-NEXT: %stack.1:{ }
-  ; CHECK-NEXT: 2: SD $x10, %stack.1, 0 :: (store (s64))
-  ; CHECK-EMPTY:
-  ; CHECK-NEXT: $x11:{ }
-  ; CHECK-NEXT: %stack.1:{ 2 }
-  ; CHECK-NEXT: 3: SD $x11, %stack.1, 0 :: (store (s64))
-  ; CHECK-EMPTY:
-  ; CHECK-NEXT: 4: PseudoRET
-  bb.0.entry:
-    liveins: $x10, $x11
-    SD $x10, %stack.0, 0 :: (store (s64))
-    SD $x11, %stack.0, 0 :: (store (s64))
-    SD $x10, %stack.1, 0 :: (store (s64))
-    SD $x11, %stack.1, 0 :: (store (s64))
-    PseudoRET
-...
+# COM: ...
+# COM: ---
+# COM: name:            test1
+# COM: tracksRegLiveness: true
+# COM: stack:
+# COM:   - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
+# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+# COM:   - { id: 1, name: '', type: default, offset: 0, size: 4, alignment: 4,
+# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+# COM: body:             |
+# COM:   ; CHECK-LABEL: Reaching definitions for for machine function: test1
+# COM:   ; CHECK-NEXT: %bb.0:
+# COM:   ; CHECK-NEXT: %stack.0:{ }
+# COM:   ; CHECK-NEXT: 0: $x10 = LD %stack.0, 0 :: (load (s64))
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: %stack.1:{ }
+# COM:   ; CHECK-NEXT: 1: $x11 = LD %stack.1, 0 :: (load (s64))
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: $x10:{ 0 }
+# COM:   ; CHECK-NEXT: $x11:{ 1 }
+# COM:   ; CHECK-NEXT: 2: $x10 = ADD $x10, $x11
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: implicit $x10:{ 2 }
+# COM:   ; CHECK-NEXT: 3: PseudoRET implicit $x10
+# COM: 
+# COM:   bb.0.entry:
+# COM:     $x10 = LD %stack.0, 0 :: (load (s64))
+# COM:     $x11 = LD %stack.1, 0 :: (load (s64))
+# COM:     $x10 = ADD $x10, $x11
+# COM:     PseudoRET implicit $x10
+# COM: 
+# COM: ...
+# COM: ---
+# COM: name:            test2
+# COM: tracksRegLiveness: true
+# COM: stack:
+# COM:   - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
+# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+# COM:   - { id: 1, name: '', type: default, offset: 0, size: 4, alignment: 4,
+# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+# COM: body:             |
+# COM:   ; CHECK-LABEL: Reaching definitions for for machine function: test2
+# COM:   ; CHECK-NEXT: %bb.0:
+# COM:   ; CHECK-NEXT: %stack.0:{ }
+# COM:   ; CHECK-NEXT: 0: $x10 = LD %stack.0, 0 :: (load (s64))
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: %stack.1:{ }
+# COM:   ; CHECK-NEXT: 1: $x11 = LD %stack.1, 0 :: (load (s64))
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: $x10:{ 0 }
+# COM:   ; CHECK-NEXT: $x11:{ 1 }
+# COM:   ; CHECK-NEXT: 2: $x10 = ADD $x10, $x11
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: $x10:{ 2 }
+# COM:   ; CHECK-NEXT: %stack.0:{ }
+# COM:   ; CHECK-NEXT: 3: SD $x10, %stack.0, 0 :: (store (s64))
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: %stack.0:{ 3 }
+# COM:   ; CHECK-NEXT: 4: $x10 = LD %stack.0, 0 :: (load (s64))
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: implicit $x10:{ 4 }
+# COM:   ; CHECK-NEXT: 5: PseudoRET implicit $x10
+# COM: 
+# COM:   bb.0.entry:
+# COM:     $x10 = LD %stack.0, 0 :: (load (s64))
+# COM:     $x11 = LD %stack.1, 0 :: (load (s64))
+# COM:     $x10 = ADD $x10, $x11
+# COM:     SD $x10, %stack.0, 0 :: (store (s64))
+# COM:     $x10 = LD %stack.0, 0 :: (load (s64))
+# COM:     PseudoRET implicit $x10
+# COM: 
+# COM: ...
+# COM: ---
+# COM: name:            test3
+# COM: tracksRegLiveness: true
+# COM: stack:
+# COM:   - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
+# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+# COM: body:             |
+# COM:   ; CHECK-LABEL: Reaching definitions for for machine function: test3
+# COM:   ; CHECK-NEXT: %bb.0:
+# COM:   ; CHECK-NEXT: $x10:{ livein }
+# COM:   ; CHECK-NEXT: $x0:{ }
+# COM:   ; CHECK-NEXT: 0: BEQ $x10, $x0, %bb.2
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: %bb.1:
+# COM:   ; CHECK-NEXT: $x10:{ livein }
+# COM:   ; CHECK-NEXT: 1: $x10 = ADDI $x10, 1
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: $x10:{ 1 }
+# COM:   ; CHECK-NEXT: %stack.0:{ }
+# COM:   ; CHECK-NEXT: 2: SD $x10, %stack.0, 0 :: (store (s64))
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: 3: PseudoBR %bb.3
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: %bb.2:
+# COM:   ; CHECK-NEXT: $x10:{ livein }
+# COM:   ; CHECK-NEXT: 4: $x10 = ADDI $x10, 2
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: $x10:{ 4 }
+# COM:   ; CHECK-NEXT: %stack.0:{ }
+# COM:   ; CHECK-NEXT: 5: SD $x10, %stack.0, 0 :: (store (s64))
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: %bb.3:
+# COM:   ; CHECK-NEXT: %stack.0:{ 2 5 }
+# COM:   ; CHECK-NEXT: 6: $x10 = LD %stack.0, 0 :: (load (s64))
+# COM:   ; CHECK-EMPTY: 
+# COM:   ; CHECK-NEXT: implicit $x10:{ 6 }
+# COM:   ; CHECK-NEXT: 7: PseudoRET implicit $x10
+# COM: 
+# COM:   bb.0.entry:
+# COM:     liveins: $x10
+# COM:     BEQ $x10, $x0, %bb.2
+# COM: 
+# COM:   bb.1:
+# COM:     liveins: $x10
+# COM:     $x10 = ADDI $x10, 1
+# COM:     SD $x10, %stack.0, 0 :: (store (s64))
+# COM:     PseudoBR %bb.3
+# COM: 
+# COM:   bb.2:
+# COM:     liveins: $x10
+# COM:     $x10 = ADDI $x10, 2
+# COM:     SD $x10, %stack.0, 0 :: (store (s64))
+# COM: 
+# COM:   bb.3:
+# COM:     $x10 = LD %stack.0, 0 :: (load (s64))
+# COM:     PseudoRET implicit $x10
+# COM: ...
+# COM: ---
+# COM: name:            test4
+# COM: tracksRegLiveness: true
+# COM: fixedStack:
+# COM:   - { id: 0, type: default, offset: 0, size: 4, alignment: 16,
+# COM:       isImmutable: true, isAliased: false }
+# COM: stack:
+# COM:   - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
+# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+# COM:   - { id: 1, name: '', type: default, offset: 0, size: 4, alignment: 4,
+# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+# COM: body:             |
+# COM:   ; CHECK-LABEL: Reaching definitions for for machine function: test4
+# COM:   ; CHECK-NEXT: %bb.0:
+# COM:   ; CHECK-NEXT: $x10:{ livein }
+# COM:   ; CHECK-NEXT: %stack.0:{ }
+# COM:   ; CHECK-NEXT: 0: SD $x10, %stack.0, 0 :: (store (s64))
+# COM:   ; CHECK-EMPTY:
+# COM:   ; CHECK-NEXT: $x11:{ livein }
+# COM:   ; CHECK-NEXT: %stack.0:{ 0 }
+# COM:   ; CHECK-NEXT: 1: SD $x11, %stack.0, 0 :: (store (s64))
+# COM:   ; CHECK-EMPTY:
+# COM:   ; CHECK-NEXT: $x10:{ livein }
+# COM:   ; CHECK-NEXT: %stack.1:{ }
+# COM:   ; CHECK-NEXT: 2: SD $x10, %stack.1, 0 :: (store (s64))
+# COM:   ; CHECK-EMPTY:
+# COM:   ; CHECK-NEXT: $x11:{ livein }
+# COM:   ; CHECK-NEXT: %stack.1:{ 2 }
+# COM:   ; CHECK-NEXT: 3: SD $x11, %stack.1, 0 :: (store (s64))
+# COM:   ; CHECK-EMPTY:
+# COM:   ; CHECK-NEXT: 4: PseudoRET
+# COM:   bb.0.entry:
+# COM:     liveins: $x10, $x11
+# COM:     SD $x10, %stack.0, 0 :: (store (s64))
+# COM:     SD $x11, %stack.0, 0 :: (store (s64))
+# COM:     SD $x10, %stack.1, 0 :: (store (s64))
+# COM:     SD $x11, %stack.1, 0 :: (store (s64))
+# COM:     PseudoRET
+# COM: ...

--- a/llvm/test/CodeGen/RISCV/rda-stack.mir
+++ b/llvm/test/CodeGen/RISCV/rda-stack.mir
@@ -20,178 +20,178 @@ body:             |
     $x10 = LD %stack.0, 0 :: (load (s64))
     PseudoRET implicit $x10
 
-# COM: ...
-# COM: ---
-# COM: name:            test1
-# COM: tracksRegLiveness: true
-# COM: stack:
-# COM:   - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
-# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-# COM:   - { id: 1, name: '', type: default, offset: 0, size: 4, alignment: 4,
-# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-# COM: body:             |
-# COM:   ; CHECK-LABEL: Reaching definitions for for machine function: test1
-# COM:   ; CHECK-NEXT: %bb.0:
-# COM:   ; CHECK-NEXT: %stack.0:{ }
-# COM:   ; CHECK-NEXT: 0: $x10 = LD %stack.0, 0 :: (load (s64))
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: %stack.1:{ }
-# COM:   ; CHECK-NEXT: 1: $x11 = LD %stack.1, 0 :: (load (s64))
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: $x10:{ 0 }
-# COM:   ; CHECK-NEXT: $x11:{ 1 }
-# COM:   ; CHECK-NEXT: 2: $x10 = ADD $x10, $x11
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: implicit $x10:{ 2 }
-# COM:   ; CHECK-NEXT: 3: PseudoRET implicit $x10
-# COM: 
-# COM:   bb.0.entry:
-# COM:     $x10 = LD %stack.0, 0 :: (load (s64))
-# COM:     $x11 = LD %stack.1, 0 :: (load (s64))
-# COM:     $x10 = ADD $x10, $x11
-# COM:     PseudoRET implicit $x10
-# COM: 
-# COM: ...
-# COM: ---
-# COM: name:            test2
-# COM: tracksRegLiveness: true
-# COM: stack:
-# COM:   - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
-# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-# COM:   - { id: 1, name: '', type: default, offset: 0, size: 4, alignment: 4,
-# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-# COM: body:             |
-# COM:   ; CHECK-LABEL: Reaching definitions for for machine function: test2
-# COM:   ; CHECK-NEXT: %bb.0:
-# COM:   ; CHECK-NEXT: %stack.0:{ }
-# COM:   ; CHECK-NEXT: 0: $x10 = LD %stack.0, 0 :: (load (s64))
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: %stack.1:{ }
-# COM:   ; CHECK-NEXT: 1: $x11 = LD %stack.1, 0 :: (load (s64))
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: $x10:{ 0 }
-# COM:   ; CHECK-NEXT: $x11:{ 1 }
-# COM:   ; CHECK-NEXT: 2: $x10 = ADD $x10, $x11
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: $x10:{ 2 }
-# COM:   ; CHECK-NEXT: %stack.0:{ }
-# COM:   ; CHECK-NEXT: 3: SD $x10, %stack.0, 0 :: (store (s64))
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: %stack.0:{ 3 }
-# COM:   ; CHECK-NEXT: 4: $x10 = LD %stack.0, 0 :: (load (s64))
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: implicit $x10:{ 4 }
-# COM:   ; CHECK-NEXT: 5: PseudoRET implicit $x10
-# COM: 
-# COM:   bb.0.entry:
-# COM:     $x10 = LD %stack.0, 0 :: (load (s64))
-# COM:     $x11 = LD %stack.1, 0 :: (load (s64))
-# COM:     $x10 = ADD $x10, $x11
-# COM:     SD $x10, %stack.0, 0 :: (store (s64))
-# COM:     $x10 = LD %stack.0, 0 :: (load (s64))
-# COM:     PseudoRET implicit $x10
-# COM: 
-# COM: ...
-# COM: ---
-# COM: name:            test3
-# COM: tracksRegLiveness: true
-# COM: stack:
-# COM:   - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
-# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-# COM: body:             |
-# COM:   ; CHECK-LABEL: Reaching definitions for for machine function: test3
-# COM:   ; CHECK-NEXT: %bb.0:
-# COM:   ; CHECK-NEXT: $x10:{ livein }
-# COM:   ; CHECK-NEXT: $x0:{ }
-# COM:   ; CHECK-NEXT: 0: BEQ $x10, $x0, %bb.2
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: %bb.1:
-# COM:   ; CHECK-NEXT: $x10:{ livein }
-# COM:   ; CHECK-NEXT: 1: $x10 = ADDI $x10, 1
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: $x10:{ 1 }
-# COM:   ; CHECK-NEXT: %stack.0:{ }
-# COM:   ; CHECK-NEXT: 2: SD $x10, %stack.0, 0 :: (store (s64))
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: 3: PseudoBR %bb.3
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: %bb.2:
-# COM:   ; CHECK-NEXT: $x10:{ livein }
-# COM:   ; CHECK-NEXT: 4: $x10 = ADDI $x10, 2
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: $x10:{ 4 }
-# COM:   ; CHECK-NEXT: %stack.0:{ }
-# COM:   ; CHECK-NEXT: 5: SD $x10, %stack.0, 0 :: (store (s64))
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: %bb.3:
-# COM:   ; CHECK-NEXT: %stack.0:{ 2 5 }
-# COM:   ; CHECK-NEXT: 6: $x10 = LD %stack.0, 0 :: (load (s64))
-# COM:   ; CHECK-EMPTY: 
-# COM:   ; CHECK-NEXT: implicit $x10:{ 6 }
-# COM:   ; CHECK-NEXT: 7: PseudoRET implicit $x10
-# COM: 
-# COM:   bb.0.entry:
-# COM:     liveins: $x10
-# COM:     BEQ $x10, $x0, %bb.2
-# COM: 
-# COM:   bb.1:
-# COM:     liveins: $x10
-# COM:     $x10 = ADDI $x10, 1
-# COM:     SD $x10, %stack.0, 0 :: (store (s64))
-# COM:     PseudoBR %bb.3
-# COM: 
-# COM:   bb.2:
-# COM:     liveins: $x10
-# COM:     $x10 = ADDI $x10, 2
-# COM:     SD $x10, %stack.0, 0 :: (store (s64))
-# COM: 
-# COM:   bb.3:
-# COM:     $x10 = LD %stack.0, 0 :: (load (s64))
-# COM:     PseudoRET implicit $x10
-# COM: ...
-# COM: ---
-# COM: name:            test4
-# COM: tracksRegLiveness: true
-# COM: fixedStack:
-# COM:   - { id: 0, type: default, offset: 0, size: 4, alignment: 16,
-# COM:       isImmutable: true, isAliased: false }
-# COM: stack:
-# COM:   - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
-# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-# COM:   - { id: 1, name: '', type: default, offset: 0, size: 4, alignment: 4,
-# COM:       stack-id: default, callee-saved-register: '', callee-saved-restored: true,
-# COM:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-# COM: body:             |
-# COM:   ; CHECK-LABEL: Reaching definitions for for machine function: test4
-# COM:   ; CHECK-NEXT: %bb.0:
-# COM:   ; CHECK-NEXT: $x10:{ livein }
-# COM:   ; CHECK-NEXT: %stack.0:{ }
-# COM:   ; CHECK-NEXT: 0: SD $x10, %stack.0, 0 :: (store (s64))
-# COM:   ; CHECK-EMPTY:
-# COM:   ; CHECK-NEXT: $x11:{ livein }
-# COM:   ; CHECK-NEXT: %stack.0:{ 0 }
-# COM:   ; CHECK-NEXT: 1: SD $x11, %stack.0, 0 :: (store (s64))
-# COM:   ; CHECK-EMPTY:
-# COM:   ; CHECK-NEXT: $x10:{ livein }
-# COM:   ; CHECK-NEXT: %stack.1:{ }
-# COM:   ; CHECK-NEXT: 2: SD $x10, %stack.1, 0 :: (store (s64))
-# COM:   ; CHECK-EMPTY:
-# COM:   ; CHECK-NEXT: $x11:{ livein }
-# COM:   ; CHECK-NEXT: %stack.1:{ 2 }
-# COM:   ; CHECK-NEXT: 3: SD $x11, %stack.1, 0 :: (store (s64))
-# COM:   ; CHECK-EMPTY:
-# COM:   ; CHECK-NEXT: 4: PseudoRET
-# COM:   bb.0.entry:
-# COM:     liveins: $x10, $x11
-# COM:     SD $x10, %stack.0, 0 :: (store (s64))
-# COM:     SD $x11, %stack.0, 0 :: (store (s64))
-# COM:     SD $x10, %stack.1, 0 :: (store (s64))
-# COM:     SD $x11, %stack.1, 0 :: (store (s64))
-# COM:     PseudoRET
-# COM: ...
+...
+---
+name:            test1
+tracksRegLiveness: true
+stack:
+  - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 1, name: '', type: default, offset: 0, size: 4, alignment: 4,
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+body:             |
+  ; CHECK-LABEL: Reaching definitions for for machine function: test1
+  ; CHECK-NEXT: %bb.0:
+  ; CHECK-NEXT: %stack.0:{ }
+  ; CHECK-NEXT: 0: $x10 = LD %stack.0, 0 :: (load (s64))
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: %stack.1:{ }
+  ; CHECK-NEXT: 1: $x11 = LD %stack.1, 0 :: (load (s64))
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: $x10:{ 0 }
+  ; CHECK-NEXT: $x11:{ 1 }
+  ; CHECK-NEXT: 2: $x10 = ADD $x10, $x11
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: implicit $x10:{ 2 }
+  ; CHECK-NEXT: 3: PseudoRET implicit $x10
+
+  bb.0.entry:
+    $x10 = LD %stack.0, 0 :: (load (s64))
+    $x11 = LD %stack.1, 0 :: (load (s64))
+    $x10 = ADD $x10, $x11
+    PseudoRET implicit $x10
+
+...
+---
+name:            test2
+tracksRegLiveness: true
+stack:
+  - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 1, name: '', type: default, offset: 0, size: 4, alignment: 4,
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+body:             |
+  ; CHECK-LABEL: Reaching definitions for for machine function: test2
+  ; CHECK-NEXT: %bb.0:
+  ; CHECK-NEXT: %stack.0:{ }
+  ; CHECK-NEXT: 0: $x10 = LD %stack.0, 0 :: (load (s64))
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: %stack.1:{ }
+  ; CHECK-NEXT: 1: $x11 = LD %stack.1, 0 :: (load (s64))
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: $x10:{ 0 }
+  ; CHECK-NEXT: $x11:{ 1 }
+  ; CHECK-NEXT: 2: $x10 = ADD $x10, $x11
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: $x10:{ 2 }
+  ; CHECK-NEXT: %stack.0:{ }
+  ; CHECK-NEXT: 3: SD $x10, %stack.0, 0 :: (store (s64))
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: %stack.0:{ 3 }
+  ; CHECK-NEXT: 4: $x10 = LD %stack.0, 0 :: (load (s64))
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: implicit $x10:{ 4 }
+  ; CHECK-NEXT: 5: PseudoRET implicit $x10
+
+  bb.0.entry:
+    $x10 = LD %stack.0, 0 :: (load (s64))
+    $x11 = LD %stack.1, 0 :: (load (s64))
+    $x10 = ADD $x10, $x11
+    SD $x10, %stack.0, 0 :: (store (s64))
+    $x10 = LD %stack.0, 0 :: (load (s64))
+    PseudoRET implicit $x10
+
+...
+---
+name:            test3
+tracksRegLiveness: true
+stack:
+  - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+body:             |
+  ; CHECK-LABEL: Reaching definitions for for machine function: test3
+  ; CHECK-NEXT: %bb.0:
+  ; CHECK-NEXT: $x10:{ livein }
+  ; CHECK-NEXT: $x0:{ }
+  ; CHECK-NEXT: 0: BEQ $x10, $x0, %bb.2
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: %bb.1:
+  ; CHECK-NEXT: $x10:{ livein }
+  ; CHECK-NEXT: 1: $x10 = ADDI $x10, 1
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: $x10:{ 1 }
+  ; CHECK-NEXT: %stack.0:{ }
+  ; CHECK-NEXT: 2: SD $x10, %stack.0, 0 :: (store (s64))
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: 3: PseudoBR %bb.3
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: %bb.2:
+  ; CHECK-NEXT: $x10:{ livein }
+  ; CHECK-NEXT: 4: $x10 = ADDI $x10, 2
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: $x10:{ 4 }
+  ; CHECK-NEXT: %stack.0:{ }
+  ; CHECK-NEXT: 5: SD $x10, %stack.0, 0 :: (store (s64))
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: %bb.3:
+  ; CHECK-NEXT: %stack.0:{ 2 5 }
+  ; CHECK-NEXT: 6: $x10 = LD %stack.0, 0 :: (load (s64))
+  ; CHECK-EMPTY: 
+  ; CHECK-NEXT: implicit $x10:{ 6 }
+  ; CHECK-NEXT: 7: PseudoRET implicit $x10
+
+  bb.0.entry:
+    liveins: $x10
+    BEQ $x10, $x0, %bb.2
+
+  bb.1:
+    liveins: $x10
+    $x10 = ADDI $x10, 1
+    SD $x10, %stack.0, 0 :: (store (s64))
+    PseudoBR %bb.3
+
+  bb.2:
+    liveins: $x10
+    $x10 = ADDI $x10, 2
+    SD $x10, %stack.0, 0 :: (store (s64))
+
+  bb.3:
+    $x10 = LD %stack.0, 0 :: (load (s64))
+    PseudoRET implicit $x10
+...
+---
+name:            test4
+tracksRegLiveness: true
+fixedStack:
+  - { id: 0, type: default, offset: 0, size: 4, alignment: 16,
+      isImmutable: true, isAliased: false }
+stack:
+  - { id: 0, name: '', type: default, offset: 0, size: 4, alignment: 4,
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 1, name: '', type: default, offset: 0, size: 4, alignment: 4,
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+body:             |
+  ; CHECK-LABEL: Reaching definitions for for machine function: test4
+  ; CHECK-NEXT: %bb.0:
+  ; CHECK-NEXT: $x10:{ livein }
+  ; CHECK-NEXT: %stack.0:{ }
+  ; CHECK-NEXT: 0: SD $x10, %stack.0, 0 :: (store (s64))
+  ; CHECK-EMPTY:
+  ; CHECK-NEXT: $x11:{ livein }
+  ; CHECK-NEXT: %stack.0:{ 0 }
+  ; CHECK-NEXT: 1: SD $x11, %stack.0, 0 :: (store (s64))
+  ; CHECK-EMPTY:
+  ; CHECK-NEXT: $x10:{ livein }
+  ; CHECK-NEXT: %stack.1:{ }
+  ; CHECK-NEXT: 2: SD $x10, %stack.1, 0 :: (store (s64))
+  ; CHECK-EMPTY:
+  ; CHECK-NEXT: $x11:{ livein }
+  ; CHECK-NEXT: %stack.1:{ 2 }
+  ; CHECK-NEXT: 3: SD $x11, %stack.1, 0 :: (store (s64))
+  ; CHECK-EMPTY:
+  ; CHECK-NEXT: 4: PseudoRET
+  bb.0.entry:
+    liveins: $x10, $x11
+    SD $x10, %stack.0, 0 :: (store (s64))
+    SD $x11, %stack.0, 0 :: (store (s64))
+    SD $x10, %stack.1, 0 :: (store (s64))
+    SD $x11, %stack.1, 0 :: (store (s64))
+    PseudoRET
+...


### PR DESCRIPTION
Make `getGlobalReachingDefs` set a flag `HasLiveInPath` which indicates if there is at least one path from function entry to `MI` along which a entry's live-in register is not modified.