### PR TITLE
[win][x64] Fix crash when enabling Windows Control Flow Guard

### DIFF
--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -479,8 +479,9 @@ static bool isIndirectBranchOrTailCall(const MachineInstr &MI) {
          Opc == X86::TCRETURNri || Opc == X86::TCRETURN_WIN64ri ||
          Opc == X86::TCRETURN_HIPE32ri || Opc == X86::TCRETURNmi ||
          Opc == X86::TCRETURN_WINmi64 || Opc == X86::TCRETURNri64 ||
-         Opc == X86::TCRETURNmi64 || Opc == X86::TCRETURNri64_ImpCall ||
-         Opc == X86::TAILJMPr64_REX || Opc == X86::TAILJMPm64_REX;
+         Opc == X86::TCRETURNmi64_GlobalAddr || Opc == X86::TCRETURNmi64 ||
+         Opc == X86::TCRETURNri64_ImpCall || Opc == X86::TAILJMPr64_REX ||
+         Opc == X86::TAILJMPm64_REX;
 }
 
 void X86AsmPrinter::emitBasicBlockEnd(const MachineBasicBlock &MBB) {

--- a/llvm/lib/Target/X86/X86FrameLowering.cpp
+++ b/llvm/lib/Target/X86/X86FrameLowering.cpp
@@ -2401,7 +2401,8 @@ static bool isTailCallOpcode(unsigned Opc) {
          Opc == X86::TCRETURN_HIPE32ri || Opc == X86::TCRETURNdi ||
          Opc == X86::TCRETURNmi || Opc == X86::TCRETURNri64 ||
          Opc == X86::TCRETURNri64_ImpCall || Opc == X86::TCRETURNdi64 ||
-         Opc == X86::TCRETURNmi64 || Opc == X86::TCRETURN_WINmi64;
+         Opc == X86::TCRETURNmi64 || Opc == X86::TCRETURN_WINmi64 ||
+         Opc == X86::TCRETURNmi64_GlobalAddr;
 }
 
 void X86FrameLowering::emitEpilogue(MachineFunction &MF,

--- a/llvm/lib/Target/X86/X86InstrCompiler.td
+++ b/llvm/lib/Target/X86/X86InstrCompiler.td
@@ -1401,14 +1401,6 @@ def : Pat<(X86tcret_6regs (load addr:$dst), timm:$off),
           (TCRETURN_WINmi64 addr:$dst, timm:$off)>,
           Requires<[IsWin64CCFunc, NotUseIndirectThunkCalls]>;
 
-def : Pat<(X86tcret_globaladdr tglobaladdr:$dst, timm:$off),
-          (TCRETURNmi64 RIP, 1, zero_reg, tglobaladdr:$dst, zero_reg, timm:$off)>,
-          Requires<[In64BitMode, IsNotWin64CCFunc]>;
-
-def : Pat<(X86tcret_globaladdr tglobaladdr:$dst, timm:$off),
-          (TCRETURN_WINmi64 RIP, 1, zero_reg, tglobaladdr:$dst, zero_reg, timm:$off)>,
-          Requires<[IsWin64CCFunc]>;
-
 def : Pat<(X86tcret ptr_rc_tailcall:$dst, timm:$off),
           (INDIRECT_THUNK_TCRETURN64 ptr_rc_tailcall:$dst, timm:$off)>,
           Requires<[In64BitMode, UseIndirectThunkCalls]>;
@@ -1432,9 +1424,6 @@ def : Pat<(X86call (i32 texternalsym:$dst)),
           (CALLpcrel32 texternalsym:$dst)>;
 def : Pat<(X86call (i32 imm:$dst)),
           (CALLpcrel32 imm:$dst)>, Requires<[CallImmAddr]>;
-
-def : Pat<(X86call_globaladdr tglobaladdr:$dst),
-          (CALL64m RIP, 1, zero_reg, tglobaladdr:$dst, zero_reg)>;
 
 // Comparisons.
 

--- a/llvm/lib/Target/X86/X86InstrControl.td
+++ b/llvm/lib/Target/X86/X86InstrControl.td
@@ -348,9 +348,14 @@ let isCall = 1, Uses = [RSP, SSP], SchedRW = [WriteJump] in {
                        Requires<[In64BitMode,FavorMemIndirectCall]>, NOTRACK;
   }
 
-  let mayLoad = 1 in
-  def FARCALL64m  : RI<0xFF, MRM3m, (outs), (ins opaquemem:$dst),
-                       "lcall{q}\t{*}$dst", []>;
+  let mayLoad = 1 in {
+    def FARCALL64m  : RI<0xFF, MRM3m, (outs), (ins opaquemem:$dst),
+                        "lcall{q}\t{*}$dst", []>;
+
+    def CALL64m_GlobalAddress :
+      PseudoI<(outs), (ins i64imm:$dst), [(X86call_globaladdr tglobaladdr:$dst)]>,
+              Requires<[In64BitMode]>;
+  }
 }
 
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1,
@@ -368,14 +373,18 @@ let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1,
                                (ins GR64_A:$dst, i32imm:$offset),
                                []>, Sched<[WriteJump]>;
 
-  let mayLoad = 1 in
-  def TCRETURNmi64   : PseudoI<(outs),
-                               (ins i64mem_TC:$dst, i32imm:$offset),
-                               []>, Sched<[WriteJumpLd]>;
-  let mayLoad = 1 in
-  def TCRETURN_WINmi64   : PseudoI<(outs),
-                               (ins i64mem_w64TC:$dst, i32imm:$offset),
-                               []>, Sched<[WriteJumpLd]>;
+  let mayLoad = 1 in {
+    def TCRETURNmi64   : PseudoI<(outs),
+                                (ins i64mem_TC:$dst, i32imm:$offset),
+                                []>, Sched<[WriteJumpLd]>;
+    def TCRETURN_WINmi64   : PseudoI<(outs),
+                                (ins i64mem_w64TC:$dst, i32imm:$offset),
+                                []>, Sched<[WriteJumpLd]>;
+
+    def TCRETURNmi64_GlobalAddr   : PseudoI<(outs),
+                                (ins i64imm:$dst, i32imm:$offset),
+                                [(X86tcret_globaladdr tglobaladdr:$dst, timm:$offset)]>, Sched<[WriteJumpLd]>;
+  }
 
   def TAILJMPd64 : PseudoI<(outs), (ins i64i32imm_brtarget:$dst),
                            []>, Sched<[WriteJump]>;

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -3702,6 +3702,7 @@ bool X86InstrInfo::isUnconditionalTailCall(const MachineInstr &MI) const {
   case X86::TCRETURNri64:
   case X86::TCRETURNri64_ImpCall:
   case X86::TCRETURNmi64:
+  case X86::TCRETURNmi64_GlobalAddr:
     return true;
   default:
     return false;

--- a/llvm/lib/Target/X86/X86RegisterInfo.cpp
+++ b/llvm/lib/Target/X86/X86RegisterInfo.cpp
@@ -986,6 +986,7 @@ unsigned X86RegisterInfo::findDeadCallerSavedReg(
   case X86::TCRETURNri64_ImpCall:
   case X86::TCRETURNmi64:
   case X86::TCRETURN_WINmi64:
+  case X86::TCRETURNmi64_GlobalAddr:
   case X86::EH_RETURN:
   case X86::EH_RETURN64: {
     LiveRegUnits LRU(*this);


### PR DESCRIPTION
While working on #174108 I switched from lowering the new `_GlobalAddr` psuedo instructions in `X86ExpandPsuedo` to using pattern matching in TableGen. Unfortunately, this seems to cause clang to crash with an AccessViolation (but not llc?) while it's trying to get the ValueType of for `RIP`, perhaps because `CALL64m` permits two different types for its first arg (see <https://github.com/llvm/llvm-project/pull/174108#discussion_r2714689515>).

As a workaround, this change switches back to using `X86ExpandPsuedo`.