### PR TITLE
[lldb] Fix crash when there is no compile unit.

### DIFF
--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -50,6 +50,9 @@ GetTypeSystemFromCU(std::shared_ptr<ExecutionContextScope> ctx) {
     return llvm::createStringError("no stack frame in this context");
   SymbolContext symbol_context =
       stack_frame->GetSymbolContext(lldb::eSymbolContextCompUnit);
+
+  if (!symbol_context.comp_unit)
+    return llvm::createStringError("no compile unit in this context");
   lldb::LanguageType language = symbol_context.comp_unit->GetLanguage();
 
   symbol_context = stack_frame->GetSymbolContext(lldb::eSymbolContextModule);


### PR DESCRIPTION
The crash occurred in lldb-dap when we are in a shared library with no debug information and we are trying to get the expression path for an address.