### PR TITLE
[lit] Fix filter-failed-rerun.py on readonly FSes

### DIFF
--- a/llvm/utils/lit/tests/filter-failed-rerun.py
+++ b/llvm/utils/lit/tests/filter-failed-rerun.py
@@ -6,7 +6,7 @@
 #
 # RUN: not %{lit} %t | FileCheck %s --check-prefix=CHECK-FIRST
 #
-# RUN: cp %t%{fs-sep}pass.txt %t%{fs-sep}fail.txt
+# RUN: cp -f %t%{fs-sep}pass.txt %t%{fs-sep}fail.txt
 # RUN: not %{lit} %t | FileCheck %s --check-prefix=CHECK-SECOND
 # RUN: not %{lit} --filter-failed %t | FileCheck %s --check-prefix=CHECK-THIRD
 


### PR DESCRIPTION
This test invokes lit in a directory and then tries to overwrite fail.txt within that directory. With the project sources mounted as read-only, fail.txt ends up being marked readonly, which causes cp to fail without -f. Use cp -f to ensure we overwrite the existing fail.txt.