### PR TITLE
[ADT][NFC] Use block numbers for po_iterator

### DIFF
--- a/llvm/include/llvm/ADT/PostOrderIterator.h
+++ b/llvm/include/llvm/ADT/PostOrderIterator.h
@@ -108,7 +108,7 @@ public:
       Data.resize(Idx + 1);
     bool Inserted = !Data[Idx];
     Data[Idx] = true;
-    return std::make_pair(std::nullopt, Inserted);
+    return {std::nullopt, Inserted};
   }
 };
 

--- a/llvm/include/llvm/ADT/PostOrderIterator.h
+++ b/llvm/include/llvm/ADT/PostOrderIterator.h
@@ -91,8 +91,36 @@ public:
   template <class NodeRef> void finishPostorder(NodeRef BB) {}
 };
 
-template <class GraphT,
-          class SetType = SmallPtrSet<typename GraphTraits<GraphT>::NodeRef, 8>,
+namespace po_detail {
+
+template <typename NodeRef> class NumberSet {
+  SmallVector<bool> Data;
+
+public:
+  void reserve(size_t Size) {
+    if (Size < Data.size())
+      Data.resize(Size, false);
+  }
+
+  std::pair<std::nullopt_t, bool> insert(NodeRef Node) {
+    unsigned Idx = GraphTraits<NodeRef>::getNumber(Node);
+    if (Idx >= Data.size())
+      Data.resize(Idx + 1);
+    bool Inserted = !Data[Idx];
+    Data[Idx] = true;
+    return std::make_pair(std::nullopt, Inserted);
+  }
+};
+
+template <typename GraphT>
+using DefaultSet =
+    std::conditional_t<GraphHasNodeNumbers<GraphT>,
+                       NumberSet<typename GraphTraits<GraphT>::NodeRef>,
+                       SmallPtrSet<typename GraphTraits<GraphT>::NodeRef, 8>>;
+
+} // namespace po_detail
+
+template <class GraphT, class SetType = po_detail::DefaultSet<GraphT>,
           bool ExtStorage = false, class GT = GraphTraits<GraphT>>
 class po_iterator : public po_iterator_storage<SetType, ExtStorage> {
 public:
@@ -205,13 +233,13 @@ struct po_ext_iterator : po_iterator<T, SetType, true> {
   po_iterator<T, SetType, true>(V) {}
 };
 
-template<class T, class SetType>
-po_ext_iterator<T, SetType> po_ext_begin(T G, SetType &S) {
+template <class T, class SetType>
+po_ext_iterator<T, SetType> po_ext_begin(const T &G, SetType &S) {
   return po_ext_iterator<T, SetType>::begin(G, S);
 }
 
-template<class T, class SetType>
-po_ext_iterator<T, SetType> po_ext_end(T G, SetType &S) {
+template <class T, class SetType>
+po_ext_iterator<T, SetType> po_ext_end(const T &G, SetType &S) {
   return po_ext_iterator<T, SetType>::end(G, S);
 }
 

--- a/llvm/unittests/ADT/PostOrderIteratorTest.cpp
+++ b/llvm/unittests/ADT/PostOrderIteratorTest.cpp
@@ -35,11 +35,13 @@ TEST(PostOrderIteratorTest, Compiles) {
 
   // Test above, but going through po_iterator (which inherits from template
   // base)
-  BasicBlock *NullBB = nullptr;
-  auto PI = po_end(NullBB);
-  PI.insertEdge(std::optional<BasicBlock *>(), NullBB);
-  auto PIExt = po_ext_end(NullBB, Ext);
-  PIExt.insertEdge(std::optional<BasicBlock *>(), NullBB);
+  Graph<6> G;
+  using NodeType = Graph<6>::NodeType;
+  NodeType *NullNode = nullptr;
+  auto PI = po_end(G);
+  PI.insertEdge(std::optional<NodeType *>(), NullNode);
+  auto PIExt = po_ext_end(G, Ext);
+  PIExt.insertEdge(std::optional<NodeType *>(), NullNode);
 }
 
 static_assert(


### PR DESCRIPTION
Avoid using hash maps for {Machine,}BasicBlock. Use SmallVector<bool> instead of BitVector for faster access, the memory cost should be neglibible compared to the size of basic blocks or a pointer set. The test change is required, because a nullptr BasicBlock cannot be asked for its number.

With the current rather complicated design of po_iterator, reserving is not easily possible.