### PR TITLE
[lld][ELF] Prefer small code model COMDAT sections over large ones

### DIFF
--- a/lld/ELF/InputFiles.h
+++ b/lld/ELF/InputFiles.h
@@ -306,6 +306,11 @@ private:
 
   bool shouldMerge(const Elf_Shdr &sec, StringRef name);
 
+  // Section indices that belong to comdat groups where this file replaced a
+  // large version with its small version. Used to ensure symbols in these
+  // sections are properly taken over during symbol resolution.
+  llvm::DenseSet<uint32_t> replacedComdatSectionIndices;
+
   // Each ELF symbol contains a section index which the symbol belongs to.
   // However, because the number of bits dedicated for that is limited, a
   // symbol can directly point to a section only when the section index is

--- a/lld/ELF/SymbolTable.h
+++ b/lld/ELF/SymbolTable.h
@@ -12,6 +12,7 @@
 #include "Symbols.h"
 #include "llvm/ADT/CachedHashString.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Compiler.h"
 
 namespace lld::elf {
@@ -68,6 +69,12 @@ public:
   // same name, only one of them is linked, and the other is ignored. This map
   // is used to uniquify them.
   llvm::DenseMap<llvm::CachedHashStringRef, const InputFile *> comdatGroups;
+
+  // Tracks comdat groups where the currently selected version has sections with
+  // SHF_X86_64_LARGE flag. When a small version is encountered, the entry is
+  // removed and the small version takes over. This ensures compatibility when
+  // mixing small and medium/large code models.
+  llvm::DenseSet<llvm::CachedHashStringRef> largeComdatGroups;
 
   // The Map of __acle_se_<sym>, <sym> pairs found in the input objects.
   // Key is the <sym> name.

--- a/lld/test/ELF/comdat-large-small.s
+++ b/lld/test/ELF/comdat-large-small.s
@@ -1,0 +1,135 @@
+# REQUIRES: x86
+## Test that when the same comdat group exists in both small and large versions
+## (with and without SHF_X86_64_LARGE), the linker prefers the small version.
+## This is important for mixed small/medium code model linking.
+
+# RUN: rm -rf %t && split-file %s %t && cd %t
+
+# RUN: llvm-mc -filetype=obj -triple=x86_64 small.s -o small.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64 large.s -o large.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64 large2.s -o large2.o
+
+## Test small first, then large - small should win
+# RUN: ld.lld -e _start small.o large.o -o sl
+# RUN: llvm-readelf -S -s sl | FileCheck %s --check-prefix=SMALL
+
+## Test large first, then small - small should still win
+# RUN: ld.lld -e _start large.o small.o -o ls
+# RUN: llvm-readelf -S -s ls | FileCheck %s --check-prefix=SMALL
+
+## When both are large, first one wins (no preference)
+# RUN: ld.lld -e _start large.o large2.o -o ll
+# RUN: llvm-readelf -S ll | FileCheck %s --check-prefix=LARGE
+
+## Verify the symbol is in .data (not .ldata) and is defined
+# SMALL:      .data{{.*}} PROGBITS
+# SMALL-NOT:  .ldata
+# SMALL:      OBJECT  GLOBAL DEFAULT [[#]] comdat_var
+
+## When both are large, we get .ldata
+# LARGE:      .ldata{{.*}} PROGBITS
+
+## Test comdat group with multiple symbols (symbol name != signature).
+## This tests that ALL symbols in the comdat are handled correctly,
+## not just the one matching the signature.
+# RUN: llvm-mc -filetype=obj -triple=x86_64 small_multi.s -o small_multi.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64 large_multi.s -o large_multi.o
+
+## Large first, then small - small should win and both symbols should be defined
+# RUN: ld.lld -e _start large_multi.o small_multi.o -o multi
+# RUN: llvm-readelf -S -s multi | FileCheck %s --check-prefix=MULTI
+
+# MULTI:      .data{{.*}} PROGBITS
+# MULTI-NOT:  .ldata
+## Both symbols from the comdat group should be properly defined
+# MULTI-DAG:  OBJECT  GLOBAL DEFAULT [[#]] primary_var
+# MULTI-DAG:  OBJECT  GLOBAL DEFAULT [[#]] secondary_var
+
+#--- small.s
+.globl _start
+_start:
+  # Access comdat_var with 32-bit PC-relative relocation (small code model)
+  movl comdat_var(%rip), %eax
+  ret
+
+.section .data.comdat_var,"awG",@progbits,comdat_var,comdat
+.globl comdat_var
+.type comdat_var, @object
+comdat_var:
+  .long 42
+  .size comdat_var, 4
+
+#--- large.s
+.globl use_large
+use_large:
+  # Access comdat_var with 64-bit absolute relocation (medium code model)
+  movabsq $comdat_var, %rax
+  movl (%rax), %eax
+  ret
+
+.section .ldata.comdat_var,"awlG",@progbits,comdat_var,comdat
+.globl comdat_var
+.type comdat_var, @object
+comdat_var:
+  .long 42
+  .size comdat_var, 4
+
+#--- large2.s
+.globl _start
+_start:
+use_large2:
+  movabsq $comdat_var, %rax
+  movl (%rax), %eax
+  ret
+
+.section .ldata.comdat_var,"awlG",@progbits,comdat_var,comdat
+.globl comdat_var
+.type comdat_var, @object
+comdat_var:
+  .long 42
+  .size comdat_var, 4
+
+#--- small_multi.s
+## Comdat group with signature "comdat_group" containing two symbols.
+## The symbol names (primary_var, secondary_var) differ from the signature.
+.globl _start
+_start:
+  movl primary_var(%rip), %eax
+  addl secondary_var(%rip), %eax
+  ret
+
+.section .data.comdat_group,"awG",@progbits,comdat_group,comdat
+.globl primary_var
+.type primary_var, @object
+primary_var:
+  .long 1
+  .size primary_var, 4
+
+.globl secondary_var
+.type secondary_var, @object
+secondary_var:
+  .long 2
+  .size secondary_var, 4
+
+#--- large_multi.s
+## Large version of the same comdat group.
+.globl use_large_multi
+use_large_multi:
+  movabsq $primary_var, %rax
+  movl (%rax), %eax
+  movabsq $secondary_var, %rcx
+  addl (%rcx), %eax
+  ret
+
+.section .ldata.comdat_group,"awlG",@progbits,comdat_group,comdat
+.globl primary_var
+.type primary_var, @object
+primary_var:
+  .long 1
+  .size primary_var, 4
+
+.globl secondary_var
+.type secondary_var, @object
+secondary_var:
+  .long 2
+  .size secondary_var, 4


### PR DESCRIPTION
When linking objects compiled with different code models (small vs medium/large), comdat groups may have both small and large (SHF_X86_64_LARGE) versions. Previously, LLD used first-come-first-served selection, which could keep the large version even when small code model code references it. This causes relocation overflows because large sections can be placed beyond ±2GB from the code, exceeding the range of R_X86_64_PC32 relocations used by small code model.

This patch makes LLD prefer small comdat sections over large ones, ensuring compatibility when mixing code models. When a comdat with SHF_X86_64_LARGE sections is already selected and a small version is encountered, the small version takes over.

Limitation: LTO/ThinLTO inputs (bitcode files) are not yet handled, since section flags like SHF_X86_64_LARGE are not available until after LTO codegen. This will be addressed in a future PR.