### PR TITLE
[mlir][emitc] Update and extend the TOSA -> EmitC test

### DIFF
--- a/mlir/test/Dialect/EmitC/tosa/lit.local.cfg
+++ b/mlir/test/Dialect/EmitC/tosa/lit.local.cfg
@@ -1,0 +1,2 @@
+# Skip files with TD sequences that are used for RUN lines
+config.excludes = ["td.mlir"]

--- a/mlir/test/Dialect/EmitC/tosa/ops.mlir
+++ b/mlir/test/Dialect/EmitC/tosa/ops.mlir
@@ -20,7 +20,7 @@
 
 // RUN: mlir-opt -split-input-file  \
 // RUN: -transform-preload-library='transform-library-paths=%p/td.mlir' \
-// RUN: -transform-interpreter %s -test-transform-dialect-erase-schedule | mlir-opt -convert-to-emitc | FileCheck %s
+// RUN: -transform-interpreter %s -test-transform-dialect-erase-schedule | FileCheck %s
 
 //      CHECK: emitc.func private @add(%[[ARG0:.*]]: !emitc.array<2xf32>, %[[ARG1:.*]]: !emitc.array<2xf32>, %[[RES:.*]]: !emitc.array<2xf32>)
 //  CHECK-DAG:   %[[C0:.*]] = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t

--- a/mlir/test/Dialect/EmitC/tosa/ops.mlir
+++ b/mlir/test/Dialect/EmitC/tosa/ops.mlir
@@ -20,7 +20,7 @@
 
 // RUN: mlir-opt -split-input-file  \
 // RUN: -transform-preload-library='transform-library-paths=%p/td.mlir' \
-// RUN: -transform-interpreter %s -test-transform-dialect-erase-schedule | FileCheck %s
+// RUN: -transform-interpreter %s -test-transform-dialect-erase-schedule | mlir-opt -convert-to-emitc | FileCheck %s
 
 //      CHECK: emitc.func private @add(%[[ARG0:.*]]: !emitc.array<2xf32>, %[[ARG1:.*]]: !emitc.array<2xf32>, %[[RES:.*]]: !emitc.array<2xf32>)
 //  CHECK-DAG:   %[[C0:.*]] = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t

--- a/mlir/test/Dialect/EmitC/tosa/ops.mlir
+++ b/mlir/test/Dialect/EmitC/tosa/ops.mlir
@@ -5,7 +5,6 @@
 // DEFINE:   one-shot-bufferize{\
 // DEFINE:     bufferize-function-boundaries\
 // DEFINE:     function-boundary-type-conversion=identity-layout-map\
-// DEFINE:     buffer-alignment=0\
 // DEFINE:   },\
 // DEFINE:   buffer-results-to-out-params{\
 // DEFINE:     hoist-static-allocs=true\
@@ -18,9 +17,12 @@
 // DEFINE: )"
 
 // RUN: mlir-opt --pass-pipeline=%{pipeline} %s | FileCheck %s
-// -----
 
-//      CHECK: emitc.func private @main(%[[ARG0:.*]]: !emitc.array<2xf32>, %[[ARG1:.*]]: !emitc.array<2xf32>, %[[RES:.*]]: !emitc.array<2xf32>)
+// RUN: mlir-opt -split-input-file  \
+// RUN: -transform-preload-library='transform-library-paths=%p/td.mlir' \
+// RUN: -transform-interpreter %s -test-transform-dialect-erase-schedule | mlir-opt -convert-to-emitc | FileCheck %s
+
+//      CHECK: emitc.func private @add(%[[ARG0:.*]]: !emitc.array<2xf32>, %[[ARG1:.*]]: !emitc.array<2xf32>, %[[RES:.*]]: !emitc.array<2xf32>)
 //  CHECK-DAG:   %[[C0:.*]] = "emitc.constant"() <{value = 0 : index}> : () -> !emitc.size_t
 //  CHECK-DAG:   %[[C1:.*]] = "emitc.constant"() <{value = 1 : index}> : () -> !emitc.size_t
 //  CHECK-DAG:   %[[C2:.*]] = "emitc.constant"() <{value = 2 : index}> : () -> !emitc.size_t
@@ -35,7 +37,7 @@
 // CHECK-NEXT:   }
 // CHECK-NEXT:   return
 // CHECK-NEXT: }
-func.func private @main(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
+func.func private @add(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
   %0 = tosa.add %arg0, %arg1 : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
   return %0 : tensor<2xf32>
 }

--- a/mlir/test/Dialect/EmitC/tosa/td.mlir
+++ b/mlir/test/Dialect/EmitC/tosa/td.mlir
@@ -31,11 +31,13 @@ module attributes {transform.with_named_sequence} {
       transform.apply_patterns.canonicalization
     } : !transform.any_op
 
-    %func_h_3 = transform.structured.match ops{["func.func"]} in %module_final_no_linalg
-      : (!transform.any_op) -> !transform.any_op
-    %module_h_2 = transform.get_parent_op %func_h_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
-    transform.apply_registered_pass "convert-to-emitc" to %module_h_2
-      : (!transform.any_op) -> !transform.op<"builtin.module">
+    // FIXME: This causes a crash, hence its commented out. See:
+    //  * https://github.com/llvm/llvm-project/issues/179247
+    // %func_h_3 = transform.structured.match ops{["func.func"]} in %module_final_no_linalg
+    //   : (!transform.any_op) -> !transform.any_op
+    // %module_h_2 = transform.get_parent_op %func_h_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    // transform.apply_registered_pass "convert-to-emitc" to %module_h_2
+    //   : (!transform.any_op) -> !transform.op<"builtin.module">
 
     transform.yield
   }

--- a/mlir/test/Dialect/EmitC/tosa/td.mlir
+++ b/mlir/test/Dialect/EmitC/tosa/td.mlir
@@ -1,0 +1,42 @@
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%module:
+  !transform.any_op{transform.consumed}) {
+    // 1. TOSA --> Linalg
+    %func_h_1 = transform.structured.match ops{["func.func"]} in %module : (!transform.any_op) -> !transform.any_op
+    transform.apply_registered_pass "tosa-to-linalg"
+      to %func_h_1 : (!transform.any_op) -> !transform.any_op
+
+    // 2. Bufferize
+    // As per BufferizationEnums.td, value 1 for `LayoutMapOption` corresponds
+    // to `IdentityLayoutMap`.
+    %module_bufferized = transform.bufferization.one_shot_bufferize %module
+      { bufferize_function_boundaries=true,
+        function_boundary_type_conversion = 1 : i32}
+      : (!transform.any_op) -> !transform.op<"builtin.module">
+
+    // 3. Apply BufferResultsToOutParams - otherwise the following error is raised:
+    //    * "error: 'emitc.func' op cannot return array type"
+    // "hoist-static-allocs" is an optional optimization step.
+    %func_h_2 = transform.structured.match ops{["func.func"]} in %module_bufferized : (!transform.op<"builtin.module">) -> !transform.any_op
+    %module_h_1 = transform.get_parent_op %func_h_2 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    %module_results_as_out_param = transform.apply_registered_pass "buffer-results-to-out-params"
+      with options = { "hoist-static-allocs" = true }
+      to %module_h_1 : (!transform.any_op) -> !transform.any_op
+
+    %module_final_no_linalg = transform.apply_registered_pass "convert-linalg-to-loops"
+       to %module_results_as_out_param : (!transform.any_op) -> !transform.any_op
+
+    // 4. Canonicalize - not strictly required
+    transform.apply_patterns to %module_final_no_linalg {
+      transform.apply_patterns.canonicalization
+    } : !transform.any_op
+
+    // FIXME: This causes a crash, which implies a bug
+    // %func_h_3 = transform.structured.match ops{["func.func"]} in %module_final_no_linalg
+    //   : (!transform.any_op) -> !transform.any_op
+    // transform.apply_registered_pass "convert-to-emitc" to %func_h_3
+    //   : (!transform.any_op) -> !transform.op<"func.func">
+
+    transform.yield
+  }
+}

--- a/mlir/test/Dialect/EmitC/tosa/td.mlir
+++ b/mlir/test/Dialect/EmitC/tosa/td.mlir
@@ -31,11 +31,11 @@ module attributes {transform.with_named_sequence} {
       transform.apply_patterns.canonicalization
     } : !transform.any_op
 
-    // FIXME: This causes a crash, which implies a bug
-    // %func_h_3 = transform.structured.match ops{["func.func"]} in %module_final_no_linalg
-    //   : (!transform.any_op) -> !transform.any_op
-    // transform.apply_registered_pass "convert-to-emitc" to %func_h_3
-    //   : (!transform.any_op) -> !transform.op<"func.func">
+    %func_h_3 = transform.structured.match ops{["func.func"]} in %module_final_no_linalg
+      : (!transform.any_op) -> !transform.any_op
+    %module_h_2 = transform.get_parent_op %func_h_3 {isolated_from_above} : (!transform.any_op) -> !transform.any_op
+    transform.apply_registered_pass "convert-to-emitc" to %module_h_2
+      : (!transform.any_op) -> !transform.op<"builtin.module">
 
     transform.yield
   }


### PR DESCRIPTION
This patch updates and extends the TOSA-to-EmitC lowering test:
  * Conversion/ConvertToEmitC/tosa.mlir

Summary of changes and rationale:
  * Remove `buffer-alignment=0` from the lowering pipeline; it is not required
    (the existing `CHECK` lines are not affected).
  * Move the test from Conversion/ConvertToEmitC/tosa.mlir to
    Dialect/EmitC/tosa/ops.mlir. Conversion tests are intended for single
    conversion passes (e.g. `-convert-dialect1-to-dialect2`), whereas this
    test exercises a more complex lowering pipeline with multiple explicit
    steps (e.g. TOSA -> Linalg, bufferization, etc.).
  * Add a Transform Dialect sequence to complement the existing lowering
    pipeline definition. This introduces an additional `RUN` line that is
    compatible with the original one. Using the Transform Dialect makes the
    pipeline easier to document, maintain, and experiment with.
