### PR TITLE
[libc] Cast in startup to silence warning

### DIFF
--- a/libc/startup/linux/gnu_property_section.cpp
+++ b/libc/startup/linux/gnu_property_section.cpp
@@ -124,7 +124,7 @@ bool GnuPropertySection::parse(const ElfW(Phdr) * gnu_property_phdr,
       break;
     }
 
-    offset += property_size;
+    offset += static_cast<ElfW(Word)>(property_size);
   }
 
   return true;


### PR DESCRIPTION
In #174772 gcc warns on an implicit cast from `ElfW(Xword)` (unsigned long
int) to `ElfW(word)` (unsigned int). This PR adds an explicit cast.
