### PR TITLE
[libc++] Use views::reverse to implement ranges::reverse_copy

### DIFF
--- a/libcxx/include/__algorithm/ranges_reverse_copy.h
+++ b/libcxx/include/__algorithm/ranges_reverse_copy.h
@@ -18,6 +18,7 @@
 #include <__ranges/access.h>
 #include <__ranges/concepts.h>
 #include <__ranges/dangling.h>
+#include <__ranges/reverse_view.h>
 #include <__ranges/subrange.h>
 #include <__utility/move.h>
 
@@ -49,7 +50,7 @@ struct __reverse_copy {
     requires indirectly_copyable<iterator_t<_Range>, _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr reverse_copy_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __range, _OutIter __result) const {
-    auto __ret = ranges::copy(std::__reverse_range(__range), std::move(__result));
+    auto __ret = ranges::copy(__range | views::reverse, std::move(__result));
     return {ranges::next(ranges::begin(__range), ranges::end(__range)), std::move(__ret.out)};
   }
 };

--- a/libcxx/include/__iterator/reverse_iterator.h
+++ b/libcxx/include/__iterator/reverse_iterator.h
@@ -15,21 +15,13 @@
 #include <__compare/three_way_comparable.h>
 #include <__concepts/convertible_to.h>
 #include <__config>
-#include <__iterator/advance.h>
 #include <__iterator/concepts.h>
 #include <__iterator/incrementable_traits.h>
 #include <__iterator/iter_move.h>
 #include <__iterator/iter_swap.h>
 #include <__iterator/iterator.h>
 #include <__iterator/iterator_traits.h>
-#include <__iterator/next.h>
-#include <__iterator/prev.h>
-#include <__iterator/readable_traits.h>
-#include <__iterator/segmented_iterator.h>
 #include <__memory/addressof.h>
-#include <__ranges/access.h>
-#include <__ranges/concepts.h>
-#include <__ranges/subrange.h>
 #include <__type_traits/conditional.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_assignable.h>
@@ -38,7 +30,6 @@
 #include <__type_traits/is_pointer.h>
 #include <__type_traits/is_same.h>
 #include <__utility/declval.h>
-#include <__utility/move.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -309,16 +300,6 @@ inline constexpr bool disable_sized_sentinel_for<reverse_iterator<_Iter1>, rever
 template <class _Iter>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 reverse_iterator<_Iter> make_reverse_iterator(_Iter __i) {
   return reverse_iterator<_Iter>(__i);
-}
-#endif
-
-#if _LIBCPP_STD_VER >= 20
-template <ranges::bidirectional_range _Range>
-_LIBCPP_HIDE_FROM_ABI constexpr ranges::subrange<reverse_iterator<ranges::iterator_t<_Range>>,
-                                                 reverse_iterator<ranges::iterator_t<_Range>>>
-__reverse_range(_Range&& __range) {
-  auto __first = ranges::begin(__range);
-  return {std::make_reverse_iterator(ranges::next(__first, ranges::end(__range))), std::make_reverse_iterator(__first)};
 }
 #endif
 


### PR DESCRIPTION
We currently have a custom utility `__reverse_range`, which does basically the same thing as `views::reverse` and the only place where we use it is in `ranges::reverse_copy`. Instead of this special utility, we can simply use `views::reverse`.

This has originally been introduced due to compile time concerns. However, there doesn't seem to actually be a significant compile time regression overall.