### PR TITLE
[SPIRV] Process indirect function calls immediately

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.h
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.h
@@ -34,8 +34,8 @@ private:
     SmallVector<Register> ArgRegs;
     Register Callee;
   };
-  void produceIndirectPtrTypes(MachineIRBuilder &MIRBuilder) const;
-  mutable SmallVector<SPIRVIndirectCall> IndirectCalls;
+  void produceIndirectPtrType(MachineIRBuilder &MIRBuilder,
+                              const SPIRVIndirectCall &IC) const;
 
 public:
   SPIRVCallLowering(const SPIRVTargetLowering &TLI, SPIRVGlobalRegistry *GR);

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fp_no_return.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fp_no_return.ll
@@ -1,0 +1,37 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - | FileCheck %s
+; TODO: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; This test verifies that indirect calls with functions lacking return statements
+; are don't cause an error.
+
+; CHECK-DAG: OpCapability FunctionPointersINTEL
+; CHECK: OpExtension "SPV_INTEL_function_pointers"
+
+; CHECK-DAG: %[[TyVoid:.*]] = OpTypeVoid
+; CHECK-DAG: %[[TyInt32:.*]] = OpTypeInt 32 0
+
+; CHECK-DAG: %[[TyFun:.*]] = OpTypeFunction %[[TyVoid]] %[[TyInt32]] %[[TyInt32]]
+; CHECK-DAG: %[[TyPtrFun:.*]] = OpTypePointer CodeSectionINTEL %[[TyFun]]
+
+; CHECK: OpFunction
+; CHECK: %[[Load:.*]] = OpLoad %[[TyPtrFun]]
+; CHECK: FunctionPointerCallINTEL %[[TyVoid]] %[[Load]]
+
+%struct.ident_t = type { i32, i32, i32, i32, ptr addrspace(4) }
+
+@0 = addrspace(1) constant %struct.ident_t { i32 0, i32 2, i32 0, i32 22, ptr addrspace(4) addrspacecast (ptr addrspace(1) null to ptr addrspace(4)) }
+
+define spir_func void @foo(ptr addrspace(4) %Ident) addrspace(9) {
+entry:
+  br label %do.body
+
+do.body:                                          ; preds = %do.body, %entry
+  %0 = load ptr addrspace(9), ptr addrspace(4) null, align 8
+  call spir_func addrspace(9) void %0(i32 0, i32 0)
+  br label %do.body
+}
+
+define spir_func void @bar() addrspace(9) {
+entry:
+  ret void
+}


### PR DESCRIPTION
The SPIR-V backend processes indirect function calls in `SPIRVCallLowering`, which is a subclass of the generic `CallLowering`.

It intends to process them function by function, by first collecting all indirect calls in a function, and then processing all of a function's indirect calls at once when the call lowering for the function is about to end.

Today, it relies on the `lowerReturn` virtual function to be called by the generic call lowering infra to know the function processing is about to end, and at that time it processes all of the collected indirect calls and clears the vector of indirect calls.

The problem is that not all functions have return instructions. Every basic block must have a terminator instruction, but it does [not](https://llvm.org/docs/LangRef.html#terminator-instructions) have to be a return.

In the failing case here, function `a` has an infinite loop, with every iteration having an indirect call and a check to see if it should break out of the infinite loop. There is a return instruction initially, but it is optimized out in the middle end.  There is also an unrelated function `b` with no indirect calls.

During call lowering, information about the indirect call in `a` is captured in the vector in SPIRVCallLowering, but since there is no return instruction, it is never processed.

Then, function `b` is processed. `b` happens to have a return instruction, so the indirect call from `a` is processed, but the processing assumes that the indirect call is inside the function being processed, and it writes to a `{function, register}->SPIRVType` map, but the function is `b` not `a`. 

This ends up causing the map to have an invalid SPIRVType for the register in function `b`, and `b` happens to have a register of the same type, causing an invalid result from the map lookup and thus invalid IR (`G_ADDRSPACE_CAST` from `ptr addrspace(4)` to `i32`).

We can't move the indirect call processing into a seperate pass because we lose required information after call lowering ends.

Here, we change the indirect call processing to be done immediately when it is seen.

Comments say the reason the collect all then process style was done was to get better type information for the caller of the indirect function if an opaque pointer is an arg to the caller and the indirect function, but [an existing test case](https://github.com/llvm/llvm-project/blob/main/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_function_pointers/fp-simple-hierarchy.ll) seems to exercise this, and the test still passes after this change and actually has the exact same assembly.

The test case added is a minimal example from `llvm-reduce`, so it's just an infinite loop with no exit condition.

