### PR TITLE
[IR] Support constructing `dead_on_return` without an argument

### DIFF
--- a/llvm/include/llvm/IR/Attributes.h
+++ b/llvm/include/llvm/IR/Attributes.h
@@ -212,6 +212,8 @@ public:
                                                  MemoryEffects ME);
   LLVM_ABI static Attribute getWithNoFPClass(LLVMContext &Context,
                                              FPClassTest Mask);
+  LLVM_ABI static Attribute getWithDeadOnReturnInfo(LLVMContext &Context,
+                                                    DeadOnReturnInfo DI);
   LLVM_ABI static Attribute getWithCaptureInfo(LLVMContext &Context,
                                                CaptureInfo CI);
 

--- a/llvm/lib/IR/Attributes.cpp
+++ b/llvm/lib/IR/Attributes.cpp
@@ -288,6 +288,11 @@ Attribute Attribute::getWithNoFPClass(LLVMContext &Context,
   return get(Context, NoFPClass, ClassMask);
 }
 
+Attribute Attribute::getWithDeadOnReturnInfo(LLVMContext &Context,
+                                             DeadOnReturnInfo DI) {
+  return get(Context, DeadOnReturn, DI.toIntValue());
+}
+
 Attribute Attribute::getWithCaptureInfo(LLVMContext &Context, CaptureInfo CI) {
   return get(Context, Captures, CI.toIntValue());
 }


### PR DESCRIPTION
After #171712, `dead_on_return` takes an optional argument indicating the number of bytes known dead. The existing clang callsite uses the attribute builder interface directly which supports the optional argument through `DeadOnReturnInfo`. However, users constructing the Attribute directly (e.g. `rustc`) were using `Attribute::get` which will now default to providing a 0 value to the optional argument.

Add the additional method `Attribute::getWithDeadOnReturnInfo` to allow users which produce explicit `Attribute` values to continue to indicate `dead_on_return` without an argument.