### PR TITLE
[RISCV] Improve vector pseudo table's experiences on translating between two different pseudo opcodes. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -771,8 +771,8 @@ namespace RISCVVInversePseudosTable {
 struct PseudoInfo {
   uint16_t Pseudo;
   uint16_t BaseInstr;
-  uint16_t VLMul : 4;
-  uint16_t SEW : 7;
+  uint16_t VLMul : 3;
+  uint16_t SEW : 8;
   uint16_t IsAltFmt : 1;
 };
 

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -771,12 +771,18 @@ namespace RISCVVInversePseudosTable {
 struct PseudoInfo {
   uint16_t Pseudo;
   uint16_t BaseInstr;
-  uint8_t VLMul;
-  uint8_t SEW;
+  uint16_t VLMul : 4;
+  uint16_t SEW : 7;
+  uint16_t IsAltFmt : 1;
 };
 
 #define GET_RISCVVInversePseudosTable_DECL
 #include "RISCVGenSearchableTables.inc"
+
+inline const PseudoInfo *getBaseInfo(unsigned BaseInstr, uint8_t VLMul,
+                                     uint8_t SEW, bool IsAltFmt = false) {
+  return getBaseInfoImpl(BaseInstr, VLMul, SEW, IsAltFmt);
+}
 } // namespace RISCVVInversePseudosTable
 
 namespace RISCV {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.h
@@ -420,8 +420,8 @@ namespace RISCVVPseudosTable {
 struct PseudoInfo {
   uint16_t Pseudo;
   uint16_t BaseInstr;
-  uint16_t VLMul : 4;
-  uint16_t SEW : 7;
+  uint16_t VLMul : 3;
+  uint16_t SEW : 8;
   uint16_t IsAltFmt : 1;
 };
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.h
@@ -420,6 +420,9 @@ namespace RISCVVPseudosTable {
 struct PseudoInfo {
   uint16_t Pseudo;
   uint16_t BaseInstr;
+  uint16_t VLMul : 4;
+  uint16_t SEW : 7;
+  uint16_t IsAltFmt : 1;
 };
 
 #define GET_RISCVVPseudosTable_DECL

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
@@ -564,6 +564,7 @@ class RISCVVPseudo<dag outs, dag ins, list<dag> pattern = [],
   Instruction BaseInstr = !cast<Instruction>(PseudoToVInst<NAME>.VInst);
   // SEW = 0 is used to denote that the Pseudo is not SEW specific (or unknown).
   bits<8> SEW = 0;
+  bit IsAltFmt = !eq(AltFmtType.Value, IS_ALTFMT.Value);
   bit IncludeInInversePseudoTable = 1;
 }
 
@@ -571,7 +572,7 @@ class RISCVVPseudo<dag outs, dag ins, list<dag> pattern = [],
 def RISCVVPseudosTable : GenericTable {
   let FilterClass = "RISCVVPseudo";
   let CppTypeName = "PseudoInfo";
-  let Fields = [ "Pseudo", "BaseInstr" ];
+  let Fields = ["Pseudo", "BaseInstr", "VLMul", "SEW", "IsAltFmt"];
   let PrimaryKey = [ "Pseudo" ];
   let PrimaryKeyName = "getPseudoInfo";
   let PrimaryKeyEarlyOut = true;
@@ -581,9 +582,9 @@ def RISCVVInversePseudosTable : GenericTable {
   let FilterClass = "RISCVVPseudo";
   let FilterClassField = "IncludeInInversePseudoTable";
   let CppTypeName = "PseudoInfo";
-  let Fields = [ "Pseudo", "BaseInstr", "VLMul", "SEW"];
-  let PrimaryKey = [ "BaseInstr", "VLMul", "SEW"];
-  let PrimaryKeyName = "getBaseInfo";
+  let Fields = ["Pseudo", "BaseInstr", "VLMul", "SEW", "IsAltFmt"];
+  let PrimaryKey = ["BaseInstr", "VLMul", "SEW", "IsAltFmt"];
+  let PrimaryKeyName = "getBaseInfoImpl";
   let PrimaryKeyEarlyOut = true;
 }
 


### PR DESCRIPTION
Sometimes we might need to translate from one vector pseudo -- like `PseudoVFMUL_ALT_VV_M8_E16` -- to its `VFSUB_VV` counterpart, namely `PseudoVFSUB_ALT_VV_M8_E16`. It's difficult to do this efficiently with the current vector pseudo search table infrastructure. So I propose two changes in this patch:
  1. Currently both `RISCVVInversePseudosTable` and `RISCVVPseudosTable` does not distinguish between F16 and BF16. This will be problematic during lookup -- especially for `RISCVVInversePseudosTable`. So I added a new single-bit field `IsAltFmt` into both tables.
  2. It'd be great for `RISCVVPseudosTable` to return not just the base instruction opcode but also LMUL & SEW (if there is any). Because the alternative will require multiple additional steps (e.g. calling `getLMul(TSFlags)`) -- especially for the SEW-specific pseudos -- that are not really ergonomic. So I added `VLMul`, `SEW`, and `IsAltFmt` to the result of `RISCVVPseudosTable::getPseudoInfo`. The downside of this is of course bloating the table size, which is why I tried to mitigate it with using bit fields.

This should be a NFC