### PR TITLE
[LoongArch] Remove DAG combination for extractelement

### DIFF
--- a/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/extractelement.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/extractelement.ll
@@ -104,7 +104,8 @@ define void @extract_32xi8_idx(ptr %src, ptr %dst, i32 %idx) nounwind {
 ; LA64:       # %bb.0:
 ; LA64-NEXT:    xvld $xr0, $a0, 0
 ; LA64-NEXT:    xvpermi.q $xr1, $xr0, 1
-; LA64-NEXT:    movgr2fr.w $fa2, $a2
+; LA64-NEXT:    bstrpick.d $a0, $a2, 31, 0
+; LA64-NEXT:    movgr2fr.w $fa2, $a0
 ; LA64-NEXT:    xvshuf.b $xr0, $xr1, $xr0, $xr2
 ; LA64-NEXT:    xvstelm.b $xr0, $a1, 0, 0
 ; LA64-NEXT:    ret
@@ -128,7 +129,8 @@ define void @extract_16xi16_idx(ptr %src, ptr %dst, i32 %idx) nounwind {
 ; LA64:       # %bb.0:
 ; LA64-NEXT:    xvld $xr0, $a0, 0
 ; LA64-NEXT:    xvpermi.q $xr1, $xr0, 1
-; LA64-NEXT:    movgr2fr.w $fa2, $a2
+; LA64-NEXT:    bstrpick.d $a0, $a2, 31, 0
+; LA64-NEXT:    movgr2fr.w $fa2, $a0
 ; LA64-NEXT:    xvshuf.h $xr2, $xr1, $xr0
 ; LA64-NEXT:    xvstelm.h $xr2, $a1, 0, 0
 ; LA64-NEXT:    ret
@@ -151,7 +153,8 @@ define void @extract_8xi32_idx(ptr %src, ptr %dst, i32 %idx) nounwind {
 ; LA64-LABEL: extract_8xi32_idx:
 ; LA64:       # %bb.0:
 ; LA64-NEXT:    xvld $xr0, $a0, 0
-; LA64-NEXT:    xvreplgr2vr.w $xr1, $a2
+; LA64-NEXT:    bstrpick.d $a0, $a2, 31, 0
+; LA64-NEXT:    xvreplgr2vr.w $xr1, $a0
 ; LA64-NEXT:    xvperm.w $xr0, $xr0, $xr1
 ; LA64-NEXT:    xvstelm.w $xr0, $a1, 0, 0
 ; LA64-NEXT:    ret
@@ -181,7 +184,8 @@ define void @extract_4xi64_idx(ptr %src, ptr %dst, i32 %idx) nounwind {
 ; LA64:       # %bb.0:
 ; LA64-NEXT:    xvld $xr0, $a0, 0
 ; LA64-NEXT:    xvpermi.q $xr1, $xr0, 1
-; LA64-NEXT:    movgr2fr.w $fa2, $a2
+; LA64-NEXT:    bstrpick.d $a0, $a2, 31, 0
+; LA64-NEXT:    movgr2fr.w $fa2, $a0
 ; LA64-NEXT:    xvshuf.d $xr2, $xr1, $xr0
 ; LA64-NEXT:    xvstelm.d $xr2, $a1, 0, 0
 ; LA64-NEXT:    ret
@@ -192,13 +196,22 @@ define void @extract_4xi64_idx(ptr %src, ptr %dst, i32 %idx) nounwind {
 }
 
 define void @extract_8xfloat_idx(ptr %src, ptr %dst, i32 %idx) nounwind {
-; CHECK-LABEL: extract_8xfloat_idx:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    xvld $xr0, $a0, 0
-; CHECK-NEXT:    xvreplgr2vr.w $xr1, $a2
-; CHECK-NEXT:    xvperm.w $xr0, $xr0, $xr1
-; CHECK-NEXT:    xvstelm.w $xr0, $a1, 0, 0
-; CHECK-NEXT:    ret
+; LA32-LABEL: extract_8xfloat_idx:
+; LA32:       # %bb.0:
+; LA32-NEXT:    xvld $xr0, $a0, 0
+; LA32-NEXT:    xvreplgr2vr.w $xr1, $a2
+; LA32-NEXT:    xvperm.w $xr0, $xr0, $xr1
+; LA32-NEXT:    xvstelm.w $xr0, $a1, 0, 0
+; LA32-NEXT:    ret
+;
+; LA64-LABEL: extract_8xfloat_idx:
+; LA64:       # %bb.0:
+; LA64-NEXT:    xvld $xr0, $a0, 0
+; LA64-NEXT:    bstrpick.d $a0, $a2, 31, 0
+; LA64-NEXT:    xvreplgr2vr.w $xr1, $a0
+; LA64-NEXT:    xvperm.w $xr0, $xr0, $xr1
+; LA64-NEXT:    xvstelm.w $xr0, $a1, 0, 0
+; LA64-NEXT:    ret
   %v = load volatile <8 x float>, ptr %src
   %e = extractelement <8 x float> %v, i32 %idx
   store float %e, ptr %dst
@@ -219,7 +232,8 @@ define void @extract_4xdouble_idx(ptr %src, ptr %dst, i32 %idx) nounwind {
 ; LA64:       # %bb.0:
 ; LA64-NEXT:    xvld $xr0, $a0, 0
 ; LA64-NEXT:    xvpermi.q $xr1, $xr0, 1
-; LA64-NEXT:    movgr2fr.w $fa2, $a2
+; LA64-NEXT:    bstrpick.d $a0, $a2, 31, 0
+; LA64-NEXT:    movgr2fr.w $fa2, $a0
 ; LA64-NEXT:    xvshuf.d $xr2, $xr1, $xr0
 ; LA64-NEXT:    xvstelm.d $xr2, $a1, 0, 0
 ; LA64-NEXT:    ret


### PR DESCRIPTION
Combination for `trunc+extend+extractelement` to a single `extractelement` may occur error, because the high bits of the extract index truncated by `trunc` operation are reserved after the combination.

This commit remove this combination and the issue
https://github.com/llvm/llvm-project/issues/176839 will never appear.