### PR TITLE
[AMDGPU] Improve crash message when S_WAITCNT_DEPCTR is missing its operand

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -10001,6 +10001,9 @@ void SIInstrInfo::fixImplicitOperands(MachineInstr &MI) const {
   if (MI.isInlineAsm())
     return;
 
+  if (MI.getNumOperands() < MI.getNumExplicitOperands())
+    return;
+
   for (auto &Op : MI.implicit_operands()) {
     if (Op.isReg() && Op.getReg() == AMDGPU::VCC)
       Op.setReg(AMDGPU::VCC_LO);

--- a/llvm/test/CodeGen/MIR/AMDGPU/s_wait_alu_missing_operand_crash.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/s_wait_alu_missing_operand_crash.mir
@@ -1,4 +1,4 @@
-# RUN: ! llc -mtriple=amdgcn -run-pass=none %s -o /dev/null 2>&1 | FileCheck %s
+# RUN: ! llc -mtriple=amdgcn -run-pass=none %s -filetype=null 2>&1 | FileCheck %s
 
 ---
 # CHECK: Bad machine code: Too few operands

--- a/llvm/test/CodeGen/MIR/AMDGPU/s_wait_alu_missing_operand_crash.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/s_wait_alu_missing_operand_crash.mir
@@ -1,4 +1,4 @@
-# RUN: ! llc -mtriple=amdgcn -run-pass=none %s -o - 2>&1 | FileCheck %s
+# RUN: ! llc -mtriple=amdgcn -run-pass=none %s -o /dev/null 2>&1 | FileCheck %s
 
 ---
 # CHECK: Bad machine code: Too few operands

--- a/llvm/test/CodeGen/MIR/AMDGPU/s_wait_alu_missing_operand_crash.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/s_wait_alu_missing_operand_crash.mir
@@ -1,0 +1,9 @@
+# RUN: ! llc -mtriple=amdgcn -run-pass=none %s -o - 2>&1 | FileCheck %s
+
+---
+# CHECK: Bad machine code: Too few operands
+name: missing_operand_crash
+body: |
+  bb.0:
+    S_WAITCNT_DEPCTR
+...


### PR DESCRIPTION
The code in the test is causing a crash in `SIInstrInfo.cpp` `fixImplicitOperands()` in `MI.implicit_operands()`:
```
  for (auto &Op : MI.implicit_operands()) {
```
MachineInstr.h:
```
  mop_range implicit_operands() {
=>  return operands_impl().drop_front(getNumExplicitOperands());
  }
```
We are trying to drop 1 operand from the operands of MI which are 0.

By early returning we are no longer crashing at that point and we are getting a more meaningful error message:

```
*** Bad machine code: Too few operands ***
- function:    missing_operand_crash
- basic block: %bb.0  (0x5a9d30ced988)
- instruction: S_WAITCNT_DEPCTR
1 operands expected, but 0 given.
```

The code is still crashing at a different location, but at least we are getting an error message.