### PR TITLE
Add control-flow-hub-finalize-same-succ-crash.ll to xfail

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -541,5 +541,6 @@ Transforms/UnifyLoopExits/nested.ll
 Transforms/UnifyLoopExits/restore-ssa.ll
 Transforms/UnifyLoopExits/switch.ll
 Transforms/UnifyLoopExits/undef-phis.ll
+Transforms/Util/control-flow-hub-finalize-same-succ-crash.ll
 Transforms/Util/libcalls-opt-remarks.ll
 Transforms/Util/lowerswitch.ll


### PR DESCRIPTION
Introduced in #176620. It appears to expose a profile propagation issue in FixIrreducible. That pass hasn't yet been addressed.