### PR TITLE
[SLP][NFC] Refactor vectorizeStores::RangeSizes

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -24432,7 +24432,7 @@ bool SLPVectorizerPass::vectorizeStores(
           }
           if (!AnyProfitableGraph && VF >= MaxRegVF && has_single_bit(VF))
             break;
-          // For the MaxRegVF, save RangeSizes to limit compile time
+          // For the MaxRegVF case, save RangeSizes to limit compile time
           if (VF == MaxRegVF)
             for (std::pair<unsigned, unsigned> &P : RangeSizes)
               if (P.first != 0)

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -24291,8 +24291,9 @@ bool SLPVectorizerPass::vectorizeStores(
       unsigned Repeat = 0;
       constexpr unsigned MaxAttempts = 4;
       // first: the best TreeSize from all prior loops over CandidateVFs, gets
-      // updated after looping through CandidateVFs second: the best TreeSize
-      // from all prior loops including the current one
+      // updated after looping through CandidateVFs
+      // second: the best TreeSize from all prior loops including the current
+      // one
       llvm::SmallVector<std::pair<unsigned, unsigned>> RangeSizesStorage(
           Operands.size(), {1, 1});
       // The `slice` and `drop_front` interfaces are convenient

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -24296,13 +24296,11 @@ bool SLPVectorizerPass::vectorizeStores(
       // The `slice` and `drop_front` interfaces are convenient
       const auto RangeSizes = MutableArrayRef(RangeSizesStorage);
       DenseMap<Value *, std::pair<unsigned, unsigned>> NonSchedulable;
-      auto IsNotVectorized = [](bool First,
-                                const std::pair<unsigned, unsigned> &P) {
-        return First ? P.first > 0 : P.second > 0;
+      auto IsNotVectorized = [](const std::pair<unsigned, unsigned> &P) {
+        return P.first > 0;
       };
-      auto IsVectorized = [](bool First,
-                             const std::pair<unsigned, unsigned> &P) {
-        return First ? P.first == 0 : P.second == 0;
+      auto IsVectorized = [](const std::pair<unsigned, unsigned> &P) {
+        return P.first == 0;
       };
       auto VFIsProfitable = [](bool First, unsigned Size,
                                const std::pair<unsigned, unsigned> &P) {
@@ -24318,18 +24316,15 @@ bool SLPVectorizerPass::vectorizeStores(
         bool AnyProfitableGraph = false;
         for (unsigned VF : CandidateVFs) {
           AnyProfitableGraph = false;
-          unsigned FirstUnvecStore =
-              std::distance(RangeSizes.begin(),
-                            find_if(RangeSizes, std::bind(IsNotVectorized,
-                                                          VF >= MaxRegVF, _1)));
+          unsigned FirstUnvecStore = std::distance(
+              RangeSizes.begin(), find_if(RangeSizes, IsNotVectorized));
 
           // Form slices of size VF starting from FirstUnvecStore and try to
           // vectorize them.
           while (FirstUnvecStore < End) {
             unsigned FirstVecStore = std::distance(
                 RangeSizes.begin(),
-                find_if(RangeSizes.drop_front(FirstUnvecStore),
-                        std::bind(IsVectorized, VF >= MaxRegVF, _1)));
+                find_if(RangeSizes.drop_front(FirstUnvecStore), IsVectorized));
             unsigned MaxSliceEnd = FirstVecStore >= End ? End : FirstVecStore;
             for (unsigned SliceStartIdx = FirstUnvecStore;
                  SliceStartIdx + VF <= MaxSliceEnd;) {
@@ -24437,16 +24432,13 @@ bool SLPVectorizerPass::vectorizeStores(
               AnyProfitableGraph = true;
             FirstUnvecStore = std::distance(
                 RangeSizes.begin(),
-                find_if(RangeSizes.drop_front(MaxSliceEnd),
-                        std::bind(IsNotVectorized, VF >= MaxRegVF, _1)));
+                find_if(RangeSizes.drop_front(MaxSliceEnd), IsNotVectorized));
           }
           if (!AnyProfitableGraph && VF >= MaxRegVF && has_single_bit(VF))
             break;
         }
         // All values vectorized - exit.
-        if (all_of(RangeSizes, [](const std::pair<unsigned, unsigned> &P) {
-              return P.first == 0 && P.second == 0;
-            }))
+        if (all_of(RangeSizes, IsVectorized))
           break;
         // Check if tried all attempts or no need for the last attempts at all.
         if (Repeat >= MaxAttempts ||
@@ -24457,9 +24449,8 @@ bool SLPVectorizerPass::vectorizeStores(
             Operands.size(),
             static_cast<unsigned>(
                 End -
-                std::distance(
-                    RangeSizes.begin(),
-                    find_if(RangeSizes, std::bind(IsNotVectorized, true, _1))) +
+                std::distance(RangeSizes.begin(),
+                              find_if(RangeSizes, IsNotVectorized)) +
                 1));
         unsigned VF = bit_ceil(CandidateVFs.front()) * 2;
         unsigned Limit =

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -24329,7 +24329,7 @@ bool SLPVectorizerPass::vectorizeStores(
             for (unsigned SliceStartIdx = FirstUnvecStore;
                  SliceStartIdx + VF <= MaxSliceEnd;) {
               if (!checkTreeSizes(RangeSizes.slice(SliceStartIdx, VF),
-                                  VF >= MaxRegVF)) {
+                                  VF > MaxRegVF)) {
                 ++SliceStartIdx;
                 continue;
               }
@@ -24397,7 +24397,7 @@ bool SLPVectorizerPass::vectorizeStores(
               }
               if (VF > 2 && Res &&
                   !all_of(RangeSizes.slice(SliceStartIdx, VF),
-                          std::bind(VFIsProfitable, VF >= MaxRegVF, TreeSize,
+                          std::bind(VFIsProfitable, VF > MaxRegVF, TreeSize,
                                     _1))) {
                 SliceStartIdx += VF;
                 continue;
@@ -24416,7 +24416,7 @@ bool SLPVectorizerPass::vectorizeStores(
               if (TreeSize > 1) {
                 for (std::pair<unsigned, unsigned> &P :
                      RangeSizes.slice(SliceStartIdx, VF)) {
-                  if (VF >= MaxRegVF)
+                  if (VF > MaxRegVF)
                     P.second = std::max(P.second, TreeSize);
                   else
                     P.first = std::max(P.first, TreeSize);

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -24431,6 +24431,11 @@ bool SLPVectorizerPass::vectorizeStores(
           }
           if (!AnyProfitableGraph && VF >= MaxRegVF && has_single_bit(VF))
             break;
+          // For the MaxRegVF, save RangeSizes to limit compile time
+          if (VF == MaxRegVF)
+            for (std::pair<unsigned, unsigned> &P : RangeSizes)
+              if (P.first != 0)
+                P.first = std::max(P.second, P.first);
         }
         // All values vectorized - exit.
         if (all_of(RangeSizes, IsVectorized))


### PR DESCRIPTION
Reopening #177228 with proper commits.

Currently `RangeSizes` is used to allow us to skip trying to vectorize clearly unprofitable trees by caching prior attempts `TreeSizes`. This PR refactors that logic to simplify and improve readability. This will make it easier to handle the [strided stores](https://github.com/llvm/llvm-project/pull/175126#issuecomment-3747644896).

Waiting on #177100 to be merged, this will need rebased on top of those changes since they will conflict.

The main two adjustments are:
1. When vectorization occurs, we always update both `RangeSize[Idx].first = RangeSize[Idx].second = 0`, so when checking if an element is or isn't vectorized, we can just check the first element always (6d5fc8b9).
2. Switch RangeSizes to hold a single `unsigned` value rather than a pair.

    When testing out different VF's within vectorizeStores, we iterate in the order
    `MaxVF, MaxVF / 2, ..., MinVF, MaxVF * 2, ...`
    where:
    - `MaxVF <= MaxRegVF`
    - We only proceed past MinVF in cases where `MaxVF == MaxRegVF` (since `MaxVF < MaxRegVF`
    only if `# stores < MaxRegVF`)
    Prior to this, RangeSizes contains a pair, and we access the first/second element
    depending on if VF < MaxRegVF.

    In the main `while` loop, we iterated though `CandidateVFs` multiple times
    - In the first iteration, we handle VFs where `VF <= MaxRegVF`
    - In subsequent iterations, we handles VFs were `VF > MaxRegVF`

    The behavior of rangeSizes prior to this change:
    - if the element at index `Idx` is vectorized, we update `RangeSizes[Idx].first = RangeSizes[Idx].second = 0`
    - if we find a new unprofitable tree, we attempt to update` RangeSizes[Idx].second` if `VF > MaxRegVF`, otherwise
    `RangeSizes[Idx].first`
    - `FirstSizeSame`, `VFIsProfitable`, and `CheckTreeSizes` use `RangeSizes[Idx].first` if `VF > MaxRegVF`, otherwise
    `RangeSizes[Idx].second`
    - After iterating through all elements in `CandidateVFs`, we then update `RangeSizes[Idx].first` with `RangeSizes[Idx].second`

    In the first iteration of the `while` loop, `RangeSizes[...].first` is used to store updated values temporarily while we access elements from second.
    In future iterations (where now `VF > MaxRegVF`), we update `RangeSizes[...].second` and access out of `RangeSizes[...].first`. The values from `second` are propogated to `first` at the end of the loop.

    So effectively, we are just using the `second` part of the pair to cache updates while we iterate through the remainder of the `CandidateVFs` for a given loop. This commit updates that so that `second` is explicitly used as a cache and `first` is used for checks.