### PR TITLE
[clang] Fix lifetime extension of temporaries in for-range-initializers in templates

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -134,6 +134,8 @@ Improvements to Coverage Mapping
 Bug Fixes in This Version
 -------------------------
 
+- Fix lifetime extension of temporaries in for-range-initializers in templates. (#GH165182)
+
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/165182.

This patch fix the lifetime extension of temporaries in for-range-initializers in templates. Whether this issue was occurred when the for-range statement in a dependent context, but itself is not type/value dependent.