### PR TITLE
[libc++] Short-cut constraints of single-argument `any` constructor

### DIFF
--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -89,6 +89,7 @@ namespace std {
 #  include <__type_traits/add_cv_quals.h>
 #  include <__type_traits/add_pointer.h>
 #  include <__type_traits/conditional.h>
+#  include <__type_traits/conjunction.h>
 #  include <__type_traits/decay.h>
 #  include <__type_traits/enable_if.h>
 #  include <__type_traits/is_constructible.h>
@@ -97,6 +98,7 @@ namespace std {
 #  include <__type_traits/is_reference.h>
 #  include <__type_traits/is_same.h>
 #  include <__type_traits/is_void.h>
+#  include <__type_traits/negation.h>
 #  include <__type_traits/remove_cv.h>
 #  include <__type_traits/remove_cvref.h>
 #  include <__type_traits/remove_reference.h>
@@ -201,10 +203,11 @@ public:
       __other.__call(_Action::_Move, this);
   }
 
-  template <class _ValueType,
-            class _Tp        = decay_t<_ValueType>,
-            enable_if_t<!is_same_v<_Tp, any> && !__is_inplace_type<_ValueType>::value && is_copy_constructible_v<_Tp>,
-                        int> = 0>
+  template <
+      class _ValueType,
+      class _Tp        = decay_t<_ValueType>,
+      enable_if_t<_And<_Not<is_same<_Tp, any>>, _Not<__is_inplace_type<_ValueType>>, is_copy_constructible<_Tp>>::value,
+                  int> = 0>
   _LIBCPP_HIDE_FROM_ABI any(_ValueType&& __value) : __h_(nullptr) {
     __any_imp::_Handler<_Tp>::__create(*this, std::forward<_ValueType>(__value));
   }


### PR DESCRIPTION
When a default template argument of a function template uses `std::is_copy_constructible<T>::value` and `T` is convertible from and to `any`, the changes in 21dc73f6a46cd786394f10f5aef46ec4a2d26175 would introduce constraint meta-recursion when compiling with Clang.

This patch short-cuts constraints of the related constructor to avoid computing `is_copy_constructible<T>` when `decay_t<T>` is `any`, which gets rid of constraint meta-recursion in the overload resolution of copy construction of `T`.

Fixes #176877.