### PR TITLE
[llvm][StringExtras][NFC] Use correct \endcode doxygen command

### DIFF
--- a/llvm/include/llvm/ADT/StringExtras.h
+++ b/llvm/include/llvm/ADT/StringExtras.h
@@ -520,7 +520,7 @@ inline std::string join_items(Sep Separator, Args &&... Items) {
 ///   ListSeparator LS;
 ///   for (auto &I : C)
 ///     OS << LS << I.getName();
-/// \end
+/// \endcode
 class ListSeparator {
   bool First = true;
   StringRef Separator;
@@ -602,9 +602,9 @@ public:
 /// \code
 ///   for (StringRef x : llvm::split("foo,bar,baz", ","))
 ///     ...;
-/// \end
+/// \endcode
 ///
-/// Note that the passed string must remain valid throuhgout lifetime
+/// Note that the passed string must remain valid throughout lifetime
 /// of the iterators.
 inline iterator_range<SplittingIterator> split(StringRef Str, StringRef Separator) {
   return {SplittingIterator(Str, Separator),


### PR DESCRIPTION
`\end` is wrong and shows up in the generated documentation.