### PR TITLE
[TableGen] Make sure ResNo is the same in CheckTypeMatcher::isContradictoryImpl.

### DIFF
--- a/llvm/utils/TableGen/DAGISelMatcher.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcher.cpp
@@ -378,8 +378,14 @@ bool CheckOpcodeMatcher::isContradictoryImpl(const Matcher *M) const {
 }
 
 bool CheckTypeMatcher::isContradictoryImpl(const Matcher *M) const {
-  if (const CheckTypeMatcher *CT = dyn_cast<CheckTypeMatcher>(M))
+  if (const CheckTypeMatcher *CT = dyn_cast<CheckTypeMatcher>(M)) {
+    // If the two checks are about different results, we don't know if they
+    // conflict!
+    if (getResNo() != CT->getResNo())
+      return false;
+
     return TypesAreContradictory(getType(), CT->getType());
+  }
   return false;
 }
 


### PR DESCRIPTION
CheckType can only be contradictory if the same result is being checked.

Noticed while looking at the code. This doesn't affect the output on any in tree targets.