### PR TITLE
[Flang][OpenMP][MLIR] Add attach and ref map type lowering to MLIR

### DIFF
--- a/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
@@ -1461,8 +1461,7 @@ bool ClauseProcessor::processMap(
     mlir::Location clauseLocation = converter.genLocation(source);
     const auto &[mapType, typeMods, attachMod, refMod, mappers, iterator,
                  objects] = clause.t;
-    if (attachMod)
-      TODO(currentLocation, "ATTACH modifier is not implemented yet");
+
     mlir::omp::ClauseMapFlags mapTypeBits = mlir::omp::ClauseMapFlags::none;
     std::string mapperIdName = "__implicit_mapper";
     // If the map type is specified, then process it else set the appropriate
@@ -1505,6 +1504,34 @@ bool ClauseProcessor::processMap(
         mapTypeBits |= mlir::omp::ClauseMapFlags::del;
       if (llvm::is_contained(*typeMods, Map::MapTypeModifier::OmpxHold))
         mapTypeBits |= mlir::omp::ClauseMapFlags::ompx_hold;
+    }
+
+    if (refMod) {
+      switch (*refMod) {
+      case Map::RefModifier::RefPtee:
+        mapTypeBits |= mlir::omp::ClauseMapFlags::ref_ptee;
+        break;
+      case Map::RefModifier::RefPtr:
+        mapTypeBits |= mlir::omp::ClauseMapFlags::ref_ptr;
+        break;
+      case Map::RefModifier::RefPtrPtee:
+        mapTypeBits |= mlir::omp::ClauseMapFlags::ref_ptr_ptee;
+        break;
+      }
+    }
+
+    if (attachMod) {
+      switch (*attachMod) {
+      case Map::AttachModifier::Always:
+        mapTypeBits |= mlir::omp::ClauseMapFlags::attach_always;
+        break;
+      case Map::AttachModifier::Never:
+        mapTypeBits |= mlir::omp::ClauseMapFlags::attach_never;
+        break;
+      case Map::AttachModifier::Auto:
+        mapTypeBits |= mlir::omp::ClauseMapFlags::attach_auto;
+        break;
+      }
     }
 
     if (iterator) {

--- a/flang/test/Lower/OpenMP/Todo/attach-modifier.f90
+++ b/flang/test/Lower/OpenMP/Todo/attach-modifier.f90
@@ -1,9 +1,0 @@
-!RUN: %not_todo_cmd bbc -emit-hlfir -fopenmp -fopenmp-version=61 -o - %s 2>&1 | FileCheck %s
-!RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=61 -o - %s 2>&1 | FileCheck %s
-
-!CHECK: not yet implemented: ATTACH modifier is not implemented yet
-subroutine f00(x)
-  integer, pointer :: x
-  !$omp target map(attach(always), tofrom: x)
-  !$omp end target
-end

--- a/flang/test/Lower/OpenMP/attach-and-ref-modifier.f90
+++ b/flang/test/Lower/OpenMP/attach-and-ref-modifier.f90
@@ -1,0 +1,63 @@
+! RUN: %flang_fc1 -fopenmp -fopenmp-version=61 -emit-hlfir %s -o - 2>&1 | FileCheck %s
+
+subroutine attach_always()
+    integer, pointer :: x
+
+!CHECK: {{.*}} = omp.map.info{{.*}}map_clauses(tofrom, attach_always){{.*}}
+    !$omp target map(attach(always): x)
+        x = 1
+    !$omp end target
+end
+
+subroutine attach_never()
+    integer, pointer :: x
+
+!CHECK: {{.*}} = omp.map.info{{.*}}map_clauses(tofrom, attach_never){{.*}}
+    !$omp target map(attach(never): x)
+        x = 1
+    !$omp end target
+end
+
+subroutine attach_auto()
+    integer, pointer :: x
+!CHECK: {{.*}} = omp.map.info{{.*}}map_clauses(tofrom, attach_auto){{.*}}
+    !$omp target map(attach(auto): x)
+        x = 1
+    !$omp end target
+end
+
+subroutine ref_ptr_ptee()
+    integer, pointer :: x
+
+!CHECK: {{.*}} = omp.map.info{{.*}}map_clauses(to, ref_ptr_ptee){{.*}}
+    !$omp target map(ref_ptr_ptee, to: x)
+        x = 1
+    !$omp end target
+end
+
+subroutine ref_ptr()
+  integer, pointer :: x
+
+!CHECK: {{.*}} = omp.map.info{{.*}}map_clauses(to, ref_ptr){{.*}}
+    !$omp target map(ref_ptr, to: x)
+        x = 1
+    !$omp end target
+end
+
+subroutine ref_ptee()
+  integer, pointer :: x
+
+!CHECK: {{.*}} = omp.map.info{{.*}}map_clauses(to, ref_ptee){{.*}}
+    !$omp target map(ref_ptee, to: x)
+        x = 1
+    !$omp end target
+end
+
+subroutine ref_ptr_ptee_attach_never()
+    integer, pointer :: x
+
+!CHECK: {{.*}} = omp.map.info{{.*}}map_clauses(to, attach_never, ref_ptr_ptee){{.*}}
+    !$omp target map(attach(never), ref_ptr_ptee, to: x)
+        x = 1
+    !$omp end target
+end


### PR DESCRIPTION
This doesn't implement the functionality, just the relevant map type lowering to MLIR's omp.map.info. The more complicated changes to MapInfoFinalizationPass.cpp and OpenMPTOLLVMIRTranslation.cpp to support attach map and the various ref/attach semantics will come in a subsequent set of PRs. This just helps compartmentalize the changeset.