### PR TITLE
[SLP][NFC] Refactor vectorizeStores::RangeSizes

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -23984,7 +23984,7 @@ bool SLPVectorizerPass::vectorizeStores(
       auto VFIsProfitable = [](unsigned Size, const unsigned RS) {
         return Size >= RS;
       };
-      auto FirstSizeSame = [](unsigned Size, const unsigned RS) {
+      auto RangeSizeSame = [](unsigned Size, const unsigned RS) {
         return Size == RS;
       };
       while (true) {
@@ -24082,7 +24082,7 @@ bool SLPVectorizerPass::vectorizeStores(
               // trees, just with larger number of elements.
               if (VF > MaxRegVF && TreeSize > 1 && VF > MaxRegVF &&
                   all_of(RangeSizes.slice(SliceStartIdx, VF),
-                         std::bind(FirstSizeSame, TreeSize, _1))) {
+                         std::bind(RangeSizeSame, TreeSize, _1))) {
                 SliceStartIdx += VF;
                 while (SliceStartIdx != MaxSliceEnd &&
                        RangeSizes[SliceStartIdx] == TreeSize)

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -24013,7 +24013,7 @@ bool SLPVectorizerPass::vectorizeStores(
             for (unsigned SliceStartIdx = FirstUnvecStore;
                  SliceStartIdx + VF <= MaxSliceEnd;) {
               if (!checkTreeSizes(RangeSizes.slice(SliceStartIdx, VF),
-                                  VF >= MaxRegVF)) {
+                                  VF > MaxRegVF)) {
                 ++SliceStartIdx;
                 continue;
               }
@@ -24081,7 +24081,7 @@ bool SLPVectorizerPass::vectorizeStores(
               }
               if (VF > 2 && Res &&
                   !all_of(RangeSizes.slice(SliceStartIdx, VF),
-                          std::bind(VFIsProfitable, VF >= MaxRegVF, TreeSize,
+                          std::bind(VFIsProfitable, VF > MaxRegVF, TreeSize,
                                     _1))) {
                 SliceStartIdx += VF;
                 continue;
@@ -24100,7 +24100,7 @@ bool SLPVectorizerPass::vectorizeStores(
               if (TreeSize > 1) {
                 for (std::pair<unsigned, unsigned> &P :
                      RangeSizes.slice(SliceStartIdx, VF)) {
-                  if (VF >= MaxRegVF)
+                  if (VF > MaxRegVF)
                     P.second = std::max(P.second, TreeSize);
                   else
                     P.first = std::max(P.first, TreeSize);


### PR DESCRIPTION
Currently `RangeSizes` is used to allow us to skip trying to vectorize clearly unprofitable trees by caching prior attempts `TreeSizes`. This PR refactors that logic to simplify and improve readability. This will make it easier to handle the [strided stores](https://github.com/llvm/llvm-project/pull/175126#issuecomment-3747644896).

Waiting on #177100 to be merged, this will need rebased on top of those changes since they will conflict.

The main two adjustments are:
1. When vectorization occurs, we always update both `RangeSize[Idx].first = RangeSize[Idx].second = 0`, so when checking if an element is or isn't vectorized, we can just check the first element always (6d5fc8b9).
2. Switch RangeSizes to hold a single `unsigned` value rather than a pair.

    When testing out different VF's within vectorizeStores, we iterate in the order
    `MaxVF, MaxVF / 2, ..., MinVF, MaxVF * 2, ...`
    where:
    - `MaxVF <= MaxRegVF`
    - We only proceed past MinVF in cases where `MaxVF == MaxRegVF` (since `MaxVF < MaxRegVF`
    only if `# stores < MaxRegVF`)
    Prior to this, RangeSizes contains a pair, and we access the first/second element
    depending on if VF < MaxRegVF.

    In the main `while` loop, we iterated though `CandidateVFs` multiple times
    - In the first iteration, we handle VFs where `VF <= MaxRegVF`
    - In subsequent iterations, we handles VFs were `VF > MaxRegVF`

    The behavior of rangeSizes prior to this change:
    - if the element at index `Idx` is vectorized, we update `RangeSizes[Idx].first = RangeSizes[Idx].second = 0`
    - if we find a new unprofitable tree, we attempt to update` RangeSizes[Idx].second` if `VF > MaxRegVF`, otherwise
    `RangeSizes[Idx].first`
    - `FirstSizeSame`, `VFIsProfitable`, and `CheckTreeSizes` use `RangeSizes[Idx].first` if `VF > MaxRegVF`, otherwise
    `RangeSizes[Idx].second`
    - After iterating through all elements in `CandidateVFs`, we then update `RangeSizes[Idx].first` with `RangeSizes[Idx].second`

    In the first iteration of the `while` loop, `RangeSizes[...].first` is used to store updated values temporarily while we access elements from second.
    In future iterations (where now `VF > MaxRegVF`), we update `RangeSizes[...].second` and access out of `RangeSizes[...].first`. The values from `second` are propogated to `first` at the end of the loop.

    So effectively, we are just using the `second` part of the pair to cache updates while we iterate through the remainder of the `CandidateVFs` for a given loop. This commit updates that so that `second` is explicitly used as a cache and `first` is used for checks.