### PR TITLE
[Bazel] Fix libc build

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -199,6 +199,11 @@ libc_support_library(
     hdrs = ["include/llvm-libc-types/size_t.h"],
 )
 
+libc_support_library(
+    name = "llvm_libc_types_char8_t",
+    hdrs = ["include/llvm-libc-types/char8_t.h"],
+)
+
 ########################### Macro Proxy Header Files ###########################
 
 libc_support_library(
@@ -302,6 +307,11 @@ libc_support_library(
 libc_support_library(
     name = "hdr_wchar_overlay",
     hdrs = ["hdr/wchar_overlay.h"],
+)
+
+libc_support_library(
+    name = "hdr_uchar_overlay",
+    hdrs = ["hdr/uchar_overlay.h"],
 )
 
 libc_support_library(
@@ -491,6 +501,22 @@ libc_support_library(
     hdrs = ["hdr/types/wint_t.h"],
     deps = [
         ":hdr_wchar_overlay",
+    ],
+)
+
+libc_support_library(
+    name = "types_char32_t",
+    hdrs = ["hdr/types/char32_t.h"],
+    deps = [
+        ":hdr_uchar_overlay",
+    ],
+)
+
+libc_support_library(
+    name = "types_char8_t",
+    hdrs = ["hdr/types/char8_t.h"],
+    deps = [
+        ":llvm_libc_types_char8_t",
     ],
 )
 
@@ -1806,6 +1832,43 @@ libc_support_library(
     deps = [
         ":__support_macros_attributes",
         ":__support_macros_config",
+        ":types_wchar_t",
+    ],
+)
+
+libc_support_library(
+    name = "__support_wchar_mbstate",
+    hdrs = ["src/__support/wchar/mbstate.h"],
+    deps = [
+        ":__support_common",
+        ":types_char32_t",
+    ],
+)
+
+libc_support_library(
+    name = "__support_wchar_character_converter",
+    hdrs = ["src/__support/wchar/character_converter.h"],
+    deps = [
+        ":__support_common",
+        ":__support_cpp_bit",
+        ":__support_error_or",
+        ":__support_math_extras",
+        ":__support_wchar_mbstate",
+        ":hdr_errno_macros",
+        ":types_char32_t",
+        ":types_char8_t",
+        ":types_size_t",
+    ],
+)
+
+libc_support_library(
+    name = "__support_wchar_wcrtomb",
+    hdrs = ["src/__support/wchar/wcrtomb.h"],
+    deps = [
+        ":__support_error_or",
+        ":__support_libc_assert",
+        ":__support_macros_null_check",
+        ":__support_wchar_character_converter",
         ":types_wchar_t",
     ],
 )
@@ -6672,6 +6735,7 @@ libc_support_library(
         ":errno",
         ":printf_config",
         ":printf_core_structs",
+        ":types_wint_t",
     ],
 )
 
@@ -6717,9 +6781,14 @@ libc_support_library(
         ":__support_libc_assert",
         ":__support_stringutil",
         ":__support_uint128",
+        ":__support_wchar_mbstate",
+        ":__support_wchar_wcrtomb",
+        ":hdr_wchar_macros",
         ":printf_config",
         ":printf_core_structs",
         ":printf_writer",
+        ":types_wchar_t",
+        ":types_wint_t",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdio/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdio/BUILD.bazel
@@ -62,7 +62,9 @@ libc_test(
     srcs = ["sprintf_test.cpp"],
     deps = [
         "//libc:__support_fputil_fp_bits",
+        "//libc:hdr_wchar_macros",
         "//libc:sprintf",
+        "//libc:types_wint_t",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
 )


### PR DESCRIPTION
Add the necessary wchar components to the tests and create targets that do not already exist that are needed.