### PR TITLE
[lldb][cmake] Fix standalone Xcode build header staging

### DIFF
--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -308,6 +308,11 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E make_directory ${lldb_header_staging_dir}
   COMMENT "LLDB headers: create staging directory for LLDB headers")
 
+# Create a target for the staging directory so that all header staging targets
+# can depend on it. This is required for Xcode's new build system which doesn't
+# allow custom commands attached to multiple targets without a common dependency.
+add_custom_target(liblldb-header-staging-dir DEPENDS ${lldb_header_staging_dir})
+
 find_program(unifdef_EXECUTABLE unifdef)
 
 add_custom_target(liblldb-header-staging)
@@ -335,10 +340,10 @@ foreach(header
   endif()
 
   add_custom_target(liblldb-stage-header-${basename} DEPENDS ${staged_header})
-  add_dependencies(liblldb-stage-header-${basename} lldb-sbapi-dwarf-enums)
+  add_dependencies(liblldb-stage-header-${basename} lldb-sbapi-dwarf-enums liblldb-header-staging-dir)
   add_dependencies(liblldb-header-staging liblldb-stage-header-${basename})
   add_custom_command(
-    DEPENDS ${header} ${lldb_header_staging_dir} OUTPUT ${staged_header}
+    DEPENDS ${header} OUTPUT ${staged_header}
     COMMAND ${copy_command}
     COMMENT "LLDB headers: stage LLDB headers in include directory")
 

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -303,10 +303,12 @@ list(REMOVE_ITEM root_public_headers ${root_private_headers})
 # Skip the initial copy of lldb-defines.h. The fixed version is generated at build time.
 list(REMOVE_ITEM root_public_headers ${LLDB_SOURCE_DIR}/include/lldb/lldb-defines.h)
 
-add_custom_target(liblldb-header-staging-dir
+add_custom_command(
   OUTPUT ${lldb_header_staging_dir}
   COMMAND ${CMAKE_COMMAND} -E make_directory ${lldb_header_staging_dir}
   COMMENT "LLDB headers: create staging directory for LLDB headers")
+
+add_custom_target(liblldb-header-staging-dir DEPENDS ${lldb_header_staging_dir})
 
 find_program(unifdef_EXECUTABLE unifdef)
 

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -303,15 +303,10 @@ list(REMOVE_ITEM root_public_headers ${root_private_headers})
 # Skip the initial copy of lldb-defines.h. The fixed version is generated at build time.
 list(REMOVE_ITEM root_public_headers ${LLDB_SOURCE_DIR}/include/lldb/lldb-defines.h)
 
-add_custom_command(
+add_custom_target(liblldb-header-staging-dir
   OUTPUT ${lldb_header_staging_dir}
   COMMAND ${CMAKE_COMMAND} -E make_directory ${lldb_header_staging_dir}
   COMMENT "LLDB headers: create staging directory for LLDB headers")
-
-# Create a target for the staging directory so that all header staging targets
-# can depend on it. This is required for Xcode's new build system which doesn't
-# allow custom commands attached to multiple targets without a common dependency.
-add_custom_target(liblldb-header-staging-dir DEPENDS ${lldb_header_staging_dir})
 
 find_program(unifdef_EXECUTABLE unifdef)
 

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -338,8 +338,9 @@ foreach(header
   add_dependencies(liblldb-stage-header-${basename} lldb-sbapi-dwarf-enums liblldb-header-staging-dir)
   add_dependencies(liblldb-header-staging liblldb-stage-header-${basename})
   add_custom_command(
-    DEPENDS ${header} OUTPUT ${staged_header}
+    OUTPUT ${staged_header}
     COMMAND ${copy_command}
+    DEPENDS ${header}     
     COMMENT "LLDB headers: stage LLDB headers in include directory")
 
   list(APPEND lldb_staged_headers ${staged_header})


### PR DESCRIPTION
The LLDB standalone build using Xcode fails because the staging directory custom command output is attached to multiple liblldb-stage-header-* targets, but none of these targets depend on each other. Xcode's new build system doesn't allow this.

This creates a new target `liblldb-header-staging-dir` that depends on the staging directory creation, and makes all header staging targets depend on it instead of directly depending on the directory in their custom commands. This ensures all targets share a common dependency, satisfying Xcode's build system requirements.