### PR TITLE
[bazel][IR2Vec] Exclude ir2vec python bindings from main tool

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -6625,10 +6625,15 @@ cc_binary(
 cc_binary(
     name = "llvm-ir2vec",
     testonly = True,
-    srcs = glob([
-        "tools/llvm-ir2vec/**/*.cpp",
-        "tools/llvm-ir2vec/lib/*.h",
-    ]),
+    srcs = glob(
+        [
+            "tools/llvm-ir2vec/**/*.cpp",
+            "tools/llvm-ir2vec/lib/*.h",
+        ],
+        exclude = [
+            "tools/llvm-ir2vec/Bindings/*.cpp",
+        ],
+    ),
     copts = llvm_copts,
     includes = ["tools/llvm-ir2vec/lib"],
     stamp = 0,


### PR DESCRIPTION
#176571 adds python bindings (using nanobind) in a subdirectory of the ir2vec tool dir, but the bazel target just globs everything. Exclude the bindings directory, which needs to be built in a special way.