### PR TITLE
[IR2Vec] Changes to support programmatic creation of Vocabulary

### DIFF
--- a/llvm/include/llvm/Analysis/IR2Vec.h
+++ b/llvm/include/llvm/Analysis/IR2Vec.h
@@ -527,8 +527,9 @@ private:
   using VocabMap = std::map<std::string, Embedding>;
 
   /// Generate VocabStorage from vocabulary maps.
-  static VocabStorage buildVocabStorage(VocabMap &OpcVocab, VocabMap &TypeVocab,
-                                        VocabMap &ArgVocab);
+  static VocabStorage buildVocabStorage(const VocabMap &OpcVocab,
+                                        const VocabMap &TypeVocab,
+                                        const VocabMap &ArgVocab);
 };
 
 /// Embedder provides the interface to generate embeddings (vector

--- a/llvm/include/llvm/Analysis/IR2Vec.h
+++ b/llvm/include/llvm/Analysis/IR2Vec.h
@@ -327,6 +327,16 @@ public:
   Vocabulary(Vocabulary &&) = default;
   Vocabulary &operator=(Vocabulary &&Other) = delete;
 
+  /// Create a Vocabulary by loading embeddings from a JSON file.
+  /// This is the primary entry point for programmatic vocabulary creation,
+  /// suitable for use in Python bindings or other contexts where command-line
+  /// options are not available. Weights are applied to scale the embeddings
+  /// for opcodes, types, and arguments respectively.
+  LLVM_ABI static Expected<Vocabulary> fromFile(StringRef VocabFilePath,
+                                                float OpcWeight = 1.0,
+                                                float TypeWeight = 0.5,
+                                                float ArgWeight = 0.2);
+
   LLVM_ABI bool isValid() const {
     return Storage.size() == NumCanonicalEntries;
   }
@@ -513,6 +523,12 @@ private:
     assert(Index < MaxPredicateKinds && "Invalid predicate index");
     return getPredicateFromLocalIndex(Index);
   }
+
+  using VocabMap = std::map<std::string, Embedding>;
+
+  /// Generate VocabStorage from vocabulary maps.
+  static VocabStorage buildVocabStorage(VocabMap &OpcVocab, VocabMap &TypeVocab,
+                                        VocabMap &ArgVocab);
 };
 
 /// Embedder provides the interface to generate embeddings (vector
@@ -612,13 +628,8 @@ public:
 /// mapping between an entity of the IR (like opcode, type, argument, etc.) and
 /// its corresponding embedding.
 class IR2VecVocabAnalysis : public AnalysisInfoMixin<IR2VecVocabAnalysis> {
-  using VocabMap = std::map<std::string, ir2vec::Embedding>;
   std::optional<ir2vec::VocabStorage> Vocab;
 
-  Error readVocabulary(VocabMap &OpcVocab, VocabMap &TypeVocab,
-                       VocabMap &ArgVocab);
-  void generateVocabStorage(VocabMap &OpcVocab, VocabMap &TypeVocab,
-                            VocabMap &ArgVocab);
   void emitError(Error Err, LLVMContext &Ctx);
 
 public:

--- a/llvm/lib/Analysis/IR2Vec.cpp
+++ b/llvm/lib/Analysis/IR2Vec.cpp
@@ -515,9 +515,9 @@ Error readVocabularyFromFile(StringRef VocabFilePath, VocabMap &OpcVocab,
 } // anonymous namespace
 
 /// Generate VocabStorage from vocabulary maps.
-VocabStorage Vocabulary::buildVocabStorage(VocabMap &OpcVocab,
-                                           VocabMap &TypeVocab,
-                                           VocabMap &ArgVocab) {
+VocabStorage Vocabulary::buildVocabStorage(const VocabMap &OpcVocab,
+                                           const VocabMap &TypeVocab,
+                                           const VocabMap &ArgVocab) {
 
   // Helper for handling missing entities in the vocabulary.
   // Currently, we use a zero vector. In the future, we will throw an error to

--- a/llvm/lib/Analysis/IR2Vec.cpp
+++ b/llvm/lib/Analysis/IR2Vec.cpp
@@ -476,18 +476,16 @@ VocabStorage Vocabulary::createDummyVocabForTest(unsigned Dim) {
   return VocabStorage(std::move(Sections));
 }
 
-// ==----------------------------------------------------------------------===//
-// IR2VecVocabAnalysis
-//===----------------------------------------------------------------------===//
+namespace {
+using VocabMap = std::map<std::string, Embedding>;
 
-// FIXME: Make this optional. We can avoid file reads
-// by auto-generating a default vocabulary during the build time.
-Error IR2VecVocabAnalysis::readVocabulary(VocabMap &OpcVocab,
-                                          VocabMap &TypeVocab,
-                                          VocabMap &ArgVocab) {
-  auto BufOrError = MemoryBuffer::getFileOrSTDIN(VocabFile, /*IsText=*/true);
+/// Read vocabulary JSON file and populate the section maps.
+Error readVocabularyFromFile(StringRef VocabFilePath, VocabMap &OpcVocab,
+                             VocabMap &TypeVocab, VocabMap &ArgVocab) {
+  auto BufOrError =
+      MemoryBuffer::getFileOrSTDIN(VocabFilePath, /*IsText=*/true);
   if (!BufOrError)
-    return createFileError(VocabFile, BufOrError.getError());
+    return createFileError(VocabFilePath, BufOrError.getError());
 
   auto Content = BufOrError.get()->getBuffer();
 
@@ -514,10 +512,12 @@ Error IR2VecVocabAnalysis::readVocabulary(VocabMap &OpcVocab,
 
   return Error::success();
 }
+} // anonymous namespace
 
-void IR2VecVocabAnalysis::generateVocabStorage(VocabMap &OpcVocab,
-                                               VocabMap &TypeVocab,
-                                               VocabMap &ArgVocab) {
+/// Generate VocabStorage from vocabulary maps.
+VocabStorage Vocabulary::buildVocabStorage(VocabMap &OpcVocab,
+                                           VocabMap &TypeVocab,
+                                           VocabMap &ArgVocab) {
 
   // Helper for handling missing entities in the vocabulary.
   // Currently, we use a zero vector. In the future, we will throw an error to
@@ -589,18 +589,47 @@ void IR2VecVocabAnalysis::generateVocabStorage(VocabMap &OpcVocab,
   // Create section-based storage instead of flat vocabulary
   // Order must match Vocabulary::Section enum
   std::vector<std::vector<Embedding>> Sections(4);
-  Sections[static_cast<unsigned>(Vocabulary::Section::Opcodes)] =
+  Sections[static_cast<unsigned>(Section::Opcodes)] =
       std::move(NumericOpcodeEmbeddings); // Section::Opcodes
-  Sections[static_cast<unsigned>(Vocabulary::Section::CanonicalTypes)] =
+  Sections[static_cast<unsigned>(Section::CanonicalTypes)] =
       std::move(NumericTypeEmbeddings); // Section::CanonicalTypes
-  Sections[static_cast<unsigned>(Vocabulary::Section::Operands)] =
+  Sections[static_cast<unsigned>(Section::Operands)] =
       std::move(NumericArgEmbeddings); // Section::Operands
-  Sections[static_cast<unsigned>(Vocabulary::Section::Predicates)] =
+  Sections[static_cast<unsigned>(Section::Predicates)] =
       std::move(NumericPredEmbeddings); // Section::Predicates
 
   // Create VocabStorage from organized sections
-  Vocab.emplace(std::move(Sections));
+  return VocabStorage(std::move(Sections));
 }
+
+// ==----------------------------------------------------------------------===//
+// Vocabulary
+//===----------------------------------------------------------------------===//
+
+Expected<Vocabulary> Vocabulary::fromFile(StringRef VocabFilePath,
+                                          float OpcWeight, float TypeWeight,
+                                          float ArgWeight) {
+  VocabMap OpcVocab, TypeVocab, ArgVocab;
+  if (auto Err =
+          readVocabularyFromFile(VocabFilePath, OpcVocab, TypeVocab, ArgVocab))
+    return std::move(Err);
+
+  // Scale the vocabulary sections based on the provided weights
+  auto scaleVocabSection = [](VocabMap &Vocab, float Weight) {
+    for (auto &Entry : Vocab)
+      Entry.second *= Weight;
+  };
+  scaleVocabSection(OpcVocab, OpcWeight);
+  scaleVocabSection(TypeVocab, TypeWeight);
+  scaleVocabSection(ArgVocab, ArgWeight);
+
+  // Generate the numeric lookup vocabulary
+  return Vocabulary(buildVocabStorage(OpcVocab, TypeVocab, ArgVocab));
+}
+
+// ==----------------------------------------------------------------------===//
+// IR2VecVocabAnalysis
+//===----------------------------------------------------------------------===//
 
 void IR2VecVocabAnalysis::emitError(Error Err, LLVMContext &Ctx) {
   handleAllErrors(std::move(Err), [&](const ErrorInfoBase &EI) {
@@ -615,7 +644,7 @@ IR2VecVocabAnalysis::run(Module &M, ModuleAnalysisManager &AM) {
   if (Vocab.has_value())
     return Vocabulary(std::move(Vocab.value()));
 
-  // Otherwise, try to read from the vocabulary file.
+  // Otherwise, try to read from the vocabulary file specified via CLI.
   if (VocabFile.empty()) {
     // FIXME: Use default vocabulary
     Ctx->emitError("IR2Vec vocabulary file path not specified; You may need to "
@@ -623,25 +652,15 @@ IR2VecVocabAnalysis::run(Module &M, ModuleAnalysisManager &AM) {
     return Vocabulary(); // Return invalid result
   }
 
-  VocabMap OpcVocab, TypeVocab, ArgVocab;
-  if (auto Err = readVocabulary(OpcVocab, TypeVocab, ArgVocab)) {
-    emitError(std::move(Err), *Ctx);
+  // Use the static factory method to load the vocabulary.
+  auto VocabOrErr =
+      Vocabulary::fromFile(VocabFile, OpcWeight, TypeWeight, ArgWeight);
+  if (!VocabOrErr) {
+    emitError(VocabOrErr.takeError(), *Ctx);
     return Vocabulary();
   }
 
-  // Scale the vocabulary sections based on the provided weights
-  auto scaleVocabSection = [](VocabMap &Vocab, double Weight) {
-    for (auto &Entry : Vocab)
-      Entry.second *= Weight;
-  };
-  scaleVocabSection(OpcVocab, OpcWeight);
-  scaleVocabSection(TypeVocab, TypeWeight);
-  scaleVocabSection(ArgVocab, ArgWeight);
-
-  // Generate the numeric lookup vocabulary
-  generateVocabStorage(OpcVocab, TypeVocab, ArgVocab);
-
-  return Vocabulary(std::move(Vocab.value()));
+  return std::move(*VocabOrErr);
 }
 
 // ==----------------------------------------------------------------------===//

--- a/llvm/unittests/Analysis/IR2VecTest.cpp
+++ b/llvm/unittests/Analysis/IR2VecTest.cpp
@@ -14,7 +14,9 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -977,6 +979,272 @@ TEST(VocabStorageTest, IteratorComparison) {
   EXPECT_EQ(it1, end);
   EXPECT_EQ(it2, end);
   EXPECT_EQ(it1, it2);
+}
+
+// Helper class for creating temporary vocabulary files for testing
+class VocabFileTest : public ::testing::Test {
+protected:
+  SmallString<128> TempFilePath;
+  int TempFD = -1;
+
+  void SetUp() override { TempFilePath.clear(); }
+
+  void TearDown() override {
+    if (!TempFilePath.empty())
+      sys::fs::remove(TempFilePath);
+  }
+
+  // Create a temporary file with the given content
+  bool createTempFile(StringRef Content) {
+    if (auto EC = sys::fs::createTemporaryFile("vocab", "json", TempFD,
+                                               TempFilePath)) {
+      return false;
+    }
+    raw_fd_ostream OS(TempFD, /*shouldClose=*/true);
+    OS << Content;
+    return true;
+  }
+
+  // Generate a minimal valid vocabulary JSON with given dimension
+  static std::string generateMinimalVocabJSON(unsigned Dim) {
+    std::string JSON = "{\n  \"Opcodes\": {\n";
+
+    // Add all required opcodes
+    const char *Opcodes[] = {"Ret",
+                             "Br",
+                             "Switch",
+                             "IndirectBr",
+                             "Invoke",
+                             "Resume",
+                             "Unreachable",
+                             "CleanupRet",
+                             "CatchRet",
+                             "CatchSwitch",
+                             "CallBr",
+                             "FNeg",
+                             "Add",
+                             "FAdd",
+                             "Sub",
+                             "FSub",
+                             "Mul",
+                             "FMul",
+                             "UDiv",
+                             "SDiv",
+                             "FDiv",
+                             "URem",
+                             "SRem",
+                             "FRem",
+                             "Shl",
+                             "LShr",
+                             "AShr",
+                             "And",
+                             "Or",
+                             "Xor",
+                             "Alloca",
+                             "Load",
+                             "Store",
+                             "GetElementPtr",
+                             "Fence",
+                             "AtomicCmpXchg",
+                             "AtomicRMW",
+                             "Trunc",
+                             "ZExt",
+                             "SExt",
+                             "FPToUI",
+                             "FPToSI",
+                             "UIToFP",
+                             "SIToFP",
+                             "FPTrunc",
+                             "FPExt",
+                             "PtrToInt",
+                             "IntToPtr",
+                             "BitCast",
+                             "AddrSpaceCast",
+                             "ICmp",
+                             "FCmp",
+                             "PHI",
+                             "Call",
+                             "Select",
+                             "UserOp1",
+                             "UserOp2",
+                             "VAArg",
+                             "ExtractElement",
+                             "InsertElement",
+                             "ShuffleVector",
+                             "ExtractValue",
+                             "InsertValue",
+                             "LandingPad",
+                             "Freeze",
+                             "PtrToAddr",
+                             "AddrToPtr",
+                             "CleanupPad",
+                             "CatchPad"};
+
+    bool First = true;
+    for (const char *Op : Opcodes) {
+      if (!First)
+        JSON += ",\n";
+      First = false;
+      JSON += "    \"";
+      JSON += Op;
+      JSON += "\": [";
+      for (unsigned I = 0; I < Dim; ++I) {
+        if (I > 0)
+          JSON += ", ";
+        JSON += "1.0";
+      }
+      JSON += "]";
+    }
+
+    JSON += "\n  },\n  \"Types\": {\n";
+
+    // Add all required types
+    const char *Types[] = {"VoidTy",    "FloatTy",  "LabelTy",   "MetadataTy",
+                           "VectorTy",  "TokenTy",  "IntegerTy", "FunctionTy",
+                           "PointerTy", "StructTy", "ArrayTy",   "UnknownTy"};
+
+    First = true;
+    for (const char *Ty : Types) {
+      if (!First)
+        JSON += ",\n";
+      First = false;
+      JSON += "    \"";
+      JSON += Ty;
+      JSON += "\": [";
+      for (unsigned I = 0; I < Dim; ++I) {
+        if (I > 0)
+          JSON += ", ";
+        JSON += "0.5";
+      }
+      JSON += "]";
+    }
+
+    JSON += "\n  },\n  \"Arguments\": {\n";
+
+    // Add all required argument types
+    const char *Args[] = {"Function", "Pointer", "Constant", "Variable"};
+
+    First = true;
+    for (const char *Arg : Args) {
+      if (!First)
+        JSON += ",\n";
+      First = false;
+      JSON += "    \"";
+      JSON += Arg;
+      JSON += "\": [";
+      for (unsigned I = 0; I < Dim; ++I) {
+        if (I > 0)
+          JSON += ", ";
+        JSON += "0.2";
+      }
+      JSON += "]";
+    }
+
+    JSON += "\n  }\n}\n";
+    return JSON;
+  }
+};
+
+TEST_F(VocabFileTest, FromFileSuccess) {
+  std::string VocabJSON = generateMinimalVocabJSON(3);
+  ASSERT_TRUE(createTempFile(VocabJSON));
+
+  auto VocabOrErr = Vocabulary::fromFile(TempFilePath);
+  ASSERT_TRUE(static_cast<bool>(VocabOrErr))
+      << "Failed to load vocabulary: " << toString(VocabOrErr.takeError());
+
+  Vocabulary &V = *VocabOrErr;
+  EXPECT_TRUE(V.isValid());
+  EXPECT_EQ(V.getDimension(), 3u);
+}
+
+TEST_F(VocabFileTest, FromFileNonExistent) {
+  auto VocabOrErr = Vocabulary::fromFile("/nonexistent/path/vocab.json");
+  EXPECT_FALSE(static_cast<bool>(VocabOrErr));
+
+  // Consume the error
+  std::string ErrMsg = toString(VocabOrErr.takeError());
+  EXPECT_FALSE(ErrMsg.empty());
+}
+
+TEST_F(VocabFileTest, FromFileInvalidJSON) {
+  ASSERT_TRUE(createTempFile("{ invalid json }"));
+
+  auto VocabOrErr = Vocabulary::fromFile(TempFilePath);
+  EXPECT_FALSE(static_cast<bool>(VocabOrErr));
+
+  std::string ErrMsg = toString(VocabOrErr.takeError());
+  EXPECT_FALSE(ErrMsg.empty());
+}
+
+TEST_F(VocabFileTest, FromFileMissingSections) {
+  // JSON with only Opcodes section, missing Types and Arguments
+  ASSERT_TRUE(createTempFile(R"({
+    "Opcodes": { "Ret": [1.0, 2.0] }
+  })"));
+
+  auto VocabOrErr = Vocabulary::fromFile(TempFilePath);
+  EXPECT_FALSE(static_cast<bool>(VocabOrErr));
+
+  std::string ErrMsg = toString(VocabOrErr.takeError());
+  EXPECT_FALSE(ErrMsg.empty());
+}
+
+TEST_F(VocabFileTest, FromFileWithWeights) {
+  std::string VocabJSON = generateMinimalVocabJSON(2);
+  ASSERT_TRUE(createTempFile(VocabJSON));
+
+  // Load with custom weights
+  float OpcWeight = 2.0f;
+  float TypeWeight = 1.0f;
+  float ArgWeight = 0.5f;
+
+  auto VocabOrErr =
+      Vocabulary::fromFile(TempFilePath, OpcWeight, TypeWeight, ArgWeight);
+  ASSERT_TRUE(static_cast<bool>(VocabOrErr))
+      << "Failed to load vocabulary: " << toString(VocabOrErr.takeError());
+
+  Vocabulary &V = *VocabOrErr;
+  EXPECT_TRUE(V.isValid());
+  EXPECT_EQ(V.getDimension(), 2u);
+
+  // Verify that weights are applied by checking embedding values
+  // Original opcode values are [1.0, 1.0], with weight 2.0 -> [2.0, 2.0]
+  const Embedding &RetEmb = V[Instruction::Ret];
+  EXPECT_TRUE(RetEmb.approximatelyEquals(Embedding(2, 2.0)));
+
+  // Original type values are [0.5, 0.5], with weight 1.0 -> [0.5, 0.5]
+  const Embedding &IntTyEmb = V[Type::IntegerTyID];
+  EXPECT_TRUE(IntTyEmb.approximatelyEquals(Embedding(2, 0.5)));
+}
+
+TEST_F(VocabFileTest, FromFileDefaultWeights) {
+  std::string VocabJSON = generateMinimalVocabJSON(2);
+  ASSERT_TRUE(createTempFile(VocabJSON));
+
+  // Load with default weights (1.0, 0.5, 0.2)
+  auto VocabOrErr = Vocabulary::fromFile(TempFilePath);
+  ASSERT_TRUE(static_cast<bool>(VocabOrErr))
+      << "Failed to load vocabulary: " << toString(VocabOrErr.takeError());
+
+  Vocabulary &V = *VocabOrErr;
+  EXPECT_TRUE(V.isValid());
+
+  // Original opcode values are [1.0, 1.0], with default weight 1.0 ->
+  // [1.0, 1.0]
+  const Embedding &RetEmb = V[Instruction::Ret];
+  EXPECT_TRUE(RetEmb.approximatelyEquals(Embedding(2, 1.0)));
+
+  // Original type values are [0.5, 0.5], with default weight 0.5 -> [0.25,
+  // 0.25]
+  const Embedding &IntTyEmb = V[Type::IntegerTyID];
+  EXPECT_TRUE(IntTyEmb.approximatelyEquals(Embedding(2, 0.25)));
+
+  // Original arg values are [0.2, 0.2], with default weight 0.2 -> [0.04, 0.04]
+  LLVMContext Ctx;
+  Constant *C = ConstantInt::get(Type::getInt32Ty(Ctx), 42);
+  const Embedding &ConstEmb = V[*C];
+  EXPECT_TRUE(ConstEmb.approximatelyEquals(Embedding(2, 0.04)));
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
These changes would help create `ir2vec::Vocabulary` in Python bindings (or any other *tool*) without having to run `IR2VecVocabAnalysis` which reads the Vocab path via command line.