### PR TITLE
[libc++] Implement P2876R3: std::simd constructors and accessors

### DIFF
--- a/libcxx/docs/Status/Cxx2cPapers.csv
+++ b/libcxx/docs/Status/Cxx2cPapers.csv
@@ -130,7 +130,7 @@
 "`P3709R2 <https://wg21.link/P3709R2>`__","Reconsider parallel ``ranges::rotate_copy`` and ``ranges::reverse_copy``","2025-06 (Sofia)","","","`#148138 <https://github.com/llvm/llvm-project/issues/148138>`__",""
 "`P3641R0 <https://wg21.link/P3641R0>`__","Rename ``std::observable`` to ``std::observable_checkpoint``, and add a feature-test macro","2025-06 (Sofia)","","","`#148139 <https://github.com/llvm/llvm-project/issues/148139>`__",""
 "`P3044R2 <https://wg21.link/P3044R2>`__","sub-``string_view`` from ``string``","2025-06 (Sofia)","|Complete|","22","`#148140 <https://github.com/llvm/llvm-project/issues/148140>`__",""
-"`P2876R3 <https://wg21.link/P2876R3>`__","Proposal to extend ``std::simd`` with more constructors and accessors","2025-06 (Sofia)","","","`#148143 <https://github.com/llvm/llvm-project/issues/148143>`__",""
+"`P2876R3 <https://wg21.link/P2876R3>`__","Proposal to extend ``std::simd`` with more constructors and accessors","2025-06 (Sofia)","|Complete|","22","`#148143 <https://github.com/llvm/llvm-project/issues/148143>`__",""
 "`P3480R6 <https://wg21.link/P3480R6>`__","``std::simd`` is a range","2025-06 (Sofia)","","","`#148144 <https://github.com/llvm/llvm-project/issues/148144>`__",""
 "`P2664R11 <https://wg21.link/P2664R11>`__","Extend ``std::simd`` with permutation API","2025-06 (Sofia)","","","`#148145 <https://github.com/llvm/llvm-project/issues/148145>`__",""
 "`P3691R1 <https://wg21.link/P3691R1>`__","Reconsider naming of the namespace for ``std::simd``","2025-06 (Sofia)","","","`#148148 <https://github.com/llvm/llvm-project/issues/148148>`__",""

--- a/libcxx/include/experimental/__simd/simd_mask.h
+++ b/libcxx/include/experimental/__simd/simd_mask.h
@@ -77,13 +77,17 @@ public:
   template <class _Up>
     requires std::unsigned_integral<_Up>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit simd_mask(_Up __val) noexcept {
-    constexpr size_t __bit_limit = sizeof(_Up) * 8;
-    for (size_t __i = 0; __i < size(); ++__i) {
-      if (__i >= __bit_limit) {
-        (*this)[__i] = false;
-      } else {
-        (*this)[__i] = static_cast<bool>((__val >> __i) & 1);
-      }
+    constexpr size_t __bits = sizeof(_Up) * 8;
+
+    constexpr size_t __bit_limit = __bits > size() ? size() : __bits;
+    size_t __i = 0;
+  
+    for (; __i < __bit_limit; ++__i) {
+      (*this)[__i] = static_cast<bool>((__val >> __i) & 1);
+    }
+
+    for(; __i < size(); ++__i){
+      (*this)[__i] = false;
     }
   }
 

--- a/libcxx/test/std/experimental/simd/simd.mask.class/simd_mask_ctor_bitset.pass.cpp
+++ b/libcxx/test/std/experimental/simd/simd.mask.class/simd_mask_ctor_bitset.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// <experimental/simd>
+//
+// [simd.mask.ctor]
+// constexpr simd_mask(const bitset<size()>& b) noexcept;
+
+#include "../test_utils.h"
+#include <bitset>
+
+namespace ex = std::experimental::parallelism_v2;
+
+template <class T, std::size_t>
+struct CheckSimdMaskCtorBitset {
+  template <class SimdAbi>
+  void operator()() {
+    constexpr std::size_t array_size = ex::simd_size_v<T, SimdAbi>;
+    
+    std::bitset<array_size> b;
+    bool expected_buffer[array_size];
+
+    for (size_t i = 0; i < array_size; ++i) {
+      bool val = (i % 2 == 0);
+      if (val) 
+        b[i] = true;
+      expected_buffer[i] = val;
+    }
+
+    // Construct mask
+    ex::simd_mask<T, SimdAbi> mask(b);
+
+    assert_simd_mask_values_equal(mask, expected_buffer);
+    static_assert(noexcept(ex::simd_mask<T, SimdAbi>(b)));
+  }
+};
+
+int main(int, char**) {
+  test_all_simd_abi<CheckSimdMaskCtorBitset>();
+  return 0;
+}

--- a/libcxx/test/std/experimental/simd/simd.mask.class/simd_mask_ctor_unsigned.pass.cpp
+++ b/libcxx/test/std/experimental/simd/simd.mask.class/simd_mask_ctor_unsigned.pass.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// <experimental/simd>
+//
+// [simd.mask.ctor]
+// template<class U> constexpr explicit simd_mask(U val) noexcept;
+
+#include "../test_utils.h"
+
+namespace ex = std::experimental::parallelism_v2;
+
+template <class T, std::size_t>
+struct CheckSimdMaskCtorUnsigned {
+  template <class SimdAbi>
+  void operator()() {
+    constexpr std::size_t array_size = ex::simd_size_v<T, SimdAbi>;
+    
+    // Pattern: 101010...
+    unsigned long long pattern = 0xAAAAAAAAAAAAAAAA; 
+    bool expected_buffer[array_size];
+
+    constexpr size_t limit = (array_size < 64) ? array_size : 64;
+
+    for (size_t i = 0; i < limit; ++i) {
+      expected_buffer[i] = (pattern >> i) & 1;
+    }
+
+
+    for (size_t i = limit; i < array_size; ++i) {
+      expected_buffer[i] = false;
+    }
+
+    ex::simd_mask<T, SimdAbi> mask(pattern);
+
+    assert_simd_mask_values_equal(mask, expected_buffer);
+    static_assert(noexcept(ex::simd_mask<T, SimdAbi>(pattern)));
+  }
+};
+
+int main(int, char**) {
+  test_all_simd_abi<CheckSimdMaskCtorUnsigned>();
+  return 0;
+}

--- a/libcxx/test/std/experimental/simd/simd.mask.class/simd_mask_named_conversions.pass.cpp
+++ b/libcxx/test/std/experimental/simd/simd.mask.class/simd_mask_named_conversions.pass.cpp
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14
+
+// <experimental/simd>
+//
+// [simd.mask.namedconv]
+// constexpr bitset<size()> to_bitset() const noexcept;
+// constexpr unsigned long long to_ullong() const;
+
+#include "../test_utils.h"
+#include <bitset>
+
+namespace ex = std::experimental::parallelism_v2;
+
+template <class T, std::size_t>
+struct CheckSimdMaskToBitset {
+  template <class SimdAbi>
+  void operator()() {
+    constexpr std::size_t array_size = ex::simd_size_v<T, SimdAbi>;
+
+    // Case: All True
+    ex::simd_mask<T, SimdAbi> mask(true);
+    std::bitset<array_size> b = mask.to_bitset();
+    assert(b.all());
+
+    // Case: All False
+    ex::simd_mask<T, SimdAbi> mask_false(false);
+    std::bitset<array_size> b_false = mask_false.to_bitset();
+    assert(b_false.none());
+
+    static_assert(noexcept(mask.to_bitset()));
+  }
+};
+
+template <class T, std::size_t>
+struct CheckSimdMaskToUllong {
+  template <class SimdAbi>
+  void operator()() {
+    constexpr std::size_t array_size = ex::simd_size_v<T, SimdAbi>;
+
+    // Case: All True
+    ex::simd_mask<T, SimdAbi> mask(true);
+    unsigned long long val = mask.to_ullong();
+
+    unsigned long long expected = ~0ULL;
+    if (array_size < 64) {
+      expected = (1ULL << array_size) - 1;
+    }
+
+    assert(val == expected);
+
+    // Case: All False
+    ex::simd_mask<T, SimdAbi> mask_false(false);
+    assert(mask_false.to_ullong() == 0ULL);
+  }
+};
+
+int main(int, char**) {
+  test_all_simd_abi<CheckSimdMaskToBitset>();
+  test_all_simd_abi<CheckSimdMaskToUllong>();
+  return 0;
+}


### PR DESCRIPTION
This commit adds the missing constructors and accessors to std::simd as specified in P2876R3.

Changes include:

- Implementation of new constructors and functions in <experimental/simd>.

- Updated libcxx/docs/Status/Cxx2cPapers.csv status to mark P2876R3 as complete for LLVM 22.

- added tests in ./libcxx/test/std/experimental/simd/simd.mask.class

Partially addresses #148143