### PR TITLE
Fix MLIR compilation bugs for NVPTX target

### DIFF
--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -559,7 +559,7 @@ NVPTXSerializer::compileToBinary(StringRef ptxCode) {
     if (result != nvFatbinResult::NVFATBIN_SUCCESS) {                          \
       emitError(loc) << llvm::Twine(#expr).concat(" failed with error: ")      \
                      << nvFatbinGetErrorString(result);                        \
-      return mlir::failure();                                                  \
+      return failure();                                                  \
     }                                                                          \
   } while (false)
 

--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -581,7 +581,7 @@ NVPTXSerializer::compileToBinaryNVPTX(StringRef ptxCode) {
   setOptionalCommandlineArguments(getTarget(), cmdOpts.second);
   // Create the compiler handle.
   RETURN_ON_NVPTXCOMPILER_ERROR(
-      nvPTXCompilerCreate(&compiler, ptxCode.size(), ptxCode.c_str()));
+      nvPTXCompilerCreate(&compiler, ptxCode.size(), ptxCode.str().c_str());
 
   // Try to compile the binary.
   status = nvPTXCompilerCompile(compiler, cmdOpts.second.size(),

--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -547,7 +547,7 @@ NVPTXSerializer::compileToBinary(StringRef ptxCode) {
     if (auto status = (expr)) {                                                \
       emitError(loc) << llvm::Twine(#expr).concat(" failed with error code ")  \
                      << status;                                                \
-      return mlir::failure();                                                     \
+      return mlir::failure();                                                  \
     }                                                                          \
   } while (false)
 
@@ -559,7 +559,7 @@ NVPTXSerializer::compileToBinary(StringRef ptxCode) {
     if (result != nvFatbinResult::NVFATBIN_SUCCESS) {                          \
       emitError(loc) << llvm::Twine(#expr).concat(" failed with error: ")      \
                      << nvFatbinGetErrorString(result);                        \
-      return std::nullopt;                                                     \
+      return mlir::failure();                                                  \
     }                                                                          \
   } while (false)
 

--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -547,7 +547,7 @@ NVPTXSerializer::compileToBinary(StringRef ptxCode) {
     if (auto status = (expr)) {                                                \
       emitError(loc) << llvm::Twine(#expr).concat(" failed with error code ")  \
                      << status;                                                \
-      return mlir::failure();                                                  \
+      return failure();                                                  \
     }                                                                          \
   } while (false)
 

--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -547,7 +547,7 @@ NVPTXSerializer::compileToBinary(StringRef ptxCode) {
     if (auto status = (expr)) {                                                \
       emitError(loc) << llvm::Twine(#expr).concat(" failed with error code ")  \
                      << status;                                                \
-      return std::nullopt;                                                     \
+      return mlir::failure();                                                     \
     }                                                                          \
   } while (false)
 

--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -581,7 +581,7 @@ NVPTXSerializer::compileToBinaryNVPTX(StringRef ptxCode) {
   setOptionalCommandlineArguments(getTarget(), cmdOpts.second);
   // Create the compiler handle.
   RETURN_ON_NVPTXCOMPILER_ERROR(
-      nvPTXCompilerCreate(&compiler, ptxCode.size(), ptxCode.str().c_str());
+      nvPTXCompilerCreate(&compiler, ptxCode.size(), ptxCode.str().c_str()));
 
   // Try to compile the binary.
   status = nvPTXCompilerCompile(compiler, cmdOpts.second.size(),


### PR DESCRIPTION
Changes:
- Change `ptxCode.c_str()` to `ptxCode.str().c_str()` to avoid error: `error: 'class llvm::StringRef' has no member named 'c_str'; did you mean 'str'?`
- Change `std::nullopt;` to `return mlir::failure();` to avoid error: `could not convert 'std::nullopt' from 'const std::nullopt_t' to 'llvm::FailureOr<llvm::SmallVector<char, 0> >'`

Extra info:
- Tested versions: tried`llvmorg-21.1.8`, `llvmorg-22.1.0-rc1`, `llvmorg-23-init`, `main`, all cannot compile without these fixes
- Test environment: `nvidia/cuda:13.1.0-devel-ubuntu24.04` docker image (comes with gcc 13.3.0 and nvcc 13.1)
- Compile command: just turn-on `-DLLVM_TARGETS_TO_BUILD="Native;NVPTX"`, `-DMLIR_ENABLE_NVPTXCOMPILER=ON` and you will see the bugs.

A full command for example:
```
cmake llvm \
    -B build \
    -G Ninja \
    -DLLVM_ENABLE_PROJECTS=mlir \
    -DCMAKE_BUILD_TYPE=Release \
    -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
    -DPython3_EXECUTABLE=python3 \
    -DLLVM_ENABLE_RTTI=ON \
    -DLLVM_INSTALL_UTILS=ON \
    -DLLVM_INCLUDE_TESTS=OFF \
    -DMLIR_INCLUDE_TESTS=OFF \
    -DLLVM_BUILD_EXAMPLES=OFF \
    -DLLVM_ENABLE_ASSERTIONS=ON \
    -DLLVM_CCACHE_BUILD=ON \
    -DCUDACXX=nvcc \
    -DCUDA_PATH=/usr/local/cuda \
    -DCMAKE_CUDA_ARCHITECTURES="80;89;120" \
    -DCMAKE_C_COMPILER=gcc \
    -DCMAKE_CXX_COMPILER=g++ \
    -DCMAKE_CUDA_COMPILER=nvcc \
    -DLLVM_TARGETS_TO_BUILD="Native;NVPTX" \
    -DMLIR_ENABLE_CUDA_RUNNER=ON \
    -DMLIR_ENABLE_CUDA_CONVERSIONS=ON \
    -DMLIR_ENABLE_NVPTXCOMPILER=ON
cmake --build build -j$(nproc) -t install
```
