### PR TITLE
[NFCI][AMDGPU] Convert more `SubtargetFeatures` to use `AMDGPUSubtargetFeature` and X-macros

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -76,59 +76,49 @@ def FeatureFastFMAF32 : SubtargetFeature<"fast-fmaf",
   "Assuming f32 fma is at least as fast as mul + add"
 >;
 
-def FeatureFastDenormalF32 : SubtargetFeature<"fast-denormal-f32",
-  "FastDenormalF32",
-  "true",
-  "Enabling denormals does not cause f32 instructions to run at f64 rates"
+defm FastDenormalF32 : AMDGPUSubtargetFeature<"fast-denormal-f32",
+  "Enabling denormals does not cause f32 instructions to run at f64 rates",
+  /*GenPredicate=*/0
 >;
 
-def FeatureMIMG_R128 : SubtargetFeature<"mimg-r128",
-  "MIMG_R128",
-  "true",
-  "Support 128-bit texture resources"
+defm MIMG_R128 : AMDGPUSubtargetFeature<"mimg-r128",
+  "Support 128-bit texture resources",
+  /*GenPredicate=*/0
 >;
 
-def HalfRate64Ops : SubtargetFeature<"half-rate-64-ops",
-  "HalfRate64Ops",
-  "true",
-  "Most fp64 instructions are half rate instead of quarter"
+defm HalfRate64Ops : AMDGPUSubtargetFeature<"half-rate-64-ops",
+  "Most fp64 instructions are half rate instead of quarter",
+  /*GenPredicate=*/0
 >;
 
-def FullRate64Ops : SubtargetFeature<"full-rate-64-ops",
-  "FullRate64Ops",
-  "true",
-  "Most fp64 instructions are full rate"
+defm FullRate64Ops : AMDGPUSubtargetFeature<"full-rate-64-ops",
+  "Most fp64 instructions are full rate",
+  /*GenPredicate=*/0
 >;
 
-def FeatureFlatAddressSpace : SubtargetFeature<"flat-address-space",
-  "FlatAddressSpace",
-  "true",
+defm FlatAddressSpace : AMDGPUSubtargetFeature<"flat-address-space",
   "Support flat address space"
 >;
 
-def FeatureFlatInstOffsets : SubtargetFeature<"flat-inst-offsets",
-  "FlatInstOffsets",
-  "true",
+defm FlatInstOffsets : AMDGPUSubtargetFeature<"flat-inst-offsets",
   "Flat instructions have immediate offset addressing mode"
 >;
 
-def FeatureFlatGlobalInsts : SubtargetFeature<"flat-global-insts",
-  "FlatGlobalInsts",
-  "true",
+defm FlatGlobalInsts : AMDGPUSubtargetFeature<"flat-global-insts",
   "Have global_* flat memory instructions",
+  /*GenPredicate=*/1,
+  /*GenAssemblerPredicate=*/1,
   [FeatureFlatAddressSpace]
 >;
 
-def FeatureFlatScratchInsts : SubtargetFeature<"flat-scratch-insts",
-  "FlatScratchInsts",
-  "true",
+defm FlatScratchInsts : AMDGPUSubtargetFeature<"flat-scratch-insts",
   "Have scratch_* flat memory instructions",
+  /*GenPredicate=*/1,
+  /*GenAssemblerPredicate=*/1,
   [FeatureFlatAddressSpace]
 >;
 
-def FeatureScalarFlatScratchInsts : SubtargetFeature<"scalar-flat-scratch-insts",
-  "ScalarFlatScratchInsts",
-  "true",
+defm ScalarFlatScratchInsts : AMDGPUSubtargetFeature<"scalar-flat-scratch-insts",
   "Have s_scratch_* flat memory instructions"
 >;
 
@@ -138,10 +128,10 @@ def FeatureEnableFlatScratch : SubtargetFeature<"enable-flat-scratch",
   "Use scratch_* flat memory instructions to access scratch"
 >;
 
-def FeatureFlatGVSMode : SubtargetFeature<"flat-gvs-mode",
-  "FlatGVSMode",
-  "true",
+defm FlatGVSMode : AMDGPUSubtargetFeature<"flat-gvs-mode",
   "Have GVS addressing mode with flat_* instructions",
+  /*GenPredicate=*/1,
+  /*GenAssemblerPredicate=*/1,
   [FeatureFlatAddressSpace]
 >;
 
@@ -151,9 +141,7 @@ def FeatureAddNoCarryInsts : SubtargetFeature<"add-no-carry-insts",
   "Have VALU add/sub instructions without carry out"
 >;
 
-def FeatureUnalignedBufferAccess : SubtargetFeature<"unaligned-buffer-access",
-  "UnalignedBufferAccess",
-  "true",
+defm UnalignedBufferAccess : AMDGPUSubtargetFeature<"unaligned-buffer-access",
   "Hardware supports unaligned global loads and stores"
 >;
 
@@ -163,21 +151,15 @@ def FeatureTrapHandler: SubtargetFeature<"trap-handler",
   "Trap handler support"
 >;
 
-def FeatureUnalignedScratchAccess : SubtargetFeature<"unaligned-scratch-access",
-  "UnalignedScratchAccess",
-  "true",
+defm UnalignedScratchAccess : AMDGPUSubtargetFeature<"unaligned-scratch-access",
   "Support unaligned scratch loads and stores"
 >;
 
-def FeatureUnalignedDSAccess : SubtargetFeature<"unaligned-ds-access",
-  "UnalignedDSAccess",
-  "true",
+defm UnalignedDSAccess : AMDGPUSubtargetFeature<"unaligned-ds-access",
   "Hardware supports unaligned local and region loads and stores"
 >;
 
-def FeatureRelaxedBufferOOBMode : SubtargetFeature<"relaxed-buffer-oob-mode",
-  "RelaxedBufferOOBMode",
-  "true",
+defm RelaxedBufferOOBMode : AMDGPUSubtargetFeature<"relaxed-buffer-oob-mode",
   "Disable strict out-of-bounds buffer guarantees. An OOB access may potentially"
   "cause an adjacent access to be treated as if it were also OOB"
 >;
@@ -255,9 +237,7 @@ def FeaturePreciseMemory
     : SubtargetFeature<"precise-memory", "EnablePreciseMemory",
                        "true", "Enable precise memory mode">;
 
-def FeatureSGPRInitBug : SubtargetFeature<"sgpr-init-bug",
-  "SGPRInitBug",
-  "true",
+defm SGPRInitBug : AMDGPUSubtargetFeature<"sgpr-init-bug",
   "VI SGPR initialization bug requiring a fixed SGPR allocation size"
 >;
 
@@ -352,9 +332,7 @@ defm FlatSegmentOffsetBug : AMDGPUSubtargetFeature<"flat-segment-offset-bug",
   /*GenPredicate=*/0
 >;
 
-def FeatureNegativeScratchOffsetBug : SubtargetFeature<"negative-scratch-offset-bug",
-  "NegativeScratchOffsetBug",
-  "true",
+defm NegativeScratchOffsetBug : AMDGPUSubtargetFeature<"negative-scratch-offset-bug",
   "Negative immediate offsets in scratch instructions with an SGPR offset page fault on GFX9"
 >;
 
@@ -406,28 +384,24 @@ class SubtargetFeatureLDSBankCount <int Value> : SubtargetFeature <
 def FeatureLDSBankCount16 : SubtargetFeatureLDSBankCount<16>;
 def FeatureLDSBankCount32 : SubtargetFeatureLDSBankCount<32>;
 
-def FeatureGCN3Encoding : SubtargetFeature<"gcn3-encoding",
-  "GCN3Encoding",
-  "true",
-  "Encoding format for VI"
+defm GCN3Encoding : AMDGPUSubtargetFeature<"gcn3-encoding",
+  "Encoding format for VI",
+  /*GenPredicate=*/0
 >;
 
-def FeatureCIInsts : SubtargetFeature<"ci-insts",
-  "CIInsts",
-  "true",
-  "Additional instructions for CI+"
+defm CIInsts : AMDGPUSubtargetFeature<"ci-insts",
+  "Additional instructions for CI+",
+  /*GenPredicate=*/0
 >;
 
-def FeatureGFX8Insts : SubtargetFeature<"gfx8-insts",
-  "GFX8Insts",
-  "true",
-  "Additional instructions for GFX8+"
+defm GFX8Insts : AMDGPUSubtargetFeature<"gfx8-insts",
+  "Additional instructions for GFX8+",
+  /*GenPredicate=*/0
 >;
 
-def FeatureGFX9Insts : SubtargetFeature<"gfx9-insts",
-  "GFX9Insts",
-  "true",
-  "Additional instructions for GFX9+"
+defm GFX9Insts : AMDGPUSubtargetFeature<"gfx9-insts",
+  "Additional instructions for GFX9+",
+  /*GenPredicate=*/0
 >;
 
 def FeatureRequiresAlignedVGPRs : SubtargetFeature<"vgpr-align2",
@@ -436,17 +410,14 @@ def FeatureRequiresAlignedVGPRs : SubtargetFeature<"vgpr-align2",
   "VGPR and AGPR tuple operands require even alignment"
 >;
 
-def FeatureGFX90AInsts : SubtargetFeature<"gfx90a-insts",
-  "GFX90AInsts",
-  "true",
-  "Additional instructions for GFX90A+"
-  // [HasAtomicFMinFMaxF64GlobalInsts, HasAtomicFMinFMaxF64FlatInsts] // TODO
+defm GFX90AInsts : AMDGPUSubtargetFeature<"gfx90a-insts",
+  "Additional instructions for GFX90A+",
+  /*GenPredicate=*/0
 >;
 
-def FeatureGFX940Insts : SubtargetFeature<"gfx940-insts",
-  "GFX940Insts",
-  "true",
-  "Additional instructions for GFX940+"
+defm GFX940Insts : AMDGPUSubtargetFeature<"gfx940-insts",
+  "Additional instructions for GFX940+",
+  /*GenPredicate=*/0
 >;
 
 defm Permlane16Swap : AMDGPUSubtargetFeature<"permlane16-swap",
@@ -493,10 +464,10 @@ defm McastLoadInsts : AMDGPUSubtargetFeature<"mcast-load-insts",
   "Has multicast load instructions"
 >;
 
-def FeatureGFX950Insts : SubtargetFeature<"gfx950-insts",
-  "GFX950Insts",
-  "true",
+defm GFX950Insts : AMDGPUSubtargetFeature<"gfx950-insts",
   "Additional instructions for GFX950+",
+  /*GenPredicate=*/1,
+  /*GenAssemblerPredicate=*/1,
   [FeaturePermlane16Swap,
    FeaturePermlane32Swap,
    FeatureAshrPkInsts,
@@ -512,40 +483,34 @@ def FeatureGFX950Insts : SubtargetFeature<"gfx950-insts",
    ]
 >;
 
-def FeatureGFX10Insts : SubtargetFeature<"gfx10-insts",
-  "GFX10Insts",
-  "true",
-  "Additional instructions for GFX10+"
+defm GFX10Insts : AMDGPUSubtargetFeature<"gfx10-insts",
+  "Additional instructions for GFX10+",
+  /*GenPredicate=*/0
 >;
 
-def FeatureGFX11Insts : SubtargetFeature<"gfx11-insts",
-  "GFX11Insts",
-  "true",
-  "Additional instructions for GFX11+"
+defm GFX11Insts : AMDGPUSubtargetFeature<"gfx11-insts",
+  "Additional instructions for GFX11+",
+  /*GenPredicate=*/0
 >;
 
-def FeatureGFX12Insts : SubtargetFeature<"gfx12-insts",
-  "GFX12Insts",
-  "true",
-  "Additional instructions for GFX12+"
+defm GFX12Insts : AMDGPUSubtargetFeature<"gfx12-insts",
+  "Additional instructions for GFX12+",
+  /*GenPredicate=*/0
 >;
 
-def FeatureGFX1250Insts : SubtargetFeature<"gfx1250-insts",
-  "GFX1250Insts",
-  "true",
-  "Additional instructions for GFX1250+"
+defm GFX1250Insts : AMDGPUSubtargetFeature<"gfx1250-insts",
+  "Additional instructions for GFX1250+",
+  /*GenPredicate=*/0
 >;
 
-def FeatureGFX10_3Insts : SubtargetFeature<"gfx10-3-insts",
-  "GFX10_3Insts",
-  "true",
-  "Additional instructions for GFX10.3"
+defm GFX10_3Insts : AMDGPUSubtargetFeature<"gfx10-3-insts",
+  "Additional instructions for GFX10.3",
+  /*GenPredicate=*/0
 >;
 
-def FeatureGFX7GFX8GFX9Insts : SubtargetFeature<"gfx7-gfx8-gfx9-insts",
-  "GFX7GFX8GFX9Insts",
-  "true",
-  "Instructions shared in GFX7, GFX8, GFX9"
+defm GFX7GFX8GFX9Insts : AMDGPUSubtargetFeature<"gfx7-gfx8-gfx9-insts",
+  "Instructions shared in GFX7, GFX8, GFX9",
+  /*GenPredicate=*/0
 >;
 
 defm SMemRealTime : AMDGPUSubtargetFeature<"s-memrealtime",
@@ -701,16 +666,14 @@ defm ExtendedImageInsts : AMDGPUSubtargetFeature<"extended-image-insts",
   "Support mips != 0, lod != 0, gather4, and get_lod"
 >;
 
-def FeatureGFX10_AEncoding : SubtargetFeature<"gfx10_a-encoding",
-  "GFX10_AEncoding",
-  "true",
-  "Has BVH ray tracing instructions"
+defm GFX10_AEncoding : AMDGPUSubtargetFeature<"gfx10_a-encoding",
+  "Has BVH ray tracing instructions",
+  /*GenPredicate=*/0
 >;
 
-def FeatureGFX10_BEncoding : SubtargetFeature<"gfx10_b-encoding",
-  "GFX10_BEncoding",
-  "true",
-  "Encoding format GFX10_B"
+defm GFX10_BEncoding : AMDGPUSubtargetFeature<"gfx10_b-encoding",
+  "Encoding format GFX10_B",
+  /*GenPredicate=*/0
 >;
 
 defm IntClamp : AMDGPUSubtargetFeature<"int-clamp-insts",
@@ -780,7 +743,6 @@ defm Dot12Insts : AMDGPUSubtargetFeature<"dot12-insts",
 defm Dot13Insts : AMDGPUSubtargetFeature<"dot13-insts",
   "Has v_dot2c_f32_bf16 instructions"
 >;
-
 
 defm MAIInsts : AMDGPUSubtargetFeature<"mai-insts",
   "Has mAI instructions"
@@ -1027,7 +989,6 @@ defm 1_5xVGPRs : AMDGPUSubtargetFeature<"allocate1_5xvgprs",
   /*GenPredicate=*/0
 >;
 
-
 defm VOPDInsts : AMDGPUSubtargetFeature<"vopd",
   "Has VOPD dual issue wave32 instructions",
   /*GenPredicate=*/0
@@ -1233,9 +1194,7 @@ def FeatureKernargPreload : SubtargetFeature <"kernarg-preload",
 
 // Alignment enforcement is controlled by a configuration register:
 // SH_MEM_CONFIG.alignment_mode
-def FeatureUnalignedAccessMode : SubtargetFeature<"unaligned-access-mode",
-  "UnalignedAccessMode",
-  "true",
+defm UnalignedAccessMode : AMDGPUSubtargetFeature<"unaligned-access-mode",
   "Enable unaligned global, local and region loads and stores if the hardware"
   " supports it"
 >;
@@ -1509,7 +1468,7 @@ class FeatureSet<list<SubtargetFeature> Features_> {
 
 def FeatureISAVersion6_0_0 : FeatureSet<[FeatureSouthernIslands,
    FeatureFastFMAF32,
-   HalfRate64Ops,
+   FeatureHalfRate64Ops,
    FeatureLDSBankCount32]>;
 
 def FeatureISAVersion6_0_1 : FeatureSet<
@@ -1526,7 +1485,7 @@ def FeatureISAVersion7_0_0 : FeatureSet<
 
 def FeatureISAVersion7_0_1 : FeatureSet<
   [FeatureSeaIslands,
-   HalfRate64Ops,
+   FeatureHalfRate64Ops,
    FeatureLDSBankCount32,
    FeatureFastFMAF32]>;
 
@@ -1555,7 +1514,7 @@ def FeatureISAVersion8_0_Common : FeatureSet<
 def FeatureISAVersion8_0_1 : FeatureSet<
   !listconcat(FeatureISAVersion8_0_Common.Features,
     [FeatureFastFMAF32,
-     HalfRate64Ops,
+     FeatureHalfRate64Ops,
      FeatureSupportsXNACK])>;
 
 def FeatureISAVersion8_0_2 : FeatureSet<
@@ -1626,7 +1585,7 @@ def FeatureISAVersion9_0_4 : FeatureSet<
 
 def FeatureISAVersion9_0_6 : FeatureSet<
   !listconcat(FeatureISAVersion9_0_Consumer_Common.Features,
-    [HalfRate64Ops,
+    [FeatureHalfRate64Ops,
      FeatureFmaMixInsts,
      FeatureDLInsts,
      FeatureDot1Insts,
@@ -1638,7 +1597,7 @@ def FeatureISAVersion9_0_6 : FeatureSet<
 def FeatureISAVersion9_0_8 : FeatureSet<
   !listconcat(FeatureISAVersion9_0_MI_Common.Features,
     [FeatureGDS,
-     HalfRate64Ops,
+     FeatureHalfRate64Ops,
      FeatureDsSrc2Insts,
      FeatureExtendedImageInsts,
      FeatureAtomicBufferGlobalPkAddF16NoRtnInsts,
@@ -1659,7 +1618,7 @@ def FeatureISAVersion9_0_A : FeatureSet<
      FeatureAtomicFaddRtnInsts,
      FeatureAtomicBufferGlobalPkAddF16Insts,
      FeaturePackedTID,
-     FullRate64Ops,
+     FeatureFullRate64Ops,
      FeatureBackOffBarrier,
      FeatureKernargPreload,
      FeatureAtomicFMinFMaxF64GlobalInsts,
@@ -1702,7 +1661,7 @@ def FeatureISAVersion9_4_Common : FeatureSet<
    FeatureSupportsSRAMECC,
    FeaturePackedTID,
    FeatureArchitectedFlatScratch,
-   FullRate64Ops,
+   FeatureFullRate64Ops,
    FeatureBackOffBarrier,
    FeatureKernargPreload,
    FeatureAtomicFMinFMaxF64GlobalInsts,
@@ -2288,10 +2247,6 @@ def isNotGFX940Plus :
   Predicate<"!Subtarget->hasGFX940Insts()">,
   AssemblerPredicate<(all_of (not FeatureGFX940Insts))>;
 
-def HasGFX950Insts :
-  Predicate<"Subtarget->hasGFX950Insts()">,
-  AssemblerPredicate<(all_of FeatureGFX950Insts)>;
-
 def isGFX8GFX9NotGFX940 :
   Predicate<"!Subtarget->hasGFX940Insts() &&"
             "(Subtarget->getGeneration() == AMDGPUSubtarget::VOLCANIC_ISLANDS ||"
@@ -2377,9 +2332,6 @@ def isGFX940orGFX1250 :
   Predicate<"Subtarget->hasGFX940Insts() || Subtarget->hasGFX1250Insts()">,
   AssemblerPredicate<(any_of FeatureGFX940Insts, FeatureGFX1250Insts)>;
 
-def HasFlatAddressSpace : Predicate<"Subtarget->hasFlatAddressSpace()">,
-  AssemblerPredicate<(all_of FeatureFlatAddressSpace)>;
-
 def HasAtomicCondSubClampFlatInsts :
   Predicate<"Subtarget->getGeneration() >= AMDGPUSubtarget::GFX12">,
   AssemblerPredicate<(all_of FeatureGFX12Insts)>;
@@ -2388,12 +2340,6 @@ def HasLdsAtomicAddF64 :
   Predicate<"Subtarget->hasLdsAtomicAddF64()">,
   AssemblerPredicate<(any_of FeatureGFX90AInsts, FeatureGFX1250Insts)>;
 
-def HasFlatGlobalInsts : Predicate<"Subtarget->hasFlatGlobalInsts()">,
-  AssemblerPredicate<(all_of FeatureFlatGlobalInsts)>;
-def HasFlatScratchInsts : Predicate<"Subtarget->hasFlatScratchInsts()">,
-  AssemblerPredicate<(all_of FeatureFlatScratchInsts)>;
-def HasScalarFlatScratchInsts : Predicate<"Subtarget->hasScalarFlatScratchInsts()">,
-  AssemblerPredicate<(all_of FeatureScalarFlatScratchInsts)>;
 def HasD16LoadStore : Predicate<"Subtarget->hasD16LoadStore()">,
   AssemblerPredicate<(all_of FeatureGFX9Insts)>;
 
@@ -2401,9 +2347,6 @@ def HasFlatScratchSTMode : Predicate<"Subtarget->hasFlatScratchSTMode()">,
   AssemblerPredicate<(any_of FeatureGFX10_3Insts, FeatureGFX940Insts)>;
 def HasFlatScratchSVSMode : Predicate<"Subtarget->hasFlatScratchSVSMode()">,
   AssemblerPredicate<(any_of FeatureGFX940Insts, FeatureGFX11Insts)>;
-
-def HasFlatGVSMode : Predicate<"Subtarget->hasFlatGVSMode()">,
-  AssemblerPredicate<(all_of FeatureFlatGVSMode)>;
 
 def HasGFX10_AEncoding : Predicate<"Subtarget->hasGFX10_AEncoding()">,
   AssemblerPredicate<(all_of FeatureGFX10_AEncoding)>;
@@ -2472,7 +2415,6 @@ def HasD16Writes32BitVgpr: Predicate<"Subtarget->hasD16Writes32BitVgpr()">,
 def NotHasD16Writes32BitVgpr: Predicate<"!Subtarget->hasD16Writes32BitVgpr()">,
   AssemblerPredicate<(all_of FeatureTrue16BitInsts, FeatureRealTrue16Insts, (not FeatureD16Writes32BitVgpr))>;
 
-
 def NotHasMed3_16 : Predicate<"!Subtarget->hasMed3_16()">;
 def HasMed3_16 : Predicate<"Subtarget->hasMed3_16()">;
 
@@ -2498,7 +2440,6 @@ def HasDPP : Predicate<"Subtarget->hasDPP()">,
 def HasDPP8 : Predicate<"Subtarget->hasDPP8()">,
   AssemblerPredicate<(all_of (not FeatureGCN3Encoding), FeatureGFX10Insts, FeatureDPP8)>;
 
-
 def HasPkMovB32 : Predicate<"Subtarget->hasPkMovB32()">,
   AssemblerPredicate<(all_of FeatureGFX90AInsts)>;
 
@@ -2509,7 +2450,6 @@ def HasFmaakFmamkF32Insts :
 def HasFmaakFmamkF64Insts :
   Predicate<"Subtarget->hasFmaakFmamkF64Insts()">,
   AssemblerPredicate<(any_of FeatureGFX1250Insts)>;
-
 
 def HasPkMinMax3Insts :
   Predicate<"Subtarget->hasPkMinMax3Insts()">,
@@ -2556,9 +2496,6 @@ def HasAddPC64Inst : Predicate<"Subtarget->hasAddPC64Inst()">,
 def EnableFlatScratch : Predicate<"Subtarget->enableFlatScratch()">;
 
 def DisableFlatScratch : Predicate<"!Subtarget->enableFlatScratch()">;
-
-def HasUnalignedAccessMode : Predicate<"Subtarget->hasUnalignedAccessMode()">,
-  AssemblerPredicate<(all_of FeatureUnalignedAccessMode)>;
 
 def NotHasMADIntraFwdBug : Predicate<"!Subtarget->hasMADIntraFwdBug()">;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUFeatures.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUFeatures.td
@@ -7,13 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 def FeatureFP64 : SubtargetFeature<"fp64",
-  "FP64",
+  "HasFP64",
   "true",
   "Enable double precision operations"
 >;
 
 def FeatureFMA : SubtargetFeature<"fmaf",
-  "FMA",
+  "HasFMA",
   "true",
   "Enable single precision FMA (not as fast as mul+add, but fused)"
 >;

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
@@ -299,7 +299,7 @@ const FeatureBitset GCNTTIImpl::InlineFeatureIgnoreList = {
     AMDGPU::FeatureSRAMECC,
 
     // Perf-tuning features
-    AMDGPU::FeatureFastFMAF32, AMDGPU::HalfRate64Ops};
+    AMDGPU::FeatureFastFMAF32, AMDGPU::FeatureHalfRate64Ops};
 
 GCNTTIImpl::GCNTTIImpl(const AMDGPUTargetMachine *TM, const Function &F)
     : BaseT(TM, F.getDataLayout()),

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -27,24 +27,50 @@
 #include "AMDGPUGenSubtargetInfo.inc"
 
 //===----------------------------------------------------------------------===//
-// X-Macro for simple subtarget features.
+// X-Macros for simple subtarget features.
 //
-// This macro defines features that follow the simple pattern:
-//   bool HasXXX = false;          // member declaration
-//   bool hasXXX() const { return HasXXX; }  // getter
+// GCN_SUBTARGET_HAS_FEATURE_MEMBER_ONLY: Features with member only (no getter)
+//   bool HasXXX = false;                      // member declaration only
+//
+// GCN_SUBTARGET_HAS_FEATURE: Features with both member and getter
+//   bool HasXXX = false;                      // member declaration
+//   bool hasXXX() const { return HasXXX; }    // getter
 //
 // To add a new simple feature:
-//   1. Add X(FeatureName) to this list
+//   1. Add X(FeatureName) to the appropriate macro below
 //   2. Remove the manual bool HasFeatureName declaration from protected section
-//   3. Remove the manual hasFeatureName() getter from public section
-//
-// The macro will generate both automatically.
+//   3. If using GCN_SUBTARGET_HAS_FEATURE, also remove the manual getter
 //
 // Note: The features are ordered alphabetically for convenience. Preferably
 // this would be generated automatically by TableGen, but there are some cases
 // where the features were not defined in a way that was compatible with the
 // auto-generation.
 //===----------------------------------------------------------------------===//
+
+// Features with member only (no getter generated).
+// These features either have custom getters or code accesses the member
+// directly.
+#define GCN_SUBTARGET_HAS_FEATURE_MEMBER_ONLY(X)                               \
+  X(CIInsts)                                                                   \
+  X(FastDenormalF32)                                                           \
+  X(GCN3Encoding)                                                              \
+  X(GFX10_3Insts)                                                              \
+  X(GFX10_AEncoding)                                                           \
+  X(GFX10_BEncoding)                                                           \
+  X(GFX10Insts)                                                                \
+  X(GFX11Insts)                                                                \
+  X(GFX1250Insts)                                                              \
+  X(GFX12Insts)                                                                \
+  X(GFX7GFX8GFX9Insts)                                                         \
+  X(GFX8Insts)                                                                 \
+  X(GFX90AInsts)                                                               \
+  X(GFX940Insts)                                                               \
+  X(GFX950Insts)                                                               \
+  X(GFX9Insts)                                                                 \
+  X(UnalignedBufferAccess)                                                     \
+  X(UnalignedScratchAccess)
+
+// Features with both member and getter.
 #define GCN_SUBTARGET_HAS_FEATURE(X)                                           \
   X(1_5xVGPRs)                                                                 \
   X(1024AddressableVGPRs)                                                      \
@@ -101,20 +127,29 @@
   X(DPPSrc1SGPR)                                                               \
   X(EmulatedSystemScopeAtomics)                                                \
   X(ExtendedImageInsts)                                                        \
+  X(FlatAddressSpace)                                                          \
   X(FlatAtomicFaddF32Inst)                                                     \
   X(FlatBufferGlobalAtomicFaddF64Inst)                                         \
+  X(FlatGlobalInsts)                                                           \
+  X(FlatGVSMode)                                                               \
+  X(FlatInstOffsets)                                                           \
+  X(FlatScratchInsts)                                                          \
   X(FlatSegmentOffsetBug)                                                      \
+  X(FMA)                                                                       \
   X(FmacF64Inst)                                                               \
   X(FmaMixBF16Insts)                                                           \
   X(FmaMixInsts)                                                               \
+  X(FP64)                                                                      \
   X(FP8ConversionInsts)                                                        \
   X(FP8E5M3Insts)                                                              \
   X(FP8Insts)                                                                  \
+  X(FullRate64Ops)                                                             \
   X(G16)                                                                       \
   X(GDS)                                                                       \
   X(GetWaveIdInst)                                                             \
   X(GloballyAddressableScratch)                                                \
   X(GWS)                                                                       \
+  X(HalfRate64Ops)                                                             \
   X(IEEEMinimumMaximumInsts)                                                   \
   X(ImageGather4D16Bug)                                                        \
   X(ImageInsts)                                                                \
@@ -131,12 +166,14 @@
   X(McastLoadInsts)                                                            \
   X(MemoryAtomicFaddF32DenormalSupport)                                        \
   X(MFMAInlineLiteralBug)                                                      \
+  X(MIMG_R128)                                                                 \
   X(Min3Max3PKF16)                                                             \
   X(Minimum3Maximum3F16)                                                       \
   X(Minimum3Maximum3F32)                                                       \
   X(Minimum3Maximum3PKF16)                                                     \
   X(Movrel)                                                                    \
   X(MSAALoadDstSelBug)                                                         \
+  X(NegativeScratchOffsetBug)                                                  \
   X(NoDataDepHazard)                                                           \
   X(NoSdstCMPX)                                                                \
   X(NSAClauseBug)                                                              \
@@ -156,6 +193,7 @@
   X(PseudoScalarTrans)                                                         \
   X(QsadInsts)                                                                 \
   X(R128A16)                                                                   \
+  X(RelaxedBufferOOBMode)                                                      \
   X(RequiredExportPriority)                                                    \
   X(RestrictedSOffset)                                                         \
   X(SadInsts)                                                                  \
@@ -164,6 +202,7 @@
   X(SALUFloatInsts)                                                            \
   X(ScalarAtomics)                                                             \
   X(ScalarDwordx3Loads)                                                        \
+  X(ScalarFlatScratchInsts)                                                    \
   X(ScalarStores)                                                              \
   X(SDWAMac)                                                                   \
   X(SDWAOmod)                                                                  \
@@ -172,6 +211,7 @@
   X(SDWASdst)                                                                  \
   X(SetPrioIncWgInst)                                                          \
   X(SetregVGPRMSBFixup)                                                        \
+  X(SGPRInitBug)                                                               \
   X(ShaderCyclesHiLoRegisters)                                                 \
   X(ShaderCyclesRegister)                                                      \
   X(SMemRealTime)                                                              \
@@ -181,6 +221,8 @@
   X(TanhInsts)                                                                 \
   X(TensorCvtLutInsts)                                                         \
   X(TransposeLoadF4F6Insts)                                                    \
+  X(UnalignedAccessMode)                                                       \
+  X(UnalignedDSAccess)                                                         \
   X(UnpackedD16VMem)                                                           \
   X(VALUTransUseHazard)                                                        \
   X(VcmpxExecWARHazard)                                                        \
@@ -236,18 +278,10 @@ protected:
   int LDSBankCount = 0;
   unsigned MaxPrivateElementSize = 0;
 
-  // Possibly statically set by tablegen, but may want to be overridden.
-  bool FastDenormalF32 = false;
-  bool HalfRate64Ops = false;
-  bool FullRate64Ops = false;
-
   // Dynamically set bits that enable features.
   bool FlatForGlobal = false;
   bool AutoWaitcntBeforeBarrier = false;
   bool BackOffBarrier = false;
-  bool UnalignedScratchAccess = false;
-  bool UnalignedAccessMode = false;
-  bool RelaxedBufferOOBMode = false;
   bool SupportsXNACK = false;
   bool KernargPreload = false;
 
@@ -270,27 +304,8 @@ protected:
   bool AssemblerPermissiveWavesize = false;
 
   // Subtarget statically properties set by tablegen
-  bool FP64 = false;
-  bool FMA = false;
-  bool MIMG_R128 = false;
-  bool CIInsts = false;
-  bool GFX8Insts = false;
-  bool GFX9Insts = false;
-  bool GFX90AInsts = false;
-  bool GFX940Insts = false;
-  bool GFX950Insts = false;
-  bool GFX10Insts = false;
-  bool GFX11Insts = false;
-  bool GFX12Insts = false;
-  bool GFX1250Insts = false;
-  bool GFX10_3Insts = false;
-  bool GFX7GFX8GFX9Insts = false;
-  bool SGPRInitBug = false;
   bool UserSGPRInit16Bug = false;
-  bool NegativeScratchOffsetBug = false;
   bool NegativeUnalignedScratchOffsetBug = false;
-  bool GFX10_AEncoding = false;
-  bool GFX10_BEncoding = false;
   /// The maximum number of instructions that may be placed within an S_CLAUSE,
   /// which is one greater than the maximum argument to S_CLAUSE. A value of 0
   /// indicates a lack of S_CLAUSE support.
@@ -304,17 +319,9 @@ protected:
   // for SRAMECC.
   bool EnableSRAMECC = false;
 
-  bool FlatAddressSpace = false;
-  bool FlatInstOffsets = false;
-  bool FlatGlobalInsts = false;
-  bool FlatScratchInsts = false;
-  bool FlatGVSMode = false;
-  bool ScalarFlatScratchInsts = false;
   bool EnableFlatScratch = false;
   bool AddNoCarryInsts = false;
   bool LDSMisalignedBug = false;
-  bool UnalignedBufferAccess = false;
-  bool UnalignedDSAccess = false;
   bool ScalarizeGlobal = false;
   bool RequiresCOV6 = false;
   bool UseBlockVGPROpsForCSR = false;
@@ -325,9 +332,9 @@ protected:
   // Dummy feature to use for assembler in tablegen.
   bool FeatureDisable = false;
 
-  // Simple subtarget features - auto-generated from X-macro.
 #define DECL_HAS_MEMBER(Name) bool Has##Name = false;
   GCN_SUBTARGET_HAS_FEATURE(DECL_HAS_MEMBER)
+  GCN_SUBTARGET_HAS_FEATURE_MEMBER_ONLY(DECL_HAS_MEMBER)
 #undef DECL_HAS_MEMBER
 
 private:
@@ -392,11 +399,13 @@ public:
   void ParseSubtargetFeatures(StringRef CPU, StringRef TuneCPU, StringRef FS);
 
   // Simple subtarget feature getters - auto-generated from X-macro.
+  // Note: GCN_SUBTARGET_HAS_FEATURE_MEMBER_ONLY features don't get getters.
 #define DECL_HAS_GETTER(Name)                                                  \
   bool has##Name() const { return Has##Name; }
   GCN_SUBTARGET_HAS_FEATURE(DECL_HAS_GETTER)
 #undef DECL_HAS_GETTER
 #undef GCN_SUBTARGET_HAS_FEATURE
+#undef GCN_SUBTARGET_HAS_FEATURE_MEMBER_ONLY
 
   Generation getGeneration() const { return (Generation)Gen; }
 
@@ -435,20 +444,12 @@ public:
   bool zeroesHigh16BitsOfDest(unsigned Opcode) const;
 
   bool supportsWGP() const {
-    if (GFX1250Insts)
+    if (HasGFX1250Insts)
       return false;
     return getGeneration() >= GFX10;
   }
 
-  bool hasFP64() const { return FP64; }
-
-  bool hasMIMG_R128() const { return MIMG_R128; }
-
-  bool hasHWFP64() const { return FP64; }
-
-  bool hasHalfRate64Ops() const { return HalfRate64Ops; }
-
-  bool hasFullRate64Ops() const { return FullRate64Ops; }
+  bool hasHWFP64() const { return HasFP64; }
 
   bool hasAddr64() const {
     return (getGeneration() < AMDGPUSubtarget::VOLCANIC_ISLANDS);
@@ -472,13 +473,11 @@ public:
     return getGeneration() >= AMDGPUSubtarget::GFX9;
   }
 
-  bool hasFMA() const { return FMA; }
+  bool hasSwap() const { return HasGFX9Insts; }
 
-  bool hasSwap() const { return GFX9Insts; }
+  bool hasScalarPackInsts() const { return HasGFX9Insts; }
 
-  bool hasScalarPackInsts() const { return GFX9Insts; }
-
-  bool hasScalarMulHiInsts() const { return GFX9Insts; }
+  bool hasScalarMulHiInsts() const { return HasGFX9Insts; }
 
   bool hasScalarSubwordLoads() const { return getGeneration() >= GFX12; }
 
@@ -550,13 +549,13 @@ public:
 
   /// \returns If target supports ds_read/write_b128 and user enables generation
   /// of ds_read/write_b128.
-  bool useDS128() const { return CIInsts && EnableDS128; }
+  bool useDS128() const { return HasCIInsts && EnableDS128; }
 
   /// \return If target supports ds_read/write_b96/128.
-  bool hasDS96AndDS128() const { return CIInsts; }
+  bool hasDS96AndDS128() const { return HasCIInsts; }
 
   /// Have v_trunc_f64, v_ceil_f64, v_rndne_f64
-  bool haveRoundOpsF64() const { return CIInsts; }
+  bool haveRoundOpsF64() const { return HasCIInsts; }
 
   /// \returns If MUBUF instructions always perform range checking, even for
   /// buffer resources used for private memory access.
@@ -574,27 +573,17 @@ public:
   /// when an exception is raised.
   bool supportsBackOffBarrier() const { return BackOffBarrier; }
 
-  bool hasUnalignedBufferAccess() const { return UnalignedBufferAccess; }
-
   bool hasUnalignedBufferAccessEnabled() const {
-    return UnalignedBufferAccess && UnalignedAccessMode;
+    return HasUnalignedBufferAccess && HasUnalignedAccessMode;
   }
-
-  bool hasUnalignedDSAccess() const { return UnalignedDSAccess; }
 
   bool hasUnalignedDSAccessEnabled() const {
-    return UnalignedDSAccess && UnalignedAccessMode;
+    return HasUnalignedDSAccess && HasUnalignedAccessMode;
   }
-
-  bool hasUnalignedScratchAccess() const { return UnalignedScratchAccess; }
 
   bool hasUnalignedScratchAccessEnabled() const {
-    return UnalignedScratchAccess && UnalignedAccessMode;
+    return HasUnalignedScratchAccess && HasUnalignedAccessMode;
   }
-
-  bool hasUnalignedAccessMode() const { return UnalignedAccessMode; }
-
-  bool hasRelaxedBufferOOBMode() const { return RelaxedBufferOOBMode; }
 
   bool isTrapHandlerEnabled() const { return TrapHandler; }
 
@@ -606,15 +595,7 @@ public:
 
   bool isPreciseMemoryEnabled() const { return EnablePreciseMemory; }
 
-  bool hasFlatAddressSpace() const { return FlatAddressSpace; }
-
   bool hasFlatScrRegister() const { return hasFlatAddressSpace(); }
-
-  bool hasFlatInstOffsets() const { return FlatInstOffsets; }
-
-  bool hasFlatGlobalInsts() const { return FlatGlobalInsts; }
-
-  bool hasFlatScratchInsts() const { return FlatScratchInsts; }
 
   // Check if target supports ST addressing mode with FLAT scratch instructions.
   // The ST addressing mode means no registers are used, either VGPR or SGPR,
@@ -623,18 +604,16 @@ public:
     return hasFlatScratchInsts() && (hasGFX10_3Insts() || hasGFX940Insts());
   }
 
-  bool hasFlatScratchSVSMode() const { return GFX940Insts || GFX11Insts; }
-
-  bool hasScalarFlatScratchInsts() const { return ScalarFlatScratchInsts; }
+  bool hasFlatScratchSVSMode() const { return HasGFX940Insts || HasGFX11Insts; }
 
   bool enableFlatScratch() const {
     return flatScratchIsArchitected() ||
            (EnableFlatScratch && hasFlatScratchInsts());
   }
 
-  bool hasGlobalAddTidInsts() const { return GFX10_BEncoding; }
+  bool hasGlobalAddTidInsts() const { return HasGFX10_BEncoding; }
 
-  bool hasAtomicCSub() const { return GFX10_BEncoding; }
+  bool hasAtomicCSub() const { return HasGFX10_BEncoding; }
 
   bool hasMTBUFInsts() const { return !hasGFX1250Insts(); }
 
@@ -644,7 +623,9 @@ public:
     return !hasGFX940Insts() && !hasGFX1250Insts();
   }
 
-  bool hasVINTERPEncoding() const { return GFX11Insts && !hasGFX1250Insts(); }
+  bool hasVINTERPEncoding() const {
+    return HasGFX11Insts && !hasGFX1250Insts();
+  }
 
   // DS_ADD_F64/DS_ADD_RTN_F64
   bool hasLdsAtomicAddF64() const {
@@ -677,7 +658,7 @@ public:
   bool hasGWSAutoReplay() const { return getGeneration() >= GFX9; }
 
   /// \returns if target has ds_gws_sema_release_all instruction.
-  bool hasGWSSemaReleaseAll() const { return CIInsts; }
+  bool hasGWSSemaReleaseAll() const { return HasCIInsts; }
 
   /// \returns true if the target has integer add/sub instructions that do not
   /// produce a carry-out. This includes v_add_[iu]32, v_sub_[iu]32,
@@ -708,7 +689,7 @@ public:
     return getGeneration() == GFX10 || getGeneration() == GFX11;
   }
 
-  bool hasPrefetch() const { return GFX12Insts; }
+  bool hasPrefetch() const { return HasGFX12Insts; }
 
   // Has s_cmpk_* instructions.
   bool hasSCmpK() const { return getGeneration() < GFX12; }
@@ -756,8 +737,10 @@ public:
     return getGeneration() >= VOLCANIC_ISLANDS;
   }
 
-  bool hasLDSFPAtomicAddF32() const { return GFX8Insts; }
-  bool hasLDSFPAtomicAddF64() const { return GFX90AInsts || GFX1250Insts; }
+  bool hasLDSFPAtomicAddF32() const { return HasGFX8Insts; }
+  bool hasLDSFPAtomicAddF64() const {
+    return HasGFX90AInsts || HasGFX1250Insts;
+  }
 
   /// \returns true if the subtarget has the v_permlanex16_b32 instruction.
   bool hasPermLaneX16() const { return getGeneration() >= GFX10; }
@@ -772,7 +755,7 @@ public:
   }
 
   // Has V_PK_MOV_B32 opcode
-  bool hasPkMovB32() const { return GFX90AInsts; }
+  bool hasPkMovB32() const { return HasGFX90AInsts; }
 
   bool hasFmaakFmamkF32Insts() const {
     return getGeneration() >= GFX10 || hasGFX940Insts();
@@ -786,33 +769,27 @@ public:
     return AMDGPU::getNSAMaxSize(*this, HasSampler);
   }
 
-  bool hasGFX10_AEncoding() const { return GFX10_AEncoding; }
+  bool hasGFX10_AEncoding() const { return HasGFX10_AEncoding; }
 
-  bool hasGFX10_BEncoding() const { return GFX10_BEncoding; }
+  bool hasGFX10_BEncoding() const { return HasGFX10_BEncoding; }
 
-  bool hasGFX10_3Insts() const { return GFX10_3Insts; }
+  bool hasGFX10_3Insts() const { return HasGFX10_3Insts; }
 
   bool hasMadF16() const;
 
-  bool hasMovB64() const { return GFX940Insts || GFX1250Insts; }
+  bool hasMovB64() const { return HasGFX940Insts || HasGFX1250Insts; }
 
   // Scalar and global loads support scale_offset bit.
-  bool hasScaleOffset() const { return GFX1250Insts; }
-
-  bool hasFlatGVSMode() const { return FlatGVSMode; }
+  bool hasScaleOffset() const { return HasGFX1250Insts; }
 
   // FLAT GLOBAL VOffset is signed
-  bool hasSignedGVSOffset() const { return GFX1250Insts; }
+  bool hasSignedGVSOffset() const { return HasGFX1250Insts; }
 
   bool enableSIScheduler() const { return EnableSIScheduler; }
 
   bool loadStoreOptEnabled() const { return EnableLoadStoreOpt; }
 
-  bool hasSGPRInitBug() const { return SGPRInitBug; }
-
   bool hasUserSGPRInit16Bug() const { return UserSGPRInit16Bug && isWave32(); }
-
-  bool hasNegativeScratchOffsetBug() const { return NegativeScratchOffsetBug; }
 
   bool hasNegativeUnalignedScratchOffsetBug() const {
     return NegativeUnalignedScratchOffsetBug;
@@ -823,7 +800,7 @@ public:
   }
 
   // \returns true if the subtarget supports DWORDX3 load/store instructions.
-  bool hasDwordx3LoadStores() const { return CIInsts; }
+  bool hasDwordx3LoadStores() const { return HasCIInsts; }
 
   bool hasReadM0MovRelInterpHazard() const {
     return getGeneration() == AMDGPUSubtarget::GFX9;
@@ -846,25 +823,27 @@ public:
 
   // Shift amount of a 64 bit shift cannot be a highest allocated register
   // if also at the end of the allocation block.
-  bool hasShift64HighRegBug() const { return GFX90AInsts && !GFX940Insts; }
+  bool hasShift64HighRegBug() const {
+    return HasGFX90AInsts && !HasGFX940Insts;
+  }
 
   // Has one cycle hazard on transcendental instruction feeding a
   // non transcendental VALU.
-  bool hasTransForwardingHazard() const { return GFX940Insts; }
+  bool hasTransForwardingHazard() const { return HasGFX940Insts; }
 
   // Has one cycle hazard on a VALU instruction partially writing dst with
   // a shift of result bits feeding another VALU instruction.
-  bool hasDstSelForwardingHazard() const { return GFX940Insts; }
+  bool hasDstSelForwardingHazard() const { return HasGFX940Insts; }
 
   // Cannot use op_sel with v_dot instructions.
-  bool hasDOTOpSelHazard() const { return GFX940Insts || GFX11Insts; }
+  bool hasDOTOpSelHazard() const { return HasGFX940Insts || HasGFX11Insts; }
 
   // Does not have HW interlocs for VALU writing and then reading SGPRs.
-  bool hasVDecCoExecHazard() const { return GFX940Insts; }
+  bool hasVDecCoExecHazard() const { return HasGFX940Insts; }
 
   bool hasHardClauses() const { return MaxHardClauseLength > 0; }
 
-  bool hasGFX90AInsts() const { return GFX90AInsts; }
+  bool hasGFX90AInsts() const { return HasGFX90AInsts; }
 
   bool hasFPAtomicToDenormModeHazard() const {
     return getGeneration() == GFX10;
@@ -880,7 +859,7 @@ public:
     return getGeneration() == GFX11;
   }
 
-  bool hasCvtScaleForwardingHazard() const { return GFX950Insts; }
+  bool hasCvtScaleForwardingHazard() const { return HasGFX950Insts; }
 
   bool requiresCodeObjectV6() const { return RequiresCOV6; }
 
@@ -888,38 +867,40 @@ public:
 
   bool hasVALUMaskWriteHazard() const { return getGeneration() == GFX11; }
 
-  bool hasVALUReadSGPRHazard() const { return GFX12Insts && !GFX1250Insts; }
+  bool hasVALUReadSGPRHazard() const {
+    return HasGFX12Insts && !HasGFX1250Insts;
+  }
 
   bool setRegModeNeedsVNOPs() const {
-    return GFX1250Insts && getGeneration() == GFX12;
+    return HasGFX1250Insts && getGeneration() == GFX12;
   }
 
   /// Return if operations acting on VGPR tuples require even alignment.
   bool needsAlignedVGPRs() const { return RequiresAlignVGPR; }
 
   /// Return true if the target has the S_PACK_HL_B32_B16 instruction.
-  bool hasSPackHL() const { return GFX11Insts; }
+  bool hasSPackHL() const { return HasGFX11Insts; }
 
   /// Return true if the target's EXP instruction has the COMPR flag, which
   /// affects the meaning of the EN (enable) bits.
-  bool hasCompressedExport() const { return !GFX11Insts; }
+  bool hasCompressedExport() const { return !HasGFX11Insts; }
 
   /// Return true if the target's EXP instruction supports the NULL export
   /// target.
-  bool hasNullExportTarget() const { return !GFX11Insts; }
+  bool hasNullExportTarget() const { return !HasGFX11Insts; }
 
   bool hasFlatScratchSVSSwizzleBug() const { return getGeneration() == GFX11; }
 
   /// Return true if the target has the S_DELAY_ALU instruction.
-  bool hasDelayAlu() const { return GFX11Insts; }
+  bool hasDelayAlu() const { return HasGFX11Insts; }
 
   // GFX94* is a derivation to GFX90A. hasGFX940Insts() being true implies that
   // hasGFX90AInsts is also true.
-  bool hasGFX940Insts() const { return GFX940Insts; }
+  bool hasGFX940Insts() const { return HasGFX940Insts; }
 
   // GFX950 is a derivation to GFX94*. hasGFX950Insts() implies that
   // hasGFX940Insts and hasGFX90AInsts are also true.
-  bool hasGFX950Insts() const { return GFX950Insts; }
+  bool hasGFX950Insts() const { return HasGFX950Insts; }
 
   /// Returns true if the target supports
   /// global_load_lds_dwordx3/global_load_lds_dwordx4 or
@@ -940,10 +921,10 @@ public:
   /// bits from a scalar operand (SGPR or literal) and replicates the bits to
   /// both channels.
   bool hasPKF32InstsReplicatingLower32BitsOfScalarInput() const {
-    return getGeneration() == GFX12 && GFX1250Insts;
+    return getGeneration() == GFX12 && HasGFX1250Insts;
   }
 
-  bool hasAddPC64Inst() const { return GFX1250Insts; }
+  bool hasAddPC64Inst() const { return HasGFX1250Insts; }
 
   bool useAddPC64Inst() const { return UseAddPC64Inst; }
 
@@ -1026,48 +1007,50 @@ public:
   /// values.
   bool hasSignedScratchOffsets() const { return getGeneration() >= GFX12; }
 
-  bool hasGFX1250Insts() const { return GFX1250Insts; }
+  bool hasGFX1250Insts() const { return HasGFX1250Insts; }
 
-  bool hasINVWBL2WaitCntRequirement() const { return GFX1250Insts; }
+  bool hasINVWBL2WaitCntRequirement() const { return HasGFX1250Insts; }
 
-  bool hasVOPD3() const { return GFX1250Insts; }
+  bool hasVOPD3() const { return HasGFX1250Insts; }
 
   // \returns true if the target has V_ADD_U64/V_SUB_U64 instructions.
 
   // \returns true if the target has V_MAD_U32 instruction.
 
   // \returns true if the target has V_MUL_U64/V_MUL_I64 instructions.
-  bool hasVectorMulU64() const { return GFX1250Insts; }
+  bool hasVectorMulU64() const { return HasGFX1250Insts; }
 
   // \returns true if the target has V_MAD_NC_U64_U32/V_MAD_NC_I64_I32
   // instructions.
-  bool hasMadU64U32NoCarry() const { return GFX1250Insts; }
+  bool hasMadU64U32NoCarry() const { return HasGFX1250Insts; }
 
   // \returns true if the target has V_{MIN|MAX}_{I|U}64 instructions.
-  bool hasIntMinMax64() const { return GFX1250Insts; }
+  bool hasIntMinMax64() const { return HasGFX1250Insts; }
 
   // \returns true if the target has V_ADD_{MIN|MAX}_{I|U}32 instructions.
 
   // \returns true if the target has V_PK_ADD_{MIN|MAX}_{I|U}16 instructions.
 
   // \returns true if the target has V_PK_{MIN|MAX}3_{I|U}16 instructions.
-  bool hasPkMinMax3Insts() const { return GFX1250Insts; }
+  bool hasPkMinMax3Insts() const { return HasGFX1250Insts; }
 
   // \returns ture if target has S_GET_SHADER_CYCLES_U64 instruction.
-  bool hasSGetShaderCyclesInst() const { return GFX1250Insts; }
+  bool hasSGetShaderCyclesInst() const { return HasGFX1250Insts; }
 
   // \returns true if S_GETPC_B64 zero-extends the result from 48 bits instead
   // of sign-extending. Note that GFX1250 has not only fixed the bug but also
   // extended VA to 57 bits.
-  bool hasGetPCZeroExtension() const { return GFX12Insts && !GFX1250Insts; }
+  bool hasGetPCZeroExtension() const {
+    return HasGFX12Insts && !HasGFX1250Insts;
+  }
 
   // \returns true if the target needs to create a prolog for backward
   // compatibility when preloading kernel arguments.
   bool needsKernArgPreloadProlog() const {
-    return hasKernargPreload() && !GFX1250Insts;
+    return hasKernargPreload() && !HasGFX1250Insts;
   }
 
-  bool hasCondSubInsts() const { return GFX12Insts; }
+  bool hasCondSubInsts() const { return HasGFX12Insts; }
 
   bool hasSubClampInsts() const { return hasGFX10_3Insts(); }
 
@@ -1281,11 +1264,11 @@ public:
 
   // \returns true if the subtarget has a hazard requiring an "s_nop 0"
   // instruction before "s_sendmsg sendmsg(MSG_DEALLOC_VGPRS)".
-  bool requiresNopBeforeDeallocVGPRs() const { return !GFX1250Insts; }
+  bool requiresNopBeforeDeallocVGPRs() const { return !HasGFX1250Insts; }
 
   // \returns true if the subtarget needs S_WAIT_ALU 0 before S_GETREG_B32 on
   // STATUS, STATE_PRIV, EXCP_FLAG_PRIV, or EXCP_FLAG_USER.
-  bool requiresWaitIdleBeforeGetReg() const { return GFX1250Insts; }
+  bool requiresWaitIdleBeforeGetReg() const { return HasGFX1250Insts; }
 
   bool isDynamicVGPREnabled() const { return DynamicVGPR; }
   unsigned getDynamicVGPRBlockSize() const {
@@ -1307,20 +1290,20 @@ public:
   // Requires s_wait_alu(0) after s102/s103 write and src_flat_scratch_base
   // read.
   bool hasScratchBaseForwardingHazard() const {
-    return GFX1250Insts && getGeneration() == GFX12;
+    return HasGFX1250Insts && getGeneration() == GFX12;
   }
 
   // src_flat_scratch_hi cannot be used as a source in SALU producing a 64-bit
   // result.
   bool hasFlatScratchHiInB64InstHazard() const {
-    return GFX1250Insts && getGeneration() == GFX12;
+    return HasGFX1250Insts && getGeneration() == GFX12;
   }
 
   /// \returns true if the subtarget requires a wait for xcnt before VMEM
   /// accesses that must never be repeated in the event of a page fault/re-try.
   /// Atomic stores/rmw and all volatile accesses fall under this criteria.
   bool requiresWaitXCntForSingleAccessInstructions() const {
-    return GFX1250Insts;
+    return HasGFX1250Insts;
   }
 
   /// \returns the number of significant bits in the immediate field of the

--- a/llvm/lib/Target/AMDGPU/R600Subtarget.h
+++ b/llvm/lib/Target/AMDGPU/R600Subtarget.h
@@ -30,12 +30,12 @@ class R600Subtarget final : public R600GenSubtargetInfo,
 private:
   R600InstrInfo InstrInfo;
   R600FrameLowering FrameLowering;
-  bool FMA = false;
+  bool HasFMA = false;
   bool CaymanISA = false;
   bool CFALUBug = false;
   bool HasVertexCache = false;
   bool R600ALUInst = false;
-  bool FP64 = false;
+  bool HasFP64 = false;
   short TexVTXClauseSize = 0;
   Generation Gen = R600;
   R600TargetLowering TLInfo;
@@ -114,7 +114,7 @@ public:
     return (getGeneration() >= EVERGREEN);
   }
 
-  bool hasFMA() const { return FMA; }
+  bool hasFMA() const { return HasFMA; }
 
   bool hasCFAluBug() const { return CFALUBug; }
 


### PR DESCRIPTION
Extend the X-macro pattern to eliminate boilerplate for additional subtarget features.

This reduces ~50 lines of repetitive member declarations and getter definitions.