### PR TITLE
[NFC][clang] Mark P3034R1 as implemented

### DIFF
--- a/clang/www/cxx_status.html
+++ b/clang/www/cxx_status.html
@@ -182,7 +182,7 @@ C++23, informally referred to as C++26.</p>
  <tr>
   <td>Module Declarations Shouldn’t be Macros</td>
   <td><a href="https://wg21.link/P3034R1">P3034R1</a> (<a href="#dr">DR</a>)</td>
-  <td class="none" align="center">No</td>
+  <td class="unreleased" align="center">Clang 23</td>
  </tr>
  <tr>
   <td>Trivial infinite loops are not Undefined Behavior</td>


### PR DESCRIPTION
Mark [P1857R3 Modules Dependency Discovery](https://wg21.link/p1857r3) as implemented.
This paper was implemented in https://github.com/llvm/llvm-project/pull/173789.