### PR TITLE
[clang-format][tablegen] Guard formatting of DAG with unit test. [NFC]

### DIFF
--- a/clang/test/Format/tablegen-dag.td
+++ b/clang/test/Format/tablegen-dag.td
@@ -1,0 +1,8 @@
+// RUN: clang-format  %s -style="{Language: TableGen}" | FileCheck %s --strict-whitespace
+
+def foo;
+def bar;
+def baz;
+
+defvar x = [(foo(bar baz:$str))];.
+// CHECK: x = [(foo(bar baz:$str))];

--- a/clang/test/Format/tablegen-dag.td
+++ b/clang/test/Format/tablegen-dag.td
@@ -1,8 +1,10 @@
-// RUN: clang-format  %s -style="{Language: TableGen}" | FileCheck %s --strict-whitespace
+// RUN: grep -Ev "// *[A-Z-]+:" %s \
+// RUN:   | clang-format  -assume-filename=%t/foo.td \
+// RUN:   | FileCheck -strict-whitespace %s
 
 def foo;
 def bar;
 def baz;
 
-defvar x = [(foo(bar baz:$str))];.
-// CHECK: x = [(foo(bar baz:$str))];
+defvar x = [(foo(bar baz:$str))];
+// CHECK: x = [(foo (bar baz:$str))];


### PR DESCRIPTION
This test makes sure that we add a space after the head node of a dag and the nested dag following.