### PR TITLE
[IR] fix parser crash on AArch64 NEON intrinsics with mismatched element types

### DIFF
--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -950,9 +950,11 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
       return IsDeferredCheck || DeferCheck(Ty);
 
     Type *NewTy = ArgTys[D.getArgumentNumber()];
-    if (VectorType *VTy = dyn_cast<VectorType>(NewTy))
+    if (VectorType *VTy = dyn_cast<VectorType>(NewTy)) {
+      if (!VTy->getElementType()->isIntegerTy())
+        return true;
       NewTy = VectorType::getExtendedElementVectorType(VTy);
-    else if (IntegerType *ITy = dyn_cast<IntegerType>(NewTy))
+    } else if (IntegerType *ITy = dyn_cast<IntegerType>(NewTy))
       NewTy = IntegerType::get(ITy->getContext(), 2 * ITy->getBitWidth());
     else
       return true;
@@ -965,9 +967,15 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
       return IsDeferredCheck || DeferCheck(Ty);
 
     Type *NewTy = ArgTys[D.getArgumentNumber()];
-    if (VectorType *VTy = dyn_cast<VectorType>(NewTy))
+    if (VectorType *VTy = dyn_cast<VectorType>(NewTy)) {
+      Type *EltTy = VTy->getElementType();
+      if (!EltTy->isIntegerTy() && !EltTy->isFloatingPointTy())
+        return true;
+      if (EltTy->isFloatingPointTy() &&
+          (EltTy->isHalfTy() || EltTy->isBFloatTy()))
+        return true;
       NewTy = VectorType::getTruncatedElementVectorType(VTy);
-    else if (IntegerType *ITy = dyn_cast<IntegerType>(NewTy))
+    } else if (IntegerType *ITy = dyn_cast<IntegerType>(NewTy))
       NewTy = IntegerType::get(ITy->getContext(), ITy->getBitWidth() / 2);
     else
       return true;

--- a/llvm/test/Verifier/intrinsic-aarch64-neon-type-mismatch.ll
+++ b/llvm/test/Verifier/intrinsic-aarch64-neon-type-mismatch.ll
@@ -1,0 +1,17 @@
+; RUN: not opt -S < %s 2>&1 | FileCheck %s
+
+; Test that AArch64 NEON intrinsics with incorrect vector element types
+; are rejected with a proper error instead of causing assertion failures.
+; This is a regression test for GitHub issue #176847.
+
+; CHECK: invalid intrinsic signature
+define <vscale x 4 x float> @test_raddhn_float_instead_of_int(<vscale x 4 x float> %arg0) {
+  %i = call <vscale x 4 x float> @llvm.aarch64.neon.raddhn.v4f32(<vscale x 4 x float> %arg0, i32 0)
+  ret <vscale x 4 x float> %i
+}
+
+; CHECK: invalid intrinsic signature
+define <8 x half> @test_sqdmull_half_instead_of_int(<8 x half> %arg0, <8 x half> %arg1) {
+  %i = call <8 x half> @llvm.aarch64.neon.sqdmull.v8f16(<8 x half> %arg0, <8 x half> %arg1)
+  ret <8 x half> %i
+}

--- a/llvm/test/Verifier/intrinsic-aarch64-neon-type-mismatch.ll
+++ b/llvm/test/Verifier/intrinsic-aarch64-neon-type-mismatch.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S < %s 2>&1 | FileCheck %s
+; RUN: not opt -S < %s 2>&1 | FileCheck %s
 
 ; Test that AArch64 NEON intrinsics with incorrect vector element types
 ; are rejected with a proper error instead of causing assertion failures.

--- a/llvm/test/Verifier/intrinsic-aarch64-neon-type-mismatch.ll
+++ b/llvm/test/Verifier/intrinsic-aarch64-neon-type-mismatch.ll
@@ -1,4 +1,4 @@
-; RUN: not opt -S < %s 2>&1 | FileCheck %s
+; RUN: opt -S < %s 2>&1 | FileCheck %s
 
 ; Test that AArch64 NEON intrinsics with incorrect vector element types
 ; are rejected with a proper error instead of causing assertion failures.

--- a/llvm/test/Verifier/intrinsic-aarch64-neon-type-mismatch.ll
+++ b/llvm/test/Verifier/intrinsic-aarch64-neon-type-mismatch.ll
@@ -4,13 +4,13 @@
 ; are rejected with a proper error instead of causing assertion failures.
 ; This is a regression test for GitHub issue #176847.
 
-; CHECK: invalid intrinsic signature
+; CHECK: error: invalid intrinsic signature
 define <vscale x 4 x float> @test_raddhn_float_instead_of_int(<vscale x 4 x float> %arg0) {
   %i = call <vscale x 4 x float> @llvm.aarch64.neon.raddhn.v4f32(<vscale x 4 x float> %arg0, i32 0)
   ret <vscale x 4 x float> %i
 }
 
-; CHECK: invalid intrinsic signature
+; CHECK: error: invalid intrinsic signature
 define <8 x half> @test_sqdmull_half_instead_of_int(<8 x half> %arg0, <8 x half> %arg1) {
   %i = call <8 x half> @llvm.aarch64.neon.sqdmull.v8f16(<8 x half> %arg0, <8 x half> %arg1)
   ret <8 x half> %i

--- a/llvm/test/Verifier/intrinsic-aarch64-neon-type-mismatch.ll
+++ b/llvm/test/Verifier/intrinsic-aarch64-neon-type-mismatch.ll
@@ -4,13 +4,13 @@
 ; are rejected with a proper error instead of causing assertion failures.
 ; This is a regression test for GitHub issue #176847.
 
-; CHECK: error: invalid intrinsic signature
+; CHECK: invalid intrinsic signature
 define <vscale x 4 x float> @test_raddhn_float_instead_of_int(<vscale x 4 x float> %arg0) {
   %i = call <vscale x 4 x float> @llvm.aarch64.neon.raddhn.v4f32(<vscale x 4 x float> %arg0, i32 0)
   ret <vscale x 4 x float> %i
 }
 
-; CHECK: error: invalid intrinsic signature
+; CHECK: invalid intrinsic signature
 define <8 x half> @test_sqdmull_half_instead_of_int(<8 x half> %arg0, <8 x half> %arg1) {
   %i = call <8 x half> @llvm.aarch64.neon.sqdmull.v8f16(<8 x half> %arg0, <8 x half> %arg1)
   ret <8 x half> %i


### PR DESCRIPTION
parser crashes when AArch64 NEON intrinsics (raddhn, sqdmull) are called with float vectors instead of required int vectors. The issue was that matchIntrinsicType() calls:
- VectorType::getExtendedElementVectorType() - no check for int elements (assertion DerivedTypes.h:492)
- VectorType::getTruncatedElementVectorType() - no check if truncatable (fp16/bf16 can't truncate, UNREACHABLE DerivedTypes.h:511)

To fix this, I added type checks before calling these functions -> return error instead of crash. 

## Test
Added llvm/test/Verifier/intrinsic-aarch64-neon-type-mismatch.ll

It now throws an error (invalid intrinsic signature) instead of assertion/crash. 

Fixes #176847