### PR TITLE
[SPIR-V] Fix OpenCL integer dot product lowering

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -1839,21 +1839,28 @@ static bool generateDotOrFMulInst(const StringRef DemangledCall,
                                   const SPIRV::IncomingCall *Call,
                                   MachineIRBuilder &MIRBuilder,
                                   SPIRVGlobalRegistry *GR) {
-  if (Call->isSpirvOp())
-    return buildOpFromWrapper(MIRBuilder, SPIRV::OpDot, Call,
-                              GR->getSPIRVTypeID(Call->ReturnType));
-
   bool IsVec = GR->getSPIRVTypeForVReg(Call->Arguments[0])->getOpcode() ==
                SPIRV::OpTypeVector;
+  bool IsInt = GR->isScalarOrVectorOfType(Call->ReturnRegister, SPIRV::OpTypeInt);
+
+  const auto *ST =
+      static_cast<const SPIRVSubtarget *>(&MIRBuilder.getMF().getSubtarget());
+  bool HasIntDotOps =
+      ST->canUseExtension(SPIRV::Extension::SPV_KHR_integer_dot_product) ||
+      ST->isAtLeastSPIRVVer(VersionTuple(1, 6));
+
+  // For integer vectors without native OpSDot/OpUDot support, expand to
+  // element-wise multiply and add.
+  if (IsInt && IsVec && !HasIntDotOps)
+    return generateIntegerDotExpansion(MIRBuilder, Call->ReturnRegister,
+                                       Call->Arguments[0], Call->Arguments[1],
+                                       GR);
+
   // Use OpDot only in case of vector args and OpFMul in case of scalar args.
   uint32_t OC = IsVec ? SPIRV::OpDot : SPIRV::OpFMulS;
   bool IsSwapReq = false;
 
-  const auto *ST =
-      static_cast<const SPIRVSubtarget *>(&MIRBuilder.getMF().getSubtarget());
-  if (GR->isScalarOrVectorOfType(Call->ReturnRegister, SPIRV::OpTypeInt) &&
-      (ST->canUseExtension(SPIRV::Extension::SPV_KHR_integer_dot_product) ||
-       ST->isAtLeastSPIRVVer(VersionTuple(1, 6)))) {
+  if (IsInt && HasIntDotOps) {
     const SPIRV::DemangledBuiltin *Builtin = Call->Builtin;
     const SPIRV::IntegerDotProductBuiltin *IntDot =
         SPIRV::lookupIntegerDotProductBuiltin(Builtin->Name);
@@ -1866,8 +1873,9 @@ static bool generateDotOrFMulInst(const StringRef DemangledCall,
       LLVMContext &Ctx = MIRBuilder.getContext();
       SmallVector<StringRef, 10> TypeStrs;
       SPIRV::parseBuiltinTypeStr(TypeStrs, DemangledCall, Ctx);
-      bool IsFirstSigned = TypeStrs[0].trim()[0] != 'u';
-      bool IsSecondSigned = TypeStrs[1].trim()[0] != 'u';
+      bool IsFirstSigned = TypeStrs.size() > 0 && TypeStrs[0].trim()[0] != 'u';
+      bool IsSecondSigned =
+          TypeStrs.size() > 1 && TypeStrs[1].trim()[0] != 'u';
 
       if (Call->BuiltinName == "dot") {
         if (IsFirstSigned && IsSecondSigned)

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -1841,7 +1841,8 @@ static bool generateDotOrFMulInst(const StringRef DemangledCall,
                                   SPIRVGlobalRegistry *GR) {
   bool IsVec = GR->getSPIRVTypeForVReg(Call->Arguments[0])->getOpcode() ==
                SPIRV::OpTypeVector;
-  bool IsInt = GR->isScalarOrVectorOfType(Call->ReturnRegister, SPIRV::OpTypeInt);
+  bool IsInt =
+      GR->isScalarOrVectorOfType(Call->ReturnRegister, SPIRV::OpTypeInt);
 
   const auto *ST =
       static_cast<const SPIRVSubtarget *>(&MIRBuilder.getMF().getSubtarget());
@@ -1874,8 +1875,7 @@ static bool generateDotOrFMulInst(const StringRef DemangledCall,
       SmallVector<StringRef, 10> TypeStrs;
       SPIRV::parseBuiltinTypeStr(TypeStrs, DemangledCall, Ctx);
       bool IsFirstSigned = TypeStrs.size() > 0 && TypeStrs[0].trim()[0] != 'u';
-      bool IsSecondSigned =
-          TypeStrs.size() > 1 && TypeStrs[1].trim()[0] != 'u';
+      bool IsSecondSigned = TypeStrs.size() > 1 && TypeStrs[1].trim()[0] != 'u';
 
       if (Call->BuiltinName == "dot") {
         if (IsFirstSigned && IsSecondSigned)

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -2410,58 +2410,16 @@ bool SPIRVInstructionSelector::selectIntegerDotExpansion(
   assert(I.getNumOperands() == 4);
   assert(I.getOperand(2).isReg());
   assert(I.getOperand(3).isReg());
-  MachineBasicBlock &BB = *I.getParent();
 
-  // Multiply the vectors, then sum the results
   Register Vec0 = I.getOperand(2).getReg();
   Register Vec1 = I.getOperand(3).getReg();
-  Register TmpVec = MRI->createVirtualRegister(GR.getRegClass(ResType));
-  SPIRVType *VecType = GR.getSPIRVTypeForVReg(Vec0);
 
-  bool Result = BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpIMulV))
-                    .addDef(TmpVec)
-                    .addUse(GR.getSPIRVTypeID(VecType))
-                    .addUse(Vec0)
-                    .addUse(Vec1)
-                    .constrainAllUses(TII, TRI, RBI);
+  MachineIRBuilder MIRBuilder;
+  MIRBuilder.setMF(*I.getParent()->getParent());
+  MIRBuilder.setMBB(*I.getParent());
+  MIRBuilder.setInstr(I);
 
-  assert(VecType->getOpcode() == SPIRV::OpTypeVector &&
-         GR.getScalarOrVectorComponentCount(VecType) > 1 &&
-         "dot product requires a vector of at least 2 components");
-
-  Register Res = MRI->createVirtualRegister(GR.getRegClass(ResType));
-  Result &= BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpCompositeExtract))
-                .addDef(Res)
-                .addUse(GR.getSPIRVTypeID(ResType))
-                .addUse(TmpVec)
-                .addImm(0)
-                .constrainAllUses(TII, TRI, RBI);
-
-  for (unsigned i = 1; i < GR.getScalarOrVectorComponentCount(VecType); i++) {
-    Register Elt = MRI->createVirtualRegister(GR.getRegClass(ResType));
-
-    Result &=
-        BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpCompositeExtract))
-            .addDef(Elt)
-            .addUse(GR.getSPIRVTypeID(ResType))
-            .addUse(TmpVec)
-            .addImm(i)
-            .constrainAllUses(TII, TRI, RBI);
-
-    Register Sum = i < GR.getScalarOrVectorComponentCount(VecType) - 1
-                       ? MRI->createVirtualRegister(GR.getRegClass(ResType))
-                       : ResVReg;
-
-    Result &= BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpIAddS))
-                  .addDef(Sum)
-                  .addUse(GR.getSPIRVTypeID(ResType))
-                  .addUse(Res)
-                  .addUse(Elt)
-                  .constrainAllUses(TII, TRI, RBI);
-    Res = Sum;
-  }
-
-  return Result;
+  return generateIntegerDotExpansion(MIRBuilder, ResVReg, Vec0, Vec1, &GR);
 }
 
 bool SPIRVInstructionSelector::selectOpIsInf(Register ResVReg,

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -1198,4 +1198,57 @@ getSpirvLinkageTypeFor(const SPIRVSubtarget &ST, const GlobalValue &GV) {
   return SPIRV::LinkageType::Export;
 }
 
+bool generateIntegerDotExpansion(MachineIRBuilder &MIRBuilder, Register ResVReg,
+                                 Register Vec0, Register Vec1,
+                                 SPIRVGlobalRegistry *GR) {
+  // Expand integer dot product to element-wise multiply and sum:
+  //   dot(a, b) = a[0]*b[0] + a[1]*b[1] + ... + a[n-1]*b[n-1]
+  MachineRegisterInfo *MRI = MIRBuilder.getMRI();
+  SPIRVType *VecType = GR->getSPIRVTypeForVReg(Vec0);
+  SPIRVType *ResType = GR->getSPIRVTypeForVReg(ResVReg);
+
+  assert(VecType && VecType->getOpcode() == SPIRV::OpTypeVector &&
+         "Expected vector type for integer dot product");
+  unsigned NumComponents = GR->getScalarOrVectorComponentCount(VecType);
+  assert(NumComponents > 1 && "dot product requires vector of at least 2");
+
+  // Multiply the vectors element-wise.
+  Register TmpVec = MRI->createVirtualRegister(GR->getRegClass(VecType));
+  MIRBuilder.buildInstr(SPIRV::OpIMulV)
+      .addDef(TmpVec)
+      .addUse(GR->getSPIRVTypeID(VecType))
+      .addUse(Vec0)
+      .addUse(Vec1);
+
+  // Extract first element as initial sum.
+  Register Sum = MRI->createVirtualRegister(GR->getRegClass(ResType));
+  MIRBuilder.buildInstr(SPIRV::OpCompositeExtract)
+      .addDef(Sum)
+      .addUse(GR->getSPIRVTypeID(ResType))
+      .addUse(TmpVec)
+      .addImm(0);
+
+  // Extract remaining elements and add to sum.
+  for (unsigned i = 1; i < NumComponents; ++i) {
+    Register Elt = MRI->createVirtualRegister(GR->getRegClass(ResType));
+    MIRBuilder.buildInstr(SPIRV::OpCompositeExtract)
+        .addDef(Elt)
+        .addUse(GR->getSPIRVTypeID(ResType))
+        .addUse(TmpVec)
+        .addImm(i);
+
+    Register NewSum = (i == NumComponents - 1)
+                          ? ResVReg
+                          : MRI->createVirtualRegister(GR->getRegClass(ResType));
+    MIRBuilder.buildInstr(SPIRV::OpIAddS)
+        .addDef(NewSum)
+        .addUse(GR->getSPIRVTypeID(ResType))
+        .addUse(Sum)
+        .addUse(Elt);
+    Sum = NewSum;
+  }
+
+  return true;
+}
+
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -1237,9 +1237,10 @@ bool generateIntegerDotExpansion(MachineIRBuilder &MIRBuilder, Register ResVReg,
         .addUse(TmpVec)
         .addImm(i);
 
-    Register NewSum = (i == NumComponents - 1)
-                          ? ResVReg
-                          : MRI->createVirtualRegister(GR->getRegClass(ResType));
+    Register NewSum =
+        (i == NumComponents - 1)
+            ? ResVReg
+            : MRI->createVirtualRegister(GR->getRegClass(ResType));
     MIRBuilder.buildInstr(SPIRV::OpIAddS)
         .addDef(NewSum)
         .addUse(GR->getSPIRVTypeID(ResType))

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -584,5 +584,12 @@ getFirstValidInstructionInsertPoint(MachineBasicBlock &BB);
 
 std::optional<SPIRV::LinkageType::LinkageType>
 getSpirvLinkageTypeFor(const SPIRVSubtarget &ST, const GlobalValue &GV);
+
+// Expand integer dot product to multiply and add operations.
+// Used when OpSDot/OpUDot are not available (SPIRV < 1.6 without
+// SPV_KHR_integer_dot_product extension).
+bool generateIntegerDotExpansion(MachineIRBuilder &MIRBuilder, Register ResVReg,
+                                 Register Vec0, Register Vec1,
+                                 SPIRVGlobalRegistry *GR);
 } // namespace llvm
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H

--- a/llvm/test/CodeGen/SPIRV/opencl/integer-dot-product.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/integer-dot-product.ll
@@ -1,0 +1,56 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; RUN: llc -O0 -mtriple=spirv1.6-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV-16
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv1.6-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Test OpenCL integer dot product lowering for SPIR-V.
+
+; CHECK-SPIRV-DAG: %[[#Int32Ty:]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG: %[[#Int32x4Ty:]] = OpTypeVector %[[#Int32Ty]] 4
+
+; CHECK-SPIRV-16-DAG: %[[#Int32Ty:]] = OpTypeInt 32 0
+
+; CHECK-SPIRV: %[[#SignedMulVec:]] = OpIMul %[[#Int32x4Ty]] %[[#SignedVec0:]] %[[#SignedVec1:]]
+; CHECK-SPIRV: %[[#SignedElt0:]] = OpCompositeExtract %[[#Int32Ty]] %[[#SignedMulVec]] 0
+; CHECK-SPIRV: %[[#SignedElt1:]] = OpCompositeExtract %[[#Int32Ty]] %[[#SignedMulVec]] 1
+; CHECK-SPIRV: %[[#SignedSum01:]] = OpIAdd %[[#Int32Ty]] %[[#SignedElt0]] %[[#SignedElt1]]
+; CHECK-SPIRV: %[[#SignedElt2:]] = OpCompositeExtract %[[#Int32Ty]] %[[#SignedMulVec]] 2
+; CHECK-SPIRV: %[[#SignedSum012:]] = OpIAdd %[[#Int32Ty]] %[[#SignedSum01]] %[[#SignedElt2]]
+; CHECK-SPIRV: %[[#SignedElt3:]] = OpCompositeExtract %[[#Int32Ty]] %[[#SignedMulVec]] 3
+; CHECK-SPIRV: %[[#SignedRes:]] = OpIAdd %[[#Int32Ty]] %[[#SignedSum012]] %[[#SignedElt3]]
+; CHECK-SPIRV: OpStore %[[#]] %[[#SignedRes]]
+
+; CHECK-SPIRV-16: %[[#SDot:]] = OpSDot %[[#Int32Ty]] %[[#]] %[[#]]
+; CHECK-SPIRV-16: OpStore %[[#]] %[[#SDot]]
+
+define spir_kernel void @testSignedIntDot(<4 x i32> %a, <4 x i32> %b, ptr addrspace(1) %out) {
+entry:
+  %call = tail call spir_func i32 @_Z3dotDv4_iS_(<4 x i32> %a, <4 x i32> %b)
+  store i32 %call, ptr addrspace(1) %out
+  ret void
+}
+
+; CHECK-SPIRV: %[[#UnsignedMulVec:]] = OpIMul %[[#Int32x4Ty]] %[[#UnsignedVec0:]] %[[#UnsignedVec1:]]
+; CHECK-SPIRV: %[[#UnsignedElt0:]] = OpCompositeExtract %[[#Int32Ty]] %[[#UnsignedMulVec]] 0
+; CHECK-SPIRV: %[[#UnsignedElt1:]] = OpCompositeExtract %[[#Int32Ty]] %[[#UnsignedMulVec]] 1
+; CHECK-SPIRV: %[[#UnsignedSum01:]] = OpIAdd %[[#Int32Ty]] %[[#UnsignedElt0]] %[[#UnsignedElt1]]
+; CHECK-SPIRV: %[[#UnsignedElt2:]] = OpCompositeExtract %[[#Int32Ty]] %[[#UnsignedMulVec]] 2
+; CHECK-SPIRV: %[[#UnsignedSum012:]] = OpIAdd %[[#Int32Ty]] %[[#UnsignedSum01]] %[[#UnsignedElt2]]
+; CHECK-SPIRV: %[[#UnsignedElt3:]] = OpCompositeExtract %[[#Int32Ty]] %[[#UnsignedMulVec]] 3
+; CHECK-SPIRV: %[[#UnsignedRes:]] = OpIAdd %[[#Int32Ty]] %[[#UnsignedSum012]] %[[#UnsignedElt3]]
+; CHECK-SPIRV: OpStore %[[#]] %[[#UnsignedRes]]
+
+; CHECK-SPIRV-16: %[[#UDot:]] = OpUDot %[[#Int32Ty]] %[[#]] %[[#]]
+; CHECK-SPIRV-16: OpStore %[[#]] %[[#UDot]]
+
+define spir_kernel void @testUnsignedIntDot(<4 x i32> %a, <4 x i32> %b, ptr addrspace(1) %out) {
+entry:
+  %call = tail call spir_func i32 @_Z3dotDv4_jS_(<4 x i32> %a, <4 x i32> %b)
+  store i32 %call, ptr addrspace(1) %out
+  ret void
+}
+
+declare spir_func i32 @_Z3dotDv4_iS_(<4 x i32>, <4 x i32>)
+
+declare spir_func i32 @_Z3dotDv4_jS_(<4 x i32>, <4 x i32>)


### PR DESCRIPTION
Previously for lowering to SPIR-V version < 1.6 with dot product extension enabled the builtins were lowered to OpDot, which is wrong.

This patch reuses expansion path from spv.dot intrinsic lowering, so now we get a valid SPIR-V even for older SPIR-V versions.

Fixes: https://github.com/llvm/llvm-project/issues/160737