### PR TITLE
llvm: Add `LLVM_ABI` annotations in SourceMgr and BranchProbability

### DIFF
--- a/llvm/include/llvm/Support/BranchProbability.h
+++ b/llvm/include/llvm/Support/BranchProbability.h
@@ -101,7 +101,7 @@ public:
   LLVM_ABI uint64_t scaleByInverse(uint64_t Num) const;
 
   /// Compute pow(Probability, N).
-  BranchProbability pow(unsigned N) const;
+  LLVM_ABI BranchProbability pow(unsigned N) const;
 
   BranchProbability &operator+=(BranchProbability RHS) {
     assert(N != UnknownN && RHS.N != UnknownN &&

--- a/llvm/include/llvm/Support/SourceMgr.h
+++ b/llvm/include/llvm/Support/SourceMgr.h
@@ -106,14 +106,14 @@ public:
   LLVM_ABI SourceMgr();
   /// Create new source manager with the capability of finding include files
   /// via the provided file system.
-  explicit SourceMgr(IntrusiveRefCntPtr<vfs::FileSystem> FS);
+  LLVM_ABI explicit SourceMgr(IntrusiveRefCntPtr<vfs::FileSystem> FS);
   SourceMgr(const SourceMgr &) = delete;
   SourceMgr &operator=(const SourceMgr &) = delete;
-  SourceMgr(SourceMgr &&);
-  SourceMgr &operator=(SourceMgr &&);
+  LLVM_ABI SourceMgr(SourceMgr &&);
+  LLVM_ABI SourceMgr &operator=(SourceMgr &&);
   LLVM_ABI ~SourceMgr();
 
-  IntrusiveRefCntPtr<vfs::FileSystem> getVirtualFileSystem() const;
+  LLVM_ABI IntrusiveRefCntPtr<vfs::FileSystem> getVirtualFileSystem() const;
   LLVM_ABI void setVirtualFileSystem(IntrusiveRefCntPtr<vfs::FileSystem> FS);
 
   /// Return the include directories of this source manager.


### PR DESCRIPTION
These were found as part of an unrelated change in #174892 [1].

This effort is tracked in #109483.

[1] https://github.com/llvm/llvm-project/pull/174892#issuecomment-3740884157