### PR TITLE
[hexagon] Add dylib cmake + toolchain_only

### DIFF
--- a/clang/cmake/caches/hexagon-unknown-linux-musl-clang-cross.cmake
+++ b/clang/cmake/caches/hexagon-unknown-linux-musl-clang-cross.cmake
@@ -15,4 +15,6 @@ set(CLANG_LINKS_TO_CREATE
             clang-cpp
             CACHE STRING "")
 
-set(LLVM_INSTALL_TOOLCHAIN_ONLY ON CACHE BOOL "")
+# Note: FORCE is required to override the OFF setting in hexagon-unknown-linux-musl-clang.cmake
+# which is loaded earlier in the -C chain.
+set(LLVM_INSTALL_TOOLCHAIN_ONLY ON CACHE BOOL "" FORCE)

--- a/clang/cmake/caches/hexagon-unknown-linux-musl-clang-dylib.cmake
+++ b/clang/cmake/caches/hexagon-unknown-linux-musl-clang-dylib.cmake
@@ -1,0 +1,7 @@
+set(LLVM_BUILD_LLVM_DYLIB ON CACHE BOOL "")
+set(LLVM_LINK_LLVM_DYLIB ON CACHE BOOL "")
+set(CLANG_LINK_LLVM_DYLIB ON CACHE BOOL "")
+
+# Clear version suffix to prevent versioned library names like libLLVM.so.22.1-rc1
+# which lld doesn't recognize. This results in libLLVM.so.22.1 instead.
+set(LLVM_VERSION_SUFFIX "" CACHE STRING "")


### PR DESCRIPTION
The toolchains take up much less space when we enable dylib, so let's create an option to build them that way.

Also: TOOLCHAIN_ONLY was ineffective in hexagon-unknown-linux-musl-clang-cross.cmake because cmake takes the first setting from hexagon-unknown-linux-musl-clang.cmake with precedence.  FORCE it to fix that issue.