### PR TITLE
[lldb] Add a GetSubsetExtractorSP method to DataExtractor

### DIFF
--- a/lldb/include/lldb/Utility/DataExtractor.h
+++ b/lldb/include/lldb/Utility/DataExtractor.h
@@ -16,6 +16,7 @@
 #include "lldb/lldb-forward.h"
 #include "lldb/lldb-types.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/SwapByteOrder.h"
 
@@ -832,6 +833,19 @@ public:
   virtual lldb::DataExtractorSP GetSubsetExtractorSP(lldb::offset_t offset,
                                                      lldb::offset_t length);
 
+  /// Return a new DataExtractor which represents a subset of an existing
+  /// data extractor's bytes, copying all other fields from the existing
+  /// data extractor.  The length will be the largest contiguous region that
+  /// can be provided starting at \a offset; it is safe to read any bytes
+  /// within the returned subset Extractor.
+  ///
+  /// \param[in] offset
+  ///     The starting byte offset into the shared data buffer.
+  ///
+  /// \return
+  ///     A shared pointer to a new DataExtractor.
+  virtual lldb::DataExtractorSP GetSubsetExtractorSP(lldb::offset_t offset);
+
   lldb::DataBufferSP &GetSharedDataBuffer() { return m_data_sp; }
 
   bool HasData() { return m_start && m_end && m_end - m_start > 0; }
@@ -1011,8 +1025,14 @@ public:
 
   void Checksum(llvm::SmallVectorImpl<uint8_t> &dest, uint64_t max_data = 0);
 
-  llvm::ArrayRef<uint8_t> GetData() const {
+  virtual llvm::ArrayRef<uint8_t> GetData() const {
     return {GetDataStart(), size_t(GetByteSize())};
+  }
+
+  llvm::DWARFDataExtractor GetAsLLVMDWARF() const {
+    return llvm::DWARFDataExtractor(GetData(),
+                                    GetByteOrder() == lldb::eByteOrderLittle,
+                                    GetAddressByteSize());
   }
 
   llvm::DataExtractor GetAsLLVM() const {

--- a/lldb/include/lldb/Utility/DataExtractor.h
+++ b/lldb/include/lldb/Utility/DataExtractor.h
@@ -818,6 +818,20 @@ public:
   ///     The extracted unsigned integer value.
   uint64_t GetULEB128(lldb::offset_t *offset_ptr) const;
 
+  /// Return a new DataExtractor which represents a subset of an existing
+  /// data extractor's bytes, copying all other fields from the existing
+  /// data extractor.
+  ///
+  /// \param[in] offset
+  ///     The starting byte offset into the shared data buffer.
+  /// \param[in] length
+  ///     The length of bytes that the new extractor can operate on.
+  ///
+  /// \return
+  ///     A shared pointer to a new DataExtractor.
+  virtual lldb::DataExtractorSP GetSubsetExtractorSP(lldb::offset_t offset,
+                                                     lldb::offset_t length);
+
   lldb::DataBufferSP &GetSharedDataBuffer() { return m_data_sp; }
 
   bool HasData() { return m_start && m_end && m_end - m_start > 0; }

--- a/lldb/include/lldb/Utility/VirtualDataExtractor.h
+++ b/lldb/include/lldb/Utility/VirtualDataExtractor.h
@@ -55,6 +55,10 @@ public:
   lldb::DataExtractorSP GetSubsetExtractorSP(lldb::offset_t offset,
                                              lldb::offset_t length) override;
 
+  lldb::DataExtractorSP GetSubsetExtractorSP(lldb::offset_t offset) override;
+
+  llvm::ArrayRef<uint8_t> GetData() const override;
+
   /// Unchecked overrides
   /// @{
   uint8_t GetU8_unchecked(lldb::offset_t *offset_ptr) const override;

--- a/lldb/include/lldb/Utility/VirtualDataExtractor.h
+++ b/lldb/include/lldb/Utility/VirtualDataExtractor.h
@@ -43,11 +43,17 @@ public:
                        lldb::ByteOrder byte_order, uint32_t addr_size,
                        LookupTable lookup_table);
 
+  VirtualDataExtractor(const lldb::DataBufferSP &data_sp,
+                       LookupTable lookup_table);
+
   const void *GetData(lldb::offset_t *offset_ptr,
                       lldb::offset_t length) const override;
 
   const uint8_t *PeekData(lldb::offset_t offset,
                           lldb::offset_t length) const override;
+
+  lldb::DataExtractorSP GetSubsetExtractorSP(lldb::offset_t offset,
+                                             lldb::offset_t length) override;
 
   /// Unchecked overrides
   /// @{

--- a/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
+++ b/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
@@ -417,14 +417,14 @@ ObjectFileSP ObjectContainerBSDArchive::GetObjectFile(const FileSpec *file) {
           lldb::offset_t data_offset = 0;
           DataExtractorSP extractor_sp =
               std::make_shared<DataExtractor>(child_data_sp);
-          return ObjectFile::FindPlugin(
+          return lldb_private::ObjectFile::FindPlugin(
               module_sp, &child, m_offset + object->file_offset,
               object->file_size, extractor_sp, data_offset);
         }
         lldb::offset_t data_offset = object->file_offset;
         DataExtractorSP extractor_sp =
             std::make_shared<DataExtractor>(m_archive_sp->GetData());
-        return ObjectFile::FindPlugin(
+        return lldb_private::ObjectFile::FindPlugin(
             module_sp, file, m_offset + object->file_offset, object->file_size,
             extractor_sp, data_offset);
       }
@@ -476,8 +476,8 @@ size_t ObjectContainerBSDArchive::GetModuleSpecifications(
             continue;
           FileSpec child = GetChildFileSpecificationsFromThin(
               object->ar_name.GetStringRef(), file);
-          if (ObjectFile::GetModuleSpecifications(child, 0, object->file_size,
-                                                  specs)) {
+          if (lldb_private::ObjectFile::GetModuleSpecifications(
+                  child, 0, object->file_size, specs)) {
             ModuleSpec &spec =
                 specs.GetModuleSpecRefAtIndex(specs.GetSize() - 1);
             llvm::sys::TimePoint<> object_mod_time(
@@ -492,7 +492,7 @@ size_t ObjectContainerBSDArchive::GetModuleSpecifications(
         const lldb::offset_t object_file_offset =
             file_offset + object->file_offset;
         if (object->file_offset < file_size && file_size > object_file_offset) {
-          if (ObjectFile::GetModuleSpecifications(
+          if (lldb_private::ObjectFile::GetModuleSpecifications(
                   file, object_file_offset, file_size - object_file_offset,
                   specs)) {
             ModuleSpec &spec =

--- a/lldb/source/Utility/DataExtractor.cpp
+++ b/lldb/source/Utility/DataExtractor.cpp
@@ -1059,3 +1059,7 @@ DataExtractorSP DataExtractor::GetSubsetExtractorSP(offset_t offset,
                   length);
   return new_sp;
 }
+
+DataExtractorSP DataExtractor::GetSubsetExtractorSP(offset_t offset) {
+  return GetSubsetExtractorSP(offset, GetByteSize() - offset);
+}

--- a/lldb/source/Utility/DataExtractor.cpp
+++ b/lldb/source/Utility/DataExtractor.cpp
@@ -1050,3 +1050,12 @@ void DataExtractor::Checksum(llvm::SmallVectorImpl<uint8_t> &dest,
   dest.clear();
   dest.append(result.begin(), result.end());
 }
+
+DataExtractorSP DataExtractor::GetSubsetExtractorSP(offset_t offset,
+                                                    offset_t length) {
+  DataExtractorSP new_sp = std::make_shared<DataExtractor>(
+      GetSharedDataBuffer(), GetByteOrder(), GetAddressByteSize());
+  new_sp->SetData(GetSharedDataBuffer(), GetSharedDataOffset() + offset,
+                  length);
+  return new_sp;
+}

--- a/lldb/source/Utility/VirtualDataExtractor.cpp
+++ b/lldb/source/Utility/VirtualDataExtractor.cpp
@@ -151,6 +151,8 @@ VirtualDataExtractor::GetSubsetExtractorSP(offset_t virtual_offset,
   assert(
       entry &&
       "VirtualDataExtractor subset extractor requires valid virtual address");
+  if (!entry)
+    return {};
 
   // Entry::data is the offset into the DataBuffer's actual start/end range
   // Entry::base is the virtual address at the start of this region of data
@@ -158,6 +160,8 @@ VirtualDataExtractor::GetSubsetExtractorSP(offset_t virtual_offset,
   assert(
       offset_into_entry_range + virtual_length <= entry->size &&
       "VirtualDataExtractor subset may not span multiple LookupTable entries");
+  if (offset_into_entry_range + virtual_length > entry->size)
+    return {};
 
   // We could support a Subset VirtualDataExtractor which covered
   // multiple LookupTable virtual entries, but we'd need to mutate
@@ -180,6 +184,8 @@ VirtualDataExtractor::GetSubsetExtractorSP(offset_t virtual_offset) {
   assert(
       entry &&
       "VirtualDataExtractor subset extractor requires valid virtual address");
+  if (!entry)
+    return {};
 
   // Entry::data is the offset into the DataBuffer's actual start/end range
   // Entry::base is the virtual address at the start of this region of data
@@ -200,5 +206,7 @@ llvm::ArrayRef<uint8_t> VirtualDataExtractor::GetData() const {
   const LookupTable::Entry *entry = FindEntry(0);
   assert(entry &&
          "VirtualDataExtractor GetData requires valid virtual address");
+  if (!entry)
+    return {};
   return {m_start + entry->data, entry->size};
 }

--- a/lldb/source/Utility/VirtualDataExtractor.cpp
+++ b/lldb/source/Utility/VirtualDataExtractor.cpp
@@ -31,6 +31,12 @@ VirtualDataExtractor::VirtualDataExtractor(const DataBufferSP &data_sp,
   m_lookup_table.Sort();
 }
 
+VirtualDataExtractor::VirtualDataExtractor(const DataBufferSP &data_sp,
+                                           LookupTable lookup_table)
+    : DataExtractor(data_sp), m_lookup_table(std::move(lookup_table)) {
+  m_lookup_table.Sort();
+}
+
 const VirtualDataExtractor::LookupTable::Entry *
 VirtualDataExtractor::FindEntry(offset_t virtual_addr) const {
   // Use RangeDataVector's binary search instead of linear search.
@@ -136,4 +142,30 @@ uint64_t VirtualDataExtractor::GetU64_unchecked(offset_t *offset_ptr) const {
   uint64_t result = DataExtractor::GetU64_unchecked(&physical_offset);
   *offset_ptr += 8;
   return result;
+}
+
+DataExtractorSP
+VirtualDataExtractor::GetSubsetExtractorSP(offset_t virtual_offset,
+                                           offset_t virtual_length) {
+  const LookupTable::Entry *entry = FindEntry(virtual_offset);
+  assert(entry && "Unchecked methods require valid virtual address");
+
+  // Entry::data is the offset into the DataBuffer's actual start/end range
+  // Entry::base is the virtual address at the start of this region of data
+  offset_t offset_into_entry_range = virtual_offset - entry->base;
+  assert(
+      offset_into_entry_range + virtual_length <= entry->size &&
+      "VirtualDataExtractor subset may not span multiple LookupTable entries");
+
+  // We could support a Subset VirtualDataExtractor which covered
+  // multiple LookupTable virtual entries, but we'd need to mutate
+  // all of the LookupTable entries that were properly included in
+  // the Subset, a bit tricky.  So we won't implement that until it's
+  // needed.
+
+  offset_t physical_start = entry->data + offset_into_entry_range;
+  std::shared_ptr<DataExtractor> new_sp = std::make_shared<DataExtractor>(
+      GetSharedDataBuffer(), GetByteOrder(), GetAddressByteSize());
+  new_sp->SetData(GetSharedDataBuffer(), physical_start, virtual_length);
+  return new_sp;
 }


### PR DESCRIPTION
We have many places where an ObjectFile subclass will take the DataExtractor representing the entire binary, create a subsection of that in a new DataExtractor for processing.  For instance, an object file might have symbol table entries with offsets into the string table.  A common code pattern is to create a DataExtractor representing the string table, and then pulling out the c-strings based on those offsets from the string table DataExtractor.

When code does this, it creates a new DataExtractor, copies the Endianness and Wordsize from the original, copies the DataBufferSP from the original, and specifies a new start and offset into the DataBuffer.

However, if the binary is actaully stored in a VirtualDataExtractor, this code pattern loses the correct virtual-to-physical table translation and will not work correctly.  This new method simplifies this common pattern, and correctly takes a subset of a VirtualDataExtractor.

The current implementation only allows a subset of a VirtualDataExtractor that is contained within a single virtual entry (LookupTable entry) and returns a DataExtractor with the corret offsets calculated from the LookupTable.  If we need to a VirtualDataExtractor to create a Subset DataExtractor representing multiple separate virtual ranges of data, we'll need to copy over the LookupTable entries that cover all the bytes, and update them to be relative to the new VirtualDataExtractor.  It's a bit of work, and it's not needed right now, so I'm not tackling that.

I am working on a larger PR which needs this new method.  This PR contains a unit test that uses it.

rdar://148939795