### PR TITLE
[profgen] optimise instruction size calculation

### DIFF
--- a/llvm/tools/llvm-profgen/ProfiledBinary.h
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.h
@@ -33,6 +33,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Transforms/IPO/SampleContextTracker.h"
+#include <algorithm>
 #include <map>
 #include <set>
 #include <sstream>
@@ -268,9 +269,6 @@ class ProfiledBinary {
   // Address to context location map. Used to expand the context.
   std::unordered_map<uint64_t, SampleContextFrameVector> AddressToLocStackMap;
 
-  // Address to instruction size map. Also used for quick Address lookup.
-  std::unordered_map<uint64_t, uint64_t> AddressToInstSizeMap;
-
   // An array of Addresses of all instructions sorted in increasing order. The
   // sorting is needed to fast advance to the next forward/backward instruction.
   std::vector<uint64_t> CodeAddressVec;
@@ -444,15 +442,9 @@ public:
     return TextSegmentOffsets;
   }
 
-  uint64_t getInstSize(uint64_t Address) const {
-    auto I = AddressToInstSizeMap.find(Address);
-    if (I == AddressToInstSizeMap.end())
-      return 0;
-    return I->second;
-  }
-
   bool addressIsCode(uint64_t Address) const {
-    return AddressToInstSizeMap.find(Address) != AddressToInstSizeMap.end();
+    return std::binary_search(CodeAddressVec.begin(), CodeAddressVec.end(),
+                              Address);
   }
 
   bool addressIsCall(uint64_t Address) const {


### PR DESCRIPTION
In both uses of getInstSize, we're already iterating through the code with an IP. Subtract addresses to get the instruction size instead of looking up in AddressToInstSizeMap.

Also use CodeAddressVec to find instruction boundaries rather than AddressToInstSizeMap, meaning we no longer need the latter.

Gives a 1.28x speedup on a large clang profile.

---

Marked as draft because special handling is needed when the instruction in question is at the end of its section. At the moment I think this will take a bit of hairy logic involving Binary->TextSections.