### PR TITLE
release/22.x: [AArch64][Driver] Allow runtime detection to override default features. (#176340)

### DIFF
--- a/clang/test/Driver/aarch64-mcpu-native.c
+++ b/clang/test/Driver/aarch64-mcpu-native.c
@@ -33,12 +33,10 @@
 // CHECK-FEAT-CA57: Extensions enabled for the given AArch64 target
 // CHECK-FEAT-CA57-EMPTY:
 // CHECK-FEAT-CA57:    Architecture Feature(s)                                Description
-// CHECK-FEAT-CA57:    FEAT_AES, FEAT_PMULL                                   Enable AES support
 // CHECK-FEAT-CA57:    FEAT_AdvSIMD                                           Enable Advanced SIMD instructions
 // CHECK-FEAT-CA57:    FEAT_CRC32                                             Enable Armv8.0-A CRC-32 checksum instructions
 // CHECK-FEAT-CA57:    FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-FEAT-CA57:    FEAT_PMUv3                                             Enable Armv8.0-A PMUv3 Performance Monitors extension
-// CHECK-FEAT-CA57:    FEAT_SHA1, FEAT_SHA256                                 Enable SHA1 and SHA256 support
 
 // RUN: export LLVM_CPUINFO=%S/Inputs/cpunative/cortex-a72
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace  --check-prefix=CHECK-FEAT-CA72 --implicit-check-not=FEAT_ %s

--- a/clang/test/Driver/print-enabled-extensions/aarch64-grace.c
+++ b/clang/test/Driver/print-enabled-extensions/aarch64-grace.c
@@ -1,7 +1,6 @@
 // REQUIRES: aarch64-registered-target,aarch64-host,system-linux
 // RUN: %clang --target=aarch64 --print-enabled-extensions -mcpu=grace | FileCheck --strict-whitespace --implicit-check-not=FEAT_ %s
-// FIXME: mcpu=native should disable FEAT_RNG.
-// RUN: env LLVM_CPUINFO=%S/../Inputs/cpunative/grace %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --check-prefixes=CHECK,NATIVE --strict-whitespace --implicit-check-not=FEAT_ %s
+// RUN: env LLVM_CPUINFO=%S/../Inputs/cpunative/grace %clang --target=aarch64 --print-enabled-extensions -mcpu=native | FileCheck --strict-whitespace --implicit-check-not=FEAT_ %s
 
 // CHECK: Extensions enabled for the given AArch64 target
 // CHECK-EMPTY:
@@ -43,7 +42,6 @@
 // CHECK-NEXT:     FEAT_PMUv3                                             Enable Armv8.0-A PMUv3 Performance Monitors extension
 // CHECK-NEXT:     FEAT_RAS, FEAT_RASv1p1                                 Enable Armv8.0-A Reliability, Availability and Serviceability Extensions
 // CHECK-NEXT:     FEAT_RDM                                               Enable Armv8.1-A Rounding Double Multiply Add/Subtract instructions
-// NATIVE-NEXT:    FEAT_RNG                                               Enable Random Number generation instructions
 // CHECK-NEXT:     FEAT_SB                                                Enable Armv8.5-A Speculation Barrier
 // CHECK-NEXT:     FEAT_SEL2                                              Enable Armv8.4-A Secure Exception Level 2 extension
 // CHECK-NEXT:     FEAT_SHA1, FEAT_SHA256                                 Enable SHA1 and SHA256 support

--- a/llvm/lib/TargetParser/Host.cpp
+++ b/llvm/lib/TargetParser/Host.cpp
@@ -2241,6 +2241,7 @@ StringMap<bool> sys::getHostCPUFeatures() {
                                    .Case("fp", "fp-armv8")
                                    .Case("crc32", "crc")
                                    .Case("atomics", "lse")
+                                   .Case("rng", "rand")
                                    .Case("sha3", "sha3")
                                    .Case("sm4", "sm4")
                                    .Case("sve", "sve")
@@ -2290,6 +2291,10 @@ StringMap<bool> sys::getHostCPUFeatures() {
   // detect support at runtime.
   if (!Features.contains("sve"))
     Features["sve"] = false;
+
+  // Also disable RNG if we can't detect support at runtime.
+  if (!Features.contains("rand"))
+    Features["rand"] = false;
 #endif
 
   return Features;


### PR DESCRIPTION
Backport https://github.com/llvm/llvm-project/pull/176340.

The initial cherry-pick failed due to the test change common with https://github.com/llvm/llvm-project/pull/166387.

If this is unsuitable to backport, please let me know.