### PR TITLE
[lld][COFF] Use `.contains` rather than `.count` for set membership. NFC

### DIFF
--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -15,12 +15,12 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Object/COFF.h"
 #include "llvm/Support/CachePruning.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <cstdint>
 #include <map>
-#include <set>
 #include <string>
 
 namespace lld::coff {
@@ -155,14 +155,14 @@ struct Configuration {
   // Symbols in this set are considered as live by the garbage collector.
   std::vector<Symbol *> gcroot;
 
-  std::set<std::string> noDefaultLibs;
+  llvm::StringSet<> noDefaultLibs;
   bool noDefaultLibAll = false;
 
   // True if we are creating a DLL.
   bool dll = false;
   StringRef implib;
   bool noimplib = false;
-  std::set<std::string> delayLoads;
+  llvm::StringSet<> delayLoads;
   std::map<std::string, int> dllOrder;
   Symbol *arm64ECIcallHelper = nullptr;
 

--- a/lld/COFF/MinGW.cpp
+++ b/lld/COFF/MinGW.cpp
@@ -150,7 +150,8 @@ bool AutoExporter::shouldExport(Defined *sym) const {
   // disallow import symbols.
   if (!isa<DefinedRegular>(sym) && !isa<DefinedCommon>(sym))
     return false;
-  if (excludeSymbols.count(sym->getName()) || manualExcludeSymbols.count(sym->getName()))
+  if (excludeSymbols.contains(sym->getName()) ||
+      manualExcludeSymbols.contains(sym->getName()))
     return false;
 
   for (StringRef prefix : excludeSymbolPrefixes.keys())
@@ -174,10 +175,10 @@ bool AutoExporter::shouldExport(Defined *sym) const {
   // Drop the file extension.
   libName = libName.substr(0, libName.rfind('.'));
   if (!libName.empty())
-    return !excludeLibs.count(libName);
+    return !excludeLibs.contains(libName);
 
   StringRef fileName = sys::path::filename(sym->getFile()->getName());
-  return !excludeObjects.count(fileName);
+  return !excludeObjects.contains(fileName);
 }
 
 void lld::coff::writeDefFile(COFFLinkerContext &ctx, StringRef name,

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -381,7 +381,7 @@ void SymbolTable::reportProblemSymbols(
     return;
 
   for (Symbol *b : ctx.config.gcroot) {
-    if (undefs.count(b))
+    if (undefs.contains(b))
       errorOrWarn(ctx) << "<root>: undefined symbol: " << printSymbol(b);
     if (localImports)
       if (Symbol *imp = localImports->lookup(b))
@@ -399,7 +399,7 @@ void SymbolTable::reportProblemSymbols(
       ++symIndex;
       if (!sym)
         continue;
-      if (undefs.count(sym)) {
+      if (undefs.contains(sym)) {
         auto [it, inserted] = firstDiag.try_emplace(sym, undefDiags.size());
         if (inserted)
           undefDiags.push_back({sym, {{file, symIndex}}});

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -1330,7 +1330,7 @@ void Writer::createImportTables() {
     if (file->impSym && !isa<DefinedImportData>(file->impSym))
       Fatal(ctx) << file->symtab.printSymbol(file->impSym) << " was replaced";
     DefinedImportData *impSym = cast_or_null<DefinedImportData>(file->impSym);
-    if (ctx.config.delayLoads.count(StringRef(file->dllName).lower())) {
+    if (ctx.config.delayLoads.contains(StringRef(file->dllName).lower())) {
       if (!file->thunkSym)
         Fatal(ctx) << "cannot delay-load " << toString(file)
                    << " due to import of data: "


### PR DESCRIPTION
Also converted a couple of `std::set` to `llvm::StringSet`/`llvm::SmallSet`.

This matches the usage in the other linker backends.

See #176610