### PR TITLE
[clang][test] Specify value of `-fopenmp=libomp` for tests.

### DIFF
--- a/clang/unittests/ASTMatchers/ASTMatchersNarrowingTest.cpp
+++ b/clang/unittests/ASTMatchers/ASTMatchersNarrowingTest.cpp
@@ -4832,7 +4832,8 @@ TEST_P(ASTMatchersTest, OMPTargetUpdateDirective_From_HasClause) {
   )";
   EXPECT_TRUE(matchesWithOpenMP(Source0, Matcher));
 
-  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
+  auto astUnit =
+      tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
   ASSERT_TRUE(astUnit);
 
   auto Results = match(ompTargetUpdateDirective().bind("directive"),
@@ -4892,7 +4893,8 @@ TEST_P(ASTMatchersTest, OMPTargetUpdateDirective_From_ArraySection_NoStride) {
     }
   )";
 
-  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
+  auto astUnit =
+      tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
   ASSERT_TRUE(astUnit);
 
   auto Results = match(ompTargetUpdateDirective().bind("directive"),
@@ -4951,7 +4953,8 @@ TEST_P(ASTMatchersTest, OMPTargetUpdateDirective_To_HasClause) {
   )";
   EXPECT_TRUE(matchesWithOpenMP(Source0, Matcher));
 
-  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
+  auto astUnit =
+      tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
   ASSERT_TRUE(astUnit);
 
   auto Results = match(ompTargetUpdateDirective().bind("directive"),
@@ -5008,7 +5011,8 @@ TEST_P(ASTMatchersTest, OMPTargetUpdateDirective_To_ArraySection_NoStride) {
     }
   )";
 
-  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
+  auto astUnit =
+      tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
   ASSERT_TRUE(astUnit);
 
   auto Results = match(ompTargetUpdateDirective().bind("directive"),

--- a/clang/unittests/ASTMatchers/ASTMatchersNarrowingTest.cpp
+++ b/clang/unittests/ASTMatchers/ASTMatchersNarrowingTest.cpp
@@ -4832,7 +4832,7 @@ TEST_P(ASTMatchersTest, OMPTargetUpdateDirective_From_HasClause) {
   )";
   EXPECT_TRUE(matchesWithOpenMP(Source0, Matcher));
 
-  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp"});
+  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
   ASSERT_TRUE(astUnit);
 
   auto Results = match(ompTargetUpdateDirective().bind("directive"),
@@ -4892,7 +4892,7 @@ TEST_P(ASTMatchersTest, OMPTargetUpdateDirective_From_ArraySection_NoStride) {
     }
   )";
 
-  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp"});
+  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
   ASSERT_TRUE(astUnit);
 
   auto Results = match(ompTargetUpdateDirective().bind("directive"),
@@ -4951,7 +4951,7 @@ TEST_P(ASTMatchersTest, OMPTargetUpdateDirective_To_HasClause) {
   )";
   EXPECT_TRUE(matchesWithOpenMP(Source0, Matcher));
 
-  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp"});
+  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
   ASSERT_TRUE(astUnit);
 
   auto Results = match(ompTargetUpdateDirective().bind("directive"),
@@ -5008,7 +5008,7 @@ TEST_P(ASTMatchersTest, OMPTargetUpdateDirective_To_ArraySection_NoStride) {
     }
   )";
 
-  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp"});
+  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
   ASSERT_TRUE(astUnit);
 
   auto Results = match(ompTargetUpdateDirective().bind("directive"),

--- a/clang/unittests/ASTMatchers/ASTMatchersNodeTest.cpp
+++ b/clang/unittests/ASTMatchers/ASTMatchersNodeTest.cpp
@@ -2829,7 +2829,7 @@ TEST(ASTMatchersTestOpenMP, OMPFromClause) {
   )";
   EXPECT_TRUE(matchesWithOpenMP(Source0, Matcher));
 
-  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp"});
+  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
   ASSERT_TRUE(astUnit);
 
   auto Results = match(ompTargetUpdateDirective().bind("directive"),
@@ -2893,7 +2893,7 @@ TEST(ASTMatchersTestOpenMP, OMPToClause) {
   )";
   EXPECT_TRUE(matchesWithOpenMP(Source0, Matcher));
 
-  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp"});
+  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
   ASSERT_TRUE(astUnit);
 
   auto Results = match(ompTargetUpdateDirective().bind("directive"),

--- a/clang/unittests/ASTMatchers/ASTMatchersNodeTest.cpp
+++ b/clang/unittests/ASTMatchers/ASTMatchersNodeTest.cpp
@@ -2829,7 +2829,8 @@ TEST(ASTMatchersTestOpenMP, OMPFromClause) {
   )";
   EXPECT_TRUE(matchesWithOpenMP(Source0, Matcher));
 
-  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
+  auto astUnit =
+      tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
   ASSERT_TRUE(astUnit);
 
   auto Results = match(ompTargetUpdateDirective().bind("directive"),
@@ -2893,7 +2894,8 @@ TEST(ASTMatchersTestOpenMP, OMPToClause) {
   )";
   EXPECT_TRUE(matchesWithOpenMP(Source0, Matcher));
 
-  auto astUnit = tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
+  auto astUnit =
+      tooling::buildASTFromCodeWithArgs(Source0, {"-fopenmp=libomp"});
   ASSERT_TRUE(astUnit);
 
   auto Results = match(ompTargetUpdateDirective().bind("directive"),


### PR DESCRIPTION
`libomp` is the default value when unconfigured in cmake, but llvm can be configured to have `libgomp` be the default instead. Explicitly specify this value so the test does not fail when it assumes libomp is always the default.

Fix for f369d23ceaa49ffa9e6ef9673851749d66b35b3f (#150580)