### PR TITLE
[LLDB] Add a setting to simulate variables with missing locations

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -70,11 +70,18 @@ class Stream;
 class SymbolContext;
 class Target;
 
-/// \class Debugger Debugger.h "lldb/Core/Debugger.h"
+#ifndef NDEBUG
+/// Global properties used in the LLDB testsuite.
+struct TestingProperties : public Properties {
+  TestingProperties();
+  bool GetInjectVarLocListError() const;
+  static TestingProperties &GetGlobalTestingProperties();
+};
+#endif
+
 /// A class to manage flag bits.
 ///
 /// Provides a global root objects for the debugger core.
-
 class Debugger : public std::enable_shared_from_this<Debugger>,
                  public UserID,
                  public Properties {

--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -88,11 +88,8 @@ public:
   uint64_t GetLLDBIndexCacheExpirationDays();
   FileSpec GetLLDBIndexCachePath() const;
   bool SetLLDBIndexCachePath(const FileSpec &path);
-
-  bool GetLoadSymbolOnDemand();
-
+  bool GetLoadSymbolOnDemand() const;
   lldb::SymbolDownload GetSymbolAutoDownload() const;
-
   PathMappingList GetSymlinkMappings() const;
 };
 

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -48,6 +48,16 @@ let Definition = "modulelist" in {
     Desc<"Enable on demand symbol loading in LLDB. LLDB will load debug info on demand for each module based on various conditions (e.g. matched breakpoint, resolved stack frame addresses and matched global variables/function symbols in symbol table) to improve performance. Please refer to docs/use/ondemand.rst for details.">;
 }
 
+#ifndef NDEBUG
+let Definition = "testing" in {
+  def InjectVarLocListError
+      : Property<"inject-variable-location-error", "Boolean">,
+        Global,
+        DefaultFalse,
+        Desc<"Used for testing LLDB only. Hide locations of local variables.">;
+}
+#endif
+
 let Definition = "debugger" in {
   def AutoConfirm: Property<"auto-confirm", "Boolean">,
     Global,

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -202,6 +202,34 @@ enum {
 #include "CorePropertiesEnum.inc"
 };
 
+#ifndef NDEBUG
+#define LLDB_PROPERTIES_testing
+#include "CoreProperties.inc"
+
+enum {
+#define LLDB_PROPERTIES_testing
+#include "CorePropertiesEnum.inc"
+};
+#endif
+
+#ifndef NDEBUG
+TestingProperties::TestingProperties() {
+  m_collection_sp = std::make_shared<OptionValueProperties>("testing");
+  m_collection_sp->Initialize(g_testing_properties);
+}
+
+bool TestingProperties::GetInjectVarLocListError() const {
+  const uint32_t idx = ePropertyInjectVarLocListError;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_testing_properties[idx].default_uint_value != 0);
+}
+
+TestingProperties &TestingProperties::GetGlobalTestingProperties() {
+  static TestingProperties g_testing_properties;
+  return g_testing_properties;
+}
+#endif
+
 LoadPluginCallbackType Debugger::g_load_plugin_callback = nullptr;
 
 Status Debugger::SetPropertyValue(const ExecutionContext *exe_ctx,

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -95,7 +95,6 @@ ModuleListProperties::ModuleListProperties() {
     llvm::sys::path::append(path, "IndexCache");
     lldbassert(SetLLDBIndexCachePath(FileSpec(path)));
   }
-
 }
 
 bool ModuleListProperties::GetEnableExternalLookup() const {
@@ -186,7 +185,7 @@ PathMappingList ModuleListProperties::GetSymlinkMappings() const {
   return m_symlink_paths;
 }
 
-bool ModuleListProperties::GetLoadSymbolOnDemand() {
+bool ModuleListProperties::GetLoadSymbolOnDemand() const {
   const uint32_t idx = ePropertyLoadSymbolOnDemand;
   return GetPropertyAtIndexAs<bool>(
       idx, g_modulelist_properties[idx].default_uint_value != 0);

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Symbol/Variable.h"
 
+#include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Symbol/Block.h"
 #include "lldb/Symbol/CompileUnit.h"
@@ -47,9 +48,16 @@ Variable::Variable(lldb::user_id_t uid, const char *name, const char *mangled,
     : UserID(uid), m_name(name), m_mangled(ConstString(mangled)),
       m_symfile_type_sp(symfile_type_sp), m_scope(scope),
       m_owner_scope(context), m_scope_range(scope_range),
-      m_declaration(decl_ptr), m_location_list(location_list), m_external(external),
-      m_artificial(artificial), m_loc_is_const_data(location_is_constant_data),
-      m_static_member(static_member) {}
+      m_declaration(decl_ptr), m_location_list(location_list),
+      m_external(external), m_artificial(artificial),
+      m_loc_is_const_data(location_is_constant_data),
+      m_static_member(static_member) {
+#ifndef NDEBUG
+  if (TestingProperties::GetGlobalTestingProperties()
+          .GetInjectVarLocListError())
+    m_location_list.Clear();
+#endif
+}
 
 Variable::~Variable() = default;
 

--- a/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
+++ b/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
@@ -272,3 +272,21 @@ note: candidate function not viable: requires single argument 'x', but 2 argumen
         self.assertEqual(err_ty.GetIntegerValue(), lldb.eErrorTypeExpression)
         diags = data.GetValueForKey("errors").GetItemAtIndex(0)
         check_error(diags)
+
+    def test_no_location(self):
+        """Test the error reporting for missing locations"""
+        self.build()
+
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "// Break here", self.main_source_spec
+        )
+        self.ci.HandleCommand(
+            "settings set testing.inject-variable-location-error true", self.res
+        )
+        if not self.res.Succeeded():
+            # This test needs assertions.
+            return
+        frame = thread.GetFrameAtIndex(0)
+        value = frame.EvaluateExpression("f")
+        error = value.GetError()
+        self.assertIn("variable not available", str(error))


### PR DESCRIPTION
Writing testcases for error handling that depends on specific DWARF is very difficult and the resulting tests tend not to be very portable. This patch adds a new setting to inject an error into variable materialization, thus making it possible to write very simple source code based tests for error handling instead.

This is primarily motivated by the Swift language plugin, but functionality is generic and should be useful for other languages as well.