### PR TITLE
[Binary] Check size of string entries when creating Offload Binaries

### DIFF
--- a/llvm/lib/Object/OffloadBinary.cpp
+++ b/llvm/lib/Object/OffloadBinary.cpp
@@ -197,7 +197,9 @@ OffloadBinary::create(MemoryBufferRef Buf) {
       reinterpret_cast<const Entry *>(&Start[TheHeader->EntryOffset]);
 
   if (TheEntry->ImageOffset > Buf.getBufferSize() ||
-      TheEntry->StringOffset > Buf.getBufferSize())
+      TheEntry->StringOffset > Buf.getBufferSize() ||
+      TheEntry->StringOffset + TheEntry->NumStrings * sizeof(StringEntry) >
+          Buf.getBufferSize())
     return errorCodeToError(object_error::unexpected_eof);
 
   return std::unique_ptr<OffloadBinary>(


### PR DESCRIPTION
Summary:
Verify this just in case the input lists more strings than actually
exist.
