### PR TITLE
[LLVM] Fix Bazel build for llvm-dwarfdump.

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -4972,10 +4972,12 @@ cc_binary(
         ":DebugInfo",
         ":DebugInfoDWARF",
         ":DebugInfoDWARFLowLevel",
+        ":IRReader",
         ":MC",
         ":Object",
         ":Support",
         ":TargetParser",
+        ":ir_headers",
     ],
 )
 


### PR DESCRIPTION
Fix is needed for https://github.com/llvm/llvm-project/pull/176725,