### PR TITLE
AMDGPU: Find device files even when ROCM_PATH is set

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -211,9 +211,9 @@ RocmInstallationDetector::getInstallationPathCandidates() {
 
   // For candidate specified by --rocm-path we do not do strict check, i.e.,
   // checking existence of HIP version file and device library files.
-  // These are added first as highest priority candidates, but we continue
-  // to add clang-relative paths to support cases where the compiler has its
-  // own device libraries (e.g., python wheels with bundled device libs).
+  // Typically the resource directory is the correct place for the device
+  // libraries. For backwards compatibility, we allow to overwrite this with
+  // the ROCM_PATH environment variable/compiler argument.
   if (!RocmPathArg.empty()) {
     ROCmSearchDirs.emplace_back(RocmPathArg.str());
   } else if (std::optional<std::string> RocmPathEnv =

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -211,16 +211,15 @@ RocmInstallationDetector::getInstallationPathCandidates() {
 
   // For candidate specified by --rocm-path we do not do strict check, i.e.,
   // checking existence of HIP version file and device library files.
+  // These are added first as highest priority candidates, but we continue
+  // to add clang-relative paths to support cases where the compiler has its
+  // own device libraries (e.g., python wheels with bundled device libs).
   if (!RocmPathArg.empty()) {
     ROCmSearchDirs.emplace_back(RocmPathArg.str());
-    DoPrintROCmSearchDirs();
-    return ROCmSearchDirs;
   } else if (std::optional<std::string> RocmPathEnv =
                  llvm::sys::Process::GetEnv("ROCM_PATH")) {
     if (!RocmPathEnv->empty()) {
       ROCmSearchDirs.emplace_back(std::move(*RocmPathEnv));
-      DoPrintROCmSearchDirs();
-      return ROCmSearchDirs;
     }
   }
 

--- a/clang/test/Driver/rocm-detect.hip
+++ b/clang/test/Driver/rocm-detect.hip
@@ -94,6 +94,16 @@
 // RUN:   --print-rocm-search-dirs %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=ROCM-REL %s
 
+// Test that device libs from resource dir are found even when ROCM_PATH is set
+// to a location without device libs.
+// This verifies that clang-relative paths are still searched after ROCM_PATH.
+// RUN: rm -rf %t/*
+// RUN: mkdir -p %t/fake_rocm
+// RUN: env ROCM_PATH=%t/fake_rocm \
+// RUN:   %clang -### --target=x86_64-linux-gnu --offload-arch=gfx900 -nogpuinc \
+// RUN:   -resource-dir=%S/Inputs/rocm_resource_dir %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=ROCM-PATH-FALLBACK %s
+
 // GFX902-DEFAULTLIBS: error: cannot find ROCm device library for gfx902; provide its path via '--rocm-path' or '--rocm-device-lib-path', or pass '-nogpulib' to build without ROCm device library
 
 // NODEFAULTLIBS-NOT: error: cannot find
@@ -118,3 +128,6 @@
 
 // ROCM-REL: ROCm installation search path: {{.*}}/opt/rocm
 // ROCM-REL: ROCm installation search path: {{.*}}/opt/rocm-3.10.0
+
+// ROCM-PATH-FALLBACK-NOT: error: cannot find ROCm device library
+// ROCM-PATH-FALLBACK: "-mlink-builtin-bitcode" "{{.*}}rocm_resource_dir{{(/|\\\\)}}lib{{(64)?}}{{(/|\\\\)}}amdgcn{{(/|\\\\)}}bitcode{{(/|\\\\)}}ocml.bc"


### PR DESCRIPTION
Fixes https://github.com/ROCm/TheRock/issues/785. ROCM_PATH doesn't always have a layout where the device libraries can be found, so fallback to resource dirs even when ROCM_PATH is set.