### PR TITLE
[Inline][CloneAndPruneFunctionInto] Consider the nonnull argument for null check

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/Cloning.h
+++ b/llvm/include/llvm/Transforms/Utils/Cloning.h
@@ -225,10 +225,10 @@ LLVM_ABI void CloneFunctionBodyInto(
     const MetadataPredicate *IdentityMD = nullptr);
 
 LLVM_ABI void CloneAndPruneIntoFromInst(
-    Function *NewFunc, const Function *OldFunc, const Instruction *StartingInst,
-    ValueToValueMapTy &VMap, bool ModuleLevelChanges,
-    SmallVectorImpl<ReturnInst *> &Returns, const char *NameSuffix = "",
-    ClonedCodeInfo *CodeInfo = nullptr);
+    CallBase &CB, Function *NewFunc, const Function *OldFunc,
+    const Instruction *StartingInst, ValueToValueMapTy &VMap,
+    bool ModuleLevelChanges, SmallVectorImpl<ReturnInst *> &Returns,
+    const char *NameSuffix = "", ClonedCodeInfo *CodeInfo = nullptr);
 
 /// This works exactly like CloneFunctionInto,
 /// except that it does some simple constant prop and DCE on the fly.  The
@@ -241,10 +241,13 @@ LLVM_ABI void CloneAndPruneIntoFromInst(
 /// If ModuleLevelChanges is false, VMap contains no non-identity GlobalValue
 /// mappings.
 ///
-LLVM_ABI void CloneAndPruneFunctionInto(
-    Function *NewFunc, const Function *OldFunc, ValueToValueMapTy &VMap,
-    bool ModuleLevelChanges, SmallVectorImpl<ReturnInst *> &Returns,
-    const char *NameSuffix = "", ClonedCodeInfo *CodeInfo = nullptr);
+LLVM_ABI void CloneAndPruneFunctionInto(CallBase &CB, Function *NewFunc,
+                                        const Function *OldFunc,
+                                        ValueToValueMapTy &VMap,
+                                        bool ModuleLevelChanges,
+                                        SmallVectorImpl<ReturnInst *> &Returns,
+                                        const char *NameSuffix = "",
+                                        ClonedCodeInfo *CodeInfo = nullptr);
 
 /// This class captures the data input to the InlineFunction call, and records
 /// the auxiliary results produced by it.

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -2714,7 +2714,7 @@ void llvm::InlineFunctionImpl(CallBase &CB, InlineFunctionInfo &IFI,
     // have no dead or constant instructions leftover after inlining occurs
     // (which can happen, e.g., because an argument was constant), but we'll be
     // happy with whatever the cloner can do.
-    CloneAndPruneFunctionInto(Caller, CalledFunc, VMap,
+    CloneAndPruneFunctionInto(CB, Caller, CalledFunc, VMap,
                               /*ModuleLevelChanges=*/false, Returns, ".i",
                               &InlinedFunctionInfo);
     // Remember the first block that is newly cloned over.

--- a/llvm/test/Transforms/Inline/nonnull.ll
+++ b/llvm/test/Transforms/Inline/nonnull.ll
@@ -76,23 +76,7 @@ define void @caller3(ptr %arg) {
 ; CHECK-LABEL: define void @caller3
 ; CHECK-SAME: (ptr [[ARG:%.*]]) {
 ; CHECK-NEXT:    [[CMP_I:%.*]] = icmp eq ptr [[ARG]], null
-; CHECK-NEXT:    br i1 [[CMP_I]], label [[EXPENSIVE_I:%.*]], label [[DONE_I:%.*]]
-; CHECK:       expensive.i:
-; CHECK-NEXT:    call void @foo()
-; CHECK-NEXT:    call void @foo()
-; CHECK-NEXT:    call void @foo()
-; CHECK-NEXT:    call void @foo()
-; CHECK-NEXT:    call void @foo()
-; CHECK-NEXT:    call void @foo()
-; CHECK-NEXT:    call void @foo()
-; CHECK-NEXT:    call void @foo()
-; CHECK-NEXT:    call void @foo()
-; CHECK-NEXT:    call void @foo()
-; CHECK-NEXT:    br label [[CALLEE_EXIT:%.*]]
-; CHECK:       done.i:
 ; CHECK-NEXT:    call void @bar()
-; CHECK-NEXT:    br label [[CALLEE_EXIT]]
-; CHECK:       callee.exit:
 ; CHECK-NEXT:    ret void
 ;
   call void @callee(ptr nonnull %arg)


### PR DESCRIPTION
Currently, for null check of a callee parameter, inline cost analysis checks if the corresponding argument at call site is marked nonnull and, if yes, the resulting dead blocks after the null check are excluded from the cost computation. But those dead blocks from the callee are still inlined into the caller. This is to teach inliner not to inline those dead blocks into the caller. This can reduce the code size of the caller after inlining.