### PR TITLE
[LoopUnroll][NFC] Simplify recent block frequency tests

### DIFF
--- a/llvm/test/Transforms/LoopUnroll/branch-weights-freq/unroll-epilog.ll
+++ b/llvm/test/Transforms/LoopUnroll/branch-weights-freq/unroll-epilog.ll
@@ -1,95 +1,205 @@
 ; Test branch weight metadata, estimated trip count metadata, and block
 ; frequencies after loop unrolling with an epilogue.
+;
+; We check various interesting unroll count values relative to the original
+; loop's body frequency of 11 (e.g., minimum and boundary values).
+;
+; For each case, we check:
+; - Iteration frequencies
+;   - When each is multiplied by the number of original loop bodies that execute
+;     within it, they should sum to almost exactly the original loop body
+;     frequency, 11.
+; - CFGs
+;   - We verify which branch weights go with which branches and that we did not
+;     overlook any other branch weights (no extra !prof or branch_weights).
+;   - We also check the number of original loop bodies (represented by a call to
+;     @f) that appear within each unrolled iteration.
+; - llvm.loop.estimated_trip_count
+;   - For the unrolled and epilogue loops, must be the number of iterations
+;     required for the original loop body to reach its original estimated trip
+;     count, which is its original frequency, 11, because there is no prior
+;     llvm.loop.estimated_trip_count.
+;   - Must not be blindly duplicated between the unrolled and epilogue loops.
+;   - Must not be blindly computed from any new latch branch weights.
 
 ; ------------------------------------------------------------------------------
-; Define substitutions.
+; Verify that the test code produces the original loop body frequency we expect.
 ;
-; Check original loop body frequency.
-; DEFINE: %{bf-fc} = opt %s -S -passes='print<block-freq>' 2>&1 | \
-; DEFINE:   FileCheck %s -check-prefixes
+; RUN: opt %s -S -passes='print<block-freq>' 2>&1 | \
+; RUN:   FileCheck %s -check-prefixes ORIG
 ;
-; Unroll loops and then check block frequency.  The -implicit-check-not options
-; make sure that no additional labels or @f calls show up.
-; DEFINE: %{ur-bf} = opt %s -S -passes='loop-unroll,print<block-freq>' 2>&1
+; ORIG: - do.body: float = 11.0,
+
+; ------------------------------------------------------------------------------
+; Define LIT substitutions for checking the unrolled and epilogue loop.
+;
+; DEFINE: %{ur-bf} = opt %s -S -passes='loop-unroll,print<block-freq>' 2>&1 \
+; DEFINE:     -unroll-runtime
 ; DEFINE: %{fc} = FileCheck %s \
-; DEFINE:     -implicit-check-not='{{^( *- )?[^ ;]*:}}' \
+; DEFINE:     -implicit-check-not='llvm.loop.estimated_trip_count' \
+; DEFINE:     -implicit-check-not='!prof' \
+; DEFINE:     -implicit-check-not='branch_weights' \
 ; DEFINE:     -implicit-check-not='call void @f' -check-prefixes
 
 ; ------------------------------------------------------------------------------
-; Check various interesting unroll count values relative to the original loop's
-; estimated trip count of 11 (e.g., minimum and boundary values).
+; Check -unroll-count=2.
 ;
-; RUN: %{bf-fc} ALL,ORIG
-; RUN: %{ur-bf} -unroll-count=2 -unroll-runtime | %{fc} ALL,UR,UR2
-; RUN: %{ur-bf} -unroll-count=4 -unroll-runtime | %{fc} ALL,UR,UR4
-; RUN: %{ur-bf} -unroll-count=10 -unroll-runtime | %{fc} ALL,UR,UR10
-; RUN: %{ur-bf} -unroll-count=11 -unroll-runtime | %{fc} ALL,UR,UR11
-; RUN: %{ur-bf} -unroll-count=12 -unroll-runtime | %{fc} ALL,UR,UR12
+; RUN: %{ur-bf} -unroll-count=2 | %{fc} UR2
+;
+; Multiply do.body by 2 and add do.body.epil to get the original loop body
+; frequency, 11.
+; UR2: - do.body: float = 5.2381,
+; UR2: - do.body.epil: float = 0.52381,
+;
+; Unrolled loop guard, body, and latch.
+; UR2: br i1 %{{.*}}, label %do.body.epil.preheader, label %entry.new, !prof !0
+; UR2-COUNT-2: call void @f
+; UR2: br i1 %{{.*}}, label %do.end.unr-lcssa, label %do.body, !prof !1, !llvm.loop !2
+;
+; Epilogue guard and its sole iteration, so it is completely unrolled with no
+; remaining conditional latches.
+; UR2: br i1 %{{.*}}, label %do.body.epil.preheader, label %do.end, !prof !5
+; UR2: call void @f
+;
+; Unrolled loop metadata.
+; UR2: !0 = !{!"branch_weights", i32 195225786, i32 1952257862}
+; UR2: !1 = !{!"branch_weights", i32 372703773, i32 1774779875}
+; UR2: !2 = distinct !{!2, !3, !4}
+; UR2: !3 = !{!"llvm.loop.estimated_trip_count", i32 5}
+; UR2: !4 = !{!"llvm.loop.unroll.disable"}
+; UR2: !5 = !{!"branch_weights", i32 1022611260, i32 1124872388}
 
 ; ------------------------------------------------------------------------------
-; Check the iteration frequencies, which, when each is multiplied by the number
-; of original loop bodies that execute within it, should sum to almost exactly
-; the original loop body frequency.
+; Check -unroll-count=4.
 ;
-; ALL-LABEL: block-frequency-info: test
+; RUN: %{ur-bf} -unroll-count=4 | %{fc} UR4
 ;
-;      ORIG: - [[ENTRY:.*]]:
-;      ORIG: - [[DO_BODY:.*]]: float = 11.0,
-;      ORIG: - [[DO_END:.*]]:
+; Multiply do.body by 4 and add do.body.epil* to get the original loop body
+; frequency, 11.
+; UR4: - do.body: float = 2.3702,
+; UR4: - do.body.epil: float = 1.5193,
 ;
-;        UR: - [[ENTRY:.*]]:
-;        UR: - [[ENTRY_NEW:.*]]:
-;       UR2: - [[DO_BODY:.*]]: float = 5.2381,
-;       UR4: - [[DO_BODY:.*]]: float = 2.3702,
-;      UR10: - [[DO_BODY:.*]]: float = 0.6902,
-;      UR11: - [[DO_BODY:.*]]: float = 0.59359,
-;      UR12: - [[DO_BODY:.*]]: float = 0.5144,
-;        UR: - [[DO_END_UNR_LCSSA:.*]]:
-;        UR: - [[DO_BODY_EPIL_PREHEADER:.*]]:
-;       UR2: - [[DO_BODY_EPIL:.*]]: float = 0.52381,
-;       UR4: - [[DO_BODY_EPIL:.*]]: float = 1.5193,
-;      UR10: - [[DO_BODY_EPIL:.*]]: float = 4.098,
-;      UR11: - [[DO_BODY_EPIL:.*]]: float = 4.4705,
-;      UR12: - [[DO_BODY_EPIL:.*]]: float = 4.8272,
-;       UR4: - [[DO_END_EPILOG_LCSSA:.*]]:
-;      UR10: - [[DO_END_EPILOG_LCSSA:.*]]:
-;      UR11: - [[DO_END_EPILOG_LCSSA:.*]]:
-;      UR12: - [[DO_END_EPILOG_LCSSA:.*]]:
-;        UR: - [[DO_END:.*]]:
+; Unrolled loop guard, body, and latch.
+; UR4: br i1 %{{.*}}, label %do.body.epil.preheader, label %entry.new, !prof !0
+; UR4-COUNT-4: call void @f
+; UR4: br i1 %{{.*}}, label %do.end.unr-lcssa, label %do.body, !prof !1, !llvm.loop !2
+;
+; Epilogue guard and loop.
+; UR4: br i1 %{{.*}}, label %do.body.epil.preheader, label %do.end, !prof !5
+; UR4: call void @f
+; UR4: br i1 %{{.*}}, label %do.body.epil, label %do.end.epilog-lcssa, !prof !6, !llvm.loop !7
+;
+; Unrolled loop metadata.
+; UR4: !0 = !{!"branch_weights", i32 534047398, i32 1613436250}
+; UR4: !1 = !{!"branch_weights", i32 680723421, i32 1466760227}
+; UR4: !2 = distinct !{!2, !3, !4}
+; UR4: !3 = !{!"llvm.loop.estimated_trip_count", i32 2}
+; UR4: !4 = !{!"llvm.loop.unroll.disable"}
+; UR4: !5 = !{!"branch_weights", i32 1531603292, i32 615880356}
+;
+; Epilogue loop metadata.
+; UR4: !6 = !{!"branch_weights", i32 1038564635, i32 1108919013}
+; UR4: !7 = distinct !{!7, !8, !4}
+; UR4: !8 = !{!"llvm.loop.estimated_trip_count", i32 3}
 
 ; ------------------------------------------------------------------------------
-; Check the CFGs, including the number of original loop bodies that appear
-; within each unrolled iteration.
+; Check -unroll-count=10.
 ;
-;      UR-LABEL: define void @test(i32 %{{.*}}) {
-;            UR: [[ENTRY]]:
-;            UR:   br i1 %{{.*}}, label %[[DO_BODY_EPIL_PREHEADER]], label %[[ENTRY_NEW]], !prof ![[#PROF_UR_GUARD:]]{{$}}
-;            UR: [[ENTRY_NEW]]:
-;            UR:   br label %[[DO_BODY]]
-;            UR: [[DO_BODY]]:
-;   UR2-COUNT-2:   call void @f
-;   UR4-COUNT-4:   call void @f
-; UR10-COUNT-10:   call void @f
-; UR11-COUNT-11:   call void @f
-; UR12-COUNT-12:   call void @f
-;            UR:   br i1 %{{.*}}, label %[[DO_END_UNR_LCSSA]], label %[[DO_BODY]], !prof ![[#PROF_UR_LATCH:]], !llvm.loop ![[#LOOP_UR_LATCH:]]{{$}}
-;            UR: [[DO_END_UNR_LCSSA]]:
-;            UR:   br i1 %{{.*}}, label %[[DO_BODY_EPIL_PREHEADER]], label %[[DO_END:.*]], !prof ![[#PROF_RM_GUARD:]]{{$}}
-;            UR: [[DO_BODY_EPIL_PREHEADER]]:
-;            UR:   br label %[[DO_BODY_EPIL]]
-;            UR: [[DO_BODY_EPIL]]:
-;            UR:   call void @f
-;           UR4:   br i1 %{{.*}}, label %[[DO_BODY_EPIL]], label %[[DO_END_EPILOG_LCSSA]], !prof ![[#PROF_RM_LATCH:]], !llvm.loop ![[#LOOP_RM_LATCH:]]{{$}}
-;          UR10:   br i1 %{{.*}}, label %[[DO_BODY_EPIL]], label %[[DO_END_EPILOG_LCSSA]], !prof ![[#PROF_RM_LATCH:]], !llvm.loop ![[#LOOP_RM_LATCH:]]{{$}}
-;          UR11:   br i1 %{{.*}}, label %[[DO_BODY_EPIL]], label %[[DO_END_EPILOG_LCSSA]], !prof ![[#PROF_RM_LATCH:]], !llvm.loop ![[#LOOP_RM_LATCH:]]{{$}}
-;          UR12:   br i1 %{{.*}}, label %[[DO_BODY_EPIL]], label %[[DO_END_EPILOG_LCSSA]], !prof ![[#PROF_RM_LATCH:]], !llvm.loop ![[#LOOP_RM_LATCH:]]{{$}}
-;           UR4: [[DO_END_EPILOG_LCSSA]]:
-;          UR10: [[DO_END_EPILOG_LCSSA]]:
-;          UR11: [[DO_END_EPILOG_LCSSA]]:
-;          UR12: [[DO_END_EPILOG_LCSSA]]:
-;            UR:   br label %[[DO_END]]
-;            UR: [[DO_END]]:
-;            UR:   ret void
+; RUN: %{ur-bf} -unroll-count=10 | %{fc} UR10
+;
+; Multiply do.body by 8 and add do.body.epil* to get the original loop body
+; frequency, 11.
+; UR10: - do.body: float = 0.6902,
+; UR10: - do.body.epil: float = 4.098,
+;
+; Unrolled loop guard, body, and latch.
+; UR10: br i1 %{{.*}}, label %do.body.epil.preheader, label %entry.new, !prof !0
+; UR10-COUNT-10: call void @f
+; UR10: br i1 %{{.*}}, label %do.end.unr-lcssa, label %do.body, !prof !1, !llvm.loop !2
+;
+; Epilogue guard and loop.
+; UR10: br i1 %{{.*}}, label %do.body.epil.preheader, label %do.end, !prof !5
+; UR10: call void @f
+; UR10: br i1 %{{.*}}, label %do.body.epil, label %do.end.epilog-lcssa, !prof !6, !llvm.loop !7
+;
+; Unrolled loop metadata.
+; UR10: !0 = !{!"branch_weights", i32 1236740947, i32 910742701}
+; UR10: !1 = !{!"branch_weights", i32 1319535738, i32 827947910}
+; UR10: !2 = distinct !{!2, !3, !4}
+; UR10: !3 = !{!"llvm.loop.estimated_trip_count", i32 1}
+; UR10: !4 = !{!"llvm.loop.unroll.disable"}
+; UR10: !5 = !{!"branch_weights", i32 1829762672, i32 317720976}
+;
+; Epilogue loop metadata.  Its llvm.loop.estimated_trip_count happens to be the
+; same as the unrolled loop's, so there's no new metadata node.
+; UR10: !6 = !{!"branch_weights", i32 1656332913, i32 491150735}
+; UR10: !7 = distinct !{!7, ![[#LOOP_UR_TC:]], ![[#DISABLE:]]}
+
+; ------------------------------------------------------------------------------
+; Check -unroll-count=11.
+;
+; RUN: %{ur-bf} -unroll-count=11 | %{fc} UR11
+;
+; Multiply do.body by 11 and add do.body.epil* to get the original loop body
+; frequency, 11.
+; UR11: - do.body: float = 0.59359,
+; UR11: - do.body.epil: float = 4.4705,
+;
+; Unrolled loop guard, body, and latch.
+; UR11: br i1 %{{.*}}, label %do.body.epil.preheader, label %entry.new, !prof !0
+; UR11-COUNT-11: call void @f
+; UR11: br i1 %{{.*}}, label %do.end.unr-lcssa, label %do.body, !prof !1, !llvm.loop !2
+
+; Epilogue guard and loop.
+; UR11: br i1 %{{.*}}, label %do.body.epil.preheader, label %do.end, !prof !5
+; UR11: call void @f
+; UR11: br i1 %{{.*}}, label %do.body.epil, label %do.end.epilog-lcssa, !prof !6, !llvm.loop !7
+;
+; Unrolled loop metadata.
+; UR11: !0 = !{!"branch_weights", i32 1319535738, i32 827947910}
+; UR11: !1 = !{!"branch_weights", i32 1394803730, i32 752679918}
+; UR11: !2 = distinct !{!2, !3, !4}
+; UR11: !3 = !{!"llvm.loop.estimated_trip_count", i32 1}
+; UR11: !4 = !{!"llvm.loop.unroll.disable"}
+; UR11: !5 = !{!"branch_weights", i32 1846907894, i32 300575754}
+;
+; Epilogue loop metadata.
+; UR11: !6 = !{!"branch_weights", i32 1693034047, i32 454449601}
+; UR11: !7 = distinct !{!7, !8, !4}
+; UR11: !8 = !{!"llvm.loop.estimated_trip_count", i32 0}
+
+; ------------------------------------------------------------------------------
+; Check -unroll-count=12.
+;
+; RUN: %{ur-bf} -unroll-count=12 | %{fc} UR12
+;
+; Multiply do.body by 12 and add do.body.epil* to get the original loop body
+; frequency, 11.
+; UR12: - do.body: float = 0.5144,
+; UR12: - do.body.epil: float = 4.8272,
+;
+; Unrolled loop guard, body, and latch.
+; UR12: br i1 %{{.*}}, label %do.body.epil.preheader, label %entry.new, !prof !0
+; UR12-COUNT-12: call void @f
+; UR12: br i1 %{{.*}}, label %do.end.unr-lcssa, label %do.body, !prof !1, !llvm.loop !2
+;
+; Epilogue guard and loop.
+; UR12: br i1 %{{.*}}, label %do.body.epil.preheader, label %do.end, !prof !5
+; UR12: call void @f
+; UR12: br i1 %{{.*}}, label %do.body.epil, label %do.end.epilog-lcssa, !prof !6, !llvm.loop !7
+;
+; Unrolled loop metadata.
+; UR12: !0 = !{!"branch_weights", i32 1394803730, i32 752679918}
+; UR12: !1 = !{!"branch_weights", i32 1463229177, i32 684254471}
+; UR12: !2 = distinct !{!2, !3, !4}
+; UR12: !3 = !{!"llvm.loop.estimated_trip_count", i32 0}
+; UR12: !4 = !{!"llvm.loop.unroll.disable"}
+; UR12: !5 = !{!"branch_weights", i32 1860963812, i32 286519836}
+;
+; Epilogue loop metadata.
+; UR12: !6 = !{!"branch_weights", i32 1723419551, i32 424064097}
+; UR12: !7 = distinct !{!7, !8, !4}
+; UR12: !8 = !{!"llvm.loop.estimated_trip_count", i32 11}
 
 declare void @f(i32)
 
@@ -108,53 +218,5 @@ do.end:
   ret void
 }
 
+; Loop body frequency is 11.
 !0 = !{!"branch_weights", i32 1, i32 10}
-
-; ------------------------------------------------------------------------------
-; Check branch weight metadata and estimated trip count metadata.
-;
-;  UR2: ![[#PROF_UR_GUARD]] = !{!"branch_weights", i32 195225786, i32 1952257862}
-;  UR4: ![[#PROF_UR_GUARD]] = !{!"branch_weights", i32 534047398, i32 1613436250}
-; UR10: ![[#PROF_UR_GUARD]] = !{!"branch_weights", i32 1236740947, i32 910742701}
-; UR11: ![[#PROF_UR_GUARD]] = !{!"branch_weights", i32 1319535738, i32 827947910}
-; UR12: ![[#PROF_UR_GUARD]] = !{!"branch_weights", i32 1394803730, i32 752679918}
-;
-;  UR2: ![[#PROF_UR_LATCH]] = !{!"branch_weights", i32 372703773, i32 1774779875}
-;  UR4: ![[#PROF_UR_LATCH]] = !{!"branch_weights", i32 680723421, i32 1466760227}
-; UR10: ![[#PROF_UR_LATCH]] = !{!"branch_weights", i32 1319535738, i32 827947910}
-; UR11: ![[#PROF_UR_LATCH]] = !{!"branch_weights", i32 1394803730, i32 752679918}
-; UR12: ![[#PROF_UR_LATCH]] = !{!"branch_weights", i32 1463229177, i32 684254471}
-;
-;  UR2: ![[#LOOP_UR_LATCH]] = distinct !{![[#LOOP_UR_LATCH]], ![[#LOOP_UR_TC:]], ![[#DISABLE:]]}
-;  UR4: ![[#LOOP_UR_LATCH]] = distinct !{![[#LOOP_UR_LATCH]], ![[#LOOP_UR_TC:]], ![[#DISABLE:]]}
-; UR10: ![[#LOOP_UR_LATCH]] = distinct !{![[#LOOP_UR_LATCH]], ![[#LOOP_UR_TC:]], ![[#DISABLE:]]}
-; UR11: ![[#LOOP_UR_LATCH]] = distinct !{![[#LOOP_UR_LATCH]], ![[#LOOP_UR_TC:]], ![[#DISABLE:]]}
-; UR12: ![[#LOOP_UR_LATCH]] = distinct !{![[#LOOP_UR_LATCH]], ![[#LOOP_UR_TC:]], ![[#DISABLE:]]}
-;
-;  UR2: ![[#LOOP_UR_TC]] = !{!"llvm.loop.estimated_trip_count", i32 5}
-;  UR4: ![[#LOOP_UR_TC]] = !{!"llvm.loop.estimated_trip_count", i32 2}
-; UR10: ![[#LOOP_UR_TC]] = !{!"llvm.loop.estimated_trip_count", i32 1}
-; UR11: ![[#LOOP_UR_TC]] = !{!"llvm.loop.estimated_trip_count", i32 1}
-; UR12: ![[#LOOP_UR_TC]] = !{!"llvm.loop.estimated_trip_count", i32 0}
-;   UR: ![[#DISABLE]] = !{!"llvm.loop.unroll.disable"}
-;
-;  UR2: ![[#PROF_RM_GUARD]] = !{!"branch_weights", i32 1022611260, i32 1124872388}
-;  UR4: ![[#PROF_RM_GUARD]] = !{!"branch_weights", i32 1531603292, i32 615880356}
-; UR10: ![[#PROF_RM_GUARD]] = !{!"branch_weights", i32 1829762672, i32 317720976}
-; UR11: ![[#PROF_RM_GUARD]] = !{!"branch_weights", i32 1846907894, i32 300575754}
-; UR12: ![[#PROF_RM_GUARD]] = !{!"branch_weights", i32 1860963812, i32 286519836}
-;
-;  UR4: ![[#PROF_RM_LATCH]] = !{!"branch_weights", i32 1038564635, i32 1108919013}
-; UR10: ![[#PROF_RM_LATCH]] = !{!"branch_weights", i32 1656332913, i32 491150735}
-; UR11: ![[#PROF_RM_LATCH]] = !{!"branch_weights", i32 1693034047, i32 454449601}
-; UR12: ![[#PROF_RM_LATCH]] = !{!"branch_weights", i32 1723419551, i32 424064097}
-
-;  UR4: ![[#LOOP_RM_LATCH]] = distinct !{![[#LOOP_RM_LATCH]], ![[#LOOP_RM_TC:]], ![[#DISABLE:]]}
-; UR10: ![[#LOOP_RM_LATCH]] = distinct !{![[#LOOP_RM_LATCH]], ![[#LOOP_UR_TC:]], ![[#DISABLE:]]}
-; UR11: ![[#LOOP_RM_LATCH]] = distinct !{![[#LOOP_RM_LATCH]], ![[#LOOP_RM_TC:]], ![[#DISABLE:]]}
-; UR12: ![[#LOOP_RM_LATCH]] = distinct !{![[#LOOP_RM_LATCH]], ![[#LOOP_RM_TC:]], ![[#DISABLE:]]}
-;
-;  UR4: ![[#LOOP_RM_TC]] = !{!"llvm.loop.estimated_trip_count", i32 3}
-; For UR10, llvm.loop.estimated_trip_count is the same for both loops.
-; UR11: ![[#LOOP_RM_TC]] = !{!"llvm.loop.estimated_trip_count", i32 0}
-; UR12: ![[#LOOP_RM_TC]] = !{!"llvm.loop.estimated_trip_count", i32 11}

--- a/llvm/test/Transforms/LoopUnroll/branch-weights-freq/unroll-partial.ll
+++ b/llvm/test/Transforms/LoopUnroll/branch-weights-freq/unroll-partial.ll
@@ -1,50 +1,52 @@
 ; Test branch weight metadata, estimated trip count metadata, and block
 ; frequencies after partial loop unrolling without -unroll-runtime.
 
+; ------------------------------------------------------------------------------
 ; RUN: opt < %s -S -passes='print<block-freq>' 2>&1 | \
 ; RUN:   FileCheck -check-prefix=CHECK %s
+;
+; Verify that the test code produces the original loop body frequency we expect.
+; CHECK: - do.body: float = 10.0,
 
-; The -implicit-check-not options make sure that no additional labels or calls
-; to @f show up.
+; ------------------------------------------------------------------------------
 ; RUN: opt < %s -S -passes='loop-unroll,print<block-freq>' \
 ; RUN:     -unroll-count=4 2>&1 | \
 ; RUN:   FileCheck %s -check-prefix=CHECK-UR \
-; RUN:       -implicit-check-not='{{^( *- )?[^ ;]*:}}' \
+; RUN:       -implicit-check-not='llvm.loop.estimated_trip_count' \
+; RUN:       -implicit-check-not='!prof' \
+; RUN:       -implicit-check-not='branch_weights' \
 ; RUN:       -implicit-check-not='call void @f'
-
-; CHECK: block-frequency-info: test
-; CHECK: do.body: float = 10.0,
-
-; The sum should still be ~10.
 ;
-; CHECK-UR: block-frequency-info: test
-; CHECK-UR: - [[ENTRY:.*]]:
-; CHECK-UR: - [[DO_BODY:.*]]: float = 2.9078,
-; CHECK-UR: - [[DO_BODY_1:.*]]: float = 2.617,
-; CHECK-UR: - [[DO_BODY_2:.*]]: float = 2.3553,
-; CHECK-UR: - [[DO_BODY_3:.*]]: float = 2.1198,
-; CHECK-UR: - [[DO_END:.*]]:
+; The sum is approximately the original loop body frequency, 10.
+; CHECK-UR: - do.body: float = 2.9078,
+; CHECK-UR: - do.body.1: float = 2.617,
+; CHECK-UR: - do.body.2: float = 2.3553,
+; CHECK-UR: - do.body.3: float = 2.1198,
+;
+; The original branch weights are preserved across all unrolled iterations and
+; the remaining loop, and there is one original loop body (represented by a call
+; to @f) within each unrolled iteration.
+; CHECK-UR: call void @f
+; CHECK-UR: br i1 %{{.*}}, label %do.end, label %do.body.1, !prof !0
+; CHECK-UR: call void @f
+; CHECK-UR: br i1 %{{.*}}, label %do.end, label %do.body.2, !prof !0
+; CHECK-UR: call void @f
+; CHECK-UR: br i1 %{{.*}}, label %do.end, label %do.body.3, !prof !0
+; CHECK-UR: call void @f
+; CHECK-UR: br i1 %{{.*}}, label %do.end, label %do.body, !prof !0, !llvm.loop !1
+; CHECK-UR: !0 = !{!"branch_weights", i32 1, i32 9}
+;
+; llvm.loop.estimated_trip_count is the original estimated trip count (which is
+; the original loop body frequency, 10, because there is no prior
+; llvm.loop.estimated_trip_count) divided by the unroll count, 4, rounded up to
+; the next integer.
+; CHECK-UR: !1 = distinct !{!1, !2, !3}
+; CHECK-UR: !2 = !{!"llvm.loop.estimated_trip_count", i32 3}
+; CHECK-UR: !3 = !{!"llvm.loop.unroll.disable"}
 
 declare void @f(i32)
 
 define void @test(i32 %n) {
-; CHECK-UR-LABEL: define void @test(i32 %{{.*}}) {
-;       CHECK-UR: [[ENTRY]]:
-;       CHECK-UR:   br label %[[DO_BODY]]
-;       CHECK-UR: [[DO_BODY]]:
-;       CHECK-UR:   call void @f
-;       CHECK-UR:   br i1 %{{.*}}, label %[[DO_END]], label %[[DO_BODY_1]], !prof ![[#PROF:]]
-;       CHECK-UR: [[DO_BODY_1]]:
-;       CHECK-UR:   call void @f
-;       CHECK-UR:   br i1 %{{.*}}, label %[[DO_END]], label %[[DO_BODY_2]], !prof ![[#PROF]]
-;       CHECK-UR: [[DO_BODY_2]]:
-;       CHECK-UR:   call void @f
-;       CHECK-UR:   br i1 %{{.*}}, label %[[DO_END]], label %[[DO_BODY_3]], !prof ![[#PROF]]
-;       CHECK-UR: [[DO_BODY_3]]:
-;       CHECK-UR:   call void @f
-;       CHECK-UR:   br i1 %{{.*}}, label %[[DO_END]], label %[[DO_BODY]], !prof ![[#PROF]], !llvm.loop ![[#LOOP_UR_LATCH:]]
-;       CHECK-UR: [[DO_END]]:
-;       CHECK-UR:   ret void
 
 entry:
   br label %do.body
@@ -61,8 +63,3 @@ do.end:
 }
 
 !0 = !{!"branch_weights", i32 1, i32 9}
-
-; CHECK-UR: ![[#PROF]] = !{!"branch_weights", i32 1, i32 9}
-; CHECK-UR: ![[#LOOP_UR_LATCH]] = distinct !{![[#LOOP_UR_LATCH]], ![[#LOOP_UR_TC:]], ![[#DISABLE:]]}
-; CHECK-UR: ![[#LOOP_UR_TC]] = !{!"llvm.loop.estimated_trip_count", i32 3}
-; CHECK-UR: ![[#DISABLE]] = !{!"llvm.loop.unroll.disable"}


### PR DESCRIPTION
Refactor a number of recent tests in
`llvm/test/Transforms/LoopUnroll/branch-weights-freq` to make it easier to understand and extend them.

The changes mostly resemble the refactoring I recently did in PR #165635 in response to reviewer comments:
- For each case (e.g., each `-unroll-count` value in `unroll-epilog.ll`), group all FileCheck directives together.  That way, while digesting a single case, the reader does not need to sift through all other cases and a complex FileCheck prefix scheme.
- Reduce CFG testing.  Drop many FileCheck directives that check for all basic block labels and branches, and drop the cryptic `-implicit-check-not` that excludes others.  Instead, just use positive checks for every loop body (represented by `call void @f`), for relevant metadata, and for the branch instructions to which the metadata is attached, and use simple negative checks (e.g., `-implicit-check-not='!prof'`) to be sure we have not missed any.
- Better document what the test intends to cover.

The result is sometimes longer tests due to comments and repetition, but I believe they are easier to maintain this way.