### PR TITLE
Remove nomenclature clash in statistic pass with one of the stats

### DIFF
--- a/llvm/lib/Analysis/FunctionPropertiesAnalysis.cpp
+++ b/llvm/lib/Analysis/FunctionPropertiesAnalysis.cpp
@@ -29,8 +29,7 @@ using namespace llvm;
 
 #define DEBUG_TYPE "func-properties-stats"
 
-#define FUNCTION_PROPERTY(Name, Description)                                   \
-  STATISTIC(Num##Name, Description);
+#define FUNCTION_PROPERTY(Name, Description) STATISTIC(Num##Name, Description);
 #define DETAILED_FUNCTION_PROPERTY(Name, Description)                          \
   STATISTIC(Num##Name, Description);
 #include "llvm/IR/FunctionProperties.def"
@@ -382,8 +381,7 @@ FunctionPropertiesStatisticsPass::run(Function &F,
                     << "\n");
   auto &AnalysisResults = FAM.getResult<FunctionPropertiesAnalysis>(F);
 
-#define FUNCTION_PROPERTY(Name, Description)                                   \
-  Num##Name += AnalysisResults.Name;
+#define FUNCTION_PROPERTY(Name, Description) Num##Name += AnalysisResults.Name;
 #define DETAILED_FUNCTION_PROPERTY(Name, Description)                          \
   Num##Name += AnalysisResults.Name;
 #include "llvm/IR/FunctionProperties.def"

--- a/llvm/lib/Analysis/FunctionPropertiesAnalysis.cpp
+++ b/llvm/lib/Analysis/FunctionPropertiesAnalysis.cpp
@@ -30,9 +30,9 @@ using namespace llvm;
 #define DEBUG_TYPE "func-properties-stats"
 
 #define FUNCTION_PROPERTY(Name, Description)                                   \
-  STATISTIC(Total##Name, Description);
+  STATISTIC(Num##Name, Description);
 #define DETAILED_FUNCTION_PROPERTY(Name, Description)                          \
-  STATISTIC(Total##Name, Description);
+  STATISTIC(Num##Name, Description);
 #include "llvm/IR/FunctionProperties.def"
 
 namespace llvm {
@@ -383,9 +383,9 @@ FunctionPropertiesStatisticsPass::run(Function &F,
   auto &AnalysisResults = FAM.getResult<FunctionPropertiesAnalysis>(F);
 
 #define FUNCTION_PROPERTY(Name, Description)                                   \
-  Total##Name += AnalysisResults.Name;
+  Num##Name += AnalysisResults.Name;
 #define DETAILED_FUNCTION_PROPERTY(Name, Description)                          \
-  Total##Name += AnalysisResults.Name;
+  Num##Name += AnalysisResults.Name;
 #include "llvm/IR/FunctionProperties.def"
 
   return PreservedAnalyses::all();


### PR DESCRIPTION
Attribute TotalInstructionCount is used, but previously the name of the stat printed out was "Total"+property, which made it look like TotalTotalInstruction. Num does not provide such clashes in the nomenclature.