### PR TITLE
[lldb] Skip TestUbsanBasic

### DIFF
--- a/lldb/test/API/functionalities/ubsan/basic/TestUbsanBasic.py
+++ b/lldb/test/API/functionalities/ubsan/basic/TestUbsanBasic.py
@@ -11,6 +11,7 @@ import json
 
 
 class UbsanBasicTestCase(TestBase):
+    @skip
     @skipUnlessUndefinedBehaviorSanitizer
     @no_debug_info_test
     def test(self):


### PR DESCRIPTION
The fix for this is being discussed in
https://github.com/llvm/llvm-project/issues/177064. Skip the test for now to get the bots green.