### PR TITLE
[lldb-mcp] Close stdin,stdout,stderr when launching lldb MCP proces from lldb-mcp

### DIFF
--- a/lldb/tools/lldb-mcp/lldb-mcp.cpp
+++ b/lldb/tools/lldb-mcp/lldb-mcp.cpp
@@ -91,6 +91,9 @@ llvm::Error launch() {
                          /*add_exe_file_as_first_arg=*/true);
   info.GetArguments().AppendArgument("-O");
   info.GetArguments().AppendArgument("protocol start MCP");
+  info.AppendCloseFileAction(STDIN_FILENO);
+  info.AppendCloseFileAction(STDOUT_FILENO);
+  info.AppendCloseFileAction(STDERR_FILENO);
   return Host::LaunchProcess(info).takeError();
 }
 


### PR DESCRIPTION
This is needed on linux where by default stdin, stdout and stderr are duplicated to the child process and interfere with the MCP protocol