### PR TITLE
[llvm-ir2vec] adding function-embedding map API to ir2vec python bindings

### DIFF
--- a/llvm/test/tools/llvm-ir2vec/Inputs/input.ll
+++ b/llvm/test/tools/llvm-ir2vec/Inputs/input.ll
@@ -3,3 +3,27 @@ entry:
   %sum = add i32 %a, %b
   ret i32 %sum
 }
+
+define i32 @multiply(i32 %x, i32 %y) {
+entry:
+  %prod = mul i32 %x, %y
+  ret i32 %prod
+}
+
+define i32 @conditional(i32 %n) {
+entry:
+  %cmp = icmp sgt i32 %n, 0
+  br i1 %cmp, label %positive, label %negative
+
+positive:
+  %pos_val = add i32 %n, 10
+  br label %exit
+
+negative:
+  %neg_val = sub i32 %n, 10
+  br label %exit
+
+exit:
+  %result = phi i32 [ %pos_val, %positive ], [ %neg_val, %negative ]
+  ret i32 %result
+}

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
@@ -12,5 +12,22 @@ if tool is not None:
     print("SUCCESS: Tool initialized")
     print(f"Tool type: {type(tool).__name__}")
 
+    # Test getFuncEmbMap
+    func_emb_map = tool.getFuncEmbMap()
+    print(f"Number of functions: {len(func_emb_map)}")
+
+    # Check that all three functions are present
+    expected_funcs = ["add", "multiply", "conditional"]
+    for func_name in expected_funcs:
+        if func_name in func_emb_map:
+            emb = func_emb_map[func_name]
+            print(f"Function '{func_name}': embedding shape = {emb.shape}")
+        else:
+            print(f"ERROR: Function '{func_name}' not found")
+
 # CHECK: SUCCESS: Tool initialized
 # CHECK: Tool type: IR2VecTool
+# CHECK: Number of functions: 3
+# CHECK: Function 'add': embedding shape =
+# CHECK: Function 'multiply': embedding shape =
+# CHECK: Function 'conditional': embedding shape =

--- a/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
+++ b/llvm/test/tools/llvm-ir2vec/bindings/ir2vec-bindings.py
@@ -13,21 +13,21 @@ if tool is not None:
     print(f"Tool type: {type(tool).__name__}")
 
     # Test getFuncEmbMap
+    print("\n=== Function Embeddings ===")
     func_emb_map = tool.getFuncEmbMap()
-    print(f"Number of functions: {len(func_emb_map)}")
 
-    # Check that all three functions are present
-    expected_funcs = ["add", "multiply", "conditional"]
-    for func_name in expected_funcs:
-        if func_name in func_emb_map:
-            emb = func_emb_map[func_name]
-            print(f"Function '{func_name}': embedding shape = {emb.shape}")
-        else:
-            print(f"ERROR: Function '{func_name}' not found")
+    # Sorting the function names for fixed-ordered output
+    for func_name in sorted(func_emb_map.keys()):
+        emb = func_emb_map[func_name]
+        print(f"Function: {func_name}")
+        print(f"  Embedding: {emb.tolist()}")
 
 # CHECK: SUCCESS: Tool initialized
 # CHECK: Tool type: IR2VecTool
-# CHECK: Number of functions: 3
-# CHECK: Function 'add': embedding shape =
-# CHECK: Function 'multiply': embedding shape =
-# CHECK: Function 'conditional': embedding shape =
+# CHECK: === Function Embeddings ===
+# CHECK: Function: add
+# CHECK-NEXT:   Embedding: [38.0, 40.0, 42.0]
+# CHECK: Function: conditional
+# CHECK-NEXT:   Embedding: [413.20000000298023, 421.20000000298023, 429.20000000298023]
+# CHECK: Function: multiply
+# CHECK-NEXT:   Embedding: [50.0, 52.0, 54.0]

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -79,13 +79,13 @@ public:
     nb::dict NBFuncEmbMap;
 
     for (const auto &[FuncPtr, FuncEmb] : *ToolFuncEmbMap) {
-      auto Data = FuncEmb.getData();
-      double *DataPtr = new double[Data.size()];
-      std::copy(Data.begin(), Data.end(), DataPtr);
+      auto FuncEmbVec = FuncEmb.getData();
+      double *NBFuncEmbVec = new double[FuncEmbVec.size()];
+      std::copy(FuncEmbVec.begin(), FuncEmbVec.end(), NBFuncEmbVec);
 
       auto NbArray = nb::ndarray<nb::numpy, double>(
-          DataPtr, {Data.size()}, nb::capsule(DataPtr, [](void *p) noexcept {
-            delete[] static_cast<double *>(p);
+          NBFuncEmbVec, {FuncEmbVec.size()}, nb::capsule(NBFuncEmbVec, [](void *P) noexcept {
+            delete[] static_cast<double *>(P);
           }));
 
       NBFuncEmbMap[nb::str(FuncPtr->getName().str().c_str())] = NbArray;

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -84,7 +84,8 @@ public:
       std::copy(FuncEmbVec.begin(), FuncEmbVec.end(), NBFuncEmbVec);
 
       auto NbArray = nb::ndarray<nb::numpy, double>(
-          NBFuncEmbVec, {FuncEmbVec.size()}, nb::capsule(NBFuncEmbVec, [](void *P) noexcept {
+          NBFuncEmbVec, {FuncEmbVec.size()},
+          nb::capsule(NBFuncEmbVec, [](void *P) noexcept {
             delete[] static_cast<double *>(P);
           }));
 

--- a/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
+++ b/llvm/tools/llvm-ir2vec/Bindings/PyIR2Vec.cpp
@@ -79,7 +79,6 @@ public:
     nb::dict NBFuncEmbMap;
 
     for (const auto &[FuncPtr, FuncEmb] : *ToolFuncEmbMap) {
-      std::string FuncName = FuncPtr->getName().str();
       auto Data = FuncEmb.getData();
       double *DataPtr = new double[Data.size()];
       std::copy(Data.begin(), Data.end(), DataPtr);
@@ -89,7 +88,7 @@ public:
             delete[] static_cast<double *>(p);
           }));
 
-      NBFuncEmbMap[nb::str(FuncName.c_str())] = NbArray;
+      NBFuncEmbMap[nb::str(FuncPtr->getName().str().c_str())] = NbArray;
     }
 
     return NBFuncEmbMap;

--- a/llvm/tools/llvm-ir2vec/lib/Utils.cpp
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.cpp
@@ -153,11 +153,9 @@ void IR2VecTool::writeEntitiesToStream(raw_ostream &OS) {
 
 std::optional<Embedding>
 IR2VecTool::getFunctionEmbedding(const Function &F, IR2VecKind Kind) const {
-  if (!Vocab || !Vocab->isValid()) {
-    WithColor::error(errs(), ToolName)
-        << "Vocabulary not initialized properly.\n";
-    return std::nullopt;
-  }
+  if (!Vocab || !Vocab->isValid())
+    return createStringError(errc::invalid_argument,
+                             "Failed to initialize IR2Vec vocabulary");
 
   if (F.isDeclaration())
     return std::nullopt;
@@ -172,11 +170,9 @@ IR2VecTool::getFunctionEmbedding(const Function &F, IR2VecKind Kind) const {
 }
 
 FuncEmbMap IR2VecTool::getFunctionEmbeddingsMap(IR2VecKind Kind) const {
-  if (!Vocab || !Vocab->isValid()) {
-    WithColor::error(errs(), ToolName)
-        << "Vocabulary not initialized properly.\n";
-    return {};
-  }
+  if (!Vocab || !Vocab->isValid())
+    return createStringError(errc::invalid_argument,
+                             "Failed to initialize IR2Vec vocabulary");
 
   FuncEmbMap Result;
 
@@ -194,11 +190,9 @@ FuncEmbMap IR2VecTool::getFunctionEmbeddingsMap(IR2VecKind Kind) const {
 
 void IR2VecTool::writeEmbeddingsToStream(raw_ostream &OS,
                                          EmbeddingLevel Level) const {
-  if (!Vocab || !Vocab->isValid()) {
-    WithColor::error(errs(), ToolName)
-        << "Vocabulary is not valid. IR2VecTool not initialized.\n";
-    return;
-  }
+  if (!Vocab || !Vocab->isValid())
+    return createStringError(errc::invalid_argument,
+                             "Failed to initialize IR2Vec vocabulary");
 
   for (const Function &F : M.getFunctionDefs())
     writeEmbeddingsToStream(F, OS, Level);
@@ -206,11 +200,10 @@ void IR2VecTool::writeEmbeddingsToStream(raw_ostream &OS,
 
 void IR2VecTool::writeEmbeddingsToStream(const Function &F, raw_ostream &OS,
                                          EmbeddingLevel Level) const {
-  if (!Vocab || !Vocab->isValid()) {
-    WithColor::error(errs(), ToolName)
-        << "Vocabulary is not valid. IR2VecTool not initialized.\n";
-    return;
-  }
+  if (!Vocab || !Vocab->isValid())
+    return createStringError(errc::invalid_argument,
+                             "Failed to initialize IR2Vec vocabulary");
+
   if (F.isDeclaration()) {
     OS << "Function " << F.getName() << " is a declaration, skipping.\n";
     return;

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -115,11 +115,11 @@ public:
   static EntityList collectEntityMappings();
 
   // Get embedding for a single function
-  std::optional<Embedding> getFunctionEmbedding(const Function &F,
-                                                IR2VecKind Kind) const;
+  Expected<Embedding> getFunctionEmbedding(const Function &F,
+                                           IR2VecKind Kind) const;
 
   /// Get embeddings for all functions in the module
-  FuncEmbMap getFunctionEmbeddingsMap(IR2VecKind Kind) const;
+  Expected<FuncEmbMap> getFunctionEmbeddingsMap(IR2VecKind Kind) const;
 
   /// Dump entity ID to string mappings
   static void writeEntitiesToStream(raw_ostream &OS);

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -115,11 +115,11 @@ public:
   static EntityList collectEntityMappings();
 
   // Get embedding for a single function
-  std::pair<const Function *, Embedding>
-  getFunctionEmbedding(const Function &F, IR2VecKind Kind) const;
+  std::optional<Embedding> getFunctionEmbedding(const Function &F,
+                                                IR2VecKind Kind) const;
 
   /// Get embeddings for all functions in the module
-  FuncEmbMap getFunctionEmbeddings(IR2VecKind Kind) const;
+  FuncEmbMap getFunctionEmbeddingsMap(IR2VecKind Kind) const;
 
   /// Dump entity ID to string mappings
   static void writeEntitiesToStream(raw_ostream &OS);

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -16,6 +16,7 @@
 #define LLVM_TOOLS_LLVM_IR2VEC_UTILS_UTILS_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/Analysis/IR2Vec.h"
 #include "llvm/CodeGen/MIR2Vec.h"
 #include "llvm/CodeGen/MIRParser/MIRParser.h"
@@ -72,6 +73,7 @@ struct TripletResult {
 
 /// Entity mappings: [entity_name]
 using EntityList = std::vector<std::string>;
+using FuncEmbMap = DenseMap<const Function *, ir2vec::Embedding>;
 
 namespace ir2vec {
 
@@ -111,6 +113,13 @@ public:
   /// Generate entity mappings for the entire vocabulary
   /// Returns EntityList containing all entity strings
   static EntityList collectEntityMappings();
+
+  // Get embedding for a single function
+  std::pair<const Function *, Embedding>
+  getFunctionEmbedding(const Function &F, IR2VecKind Kind) const;
+
+  /// Get embeddings for all functions in the module
+  FuncEmbMap getFunctionEmbeddings(IR2VecKind Kind) const;
 
   /// Dump entity ID to string mappings
   static void writeEntitiesToStream(raw_ostream &OS);


### PR DESCRIPTION
Adding `getFuncEmbMap` to the llvm-ir2vec python bindings

CC - @svkeerthy , @boomanaiden154 , @mtrofin, @nikic 