### PR TITLE
[TargetLowering] Avoid unnecessary EVT -> Type -> EVT roundtrip (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -1759,16 +1759,10 @@ public:
     if (auto *PTy = dyn_cast<PointerType>(Ty))
       return getPointerTy(DL, PTy->getAddressSpace());
 
-    if (auto *VTy = dyn_cast<VectorType>(Ty)) {
-      Type *EltTy = VTy->getElementType();
-      // Lower vectors of pointers to native pointer types.
-      if (auto *PTy = dyn_cast<PointerType>(EltTy)) {
-        EVT PointerTy(getPointerTy(DL, PTy->getAddressSpace()));
-        EltTy = PointerTy.getTypeForEVT(Ty->getContext());
-      }
-      return EVT::getVectorVT(Ty->getContext(), EVT::getEVT(EltTy, false),
+    if (auto *VTy = dyn_cast<VectorType>(Ty))
+      return EVT::getVectorVT(Ty->getContext(),
+                              getValueType(DL, VTy->getElementType(), false),
                               VTy->getElementCount());
-    }
 
     return EVT::getEVT(Ty, AllowUnknown);
   }
@@ -1779,15 +1773,10 @@ public:
     if (auto *PTy = dyn_cast<PointerType>(Ty))
       return getPointerMemTy(DL, PTy->getAddressSpace());
 
-    if (auto *VTy = dyn_cast<VectorType>(Ty)) {
-      Type *EltTy = VTy->getElementType();
-      if (auto *PTy = dyn_cast<PointerType>(EltTy)) {
-        EVT PointerTy(getPointerMemTy(DL, PTy->getAddressSpace()));
-        EltTy = PointerTy.getTypeForEVT(Ty->getContext());
-      }
-      return EVT::getVectorVT(Ty->getContext(), EVT::getEVT(EltTy, false),
+    if (auto *VTy = dyn_cast<VectorType>(Ty))
+      return EVT::getVectorVT(Ty->getContext(),
+                              getMemValueType(DL, VTy->getElementType(), false),
                               VTy->getElementCount());
-    }
 
     return getValueType(DL, Ty, AllowUnknown);
   }


### PR DESCRIPTION
For pointers, this gets the pointer EVT, then converts it back into a type, and then gets the EVT for that type again. We can directly use the pointer EVT.