### PR TITLE
[CoroFrame][NFC] Reduce insertSpills size through a helper function

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -979,6 +979,52 @@ static StructType *buildFrameType(Function &F, coro::Shape &Shape,
   return FrameTy;
 }
 
+/// Returns a GEP into the coroutine frame at the offset where Orig is located.
+static Value *createGEPToFramePointer(const FrameDataInfo &FrameData,
+                                      IRBuilder<> &Builder, coro::Shape &Shape,
+                                      Value *Orig) {
+  LLVMContext &Ctx = Shape.CoroBegin->getContext();
+  FieldIDType Index = FrameData.getFieldIndex(Orig);
+  SmallVector<Value *, 3> Indices = {
+      ConstantInt::get(Type::getInt32Ty(Ctx), 0),
+      ConstantInt::get(Type::getInt32Ty(Ctx), Index),
+  };
+
+  // If Orig is an array alloca, preserve the original type by adding an extra
+  // zero offset.
+  if (auto *AI = dyn_cast<AllocaInst>(Orig)) {
+    if (ConstantInt *CI = dyn_cast<ConstantInt>(AI->getArraySize())) {
+      auto Count = CI->getValue().getZExtValue();
+      if (Count > 1)
+        Indices.push_back(ConstantInt::get(Type::getInt32Ty(Ctx), 0));
+    } else {
+      report_fatal_error("Coroutines cannot handle non static allocas yet");
+    }
+  }
+
+  auto *GEP = Builder.CreateInBoundsGEP(Shape.FrameTy, Shape.FramePtr, Indices);
+  if (auto *AI = dyn_cast<AllocaInst>(Orig)) {
+    if (FrameData.getDynamicAlign(Orig) != 0) {
+      assert(FrameData.getDynamicAlign(Orig) == AI->getAlign().value());
+      auto *M = AI->getModule();
+      auto *IntPtrTy = M->getDataLayout().getIntPtrType(AI->getType());
+      auto *PtrValue = Builder.CreatePtrToInt(GEP, IntPtrTy);
+      auto *AlignMask = ConstantInt::get(IntPtrTy, AI->getAlign().value() - 1);
+      PtrValue = Builder.CreateAdd(PtrValue, AlignMask);
+      PtrValue = Builder.CreateAnd(PtrValue, Builder.CreateNot(AlignMask));
+      return Builder.CreateIntToPtr(PtrValue, AI->getType());
+    }
+    // If the type of GEP is not equal to the type of AllocaInst, it implies
+    // that the AllocaInst may be reused in the Frame slot of other AllocaInst.
+    // Note: If the strategy dealing with alignment changes, this cast must be
+    // refined
+    if (GEP->getType() != Orig->getType())
+      GEP = Builder.CreateAddrSpaceCast(GEP, Orig->getType(),
+                                        Orig->getName() + Twine(".cast"));
+  }
+  return GEP;
+}
+
 // Replace all alloca and SSA values that are accessed across suspend points
 // with GetElementPointer from coroutine frame + loads and stores. Create an
 // AllocaSpillBB that will become the new entry block for the resume parts of
@@ -1008,55 +1054,6 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
   Value *FramePtr = Shape.FramePtr;
   DominatorTree DT(*F);
   SmallDenseMap<Argument *, AllocaInst *, 4> ArgToAllocaMap;
-
-  // Create a GEP with the given index into the coroutine frame for the original
-  // value Orig. Appends an extra 0 index for array-allocas, preserving the
-  // original type.
-  auto GetFramePointer = [&](Value *Orig) -> Value * {
-    FieldIDType Index = FrameData.getFieldIndex(Orig);
-    SmallVector<Value *, 3> Indices = {
-        ConstantInt::get(Type::getInt32Ty(C), 0),
-        ConstantInt::get(Type::getInt32Ty(C), Index),
-    };
-
-    if (auto *AI = dyn_cast<AllocaInst>(Orig)) {
-      if (auto *CI = dyn_cast<ConstantInt>(AI->getArraySize())) {
-        auto Count = CI->getValue().getZExtValue();
-        if (Count > 1) {
-          Indices.push_back(ConstantInt::get(Type::getInt32Ty(C), 0));
-        }
-      } else {
-        report_fatal_error("Coroutines cannot handle non static allocas yet");
-      }
-    }
-
-    auto GEP = cast<GetElementPtrInst>(
-        Builder.CreateInBoundsGEP(FrameTy, FramePtr, Indices));
-    if (auto *AI = dyn_cast<AllocaInst>(Orig)) {
-      if (FrameData.getDynamicAlign(Orig) != 0) {
-        assert(FrameData.getDynamicAlign(Orig) == AI->getAlign().value());
-        auto *M = AI->getModule();
-        auto *IntPtrTy = M->getDataLayout().getIntPtrType(AI->getType());
-        auto *PtrValue = Builder.CreatePtrToInt(GEP, IntPtrTy);
-        auto *AlignMask =
-            ConstantInt::get(IntPtrTy, AI->getAlign().value() - 1);
-        PtrValue = Builder.CreateAdd(PtrValue, AlignMask);
-        PtrValue = Builder.CreateAnd(PtrValue, Builder.CreateNot(AlignMask));
-        return Builder.CreateIntToPtr(PtrValue, AI->getType());
-      }
-      // If the type of GEP is not equal to the type of AllocaInst, it implies
-      // that the AllocaInst may be reused in the Frame slot of other
-      // AllocaInst. So We cast GEP to the AllocaInst here to re-use
-      // the Frame storage.
-      //
-      // Note: If we change the strategy dealing with alignment, we need to refine
-      // this casting.
-      if (GEP->getType() != Orig->getType())
-        return Builder.CreateAddrSpaceCast(GEP, Orig->getType(),
-                                           Orig->getName() + Twine(".cast"));
-    }
-    return GEP;
-  };
 
   for (auto const &E : FrameData.Spills) {
     Value *Def = E.first;
@@ -1099,7 +1096,7 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
         Builder.SetInsertPoint(CurrentBlock,
                                CurrentBlock->getFirstInsertionPt());
 
-        auto *GEP = GetFramePointer(E.first);
+        auto *GEP = createGEPToFramePointer(FrameData, Builder, Shape, E.first);
         GEP->setName(E.first->getName() + Twine(".reload.addr"));
         if (ByValTy)
           CurrentReload = GEP;
@@ -1220,7 +1217,7 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
     Builder.SetInsertPoint(SpillBlock, SpillBlock->begin());
     for (const auto &P : FrameData.Allocas) {
       AllocaInst *Alloca = P.Alloca;
-      auto *G = GetFramePointer(Alloca);
+      auto *G = createGEPToFramePointer(FrameData, Builder, Shape, Alloca);
 
       // Remove any lifetime intrinsics, now that these are no longer allocas.
       for (User *U : make_early_inc_range(Alloca->users())) {
@@ -1262,7 +1259,7 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
 
     if (UsersToUpdate.empty())
       continue;
-    auto *G = GetFramePointer(Alloca);
+    auto *G = createGEPToFramePointer(FrameData, Builder, Shape, Alloca);
     G->setName(Alloca->getName() + Twine(".reload.addr"));
 
     SmallVector<DbgVariableRecord *> DbgVariableRecords;
@@ -1282,7 +1279,7 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
         report_fatal_error(
             "Coroutines cannot handle copying of array allocas yet");
 
-      auto *G = GetFramePointer(Alloca);
+      auto *G = createGEPToFramePointer(FrameData, Builder, Shape, Alloca);
       auto *Value = Builder.CreateLoad(Alloca->getAllocatedType(), Alloca);
       Builder.CreateStore(Value, G);
     }
@@ -1290,7 +1287,8 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
     // CoroBegin, we recreate them after CoroBegin by applying the offset
     // to the pointer in the frame.
     for (const auto &Alias : A.Aliases) {
-      auto *FramePtr = GetFramePointer(Alloca);
+      auto *FramePtr =
+          createGEPToFramePointer(FrameData, Builder, Shape, Alloca);
       auto &Value = *Alias.second;
       auto ITy = IntegerType::get(C, Value.getBitWidth());
       auto *AliasPtr =
@@ -1335,7 +1333,7 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
     });
     if (HasAccessingPromiseBeforeCB) {
       Builder.SetInsertPoint(&*Shape.getInsertPtAfterFramePtr());
-      auto *G = GetFramePointer(PA);
+      auto *G = createGEPToFramePointer(FrameData, Builder, Shape, PA);
       auto *Value = Builder.CreateLoad(PA->getAllocatedType(), PA);
       Builder.CreateStore(Value, G);
     }


### PR DESCRIPTION
This function can be pretty difficult to follow due to its size and how much work it does. This commit moves a lambda capturing a lot of state into a self-contained function.

It will allow subsequent patches to simplify code and delete variables.