### PR TITLE
[libc++] Use the fast path for move assignment in __tree if the allocator is_always_equal

### DIFF
--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -998,7 +998,10 @@ public:
                  ((__node_traits::propagate_on_container_move_assignment::value &&
                    is_nothrow_move_assignable<__node_allocator>::value) ||
                   allocator_traits<__node_allocator>::is_always_equal::value)) {
-    __move_assign(__t, integral_constant<bool, __node_traits::propagate_on_container_move_assignment::value>());
+    __move_assign(__t,
+                  integral_constant<bool,
+                                    __node_traits::propagate_on_container_move_assignment::value ||
+                                        __node_traits::is_always_equal::value>());
     return *this;
   }
 


### PR DESCRIPTION
This avoids instantiating some code that we know is dead. This is also a prerequisite for #134330, since we avoid trying to `const_cast` in the common case now.
