### PR TITLE
[RISCV] Use DecoderMethod and a template function to reduce the amount of boilerplate for decodings a register class. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -94,7 +94,7 @@ static DecodeStatus DecodeSimpleRegisterClass(MCInst &Inst, uint32_t RegNo,
 }
 
 constexpr auto DecodeGPRRegisterClass =
-    DecodeSimpleRegisterClass<RISCV::X0, 32, /*CheckRVE*/ true>;
+    DecodeSimpleRegisterClass<RISCV::X0, 32, /*RVELimit=*/16>;
 
 static DecodeStatus DecodeGPRX1X5RegisterClass(MCInst &Inst, uint32_t RegNo,
                                                uint64_t Address,

--- a/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -78,44 +78,23 @@ LLVMInitializeRISCVDisassembler() {
                                          createRISCVDisassembler);
 }
 
-static DecodeStatus DecodeGPRRegisterClass(MCInst &Inst, uint32_t RegNo,
-                                           uint64_t Address,
-                                           const MCDisassembler *Decoder) {
-  bool IsRVE = Decoder->getSubtargetInfo().hasFeature(RISCV::FeatureStdExtE);
-
-  if (RegNo >= 32 || (IsRVE && RegNo >= 16))
-    return MCDisassembler::Fail;
-
-  MCRegister Reg = RISCV::X0 + RegNo;
-  Inst.addOperand(MCOperand::createReg(Reg));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus DecodeGPRF16RegisterClass(MCInst &Inst, uint32_t RegNo,
+template <unsigned FirstReg, unsigned NumRegsInClass, bool CheckRVE = false>
+static DecodeStatus DecodeSimpleRegisterClass(MCInst &Inst, uint32_t RegNo,
                                               uint64_t Address,
                                               const MCDisassembler *Decoder) {
-  bool IsRVE = Decoder->getSubtargetInfo().hasFeature(RISCV::FeatureStdExtE);
+  bool IsRVE =
+      CheckRVE && Decoder->getSubtargetInfo().hasFeature(RISCV::FeatureStdExtE);
 
-  if (RegNo >= 32 || (IsRVE && RegNo >= 16))
+  if (RegNo >= NumRegsInClass || (IsRVE && RegNo >= 16))
     return MCDisassembler::Fail;
 
-  MCRegister Reg = RISCV::X0_H + RegNo;
+  MCRegister Reg = FirstReg + RegNo;
   Inst.addOperand(MCOperand::createReg(Reg));
   return MCDisassembler::Success;
 }
 
-static DecodeStatus DecodeGPRF32RegisterClass(MCInst &Inst, uint32_t RegNo,
-                                              uint64_t Address,
-                                              const MCDisassembler *Decoder) {
-  bool IsRVE = Decoder->getSubtargetInfo().hasFeature(RISCV::FeatureStdExtE);
-
-  if (RegNo >= 32 || (IsRVE && RegNo >= 16))
-    return MCDisassembler::Fail;
-
-  MCRegister Reg = RISCV::X0_W + RegNo;
-  Inst.addOperand(MCOperand::createReg(Reg));
-  return MCDisassembler::Success;
-}
+constexpr auto DecodeGPRRegisterClass =
+    DecodeSimpleRegisterClass<RISCV::X0, 32, /*CheckRVE*/ true>;
 
 static DecodeStatus DecodeGPRX1X5RegisterClass(MCInst &Inst, uint32_t RegNo,
                                                uint64_t Address,
@@ -124,94 +103,6 @@ static DecodeStatus DecodeGPRX1X5RegisterClass(MCInst &Inst, uint32_t RegNo,
   if (Reg != RISCV::X1 && Reg != RISCV::X5)
     return MCDisassembler::Fail;
 
-  Inst.addOperand(MCOperand::createReg(Reg));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus DecodeFPR16RegisterClass(MCInst &Inst, uint32_t RegNo,
-                                             uint64_t Address,
-                                             const MCDisassembler *Decoder) {
-  if (RegNo >= 32)
-    return MCDisassembler::Fail;
-
-  MCRegister Reg = RISCV::F0_H + RegNo;
-  Inst.addOperand(MCOperand::createReg(Reg));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus DecodeFPR32RegisterClass(MCInst &Inst, uint32_t RegNo,
-                                             uint64_t Address,
-                                             const MCDisassembler *Decoder) {
-  if (RegNo >= 32)
-    return MCDisassembler::Fail;
-
-  MCRegister Reg = RISCV::F0_F + RegNo;
-  Inst.addOperand(MCOperand::createReg(Reg));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus DecodeFPR32CRegisterClass(MCInst &Inst, uint32_t RegNo,
-                                              uint64_t Address,
-                                              const MCDisassembler *Decoder) {
-  if (RegNo >= 8) {
-    return MCDisassembler::Fail;
-  }
-  MCRegister Reg = RISCV::F8_F + RegNo;
-  Inst.addOperand(MCOperand::createReg(Reg));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus DecodeFPR64RegisterClass(MCInst &Inst, uint32_t RegNo,
-                                             uint64_t Address,
-                                             const MCDisassembler *Decoder) {
-  if (RegNo >= 32)
-    return MCDisassembler::Fail;
-
-  MCRegister Reg = RISCV::F0_D + RegNo;
-  Inst.addOperand(MCOperand::createReg(Reg));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus DecodeFPR64CRegisterClass(MCInst &Inst, uint32_t RegNo,
-                                              uint64_t Address,
-                                              const MCDisassembler *Decoder) {
-  if (RegNo >= 8) {
-    return MCDisassembler::Fail;
-  }
-  MCRegister Reg = RISCV::F8_D + RegNo;
-  Inst.addOperand(MCOperand::createReg(Reg));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus DecodeFPR128RegisterClass(MCInst &Inst, uint32_t RegNo,
-                                              uint64_t Address,
-                                              const MCDisassembler *Decoder) {
-  if (RegNo >= 32)
-    return MCDisassembler::Fail;
-
-  MCRegister Reg = RISCV::F0_Q + RegNo;
-  Inst.addOperand(MCOperand::createReg(Reg));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus DecodeFPR256RegisterClass(MCInst &Inst, uint32_t RegNo,
-                                              uint64_t Address,
-                                              const void *Decoder) {
-  if (RegNo >= 32)
-    return MCDisassembler::Fail;
-
-  MCRegister Reg = RISCV::F0_Q2 + RegNo;
-  Inst.addOperand(MCOperand::createReg(Reg));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus DecodeMRRegisterClass(MCInst &Inst, uint32_t RegNo,
-                                          uint64_t Address,
-                                          const void *Decoder) {
-  if (RegNo >= 8)
-    return MCDisassembler::Fail;
-
-  MCRegister Reg = RISCV::M0 + RegNo;
   Inst.addOperand(MCOperand::createReg(Reg));
   return MCDisassembler::Success;
 }
@@ -268,17 +159,6 @@ static DecodeStatus DecodeGPRNoX31RegisterClass(MCInst &Inst, uint32_t RegNo,
   }
 
   return DecodeGPRRegisterClass(Inst, RegNo, Address, Decoder);
-}
-
-static DecodeStatus DecodeGPRCRegisterClass(MCInst &Inst, uint32_t RegNo,
-                                            uint64_t Address,
-                                            const MCDisassembler *Decoder) {
-  if (RegNo >= 8)
-    return MCDisassembler::Fail;
-
-  MCRegister Reg = RISCV::X8 + RegNo;
-  Inst.addOperand(MCOperand::createReg(Reg));
-  return MCDisassembler::Success;
 }
 
 static DecodeStatus DecodeGPRPairRegisterClass(MCInst &Inst, uint32_t RegNo,

--- a/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -78,14 +78,14 @@ LLVMInitializeRISCVDisassembler() {
                                          createRISCVDisassembler);
 }
 
-template <unsigned FirstReg, unsigned NumRegsInClass, bool CheckRVE = false>
+template <unsigned FirstReg, unsigned NumRegsInClass, unsigned RVELimit = 0>
 static DecodeStatus DecodeSimpleRegisterClass(MCInst &Inst, uint32_t RegNo,
                                               uint64_t Address,
                                               const MCDisassembler *Decoder) {
-  bool IsRVE =
-      CheckRVE && Decoder->getSubtargetInfo().hasFeature(RISCV::FeatureStdExtE);
+  bool CheckRVE = RVELimit != 0 &&
+                  Decoder->getSubtargetInfo().hasFeature(RISCV::FeatureStdExtE);
 
-  if (RegNo >= NumRegsInClass || (IsRVE && RegNo >= 16))
+  if (RegNo >= NumRegsInClass || (CheckRVE && RegNo >= RVELimit))
     return MCDisassembler::Fail;
 
   MCRegister Reg = FirstReg + RegNo;

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -323,7 +323,7 @@ def YGPR : RegisterClass<"RISCV", [YLenVT], 64,
                               (sequence "X%u_Y", 18, 27),
                               (sequence "X%u_Y", 0, 4))> {
   let RegInfos = YLenRI;
-  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X0_Y, 32, /*CheckRVE=*/true>";
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X0_Y, 32, /*RVELimit=/*16>";
 }
 
 def GPRX0 : GPRRegisterClass<(add X0)>;
@@ -557,7 +557,7 @@ def GPRF16 : RISCVRegisterClass<[f16], 16, (add (sequence "X%u_H", 10, 17),
                                                 (sequence "X%u_H", 8, 9),
                                                 (sequence "X%u_H", 18, 27),
                                                 (sequence "X%u_H", 0, 4))> {
-  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X0_H, 32, /*CheckRVE=*/true>";
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X0_H, 32, /*RVELimit=*/16>";
 }
 def GPRF16C : RISCVRegisterClass<[f16], 16, (add (sequence "X%u_H", 10, 15),
                                                  (sequence "X%u_H", 8, 9))> {
@@ -571,7 +571,7 @@ def GPRF32 : RISCVRegisterClass<[f32], 32, (add (sequence "X%u_W", 10, 17),
                                                 (sequence "X%u_W", 8, 9),
                                                 (sequence "X%u_W", 18, 27),
                                                 (sequence "X%u_W", 0, 4))> {
-  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X0_W, 32, /*CheckRVE=*/true>";
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X0_W, 32, /*RVELimit=*/16>";
 }
 def GPRF32C : RISCVRegisterClass<[f32], 32, (add (sequence "X%u_W", 10, 15),
                                                  (sequence "X%u_W", 8, 9))> {

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -323,7 +323,7 @@ def YGPR : RegisterClass<"RISCV", [YLenVT], 64,
                               (sequence "X%u_Y", 18, 27),
                               (sequence "X%u_Y", 0, 4))> {
   let RegInfos = YLenRI;
-  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X0_Y, 32, /*RVELimit=/*16>";
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X0_Y, 32, /*RVELimit=*/16>";
 }
 
 def GPRX0 : GPRRegisterClass<(add X0)>;

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -365,7 +365,7 @@ def GPRJALRNonX7 : GPRRegisterClass<(sub GPRJALR, X7)>;
 
 def GPRC : GPRRegisterClass<(add (sequence "X%u", 10, 15),
                                  (sequence "X%u", 8, 9))> {
-  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X8, 8, /*CheckRVE=*/true>";
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X8, 8>";
 }
 
 // For indirect tail calls, we can't use callee-saved registers, as they are

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -323,6 +323,7 @@ def YGPR : RegisterClass<"RISCV", [YLenVT], 64,
                               (sequence "X%u_Y", 18, 27),
                               (sequence "X%u_Y", 0, 4))> {
   let RegInfos = YLenRI;
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X0_Y, 32, /*CheckRVE=*/true>";
 }
 
 def GPRX0 : GPRRegisterClass<(add X0)>;
@@ -363,7 +364,9 @@ def GPRJALR : GPRRegisterClass<(sub GPR, (sequence "X%u", 0, 5))>;
 def GPRJALRNonX7 : GPRRegisterClass<(sub GPRJALR, X7)>;
 
 def GPRC : GPRRegisterClass<(add (sequence "X%u", 10, 15),
-                                 (sequence "X%u", 8, 9))>;
+                                 (sequence "X%u", 8, 9))> {
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X8, 8, /*CheckRVE=*/true>";
+}
 
 // For indirect tail calls, we can't use callee-saved registers, as they are
 // restored to the saved value before the tail call, which would clobber a call
@@ -511,13 +514,17 @@ class FPRRegisterClass<list<ValueType> regTypes, int align, string regSuffix>
                               (sequence "F%u_" # regSuffix, 28, 31), // ft8-ft11
                               (sequence "F%u_" # regSuffix, 8, 9),   // fs0-fs1
                               (sequence "F%u_" # regSuffix, 18, 27)  // fs2-fs11
-)>;
+)> {
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::F0_" # regSuffix # ", 32>";
+}
 
 class FPRCRegisterClass<list<ValueType> regTypes, int align, string regSuffix>
     : RISCVRegisterClass<regTypes, align,
                          (add (sequence "F%u_" # regSuffix, 15, 10), // fa5-fa0
                               (sequence "F%u_" # regSuffix, 8, 9)    // ft0-f7
-)>;
+)> {
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::F8_" # regSuffix # ", 8>";
+}
 
 // The order of registers represents the preferred allocation sequence,
 // meaning caller-save regs are listed before callee-save.
@@ -549,9 +556,13 @@ def GPRF16 : RISCVRegisterClass<[f16], 16, (add (sequence "X%u_H", 10, 17),
                                                 (sequence "X%u_H", 28, 31),
                                                 (sequence "X%u_H", 8, 9),
                                                 (sequence "X%u_H", 18, 27),
-                                                (sequence "X%u_H", 0, 4))>;
+                                                (sequence "X%u_H", 0, 4))> {
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X0_H, 32, /*CheckRVE=*/true>";
+}
 def GPRF16C : RISCVRegisterClass<[f16], 16, (add (sequence "X%u_H", 10, 15),
-                                                 (sequence "X%u_H", 8, 9))>;
+                                                 (sequence "X%u_H", 8, 9))> {
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X8_H, 8>";
+}
 def GPRF16NoX0 : RISCVRegisterClass<[f16], 16, (sub GPRF16, X0_H)>;
 
 def GPRF32 : RISCVRegisterClass<[f32], 32, (add (sequence "X%u_W", 10, 17),
@@ -559,9 +570,13 @@ def GPRF32 : RISCVRegisterClass<[f32], 32, (add (sequence "X%u_W", 10, 17),
                                                 (sequence "X%u_W", 28, 31),
                                                 (sequence "X%u_W", 8, 9),
                                                 (sequence "X%u_W", 18, 27),
-                                                (sequence "X%u_W", 0, 4))>;
+                                                (sequence "X%u_W", 0, 4))> {
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X0_W, 32, /*CheckRVE=*/true>";
+}
 def GPRF32C : RISCVRegisterClass<[f32], 32, (add (sequence "X%u_W", 10, 15),
-                                                 (sequence "X%u_W", 8, 9))>;
+                                                 (sequence "X%u_W", 8, 9))> {
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::X8_W, 8>";
+}
 def GPRF32NoX0 : RISCVRegisterClass<[f32], 32, (sub GPRF32, X0_W)>;
 
 //===----------------------------------------------------------------------===//
@@ -974,6 +989,8 @@ foreach Index = 0-7 in
 
 // Allowing i8 in addition to v8i1 simplifies the handling of builtins
 def MR : RISCVRegisterClass<[i8, v8i1], 8,
-                            (add (sequence "M%u", 1, 7), M0)>;
+                            (add (sequence "M%u", 1, 7), M0)> {
+  let DecoderMethod = "DecodeSimpleRegisterClass<RISCV::M0, 8>";
+}
 
 def MR0 : RISCVRegisterClass<[i8, v8i1], 8, (add M0)>;


### PR DESCRIPTION
The decode functions for GPR/FPR and their compressed register classes are very similar. We just need the number of registers, the constant for the first register in the class, and whether or not the register class is shrunk by RVE.

I've added a template function that takes this information and used the DecoderMethod in tablegen to provide the values for the the template parameters.

I kept an alias for DecodeGPRRegisterClass because it has multiple callers.