### PR TITLE
[clang-format]  Ignore imports in comments for Java import sorting

### DIFF
--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3759,12 +3759,13 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
   SmallVector<JavaImportDirective, 16> ImportsInBlock;
   SmallVector<StringRef> AssociatedCommentLines;
 
-  bool FormattingOff = false;
-
-  for (;;) {
+  for (bool FormattingOff = false;;) {
     auto Pos = Code.find('\n', Prev);
-    StringRef Line =
-        Code.substr(Prev, (Pos != StringRef::npos ? Pos : Code.size()) - Prev);
+    auto GetLine = [&] {
+      return Code.substr(Prev,
+                         (Pos != StringRef::npos ? Pos : Code.size()) - Prev);
+    };
+    StringRef Line = GetLine();
 
     StringRef Trimmed = Line.trim();
     if (Trimmed.empty() || PackageRegex.match(Trimmed)) {
@@ -3784,8 +3785,7 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
       if (HasImport) {
         // Extend `Line` for a multiline comment to include all lines the
         // comment spans.
-        Line =
-            Code.substr(Prev, (Pos != StringRef::npos ? Pos : Code.size()) - Prev);
+        Line = GetLine();
         AssociatedCommentLines.push_back(Line);
       }
     } else if (ImportRegex.match(Trimmed, &Matches)) {

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3740,8 +3740,8 @@ static void sortJavaImports(const FormatStyle &Style,
 
 namespace {
 
-constexpr StringRef JavaImportRegexPattern(
-"^import[\t ]+(static[\t ]*)?([^\t ]*)[\t ]*;");
+constexpr StringRef 
+    JavaImportRegexPattern("^import[\t ]+(static[\t ]*)?([^\t ]*)[\t ]*;");
 
 constexpr StringRef JavaPackageRegexPattern("^package[\t ]+");
 

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3766,15 +3766,7 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
     StringRef Line =
         Code.substr(Prev, (Pos != StringRef::npos ? Pos : Code.size()) - Prev);
 
-    StringRef Trimmed = Line.trim();
-    if (isClangFormatOff(Trimmed))
-      FormattingOff = true;
-    else if (isClangFormatOn(Trimmed))
-      FormattingOff = false;
-
-    if (Trimmed.empty()) {
-      // Skip empty lines.
-    } else if (Trimmed.starts_with("//")) {
+    StringRef Trimmed = Line.trim();`r`n    if (Trimmed.empty()) {`r`n      // Skip empty lines.`r`n    } else if (isClangFormatOff(Trimmed)) {`r`n      FormattingOff = true;`r`n    } else if (isClangFormatOn(Trimmed)) {`r`n      FormattingOff = false;`r`n    } else if (Trimmed.starts_with("//")) {
       if (!ImportsInBlock.empty())
         AssociatedCommentLines.push_back(Line);
     } else if (Trimmed.starts_with("/*")) {

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3752,7 +3752,7 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
                                       StringRef FileName,
                                       tooling::Replacements &Replaces) {
   unsigned Prev = 0;
-  unsigned SearchFrom = 0;
+  bool HasImport = false;
   llvm::Regex ImportRegex(JavaImportRegexPattern);
   llvm::Regex PackageRegex(JavaPackageRegexPattern);
   SmallVector<StringRef, 4> Matches;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3740,10 +3740,10 @@ static void sortJavaImports(const FormatStyle &Style,
 
 namespace {
 
-const char JavaImportRegexPattern[] =
-    "^[\t ]*import[\t ]+(static[\t ]*)?([^\t ]*)[\t ]*;";
+constexpr StringRef JavaImportRegexPattern(
+"^import[\t ]+(static[\t ]*)?([^\t ]*)[\t ]*;");
 
-const char JavaPackageRegexPattern[] = "^[\t ]*package[\t ]+[^;]+;";
+constexpr StringRef JavaPackageRegexPattern("^package[\t ]+");
 
 } // anonymous namespace
 

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3803,6 +3803,8 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
       HasImport = true;
       AssociatedCommentLines.clear();
     } else {
+      // `Trimmed` is neither empty, nor a comment or a package/import
+      // statement.
       break;
     }
     Prev = Pos + 1;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3740,7 +3740,7 @@ static void sortJavaImports(const FormatStyle &Style,
 
 namespace {
 
-constexpr StringRef 
+constexpr StringRef
     JavaImportRegexPattern("^import[\t ]+(static[\t ]*)?([^\t ]*)[\t ]*;");
 
 constexpr StringRef JavaPackageRegexPattern("^package[\t ]+");

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3774,7 +3774,8 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
     } else if (isClangFormatOn(Trimmed)) {
       FormattingOff = false;
     } else if (Trimmed.starts_with("//")) {
-      if (!ImportsInBlock.empty())
+      // Associating comments within the imports with the nearest import below.
+      if (HasImport)
         AssociatedCommentLines.push_back(Line);
     } else if (Trimmed.starts_with("/*")) {
       auto EndPos = Code.find("*/", SearchFrom + 2);

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3778,15 +3778,15 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
       if (HasImport)
         AssociatedCommentLines.push_back(Line);
     } else if (Trimmed.starts_with("/*")) {
-      auto EndPos = Code.find("*/", SearchFrom + 2);
-      if (EndPos != StringRef::npos) {
-        Line = Code.substr(Prev, EndPos + 2 - Prev);
-        Pos = EndPos + 1;
-      }
-      if (!ImportsInBlock.empty())
+      Pos = Code.find("*/", Pos + 2);
+      if (Pos != StringRef::npos)
+        Pos = Code.find('\n', Pos + 2);
+      if (HasImport) {
+        // Extend `Line` for a multiline comment to include all lines the
+        // comment spans.
+        Line = GetLine();
         AssociatedCommentLines.push_back(Line);
-    } else if (PackageRegex.match(Trimmed)) {
-      // Skip package declarations.
+      }
     } else if (ImportRegex.match(Trimmed, &Matches)) {
       if (FormattingOff) {
         // If at least one import line has formatting turned off, turn off

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3767,8 +3767,8 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
         Code.substr(Prev, (Pos != StringRef::npos ? Pos : Code.size()) - Prev);
 
     StringRef Trimmed = Line.trim();
-    if (Trimmed.empty()) {
-      // Skip empty lines.
+    if (Trimmed.empty() || PackageRegex.match(Trimmed)) {
+      // Skip empty line and package statement.
     } else if (isClangFormatOff(Trimmed)) {
       FormattingOff = true;
     } else if (isClangFormatOn(Trimmed)) {

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3766,7 +3766,14 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
     StringRef Line =
         Code.substr(Prev, (Pos != StringRef::npos ? Pos : Code.size()) - Prev);
 
-    StringRef Trimmed = Line.trim();`r`n    if (Trimmed.empty()) {`r`n      // Skip empty lines.`r`n    } else if (isClangFormatOff(Trimmed)) {`r`n      FormattingOff = true;`r`n    } else if (isClangFormatOn(Trimmed)) {`r`n      FormattingOff = false;`r`n    } else if (Trimmed.starts_with("//")) {
+    StringRef Trimmed = Line.trim();
+    if (Trimmed.empty()) {
+      // Skip empty lines.
+    } else if (isClangFormatOff(Trimmed)) {
+      FormattingOff = true;
+    } else if (isClangFormatOn(Trimmed)) {
+      FormattingOff = false;
+    } else if (Trimmed.starts_with("//")) {
       if (!ImportsInBlock.empty())
         AssociatedCommentLines.push_back(Line);
     } else if (Trimmed.starts_with("/*")) {

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3810,7 +3810,7 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
     Prev = Pos + 1;
     if (Pos == StringRef::npos || Pos + 1 == Code.size())
       break;
-    SearchFrom = Pos + 1;
+    Prev = Pos + 1;
   }
   if (HasImport)
     sortJavaImports(Style, ImportsInBlock, Ranges, FileName, Code, Replaces);

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3810,7 +3810,7 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
       break;
     SearchFrom = Pos + 1;
   }
-  if (!ImportsInBlock.empty())
+  if (HasImport)
     sortJavaImports(Style, ImportsInBlock, Ranges, FileName, Code, Replaces);
   return Replaces;
 }

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3800,6 +3800,7 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
         IsStatic = true;
       ImportsInBlock.push_back(
           {Identifier, Line, Prev, AssociatedCommentLines, IsStatic});
+      HasImport = true;
       AssociatedCommentLines.clear();
     } else {
       break;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3744,7 +3744,7 @@ const char JavaImportRegexPattern[] =
     "^[\t ]*import[\t ]+(static[\t ]*)?([^\t ]*)[\t ]*;";
 
 const char JavaTypeDeclRegexPattern[] =
-    "^[\t ]*(public|private|protected|static|final|abstract|sealed|strictfp)?"
+    "^[\t ]*(public|private|protected|static|final|abstract)*"
     "[\t ]*(class|interface|enum|record|@interface)[\t ]+";
 
 } // anonymous namespace

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3778,17 +3778,14 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
     bool IsBlockComment = false;
     if (Trimmed.starts_with("/*")) {
       IsBlockComment = true;
-      // Only skip multi-line comments if we haven't started collecting imports yet.
-      // Comments between imports should be associated with the import below.
-      if (ImportsInBlock.empty()) {
+      // Skip block comments before imports start.
+      if (ImportsInBlock.empty())
         Pos = Code.find("*/", SearchFrom + 2);
-      }
     }
 
-    // Check if we've encountered a type declaration - we're past imports.
-    if (!IsBlockComment && TypeDeclRegex.match(Trimmed)) {
+    // Check if we've encountered a type declaration.
+    if (!IsBlockComment && TypeDeclRegex.match(Trimmed))
       break;
-    }
 
     if (!IsBlockComment && ImportRegex.match(Line, &Matches)) {
       if (FormattingOff) {

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3779,9 +3779,9 @@ tooling::Replacements sortJavaImports(const FormatStyle &Style, StringRef Code,
       if (HasImport)
         AssociatedCommentLines.push_back(Line);
     } else if (Trimmed.starts_with("/*")) {
-      const auto EndPos = Code.find("*/", Prev + 2);
-      Pos = EndPos != StringRef::npos ? Code.find('\n', EndPos + 2)
-                                      : StringRef::npos;
+      Pos = Code.find("*/", Pos + 2);
+      if (Pos != StringRef::npos)
+        Pos = Code.find('\n', Pos + 2);
       if (HasImport) {
         // Extend `Line` for a multiline comment to include all lines the
         // comment spans.

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3743,7 +3743,7 @@ namespace {
 constexpr StringRef
     JavaImportRegexPattern("^import[\t ]+(static[\t ]*)?([^\t ]*)[\t ]*;");
 
-constexpr StringRef JavaPackageRegexPattern("^package[\t ]+");
+constexpr StringRef JavaPackageRegexPattern("^package[\t ]");
 
 } // anonymous namespace
 

--- a/clang/unittests/Format/SortImportsTestJava.cpp
+++ b/clang/unittests/Format/SortImportsTestJava.cpp
@@ -376,6 +376,17 @@ TEST_F(SortImportsTestJava, StopAtClassDeclaration) {
                  "}"));
 }
 
+TEST_F(SortImportsTestJava, SortImportsAfterPackageStatement) {
+  EXPECT_EQ("package org.a;\n"
+            "\n"
+            "import org.a;\n"
+            "import org.b;\n",
+            sort("package org.a;\n"
+                 "\n"
+                 "import org.b;\n"
+                 "import org.a;\n"));
+}
+
 } // end namespace
 } // end namespace format
 } // end namespace clang

--- a/clang/unittests/Format/SortImportsTestJava.cpp
+++ b/clang/unittests/Format/SortImportsTestJava.cpp
@@ -350,14 +350,11 @@ TEST_F(SortImportsTestJava, NoReplacementsForValidImportsWindows) {
 }
 
 TEST_F(SortImportsTestJava, DoNotSortImportsInBlockComment) {
-  EXPECT_EQ("/* import org.d;\n"
-            "import org.c;\n"
-            "import org.b; */\n"
-            "import org.a;",
-            sort("/* import org.d;\n"
-                 "import org.c;\n"
-                 "import org.b; */\n"
-                 "import org.a;"));
+  constexpr StringRef Code("/* import org.d;\n"
+                           "import org.c;\n"
+                           "import org.b; */\n"
+                           "import org.a;");
+  EXPECT_EQ(Code, sort(Code));
 }
 
 TEST_F(SortImportsTestJava, StopAtClassDeclaration) {

--- a/clang/unittests/Format/SortImportsTestJava.cpp
+++ b/clang/unittests/Format/SortImportsTestJava.cpp
@@ -360,19 +360,23 @@ TEST_F(SortImportsTestJava, DoNotSortImportsInBlockComment) {
                  "import org.a;"));
 }
 
-TEST_F(SortImportsTestJava, DoNotSortImportsInTextBlock) {
-  EXPECT_EQ("String code = \"\"\"\n"
-            "    import org.c;\n"
-            "    \\\"\"\"\n"
-            "    import org.b;\n"
-            "\\\\\"\"\";\n"
-            "import org.a;",
-            sort("String code = \"\"\"\n"
-                 "    import org.c;\n"
-                 "    \\\"\"\"\n"
-                 "    import org.b;\n"
-                 "\\\\\"\"\";\n"
-                 "import org.a;"));
+TEST_F(SortImportsTestJava, StopAtClassDeclaration) {
+  EXPECT_EQ("import org.a;\n"
+            "\n"
+            "class Foo {\n"
+            "  String code = \"\"\"\n"
+            "      import org.c;\n"
+            "      import org.b;\n"
+            "  \"\"\";\n"
+            "}",
+            sort("import org.a;\n"
+                 "\n"
+                 "class Foo {\n"
+                 "  String code = \"\"\"\n"
+                 "      import org.c;\n"
+                 "      import org.b;\n"
+                 "  \"\"\";\n"
+                 "}"));
 }
 
 } // end namespace

--- a/clang/unittests/Format/SortImportsTestJava.cpp
+++ b/clang/unittests/Format/SortImportsTestJava.cpp
@@ -349,6 +349,32 @@ TEST_F(SortImportsTestJava, NoReplacementsForValidImportsWindows) {
       sortIncludes(FmtStyle, Code, GetCodeRange(Code), "input.java").empty());
 }
 
+TEST_F(SortImportsTestJava, DoNotSortImportsInBlockComment) {
+  EXPECT_EQ("/* import org.d;\n"
+            "import org.c;\n"
+            "import org.b; */\n"
+            "import org.a;",
+            sort("/* import org.d;\n"
+                 "import org.c;\n"
+                 "import org.b; */\n"
+                 "import org.a;"));
+}
+
+TEST_F(SortImportsTestJava, DoNotSortImportsInTextBlock) {
+  EXPECT_EQ("String code = \"\"\"\n"
+            "    import org.c;\n"
+            "    \\\"\"\"\n"
+            "    import org.b;\n"
+            "\\\\\"\"\";\n"
+            "import org.a;",
+            sort("String code = \"\"\"\n"
+                 "    import org.c;\n"
+                 "    \\\"\"\"\n"
+                 "    import org.b;\n"
+                 "\\\\\"\"\";\n"
+                 "import org.a;"));
+}
+
 } // end namespace
 } // end namespace format
 } // end namespace clang

--- a/clang/unittests/Format/SortImportsTestJava.cpp
+++ b/clang/unittests/Format/SortImportsTestJava.cpp
@@ -358,22 +358,15 @@ TEST_F(SortImportsTestJava, DoNotSortImportsInBlockComment) {
 }
 
 TEST_F(SortImportsTestJava, StopAtClassDeclaration) {
-  EXPECT_EQ("import org.a;\n"
-            "\n"
-            "class Foo {\n"
-            "  String code = \"\"\"\n"
-            "      import org.c;\n"
-            "      import org.b;\n"
-            "  \"\"\";\n"
-            "}",
-            sort("import org.a;\n"
-                 "\n"
-                 "class Foo {\n"
-                 "  String code = \"\"\"\n"
-                 "      import org.c;\n"
-                 "      import org.b;\n"
-                 "  \"\"\";\n"
-                 "}"));
+  constexpr StringRef Code("import org.a;\n"
+                           "\n"
+                           "class Foo {\n"
+                           "  String code = \"\"\"\n"
+                           "      import org.c;\n"
+                           "      import org.b;\n"
+                           "  \"\"\";\n"
+                           "}");
+  EXPECT_EQ(Code, sort(Code));
 }
 
 TEST_F(SortImportsTestJava, SortImportsAfterPackageStatement) {

--- a/clang/unittests/Format/SortImportsTestJava.cpp
+++ b/clang/unittests/Format/SortImportsTestJava.cpp
@@ -380,7 +380,7 @@ TEST_F(SortImportsTestJava, SortImportsAfterPackageStatement) {
   EXPECT_EQ("package org.a;\n"
             "\n"
             "import org.a;\n"
-            "import org.b;\n",
+            "import org.b;",
             sort("package org.a;\n"
                  "\n"
                  "import org.b;\n"

--- a/clang/unittests/Format/SortImportsTestJava.cpp
+++ b/clang/unittests/Format/SortImportsTestJava.cpp
@@ -384,7 +384,7 @@ TEST_F(SortImportsTestJava, SortImportsAfterPackageStatement) {
             sort("package org.a;\n"
                  "\n"
                  "import org.b;\n"
-                 "import org.a;\n"));
+                 "import org.a;"));
 }
 
 } // end namespace


### PR DESCRIPTION
Java source files can contain apparent import statements inside block comments (e.g., showing a code example). These can get mixed up with real import statements when run through clang-format.

This patch tracks block comments (/* ... */) so that we skip lines that are inside them. 

Fixes #176771