### PR TITLE
[MachineCombiner] Defer pattern order verfication. NFC

### DIFF
--- a/llvm/lib/CodeGen/MachineCombiner.cpp
+++ b/llvm/lib/CodeGen/MachineCombiner.cpp
@@ -118,8 +118,6 @@ private:
                                 SmallVectorImpl<MachineInstr *> &DelInstrs,
                                 MachineTraceMetrics::Trace BlockTrace);
 
-  void verifyPatternOrder(MachineBasicBlock *MBB, MachineInstr &Root,
-                          SmallVector<unsigned, 16> &Patterns);
   CombinerObjective getCombinerObjective(unsigned Pattern);
 };
 }
@@ -516,35 +514,6 @@ insertDeleteInstructions(MachineBasicBlock *MBB, MachineInstr &MI,
   NumInstCombined++;
 }
 
-// Check that the difference between original and new latency is decreasing for
-// later patterns. This helps to discover sub-optimal pattern orderings.
-void MachineCombiner::verifyPatternOrder(MachineBasicBlock *MBB,
-                                         MachineInstr &Root,
-                                         SmallVector<unsigned, 16> &Patterns) {
-  long PrevLatencyDiff = std::numeric_limits<long>::max();
-  (void)PrevLatencyDiff; // Variable is used in assert only.
-  for (auto P : Patterns) {
-    SmallVector<MachineInstr *, 16> InsInstrs;
-    SmallVector<MachineInstr *, 16> DelInstrs;
-    DenseMap<Register, unsigned> InstrIdxForVirtReg;
-    TII->genAlternativeCodeSequence(Root, P, InsInstrs, DelInstrs,
-                                    InstrIdxForVirtReg);
-    // Found pattern, but did not generate alternative sequence.
-    // This can happen e.g. when an immediate could not be materialized
-    // in a single instruction.
-    if (InsInstrs.empty() || !TSchedModel.hasInstrSchedModelOrItineraries())
-      continue;
-
-    unsigned NewRootLatency, RootLatency;
-    std::tie(NewRootLatency, RootLatency) = getLatenciesForInstrSequences(
-        Root, InsInstrs, DelInstrs, TraceEnsemble->getTrace(MBB));
-    long CurrentLatencyDiff = ((long)RootLatency) - ((long)NewRootLatency);
-    assert(CurrentLatencyDiff <= PrevLatencyDiff &&
-           "Current pattern is better than previous pattern.");
-    PrevLatencyDiff = CurrentLatencyDiff;
-  }
-}
-
 /// Substitute a slow code sequence with a faster one by
 /// evaluating instruction combining pattern.
 /// The prototype of such a pattern is MUl + ADD -> MADD. Performs instruction
@@ -605,8 +574,8 @@ bool MachineCombiner::combineInstructions(MachineBasicBlock *MBB) {
     if (!TII->getMachineCombinerPatterns(MI, Patterns, DoRegPressureReduce))
       continue;
 
-    if (VerifyPatternOrder)
-      verifyPatternOrder(MBB, MI, Patterns);
+    // Only used when VerifyPatternOrder is enabled.
+    [[maybe_unused]] long PrevLatencyDiff = std::numeric_limits<long>::max();
 
     for (const auto P : Patterns) {
       SmallVector<MachineInstr *, 16> InsInstrs;
@@ -631,6 +600,19 @@ bool MachineCombiner::combineInstructions(MachineBasicBlock *MBB) {
           InstrPtr->print(dbgs(), /*IsStandalone*/false, /*SkipOpers*/false,
                           /*SkipDebugLoc*/false, /*AddNewLine*/true, TII);
       });
+
+      // Check that the difference between original and new latency is
+      // decreasing for later patterns. This helps to discover sub-optimal
+      // pattern orderings.
+      if (VerifyPatternOrder && TSchedModel.hasInstrSchedModelOrItineraries()) {
+        auto [NewRootLatency, RootLatency] = getLatenciesForInstrSequences(
+            MI, InsInstrs, DelInstrs, TraceEnsemble->getTrace(MBB));
+        long CurrentLatencyDiff = ((long)RootLatency) - ((long)NewRootLatency);
+        assert(CurrentLatencyDiff <= PrevLatencyDiff &&
+               "Current pattern is expected to be better than the previous "
+               "pattern.");
+        PrevLatencyDiff = CurrentLatencyDiff;
+      }
 
       if (IncrementalUpdate && LastUpdate != BlockIter) {
         // Update depths since the last incremental update.


### PR DESCRIPTION
The `verifyPatternOrder` function was created to check if machine combiner patterns are ordered by their latency reduction degree. This function can be merged into the following loop, which iterates through all the patterns, such that (1) `TII::genAlternativeCodeSequence`, which can be quite expensive, won't be called twice (2) since it's now placed after we print out the candidate sequence through debug print, if anything goes wrong during the verification, we at least know what the sequence looks like (3) we don't need to verify all patterns if we will eventually exit early.

This should be a NFC