### PR TITLE
[flang][flang-rt] Fix abort on intrinsic assignment from ZLA

### DIFF
--- a/flang-rt/lib/runtime/assign.cpp
+++ b/flang-rt/lib/runtime/assign.cpp
@@ -451,7 +451,7 @@ RT_API_ATTRS int AssignTicket::Continue(WorkQueue &workQueue) {
   std::size_t toElements{to_.InlineElements()};
   if (from_->rank() > 0) {
     std::size_t fromElements{from_->InlineElements()};
-    if (toElements != fromElements) {
+    if (fromElements && toElements != fromElements) {
       workQueue.terminator().Crash("Assign: mismatching element counts in "
                                    "array assignment (to %zd, from %zd)",
           toElements, fromElements);


### PR DESCRIPTION
Intrinsic assignment from a zero-length character array should result in the destination being blank-padded to its length (10.2.1.3).