### PR TITLE
[profcheck] Print the function name in the error

### DIFF
--- a/llvm/lib/Transforms/Utils/ProfileVerify.cpp
+++ b/llvm/lib/Transforms/Utils/ProfileVerify.cpp
@@ -237,8 +237,9 @@ PreservedAnalyses ProfileVerifierPass::run(Function &F,
   if (!EntryCount) {
     auto *MD = F.getMetadata(LLVMContext::MD_prof);
     if (!MD || !isExplicitlyUnknownProfileMetadata(*MD)) {
-      F.getContext().emitError("Profile verification failed: function entry "
-                               "count missing (set to 0 if cold)");
+      F.getContext().emitError(
+          "Profile verification failed for function '" + F.getName() +
+          "': function entry count missing (set to 0 if cold)");
       return PreservedAnalyses::all();
     }
   } else if (EntryCount->getCount() == 0) {
@@ -253,14 +254,15 @@ PreservedAnalyses ProfileVerifierPass::run(Function &F,
           if (I.getMetadata(LLVMContext::MD_prof))
             continue;
           F.getContext().emitError(
-              "Profile verification failed: select annotation missing");
+              "Profile verification failed for function '" + F.getName() +
+              "': select annotation missing");
         }
     }
     if (const auto *Term =
             ProfileInjector::getTerminatorBenefitingFromMDProf(BB))
       if (!Term->getMetadata(LLVMContext::MD_prof))
-        F.getContext().emitError(
-            "Profile verification failed: branch annotation missing");
+        F.getContext().emitError("Profile verification failed for function '" +
+                                 F.getName() + "': branch annotation missing");
   }
   return PreservedAnalyses::all();
 }

--- a/llvm/test/Transforms/PGOProfile/prof-verify-no-entrycount.ll
+++ b/llvm/test/Transforms/PGOProfile/prof-verify-no-entrycount.ll
@@ -15,4 +15,4 @@ no:
   ret void
 }
 
-; CHECK: Profile verification failed: function entry count missing (set to 0 if cold)
+; CHECK: Profile verification failed for function 'foo': function entry count missing (set to 0 if cold)

--- a/llvm/test/Transforms/PGOProfile/prof-verify.ll
+++ b/llvm/test/Transforms/PGOProfile/prof-verify.ll
@@ -23,3 +23,4 @@ no:
 ; INJECT: !1 = !{!"branch_weights", i32 3, i32 5}
 
 ; VERIFY: Profile verification failed for function 'foo': branch annotation missing
+

--- a/llvm/test/Transforms/PGOProfile/prof-verify.ll
+++ b/llvm/test/Transforms/PGOProfile/prof-verify.ll
@@ -22,4 +22,4 @@ no:
 ; INJECT: br i1 %c, label %yes, label %no, !prof !1
 ; INJECT: !1 = !{!"branch_weights", i32 3, i32 5}
 
-; VERIFY: Profile verification failed: branch annotation missing
+; VERIFY: Profile verification failed for function 'foo': branch annotation missing

--- a/llvm/test/Transforms/PGOProfile/profcheck-llvm.global_ctors.ll
+++ b/llvm/test/Transforms/PGOProfile/profcheck-llvm.global_ctors.ll
@@ -10,4 +10,4 @@ define internal void @dtor() {
   ret void
 }
 
-; CHECK-NOT: Profile verification failed: function entry count missing
+; CHECK-NOT: Profile verification failed for function {{.+}}: function entry count missing

--- a/llvm/test/Transforms/PGOProfile/profcheck-select.ll
+++ b/llvm/test/Transforms/PGOProfile/profcheck-select.ll
@@ -66,7 +66,7 @@ define void @bar(i1 %c) !prof !0 {
 }
 !0 = !{!"function_entry_count", i64 1000}
 !1 = !{!"branch_weights", i32 1, i32 7}
-; CHECK-NOT: Profile verification failed: select annotation missing
+; CHECK-NOT: Profile verification failed for function 'bar': select annotation missing
 
 ;--- verify-missing.ll
 declare void @foo(i32 %a);
@@ -76,7 +76,7 @@ define void @bar(i1 %c) !prof !0 {
   ret void
 }
 !0 = !{!"function_entry_count", i64 1000}
-; CHECK: Profile verification failed: select annotation missing
+; CHECK: Profile verification failed for function 'bar': select annotation missing
 
 ;--- verify-vec.ll
 define <2 x i32> @vec(<2 x i1> %c, <2 x i32> %v1, <2 x i32> %v2) !prof !{!"function_entry_count", i32 10} {


### PR DESCRIPTION
This is helpful for tests with a lot of test cases and grepping for instructions with missing profile data isn't feasible because it doesn't account for things like vectors which are exempt.

Tracking issue: #147390