### PR TITLE
[clang-tidy] Fix false positive in readability-non-const-parameter for dependent expression

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -137,6 +137,10 @@ Changes in existing checks
   now uses separate note diagnostics for each uninitialized enumerator, making
   it easier to see which specific enumerators need explicit initialization.
 
+- Improved :doc:`readability-non-const-parameter
+  <clang-tidy/checks/readability/non-const-parameter>` check by avoiding false
+  positives on parameters used in dependent expressions.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
@@ -360,6 +360,6 @@ public:
 };
 
 void gh176623() {
-    auto const _ = []<bool tc>(char* p) { auto _ = A<tc>(p); };
-    auto const _ = []<bool tc>(char* p) { auto _ = B(p); };
+    auto const V1 = []<bool tc>(char* p) { auto X = A<tc>(p); };
+    auto const V2 = []<bool tc>(char* p) { auto Y = B(p); };
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/non-const-parameter.cpp
@@ -341,3 +341,25 @@ void constructLVRef(int *p) {
   // CHECK-MESSAGES-NOT: warning: pointer parameter 'p' can be
   Temp1 t(*p);
 }
+
+template<bool>
+class A final {
+    char* sz_ = {};
+
+public:
+    explicit A(char* sz) noexcept : sz_(sz) {}
+    void f() { sz_ = {}; }
+};
+
+class B final {
+    char* sz_ = {};
+
+public:
+    explicit B(char* sz) noexcept : sz_(sz) {}
+    void f() { sz_ = {}; }
+};
+
+void gh176623() {
+    auto const _ = []<bool tc>(char* p) { auto _ = A<tc>(p); };
+    auto const _ = []<bool tc>(char* p) { auto _ = B(p); };
+}


### PR DESCRIPTION
Closes #176623