### PR TITLE
[flang] Allow multiple identical DATA initializations

### DIFF
--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -478,6 +478,9 @@ end
   to be a pointer so long as it is `INTENT(IN)`.
   (This extension is not yet supported for procedure pointer component
   interfaces.)
+* A data object can be initialized multiple times by `DATA` statements
+  and default component initialization, but only when all initializations
+  are to the same value.  Distinct initializations remain errors.
 
 ### Extensions supported when enabled by options
 

--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -56,7 +56,7 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     IgnoreIrrelevantAttributes, Unsigned, AmbiguousStructureConstructor,
     ContiguousOkForSeqAssociation, ForwardRefExplicitTypeDummy,
     InaccessibleDeferredOverride, CudaWarpMatchFunction, DoConcurrentOffload,
-    TransferBOZ, Coarray, PointerPassObject)
+    TransferBOZ, Coarray, PointerPassObject, MultipleIdenticalDATA)
 
 // Portability and suspicious usage warnings
 ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,

--- a/flang/lib/Evaluate/fold.cpp
+++ b/flang/lib/Evaluate/fold.cpp
@@ -278,7 +278,7 @@ std::optional<Expr<SomeType>> FoldTransfer(
         (elements == 0 || totalBytes / elements == *sourceBytes)) {
       InitialImage image{*sourceBytes};
       auto status{image.Add(0, *sourceBytes, *source, context)};
-      if (status == InitialImage::Ok) {
+      if (status == InitialImage::Ok || status == InitialImage::OkNoChange) {
         return image.AsConstant(
             context, *moldType, moldLength, *extents, true /*pad with 0*/);
       } else {

--- a/flang/lib/Semantics/data-to-inits.cpp
+++ b/flang/lib/Semantics/data-to-inits.cpp
@@ -335,7 +335,7 @@ bool DataInitializationCompiler<DSV>::InitElement(
       return ss.str();
     }
   }};
-  const auto GetImage{[&]() -> evaluate::InitialImage & {
+  const auto GetSymbolInit{[&]() -> SymbolDataInitialization & {
     // This could be (and was) written to always call std::map<>::emplace(),
     // which should handle duplicate entries gracefully, but it was still
     // causing memory allocation & deallocation with gcc.
@@ -343,9 +343,7 @@ bool DataInitializationCompiler<DSV>::InitElement(
     if (iter == inits_.end()) {
       iter = inits_.emplace(&symbol, symbol.size()).first;
     }
-    auto &symbolInit{iter->second};
-    symbolInit.NoteInitializedRange(offsetSymbol);
-    return symbolInit.image;
+    return iter->second;
   }};
   const auto OutOfRangeError{[&]() {
     evaluate::AttachDeclaration(
@@ -394,7 +392,10 @@ bool DataInitializationCompiler<DSV>::InitElement(
                 scope,
                 /*isBoundsRemapping=*/false, /*isAssumedRank=*/false)) {
           if (lastSymbol->has<ProcEntityDetails>()) {
-            GetImage().AddPointer(offsetSymbol.offset(), *expr);
+            auto &symInit{GetSymbolInit()};
+            symInit.NoteInitializedRange(offsetSymbol, /*isDuplicate=*/
+                symInit.image.AddPointer(offsetSymbol.offset(), *expr) ==
+                    evaluate::InitialImage::OkNoChange);
             return true;
           } else {
             evaluate::AttachDeclaration(
@@ -415,7 +416,10 @@ bool DataInitializationCompiler<DSV>::InitElement(
           expr->AsFortran(), DescribeElement());
     } else if (CheckInitialDataPointerTarget(
                    exprAnalyzer_.context(), designator, *expr, scope)) {
-      GetImage().AddPointer(offsetSymbol.offset(), *expr);
+      auto &symInit{GetSymbolInit()};
+      symInit.NoteInitializedRange(offsetSymbol, /*isDuplicate=*/
+          symInit.image.AddPointer(offsetSymbol.offset(), *expr) ==
+              evaluate::InitialImage::OkNoChange);
       return true;
     }
   } else if (evaluate::IsNullPointer(expr)) {
@@ -448,9 +452,14 @@ bool DataInitializationCompiler<DSV>::InitElement(
       // Rewritten from a switch() in order to avoid getting complaints
       // about a missing "default:" from some compilers and complaints
       // about a redundant "default:" from others.
-      auto status{GetImage().Add(
+      auto &symInit{GetSymbolInit()};
+      auto status{symInit.image.Add(
           offsetSymbol.offset(), offsetSymbol.size(), folded, context)};
       if (status == evaluate::InitialImage::Ok) {
+        symInit.NoteInitializedRange(offsetSymbol, /*isDuplicate=*/false);
+        return true;
+      } else if (status == evaluate::InitialImage::OkNoChange) {
+        symInit.NoteInitializedRange(offsetSymbol, /*isDuplicate=*/true);
         return true;
       } else if (status == evaluate::InitialImage::NotAConstant) {
         exprAnalyzer_.Say(
@@ -567,48 +576,36 @@ static void PopulateWithComponentDefaults(SymbolDataInitialization &init,
       if (!IsAllocatable(component) && !IsAutomatic(component)) {
         bool initialized{false};
         if (object->init()) {
-          initialized = true;
           if (IsPointer(component)) {
-            if (auto extant{init.image.AsConstantPointer(componentOffset)}) {
-              initialized = !(*extant == *object->init());
-            }
-            if (initialized) {
-              init.image.AddPointer(componentOffset, *object->init());
+            if (init.image.AddPointer(componentOffset, *object->init()) ==
+                evaluate::InitialImage::Ok) {
+              initialized = true;
             }
           } else { // data, not pointer
-            if (auto dyType{evaluate::DynamicType::From(component)}) {
-              if (auto extents{evaluate::GetConstantExtents(
-                      foldingContext, component)}) {
-                if (auto extant{init.image.AsConstant(foldingContext, *dyType,
-                        std::nullopt, *extents, false /*don't pad*/,
-                        componentOffset)}) {
-                  initialized = !(*extant == *object->init());
-                }
-              }
-            }
-            if (initialized) {
-              init.image.Add(componentOffset, component.size(), *object->init(),
-                  foldingContext);
+            if (init.image.Add(componentOffset, component.size(),
+                    *object->init(),
+                    foldingContext) == evaluate::InitialImage::Ok) {
+              initialized = true;
             }
           }
-        } else if (const DeclTypeSpec * type{component.GetType()}) {
+        } else if (const DeclTypeSpec *type{component.GetType()}) {
           if (const DerivedTypeSpec * componentDerived{type->AsDerived()}) {
             PopulateWithComponentDefaults(init, componentOffset,
                 *componentDerived, foldingContext, component);
           }
         }
         if (initialized) {
-          init.NoteInitializedRange(componentOffset, component.size());
+          init.NoteInitializedRange(componentOffset, component.size(),
+              /*isDuplicate=*/false);
         }
       }
     } else if (const auto *proc{component.detailsIf<ProcEntityDetails>()}) {
       if (proc->init() && *proc->init()) {
         SomeExpr procPtrInit{evaluate::ProcedureDesignator{**proc->init()}};
-        auto extant{init.image.AsConstantPointer(componentOffset)};
-        if (!extant || !(*extant == procPtrInit)) {
-          init.NoteInitializedRange(componentOffset, component.size());
-          init.image.AddPointer(componentOffset, std::move(procPtrInit));
-        }
+        init.NoteInitializedRange(componentOffset,
+            component.size(), /*isDuplicate=*/
+            init.image.AddPointer(componentOffset, std::move(procPtrInit)) ==
+                evaluate::InitialImage::OkNoChange);
       }
     }
   }
@@ -620,27 +617,56 @@ static bool CheckForOverlappingInitialization(
     evaluate::ExpressionAnalyzer &exprAnalyzer, const std::string &what) {
   bool result{true};
   auto &context{exprAnalyzer.GetFoldingContext()};
-  initialization.initializedRanges.sort();
+  initialization.initializationItems.sort();
   ConstantSubscript next{0};
-  for (const auto &range : initialization.initializedRanges) {
-    if (range.start() < next) {
+  SourceOrderedSymbolSet errors;
+  // Emit errors for multiple distinct initializations
+  for (const auto &item : initialization.initializationItems) {
+    const auto &range{item.range};
+    if (range.start() < next && !item.isDuplicate) {
       result = false; // error: overlap
       bool hit{false};
       for (const Symbol &symbol : symbols) {
         auto offset{range.start() -
             static_cast<ConstantSubscript>(
                 symbol.offset() - symbols.front()->offset())};
-        if (offset >= 0) {
+        if (offset >= 0 && static_cast<std::size_t>(offset) < symbol.size()) {
           if (auto badDesignator{evaluate::OffsetToDesignator(
                   context, symbol, offset, range.size())}) {
             hit = true;
+            errors.insert(symbol);
             exprAnalyzer.Say(symbol.name(),
-                "%s affect '%s' more than once"_err_en_US, what,
+                "%s affect '%s' more than once, distinctly"_err_en_US, what,
                 badDesignator->AsFortran());
           }
         }
       }
       CHECK(hit);
+    }
+    next = range.start() + range.size();
+    CHECK(next <= static_cast<ConstantSubscript>(initialization.image.size()));
+  }
+  // Emit warnings for multiple identical initializations
+  next = 0;
+  for (const auto &item : initialization.initializationItems) {
+    const auto &range{item.range};
+    if (range.start() < next && item.isDuplicate) {
+      for (const Symbol &symbol : symbols) {
+        if (errors.find(symbol) == errors.end()) {
+          auto offset{range.start() -
+              static_cast<ConstantSubscript>(
+                  symbol.offset() - symbols.front()->offset())};
+          if (offset >= 0) {
+            if (auto badDesignator{evaluate::OffsetToDesignator(
+                    context, symbol, offset, range.size())}) {
+              exprAnalyzer.Warn(common::LanguageFeature::MultipleIdenticalDATA,
+                  symbol.name(),
+                  "%s affect '%s' more than once, identically"_port_en_US, what,
+                  badDesignator->AsFortran());
+            }
+          }
+        }
+      }
     }
     next = range.start() + range.size();
     CHECK(next <= static_cast<ConstantSubscript>(initialization.image.size()));
@@ -655,11 +681,13 @@ static void IncorporateExplicitInitialization(
   auto iter{inits.find(&symbol)};
   const auto offset{symbol.offset() - firstOffset};
   if (iter != inits.end()) { // DATA statement initialization
-    for (const auto &range : iter->second.initializedRanges) {
-      auto at{offset + range.start()};
-      combined.NoteInitializedRange(at, range.size());
-      combined.image.Incorporate(
-          at, iter->second.image, range.start(), range.size());
+    for (const auto &item : iter->second.initializationItems) {
+      auto at{offset + item.range.start()};
+      if (combined.image.Incorporate(
+              at, iter->second.image, item.range.start(), item.range.size())) {
+        combined.NoteInitializedRange(
+            at, item.range.size(), /*isDuplicate=*/false);
+      }
     }
     if (removeOriginalInits) {
       inits.erase(iter);
@@ -669,17 +697,21 @@ static void IncorporateExplicitInitialization(
     if (IsPointer(mutableSymbol)) {
       if (auto *object{mutableSymbol.detailsIf<ObjectEntityDetails>()}) {
         if (object->init()) {
-          combined.NoteInitializedRange(offset, mutableSymbol.size());
-          combined.image.AddPointer(offset, *object->init());
+          combined.NoteInitializedRange(offset,
+              mutableSymbol.size(), /*isDuplicate=*/
+              combined.image.AddPointer(offset, *object->init()) ==
+                  evaluate::InitialImage::OkNoChange);
           if (removeOriginalInits) {
             object->init().reset();
           }
         }
       } else if (auto *proc{mutableSymbol.detailsIf<ProcEntityDetails>()}) {
         if (proc->init() && *proc->init()) {
-          combined.NoteInitializedRange(offset, mutableSymbol.size());
-          combined.image.AddPointer(
-              offset, SomeExpr{evaluate::ProcedureDesignator{**proc->init()}});
+          combined.NoteInitializedRange(offset,
+              mutableSymbol.size(), /*isDuplicate=*/
+              combined.image.AddPointer(offset,
+                  SomeExpr{evaluate::ProcedureDesignator{**proc->init()}}) ==
+                  evaluate::InitialImage::OkNoChange);
           if (removeOriginalInits) {
             proc->init().reset();
           }
@@ -687,9 +719,10 @@ static void IncorporateExplicitInitialization(
       }
     } else if (auto *object{mutableSymbol.detailsIf<ObjectEntityDetails>()}) {
       if (!IsNamedConstant(mutableSymbol) && object->init()) {
-        combined.NoteInitializedRange(offset, mutableSymbol.size());
-        combined.image.Add(
-            offset, mutableSymbol.size(), *object->init(), foldingContext);
+        auto status{combined.image.Add(
+            offset, mutableSymbol.size(), *object->init(), foldingContext)};
+        combined.NoteInitializedRange(offset, mutableSymbol.size(),
+            status == evaluate::InitialImage::OkNoChange);
         if (removeOriginalInits) {
           object->init().reset();
         }
@@ -759,12 +792,12 @@ static bool CombineEquivalencedInitialization(
     }
   }
   if (!CheckForOverlappingInitialization(associated, combined, exprAnalyzer,
-          "Distinct default component initializations of equivalenced objects"s)) {
+          "Default component initializations of equivalenced objects"s)) {
     return false;
   }
   // Don't complain about overlap between explicit initializations and
   // default initializations.
-  combined.initializedRanges.clear();
+  combined.initializationItems.clear();
   // Now overlay all explicit initializations from DATA statements and
   // from initializers in declarations.
   for (const Symbol &symbol : associated) {

--- a/flang/lib/Semantics/semantics.cpp
+++ b/flang/lib/Semantics/semantics.cpp
@@ -261,12 +261,8 @@ static bool PerformStatementSemantics(
   }
   if (!context.messages().AnyFatalError()) {
     WarnUndefinedFunctionResult(context, context.globalScope());
-  }
-  if (!context.messages().AnyFatalError()) {
-    WarnUnusedOrUndefinedLocal(context, context.globalScope());
-  }
-  if (!context.AnyFatalError()) {
     pass2.CompileDataInitializationsIntoInitializers();
+    WarnUnusedOrUndefinedLocal(context, context.globalScope());
   }
   return !context.AnyFatalError();
 }

--- a/flang/test/Semantics/bug2098.f90
+++ b/flang/test/Semantics/bug2098.f90
@@ -1,0 +1,14 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
+!ERROR: DATA statement initializations affect 'a(1_8)' more than once, distinctly
+!PORTABILITY: DATA statement initializations affect 'b(1_8)' more than once, identically [-Wmultiple-identical-data]
+integer a(2), b(2)
+data a(1)/1/
+data a(2)/2/
+data a(1)/3/
+data a(2)/2/
+data b(1)/4/
+data b(2)/5/
+data b(1)/4/
+data b(2)/5/
+print *, a, b
+end

--- a/flang/test/Semantics/data07.f90
+++ b/flang/test/Semantics/data07.f90
@@ -2,7 +2,7 @@
 module m
  contains
   subroutine s1
-    !ERROR: DATA statement initializations affect 'jb(5_8)' more than once
+    !ERROR: DATA statement initializations affect 'jb(5_8)' more than once, distinctly
     integer :: ja(10), jb(10)
     data (ja(k),k=1,9,2) / 5*1 / ! ok
     data (ja(k),k=10,2,-2) / 5*2 / ! ok

--- a/flang/test/Semantics/data12.f90
+++ b/flang/test/Semantics/data12.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 type :: t1
   sequence
   integer :: m = 123
@@ -14,14 +14,14 @@ type :: t3
   integer :: k = 234
   integer :: pad
 end type
-!ERROR: Distinct default component initializations of equivalenced objects affect 'x1a%m' more than once
+!ERROR: Default component initializations of equivalenced objects affect 'x1a%m' more than once, distinctly
 type(t1) :: x1a
-!ERROR: Distinct default component initializations of equivalenced objects affect 'x2a%n' more than once
+!ERROR: Default component initializations of equivalenced objects affect 'x2a%n' more than once, distinctly
 type(t2) :: x2a
-!ERROR: Distinct default component initializations of equivalenced objects affect 'x3%k' more than once
+!ERROR: Default component initializations of equivalenced objects affect 'x3%k' more than once, distinctly
 type(t3), save :: x3
-!ERROR: Explicit initializations of equivalenced objects affect 'ja(2_8)' more than once
-!ERROR: Explicit initializations of equivalenced objects affect 'ka(1_8)' more than once
+!ERROR: Explicit initializations of equivalenced objects affect 'ja(2_8)' more than once, distinctly
+!ERROR: Explicit initializations of equivalenced objects affect 'ka(1_8)' more than once, distinctly
 integer :: ja(2), ka(2)
 data ja/345, 456/
 data ka/456, 567/

--- a/flang/test/Semantics/data23.f90
+++ b/flang/test/Semantics/data23.f90
@@ -1,18 +1,35 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 program p
   interface
-    subroutine s
+    subroutine s1
+    end subroutine
+    subroutine s2
     end subroutine
   end interface
-  !ERROR: DATA statement initializations affect 'p' more than once
-  procedure(s), pointer :: p
+  !ERROR: DATA statement initializations affect 'p1' more than once, distinctly
+  procedure(s1), pointer :: p1
+  !PORTABILITY: DATA statement initializations affect 'p2' more than once, identically [-Wmultiple-identical-data]
+  procedure(s2), pointer :: p2
   type t
-    procedure(s), pointer, nopass :: p
+    procedure(s1), pointer, nopass :: p
   end type
-  !ERROR: DATA statement initializations affect 'x%p' more than once
-  type(t) x
-  data p /s/
-  data p /s/
-  data x%p /s/
-  data x%p /s/
+  !ERROR: DATA statement initializations affect 'x1%p' more than once, distinctly
+  !PORTABILITY: DATA statement initializations affect 'x2%p' more than once, identically [-Wmultiple-identical-data]
+  type(t) x1, x2
+  !PORTABILITY: Procedure pointer 'p1' in a DATA statement is not standard [-Wdata-stmt-extensions]
+  data p1 /s1/
+  !PORTABILITY: Procedure pointer 'p1' in a DATA statement is not standard [-Wdata-stmt-extensions]
+  data p1 /s2/
+  !PORTABILITY: Procedure pointer 'p2' in a DATA statement is not standard [-Wdata-stmt-extensions]
+  data p2 /s1/
+  !PORTABILITY: Procedure pointer 'p2' in a DATA statement is not standard [-Wdata-stmt-extensions]
+  data p2 /s1/
+  !PORTABILITY: Procedure pointer 'p' in a DATA statement is not standard [-Wdata-stmt-extensions]
+  data x1%p /s1/
+  !PORTABILITY: Procedure pointer 'p' in a DATA statement is not standard [-Wdata-stmt-extensions]
+  data x1%p /s2/
+  !PORTABILITY: Procedure pointer 'p' in a DATA statement is not standard [-Wdata-stmt-extensions]
+  data x2%p /s1/
+  !PORTABILITY: Procedure pointer 'p' in a DATA statement is not standard [-Wdata-stmt-extensions]
+  data x2%p /s1/
 end

--- a/flang/test/Semantics/equivalence02.f90
+++ b/flang/test/Semantics/equivalence02.f90
@@ -7,23 +7,21 @@ type t0
 end type
 type t1
   sequence
-  integer, dimension(2):: i/41, 2/      
+  integer, dimension(2):: i/41, 2/
 end type
 type t2
   sequence
   integer :: j(2) = [42, 2]
 end type
-! ERROR: Distinct default component initializations of equivalenced objects affect 'o1' more than once
 type (t0) :: O1
-! ERROR: Distinct default component initializations of equivalenced objects affect 'a%i(1_8)' more than once
+! ERROR: Default component initializations of equivalenced objects affect 'a%i(1_8)' more than once, distinctly
 type (t1) :: A
-! ERROR: Distinct default component initializations of equivalenced objects affect 'b%j(1_8)' more than once
+! ERROR: Default component initializations of equivalenced objects affect 'b%j(1_8)' more than once, distinctly
 type (t2) :: B
-! ERROR: Distinct default component initializations of equivalenced objects affect 'x' more than once
-! ERROR: Distinct default component initializations of equivalenced objects affect 'o2(1_8)' more than once
+! ERROR: Default component initializations of equivalenced objects affect 'x' more than once, distinctly
 integer :: x, O2(0)
 data x/42/
-! ERROR: Distinct default component initializations of equivalenced objects affect 'undeclared' more than once
+! ERROR: Default component initializations of equivalenced objects affect 'undeclared' more than once, distinctly
 equivalence (A, B, x, O1, O2, Undeclared)
 call p(x)
 call s()
@@ -38,12 +36,12 @@ subroutine s()
     sequence
     integer(kind=8)::d = 2_8
   end type
-  ! ERROR: Distinct default component initializations of equivalenced objects affect 'c%d' more than once
+  ! ERROR: Default component initializations of equivalenced objects affect 'c%d' more than once, distinctly
   type (g1) :: C
-  ! ERROR: Distinct default component initializations of equivalenced objects affect 'd%d' more than once
+  ! ERROR: Default component initializations of equivalenced objects affect 'd%d' more than once, distinctly
   type (g2) :: D
-  ! ERROR: Distinct default component initializations of equivalenced objects affect 'x' more than once
-  ! ERROR: Distinct default component initializations of equivalenced objects affect 'y' more than once
+  ! ERROR: Default component initializations of equivalenced objects affect 'x' more than once, distinctly
+  ! ERROR: Default component initializations of equivalenced objects affect 'y' more than once, distinctly
   integer :: x, y
   data x/1/, y/2/
   equivalence (C, x)


### PR DESCRIPTION
ISO Fortran disallows DATA statements from affecting the same bit of memory more than once; however, all (but one) other compilers allow this usage.  They differ, however, in the case of multiple distinct initializations -- some compilers take the "last" value in source order, some don't.

This patch accepts multiple identical DATA initializations, which is portable usage that appears in code, and emits an optional warning.  It continues to detect and report multiple distinct DATA initializations, since they are not portable.