### PR TITLE
[libc][wctype] Implement public wctype classification functions

### DIFF
--- a/libc/include/wctype.yaml
+++ b/libc/include/wctype.yaml
@@ -2,9 +2,51 @@ header: wctype.h
 types:
   - type_name: wint_t
 functions:
+  - name: iswalnum
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: wint_t
   - name: iswalpha
     standards:
       - stdc
     return_type: int
+    arguments:
+      - type: wint_t
+  - name: iswdigit
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: wint_t
+  - name: iswlower
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: wint_t
+  - name: iswspace
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: wint_t
+  - name: iswupper
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: wint_t
+  - name: towlower
+    standards:
+      - stdc
+    return_type: wint_t
+    arguments:
+      - type: wint_t
+  - name: towupper
+    standards:
+      - stdc
+    return_type: wint_t
     arguments:
       - type: wint_t

--- a/libc/src/wctype/CMakeLists.txt
+++ b/libc/src/wctype/CMakeLists.txt
@@ -1,9 +1,79 @@
 add_entrypoint_object(
+  iswalnum
+  SRCS
+    iswalnum.cpp
+  HDRS
+    iswalnum.h
+  DEPENDS
+    libc.src.__support.wctype_utils
+)
+
+add_entrypoint_object(
   iswalpha
   SRCS
     iswalpha.cpp
   HDRS
     iswalpha.h
   DEPENDS
-    libc.src.__support.wctype_utils    
+    libc.src.__support.wctype_utils
+)
+
+add_entrypoint_object(
+  iswdigit
+  SRCS
+    iswdigit.cpp
+  HDRS
+    iswdigit.h
+  DEPENDS
+    libc.src.__support.wctype_utils
+)
+
+add_entrypoint_object(
+  iswlower
+  SRCS
+    iswlower.cpp
+  HDRS
+    iswlower.h
+  DEPENDS
+    libc.src.__support.wctype_utils
+)
+
+add_entrypoint_object(
+  iswspace
+  SRCS
+    iswspace.cpp
+  HDRS
+    iswspace.h
+  DEPENDS
+    libc.src.__support.wctype_utils
+)
+
+add_entrypoint_object(
+  iswupper
+  SRCS
+    iswupper.cpp
+  HDRS
+    iswupper.h
+  DEPENDS
+    libc.src.__support.wctype_utils
+)
+
+add_entrypoint_object(
+  towlower
+  SRCS
+    towlower.cpp
+  HDRS
+    towlower.h
+  DEPENDS
+    libc.src.__support.wctype_utils
+)
+
+add_entrypoint_object(
+  towupper
+  SRCS
+    towupper.cpp
+  HDRS
+    towupper.h
+  DEPENDS
+    libc.src.__support.wctype_utils
 )

--- a/libc/src/wctype/iswalnum.cpp
+++ b/libc/src/wctype/iswalnum.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of iswalnum ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wctype/iswalnum.h"
+#include "src/__support/common.h"
+#include "src/__support/wctype_utils.h"
+
+#include "hdr/types/wint_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, iswalnum, (wint_t c)) {
+  return internal::isalnum(static_cast<wchar_t>(c));
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wctype/iswalnum.h
+++ b/libc/src/wctype/iswalnum.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for iswalnum ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCTYPE_ISWALNUM_H
+#define LLVM_LIBC_SRC_WCTYPE_ISWALNUM_H
+
+#include "hdr/types/wint_t.h"
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int iswalnum(wint_t c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCTYPE_ISWALNUM_H

--- a/libc/src/wctype/iswdigit.cpp
+++ b/libc/src/wctype/iswdigit.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of iswdigit ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wctype/iswdigit.h"
+#include "src/__support/common.h"
+#include "src/__support/wctype_utils.h"
+
+#include "hdr/types/wint_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, iswdigit, (wint_t c)) {
+  return internal::isdigit(static_cast<wchar_t>(c));
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wctype/iswdigit.h
+++ b/libc/src/wctype/iswdigit.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for iswdigit ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCTYPE_ISWDIGIT_H
+#define LLVM_LIBC_SRC_WCTYPE_ISWDIGIT_H
+
+#include "hdr/types/wint_t.h"
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int iswdigit(wint_t c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCTYPE_ISWDIGIT_H

--- a/libc/src/wctype/iswlower.cpp
+++ b/libc/src/wctype/iswlower.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of iswlower ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wctype/iswlower.h"
+#include "src/__support/common.h"
+#include "src/__support/wctype_utils.h"
+
+#include "hdr/types/wint_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, iswlower, (wint_t c)) {
+  return internal::islower(static_cast<wchar_t>(c));
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wctype/iswlower.h
+++ b/libc/src/wctype/iswlower.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for iswlower ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCTYPE_ISWLOWER_H
+#define LLVM_LIBC_SRC_WCTYPE_ISWLOWER_H
+
+#include "hdr/types/wint_t.h"
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int iswlower(wint_t c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCTYPE_ISWLOWER_H

--- a/libc/src/wctype/iswspace.cpp
+++ b/libc/src/wctype/iswspace.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of iswspace ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wctype/iswspace.h"
+#include "src/__support/common.h"
+#include "src/__support/wctype_utils.h"
+
+#include "hdr/types/wint_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, iswspace, (wint_t c)) {
+  return internal::isspace(static_cast<wchar_t>(c));
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wctype/iswspace.h
+++ b/libc/src/wctype/iswspace.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for iswspace ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCTYPE_ISWSPACE_H
+#define LLVM_LIBC_SRC_WCTYPE_ISWSPACE_H
+
+#include "hdr/types/wint_t.h"
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int iswspace(wint_t c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCTYPE_ISWSPACE_H

--- a/libc/src/wctype/iswupper.cpp
+++ b/libc/src/wctype/iswupper.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of iswupper ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wctype/iswupper.h"
+#include "src/__support/common.h"
+#include "src/__support/wctype_utils.h"
+
+#include "hdr/types/wint_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, iswupper, (wint_t c)) {
+  return internal::isupper(static_cast<wchar_t>(c));
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wctype/iswupper.h
+++ b/libc/src/wctype/iswupper.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for iswupper ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCTYPE_ISWUPPER_H
+#define LLVM_LIBC_SRC_WCTYPE_ISWUPPER_H
+
+#include "hdr/types/wint_t.h"
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int iswupper(wint_t c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCTYPE_ISWUPPER_H

--- a/libc/src/wctype/towlower.cpp
+++ b/libc/src/wctype/towlower.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of towlower ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wctype/towlower.h"
+#include "src/__support/common.h"
+#include "src/__support/wctype_utils.h"
+
+#include "hdr/types/wint_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(wint_t, towlower, (wint_t c)) {
+  return internal::tolower(static_cast<wchar_t>(c));
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wctype/towlower.h
+++ b/libc/src/wctype/towlower.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for towlower ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCTYPE_TOWLOWER_H
+#define LLVM_LIBC_SRC_WCTYPE_TOWLOWER_H
+
+#include "hdr/types/wint_t.h"
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+wint_t towlower(wint_t c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCTYPE_TOWLOWER_H

--- a/libc/src/wctype/towupper.cpp
+++ b/libc/src/wctype/towupper.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of towupper ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wctype/towupper.h"
+#include "src/__support/common.h"
+#include "src/__support/wctype_utils.h"
+
+#include "hdr/types/wint_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(wint_t, towupper, (wint_t c)) {
+  return internal::toupper(static_cast<wchar_t>(c));
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wctype/towupper.h
+++ b/libc/src/wctype/towupper.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for towupper ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCTYPE_TOWUPPER_H
+#define LLVM_LIBC_SRC_WCTYPE_TOWUPPER_H
+
+#include "hdr/types/wint_t.h"
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+wint_t towupper(wint_t c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCTYPE_TOWUPPER_H


### PR DESCRIPTION
## Summary

Add implementations for the following wctype classification functions from the C standard library:

- `iswalnum` - test for alphanumeric wide character
- `iswdigit` - test for decimal digit wide character  
- `iswlower` - test for lowercase wide character
- `iswupper` - test for uppercase wide character
- `iswspace` - test for whitespace wide character
- `towlower` - convert wide character to lowercase
- `towupper` - convert wide character to uppercase

## Details

These functions use the existing internal helper functions from `wctype_utils.h`. The implementations follow the same pattern as the existing `iswalpha` function.

Each function:
1. Takes a `wint_t` parameter
2. Casts it to `wchar_t`
3. Calls the corresponding internal helper function

## Related Issues

Fixes #175003
