### PR TITLE
[AArch64][Driver] Enable host supported features with march=native.

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
@@ -35,6 +35,11 @@ std::string aarch64::getAArch64TargetCPU(const ArgList &Args,
   if ((A = Args.getLastArg(options::OPT_mcpu_EQ))) {
     StringRef Mcpu = A->getValue();
     CPU = Mcpu.split("+").first.lower();
+  } else if (const Arg *MArch = Args.getLastArg(options::OPT_march_EQ)) {
+    // Otherwise, use -march=native if specified.
+    StringRef MArchValue = MArch->getValue();
+    if (MArchValue.split("+").first.equals_insensitive("native"))
+      CPU = "native";
   }
 
   CPU = llvm::AArch64::resolveCPUAlias(CPU);

--- a/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/AArch64.cpp
@@ -159,10 +159,11 @@ getAArch64ArchFeaturesFromMarch(const Driver &D, StringRef March,
   std::string MarchLowerCase = March.lower();
   std::pair<StringRef, StringRef> Split = StringRef(MarchLowerCase).split("+");
 
+  if (Split.first == "native")
+    return DecodeAArch64Mcpu(D, MarchLowerCase, Extensions);
+
   const llvm::AArch64::ArchInfo *ArchInfo =
       llvm::AArch64::parseArch(Split.first);
-  if (Split.first == "native")
-    ArchInfo = llvm::AArch64::getArchForCpu(llvm::sys::getHostCPUName().str());
   if (!ArchInfo)
     return false;
 

--- a/clang/test/Driver/aarch64-mcpu-native.c
+++ b/clang/test/Driver/aarch64-mcpu-native.c
@@ -27,6 +27,9 @@
 // CHECK-FEAT-NN1:    FEAT_UAO                                               Enable Armv8.2-A UAO PState
 // CHECK-FEAT-NN1:    FEAT_VHE                                               Enable Armv8.1-A Virtual Host extension
 
+// RUN: %clang --target=aarch64 -mcpu=native -### -c %s 2>&1 | FileCheck -check-prefix=NEOVERSE-N1 %s
+// RUN: %clang --target=aarch64 -march=native -### -c %s 2>&1 | FileCheck -check-prefix=NEOVERSE-N1 %s
+// NEOVERSE-N1: "-cc1"{{.*}} "-triple" "aarch64{{.*}}" "-target-cpu" "neoverse-n1"
 
 // RUN: export LLVM_CPUINFO=%S/Inputs/cpunative/cortex-a57
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace --check-prefix=CHECK-FEAT-CA57 --implicit-check-not=FEAT_ %s
@@ -39,6 +42,10 @@
 // CHECK-FEAT-CA57:    FEAT_CRC32                                             Enable Armv8.0-A CRC-32 checksum instructions
 // CHECK-FEAT-CA57:    FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-FEAT-CA57:    FEAT_PMUv3                                             Enable Armv8.0-A PMUv3 Performance Monitors extension
+
+// RUN: %clang --target=aarch64 -mcpu=native -### -c %s 2>&1 | FileCheck -check-prefix=CORTEX-A57 %s
+// RUN: %clang --target=aarch64 -march=native -### -c %s 2>&1 | FileCheck -check-prefix=CORTEX-A57 %s
+// CORTEX-A57: "-cc1"{{.*}} "-triple" "aarch64{{.*}}" "-target-cpu" "cortex-a57"
 
 // RUN: export LLVM_CPUINFO=%S/Inputs/cpunative/cortex-a72
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace  --check-prefix=CHECK-FEAT-CA72 --implicit-check-not=FEAT_ %s
@@ -53,6 +60,10 @@
 // CHECK-FEAT-CA72:    FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-FEAT-CA72:    FEAT_PMUv3                                             Enable Armv8.0-A PMUv3 Performance Monitors extension
 // CHECK-FEAT-CA72:    FEAT_SHA1, FEAT_SHA256                                 Enable SHA1 and SHA256 support
+
+// RUN: %clang --target=aarch64 -mcpu=native -### -c %s 2>&1 | FileCheck -check-prefix=CORTEX-A72 %s
+// RUN: %clang --target=aarch64 -march=native -### -c %s 2>&1 | FileCheck -check-prefix=CORTEX-A72 %s
+// CORTEX-A72: "-cc1"{{.*}} "-triple" "aarch64{{.*}}" "-target-cpu" "cortex-a72"
 
 // RUN: export LLVM_CPUINFO=%S/Inputs/cpunative/cortex-a76
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace --check-prefix=CHECK-FEAT-CA76 --implicit-check-not=FEAT_ %s
@@ -80,3 +91,7 @@
 // CHECK-FEAT-CA76:    FEAT_SSBS, FEAT_SSBS2                                  Enable Speculative Store Bypass Safe bit
 // CHECK-FEAT-CA76:    FEAT_UAO                                               Enable Armv8.2-A UAO PState
 // CHECK-FEAT-CA76:    FEAT_VHE                                               Enable Armv8.1-A Virtual Host extension
+
+// RUN: %clang --target=aarch64 -mcpu=native -### -c %s 2>&1 | FileCheck -check-prefix=CORTEX-A76 %s
+// RUN: %clang --target=aarch64 -march=native -### -c %s 2>&1 | FileCheck -check-prefix=CORTEX-A76 %s
+// CORTEX-A76: "-cc1"{{.*}} "-triple" "aarch64{{.*}}" "-target-cpu" "cortex-a76"

--- a/clang/test/Driver/aarch64-mcpu-native.c
+++ b/clang/test/Driver/aarch64-mcpu-native.c
@@ -1,7 +1,7 @@
 // REQUIRES: aarch64-registered-target,system-linux,aarch64-host
 // RUN: export LLVM_CPUINFO=%S/Inputs/cpunative/neoverse-n1
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace --check-prefix=CHECK-FEAT-NN1 --implicit-check-not=FEAT_ %s
-// RUN: %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace --check-prefixes=CHECK-FEAT-NN1,CHECK-GENERIC-NN1 --implicit-check-not=FEAT_ %s
+// RUN: %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace --check-prefix=CHECK-FEAT-NN1 --implicit-check-not=FEAT_ %s
 
 // CHECK-FEAT-NN1: Extensions enabled for the given AArch64 target
 // CHECK-FEAT-NN1-EMPTY:
@@ -11,7 +11,6 @@
 // CHECK-FEAT-NN1:    FEAT_CRC32                                             Enable Armv8.0-A CRC-32 checksum instructions
 // CHECK-FEAT-NN1:    FEAT_DPB                                               Enable Armv8.2-A data Cache Clean to Point of Persistence
 // CHECK-FEAT-NN1:    FEAT_DotProd                                           Enable dot product support
-// CHECK-GENERIC-NN1: FEAT_ETE                                               Enable Embedded Trace Extension
 // CHECK-FEAT-NN1:    FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-FEAT-NN1:    FEAT_FP16                                              Enable half-precision floating-point data processing
 // CHECK-FEAT-NN1:    FEAT_LOR                                               Enable Armv8.1-A Limited Ordering Regions extension
@@ -25,28 +24,25 @@
 // CHECK-FEAT-NN1:    FEAT_SHA1, FEAT_SHA256                                 Enable SHA1 and SHA256 support
 // CHECK-FEAT-NN1:    FEAT_SPE                                               Enable Statistical Profiling extension
 // CHECK-FEAT-NN1:    FEAT_SSBS, FEAT_SSBS2                                  Enable Speculative Store Bypass Safe bit
-// CHECK-GENERIC-NN1: FEAT_TRBE                                              Enable Trace Buffer Extension
 // CHECK-FEAT-NN1:    FEAT_UAO                                               Enable Armv8.2-A UAO PState
 // CHECK-FEAT-NN1:    FEAT_VHE                                               Enable Armv8.1-A Virtual Host extension
 
 
 // RUN: export LLVM_CPUINFO=%S/Inputs/cpunative/cortex-a57
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace --check-prefix=CHECK-FEAT-CA57 --implicit-check-not=FEAT_ %s
-// RUN: %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace --check-prefixes=CHECK-FEAT-CA57,CHECK-GENERIC-CA57 --implicit-check-not=FEAT_ %s
+// RUN: %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace --check-prefix=CHECK-FEAT-CA57 --implicit-check-not=FEAT_ %s
 
 // CHECK-FEAT-CA57: Extensions enabled for the given AArch64 target
 // CHECK-FEAT-CA57-EMPTY:
 // CHECK-FEAT-CA57:    Architecture Feature(s)                                Description
 // CHECK-FEAT-CA57:    FEAT_AdvSIMD                                           Enable Advanced SIMD instructions
 // CHECK-FEAT-CA57:    FEAT_CRC32                                             Enable Armv8.0-A CRC-32 checksum instructions
-// CHECK-GENERIC-CA57: FEAT_ETE                                               Enable Embedded Trace Extension
 // CHECK-FEAT-CA57:    FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-FEAT-CA57:    FEAT_PMUv3                                             Enable Armv8.0-A PMUv3 Performance Monitors extension
-// CHECK-GENERIC-CA57: FEAT_TRBE                                              Enable Trace Buffer Extension
 
 // RUN: export LLVM_CPUINFO=%S/Inputs/cpunative/cortex-a72
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace  --check-prefix=CHECK-FEAT-CA72 --implicit-check-not=FEAT_ %s
-// RUN: %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace  --check-prefixes=CHECK-FEAT-CA72,CHECK-GENERIC-CA72 --implicit-check-not=FEAT_ %s
+// RUN: %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace  --check-prefix=CHECK-FEAT-CA72 --implicit-check-not=FEAT_ %s
 
 // CHECK-FEAT-CA72: Extensions enabled for the given AArch64 target
 // CHECK-EMPTY:
@@ -54,15 +50,13 @@
 // CHECK-FEAT-CA72:    FEAT_AES, FEAT_PMULL                                   Enable AES support
 // CHECK-FEAT-CA72:    FEAT_AdvSIMD                                           Enable Advanced SIMD instructions
 // CHECK-FEAT-CA72:    FEAT_CRC32                                             Enable Armv8.0-A CRC-32 checksum instructions
-// CHECK-GENERIC-CA72: FEAT_ETE                                               Enable Embedded Trace Extension
 // CHECK-FEAT-CA72:    FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-FEAT-CA72:    FEAT_PMUv3                                             Enable Armv8.0-A PMUv3 Performance Monitors extension
 // CHECK-FEAT-CA72:    FEAT_SHA1, FEAT_SHA256                                 Enable SHA1 and SHA256 support
-// CHECK-GENERIC-CA72: FEAT_TRBE                                              Enable Trace Buffer Extension
 
 // RUN: export LLVM_CPUINFO=%S/Inputs/cpunative/cortex-a76
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace --check-prefix=CHECK-FEAT-CA76 --implicit-check-not=FEAT_ %s
-// RUN: %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace --check-prefixes=CHECK-FEAT-CA76,CHECK-GENERIC-CA76 --implicit-check-not=FEAT_ %s
+// RUN: %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace --check-prefix=CHECK-FEAT-CA76 --implicit-check-not=FEAT_ %s
 
 // CHECK-FEAT-CA76: Extensions enabled for the given AArch64 target
 // CHECK-FEAT-CA76-EMPTY:
@@ -72,7 +66,6 @@
 // CHECK-FEAT-CA76:    FEAT_CRC32                                             Enable Armv8.0-A CRC-32 checksum instructions
 // CHECK-FEAT-CA76:    FEAT_DPB                                               Enable Armv8.2-A data Cache Clean to Point of Persistence
 // CHECK-FEAT-CA76:    FEAT_DotProd                                           Enable dot product support
-// CHECK-GENERIC-CA76: FEAT_ETE                                               Enable Embedded Trace Extension
 // CHECK-FEAT-CA76:    FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-FEAT-CA76:    FEAT_FP16                                              Enable half-precision floating-point data processing
 // CHECK-FEAT-CA76:    FEAT_LOR                                               Enable Armv8.1-A Limited Ordering Regions extension
@@ -85,6 +78,5 @@
 // CHECK-FEAT-CA76:    FEAT_RDM                                               Enable Armv8.1-A Rounding Double Multiply Add/Subtract instructions
 // CHECK-FEAT-CA76:    FEAT_SHA1, FEAT_SHA256                                 Enable SHA1 and SHA256 support
 // CHECK-FEAT-CA76:    FEAT_SSBS, FEAT_SSBS2                                  Enable Speculative Store Bypass Safe bit
-// CHECK-GENERIC-CA76: FEAT_TRBE                                              Enable Trace Buffer Extension
 // CHECK-FEAT-CA76:    FEAT_UAO                                               Enable Armv8.2-A UAO PState
 // CHECK-FEAT-CA76:    FEAT_VHE                                               Enable Armv8.1-A Virtual Host extension

--- a/clang/test/Driver/aarch64-mcpu-native.c
+++ b/clang/test/Driver/aarch64-mcpu-native.c
@@ -1,6 +1,7 @@
 // REQUIRES: aarch64-registered-target,system-linux,aarch64-host
 // RUN: export LLVM_CPUINFO=%S/Inputs/cpunative/neoverse-n1
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace --check-prefix=CHECK-FEAT-NN1 --implicit-check-not=FEAT_ %s
+// RUN: %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace --check-prefixes=CHECK-FEAT-NN1,CHECK-GENERIC-NN1 --implicit-check-not=FEAT_ %s
 
 // CHECK-FEAT-NN1: Extensions enabled for the given AArch64 target
 // CHECK-FEAT-NN1-EMPTY:
@@ -10,6 +11,7 @@
 // CHECK-FEAT-NN1:    FEAT_CRC32                                             Enable Armv8.0-A CRC-32 checksum instructions
 // CHECK-FEAT-NN1:    FEAT_DPB                                               Enable Armv8.2-A data Cache Clean to Point of Persistence
 // CHECK-FEAT-NN1:    FEAT_DotProd                                           Enable dot product support
+// CHECK-GENERIC-NN1: FEAT_ETE                                               Enable Embedded Trace Extension
 // CHECK-FEAT-NN1:    FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-FEAT-NN1:    FEAT_FP16                                              Enable half-precision floating-point data processing
 // CHECK-FEAT-NN1:    FEAT_LOR                                               Enable Armv8.1-A Limited Ordering Regions extension
@@ -23,23 +25,28 @@
 // CHECK-FEAT-NN1:    FEAT_SHA1, FEAT_SHA256                                 Enable SHA1 and SHA256 support
 // CHECK-FEAT-NN1:    FEAT_SPE                                               Enable Statistical Profiling extension
 // CHECK-FEAT-NN1:    FEAT_SSBS, FEAT_SSBS2                                  Enable Speculative Store Bypass Safe bit
+// CHECK-GENERIC-NN1: FEAT_TRBE                                              Enable Trace Buffer Extension
 // CHECK-FEAT-NN1:    FEAT_UAO                                               Enable Armv8.2-A UAO PState
 // CHECK-FEAT-NN1:    FEAT_VHE                                               Enable Armv8.1-A Virtual Host extension
 
 
 // RUN: export LLVM_CPUINFO=%S/Inputs/cpunative/cortex-a57
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace --check-prefix=CHECK-FEAT-CA57 --implicit-check-not=FEAT_ %s
+// RUN: %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace --check-prefixes=CHECK-FEAT-CA57,CHECK-GENERIC-CA57 --implicit-check-not=FEAT_ %s
 
 // CHECK-FEAT-CA57: Extensions enabled for the given AArch64 target
 // CHECK-FEAT-CA57-EMPTY:
 // CHECK-FEAT-CA57:    Architecture Feature(s)                                Description
 // CHECK-FEAT-CA57:    FEAT_AdvSIMD                                           Enable Advanced SIMD instructions
 // CHECK-FEAT-CA57:    FEAT_CRC32                                             Enable Armv8.0-A CRC-32 checksum instructions
+// CHECK-GENERIC-CA57: FEAT_ETE                                               Enable Embedded Trace Extension
 // CHECK-FEAT-CA57:    FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-FEAT-CA57:    FEAT_PMUv3                                             Enable Armv8.0-A PMUv3 Performance Monitors extension
+// CHECK-GENERIC-CA57: FEAT_TRBE                                              Enable Trace Buffer Extension
 
 // RUN: export LLVM_CPUINFO=%S/Inputs/cpunative/cortex-a72
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace  --check-prefix=CHECK-FEAT-CA72 --implicit-check-not=FEAT_ %s
+// RUN: %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace  --check-prefixes=CHECK-FEAT-CA72,CHECK-GENERIC-CA72 --implicit-check-not=FEAT_ %s
 
 // CHECK-FEAT-CA72: Extensions enabled for the given AArch64 target
 // CHECK-EMPTY:
@@ -47,12 +54,15 @@
 // CHECK-FEAT-CA72:    FEAT_AES, FEAT_PMULL                                   Enable AES support
 // CHECK-FEAT-CA72:    FEAT_AdvSIMD                                           Enable Advanced SIMD instructions
 // CHECK-FEAT-CA72:    FEAT_CRC32                                             Enable Armv8.0-A CRC-32 checksum instructions
+// CHECK-GENERIC-CA72: FEAT_ETE                                               Enable Embedded Trace Extension
 // CHECK-FEAT-CA72:    FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-FEAT-CA72:    FEAT_PMUv3                                             Enable Armv8.0-A PMUv3 Performance Monitors extension
 // CHECK-FEAT-CA72:    FEAT_SHA1, FEAT_SHA256                                 Enable SHA1 and SHA256 support
+// CHECK-GENERIC-CA72: FEAT_TRBE                                              Enable Trace Buffer Extension
 
 // RUN: export LLVM_CPUINFO=%S/Inputs/cpunative/cortex-a76
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace --check-prefix=CHECK-FEAT-CA76 --implicit-check-not=FEAT_ %s
+// RUN: %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace --check-prefixes=CHECK-FEAT-CA76,CHECK-GENERIC-CA76 --implicit-check-not=FEAT_ %s
 
 // CHECK-FEAT-CA76: Extensions enabled for the given AArch64 target
 // CHECK-FEAT-CA76-EMPTY:
@@ -62,6 +72,7 @@
 // CHECK-FEAT-CA76:    FEAT_CRC32                                             Enable Armv8.0-A CRC-32 checksum instructions
 // CHECK-FEAT-CA76:    FEAT_DPB                                               Enable Armv8.2-A data Cache Clean to Point of Persistence
 // CHECK-FEAT-CA76:    FEAT_DotProd                                           Enable dot product support
+// CHECK-GENERIC-CA76: FEAT_ETE                                               Enable Embedded Trace Extension
 // CHECK-FEAT-CA76:    FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-FEAT-CA76:    FEAT_FP16                                              Enable half-precision floating-point data processing
 // CHECK-FEAT-CA76:    FEAT_LOR                                               Enable Armv8.1-A Limited Ordering Regions extension
@@ -74,5 +85,6 @@
 // CHECK-FEAT-CA76:    FEAT_RDM                                               Enable Armv8.1-A Rounding Double Multiply Add/Subtract instructions
 // CHECK-FEAT-CA76:    FEAT_SHA1, FEAT_SHA256                                 Enable SHA1 and SHA256 support
 // CHECK-FEAT-CA76:    FEAT_SSBS, FEAT_SSBS2                                  Enable Speculative Store Bypass Safe bit
+// CHECK-GENERIC-CA76: FEAT_TRBE                                              Enable Trace Buffer Extension
 // CHECK-FEAT-CA76:    FEAT_UAO                                               Enable Armv8.2-A UAO PState
 // CHECK-FEAT-CA76:    FEAT_VHE                                               Enable Armv8.1-A Virtual Host extension

--- a/clang/test/Driver/print-enabled-extensions/aarch64-grace.c
+++ b/clang/test/Driver/print-enabled-extensions/aarch64-grace.c
@@ -62,3 +62,7 @@
 // CHECK-NEXT:     FEAT_TRF                                               Enable Armv8.4-A Trace extension
 // CHECK-NEXT:     FEAT_UAO                                               Enable Armv8.2-A UAO PState
 // CHECK-NEXT:     FEAT_VHE                                               Enable Armv8.1-A Virtual Host extension
+
+// RUN: env LLVM_CPUINFO=%S/../Inputs/cpunative/grace %clang --target=aarch64 -mcpu=native -### -c %s 2>&1 | FileCheck -check-prefix=NEOVERSE-V2 %s
+// RUN: env LLVM_CPUINFO=%S/../Inputs/cpunative/grace %clang --target=aarch64 -march=native -### -c %s 2>&1 | FileCheck -check-prefix=NEOVERSE-V2 %s
+// NEOVERSE-V2: "-cc1"{{.*}} "-triple" "aarch64{{.*}}" "-target-cpu" "neoverse-v2"

--- a/clang/test/Driver/print-enabled-extensions/aarch64-grace.c
+++ b/clang/test/Driver/print-enabled-extensions/aarch64-grace.c
@@ -1,6 +1,7 @@
 // REQUIRES: aarch64-registered-target,aarch64-host,system-linux
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=grace | FileCheck --strict-whitespace --implicit-check-not=FEAT_ %s
 // RUN: env LLVM_CPUINFO=%S/../Inputs/cpunative/grace %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace --implicit-check-not=FEAT_ %s
+// RUN: env LLVM_CPUINFO=%S/../Inputs/cpunative/grace %clang --target=aarch64 --print-enabled-extensions -march=native | FileCheck --strict-whitespace --implicit-check-not=FEAT_ %s
 
 // CHECK: Extensions enabled for the given AArch64 target
 // CHECK-EMPTY:


### PR DESCRIPTION
Currently, march=native enables the base features implied by the host system architecture, such as Armv8.2-A, Armv9-A, etc, rather than the actual features supported by the host (e.g. crypto). This is suboptimal as it generally leaves optional but supported features disabled.

This patch aligns the behaviour of march=native with mcpu=native by using the latter's decoding logic to decode the former as well. This means both options should enable a similar set of features. We also set the target-cpu accordingly, so that march=native becomes a drop-in replacement for mcpu=native.