### PR TITLE
[MC] Explicitly use memcpy in emitBytes() (NFC)

### DIFF
--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -109,7 +109,9 @@ void MCObjectStreamer::addSpecialFragment(MCFragment *Frag) {
 void MCObjectStreamer::appendContents(ArrayRef<char> Contents) {
   ensureHeadroom(Contents.size());
   assert(FragSpace >= Contents.size());
-  llvm::copy(Contents, getCurFragEnd());
+  // As this is performance-sensitive code, explicitly use std::memcpy.
+  // Optimization of std::copy to memmove is unreliable.
+  std::memcpy(getCurFragEnd(), Contents.begin(), Contents.size());
   CurFrag->FixedSize += Contents.size();
   FragSpace -= Contents.size();
 }


### PR DESCRIPTION
We've observed a compile-time regression in LLVM 22 when including large blobs. The root cause was that emitBytes() was copying bytes one-by-one, which is much slower than using memcpy for large objects.

Optimization of std::copy to memmove is apparently much less reliable than one might think. In particular, when using a non-bleeding-edge libstdc++ (anything older than version 15), this does not happen if the types of the input and output iterators do not match (like here, where there is a signed/unsigned mismatch).

As this code is performance sensitive, I think it makes sense to directly use memcpy.

Previously this code used SmallVector::append, which explicitly uses memcpy here: https://github.com/llvm/llvm-project/blob/82d7a52219764ab93f9dc2efc123ad9d7d8f8c2f/llvm/include/llvm/ADT/SmallVector.h#L519