### PR TITLE
[HLSL] Add wave active ballot to set of wave ops that set waveops shader flag

### DIFF
--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -65,7 +65,6 @@ static bool checkWaveOps(Intrinsic::ID IID) {
   // Currently unsupported intrinsics
   // case Intrinsic::dx_wave_getlanecount:
   // case Intrinsic::dx_wave_allequal:
-  // case Intrinsic::dx_wave_ballot:
   // case Intrinsic::dx_wave_readfirst:
   // case Intrinsic::dx_wave_reduce.and:
   // case Intrinsic::dx_wave_reduce.or:
@@ -89,6 +88,7 @@ static bool checkWaveOps(Intrinsic::ID IID) {
   case Intrinsic::dx_wave_all:
   case Intrinsic::dx_wave_readlane:
   case Intrinsic::dx_wave_active_countbits:
+  case Intrinsic::dx_wave_ballot:
   // Wave Active Op Variants
   case Intrinsic::dx_wave_reduce_sum:
   case Intrinsic::dx_wave_reduce_usum:

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/wave-ops.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/wave-ops.ll
@@ -9,6 +9,7 @@
 ; CHECK-NEXT: ; Note: extra DXIL module flags:
 
 target triple = "dxil-pc-shadermodel6.7-library"
+%dx.types.fouri32 = type { i32, i32, i32, i32 }
 
 ; Test the indiviual ops that they have the same Shader Wave flag at the
 ; function level to ensure that each op is setting it accordingly
@@ -94,5 +95,12 @@ define void @wave_active_countbits(i1 %expr) {
 entry:
   ; CHECK: Function wave_active_countbits : [[WAVE_FLAG]]
   %0 = call i32 @llvm.dx.wave.active.countbits(i1 %expr)
+  ret void
+}
+
+define void @wave_active_ballot(i1 %expr) {
+entry:
+  ; CHECK: Function wave_active_ballot : [[WAVE_FLAG]]
+  %0 = call %dx.types.fouri32 @llvm.dx.wave.ballot(i1 %expr)
   ret void
 }


### PR DESCRIPTION
This PR simply adds wave active ballot to the set of wave ops that switch on the waveops shader flag.