### PR TITLE
In-class initialize DenseMapBase members.

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -751,10 +751,10 @@ class DenseMap : public DenseMapBase<DenseMap<KeyT, ValueT, KeyInfoT, BucketT>,
   // simplicity of referring to them.
   using BaseT = DenseMapBase<DenseMap, KeyT, ValueT, KeyInfoT, BucketT>;
 
-  BucketT *Buckets;
-  unsigned NumEntries;
-  unsigned NumTombstones;
-  unsigned NumBuckets;
+  BucketT *Buckets = nullptr;
+  unsigned NumEntries = 0;
+  unsigned NumTombstones = 0;
+  unsigned NumBuckets = 0;
 
   explicit DenseMap(unsigned NumBuckets, typename BaseT::ExactBucketCount) {
     this->initWithExactBucketCount(NumBuckets);


### PR DESCRIPTION
I've seen a number of false positive defects in Coverity regarding uninitialized instances of some of these members.  I've decided to in-class initialize 3 scalar members of `DenseMapBase` to hopefully silence Coverity.

Since the initialization is performed through `initWithExactBucketCount` I think it makes sense to just zero init them.  I assume the original intent was to avoid some initialization overhead; however, that seems negligible from my last compile-time tracker results (If I'm reading the results correctly).

I do see some of the insn size percentages jump around but that might be noise.  I had run an earlier compile time tracker on the same data, and I think the timing results were a bit different, the most recent run information is below.

Compile time tracker is showing the following output:
Metric | Old | New
-- | -- | --
instructions:u | 35718151M | 35718325M (+0.00%)
wall-time | 614.01s | 613.82s (-0.03%)
size-file | 132278KiB | 132278KiB (+0.00%)
size-file (stage1) | 151065KiB | 151065KiB (-0.00%)

clang build:
Metric	Old	New
[instructions:u](https://llvm-compile-time-tracker.com/compare_clang.php?from=f97f53e1d925fe702c23ad3a120ad3ab40b4eb51&to=d925643ace32566ea76a60d0642180d077f476f5&stat=instructions%3Au)	35718151M	35718325M (+0.00%)
[wall-time](https://llvm-compile-time-tracker.com/compare_clang.php?from=f97f53e1d925fe702c23ad3a120ad3ab40b4eb51&to=d925643ace32566ea76a60d0642180d077f476f5&stat=wall-time)	614.01s	613.82s (-0.03%)
[size-file](https://llvm-compile-time-tracker.com/compare_clang.php?from=f97f53e1d925fe702c23ad3a120ad3ab40b4eb51&to=d925643ace32566ea76a60d0642180d077f476f5&stat=size-file)	132278KiB	132278KiB (+0.00%)
size-file (stage1)	151065KiB	151065KiB (-0.00%)`
