### PR TITLE
[VPlan] Fix -Wimplicit-fallthrough warning

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -849,7 +849,6 @@ public:
       break;
     case OperationType::ReductionOp:
       llvm_unreachable("reduction ops should not use applyFlags");
-      [[fallthrough]];
     case OperationType::Cmp:
     case OperationType::Other:
       break;


### PR DESCRIPTION
Fixes the following warning seen after https://github.com/llvm/llvm-project/pull/174026

```
llvm/lib/Transforms/Vectorize/VPlan.h:852:7: warning: fallthrough annotation in unreachable code [-Wimplicit-fallthrough]
      [[fallthrough]];
      ^
1 warning generated.
```