### PR TITLE
[lldb] Fix error when running "memory region --all" repeatedly

### DIFF
--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -1735,7 +1735,24 @@ protected:
     const size_t argc = command.GetArgumentCount();
     const lldb::ABISP &abi = process_sp->GetABI();
 
-    if (argc == 1) {
+    if (argc == 0) {
+      if (!m_memory_region_options.m_all) {
+        if ( // When we're repeating the command, the previous end
+             // address is used for load_addr. If that was 0xF...F then
+             // we must have reached the end of memory.
+            (load_addr == LLDB_INVALID_ADDRESS) ||
+            // If the target has non-address bits (tags, limited virtual
+            // address size, etc.), the end of mappable memory will be
+            // lower than that. So if we find any non-address bit set,
+            // we must be at the end of the mappable range.
+            (abi && (abi->FixAnyAddress(load_addr) != load_addr))) {
+          result.AppendErrorWithFormat(
+              "'%s' takes one argument or \"--all\" option:\nUsage: %s\n",
+              m_cmd_name.c_str(), m_cmd_syntax.c_str());
+          return;
+        }
+      }
+    } else if (argc == 1) {
       if (m_memory_region_options.m_all) {
         result.AppendError(
             "The \"--all\" option cannot be used when an address "
@@ -1751,18 +1768,8 @@ protected:
                                      command[0].c_str(), error.AsCString());
         return;
       }
-    } else if (argc > 1 ||
-               (!m_memory_region_options.m_all &&
-                (
-                    // When we're repeating the command, the previous end
-                    // address is used for load_addr. If that was 0xF...F then
-                    // we must have reached the end of memory.
-                    (argc == 0 && load_addr == LLDB_INVALID_ADDRESS) ||
-                    // If the target has non-address bits (tags, limited virtual
-                    // address size, etc.), the end of mappable memory will be
-                    // lower than that. So if we find any non-address bit set,
-                    // we must be at the end of the mappable range.
-                    (abi && (abi->FixAnyAddress(load_addr) != load_addr))))) {
+    } else {
+      // argc > 1
       result.AppendErrorWithFormat(
           "'%s' takes one argument or \"--all\" option:\nUsage: %s\n",
           m_cmd_name.c_str(), m_cmd_syntax.c_str());

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -1752,16 +1752,17 @@ protected:
         return;
       }
     } else if (argc > 1 ||
-               // When we're repeating the command, the previous end address is
-               // used for load_addr. If that was 0xF...F then we must have
-               // reached the end of memory.
-               (argc == 0 && !m_memory_region_options.m_all &&
-                load_addr == LLDB_INVALID_ADDRESS) ||
-               // If the target has non-address bits (tags, limited virtual
-               // address size, etc.), the end of mappable memory will be lower
-               // than that. So if we find any non-address bit set, we must be
-               // at the end of the mappable range.
-               (abi && (abi->FixAnyAddress(load_addr) != load_addr))) {
+               (!m_memory_region_options.m_all &&
+                (
+                    // When we're repeating the command, the previous end
+                    // address is used for load_addr. If that was 0xF...F then
+                    // we must have reached the end of memory.
+                    (argc == 0 && load_addr == LLDB_INVALID_ADDRESS) ||
+                    // If the target has non-address bits (tags, limited virtual
+                    // address size, etc.), the end of mappable memory will be
+                    // lower than that. So if we find any non-address bit set,
+                    // we must be at the end of the mappable range.
+                    (abi && (abi->FixAnyAddress(load_addr) != load_addr))))) {
       result.AppendErrorWithFormat(
           "'%s' takes one argument or \"--all\" option:\nUsage: %s\n",
           m_cmd_name.c_str(), m_cmd_syntax.c_str());

--- a/lldb/test/Shell/Commands/command-memory-region.test
+++ b/lldb/test/Shell/Commands/command-memory-region.test
@@ -1,0 +1,10 @@
+## --all should be able to be used many times in a row. As it is not
+## repeatable and starts fresh each time.
+
+# RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t.out
+# RUN: %lldb %t.out -b -o 'b main' -o 'run' -o 'memory region --all' \
+# RUN:    -o 'memory region --all' | FileCheck %s
+# CHECK-LABEL: memory region --all
+# CHECK-NEXT: [0x{{[0-9a-f]+}}-0x{{[0-9a-f]+}})
+# CHECK-LABEL: memory region --all
+# CHECK-NEXT: [0x{{[0-9a-f]+}}-0x{{[0-9a-f]+}})


### PR DESCRIPTION
Due to some faulty logic, if you ran "memory region --all" twice, the second time lldb would try to repeat the command. There's nothing to repeat, so it failed with an error. It should treat each "--all" use as starting from scratch.

The logic here was written in a confusing way, so I've refactored it to first look at how many arguments there are (aka how many address expressions there are) and then validate based on that.

For reasons unknown, I could not reproduce this issue using the API test TestMemoryRegion.py. So I have added a shell test that I confirmed does fail without this fix.