### PR TITLE
[GlobalISel] Provide a fast path for ResetMachineFunctionPass when the function is empty

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -239,6 +239,14 @@ public:
     return *this;
   }
 
+  /// Reset all properties and re-establish baseline invariants.
+  MachineFunctionProperties &resetToInitial() {
+    reset();
+    setIsSSA();
+    setTracksLiveness();
+    return *this;
+  }
+
   MachineFunctionProperties &set(const MachineFunctionProperties &MFP) {
     Properties |= MFP.Properties;
     return *this;

--- a/llvm/lib/CodeGen/ResetMachineFunctionPass.cpp
+++ b/llvm/lib/CodeGen/ResetMachineFunctionPass.cpp
@@ -74,9 +74,7 @@ namespace {
         // tearing down and rebuilding all of the per-function state. Just clear
         // the FailedISel bit so the SelectionDAG pipeline can proceed.
         auto &Props = MF.getProperties();
-        Props.reset();
-        Props.setIsSSA();
-        Props.setTracksLiveness();
+        Props.resetToInitial();
       } else {
         MF.reset();
         MF.initTargetMachineFunctionInfo(MF.getSubtarget());

--- a/llvm/lib/CodeGen/ResetMachineFunctionPass.cpp
+++ b/llvm/lib/CodeGen/ResetMachineFunctionPass.cpp
@@ -60,26 +60,38 @@ namespace {
       llvm::scope_exit ClearVRegTypesOnReturn(
           [&MF]() { MF.getRegInfo().clearVirtRegTypes(); });
 
-      if (MF.getProperties().hasFailedISel()) {
-        if (AbortOnFailedISel)
-          report_fatal_error("Instruction selection failed");
-        LLVM_DEBUG(dbgs() << "Resetting: " << MF.getName() << '\n');
-        ++NumFunctionsReset;
+      if (!MF.getProperties().hasFailedISel())
+        return false;
+
+      if (AbortOnFailedISel)
+        report_fatal_error("Instruction selection failed");
+
+      LLVM_DEBUG(dbgs() << "Resetting: " << MF.getName() << '\n');
+      ++NumFunctionsReset;
+
+      if (MF.empty()) {
+        // Nothing was materialized in the MachineFunction, so avoid the cost of
+        // tearing down and rebuilding all of the per-function state. Just clear
+        // the FailedISel bit so the SelectionDAG pipeline can proceed.
+        auto &Props = MF.getProperties();
+        Props.reset();
+        Props.setIsSSA();
+        Props.setTracksLiveness();
+      } else {
         MF.reset();
         MF.initTargetMachineFunctionInfo(MF.getSubtarget());
 
         const TargetMachine &TM = MF.getTarget();
         // MRI callback for target specific initializations.
         TM.registerMachineRegisterInfoCallback(MF);
-
-        if (EmitFallbackDiag) {
-          const Function &F = MF.getFunction();
-          DiagnosticInfoISelFallback DiagFallback(F);
-          F.getContext().diagnose(DiagFallback);
-        }
-        return true;
       }
-      return false;
+
+      if (EmitFallbackDiag) {
+        const Function &F = MF.getFunction();
+        DiagnosticInfoISelFallback DiagFallback(F);
+        F.getContext().diagnose(DiagFallback);
+      }
+      return true;
     }
 
   };


### PR DESCRIPTION
As part of https://github.com/llvm/llvm-project/pull/174746 I encountered a compile time regression due to ResetMachineFunction performing full resets on empty functions. In normal operation, this behaviour is not likely to impact compile time, as the pass is only inserted when using GlobalISel.

https://github.com/llvm/llvm-project/pull/174746 includes GlobalISel passes in the SDAG pipeline (only on AArch64) and skips them if a given function is not optnone surfacing this. By checking if the MachineFunction is empty we can perform a more lightweight reset that just sets the required flags, reducing the impact of this change.