### PR TITLE
[Offload] Cast to `void *` in the debug message

### DIFF
--- a/offload/libomptarget/OpenMP/Mapping.cpp
+++ b/offload/libomptarget/OpenMP/Mapping.cpp
@@ -83,10 +83,14 @@ int MappingInfoTy::associatePtr(void *HstPtrBegin, void *TgtPtrBegin,
                /*UseHoldRefCount=*/false, /*Name=*/nullptr,
                /*IsRefCountINF=*/true))
            .first->HDTT;
-  ODBG(ODT_Mapping) << "Creating new map entry: HstBase=" << NewEntry.HstPtrBase
-                    << ", HstBegin=" << NewEntry.HstPtrBegin
-                    << ", HstEnd=" << NewEntry.HstPtrEnd
-                    << ", TgtBegin=" << NewEntry.TgtPtrBegin
+  ODBG(ODT_Mapping) << "Creating new map entry: HstBase="
+                    << reinterpret_cast<void *>(NewEntry.HstPtrBase)
+                    << ", HstBegin="
+                    << reinterpret_cast<void *>(NewEntry.HstPtrBegin)
+                    << ", HstEnd="
+                    << reinterpret_cast<void *>(NewEntry.HstPtrEnd)
+                    << ", TgtBegin="
+                    << reinterpret_cast<void *>(NewEntry.TgtPtrBegin)
                     << ", DynRefCount=" << NewEntry.dynRefCountToStr()
                     << ", HoldRefCount=" << NewEntry.holdRefCountToStr();
   (void)NewEntry;
@@ -502,9 +506,11 @@ int MappingInfoTy::deallocTgtPtrAndEntry(HostDataToTargetTy *Entry,
                                          int64_t Size) {
   assert(Entry && "Trying to deallocate a null entry.");
 
-  ODBG(ODT_Mapping) << "Deleting tgt data " << Entry->TgtPtrBegin << " of size "
-                    << Size << " by freeing allocation "
-                    << "starting at " << Entry->TgtAllocBegin;
+  ODBG(ODT_Mapping) << "Deleting tgt data "
+                    << reinterpret_cast<void *>(Entry->TgtPtrBegin)
+                    << " of size " << Size << " by freeing allocation "
+                    << "starting at "
+                    << reinterpret_cast<void *>(Entry->TgtAllocBegin);
 
   void *Event = Entry->getEvent();
   if (Event && Device.destroyEvent(Event) != OFFLOAD_SUCCESS) {

--- a/offload/libomptarget/omptarget.cpp
+++ b/offload/libomptarget/omptarget.cpp
@@ -1260,12 +1260,12 @@ static int targetDataContiguous(ident_t *Loc, DeviceTy &Device, void *ArgsBase,
                   << "Restoring target descriptor " << ShadowPtr.TgtPtrAddr
                   << " to its original content (" << ShadowPtr.PtrSize
                   << " bytes), containing pointee address "
-                  << ShadowPtr.TgtPtrContent.data();
+                  << static_cast<const void *>(ShadowPtr.TgtPtrContent.data());
             } else {
               ODBG(ODT_Mapping)
                   << "Restoring target pointer " << ShadowPtr.TgtPtrAddr
                   << " to its original value "
-                  << ShadowPtr.TgtPtrContent.data();
+                  << static_cast<const void *>(ShadowPtr.TgtPtrContent.data());
             }
             Ret = Device.submitData(ShadowPtr.TgtPtrAddr,
                                     ShadowPtr.TgtPtrContent.data(),
@@ -1305,12 +1305,14 @@ static int targetDataContiguous(ident_t *Loc, DeviceTy &Device, void *ArgsBase,
                     << "Restoring host descriptor " << ShadowPtr.HstPtrAddr
                     << " to its original content (" << ShadowPtr.PtrSize
                     << " bytes), containing pointee address "
-                    << ShadowPtr.HstPtrContent.data();
+                    << static_cast<const void *>(
+                           ShadowPtr.HstPtrContent.data());
               } else {
                 ODBG(ODT_Mapping)
                     << "Restoring host pointer " << ShadowPtr.HstPtrAddr
                     << " to its original value "
-                    << ShadowPtr.HstPtrContent.data();
+                    << static_cast<const void *>(
+                           ShadowPtr.HstPtrContent.data());
               }
               std::memcpy(ShadowPtr.HstPtrAddr, ShadowPtr.HstPtrContent.data(),
                           ShadowPtr.PtrSize);

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -849,7 +849,8 @@ Error GenericDeviceTy::deinit(GenericPluginTy &Plugin) {
 }
 Expected<DeviceImageTy *> GenericDeviceTy::loadBinary(GenericPluginTy &Plugin,
                                                       StringRef InputTgtImage) {
-  ODBG(OLDT_Init) << "Load data from image " << InputTgtImage.bytes_begin();
+  ODBG(OLDT_Init) << "Load data from image "
+                  << static_cast<const void *>(InputTgtImage.bytes_begin());
 
   std::unique_ptr<MemoryBuffer> Buffer;
   if (identify_magic(InputTgtImage) == file_magic::bitcode) {
@@ -1657,8 +1658,9 @@ int32_t GenericPluginTy::is_initialized() const { return Initialized; }
 int32_t GenericPluginTy::isPluginCompatible(StringRef Image) {
   auto HandleError = [&](Error Err) -> bool {
     std::string ErrStr = toString(std::move(Err));
-    ODBG(OLDT_Init) << "Failure to check validity of image " << Image.data()
-                    << ": " << ErrStr;
+    ODBG(OLDT_Init) << "Failure to check validity of image "
+                    << static_cast<const void *>(Image.data()) << ": "
+                    << ErrStr;
     return false;
   };
   switch (identify_magic(Image)) {
@@ -1686,7 +1688,8 @@ int32_t GenericPluginTy::isPluginCompatible(StringRef Image) {
 int32_t GenericPluginTy::isDeviceCompatible(int32_t DeviceId, StringRef Image) {
   auto HandleError = [&](Error Err) -> bool {
     std::string ErrStr = toString(std::move(Err));
-    ODBG(OLDT_Init) << "Failure to check validity of image " << Image << ": "
+    ODBG(OLDT_Init) << "Failure to check validity of image "
+                    << static_cast<const void *>(Image.data()) << ": "
                     << ErrStr;
     return false;
   };


### PR DESCRIPTION
There are a few places where data types based on character array or string are printed in the debug message while they do not represent strings. Such expressions should be casted to `void *` unless they represent actual strings. Change also includes casting from integral type to pointer type when appropriate.