### PR TITLE
[lldb-dap] Fix the completion provided to the DAP client.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
+++ b/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
@@ -30,7 +30,7 @@ class CompletionItem:
         return replace(self, **kwargs)
 
 
-@dataclass
+@dataclass(frozen=True)
 class TestCase:
     input: str
     expected: set[CompletionItem]

--- a/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
+++ b/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
@@ -120,10 +120,10 @@ class TestDAP_completions(lldbdap_testcase.DAPTestCaseBase):
         )
 
         # complete the command
-        self.verify_completions(TestCase(input=part, expected={expected_item.clone()}))
+        self.verify_completions(TestCase(input=part, expected={expected_item}))
         # complete the help
         self.verify_completions(
-            TestCase(input=f"help {part}", expected={expected_item.clone()})
+            TestCase(input=f"help {part}", expected={expected_item})
         )
 
         # remove the alias
@@ -186,11 +186,7 @@ class TestDAP_completions(lldbdap_testcase.DAPTestCaseBase):
         self.verify_completions(
             TestCase(
                 input="`",
-                expected={
-                    session_completion.clone(),
-                    settings_completion.clone(),
-                    memory_completion.clone(),
-                },
+                expected={session_completion, settings_completion, memory_completion},
             )
         )
 
@@ -225,8 +221,8 @@ class TestDAP_completions(lldbdap_testcase.DAPTestCaseBase):
         self.verify_completions(
             TestCase(
                 input="var",
-                expected={command_var_completion.clone()},
-                not_expected={variable_var_completion.clone()},
+                expected={command_var_completion},
+                not_expected={variable_var_completion},
             )
         )
 
@@ -261,8 +257,8 @@ class TestDAP_completions(lldbdap_testcase.DAPTestCaseBase):
         self.verify_completions(
             TestCase(
                 input="var",
-                expected={variable_var_completion.clone()},
-                not_expected={command_var_completion.clone()},
+                expected={variable_var_completion},
+                not_expected={command_var_completion},
             )
         )
 

--- a/lldb/tools/lldb-dap/Handler/CompletionsHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/CompletionsHandler.cpp
@@ -79,9 +79,9 @@ static size_t GetPartialTokenCodeUnits(StringRef line, size_t cursor_pos) {
 
   const size_t byte_offset = (idx == StringRef::npos) ? 0 : idx + 1;
   const StringRef byte_token = line.substr(byte_offset);
-  llvm::SmallVector<UTF16, 20> utf16_token;
+  SmallVector<UTF16, 20> utf16_token;
 
-  if (llvm::convertUTF8ToUTF16String(byte_token, utf16_token))
+  if (convertUTF8ToUTF16String(byte_token, utf16_token))
     return utf16_token.size();
   return byte_token.size(); // fallback to back to byte offset.
 }

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
@@ -168,24 +168,24 @@ struct CompletionItem {
   /// whether it is 0- or 1-based. If the start position is omitted the text
   /// is added at the location specified by the `column` attribute of the
   /// `completions` request.
-  int64_t start = 0;
+  uint64_t start = 0;
 
   /// Length determines how many characters are overwritten by the completion
   /// text and it is measured in UTF-16 code units. If missing the value 0 is
   /// assumed which results in the completion text being inserted.
-  int64_t length = 0;
+  uint64_t length = 0;
 
   /// Determines the start of the new selection after the text has been
   /// inserted (or replaced). `selectionStart` is measured in UTF-16 code
   /// units and must be in the range 0 and length of the completion text. If
   /// omitted the selection starts at the end of the completion text.
-  int64_t selectionStart = 0;
+  uint64_t selectionStart = 0;
 
   /// Determines the length of the new selection after the text has been
   /// inserted (or replaced) and it is measured in UTF-16 code units. The
   /// selection can not extend beyond the bounds of the completion text. If
   /// omitted the length is assumed to be 0.
-  int64_t selectionLength = 0;
+  uint64_t selectionLength = 0;
 };
 bool fromJSON(const llvm::json::Value &, CompletionItem &, llvm::json::Path);
 llvm::json::Value toJSON(const CompletionItem &);


### PR DESCRIPTION
Previously, completion behavior was inconsistent,
sometimes including the partial token or removing existing user text. Since LLDB completions includes the partial token by default, we now strip it before sending to the client.

The completion heuristic:
1. Strip the commandEscapePrefix
2. Request completions from the debugger
3. Get the line at cursor position
4. Calculate the length of any partial token
5. Offset each completion by the partial token length

In all cases, the completion starts from the cursor position. then offsets by `Length` to the left and inserts the completion.

Examples (single quotes show whitespace and are not part of the input):
```md
| Input      | Partial Token | Length | Completion    |
|------------|---------------|--------|---------------|
| m          | m             | 1      | memory        |
| `m         | m             | 1      | memory        |
| myfoo.     | myfoo.        | 6      | myfoo.method( |
| myfoo.fi   | myfoo.fi      | 7      | myfoo.field   |
| myfoo. b   | b             | 1      | myfoo. bar    |
| 'memory '  |               | 0      | memory read   |
| memory     | memory        | 6      | memory        |
| settings s | s             | 1      | settings show |
```

Fixes #176424