### PR TITLE
[Intrinsics]Handle invalid return type gracefully instead of crashing

### DIFF
--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -968,7 +968,7 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     if (VectorType *VTy = dyn_cast<VectorType>(NewTy)) {
       unsigned EltBits =
           VTy->getElementType()->getPrimitiveSizeInBits().getFixedValue();
-      if (EltBits & 1 == 0)
+      if ((EltBits & 1) == 0)
         NewTy = VectorType::getTruncatedElementVectorType(VTy);
     } else if (IntegerType *ITy = dyn_cast<IntegerType>(NewTy))
       NewTy = IntegerType::get(ITy->getContext(), ITy->getBitWidth() / 2);

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -970,8 +970,7 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
           VTy->getElementType()->getPrimitiveSizeInBits().getFixedValue();
       if (EltBits & 1 == 0)
         NewTy = VectorType::getTruncatedElementVectorType(VTy);
-    }
-    else if (IntegerType *ITy = dyn_cast<IntegerType>(NewTy))
+    } else if (IntegerType *ITy = dyn_cast<IntegerType>(NewTy))
       NewTy = IntegerType::get(ITy->getContext(), ITy->getBitWidth() / 2);
     else
       return true;

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -970,6 +970,8 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
           VTy->getElementType()->getPrimitiveSizeInBits().getFixedValue();
       if ((EltBits & 1) == 0)
         NewTy = VectorType::getTruncatedElementVectorType(VTy);
+      else
+        return true;
     } else if (IntegerType *ITy = dyn_cast<IntegerType>(NewTy))
       NewTy = IntegerType::get(ITy->getContext(), ITy->getBitWidth() / 2);
     else

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -965,8 +965,12 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
       return IsDeferredCheck || DeferCheck(Ty);
 
     Type *NewTy = ArgTys[D.getArgumentNumber()];
-    if (VectorType *VTy = dyn_cast<VectorType>(NewTy))
-      NewTy = VectorType::getTruncatedElementVectorType(VTy);
+    if (VectorType *VTy = dyn_cast<VectorType>(NewTy)) {
+      unsigned EltBits =
+          VTy->getElementType()->getPrimitiveSizeInBits().getFixedValue();
+      if (EltBits & 1 == 0)
+        NewTy = VectorType::getTruncatedElementVectorType(VTy);
+    }
     else if (IntegerType *ITy = dyn_cast<IntegerType>(NewTy))
       NewTy = IntegerType::get(ITy->getContext(), ITy->getBitWidth() / 2);
     else

--- a/llvm/test/Verifier/aarch64-invalid-smull.ll
+++ b/llvm/test/Verifier/aarch64-invalid-smull.ll
@@ -1,0 +1,7 @@
+; RUN: not llvm-as %s -o /dev/null 2>&1 | FileCheck %s
+; CHECK: error: invalid intrinsic signature
+
+define <2 x i1> @test(<2 x i32> %b) {
+  %2 = tail call <2 x i1> @llvm.aarch64.neon.smull.v2i1(<2 x i32> %b, <2 x i32> %b)
+  ret <2 x i1> %2
+}


### PR DESCRIPTION
When an invalid return type is passed to llvm.aarch64.neon.smull intrinsic
it must gracefully reject the invalid return type. However for Vector types 
with odd bit-widths this results in a assertion failure as the
getTruncatedElementVectorType() function asserts the bit-width to be only
even using the EltBits & 1 == 0 condition. Add checks to ensure that
getTruncatedElementVectorType() doesn't get called with odd bit-width
vector types.

Fixes #176455 