### PR TITLE
[TargetParser][cmake] Recurse for TableGen deps

### DIFF
--- a/llvm/cmake/modules/TableGen.cmake
+++ b/llvm/cmake/modules/TableGen.cmake
@@ -49,7 +49,7 @@ function(tablegen project ofn)
   else()
     set(include_td_dirs "${tblgen_includes}")
     list(TRANSFORM include_td_dirs APPEND "/*.td")
-    file(GLOB global_tds ${include_td_dirs})
+    file(GLOB_RECURSE global_tds ${include_td_dirs})
     set(additional_cmdline
       -o ${CMAKE_CURRENT_BINARY_DIR}/${ofn}
       )


### PR DESCRIPTION
In the dependency tracking for TableGen-generated files, globbing was previously limited to the root of include directories. This missed transitive dependencies in subdirectories, such as the target-specific intrinsic definitions located in llvm/IR/.

Modifying these untracked files could cause global state (like the intrinsic enum) to shift without triggering a rebuild of downstream instruction selectors. This resulted in "Cannot select: intrinsic" errors during incremental builds. Using a recursive glob ensures all relevant TableGen files are correctly tracked regardless of their directory depth.

Fixes #156744