### PR TITLE
[AMDGPU] Fix use-after-erase in OpenCL printf runtime binding

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPrintfRuntimeBinding.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPrintfRuntimeBinding.cpp
@@ -420,7 +420,7 @@ bool AMDGPUPrintfRuntimeBindingImpl::lowerPrintfForGpu(Module &M) {
   // Since OpenCL only specifies undefined behaviors and not success criteria,
   // returning 0 sinalling success always is valid.
   for (auto *CI : Printfs) {
-    CI->replaceAllUsesWith(ConstantInt::get(I32Ty, 0));
+    CI->replaceAllUsesWith(ConstantInt::get(CI->getType(), 0));
     CI->eraseFromParent();
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUPrintfRuntimeBinding.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPrintfRuntimeBinding.cpp
@@ -416,9 +416,13 @@ bool AMDGPUPrintfRuntimeBindingImpl::lowerPrintfForGpu(Module &M) {
     }
   }
 
-  // erase the printf calls
-  for (auto *CI : Printfs)
+  // Erase the printf calls and replace all uses with 0, signaling success.
+  // Since OpenCL only specifies undefined behaviors and not success criteria,
+  // returning 0 sinalling success always is valid.
+  for (auto *CI : Printfs) {
+    CI->replaceAllUsesWith(ConstantInt::get(I32Ty, 0));
     CI->eraseFromParent();
+  }
 
   Printfs.clear();
   return true;

--- a/llvm/test/CodeGen/AMDGPU/opencl-printf.ll
+++ b/llvm/test/CodeGen/AMDGPU/opencl-printf.ll
@@ -105,59 +105,6 @@ define amdgpu_kernel void @format_str_f(float %f32.0, double %f64, float %f32.1,
   ret void
 }
 
-define i32 @format_str_f_with_use(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
-; R600-LABEL: @format_str_f_with_use(
-; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
-; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.f, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @format_str_f_with_use(
-; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
-; GCN-NEXT:    [[TMP1:%.*]] = sext i16 [[I16:%.*]] to i32
-; GCN-NEXT:    [[TMP2:%.*]] = bitcast half [[F16:%.*]] to i16
-; GCN-NEXT:    [[TMP3:%.*]] = sext i16 [[TMP2]] to i32
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 64)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP4:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP4]], label [[TMP5:%.*]], label [[TMP6:%.*]]
-; GCN:       5:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 2, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store double [[F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 8
-; GCN-NEXT:    store float [[F32_1]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
-; GCN-NEXT:    store float 1.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store float 2.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
-; GCN-NEXT:    store i32 [[TMP1]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
-; GCN-NEXT:    store i32 [[I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 4
-; GCN-NEXT:    store i64 [[I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 8
-; GCN-NEXT:    store <2 x float> <float 1.000000e+00, float 2.000000e+00>, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR8:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], i32 8
-; GCN-NEXT:    store <2 x i32> <i32 8, i32 234>, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR9:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], i32 8
-; GCN-NEXT:    store i32 [[TMP3]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
-; GCN-NEXT:    br label [[TMP6]]
-; GCN:       6:
-; GCN-NEXT:    [[TMP7:%.*]] = xor i1 [[TMP4]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP7]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %fpext.f32.to.f64 = fpext float %f32.1 to double
-  %call1 = call i32 @printf(ptr addrspace(4) @format.str.f, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
-  ret i32 %call1
-}
-
 define amdgpu_kernel void @format_str_F(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
 ; R600-LABEL: @format_str_F(
 ; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
@@ -177,7 +124,7 @@ define amdgpu_kernel void @format_str_F(float %f32.0, double %f64, float %f32.1,
 ; GCN:       5:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 3, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 2, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -207,59 +154,6 @@ define amdgpu_kernel void @format_str_F(float %f32.0, double %f64, float %f32.1,
   %fpext.f32.to.f64 = fpext float %f32.1 to double
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.F, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
   ret void
-}
-
-define i32 @format_str_F_with_use(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
-; R600-LABEL: @format_str_F_with_use(
-; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
-; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.F, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @format_str_F_with_use(
-; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
-; GCN-NEXT:    [[TMP5:%.*]] = sext i16 [[I16:%.*]] to i32
-; GCN-NEXT:    [[TMP6:%.*]] = bitcast half [[F16:%.*]] to i16
-; GCN-NEXT:    [[TMP7:%.*]] = sext i16 [[TMP6]] to i32
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 72)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       5:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 4, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store double [[F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 8
-; GCN-NEXT:    store double [[FPEXT_F32_TO_F64]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 8
-; GCN-NEXT:    store float 1.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store double 2.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 8
-; GCN-NEXT:    store i32 [[TMP5]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
-; GCN-NEXT:    store i32 [[I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 4
-; GCN-NEXT:    store i64 [[I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 8
-; GCN-NEXT:    store <2 x float> <float 1.000000e+00, float 2.000000e+00>, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR8:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], i32 8
-; GCN-NEXT:    store <2 x i32> <i32 8, i32 234>, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR9:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], i32 8
-; GCN-NEXT:    store i32 [[TMP7]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       6:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %fpext.f32.to.f64 = fpext float %f32.1 to double
-  %call1 = call i32 @printf(ptr addrspace(4) @format.str.F, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
-  ret i32 %call1
 }
 
 define amdgpu_kernel void @format_str_a(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
@@ -281,7 +175,7 @@ define amdgpu_kernel void @format_str_a(float %f32.0, double %f64, float %f32.1,
 ; GCN:       5:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 5, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 3, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -313,59 +207,6 @@ define amdgpu_kernel void @format_str_a(float %f32.0, double %f64, float %f32.1,
   ret void
 }
 
-define i32 @format_str_a_with_use(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
-; R600-LABEL: @format_str_a_with_use(
-; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
-; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.a, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @format_str_a_with_use(
-; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
-; GCN-NEXT:    [[TMP1:%.*]] = sext i16 [[I16:%.*]] to i32
-; GCN-NEXT:    [[TMP2:%.*]] = bitcast half [[F16:%.*]] to i16
-; GCN-NEXT:    [[TMP3:%.*]] = sext i16 [[TMP2]] to i32
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 72)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP4:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP4]], label [[TMP5:%.*]], label [[TMP6:%.*]]
-; GCN:       5:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 6, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store double [[F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 8
-; GCN-NEXT:    store double [[FPEXT_F32_TO_F64]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 8
-; GCN-NEXT:    store float 1.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store double 2.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 8
-; GCN-NEXT:    store i32 [[TMP1]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
-; GCN-NEXT:    store i32 [[I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 4
-; GCN-NEXT:    store i64 [[I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 8
-; GCN-NEXT:    store <2 x float> <float 1.000000e+00, float 2.000000e+00>, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR8:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], i32 8
-; GCN-NEXT:    store <2 x i32> <i32 8, i32 234>, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR9:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], i32 8
-; GCN-NEXT:    store i32 [[TMP3]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
-; GCN-NEXT:    br label [[TMP6]]
-; GCN:       6:
-; GCN-NEXT:    [[TMP7:%.*]] = xor i1 [[TMP4]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP7]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %fpext.f32.to.f64 = fpext float %f32.1 to double
-  %call1 = call i32 @printf(ptr addrspace(4) @format.str.a, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
-  ret i32 %call1
-}
-
 define amdgpu_kernel void @format_str_A(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
 ; R600-LABEL: @format_str_A(
 ; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
@@ -385,7 +226,7 @@ define amdgpu_kernel void @format_str_A(float %f32.0, double %f64, float %f32.1,
 ; GCN:       5:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 7, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 4, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -417,59 +258,6 @@ define amdgpu_kernel void @format_str_A(float %f32.0, double %f64, float %f32.1,
   ret void
 }
 
-define i32 @format_str_A_with_use(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
-; R600-LABEL: @format_str_A_with_use(
-; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
-; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.A, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @format_str_A_with_use(
-; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
-; GCN-NEXT:    [[TMP5:%.*]] = sext i16 [[I16:%.*]] to i32
-; GCN-NEXT:    [[TMP6:%.*]] = bitcast half [[F16:%.*]] to i16
-; GCN-NEXT:    [[TMP7:%.*]] = sext i16 [[TMP6]] to i32
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 72)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       5:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 8, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store double [[F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 8
-; GCN-NEXT:    store double [[FPEXT_F32_TO_F64]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 8
-; GCN-NEXT:    store float 1.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store double 2.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 8
-; GCN-NEXT:    store i32 [[TMP5]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
-; GCN-NEXT:    store i32 [[I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 4
-; GCN-NEXT:    store i64 [[I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 8
-; GCN-NEXT:    store <2 x float> <float 1.000000e+00, float 2.000000e+00>, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR8:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], i32 8
-; GCN-NEXT:    store <2 x i32> <i32 8, i32 234>, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR9:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], i32 8
-; GCN-NEXT:    store i32 [[TMP7]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       6:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %fpext.f32.to.f64 = fpext float %f32.1 to double
-  %call1 = call i32 @printf(ptr addrspace(4) @format.str.A, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
-  ret i32 %call1
-}
-
 define void @format_str_ptr(ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspace(1) %ptr.global, ptr addrspace(5) %ptr.stack, ptr addrspace(4) %ptr.const) {
 ; R600-LABEL: @format_str_ptr(
 ; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.p, ptr [[PTR_FLAT:%.*]], ptr addrspace(3) [[PTR_LDS:%.*]], ptr addrspace(1) [[PTR_GLOBAL:%.*]], ptr addrspace(5) [[PTR_STACK:%.*]], ptr addrspace(4) [[PTR_CONST:%.*]])
@@ -484,7 +272,7 @@ define void @format_str_ptr(ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrsp
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 9, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 5, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store ptr [[PTR_FLAT:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 8
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 8
@@ -501,41 +289,6 @@ define void @format_str_ptr(ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrsp
 ;
   %call = call i32 @printf(ptr addrspace(4) @format.str.p, ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspace(1) %ptr.global, ptr addrspace(5) %ptr.stack, ptr addrspace(4) %ptr.const)
   ret void
-}
-
-define i32 @format_str_ptr_with_use(ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspace(1) %ptr.global, ptr addrspace(5) %ptr.stack, ptr addrspace(4) %ptr.const) {
-; R600-LABEL: @format_str_ptr_with_use(
-; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.p, ptr [[PTR_FLAT:%.*]], ptr addrspace(3) [[PTR_LDS:%.*]], ptr addrspace(1) [[PTR_GLOBAL:%.*]], ptr addrspace(5) [[PTR_STACK:%.*]], ptr addrspace(4) [[PTR_CONST:%.*]])
-; R600-NEXT:    ret i32 [[CALL]]
-;
-; GCN-LABEL: @format_str_ptr_with_use(
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 36)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 10, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store ptr [[PTR_FLAT:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 8
-; GCN-NEXT:    store ptr addrspace(3) [[PTR_LDS:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
-; GCN-NEXT:    store ptr addrspace(1) [[PTR_GLOBAL:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 8
-; GCN-NEXT:    store ptr addrspace(5) [[PTR_STACK:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store ptr addrspace(4) [[PTR_CONST:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %call = call i32 @printf(ptr addrspace(4) @format.str.p, ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspace(1) %ptr.global, ptr addrspace(5) %ptr.stack, ptr addrspace(4) %ptr.const)
-  ret i32 %call
 }
 
 define amdgpu_kernel void @format_str_d(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
@@ -556,7 +309,7 @@ define amdgpu_kernel void @format_str_d(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i
 ; GCN:       6:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 11, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 6, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 [[TMP1]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -583,55 +336,6 @@ define amdgpu_kernel void @format_str_d(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i
 ;
   %call = call i32 @printf(ptr addrspace(4) @format.str.d, i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128, i32 1234)
   ret void
-}
-
-define i32 @format_str_d_with_use(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
-; R600-LABEL: @format_str_d_with_use(
-; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.d, i1 [[I1:%.*]], i4 [[I4:%.*]], i8 [[I8:%.*]], i24 [[I24:%.*]], i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], i96 [[I96:%.*]], i128 [[I128:%.*]], i32 1234)
-; R600-NEXT:    ret i32 [[CALL]]
-;
-; GCN-LABEL: @format_str_d_with_use(
-; GCN-NEXT:    [[TMP1:%.*]] = sext i1 [[I1:%.*]] to i32
-; GCN-NEXT:    [[TMP2:%.*]] = sext i4 [[I4:%.*]] to i32
-; GCN-NEXT:    [[TMP3:%.*]] = sext i8 [[I8:%.*]] to i32
-; GCN-NEXT:    [[TMP4:%.*]] = sext i16 [[I16:%.*]] to i32
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 72)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP5:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP5]], label [[TMP6:%.*]], label [[TMP7:%.*]]
-; GCN:       6:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 12, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 [[TMP1]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[TMP2]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
-; GCN-NEXT:    store i32 [[TMP3]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
-; GCN-NEXT:    store i24 [[I24:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store i32 [[TMP4]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
-; GCN-NEXT:    store i32 [[I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
-; GCN-NEXT:    store i64 [[I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 8
-; GCN-NEXT:    store i96 [[I96:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 16
-; GCN-NEXT:    store i128 [[I128:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR8:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], i32 16
-; GCN-NEXT:    store i32 1234, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 4
-; GCN-NEXT:    br label [[TMP7]]
-; GCN:       7:
-; GCN-NEXT:    [[TMP8:%.*]] = xor i1 [[TMP5]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP8]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %call = call i32 @printf(ptr addrspace(4) @format.str.d, i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128, i32 1234)
-  ret i32 %call
 }
 
 define amdgpu_kernel void @format_str_u(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
@@ -652,7 +356,7 @@ define amdgpu_kernel void @format_str_u(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i
 ; GCN:       6:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 13, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 7, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 [[TMP1]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -679,55 +383,6 @@ define amdgpu_kernel void @format_str_u(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i
 ;
   %call = call i32 @printf(ptr addrspace(4) @format.str.u, i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128, i32 1234)
   ret void
-}
-
-define i32 @format_str_u_with_use(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
-; R600-LABEL: @format_str_u_with_use(
-; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.u, i1 [[I1:%.*]], i4 [[I4:%.*]], i8 [[I8:%.*]], i24 [[I24:%.*]], i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], i96 [[I96:%.*]], i128 [[I128:%.*]], i32 1234)
-; R600-NEXT:    ret i32 [[CALL]]
-;
-; GCN-LABEL: @format_str_u_with_use(
-; GCN-NEXT:    [[TMP1:%.*]] = zext i1 [[I1:%.*]] to i32
-; GCN-NEXT:    [[TMP2:%.*]] = zext i4 [[I4:%.*]] to i32
-; GCN-NEXT:    [[TMP3:%.*]] = zext i8 [[I8:%.*]] to i32
-; GCN-NEXT:    [[TMP4:%.*]] = zext i16 [[I16:%.*]] to i32
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 72)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP5:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP5]], label [[TMP6:%.*]], label [[TMP7:%.*]]
-; GCN:       6:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 14, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 [[TMP1]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[TMP2]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
-; GCN-NEXT:    store i32 [[TMP3]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
-; GCN-NEXT:    store i24 [[I24:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store i32 [[TMP4]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
-; GCN-NEXT:    store i32 [[I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
-; GCN-NEXT:    store i64 [[I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 8
-; GCN-NEXT:    store i96 [[I96:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 16
-; GCN-NEXT:    store i128 [[I128:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR8:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], i32 16
-; GCN-NEXT:    store i32 1234, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 4
-; GCN-NEXT:    br label [[TMP7]]
-; GCN:       7:
-; GCN-NEXT:    [[TMP8:%.*]] = xor i1 [[TMP5]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP8]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %call = call i32 @printf(ptr addrspace(4) @format.str.u, i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128, i32 1234)
-  ret i32 %call
 }
 
 define void @format_str_v1(<1 x float> %v1f32.0, <1 x float> %v1f32.1, <1 x double> %v1f64, <1 x i8> %v1i8, <1 x i16> %v1i16, <1 x i32> %v1i32, <1 x i64> %v1i64,
@@ -748,7 +403,7 @@ define void @format_str_v1(<1 x float> %v1f32.0, <1 x float> %v1f32.1, <1 x doub
 ; GCN:       4:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 15, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 8, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store <1 x float> [[V1F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -773,53 +428,6 @@ define void @format_str_v1(<1 x float> %v1f32.0, <1 x float> %v1f32.1, <1 x doub
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.v1, <1 x float> %v1f32.0, <1 x double> %v1f32.1.fpext, <1 x double> %v1f64, <1 x i8> %v1i8, <1 x i16> %v1i16, <1 x i32> %v1i32, <1 x i64> %v1i64,
   <1 x ptr addrspace(1)> %v1p1, <1 x ptr addrspace(3)> %v1p3, <1 x half> %v1f16)
   ret void
-}
-
-define i32 @format_str_v1_with_use(<1 x float> %v1f32.0, <1 x float> %v1f32.1, <1 x double> %v1f64, <1 x i8> %v1i8, <1 x i16> %v1i16, <1 x i32> %v1i32, <1 x i64> %v1i64,
-; R600-LABEL: @format_str_v1_with_use(
-; R600-NEXT:    [[V1F32_1_FPEXT:%.*]] = fpext <1 x float> [[V1F32_1:%.*]] to <1 x double>
-; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v1, <1 x float> [[V1F32_0:%.*]], <1 x double> [[V1F32_1_FPEXT]], <1 x double> [[V1F64:%.*]], <1 x i8> [[V1I8:%.*]], <1 x i16> [[V1I16:%.*]], <1 x i32> [[V1I32:%.*]], <1 x i64> [[V1I64:%.*]], <1 x ptr addrspace(1)> [[V1P1:%.*]], <1 x ptr addrspace(3)> [[V1P3:%.*]], <1 x half> [[V1F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @format_str_v1_with_use(
-; GCN-NEXT:    [[V1F32_1_FPEXT:%.*]] = fpext <1 x float> [[V1F32_1:%.*]] to <1 x double>
-; GCN-NEXT:    [[TMP1:%.*]] = sext <1 x i8> [[V1I8:%.*]] to <1 x i32>
-; GCN-NEXT:    [[TMP2:%.*]] = sext <1 x i16> [[V1I16:%.*]] to <1 x i32>
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 44)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP3:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP3]], label [[TMP4:%.*]], label [[TMP5:%.*]]
-; GCN:       4:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 16, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store <1 x float> [[V1F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store <1 x double> [[V1F32_1_FPEXT]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 8
-; GCN-NEXT:    store <1 x double> [[V1F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 8
-; GCN-NEXT:    store <1 x i32> [[TMP1]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store <1 x i32> [[TMP2]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
-; GCN-NEXT:    store <1 x i32> [[V1I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
-; GCN-NEXT:    store <1 x i64> [[V1I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 8
-; GCN-NEXT:    br label [[TMP5]]
-; GCN:       5:
-; GCN-NEXT:    [[TMP6:%.*]] = xor i1 [[TMP3]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP6]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  <1 x ptr addrspace(1)> %v1p1, <1 x ptr addrspace(3)> %v1p3, <1 x half> %v1f16) {
-  %v1f32.1.fpext = fpext <1 x float> %v1f32.1 to <1 x double>
-  %call1 = call i32 @printf(ptr addrspace(4) @format.str.v1, <1 x float> %v1f32.0, <1 x double> %v1f32.1.fpext, <1 x double> %v1f64, <1 x i8> %v1i8, <1 x i16> %v1i16, <1 x i32> %v1i32, <1 x i64> %v1i64,
-  <1 x ptr addrspace(1)> %v1p1, <1 x ptr addrspace(3)> %v1p3, <1 x half> %v1f16)
-  ret i32 %call1
 }
 
 define void @format_str_v2(<2 x float> %v2f32.0, <2 x float> %v2f32.1, <2 x double> %v2f64, <2 x i8> %v2i8, <2 x i16> %v2i16, <2 x i32> %v2i32, <2 x i64> %v2i64,
@@ -839,7 +447,7 @@ define void @format_str_v2(<2 x float> %v2f32.0, <2 x float> %v2f32.1, <2 x doub
 ; GCN:       3:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 17, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 9, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store <2 x float> [[V2F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 8
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 8
@@ -864,52 +472,6 @@ define void @format_str_v2(<2 x float> %v2f32.0, <2 x float> %v2f32.1, <2 x doub
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.v2, <2 x float> %v2f32.0, <2 x double> %v2f32.1.fpext, <2 x double> %v2f64, <2 x i8> %v2i8, <2 x i16> %v2i16, <2 x i32> %v2i32, <2 x i64> %v2i64,
   <2 x ptr addrspace(1)> %v2p1, <2 x ptr addrspace(3)> %v2p3, <2 x half> %v2f16)
   ret void
-}
-
-define i32 @format_str_v2_with_use(<2 x float> %v2f32.0, <2 x float> %v2f32.1, <2 x double> %v2f64, <2 x i8> %v2i8, <2 x i16> %v2i16, <2 x i32> %v2i32, <2 x i64> %v2i64,
-; R600-LABEL: @format_str_v2_with_use(
-; R600-NEXT:    [[V2F32_1_FPEXT:%.*]] = fpext <2 x float> [[V2F32_1:%.*]] to <2 x double>
-; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v2, <2 x float> [[V2F32_0:%.*]], <2 x double> [[V2F32_1_FPEXT]], <2 x double> [[V2F64:%.*]], <2 x i8> [[V2I8:%.*]], <2 x i16> [[V2I16:%.*]], <2 x i32> [[V2I32:%.*]], <2 x i64> [[V2I64:%.*]], <2 x ptr addrspace(1)> [[V2P1:%.*]], <2 x ptr addrspace(3)> [[V2P3:%.*]], <2 x half> [[V2F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @format_str_v2_with_use(
-; GCN-NEXT:    [[V2F32_1_FPEXT:%.*]] = fpext <2 x float> [[V2F32_1:%.*]] to <2 x double>
-; GCN-NEXT:    [[TMP1:%.*]] = sext <2 x i8> [[V2I8:%.*]] to <2 x i32>
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 80)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP2:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP2]], label [[TMP3:%.*]], label [[TMP4:%.*]]
-; GCN:       3:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 18, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store <2 x float> [[V2F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 8
-; GCN-NEXT:    store <2 x double> [[V2F32_1_FPEXT]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 16
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 16
-; GCN-NEXT:    store <2 x double> [[V2F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 16
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 16
-; GCN-NEXT:    store <2 x i32> [[TMP1]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 8
-; GCN-NEXT:    store <2 x i16> [[V2I16:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
-; GCN-NEXT:    store <2 x i32> [[V2I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 8
-; GCN-NEXT:    store <2 x i64> [[V2I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 16
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 16
-; GCN-NEXT:    br label [[TMP4]]
-; GCN:       4:
-; GCN-NEXT:    [[TMP5:%.*]] = xor i1 [[TMP2]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP5]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  <2 x ptr addrspace(1)> %v2p1, <2 x ptr addrspace(3)> %v2p3, <2 x half> %v2f16) {
-  %v2f32.1.fpext = fpext <2 x float> %v2f32.1 to <2 x double>
-  %call1 = call i32 @printf(ptr addrspace(4) @format.str.v2, <2 x float> %v2f32.0, <2 x double> %v2f32.1.fpext, <2 x double> %v2f64, <2 x i8> %v2i8, <2 x i16> %v2i16, <2 x i32> %v2i32, <2 x i64> %v2i64,
-  <2 x ptr addrspace(1)> %v2p1, <2 x ptr addrspace(3)> %v2p3, <2 x half> %v2f16)
-  ret i32 %call1
 }
 
 define void @format_str_v3(<3 x float> %v3f32.0, <3 x float> %v3f32.1, <3 x double> %v3f64, <3 x i8> %v3i8, <3 x i16> %v3i16, <3 x i32> %v3i32, <3 x i64> %v3i64,
@@ -928,7 +490,7 @@ define void @format_str_v3(<3 x float> %v3f32.0, <3 x float> %v3f32.1, <3 x doub
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 19, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 10, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store <3 x float> [[V3F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 16
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 16
@@ -953,51 +515,6 @@ define void @format_str_v3(<3 x float> %v3f32.0, <3 x float> %v3f32.1, <3 x doub
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.v3, <3 x float> %v3f32.0, <3 x double> %v3f32.1.fpext, <3 x double> %v3f64, <3 x i8> %v3i8, <3 x i16> %v3i16, <3 x i32> %v3i32, <3 x i64> %v3i64,
   <3 x ptr addrspace(1)> %v3p1, <3 x ptr addrspace(3)> %v3p3, <3 x half> %v3f16)
   ret void
-}
-
-define i32 @format_str_v3_with_use(<3 x float> %v3f32.0, <3 x float> %v3f32.1, <3 x double> %v3f64, <3 x i8> %v3i8, <3 x i16> %v3i16, <3 x i32> %v3i32, <3 x i64> %v3i64,
-; R600-LABEL: @format_str_v3_with_use(
-; R600-NEXT:    [[V3F32_1_FPEXT:%.*]] = fpext <3 x float> [[V3F32_1:%.*]] to <3 x double>
-; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v3, <3 x float> [[V3F32_0:%.*]], <3 x double> [[V3F32_1_FPEXT]], <3 x double> [[V3F64:%.*]], <3 x i8> [[V3I8:%.*]], <3 x i16> [[V3I16:%.*]], <3 x i32> [[V3I32:%.*]], <3 x i64> [[V3I64:%.*]], <3 x ptr addrspace(1)> [[V3P1:%.*]], <3 x ptr addrspace(3)> [[V3P3:%.*]], <3 x half> [[V3F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @format_str_v3_with_use(
-; GCN-NEXT:    [[V3F32_1_FPEXT:%.*]] = fpext <3 x float> [[V3F32_1:%.*]] to <3 x double>
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 144)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 20, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store <3 x float> [[V3F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 16
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 16
-; GCN-NEXT:    store <3 x double> [[V3F32_1_FPEXT]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 32
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 32
-; GCN-NEXT:    store <3 x double> [[V3F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 32
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 32
-; GCN-NEXT:    store <3 x i8> [[V3I8:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store <3 x i16> [[V3I16:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 8
-; GCN-NEXT:    store <3 x i32> [[V3I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 16
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 16
-; GCN-NEXT:    store <3 x i64> [[V3I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 32
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 32
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  <3 x ptr addrspace(1)> %v3p1, <3 x ptr addrspace(3)> %v3p3, <3 x half> %v3f16) {
-  %v3f32.1.fpext = fpext <3 x float> %v3f32.1 to <3 x double>
-  %call1 = call i32 @printf(ptr addrspace(4) @format.str.v3, <3 x float> %v3f32.0, <3 x double> %v3f32.1.fpext, <3 x double> %v3f64, <3 x i8> %v3i8, <3 x i16> %v3i16, <3 x i32> %v3i32, <3 x i64> %v3i64,
-  <3 x ptr addrspace(1)> %v3p1, <3 x ptr addrspace(3)> %v3p3, <3 x half> %v3f16)
-  ret i32 %call1
 }
 
 define void @format_str_v4(<4 x float> %v4f32.0, <4 x float> %v4f32.1, <4 x double> %v4f64, <4 x i8> %v4i8, <4 x i16> %v4i16, <4 x i32> %v4i32, <4 x i64> %v4i64,
@@ -1016,7 +533,7 @@ define void @format_str_v4(<4 x float> %v4f32.0, <4 x float> %v4f32.1, <4 x doub
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 21, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 11, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store <4 x float> [[V4F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 16
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 16
@@ -1041,51 +558,6 @@ define void @format_str_v4(<4 x float> %v4f32.0, <4 x float> %v4f32.1, <4 x doub
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.v4, <4 x float> %v4f32.0, <4 x double> %v4f32.1.fpext, <4 x double> %v4f64, <4 x i8> %v4i8, <4 x i16> %v4i16, <4 x i32> %v4i32, <4 x i64> %v4i64,
   <4 x ptr addrspace(1)> %v4p1, <4 x ptr addrspace(3)> %v4p3, <4 x half> %v4f16)
   ret void
-}
-
-define i32 @format_str_v4_with_use(<4 x float> %v4f32.0, <4 x float> %v4f32.1, <4 x double> %v4f64, <4 x i8> %v4i8, <4 x i16> %v4i16, <4 x i32> %v4i32, <4 x i64> %v4i64,
-; R600-LABEL: @format_str_v4_with_use(
-; R600-NEXT:    [[V4F32_1_FPEXT:%.*]] = fpext <4 x float> [[V4F32_1:%.*]] to <4 x double>
-; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v4, <4 x float> [[V4F32_0:%.*]], <4 x double> [[V4F32_1_FPEXT]], <4 x double> [[V4F64:%.*]], <4 x i8> [[V4I8:%.*]], <4 x i16> [[V4I16:%.*]], <4 x i32> [[V4I32:%.*]], <4 x i64> [[V4I64:%.*]], <4 x ptr addrspace(1)> [[V4P1:%.*]], <4 x ptr addrspace(3)> [[V4P3:%.*]], <4 x half> [[V4F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @format_str_v4_with_use(
-; GCN-NEXT:    [[V4F32_1_FPEXT:%.*]] = fpext <4 x float> [[V4F32_1:%.*]] to <4 x double>
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 144)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 22, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store <4 x float> [[V4F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 16
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 16
-; GCN-NEXT:    store <4 x double> [[V4F32_1_FPEXT]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 32
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 32
-; GCN-NEXT:    store <4 x double> [[V4F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 32
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 32
-; GCN-NEXT:    store <4 x i8> [[V4I8:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store <4 x i16> [[V4I16:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 8
-; GCN-NEXT:    store <4 x i32> [[V4I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 16
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 16
-; GCN-NEXT:    store <4 x i64> [[V4I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 32
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 32
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  <4 x ptr addrspace(1)> %v4p1, <4 x ptr addrspace(3)> %v4p3, <4 x half> %v4f16) {
-  %v4f32.1.fpext = fpext <4 x float> %v4f32.1 to <4 x double>
-  %call1 = call i32 @printf(ptr addrspace(4) @format.str.v4, <4 x float> %v4f32.0, <4 x double> %v4f32.1.fpext, <4 x double> %v4f64, <4 x i8> %v4i8, <4 x i16> %v4i16, <4 x i32> %v4i32, <4 x i64> %v4i64,
-  <4 x ptr addrspace(1)> %v4p1, <4 x ptr addrspace(3)> %v4p3, <4 x half> %v4f16)
-  ret i32 %call1
 }
 
 define void @format_str_v8(<8 x float> %v8f32.0, <8 x float> %v8f32.1, <8 x double> %v8f64, <8 x i8> %v8i8, <8 x i16> %v8i16, <8 x i32> %v8i32, <8 x i64> %v8i64,
@@ -1104,7 +576,7 @@ define void @format_str_v8(<8 x float> %v8f32.0, <8 x float> %v8f32.1, <8 x doub
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 23, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 12, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store <8 x float> [[V8F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 32
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 32
@@ -1129,51 +601,6 @@ define void @format_str_v8(<8 x float> %v8f32.0, <8 x float> %v8f32.1, <8 x doub
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.v8, <8 x float> %v8f32.0, <8 x double> %v8f32.1.fpext, <8 x double> %v8f64, <8 x i8> %v8i8, <8 x i16> %v8i16, <8 x i32> %v8i32, <8 x i64> %v8i64,
   <8 x ptr addrspace(1)> %v8p1, <8 x ptr addrspace(3)> %v8p3, <8 x half> %v8f16)
   ret void
-}
-
-define i32 @format_str_v8_with_use(<8 x float> %v8f32.0, <8 x float> %v8f32.1, <8 x double> %v8f64, <8 x i8> %v8i8, <8 x i16> %v8i16, <8 x i32> %v8i32, <8 x i64> %v8i64,
-; R600-LABEL: @format_str_v8_with_use(
-; R600-NEXT:    [[V8F32_1_FPEXT:%.*]] = fpext <8 x float> [[V8F32_1:%.*]] to <8 x double>
-; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v8, <8 x float> [[V8F32_0:%.*]], <8 x double> [[V8F32_1_FPEXT]], <8 x double> [[V8F64:%.*]], <8 x i8> [[V8I8:%.*]], <8 x i16> [[V8I16:%.*]], <8 x i32> [[V8I32:%.*]], <8 x i64> [[V8I64:%.*]], <8 x ptr addrspace(1)> [[V8P1:%.*]], <8 x ptr addrspace(3)> [[V8P3:%.*]], <8 x half> [[V8F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @format_str_v8_with_use(
-; GCN-NEXT:    [[V8F32_1_FPEXT:%.*]] = fpext <8 x float> [[V8F32_1:%.*]] to <8 x double>
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 284)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 24, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store <8 x float> [[V8F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 32
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 32
-; GCN-NEXT:    store <8 x double> [[V8F32_1_FPEXT]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 64
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 64
-; GCN-NEXT:    store <8 x double> [[V8F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 64
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 64
-; GCN-NEXT:    store <8 x i8> [[V8I8:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 8
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 8
-; GCN-NEXT:    store <8 x i16> [[V8I16:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 16
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 16
-; GCN-NEXT:    store <8 x i32> [[V8I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 32
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 32
-; GCN-NEXT:    store <8 x i64> [[V8I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 64
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 64
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  <8 x ptr addrspace(1)> %v8p1, <8 x ptr addrspace(3)> %v8p3, <8 x half> %v8f16) {
-  %v8f32.1.fpext = fpext <8 x float> %v8f32.1 to <8 x double>
-  %call1 = call i32 @printf(ptr addrspace(4) @format.str.v8, <8 x float> %v8f32.0, <8 x double> %v8f32.1.fpext, <8 x double> %v8f64, <8 x i8> %v8i8, <8 x i16> %v8i16, <8 x i32> %v8i32, <8 x i64> %v8i64,
-  <8 x ptr addrspace(1)> %v8p1, <8 x ptr addrspace(3)> %v8p3, <8 x half> %v8f16)
-  ret i32 %call1
 }
 
 define void @format_str_v16(<16 x float> %v16f32.0, <16 x float> %v16f32.1, <16 x double> %v16f64, <16 x i8> %v16i8, <16 x i16> %v16i16, <16 x i32> %v16i32, <16 x i64> %v16i64,
@@ -1192,7 +619,7 @@ define void @format_str_v16(<16 x float> %v16f32.0, <16 x float> %v16f32.1, <16 
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 25, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 13, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store <16 x float> [[V16F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 64
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 64
@@ -1217,51 +644,6 @@ define void @format_str_v16(<16 x float> %v16f32.0, <16 x float> %v16f32.1, <16 
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.v16, <16 x float> %v16f32.0, <16 x double> %v16f32.1.fpext, <16 x double> %v16f64, <16 x i8> %v16i8, <16 x i16> %v16i16, <16 x i32> %v16i32, <16 x i64> %v16i64,
   <16 x ptr addrspace(1)> %v16p1, <16 x ptr addrspace(3)> %v16p3, <16 x half> %v16f16)
   ret void
-}
-
-define i32 @format_str_v16_with_use(<16 x float> %v16f32.0, <16 x float> %v16f32.1, <16 x double> %v16f64, <16 x i8> %v16i8, <16 x i16> %v16i16, <16 x i32> %v16i32, <16 x i64> %v16i64,
-; R600-LABEL: @format_str_v16_with_use(
-; R600-NEXT:    [[V16F32_1_FPEXT:%.*]] = fpext <16 x float> [[V16F32_1:%.*]] to <16 x double>
-; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v16, <16 x float> [[V16F32_0:%.*]], <16 x double> [[V16F32_1_FPEXT]], <16 x double> [[V16F64:%.*]], <16 x i8> [[V16I8:%.*]], <16 x i16> [[V16I16:%.*]], <16 x i32> [[V16I32:%.*]], <16 x i64> [[V16I64:%.*]], <16 x ptr addrspace(1)> [[V16P1:%.*]], <16 x ptr addrspace(3)> [[V16P3:%.*]], <16 x half> [[V16F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @format_str_v16_with_use(
-; GCN-NEXT:    [[V16F32_1_FPEXT:%.*]] = fpext <16 x float> [[V16F32_1:%.*]] to <16 x double>
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 564)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 26, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store <16 x float> [[V16F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 64
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 64
-; GCN-NEXT:    store <16 x double> [[V16F32_1_FPEXT]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 128
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 128
-; GCN-NEXT:    store <16 x double> [[V16F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 128
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 128
-; GCN-NEXT:    store <16 x i8> [[V16I8:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 16
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 16
-; GCN-NEXT:    store <16 x i16> [[V16I16:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 32
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 32
-; GCN-NEXT:    store <16 x i32> [[V16I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 64
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 64
-; GCN-NEXT:    store <16 x i64> [[V16I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 128
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 128
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  <16 x ptr addrspace(1)> %v16p1, <16 x ptr addrspace(3)> %v16p3, <16 x half> %v16f16) {
-  %v16f32.1.fpext = fpext <16 x float> %v16f32.1 to <16 x double>
-  %call1 = call i32 @printf(ptr addrspace(4) @format.str.v16, <16 x float> %v16f32.0, <16 x double> %v16f32.1.fpext, <16 x double> %v16f64, <16 x i8> %v16i8, <16 x i16> %v16i16, <16 x i32> %v16i32, <16 x i64> %v16i64,
-  <16 x ptr addrspace(1)> %v16p1, <16 x ptr addrspace(3)> %v16p3, <16 x half> %v16f16)
-  ret i32 %call1
 }
 
 define amdgpu_kernel void @test_kernel(i32 %n) {
@@ -1282,7 +664,7 @@ define amdgpu_kernel void @test_kernel(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 27, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 14, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1313,7 +695,7 @@ define amdgpu_kernel void @test_format_str_no_null_terminator(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 28, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 15, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
@@ -1323,36 +705,6 @@ define amdgpu_kernel void @test_format_str_no_null_terminator(i32 %n) {
 entry:
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @format.str.no.null.terminator, i32 %n)
   ret void
-}
-
-define i32 @test_format_str_no_null_terminator_with_use(i32 %n) {
-; R600-LABEL: @test_format_str_no_null_terminator_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @format.str.no.null.terminator, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @test_format_str_no_null_terminator_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 8)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 29, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @format.str.no.null.terminator, i32 %n)
-  ret i32 %call1
 }
 
 
@@ -1372,7 +724,7 @@ define amdgpu_kernel void @test_indexed_format_str(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 30, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 16, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
@@ -1382,36 +734,6 @@ define amdgpu_kernel void @test_indexed_format_str(i32 %n) {
 entry:
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i32 7), i32 %n)
   ret void
-}
-
-define i32 @test_indexed_format_str_with_use(i32 %n) {
-; R600-LABEL: @test_indexed_format_str_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i32 7), i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @test_indexed_format_str_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 8)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 31, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i32 7), i32 %n)
-  ret i32 %call1
 }
 
 define amdgpu_kernel void @test_indexed_format_str_oob(i32 %n) {
@@ -1430,7 +752,7 @@ define amdgpu_kernel void @test_indexed_format_str_oob(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 32, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 17, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
@@ -1439,35 +761,6 @@ define amdgpu_kernel void @test_indexed_format_str_oob(i32 %n) {
 entry:
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i64 11), i32 %n)
   ret void
-}
-
-define i32 @test_indexed_format_str_oob_with_use(i32 %n) {
-; R600-LABEL: @test_indexed_format_str_oob_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i64 11), i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @test_indexed_format_str_oob_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 4)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 33, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i64 11), i32 %n)
-  ret i32 %call1
 }
 
 define amdgpu_kernel void @string_pointee_type(i32 %n) {
@@ -1486,7 +779,7 @@ define amdgpu_kernel void @string_pointee_type(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 34, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 18, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1498,38 +791,6 @@ define amdgpu_kernel void @string_pointee_type(i32 %n) {
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(5) %str, i32 %n)
   ret void
-}
-
-define i32 @string_pointee_type_with_use(i32 %n) {
-; R600-LABEL: @string_pointee_type_with_use(
-; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @string_pointee_type_with_use(
-; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 35, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %str = alloca [9 x i8], align 1, addrspace(5)
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(5) %str, i32 %n)
-  ret i32 %call1
 }
 
 define amdgpu_kernel void @string_address_space4(i32 %n, ptr addrspace(4) %str) {
@@ -1546,7 +807,7 @@ define amdgpu_kernel void @string_address_space4(i32 %n, ptr addrspace(4) %str) 
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 36, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 19, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1557,35 +818,6 @@ define amdgpu_kernel void @string_address_space4(i32 %n, ptr addrspace(4) %str) 
 ;
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) %str, i32 %n)
   ret void
-}
-
-define i32 @string_address_space4_with_use(i32 %n, ptr addrspace(4) %str) {
-; R600-LABEL: @string_address_space4_with_use(
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) [[STR:%.*]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @string_address_space4_with_use(
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 37, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) %str, i32 %n)
-  ret i32 %call1
 }
 
 define amdgpu_kernel void @string_address_space1(i32 %n, ptr addrspace(1) %str) {
@@ -1602,7 +834,7 @@ define amdgpu_kernel void @string_address_space1(i32 %n, ptr addrspace(1) %str) 
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 38, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 20, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1613,35 +845,6 @@ define amdgpu_kernel void @string_address_space1(i32 %n, ptr addrspace(1) %str) 
 ;
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(1) %str, i32 %n)
   ret void
-}
-
-define i32 @string_address_space1_with_use(i32 %n, ptr addrspace(1) %str) {
-; R600-LABEL: @string_address_space1_with_use(
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(1) [[STR:%.*]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @string_address_space1_with_use(
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 39, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(1) %str, i32 %n)
-  ret i32 %call1
 }
 
 define amdgpu_kernel void @string_format_passed_i32(i32 %n, i32 %str) {
@@ -1658,7 +861,7 @@ define amdgpu_kernel void @string_format_passed_i32(i32 %n, i32 %str) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 40, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 21, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 [[STR:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1671,34 +874,6 @@ define amdgpu_kernel void @string_format_passed_i32(i32 %n, i32 %str) {
   ret void
 }
 
-define i32 @string_format_passed_i32_with_use(i32 %n, i32 %str) {
-; R600-LABEL: @string_format_passed_i32_with_use(
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, i32 [[STR:%.*]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @string_format_passed_i32_with_use(
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 41, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 [[STR:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, i32 %str, i32 %n)
-  ret i32 %call1
-}
 
 @str.as1 = private unnamed_addr addrspace(1) constant [6 x i8] c"%s:%d\00", align 1
 
@@ -1722,7 +897,7 @@ define amdgpu_kernel void @test_kernel_addrspacecasted_format_str(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 42, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 22, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1736,44 +911,6 @@ entry:
   %arraydecay = getelementptr inbounds [9 x i8], ptr addrspace(5) %str, i32 0, i32 0
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) addrspacecast (ptr addrspace(1) @str.as1 to ptr addrspace(4)), ptr addrspace(5) %arraydecay, i32 %n)
   ret void
-}
-
-define i32 @test_kernel_addrspacecasted_format_str_with_use(i32 %n) {
-; R600-LABEL: @test_kernel_addrspacecasted_format_str_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; R600-NEXT:    [[ARRAYDECAY:%.*]] = getelementptr inbounds [9 x i8], ptr addrspace(5) [[STR]], i32 0, i32 0
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) addrspacecast (ptr addrspace(1) @str.as1 to ptr addrspace(4)), ptr addrspace(5) [[ARRAYDECAY]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @test_kernel_addrspacecasted_format_str_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    [[ARRAYDECAY:%.*]] = getelementptr inbounds [9 x i8], ptr addrspace(5) [[STR]], i32 0, i32 0
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 43, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %str = alloca [9 x i8], align 1, addrspace(5)
-  %arraydecay = getelementptr inbounds [9 x i8], ptr addrspace(5) %str, i32 0, i32 0
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) addrspacecast (ptr addrspace(1) @str.as1 to ptr addrspace(4)), ptr addrspace(5) %arraydecay, i32 %n)
-  ret i32 %call1
 }
 
 define amdgpu_kernel void @test_undef_argument(i32 %n) {
@@ -1806,21 +943,6 @@ define amdgpu_kernel void @test_poison_argument(i32 %n) {
   ret void
 }
 
-define i32 @test_poison_argument_with_use(i32 %n) {
-; R600-LABEL: @test_poison_argument_with_use(
-; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @test_poison_argument_with_use(
-; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    ret i32 0
-;
-  %str = alloca [9 x i8], align 1, addrspace(5)
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) %str, i32 %n)
-  ret i32 %call1
-}
-
 define amdgpu_kernel void @test_null_argument(i32 %n) {
 ; R600-LABEL: @test_null_argument(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -1834,21 +956,6 @@ define amdgpu_kernel void @test_null_argument(i32 %n) {
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) null, ptr addrspace(5) %str, i32 %n)
   ret void
-}
-
-define i32 @test_null_argument_with_use(i32 %n) {
-; R600-LABEL: @test_null_argument_with_use(
-; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) null, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @test_null_argument_with_use(
-; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    ret i32 0
-;
-  %str = alloca [9 x i8], align 1, addrspace(5)
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) null, ptr addrspace(5) %str, i32 %n)
-  ret i32 %call1
 }
 
 @undef.initializer = private unnamed_addr addrspace(4) constant [6 x i8] undef
@@ -1869,7 +976,7 @@ define amdgpu_kernel void @undef_initializer_gv(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 44, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 23, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -1898,7 +1005,7 @@ define amdgpu_kernel void @poison_initializer_gv(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 45, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 24, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -1907,35 +1014,6 @@ define amdgpu_kernel void @poison_initializer_gv(i32 %n) {
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) %str, i32 %n)
   ret void
-}
-
-define i32 @poison_initializer_gv_with_use(i32 %n) {
-; R600-LABEL: @poison_initializer_gv_with_use(
-; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @poison_initializer_gv_with_use(
-; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 4)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 46, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %str = alloca [9 x i8], align 1, addrspace(5)
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) %str, i32 %n)
-  ret i32 %call1
 }
 
 @zero.initializer = private unnamed_addr addrspace(4) constant [6 x i8] zeroinitializer
@@ -1956,7 +1034,7 @@ define amdgpu_kernel void @zero_initializer_gv(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 47, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 25, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -1965,35 +1043,6 @@ define amdgpu_kernel void @zero_initializer_gv(i32 %n) {
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) %str, i32 %n)
   ret void
-}
-
-define i32 @zero_initializer_gv_with_use(i32 %n) {
-; R600-LABEL: @zero_initializer_gv_with_use(
-; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @zero_initializer_gv_with_use(
-; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 4)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 48, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %str = alloca [9 x i8], align 1, addrspace(5)
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) %str, i32 %n)
-  ret i32 %call1
 }
 
 define amdgpu_kernel void @test_print_string_literal_size0(i32 %n) {
@@ -2012,7 +1061,7 @@ define amdgpu_kernel void @test_print_string_literal_size0(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 49, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 26, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2024,38 +1073,6 @@ define amdgpu_kernel void @test_print_string_literal_size0(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size0, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size0_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size0_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size0, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size0_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 50, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size0, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_1ai8.zero(i32 %n) {
@@ -2074,7 +1091,7 @@ define amdgpu_kernel void @test_print_string_literal_1ai8.zero(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 51, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 27, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2086,38 +1103,6 @@ define amdgpu_kernel void @test_print_string_literal_1ai8.zero(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.zero, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_1ai8_with_use.zero(i32 %n) {
-; R600-LABEL: @test_print_string_literal_1ai8_with_use.zero(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.zero, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_1ai8_with_use.zero(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 52, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.zero, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_1ai8.undef(i32 %n) {
@@ -2136,7 +1121,7 @@ define amdgpu_kernel void @test_print_string_literal_1ai8.undef(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 53, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 28, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2166,7 +1151,7 @@ define amdgpu_kernel void @test_print_string_literal_i8.zero(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 54, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 29, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2178,38 +1163,6 @@ define amdgpu_kernel void @test_print_string_literal_i8.zero(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.i8.zero, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_i8_with_use.zero(i32 %n) {
-; R600-LABEL: @test_print_string_literal_i8_with_use.zero(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.i8.zero, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_i8_with_use.zero(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 55, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.i8.zero, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size2(i32 %n) {
@@ -2228,7 +1181,7 @@ define amdgpu_kernel void @test_print_string_literal_size2(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 56, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 30, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 27, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2240,38 +1193,6 @@ define amdgpu_kernel void @test_print_string_literal_size2(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size2, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size2_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size2_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size2, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size2_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 57, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 27, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size2, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size3(i32 %n) {
@@ -2290,7 +1211,7 @@ define amdgpu_kernel void @test_print_string_literal_size3(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 58, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 31, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 7195, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2302,38 +1223,6 @@ define amdgpu_kernel void @test_print_string_literal_size3(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size3_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size3_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size3_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 59, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 7195, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size3_zero(i32 %n) {
@@ -2352,7 +1241,7 @@ define amdgpu_kernel void @test_print_string_literal_size3_zero(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 60, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 32, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2364,38 +1253,6 @@ define amdgpu_kernel void @test_print_string_literal_size3_zero(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3.zero, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size3_zero_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size3_zero_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3.zero, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size3_zero_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 61, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3.zero, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size4(i32 %n) {
@@ -2414,7 +1271,7 @@ define amdgpu_kernel void @test_print_string_literal_size4(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 62, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 33, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 6513249, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2426,38 +1283,6 @@ define amdgpu_kernel void @test_print_string_literal_size4(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size4_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size4_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size4_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 63, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 6513249, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size4_nonull_term(i32 %n) {
@@ -2476,7 +1301,7 @@ define amdgpu_kernel void @test_print_string_literal_size4_nonull_term(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 64, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 34, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2488,38 +1313,6 @@ define amdgpu_kernel void @test_print_string_literal_size4_nonull_term(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4.nonull.term, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size4_nonull_term_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size4_nonull_term_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4.nonull.term, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size4_nonull_term_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 65, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4.nonull.term, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size5(i32 %n) {
@@ -2538,7 +1331,7 @@ define amdgpu_kernel void @test_print_string_literal_size5(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 66, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 35, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2550,38 +1343,6 @@ define amdgpu_kernel void @test_print_string_literal_size5(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size5, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size5_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size5_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size5, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size5_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 67, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size5, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size6(i32 %n) {
@@ -2600,7 +1361,7 @@ define amdgpu_kernel void @test_print_string_literal_size6(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 68, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 36, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2614,40 +1375,6 @@ define amdgpu_kernel void @test_print_string_literal_size6(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size6_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size6_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size6_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 69, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 101, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size7(i32 %n) {
@@ -2666,7 +1393,7 @@ define amdgpu_kernel void @test_print_string_literal_size7(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 70, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 37, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2680,40 +1407,6 @@ define amdgpu_kernel void @test_print_string_literal_size7(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size7_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size7_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size7_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 71, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 101, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size8(i32 %n) {
@@ -2732,7 +1425,7 @@ define amdgpu_kernel void @test_print_string_literal_size8(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 72, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 38, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2746,40 +1439,6 @@ define amdgpu_kernel void @test_print_string_literal_size8(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size8, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size8_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size8_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size8, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size8_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 73, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 7565921, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size8, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size9(i32 %n) {
@@ -2798,7 +1457,7 @@ define amdgpu_kernel void @test_print_string_literal_size9(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 74, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 39, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684104548, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2812,40 +1471,6 @@ define amdgpu_kernel void @test_print_string_literal_size9(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size9, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size9_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size9_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size9, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size9_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 20)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 75, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 1684104548, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 1717921122, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size9, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size16(i32 %n) {
@@ -2864,7 +1489,7 @@ define amdgpu_kernel void @test_print_string_literal_size16(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 76, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 40, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 909194801, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2882,44 +1507,6 @@ define amdgpu_kernel void @test_print_string_literal_size16(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size16, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size16_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size16_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size16, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size16_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 24)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 77, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 909194801, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 909194801, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
-; GCN-NEXT:    store i32 909194801, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
-; GCN-NEXT:    store i32 3225137, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size16, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size17(i32 %n) {
@@ -2938,7 +1525,7 @@ define amdgpu_kernel void @test_print_string_literal_size17(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 78, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 41, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 925972273, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2956,44 +1543,6 @@ define amdgpu_kernel void @test_print_string_literal_size17(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size17, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size17_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size17_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size17, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size17_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 28)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 79, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 925972273, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 925972273, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
-; GCN-NEXT:    store i32 925972273, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
-; GCN-NEXT:    store i32 925972273, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size17, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size20(i32 %n) {
@@ -3012,7 +1561,7 @@ define amdgpu_kernel void @test_print_string_literal_size20(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 80, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 42, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3032,46 +1581,6 @@ define amdgpu_kernel void @test_print_string_literal_size20(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size20, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size20_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size20_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size20, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size20_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 28)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 81, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 1751606885, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
-; GCN-NEXT:    store i32 1818978921, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
-; GCN-NEXT:    store i32 1886350957, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store i32 7565937, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size20, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_size32(i32 %n) {
@@ -3090,7 +1599,7 @@ define amdgpu_kernel void @test_print_string_literal_size32(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 82, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 43, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3116,52 +1625,6 @@ define amdgpu_kernel void @test_print_string_literal_size32(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size32, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_size32_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_size32_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size32, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_size32_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 40)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 83, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
-; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
-; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
-; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
-; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 4
-; GCN-NEXT:    store i32 7565921, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size32, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_not_constant_global(i32 %n) {
@@ -3180,7 +1643,7 @@ define amdgpu_kernel void @test_print_string_not_constant_global(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 84, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 44, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3192,38 +1655,6 @@ define amdgpu_kernel void @test_print_string_not_constant_global(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.not.constant.size4, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_not_constant_global_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_not_constant_global_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.not.constant.size4, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_not_constant_global_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 85, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.not.constant.size4, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_constant_interposable_global(i32 %n) {
@@ -3242,7 +1673,7 @@ define amdgpu_kernel void @test_print_string_constant_interposable_global(i32 %n
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 86, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 45, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3254,38 +1685,6 @@ define amdgpu_kernel void @test_print_string_constant_interposable_global(i32 %n
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.interposable.size4, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_constant_interposable_global_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_constant_interposable_global_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.interposable.size4, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_constant_interposable_global_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 87, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.interposable.size4, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_v4i8(i32 %n) {
@@ -3304,7 +1703,7 @@ define amdgpu_kernel void @test_print_string_literal_v4i8(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 88, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 46, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 67305985, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3316,38 +1715,6 @@ define amdgpu_kernel void @test_print_string_literal_v4i8(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i8, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_v4i8_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_v4i8_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i8, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_v4i8_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 89, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 67305985, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i8, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_v4i32(i32 %n) {
@@ -3366,7 +1733,7 @@ define amdgpu_kernel void @test_print_string_literal_v4i32(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 90, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 47, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3378,38 +1745,6 @@ define amdgpu_kernel void @test_print_string_literal_v4i32(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i32, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_v4i32_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_v4i32_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i32, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_v4i32_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 91, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 1, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i32, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_struct(i32 %n) {
@@ -3428,7 +1763,7 @@ define amdgpu_kernel void @test_print_string_literal_struct(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 92, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 48, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 66, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3440,38 +1775,6 @@ define amdgpu_kernel void @test_print_string_literal_struct(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.struct, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_struct_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_literal_struct_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.struct, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_struct_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 93, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 66, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.struct, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_undef(i32 %n) {
@@ -3490,7 +1793,7 @@ define amdgpu_kernel void @test_print_string_undef(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 94, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 49, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3520,7 +1823,7 @@ define amdgpu_kernel void @test_print_string_poison(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 95, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 50, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3532,38 +1835,6 @@ define amdgpu_kernel void @test_print_string_poison(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_poison_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_poison_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_poison_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 96, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_null(i32 %n) {
@@ -3582,7 +1853,7 @@ define amdgpu_kernel void @test_print_string_null(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 97, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 51, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3594,38 +1865,6 @@ define amdgpu_kernel void @test_print_string_null(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) null, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_null_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_null_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) null, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_null_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 98, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) null, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_inttoptr(i32 %n) {
@@ -3644,7 +1883,7 @@ define amdgpu_kernel void @test_print_string_inttoptr(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 99, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 52, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3656,38 +1895,6 @@ define amdgpu_kernel void @test_print_string_inttoptr(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) inttoptr (i64 1234 to ptr addrspace(4)), i32 %n)
   ret void
-}
-
-define i32 @test_print_string_inttoptr_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_inttoptr_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) inttoptr (i64 1234 to ptr addrspace(4)), i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_inttoptr_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 100, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) inttoptr (i64 1234 to ptr addrspace(4)), i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_float_neg0(i32 %n) {
@@ -3706,7 +1913,7 @@ define amdgpu_kernel void @test_print_string_float_neg0(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 101, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 53, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3718,38 +1925,6 @@ define amdgpu_kernel void @test_print_string_float_neg0(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_float_neg0_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_float_neg0_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_float_neg0_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 102, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_float_0(i32 %n) {
@@ -3768,7 +1943,7 @@ define amdgpu_kernel void @test_print_string_float_0(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 103, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 54, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3780,38 +1955,6 @@ define amdgpu_kernel void @test_print_string_float_0(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_float_0_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_float_0_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_float_0_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 104, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_ptr_null(i32 %n) {
@@ -3830,7 +1973,7 @@ define amdgpu_kernel void @test_print_string_ptr_null(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 105, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 55, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3842,38 +1985,6 @@ define amdgpu_kernel void @test_print_string_ptr_null(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.null, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_ptr_null_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_ptr_null_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.null, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_ptr_null_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 106, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.null, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_ptr_undef(i32 %n) {
@@ -3892,7 +2003,7 @@ define amdgpu_kernel void @test_print_string_ptr_undef(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 107, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 56, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3922,7 +2033,7 @@ define amdgpu_kernel void @test_print_string_indexed(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 108, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 57, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1936875892, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3940,44 +2051,6 @@ define amdgpu_kernel void @test_print_string_indexed(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 15), i32 %n)
   ret void
-}
-
-define i32 @test_print_string_indexed_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_indexed_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 15), i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_indexed_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 28)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 109, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 1936875892, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 1936875892, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
-; GCN-NEXT:    store i32 1936875892, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
-; GCN-NEXT:    store i32 1936875892, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 15), i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_indexed_oob(i32 %n) {
@@ -3996,7 +2069,7 @@ define amdgpu_kernel void @test_print_string_indexed_oob(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 110, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 58, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -4008,38 +2081,6 @@ define amdgpu_kernel void @test_print_string_indexed_oob(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 32), i32 %n)
   ret void
-}
-
-define i32 @test_print_string_indexed_oob_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_indexed_oob_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 32), i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_indexed_oob_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 111, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 32), i32 %n)
-  ret i32 %printf
 }
 
 @array.i16 = private unnamed_addr addrspace(4) constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
@@ -4061,7 +2102,7 @@ define amdgpu_kernel void @test_format_array_i16(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 112, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 59, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -4070,35 +2111,6 @@ define amdgpu_kernel void @test_format_array_i16(i32 %n) {
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @array.i16, ptr addrspace(5) %str, i32 %n)
   ret void
-}
-
-define i32 @test_format_array_i16_with_use(i32 %n) {
-; R600-LABEL: @test_format_array_i16_with_use(
-; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @array.i16, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @test_format_array_i16_with_use(
-; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 4)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 113, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %str = alloca [9 x i8], align 1, addrspace(5)
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @array.i16, ptr addrspace(5) %str, i32 %n)
-  ret i32 %call1
 }
 
 @struct = private unnamed_addr addrspace(4) constant { [6 x i8] } { [6 x i8] [i8 1, i8 2, i8 3, i8 4, i8 5, i8 6] }
@@ -4119,7 +2131,7 @@ define amdgpu_kernel void @test_format_struct(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 114, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 60, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -4128,35 +2140,6 @@ define amdgpu_kernel void @test_format_struct(i32 %n) {
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @struct, ptr addrspace(5) %str, i32 %n)
   ret void
-}
-
-define i32 @test_format_struct_with_use(i32 %n) {
-; R600-LABEL: @test_format_struct_with_use(
-; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @struct, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @test_format_struct_with_use(
-; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 4)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 115, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %str = alloca [9 x i8], align 1, addrspace(5)
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @struct, ptr addrspace(5) %str, i32 %n)
-  ret i32 %call1
 }
 
 declare void @func(ptr)
@@ -4188,7 +2171,7 @@ define void @printf_printf(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 116, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 61, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store ptr @printf, ptr addrspace(1) [[PRINTBUFFGEP]], align 8
 ; GCN-NEXT:    br label [[TMP3]]
@@ -4197,6 +2180,97 @@ define void @printf_printf(i32 %n) {
 ;
   %call = call i32 @printf(ptr addrspace(4) @format.str.one.ptr, ptr @printf)
   ret void
+}
+
+define amdgpu_kernel void @test_kernel_return_value_use(i32 %n) {
+; R600-LABEL: @test_kernel_return_value_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[MEM:%.*]] = alloca i32, align 4, addrspace(5)
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
+; R600-NEXT:    store i32 [[CALL1]], ptr addrspace(5) [[MEM]], align 4
+; R600-NEXT:    ret void
+;
+; GCN-LABEL: @test_kernel_return_value_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[MEM:%.*]] = alloca i32, align 4, addrspace(5)
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 62, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    store i32 [[PRINTF_RES]], ptr addrspace(5) [[MEM]], align 4
+; GCN-NEXT:    ret void
+;
+entry:
+  %mem = alloca i32, align 4, addrspace(5)
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(5) %str, i32 %n)
+  store i32 %call1, ptr addrspace(5) %mem, align 4
+  ret void
+}
+
+define i32 @test_func_return_value_use(i32 %n) {
+; R600-LABEL: @test_func_return_value_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @test_func_return_value_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 63, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
+;
+entry:
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(5) %str, i32 %n)
+  ret i32 %call1
+}
+
+define i32 @test_null_argument_return_value_use(i32 %n) {
+; R600-LABEL: @test_null_argument_return_value_use(
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) null, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @test_null_argument_return_value_use(
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    ret i32 0
+;
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) null, ptr addrspace(5) %str, i32 %n)
+  ret i32 %call1
 }
 
 declare i32 @printf(ptr addrspace(4), ...)

--- a/llvm/test/CodeGen/AMDGPU/opencl-printf.ll
+++ b/llvm/test/CodeGen/AMDGPU/opencl-printf.ll
@@ -54,11 +54,11 @@
 @format.str.one.ptr = private unnamed_addr addrspace(4) constant [8 x i8] c"arst %p\00", align 1
 
 
-define i32 @format_str_f(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
+define amdgpu_kernel void @format_str_f(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
 ; R600-LABEL: @format_str_f(
 ; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.f, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_f(
 ; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
@@ -98,6 +98,57 @@ define i32 @format_str_f(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 
 ; GCN-NEXT:    store i32 [[TMP3]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
 ; GCN-NEXT:    br label [[TMP6]]
 ; GCN:       6:
+; GCN-NEXT:    ret void
+;
+  %fpext.f32.to.f64 = fpext float %f32.1 to double
+  %call1 = call i32 @printf(ptr addrspace(4) @format.str.f, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
+  ret void
+}
+
+define i32 @format_str_f_with_use(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
+; R600-LABEL: @format_str_f_with_use(
+; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
+; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.f, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @format_str_f_with_use(
+; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
+; GCN-NEXT:    [[TMP1:%.*]] = sext i16 [[I16:%.*]] to i32
+; GCN-NEXT:    [[TMP2:%.*]] = bitcast half [[F16:%.*]] to i16
+; GCN-NEXT:    [[TMP3:%.*]] = sext i16 [[TMP2]] to i32
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 64)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP4:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP4]], label [[TMP5:%.*]], label [[TMP6:%.*]]
+; GCN:       5:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 2, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store double [[F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 8
+; GCN-NEXT:    store float [[F32_1]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
+; GCN-NEXT:    store float 1.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store float 2.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
+; GCN-NEXT:    store i32 [[TMP1]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
+; GCN-NEXT:    store i32 [[I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 4
+; GCN-NEXT:    store i64 [[I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 8
+; GCN-NEXT:    store <2 x float> <float 1.000000e+00, float 2.000000e+00>, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR8:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], i32 8
+; GCN-NEXT:    store <2 x i32> <i32 8, i32 234>, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR9:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], i32 8
+; GCN-NEXT:    store i32 [[TMP3]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
+; GCN-NEXT:    br label [[TMP6]]
+; GCN:       6:
 ; GCN-NEXT:    [[TMP7:%.*]] = xor i1 [[TMP4]], true
 ; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP7]] to i32
 ; GCN-NEXT:    ret i32 [[PRINTF_RES]]
@@ -107,11 +158,11 @@ define i32 @format_str_f(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 
   ret i32 %call1
 }
 
-define i32 @format_str_F(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
+define amdgpu_kernel void @format_str_F(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
 ; R600-LABEL: @format_str_F(
 ; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.F, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_F(
 ; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
@@ -126,7 +177,7 @@ define i32 @format_str_F(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 
 ; GCN:       5:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 2, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 3, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -151,8 +202,59 @@ define i32 @format_str_F(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 
 ; GCN-NEXT:    store i32 [[TMP6]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       6:
-; GCN-NEXT:    [[TMP7:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP7]] to i32
+; GCN-NEXT:    ret void
+;
+  %fpext.f32.to.f64 = fpext float %f32.1 to double
+  %call1 = call i32 @printf(ptr addrspace(4) @format.str.F, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
+  ret void
+}
+
+define i32 @format_str_F_with_use(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
+; R600-LABEL: @format_str_F_with_use(
+; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
+; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.F, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @format_str_F_with_use(
+; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
+; GCN-NEXT:    [[TMP5:%.*]] = sext i16 [[I16:%.*]] to i32
+; GCN-NEXT:    [[TMP6:%.*]] = bitcast half [[F16:%.*]] to i16
+; GCN-NEXT:    [[TMP7:%.*]] = sext i16 [[TMP6]] to i32
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 72)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       5:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 4, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store double [[F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 8
+; GCN-NEXT:    store double [[FPEXT_F32_TO_F64]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 8
+; GCN-NEXT:    store float 1.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store double 2.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 8
+; GCN-NEXT:    store i32 [[TMP5]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
+; GCN-NEXT:    store i32 [[I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 4
+; GCN-NEXT:    store i64 [[I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 8
+; GCN-NEXT:    store <2 x float> <float 1.000000e+00, float 2.000000e+00>, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR8:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], i32 8
+; GCN-NEXT:    store <2 x i32> <i32 8, i32 234>, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR9:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], i32 8
+; GCN-NEXT:    store i32 [[TMP7]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       6:
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
 ; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %fpext.f32.to.f64 = fpext float %f32.1 to double
@@ -160,11 +262,11 @@ define i32 @format_str_F(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 
   ret i32 %call1
 }
 
-define i32 @format_str_a(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
+define amdgpu_kernel void @format_str_a(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
 ; R600-LABEL: @format_str_a(
 ; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.a, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_a(
 ; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
@@ -179,7 +281,58 @@ define i32 @format_str_a(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 
 ; GCN:       5:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 3, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 5, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store double [[F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 8
+; GCN-NEXT:    store double [[FPEXT_F32_TO_F64]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 8
+; GCN-NEXT:    store float 1.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store double 2.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 8
+; GCN-NEXT:    store i32 [[TMP1]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
+; GCN-NEXT:    store i32 [[I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 4
+; GCN-NEXT:    store i64 [[I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 8
+; GCN-NEXT:    store <2 x float> <float 1.000000e+00, float 2.000000e+00>, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR8:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], i32 8
+; GCN-NEXT:    store <2 x i32> <i32 8, i32 234>, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR9:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], i32 8
+; GCN-NEXT:    store i32 [[TMP3]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
+; GCN-NEXT:    br label [[TMP6]]
+; GCN:       6:
+; GCN-NEXT:    ret void
+;
+  %fpext.f32.to.f64 = fpext float %f32.1 to double
+  %call1 = call i32 @printf(ptr addrspace(4) @format.str.a, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
+  ret void
+}
+
+define i32 @format_str_a_with_use(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
+; R600-LABEL: @format_str_a_with_use(
+; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
+; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.a, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @format_str_a_with_use(
+; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
+; GCN-NEXT:    [[TMP1:%.*]] = sext i16 [[I16:%.*]] to i32
+; GCN-NEXT:    [[TMP2:%.*]] = bitcast half [[F16:%.*]] to i16
+; GCN-NEXT:    [[TMP3:%.*]] = sext i16 [[TMP2]] to i32
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 72)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP4:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP4]], label [[TMP5:%.*]], label [[TMP6:%.*]]
+; GCN:       5:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 6, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -213,11 +366,11 @@ define i32 @format_str_a(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 
   ret i32 %call1
 }
 
-define i32 @format_str_A(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
+define amdgpu_kernel void @format_str_A(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
 ; R600-LABEL: @format_str_A(
 ; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.A, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_A(
 ; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
@@ -232,7 +385,7 @@ define i32 @format_str_A(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 
 ; GCN:       5:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 4, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 7, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -257,8 +410,59 @@ define i32 @format_str_A(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 
 ; GCN-NEXT:    store i32 [[TMP6]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       6:
-; GCN-NEXT:    [[TMP7:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP7]] to i32
+; GCN-NEXT:    ret void
+;
+  %fpext.f32.to.f64 = fpext float %f32.1 to double
+  %call1 = call i32 @printf(ptr addrspace(4) @format.str.A, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
+  ret void
+}
+
+define i32 @format_str_A_with_use(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
+; R600-LABEL: @format_str_A_with_use(
+; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
+; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.A, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @format_str_A_with_use(
+; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
+; GCN-NEXT:    [[TMP5:%.*]] = sext i16 [[I16:%.*]] to i32
+; GCN-NEXT:    [[TMP6:%.*]] = bitcast half [[F16:%.*]] to i16
+; GCN-NEXT:    [[TMP7:%.*]] = sext i16 [[TMP6]] to i32
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 72)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       5:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 8, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store float [[F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store double [[F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 8
+; GCN-NEXT:    store double [[FPEXT_F32_TO_F64]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 8
+; GCN-NEXT:    store float 1.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store double 2.000000e+00, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 8
+; GCN-NEXT:    store i32 [[TMP5]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
+; GCN-NEXT:    store i32 [[I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 4
+; GCN-NEXT:    store i64 [[I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 8
+; GCN-NEXT:    store <2 x float> <float 1.000000e+00, float 2.000000e+00>, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR8:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], i32 8
+; GCN-NEXT:    store <2 x i32> <i32 8, i32 234>, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR9:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], i32 8
+; GCN-NEXT:    store i32 [[TMP7]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       6:
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
 ; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %fpext.f32.to.f64 = fpext float %f32.1 to double
@@ -266,10 +470,10 @@ define i32 @format_str_A(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 
   ret i32 %call1
 }
 
-define i32 @format_str_ptr(ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspace(1) %ptr.global, ptr addrspace(5) %ptr.stack, ptr addrspace(4) %ptr.const) {
+define void @format_str_ptr(ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspace(1) %ptr.global, ptr addrspace(5) %ptr.stack, ptr addrspace(4) %ptr.const) {
 ; R600-LABEL: @format_str_ptr(
 ; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.p, ptr [[PTR_FLAT:%.*]], ptr addrspace(3) [[PTR_LDS:%.*]], ptr addrspace(1) [[PTR_GLOBAL:%.*]], ptr addrspace(5) [[PTR_STACK:%.*]], ptr addrspace(4) [[PTR_CONST:%.*]])
-; R600-NEXT:    ret i32 [[CALL]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_ptr(
 ; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 36)
@@ -280,7 +484,40 @@ define i32 @format_str_ptr(ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspa
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 5, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 9, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store ptr [[PTR_FLAT:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 8
+; GCN-NEXT:    store ptr addrspace(3) [[PTR_LDS:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
+; GCN-NEXT:    store ptr addrspace(1) [[PTR_GLOBAL:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 8
+; GCN-NEXT:    store ptr addrspace(5) [[PTR_STACK:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store ptr addrspace(4) [[PTR_CONST:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  %call = call i32 @printf(ptr addrspace(4) @format.str.p, ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspace(1) %ptr.global, ptr addrspace(5) %ptr.stack, ptr addrspace(4) %ptr.const)
+  ret void
+}
+
+define i32 @format_str_ptr_with_use(ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspace(1) %ptr.global, ptr addrspace(5) %ptr.stack, ptr addrspace(4) %ptr.const) {
+; R600-LABEL: @format_str_ptr_with_use(
+; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.p, ptr [[PTR_FLAT:%.*]], ptr addrspace(3) [[PTR_LDS:%.*]], ptr addrspace(1) [[PTR_GLOBAL:%.*]], ptr addrspace(5) [[PTR_STACK:%.*]], ptr addrspace(4) [[PTR_CONST:%.*]])
+; R600-NEXT:    ret i32 [[CALL]]
+;
+; GCN-LABEL: @format_str_ptr_with_use(
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 36)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 10, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store ptr [[PTR_FLAT:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 8
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 8
@@ -301,10 +538,10 @@ define i32 @format_str_ptr(ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspa
   ret i32 %call
 }
 
-define i32 @format_str_d(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
+define amdgpu_kernel void @format_str_d(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
 ; R600-LABEL: @format_str_d(
 ; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.d, i1 [[I1:%.*]], i4 [[I4:%.*]], i8 [[I8:%.*]], i24 [[I24:%.*]], i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], i96 [[I96:%.*]], i128 [[I128:%.*]], i32 1234)
-; R600-NEXT:    ret i32 [[CALL]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_d(
 ; GCN-NEXT:    [[TMP1:%.*]] = sext i1 [[I1:%.*]] to i32
@@ -319,7 +556,54 @@ define i32 @format_str_d(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i
 ; GCN:       6:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 6, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 11, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 [[TMP1]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[TMP2]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
+; GCN-NEXT:    store i32 [[TMP3]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
+; GCN-NEXT:    store i24 [[I24:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store i32 [[TMP4]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
+; GCN-NEXT:    store i32 [[I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
+; GCN-NEXT:    store i64 [[I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 8
+; GCN-NEXT:    store i96 [[I96:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 16
+; GCN-NEXT:    store i128 [[I128:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR8:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], i32 16
+; GCN-NEXT:    store i32 1234, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 4
+; GCN-NEXT:    br label [[TMP7]]
+; GCN:       7:
+; GCN-NEXT:    ret void
+;
+  %call = call i32 @printf(ptr addrspace(4) @format.str.d, i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128, i32 1234)
+  ret void
+}
+
+define i32 @format_str_d_with_use(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
+; R600-LABEL: @format_str_d_with_use(
+; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.d, i1 [[I1:%.*]], i4 [[I4:%.*]], i8 [[I8:%.*]], i24 [[I24:%.*]], i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], i96 [[I96:%.*]], i128 [[I128:%.*]], i32 1234)
+; R600-NEXT:    ret i32 [[CALL]]
+;
+; GCN-LABEL: @format_str_d_with_use(
+; GCN-NEXT:    [[TMP1:%.*]] = sext i1 [[I1:%.*]] to i32
+; GCN-NEXT:    [[TMP2:%.*]] = sext i4 [[I4:%.*]] to i32
+; GCN-NEXT:    [[TMP3:%.*]] = sext i8 [[I8:%.*]] to i32
+; GCN-NEXT:    [[TMP4:%.*]] = sext i16 [[I16:%.*]] to i32
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 72)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP5:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP5]], label [[TMP6:%.*]], label [[TMP7:%.*]]
+; GCN:       6:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 12, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 [[TMP1]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -350,10 +634,10 @@ define i32 @format_str_d(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i
   ret i32 %call
 }
 
-define i32 @format_str_u(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
+define amdgpu_kernel void @format_str_u(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
 ; R600-LABEL: @format_str_u(
 ; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.u, i1 [[I1:%.*]], i4 [[I4:%.*]], i8 [[I8:%.*]], i24 [[I24:%.*]], i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], i96 [[I96:%.*]], i128 [[I128:%.*]], i32 1234)
-; R600-NEXT:    ret i32 [[CALL]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_u(
 ; GCN-NEXT:    [[TMP1:%.*]] = zext i1 [[I1:%.*]] to i32
@@ -368,7 +652,54 @@ define i32 @format_str_u(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i
 ; GCN:       6:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 7, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 13, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 [[TMP1]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[TMP2]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
+; GCN-NEXT:    store i32 [[TMP3]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
+; GCN-NEXT:    store i24 [[I24:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store i32 [[TMP4]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
+; GCN-NEXT:    store i32 [[I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
+; GCN-NEXT:    store i64 [[I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 8
+; GCN-NEXT:    store i96 [[I96:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 16
+; GCN-NEXT:    store i128 [[I128:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR8:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], i32 16
+; GCN-NEXT:    store i32 1234, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 4
+; GCN-NEXT:    br label [[TMP7]]
+; GCN:       7:
+; GCN-NEXT:    ret void
+;
+  %call = call i32 @printf(ptr addrspace(4) @format.str.u, i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128, i32 1234)
+  ret void
+}
+
+define i32 @format_str_u_with_use(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
+; R600-LABEL: @format_str_u_with_use(
+; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.u, i1 [[I1:%.*]], i4 [[I4:%.*]], i8 [[I8:%.*]], i24 [[I24:%.*]], i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], i96 [[I96:%.*]], i128 [[I128:%.*]], i32 1234)
+; R600-NEXT:    ret i32 [[CALL]]
+;
+; GCN-LABEL: @format_str_u_with_use(
+; GCN-NEXT:    [[TMP1:%.*]] = zext i1 [[I1:%.*]] to i32
+; GCN-NEXT:    [[TMP2:%.*]] = zext i4 [[I4:%.*]] to i32
+; GCN-NEXT:    [[TMP3:%.*]] = zext i8 [[I8:%.*]] to i32
+; GCN-NEXT:    [[TMP4:%.*]] = zext i16 [[I16:%.*]] to i32
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 72)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP5:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP5]], label [[TMP6:%.*]], label [[TMP7:%.*]]
+; GCN:       6:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 14, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 [[TMP1]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -399,11 +730,11 @@ define i32 @format_str_u(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i
   ret i32 %call
 }
 
-define i32 @format_str_v1(<1 x float> %v1f32.0, <1 x float> %v1f32.1, <1 x double> %v1f64, <1 x i8> %v1i8, <1 x i16> %v1i16, <1 x i32> %v1i32, <1 x i64> %v1i64,
+define void @format_str_v1(<1 x float> %v1f32.0, <1 x float> %v1f32.1, <1 x double> %v1f64, <1 x i8> %v1i8, <1 x i16> %v1i16, <1 x i32> %v1i32, <1 x i64> %v1i64,
 ; R600-LABEL: @format_str_v1(
 ; R600-NEXT:    [[V1F32_1_FPEXT:%.*]] = fpext <1 x float> [[V1F32_1:%.*]] to <1 x double>
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v1, <1 x float> [[V1F32_0:%.*]], <1 x double> [[V1F32_1_FPEXT]], <1 x double> [[V1F64:%.*]], <1 x i8> [[V1I8:%.*]], <1 x i16> [[V1I16:%.*]], <1 x i32> [[V1I32:%.*]], <1 x i64> [[V1I64:%.*]], <1 x ptr addrspace(1)> [[V1P1:%.*]], <1 x ptr addrspace(3)> [[V1P3:%.*]], <1 x half> [[V1F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_v1(
 ; GCN-NEXT:    [[V1F32_1_FPEXT:%.*]] = fpext <1 x float> [[V1F32_1:%.*]] to <1 x double>
@@ -417,7 +748,52 @@ define i32 @format_str_v1(<1 x float> %v1f32.0, <1 x float> %v1f32.1, <1 x doubl
 ; GCN:       4:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 8, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 15, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store <1 x float> [[V1F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store <1 x double> [[V1F32_1_FPEXT]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 8
+; GCN-NEXT:    store <1 x double> [[V1F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 8
+; GCN-NEXT:    store <1 x i32> [[TMP1]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store <1 x i32> [[TMP2]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
+; GCN-NEXT:    store <1 x i32> [[V1I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
+; GCN-NEXT:    store <1 x i64> [[V1I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 8
+; GCN-NEXT:    br label [[TMP5]]
+; GCN:       5:
+; GCN-NEXT:    ret void
+;
+  <1 x ptr addrspace(1)> %v1p1, <1 x ptr addrspace(3)> %v1p3, <1 x half> %v1f16) {
+  %v1f32.1.fpext = fpext <1 x float> %v1f32.1 to <1 x double>
+  %call1 = call i32 @printf(ptr addrspace(4) @format.str.v1, <1 x float> %v1f32.0, <1 x double> %v1f32.1.fpext, <1 x double> %v1f64, <1 x i8> %v1i8, <1 x i16> %v1i16, <1 x i32> %v1i32, <1 x i64> %v1i64,
+  <1 x ptr addrspace(1)> %v1p1, <1 x ptr addrspace(3)> %v1p3, <1 x half> %v1f16)
+  ret void
+}
+
+define i32 @format_str_v1_with_use(<1 x float> %v1f32.0, <1 x float> %v1f32.1, <1 x double> %v1f64, <1 x i8> %v1i8, <1 x i16> %v1i16, <1 x i32> %v1i32, <1 x i64> %v1i64,
+; R600-LABEL: @format_str_v1_with_use(
+; R600-NEXT:    [[V1F32_1_FPEXT:%.*]] = fpext <1 x float> [[V1F32_1:%.*]] to <1 x double>
+; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v1, <1 x float> [[V1F32_0:%.*]], <1 x double> [[V1F32_1_FPEXT]], <1 x double> [[V1F64:%.*]], <1 x i8> [[V1I8:%.*]], <1 x i16> [[V1I16:%.*]], <1 x i32> [[V1I32:%.*]], <1 x i64> [[V1I64:%.*]], <1 x ptr addrspace(1)> [[V1P1:%.*]], <1 x ptr addrspace(3)> [[V1P3:%.*]], <1 x half> [[V1F16:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @format_str_v1_with_use(
+; GCN-NEXT:    [[V1F32_1_FPEXT:%.*]] = fpext <1 x float> [[V1F32_1:%.*]] to <1 x double>
+; GCN-NEXT:    [[TMP1:%.*]] = sext <1 x i8> [[V1I8:%.*]] to <1 x i32>
+; GCN-NEXT:    [[TMP2:%.*]] = sext <1 x i16> [[V1I16:%.*]] to <1 x i32>
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 44)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP3:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP3]], label [[TMP4:%.*]], label [[TMP5:%.*]]
+; GCN:       4:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 16, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store <1 x float> [[V1F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -446,11 +822,11 @@ define i32 @format_str_v1(<1 x float> %v1f32.0, <1 x float> %v1f32.1, <1 x doubl
   ret i32 %call1
 }
 
-define i32 @format_str_v2(<2 x float> %v2f32.0, <2 x float> %v2f32.1, <2 x double> %v2f64, <2 x i8> %v2i8, <2 x i16> %v2i16, <2 x i32> %v2i32, <2 x i64> %v2i64,
+define void @format_str_v2(<2 x float> %v2f32.0, <2 x float> %v2f32.1, <2 x double> %v2f64, <2 x i8> %v2i8, <2 x i16> %v2i16, <2 x i32> %v2i32, <2 x i64> %v2i64,
 ; R600-LABEL: @format_str_v2(
 ; R600-NEXT:    [[V2F32_1_FPEXT:%.*]] = fpext <2 x float> [[V2F32_1:%.*]] to <2 x double>
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v2, <2 x float> [[V2F32_0:%.*]], <2 x double> [[V2F32_1_FPEXT]], <2 x double> [[V2F64:%.*]], <2 x i8> [[V2I8:%.*]], <2 x i16> [[V2I16:%.*]], <2 x i32> [[V2I32:%.*]], <2 x i64> [[V2I64:%.*]], <2 x ptr addrspace(1)> [[V2P1:%.*]], <2 x ptr addrspace(3)> [[V2P3:%.*]], <2 x half> [[V2F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_v2(
 ; GCN-NEXT:    [[V2F32_1_FPEXT:%.*]] = fpext <2 x float> [[V2F32_1:%.*]] to <2 x double>
@@ -463,7 +839,51 @@ define i32 @format_str_v2(<2 x float> %v2f32.0, <2 x float> %v2f32.1, <2 x doubl
 ; GCN:       3:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 9, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 17, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store <2 x float> [[V2F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 8
+; GCN-NEXT:    store <2 x double> [[V2F32_1_FPEXT]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 16
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 16
+; GCN-NEXT:    store <2 x double> [[V2F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 16
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 16
+; GCN-NEXT:    store <2 x i32> [[TMP1]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 8
+; GCN-NEXT:    store <2 x i16> [[V2I16:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
+; GCN-NEXT:    store <2 x i32> [[V2I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 8
+; GCN-NEXT:    store <2 x i64> [[V2I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 16
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 16
+; GCN-NEXT:    br label [[TMP4]]
+; GCN:       4:
+; GCN-NEXT:    ret void
+;
+  <2 x ptr addrspace(1)> %v2p1, <2 x ptr addrspace(3)> %v2p3, <2 x half> %v2f16) {
+  %v2f32.1.fpext = fpext <2 x float> %v2f32.1 to <2 x double>
+  %call1 = call i32 @printf(ptr addrspace(4) @format.str.v2, <2 x float> %v2f32.0, <2 x double> %v2f32.1.fpext, <2 x double> %v2f64, <2 x i8> %v2i8, <2 x i16> %v2i16, <2 x i32> %v2i32, <2 x i64> %v2i64,
+  <2 x ptr addrspace(1)> %v2p1, <2 x ptr addrspace(3)> %v2p3, <2 x half> %v2f16)
+  ret void
+}
+
+define i32 @format_str_v2_with_use(<2 x float> %v2f32.0, <2 x float> %v2f32.1, <2 x double> %v2f64, <2 x i8> %v2i8, <2 x i16> %v2i16, <2 x i32> %v2i32, <2 x i64> %v2i64,
+; R600-LABEL: @format_str_v2_with_use(
+; R600-NEXT:    [[V2F32_1_FPEXT:%.*]] = fpext <2 x float> [[V2F32_1:%.*]] to <2 x double>
+; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v2, <2 x float> [[V2F32_0:%.*]], <2 x double> [[V2F32_1_FPEXT]], <2 x double> [[V2F64:%.*]], <2 x i8> [[V2I8:%.*]], <2 x i16> [[V2I16:%.*]], <2 x i32> [[V2I32:%.*]], <2 x i64> [[V2I64:%.*]], <2 x ptr addrspace(1)> [[V2P1:%.*]], <2 x ptr addrspace(3)> [[V2P3:%.*]], <2 x half> [[V2F16:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @format_str_v2_with_use(
+; GCN-NEXT:    [[V2F32_1_FPEXT:%.*]] = fpext <2 x float> [[V2F32_1:%.*]] to <2 x double>
+; GCN-NEXT:    [[TMP1:%.*]] = sext <2 x i8> [[V2I8:%.*]] to <2 x i32>
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 80)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP2:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP2]], label [[TMP3:%.*]], label [[TMP4:%.*]]
+; GCN:       3:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 18, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store <2 x float> [[V2F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 8
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 8
@@ -492,11 +912,11 @@ define i32 @format_str_v2(<2 x float> %v2f32.0, <2 x float> %v2f32.1, <2 x doubl
   ret i32 %call1
 }
 
-define i32 @format_str_v3(<3 x float> %v3f32.0, <3 x float> %v3f32.1, <3 x double> %v3f64, <3 x i8> %v3i8, <3 x i16> %v3i16, <3 x i32> %v3i32, <3 x i64> %v3i64,
+define void @format_str_v3(<3 x float> %v3f32.0, <3 x float> %v3f32.1, <3 x double> %v3f64, <3 x i8> %v3i8, <3 x i16> %v3i16, <3 x i32> %v3i32, <3 x i64> %v3i64,
 ; R600-LABEL: @format_str_v3(
 ; R600-NEXT:    [[V3F32_1_FPEXT:%.*]] = fpext <3 x float> [[V3F32_1:%.*]] to <3 x double>
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v3, <3 x float> [[V3F32_0:%.*]], <3 x double> [[V3F32_1_FPEXT]], <3 x double> [[V3F64:%.*]], <3 x i8> [[V3I8:%.*]], <3 x i16> [[V3I16:%.*]], <3 x i32> [[V3I32:%.*]], <3 x i64> [[V3I64:%.*]], <3 x ptr addrspace(1)> [[V3P1:%.*]], <3 x ptr addrspace(3)> [[V3P3:%.*]], <3 x half> [[V3F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_v3(
 ; GCN-NEXT:    [[V3F32_1_FPEXT:%.*]] = fpext <3 x float> [[V3F32_1:%.*]] to <3 x double>
@@ -508,7 +928,50 @@ define i32 @format_str_v3(<3 x float> %v3f32.0, <3 x float> %v3f32.1, <3 x doubl
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 10, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 19, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store <3 x float> [[V3F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 16
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 16
+; GCN-NEXT:    store <3 x double> [[V3F32_1_FPEXT]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 32
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 32
+; GCN-NEXT:    store <3 x double> [[V3F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 32
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 32
+; GCN-NEXT:    store <3 x i8> [[V3I8:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store <3 x i16> [[V3I16:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 8
+; GCN-NEXT:    store <3 x i32> [[V3I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 16
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 16
+; GCN-NEXT:    store <3 x i64> [[V3I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 32
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 32
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  <3 x ptr addrspace(1)> %v3p1, <3 x ptr addrspace(3)> %v3p3, <3 x half> %v3f16) {
+  %v3f32.1.fpext = fpext <3 x float> %v3f32.1 to <3 x double>
+  %call1 = call i32 @printf(ptr addrspace(4) @format.str.v3, <3 x float> %v3f32.0, <3 x double> %v3f32.1.fpext, <3 x double> %v3f64, <3 x i8> %v3i8, <3 x i16> %v3i16, <3 x i32> %v3i32, <3 x i64> %v3i64,
+  <3 x ptr addrspace(1)> %v3p1, <3 x ptr addrspace(3)> %v3p3, <3 x half> %v3f16)
+  ret void
+}
+
+define i32 @format_str_v3_with_use(<3 x float> %v3f32.0, <3 x float> %v3f32.1, <3 x double> %v3f64, <3 x i8> %v3i8, <3 x i16> %v3i16, <3 x i32> %v3i32, <3 x i64> %v3i64,
+; R600-LABEL: @format_str_v3_with_use(
+; R600-NEXT:    [[V3F32_1_FPEXT:%.*]] = fpext <3 x float> [[V3F32_1:%.*]] to <3 x double>
+; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v3, <3 x float> [[V3F32_0:%.*]], <3 x double> [[V3F32_1_FPEXT]], <3 x double> [[V3F64:%.*]], <3 x i8> [[V3I8:%.*]], <3 x i16> [[V3I16:%.*]], <3 x i32> [[V3I32:%.*]], <3 x i64> [[V3I64:%.*]], <3 x ptr addrspace(1)> [[V3P1:%.*]], <3 x ptr addrspace(3)> [[V3P3:%.*]], <3 x half> [[V3F16:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @format_str_v3_with_use(
+; GCN-NEXT:    [[V3F32_1_FPEXT:%.*]] = fpext <3 x float> [[V3F32_1:%.*]] to <3 x double>
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 144)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 20, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store <3 x float> [[V3F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 16
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 16
@@ -537,11 +1000,11 @@ define i32 @format_str_v3(<3 x float> %v3f32.0, <3 x float> %v3f32.1, <3 x doubl
   ret i32 %call1
 }
 
-define i32 @format_str_v4(<4 x float> %v4f32.0, <4 x float> %v4f32.1, <4 x double> %v4f64, <4 x i8> %v4i8, <4 x i16> %v4i16, <4 x i32> %v4i32, <4 x i64> %v4i64,
+define void @format_str_v4(<4 x float> %v4f32.0, <4 x float> %v4f32.1, <4 x double> %v4f64, <4 x i8> %v4i8, <4 x i16> %v4i16, <4 x i32> %v4i32, <4 x i64> %v4i64,
 ; R600-LABEL: @format_str_v4(
 ; R600-NEXT:    [[V4F32_1_FPEXT:%.*]] = fpext <4 x float> [[V4F32_1:%.*]] to <4 x double>
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v4, <4 x float> [[V4F32_0:%.*]], <4 x double> [[V4F32_1_FPEXT]], <4 x double> [[V4F64:%.*]], <4 x i8> [[V4I8:%.*]], <4 x i16> [[V4I16:%.*]], <4 x i32> [[V4I32:%.*]], <4 x i64> [[V4I64:%.*]], <4 x ptr addrspace(1)> [[V4P1:%.*]], <4 x ptr addrspace(3)> [[V4P3:%.*]], <4 x half> [[V4F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_v4(
 ; GCN-NEXT:    [[V4F32_1_FPEXT:%.*]] = fpext <4 x float> [[V4F32_1:%.*]] to <4 x double>
@@ -553,7 +1016,50 @@ define i32 @format_str_v4(<4 x float> %v4f32.0, <4 x float> %v4f32.1, <4 x doubl
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 11, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 21, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store <4 x float> [[V4F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 16
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 16
+; GCN-NEXT:    store <4 x double> [[V4F32_1_FPEXT]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 32
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 32
+; GCN-NEXT:    store <4 x double> [[V4F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 32
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 32
+; GCN-NEXT:    store <4 x i8> [[V4I8:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store <4 x i16> [[V4I16:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 8
+; GCN-NEXT:    store <4 x i32> [[V4I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 16
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 16
+; GCN-NEXT:    store <4 x i64> [[V4I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 32
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 32
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  <4 x ptr addrspace(1)> %v4p1, <4 x ptr addrspace(3)> %v4p3, <4 x half> %v4f16) {
+  %v4f32.1.fpext = fpext <4 x float> %v4f32.1 to <4 x double>
+  %call1 = call i32 @printf(ptr addrspace(4) @format.str.v4, <4 x float> %v4f32.0, <4 x double> %v4f32.1.fpext, <4 x double> %v4f64, <4 x i8> %v4i8, <4 x i16> %v4i16, <4 x i32> %v4i32, <4 x i64> %v4i64,
+  <4 x ptr addrspace(1)> %v4p1, <4 x ptr addrspace(3)> %v4p3, <4 x half> %v4f16)
+  ret void
+}
+
+define i32 @format_str_v4_with_use(<4 x float> %v4f32.0, <4 x float> %v4f32.1, <4 x double> %v4f64, <4 x i8> %v4i8, <4 x i16> %v4i16, <4 x i32> %v4i32, <4 x i64> %v4i64,
+; R600-LABEL: @format_str_v4_with_use(
+; R600-NEXT:    [[V4F32_1_FPEXT:%.*]] = fpext <4 x float> [[V4F32_1:%.*]] to <4 x double>
+; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v4, <4 x float> [[V4F32_0:%.*]], <4 x double> [[V4F32_1_FPEXT]], <4 x double> [[V4F64:%.*]], <4 x i8> [[V4I8:%.*]], <4 x i16> [[V4I16:%.*]], <4 x i32> [[V4I32:%.*]], <4 x i64> [[V4I64:%.*]], <4 x ptr addrspace(1)> [[V4P1:%.*]], <4 x ptr addrspace(3)> [[V4P3:%.*]], <4 x half> [[V4F16:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @format_str_v4_with_use(
+; GCN-NEXT:    [[V4F32_1_FPEXT:%.*]] = fpext <4 x float> [[V4F32_1:%.*]] to <4 x double>
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 144)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 22, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store <4 x float> [[V4F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 16
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 16
@@ -582,11 +1088,11 @@ define i32 @format_str_v4(<4 x float> %v4f32.0, <4 x float> %v4f32.1, <4 x doubl
   ret i32 %call1
 }
 
-define i32 @format_str_v8(<8 x float> %v8f32.0, <8 x float> %v8f32.1, <8 x double> %v8f64, <8 x i8> %v8i8, <8 x i16> %v8i16, <8 x i32> %v8i32, <8 x i64> %v8i64,
+define void @format_str_v8(<8 x float> %v8f32.0, <8 x float> %v8f32.1, <8 x double> %v8f64, <8 x i8> %v8i8, <8 x i16> %v8i16, <8 x i32> %v8i32, <8 x i64> %v8i64,
 ; R600-LABEL: @format_str_v8(
 ; R600-NEXT:    [[V8F32_1_FPEXT:%.*]] = fpext <8 x float> [[V8F32_1:%.*]] to <8 x double>
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v8, <8 x float> [[V8F32_0:%.*]], <8 x double> [[V8F32_1_FPEXT]], <8 x double> [[V8F64:%.*]], <8 x i8> [[V8I8:%.*]], <8 x i16> [[V8I16:%.*]], <8 x i32> [[V8I32:%.*]], <8 x i64> [[V8I64:%.*]], <8 x ptr addrspace(1)> [[V8P1:%.*]], <8 x ptr addrspace(3)> [[V8P3:%.*]], <8 x half> [[V8F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_v8(
 ; GCN-NEXT:    [[V8F32_1_FPEXT:%.*]] = fpext <8 x float> [[V8F32_1:%.*]] to <8 x double>
@@ -598,7 +1104,50 @@ define i32 @format_str_v8(<8 x float> %v8f32.0, <8 x float> %v8f32.1, <8 x doubl
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 12, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 23, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store <8 x float> [[V8F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 32
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 32
+; GCN-NEXT:    store <8 x double> [[V8F32_1_FPEXT]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 64
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 64
+; GCN-NEXT:    store <8 x double> [[V8F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 64
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 64
+; GCN-NEXT:    store <8 x i8> [[V8I8:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 8
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 8
+; GCN-NEXT:    store <8 x i16> [[V8I16:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 16
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 16
+; GCN-NEXT:    store <8 x i32> [[V8I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 32
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 32
+; GCN-NEXT:    store <8 x i64> [[V8I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 64
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 64
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  <8 x ptr addrspace(1)> %v8p1, <8 x ptr addrspace(3)> %v8p3, <8 x half> %v8f16) {
+  %v8f32.1.fpext = fpext <8 x float> %v8f32.1 to <8 x double>
+  %call1 = call i32 @printf(ptr addrspace(4) @format.str.v8, <8 x float> %v8f32.0, <8 x double> %v8f32.1.fpext, <8 x double> %v8f64, <8 x i8> %v8i8, <8 x i16> %v8i16, <8 x i32> %v8i32, <8 x i64> %v8i64,
+  <8 x ptr addrspace(1)> %v8p1, <8 x ptr addrspace(3)> %v8p3, <8 x half> %v8f16)
+  ret void
+}
+
+define i32 @format_str_v8_with_use(<8 x float> %v8f32.0, <8 x float> %v8f32.1, <8 x double> %v8f64, <8 x i8> %v8i8, <8 x i16> %v8i16, <8 x i32> %v8i32, <8 x i64> %v8i64,
+; R600-LABEL: @format_str_v8_with_use(
+; R600-NEXT:    [[V8F32_1_FPEXT:%.*]] = fpext <8 x float> [[V8F32_1:%.*]] to <8 x double>
+; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v8, <8 x float> [[V8F32_0:%.*]], <8 x double> [[V8F32_1_FPEXT]], <8 x double> [[V8F64:%.*]], <8 x i8> [[V8I8:%.*]], <8 x i16> [[V8I16:%.*]], <8 x i32> [[V8I32:%.*]], <8 x i64> [[V8I64:%.*]], <8 x ptr addrspace(1)> [[V8P1:%.*]], <8 x ptr addrspace(3)> [[V8P3:%.*]], <8 x half> [[V8F16:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @format_str_v8_with_use(
+; GCN-NEXT:    [[V8F32_1_FPEXT:%.*]] = fpext <8 x float> [[V8F32_1:%.*]] to <8 x double>
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 284)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 24, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store <8 x float> [[V8F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 32
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 32
@@ -627,11 +1176,11 @@ define i32 @format_str_v8(<8 x float> %v8f32.0, <8 x float> %v8f32.1, <8 x doubl
   ret i32 %call1
 }
 
-define i32 @format_str_v16(<16 x float> %v16f32.0, <16 x float> %v16f32.1, <16 x double> %v16f64, <16 x i8> %v16i8, <16 x i16> %v16i16, <16 x i32> %v16i32, <16 x i64> %v16i64,
+define void @format_str_v16(<16 x float> %v16f32.0, <16 x float> %v16f32.1, <16 x double> %v16f64, <16 x i8> %v16i8, <16 x i16> %v16i16, <16 x i32> %v16i32, <16 x i64> %v16i64,
 ; R600-LABEL: @format_str_v16(
 ; R600-NEXT:    [[V16F32_1_FPEXT:%.*]] = fpext <16 x float> [[V16F32_1:%.*]] to <16 x double>
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v16, <16 x float> [[V16F32_0:%.*]], <16 x double> [[V16F32_1_FPEXT]], <16 x double> [[V16F64:%.*]], <16 x i8> [[V16I8:%.*]], <16 x i16> [[V16I16:%.*]], <16 x i32> [[V16I32:%.*]], <16 x i64> [[V16I64:%.*]], <16 x ptr addrspace(1)> [[V16P1:%.*]], <16 x ptr addrspace(3)> [[V16P3:%.*]], <16 x half> [[V16F16:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @format_str_v16(
 ; GCN-NEXT:    [[V16F32_1_FPEXT:%.*]] = fpext <16 x float> [[V16F32_1:%.*]] to <16 x double>
@@ -643,7 +1192,50 @@ define i32 @format_str_v16(<16 x float> %v16f32.0, <16 x float> %v16f32.1, <16 x
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 13, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 25, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store <16 x float> [[V16F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 64
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 64
+; GCN-NEXT:    store <16 x double> [[V16F32_1_FPEXT]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 128
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 128
+; GCN-NEXT:    store <16 x double> [[V16F64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 128
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 128
+; GCN-NEXT:    store <16 x i8> [[V16I8:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 16
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 16
+; GCN-NEXT:    store <16 x i16> [[V16I16:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 32
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 32
+; GCN-NEXT:    store <16 x i32> [[V16I32:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 64
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 64
+; GCN-NEXT:    store <16 x i64> [[V16I64:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 128
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 128
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  <16 x ptr addrspace(1)> %v16p1, <16 x ptr addrspace(3)> %v16p3, <16 x half> %v16f16) {
+  %v16f32.1.fpext = fpext <16 x float> %v16f32.1 to <16 x double>
+  %call1 = call i32 @printf(ptr addrspace(4) @format.str.v16, <16 x float> %v16f32.0, <16 x double> %v16f32.1.fpext, <16 x double> %v16f64, <16 x i8> %v16i8, <16 x i16> %v16i16, <16 x i32> %v16i32, <16 x i64> %v16i64,
+  <16 x ptr addrspace(1)> %v16p1, <16 x ptr addrspace(3)> %v16p3, <16 x half> %v16f16)
+  ret void
+}
+
+define i32 @format_str_v16_with_use(<16 x float> %v16f32.0, <16 x float> %v16f32.1, <16 x double> %v16f64, <16 x i8> %v16i8, <16 x i16> %v16i16, <16 x i32> %v16i32, <16 x i64> %v16i64,
+; R600-LABEL: @format_str_v16_with_use(
+; R600-NEXT:    [[V16F32_1_FPEXT:%.*]] = fpext <16 x float> [[V16F32_1:%.*]] to <16 x double>
+; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v16, <16 x float> [[V16F32_0:%.*]], <16 x double> [[V16F32_1_FPEXT]], <16 x double> [[V16F64:%.*]], <16 x i8> [[V16I8:%.*]], <16 x i16> [[V16I16:%.*]], <16 x i32> [[V16I32:%.*]], <16 x i64> [[V16I64:%.*]], <16 x ptr addrspace(1)> [[V16P1:%.*]], <16 x ptr addrspace(3)> [[V16P3:%.*]], <16 x half> [[V16F16:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @format_str_v16_with_use(
+; GCN-NEXT:    [[V16F32_1_FPEXT:%.*]] = fpext <16 x float> [[V16F32_1:%.*]] to <16 x double>
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 564)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 26, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store <16 x float> [[V16F32_0:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 64
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 64
@@ -690,7 +1282,7 @@ define amdgpu_kernel void @test_kernel(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 14, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 27, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -705,11 +1297,11 @@ entry:
   ret void
 }
 
-define i32 @test_format_str_no_null_terminator(i32 %n) {
+define amdgpu_kernel void @test_format_str_no_null_terminator(i32 %n) {
 ; R600-LABEL: @test_format_str_no_null_terminator(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @format.str.no.null.terminator, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_format_str_no_null_terminator(
 ; GCN-NEXT:  entry:
@@ -721,7 +1313,35 @@ define i32 @test_format_str_no_null_terminator(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 15, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 28, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @format.str.no.null.terminator, i32 %n)
+  ret void
+}
+
+define i32 @test_format_str_no_null_terminator_with_use(i32 %n) {
+; R600-LABEL: @test_format_str_no_null_terminator_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @format.str.no.null.terminator, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @test_format_str_no_null_terminator_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 8)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 29, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
@@ -736,11 +1356,11 @@ entry:
 }
 
 
-define i32 @test_indexed_format_str(i32 %n) {
+define amdgpu_kernel void @test_indexed_format_str(i32 %n) {
 ; R600-LABEL: @test_indexed_format_str(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i32 7), i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_indexed_format_str(
 ; GCN-NEXT:  entry:
@@ -752,7 +1372,35 @@ define i32 @test_indexed_format_str(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 16, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 30, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i32 7), i32 %n)
+  ret void
+}
+
+define i32 @test_indexed_format_str_with_use(i32 %n) {
+; R600-LABEL: @test_indexed_format_str_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i32 7), i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @test_indexed_format_str_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 8)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 31, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
@@ -766,11 +1414,11 @@ entry:
   ret i32 %call1
 }
 
-define i32 @test_indexed_format_str_oob(i32 %n) {
+define amdgpu_kernel void @test_indexed_format_str_oob(i32 %n) {
 ; R600-LABEL: @test_indexed_format_str_oob(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i64 11), i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_indexed_format_str_oob(
 ; GCN-NEXT:  entry:
@@ -782,7 +1430,34 @@ define i32 @test_indexed_format_str_oob(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 17, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 32, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i64 11), i32 %n)
+  ret void
+}
+
+define i32 @test_indexed_format_str_oob_with_use(i32 %n) {
+; R600-LABEL: @test_indexed_format_str_oob_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i64 11), i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @test_indexed_format_str_oob_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 4)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 33, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
@@ -795,11 +1470,11 @@ entry:
   ret i32 %call1
 }
 
-define i32 @string_pointee_type(i32 %n) {
+define amdgpu_kernel void @string_pointee_type(i32 %n) {
 ; R600-LABEL: @string_pointee_type(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @string_pointee_type(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -811,7 +1486,37 @@ define i32 @string_pointee_type(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 18, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 34, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(5) %str, i32 %n)
+  ret void
+}
+
+define i32 @string_pointee_type_with_use(i32 %n) {
+; R600-LABEL: @string_pointee_type_with_use(
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @string_pointee_type_with_use(
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 35, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -827,10 +1532,10 @@ define i32 @string_pointee_type(i32 %n) {
   ret i32 %call1
 }
 
-define i32 @string_address_space4(i32 %n, ptr addrspace(4) %str) {
+define amdgpu_kernel void @string_address_space4(i32 %n, ptr addrspace(4) %str) {
 ; R600-LABEL: @string_address_space4(
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) [[STR:%.*]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @string_address_space4(
 ; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
@@ -841,7 +1546,34 @@ define i32 @string_address_space4(i32 %n, ptr addrspace(4) %str) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 19, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 36, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) %str, i32 %n)
+  ret void
+}
+
+define i32 @string_address_space4_with_use(i32 %n, ptr addrspace(4) %str) {
+; R600-LABEL: @string_address_space4_with_use(
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) [[STR:%.*]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @string_address_space4_with_use(
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 37, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -856,10 +1588,10 @@ define i32 @string_address_space4(i32 %n, ptr addrspace(4) %str) {
   ret i32 %call1
 }
 
-define i32 @string_address_space1(i32 %n, ptr addrspace(1) %str) {
+define amdgpu_kernel void @string_address_space1(i32 %n, ptr addrspace(1) %str) {
 ; R600-LABEL: @string_address_space1(
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(1) [[STR:%.*]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @string_address_space1(
 ; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
@@ -870,7 +1602,34 @@ define i32 @string_address_space1(i32 %n, ptr addrspace(1) %str) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 20, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 38, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(1) %str, i32 %n)
+  ret void
+}
+
+define i32 @string_address_space1_with_use(i32 %n, ptr addrspace(1) %str) {
+; R600-LABEL: @string_address_space1_with_use(
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(1) [[STR:%.*]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @string_address_space1_with_use(
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 39, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -885,10 +1644,10 @@ define i32 @string_address_space1(i32 %n, ptr addrspace(1) %str) {
   ret i32 %call1
 }
 
-define i32 @string_format_passed_i32(i32 %n, i32 %str) {
+define amdgpu_kernel void @string_format_passed_i32(i32 %n, i32 %str) {
 ; R600-LABEL: @string_format_passed_i32(
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, i32 [[STR:%.*]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @string_format_passed_i32(
 ; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
@@ -899,7 +1658,34 @@ define i32 @string_format_passed_i32(i32 %n, i32 %str) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 21, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 40, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 [[STR:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, i32 %str, i32 %n)
+  ret void
+}
+
+define i32 @string_format_passed_i32_with_use(i32 %n, i32 %str) {
+; R600-LABEL: @string_format_passed_i32_with_use(
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, i32 [[STR:%.*]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @string_format_passed_i32_with_use(
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 41, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 [[STR:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -914,16 +1700,15 @@ define i32 @string_format_passed_i32(i32 %n, i32 %str) {
   ret i32 %call1
 }
 
-
 @str.as1 = private unnamed_addr addrspace(1) constant [6 x i8] c"%s:%d\00", align 1
 
-define i32 @test_kernel_addrspacecasted_format_str(i32 %n) {
+define amdgpu_kernel void @test_kernel_addrspacecasted_format_str(i32 %n) {
 ; R600-LABEL: @test_kernel_addrspacecasted_format_str(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[ARRAYDECAY:%.*]] = getelementptr inbounds [9 x i8], ptr addrspace(5) [[STR]], i32 0, i32 0
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) addrspacecast (ptr addrspace(1) @str.as1 to ptr addrspace(4)), ptr addrspace(5) [[ARRAYDECAY]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_kernel_addrspacecasted_format_str(
 ; GCN-NEXT:  entry:
@@ -937,7 +1722,43 @@ define i32 @test_kernel_addrspacecasted_format_str(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 22, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 42, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %arraydecay = getelementptr inbounds [9 x i8], ptr addrspace(5) %str, i32 0, i32 0
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) addrspacecast (ptr addrspace(1) @str.as1 to ptr addrspace(4)), ptr addrspace(5) %arraydecay, i32 %n)
+  ret void
+}
+
+define i32 @test_kernel_addrspacecasted_format_str_with_use(i32 %n) {
+; R600-LABEL: @test_kernel_addrspacecasted_format_str_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[ARRAYDECAY:%.*]] = getelementptr inbounds [9 x i8], ptr addrspace(5) [[STR]], i32 0, i32 0
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) addrspacecast (ptr addrspace(1) @str.as1 to ptr addrspace(4)), ptr addrspace(5) [[ARRAYDECAY]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @test_kernel_addrspacecasted_format_str_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    [[ARRAYDECAY:%.*]] = getelementptr inbounds [9 x i8], ptr addrspace(5) [[STR]], i32 0, i32 0
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 43, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -955,28 +1776,28 @@ entry:
   ret i32 %call1
 }
 
-define i32 @test_undef_argument(i32 %n) {
+define amdgpu_kernel void @test_undef_argument(i32 %n) {
 ; R600-LABEL: @test_undef_argument(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_undef_argument(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    ret i32 0
+; GCN-NEXT:    ret void
 ;
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) %str, i32 %n)
-  ret i32 %call1
+  ret void
 }
 
-define i32 @test_poison_argument(i32 %n) {
-; R600-LABEL: @test_poison_argument(
+define i32 @test_undef_argument_with_use(i32 %n) {
+; R600-LABEL: @test_undef_argument_with_use(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
 ; R600-NEXT:    ret i32 [[CALL1]]
 ;
-; GCN-LABEL: @test_poison_argument(
+; GCN-LABEL: @test_undef_argument_with_use(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; GCN-NEXT:    ret i32 0
 ;
@@ -985,13 +1806,58 @@ define i32 @test_poison_argument(i32 %n) {
   ret i32 %call1
 }
 
-define i32 @test_null_argument(i32 %n) {
+define amdgpu_kernel void @test_poison_argument(i32 %n) {
+; R600-LABEL: @test_poison_argument(
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
+; R600-NEXT:    ret void
+;
+; GCN-LABEL: @test_poison_argument(
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    ret void
+;
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) %str, i32 %n)
+  ret void
+}
+
+define i32 @test_poison_argument_with_use(i32 %n) {
+; R600-LABEL: @test_poison_argument_with_use(
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @test_poison_argument_with_use(
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    ret i32 0
+;
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) %str, i32 %n)
+  ret i32 %call1
+}
+
+define amdgpu_kernel void @test_null_argument(i32 %n) {
 ; R600-LABEL: @test_null_argument(
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) null, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
+; R600-NEXT:    ret void
+;
+; GCN-LABEL: @test_null_argument(
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    ret void
+;
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) null, ptr addrspace(5) %str, i32 %n)
+  ret void
+}
+
+define i32 @test_null_argument_with_use(i32 %n) {
+; R600-LABEL: @test_null_argument_with_use(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) null, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
 ; R600-NEXT:    ret i32 [[CALL1]]
 ;
-; GCN-LABEL: @test_null_argument(
+; GCN-LABEL: @test_null_argument_with_use(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; GCN-NEXT:    ret i32 0
 ;
@@ -1002,11 +1868,11 @@ define i32 @test_null_argument(i32 %n) {
 
 @undef.initializer = private unnamed_addr addrspace(4) constant [6 x i8] undef
 
-define i32 @undef_initializer_gv(i32 %n) {
+define amdgpu_kernel void @undef_initializer_gv(i32 %n) {
 ; R600-LABEL: @undef_initializer_gv(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @undef_initializer_gv(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -1018,7 +1884,34 @@ define i32 @undef_initializer_gv(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 23, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 44, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) %str, i32 %n)
+  ret void
+}
+
+define i32 @undef_initializer_gv_with_use(i32 %n) {
+; R600-LABEL: @undef_initializer_gv_with_use(
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @undef_initializer_gv_with_use(
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 4)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 45, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -1033,11 +1926,11 @@ define i32 @undef_initializer_gv(i32 %n) {
 
 @poison.initializer = private unnamed_addr addrspace(4) constant [6 x i8] poison
 
-define i32 @poison_initializer_gv(i32 %n) {
+define amdgpu_kernel void @poison_initializer_gv(i32 %n) {
 ; R600-LABEL: @poison_initializer_gv(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @poison_initializer_gv(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -1049,7 +1942,34 @@ define i32 @poison_initializer_gv(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 24, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 46, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) %str, i32 %n)
+  ret void
+}
+
+define i32 @poison_initializer_gv_with_use(i32 %n) {
+; R600-LABEL: @poison_initializer_gv_with_use(
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @poison_initializer_gv_with_use(
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 4)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 47, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -1064,11 +1984,11 @@ define i32 @poison_initializer_gv(i32 %n) {
 
 @zero.initializer = private unnamed_addr addrspace(4) constant [6 x i8] zeroinitializer
 
-define i32 @zero_initializer_gv(i32 %n) {
+define amdgpu_kernel void @zero_initializer_gv(i32 %n) {
 ; R600-LABEL: @zero_initializer_gv(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @zero_initializer_gv(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -1080,7 +2000,34 @@ define i32 @zero_initializer_gv(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 25, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 48, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) %str, i32 %n)
+  ret void
+}
+
+define i32 @zero_initializer_gv_with_use(i32 %n) {
+; R600-LABEL: @zero_initializer_gv_with_use(
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @zero_initializer_gv_with_use(
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 4)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 49, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -1093,11 +2040,11 @@ define i32 @zero_initializer_gv(i32 %n) {
   ret i32 %call1
 }
 
-define i32 @test_print_string_literal_size0(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size0(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size0(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size0, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size0(
 ; GCN-NEXT:  entry:
@@ -1109,7 +2056,37 @@ define i32 @test_print_string_literal_size0(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 26, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 50, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size0, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size0_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size0_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size0, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size0_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 51, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1125,11 +2102,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_1ai8.zero(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_1ai8.zero(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_1ai8.zero(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.zero, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_1ai8.zero(
 ; GCN-NEXT:  entry:
@@ -1141,7 +2118,37 @@ define i32 @test_print_string_literal_1ai8.zero(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 27, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 52, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.zero, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_1ai8_with_use.zero(i32 %n) {
+; R600-LABEL: @test_print_string_literal_1ai8_with_use.zero(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.zero, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_1ai8_with_use.zero(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 53, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1157,11 +2164,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_1ai8.undef(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_1ai8.undef(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_1ai8.undef(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.undef, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_1ai8.undef(
 ; GCN-NEXT:  entry:
@@ -1173,7 +2180,37 @@ define i32 @test_print_string_literal_1ai8.undef(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 28, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 54, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.undef, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_1ai8_with_use.undef(i32 %n) {
+; R600-LABEL: @test_print_string_literal_1ai8_with_use.undef(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.undef, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_1ai8_with_use.undef(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 55, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1189,11 +2226,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_i8.zero(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_i8.zero(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_i8.zero(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.i8.zero, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_i8.zero(
 ; GCN-NEXT:  entry:
@@ -1205,7 +2242,37 @@ define i32 @test_print_string_literal_i8.zero(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 29, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 56, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.i8.zero, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_i8_with_use.zero(i32 %n) {
+; R600-LABEL: @test_print_string_literal_i8_with_use.zero(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.i8.zero, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_i8_with_use.zero(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 57, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1221,11 +2288,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size2(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size2(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size2(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size2, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size2(
 ; GCN-NEXT:  entry:
@@ -1237,7 +2304,37 @@ define i32 @test_print_string_literal_size2(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 30, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 58, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 27, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size2, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size2_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size2_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size2, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size2_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 59, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 27, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1253,11 +2350,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size3(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size3(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size3(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size3(
 ; GCN-NEXT:  entry:
@@ -1269,7 +2366,37 @@ define i32 @test_print_string_literal_size3(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 31, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 60, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 7195, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size3_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size3_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size3_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 61, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 7195, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1285,11 +2412,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size3_zero(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size3_zero(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size3_zero(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3.zero, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size3_zero(
 ; GCN-NEXT:  entry:
@@ -1301,7 +2428,37 @@ define i32 @test_print_string_literal_size3_zero(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 32, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 62, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3.zero, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size3_zero_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size3_zero_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3.zero, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size3_zero_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 63, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1317,11 +2474,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size4(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size4(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size4(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size4(
 ; GCN-NEXT:  entry:
@@ -1333,7 +2490,37 @@ define i32 @test_print_string_literal_size4(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 33, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 64, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 6513249, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size4_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size4_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size4_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 65, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 6513249, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1349,11 +2536,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size4_nonull_term(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size4_nonull_term(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size4_nonull_term(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4.nonull.term, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size4_nonull_term(
 ; GCN-NEXT:  entry:
@@ -1365,7 +2552,37 @@ define i32 @test_print_string_literal_size4_nonull_term(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 34, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 66, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4.nonull.term, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size4_nonull_term_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size4_nonull_term_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4.nonull.term, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size4_nonull_term_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 67, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1381,11 +2598,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size5(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size5(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size5(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size5, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size5(
 ; GCN-NEXT:  entry:
@@ -1397,7 +2614,37 @@ define i32 @test_print_string_literal_size5(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 35, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 68, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size5, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size5_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size5_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size5, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size5_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 69, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1413,11 +2660,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size6(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size6(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size6(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size6(
 ; GCN-NEXT:  entry:
@@ -1429,7 +2676,39 @@ define i32 @test_print_string_literal_size6(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 36, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 70, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 101, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size6_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size6_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size6_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 71, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1447,11 +2726,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size7(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size7(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size7(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size7(
 ; GCN-NEXT:  entry:
@@ -1463,7 +2742,39 @@ define i32 @test_print_string_literal_size7(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 37, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 72, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 101, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size7_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size7_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size7_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 73, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1481,11 +2792,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size8(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size8(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size8(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size8, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size8(
 ; GCN-NEXT:  entry:
@@ -1497,7 +2808,39 @@ define i32 @test_print_string_literal_size8(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 38, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 74, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 7565921, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size8, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size8_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size8_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size8, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size8_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 75, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1515,11 +2858,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size9(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size9(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size9(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size9, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size9(
 ; GCN-NEXT:  entry:
@@ -1531,7 +2874,39 @@ define i32 @test_print_string_literal_size9(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 39, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 76, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 1684104548, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 1717921122, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size9, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size9_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size9_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size9, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size9_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 20)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 77, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684104548, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1549,11 +2924,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size16(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size16(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size16(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size16, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size16(
 ; GCN-NEXT:  entry:
@@ -1565,7 +2940,43 @@ define i32 @test_print_string_literal_size16(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 40, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 78, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 909194801, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 909194801, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
+; GCN-NEXT:    store i32 909194801, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
+; GCN-NEXT:    store i32 3225137, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size16, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size16_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size16_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size16, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size16_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 24)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 79, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 909194801, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1587,11 +2998,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size17(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size17(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size17(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size17, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size17(
 ; GCN-NEXT:  entry:
@@ -1603,7 +3014,43 @@ define i32 @test_print_string_literal_size17(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 41, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 80, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 925972273, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 925972273, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
+; GCN-NEXT:    store i32 925972273, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
+; GCN-NEXT:    store i32 925972273, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size17, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size17_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size17_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size17, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size17_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 28)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 81, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 925972273, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1625,11 +3072,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size20(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size20(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size20(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size20, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size20(
 ; GCN-NEXT:  entry:
@@ -1641,7 +3088,45 @@ define i32 @test_print_string_literal_size20(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 42, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 82, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 1751606885, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
+; GCN-NEXT:    store i32 1818978921, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
+; GCN-NEXT:    store i32 1886350957, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store i32 7565937, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size20, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size20_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size20_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size20, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size20_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 28)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 83, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1665,11 +3150,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_size32(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_size32(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size32(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size32, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_size32(
 ; GCN-NEXT:  entry:
@@ -1681,7 +3166,51 @@ define i32 @test_print_string_literal_size32(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 43, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 84, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
+; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
+; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR4:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], i32 4
+; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR5:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], i32 4
+; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 4
+; GCN-NEXT:    store i32 7565921, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR7:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR6]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size32, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_size32_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_size32_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size32, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_size32_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 40)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 85, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1711,11 +3240,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_not_constant_global(i32 %n) {
+define amdgpu_kernel void @test_print_string_not_constant_global(i32 %n) {
 ; R600-LABEL: @test_print_string_not_constant_global(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.not.constant.size4, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_not_constant_global(
 ; GCN-NEXT:  entry:
@@ -1727,7 +3256,37 @@ define i32 @test_print_string_not_constant_global(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 44, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 86, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.not.constant.size4, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_not_constant_global_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_not_constant_global_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.not.constant.size4, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_not_constant_global_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 87, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1743,11 +3302,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_constant_interposable_global(i32 %n) {
+define amdgpu_kernel void @test_print_string_constant_interposable_global(i32 %n) {
 ; R600-LABEL: @test_print_string_constant_interposable_global(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.interposable.size4, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_constant_interposable_global(
 ; GCN-NEXT:  entry:
@@ -1759,7 +3318,37 @@ define i32 @test_print_string_constant_interposable_global(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 45, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 88, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.interposable.size4, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_constant_interposable_global_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_constant_interposable_global_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.interposable.size4, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_constant_interposable_global_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 89, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1775,11 +3364,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_v4i8(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_v4i8(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_v4i8(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i8, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_v4i8(
 ; GCN-NEXT:  entry:
@@ -1791,7 +3380,37 @@ define i32 @test_print_string_literal_v4i8(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 46, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 90, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 67305985, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i8, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_v4i8_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_v4i8_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i8, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_v4i8_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 16)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 91, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 67305985, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1807,11 +3426,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_v4i32(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_v4i32(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_v4i32(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i32, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_v4i32(
 ; GCN-NEXT:  entry:
@@ -1823,7 +3442,37 @@ define i32 @test_print_string_literal_v4i32(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 47, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 92, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 1, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i32, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_v4i32_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_v4i32_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i32, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_v4i32_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 93, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1839,11 +3488,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_literal_struct(i32 %n) {
+define amdgpu_kernel void @test_print_string_literal_struct(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_struct(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.struct, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_literal_struct(
 ; GCN-NEXT:  entry:
@@ -1855,7 +3504,37 @@ define i32 @test_print_string_literal_struct(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 48, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 94, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 66, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.struct, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_literal_struct_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_literal_struct_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.struct, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_literal_struct_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 95, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 66, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1871,11 +3550,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_undef(i32 %n) {
+define amdgpu_kernel void @test_print_string_undef(i32 %n) {
 ; R600-LABEL: @test_print_string_undef(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_undef(
 ; GCN-NEXT:  entry:
@@ -1887,7 +3566,37 @@ define i32 @test_print_string_undef(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 49, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 96, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_undef_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_undef_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_undef_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 97, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1903,11 +3612,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_poison(i32 %n) {
+define amdgpu_kernel void @test_print_string_poison(i32 %n) {
 ; R600-LABEL: @test_print_string_poison(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_poison(
 ; GCN-NEXT:  entry:
@@ -1919,7 +3628,37 @@ define i32 @test_print_string_poison(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 50, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 98, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_poison_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_poison_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_poison_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 99, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1935,11 +3674,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_null(i32 %n) {
+define amdgpu_kernel void @test_print_string_null(i32 %n) {
 ; R600-LABEL: @test_print_string_null(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) null, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_null(
 ; GCN-NEXT:  entry:
@@ -1951,7 +3690,37 @@ define i32 @test_print_string_null(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 51, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 100, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) null, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_null_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_null_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) null, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_null_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 101, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1967,11 +3736,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_inttoptr(i32 %n) {
+define amdgpu_kernel void @test_print_string_inttoptr(i32 %n) {
 ; R600-LABEL: @test_print_string_inttoptr(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) inttoptr (i64 1234 to ptr addrspace(4)), i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_inttoptr(
 ; GCN-NEXT:  entry:
@@ -1983,7 +3752,37 @@ define i32 @test_print_string_inttoptr(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 52, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 102, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) inttoptr (i64 1234 to ptr addrspace(4)), i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_inttoptr_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_inttoptr_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) inttoptr (i64 1234 to ptr addrspace(4)), i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_inttoptr_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 103, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -1999,11 +3798,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_float_neg0(i32 %n) {
+define amdgpu_kernel void @test_print_string_float_neg0(i32 %n) {
 ; R600-LABEL: @test_print_string_float_neg0(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_float_neg0(
 ; GCN-NEXT:  entry:
@@ -2015,7 +3814,37 @@ define i32 @test_print_string_float_neg0(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 53, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 104, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_float_neg0_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_float_neg0_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_float_neg0_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 105, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2031,11 +3860,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_float_0(i32 %n) {
+define amdgpu_kernel void @test_print_string_float_0(i32 %n) {
 ; R600-LABEL: @test_print_string_float_0(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_float_0(
 ; GCN-NEXT:  entry:
@@ -2047,7 +3876,37 @@ define i32 @test_print_string_float_0(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 54, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 106, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_float_0_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_float_0_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_float_0_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 107, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2063,11 +3922,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_ptr_null(i32 %n) {
+define amdgpu_kernel void @test_print_string_ptr_null(i32 %n) {
 ; R600-LABEL: @test_print_string_ptr_null(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.null, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_ptr_null(
 ; GCN-NEXT:  entry:
@@ -2079,7 +3938,37 @@ define i32 @test_print_string_ptr_null(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 55, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 108, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.null, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_ptr_null_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_ptr_null_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.null, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_ptr_null_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 109, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2095,11 +3984,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_ptr_undef(i32 %n) {
+define amdgpu_kernel void @test_print_string_ptr_undef(i32 %n) {
 ; R600-LABEL: @test_print_string_ptr_undef(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.undef, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_ptr_undef(
 ; GCN-NEXT:  entry:
@@ -2111,7 +4000,37 @@ define i32 @test_print_string_ptr_undef(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 56, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 110, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.undef, i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_ptr_undef_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_ptr_undef_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.undef, i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_ptr_undef_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 111, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2127,11 +4046,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_indexed(i32 %n) {
+define amdgpu_kernel void @test_print_string_indexed(i32 %n) {
 ; R600-LABEL: @test_print_string_indexed(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 15), i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_indexed(
 ; GCN-NEXT:  entry:
@@ -2143,7 +4062,43 @@ define i32 @test_print_string_indexed(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 57, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 112, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 1936875892, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 1936875892, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR1:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR]], i32 4
+; GCN-NEXT:    store i32 1936875892, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR2:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], i32 4
+; GCN-NEXT:    store i32 1936875892, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR3:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR2]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 15), i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_indexed_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_indexed_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 15), i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_indexed_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 28)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 113, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1936875892, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2165,11 +4120,11 @@ entry:
   ret i32 %printf
 }
 
-define i32 @test_print_string_indexed_oob(i32 %n) {
+define amdgpu_kernel void @test_print_string_indexed_oob(i32 %n) {
 ; R600-LABEL: @test_print_string_indexed_oob(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 32), i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_print_string_indexed_oob(
 ; GCN-NEXT:  entry:
@@ -2181,7 +4136,37 @@ define i32 @test_print_string_indexed_oob(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 58, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 114, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
+; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
+; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
+; GCN-NEXT:    br label [[TMP2]]
+; GCN:       2:
+; GCN-NEXT:    ret void
+;
+entry:
+  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 32), i32 %n)
+  ret void
+}
+
+define i32 @test_print_string_indexed_oob_with_use(i32 %n) {
+; R600-LABEL: @test_print_string_indexed_oob_with_use(
+; R600-NEXT:  entry:
+; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 32), i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[PRINTF]]
+;
+; GCN-LABEL: @test_print_string_indexed_oob_with_use(
+; GCN-NEXT:  entry:
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
+; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
+; GCN:       entry.split:
+; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
+; GCN:       1:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 115, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2200,11 +4185,11 @@ entry:
 @array.i16 = private unnamed_addr addrspace(4) constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
 
 ; CHECK: error: <unknown>:0:0: in function test_format_array_i16 void (i32): printf format string must be a trivially resolved constant string global variable
-define i32 @test_format_array_i16(i32 %n) {
+define amdgpu_kernel void @test_format_array_i16(i32 %n) {
 ; R600-LABEL: @test_format_array_i16(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @array.i16, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_format_array_i16(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -2216,7 +4201,34 @@ define i32 @test_format_array_i16(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 59, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 116, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @array.i16, ptr addrspace(5) %str, i32 %n)
+  ret void
+}
+
+define i32 @test_format_array_i16_with_use(i32 %n) {
+; R600-LABEL: @test_format_array_i16_with_use(
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @array.i16, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @test_format_array_i16_with_use(
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 4)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 117, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -2231,11 +4243,11 @@ define i32 @test_format_array_i16(i32 %n) {
 
 @struct = private unnamed_addr addrspace(4) constant { [6 x i8] } { [6 x i8] [i8 1, i8 2, i8 3, i8 4, i8 5, i8 6] }
 
-define i32 @test_format_struct(i32 %n) {
+define amdgpu_kernel void @test_format_struct(i32 %n) {
 ; R600-LABEL: @test_format_struct(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @struct, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @test_format_struct(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -2247,7 +4259,34 @@ define i32 @test_format_struct(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 60, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 118, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
+; GCN-NEXT:    br label [[TMP3]]
+; GCN:       3:
+; GCN-NEXT:    ret void
+;
+  %str = alloca [9 x i8], align 1, addrspace(5)
+  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @struct, ptr addrspace(5) %str, i32 %n)
+  ret void
+}
+
+define i32 @test_format_struct_with_use(i32 %n) {
+; R600-LABEL: @test_format_struct_with_use(
+; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @struct, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
+; R600-NEXT:    ret i32 [[CALL1]]
+;
+; GCN-LABEL: @test_format_struct_with_use(
+; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
+; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 4)
+; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
+; GCN:       .split:
+; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
+; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
+; GCN:       2:
+; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
+; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
+; GCN-NEXT:    store i32 119, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -2275,10 +4314,10 @@ define void @not_call_operand_printf() {
   ret void
 }
 
-define i32 @printf_printf(i32 %n) {
+define void @printf_printf(i32 %n) {
 ; R600-LABEL: @printf_printf(
 ; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.one.ptr, ptr @printf)
-; R600-NEXT:    ret i32 [[CALL]]
+; R600-NEXT:    ret void
 ;
 ; GCN-LABEL: @printf_printf(
 ; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
@@ -2289,17 +4328,15 @@ define i32 @printf_printf(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 61, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 120, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store ptr @printf, ptr addrspace(1) [[PRINTBUFFGEP]], align 8
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
+; GCN-NEXT:    ret void
 ;
   %call = call i32 @printf(ptr addrspace(4) @format.str.one.ptr, ptr @printf)
-  ret i32 %call
+  ret void
 }
 
 declare i32 @printf(ptr addrspace(4), ...)

--- a/llvm/test/CodeGen/AMDGPU/opencl-printf.ll
+++ b/llvm/test/CodeGen/AMDGPU/opencl-printf.ll
@@ -1791,21 +1791,6 @@ define amdgpu_kernel void @test_undef_argument(i32 %n) {
   ret void
 }
 
-define i32 @test_undef_argument_with_use(i32 %n) {
-; R600-LABEL: @test_undef_argument_with_use(
-; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @test_undef_argument_with_use(
-; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    ret i32 0
-;
-  %str = alloca [9 x i8], align 1, addrspace(5)
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) %str, i32 %n)
-  ret i32 %call1
-}
-
 define amdgpu_kernel void @test_poison_argument(i32 %n) {
 ; R600-LABEL: @test_poison_argument(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -1895,35 +1880,6 @@ define amdgpu_kernel void @undef_initializer_gv(i32 %n) {
   ret void
 }
 
-define i32 @undef_initializer_gv_with_use(i32 %n) {
-; R600-LABEL: @undef_initializer_gv_with_use(
-; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[CALL1]]
-;
-; GCN-LABEL: @undef_initializer_gv_with_use(
-; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 4)
-; GCN-NEXT:    br label [[DOTSPLIT:%.*]]
-; GCN:       .split:
-; GCN-NEXT:    [[TMP1:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP1]], label [[TMP2:%.*]], label [[TMP3:%.*]]
-; GCN:       2:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 45, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    br label [[TMP3]]
-; GCN:       3:
-; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-  %str = alloca [9 x i8], align 1, addrspace(5)
-  %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) %str, i32 %n)
-  ret i32 %call1
-}
-
 @poison.initializer = private unnamed_addr addrspace(4) constant [6 x i8] poison
 
 define amdgpu_kernel void @poison_initializer_gv(i32 %n) {
@@ -1942,7 +1898,7 @@ define amdgpu_kernel void @poison_initializer_gv(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 46, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 45, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -1969,7 +1925,7 @@ define i32 @poison_initializer_gv_with_use(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 47, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 46, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -2000,7 +1956,7 @@ define amdgpu_kernel void @zero_initializer_gv(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 48, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 47, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -2027,7 +1983,7 @@ define i32 @zero_initializer_gv_with_use(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 49, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 48, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -2056,7 +2012,7 @@ define amdgpu_kernel void @test_print_string_literal_size0(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 50, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 49, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2086,7 +2042,7 @@ define i32 @test_print_string_literal_size0_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 51, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 50, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2118,7 +2074,7 @@ define amdgpu_kernel void @test_print_string_literal_1ai8.zero(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 52, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 51, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2148,7 +2104,7 @@ define i32 @test_print_string_literal_1ai8_with_use.zero(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 53, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 52, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2180,7 +2136,7 @@ define amdgpu_kernel void @test_print_string_literal_1ai8.undef(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 54, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 53, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2192,38 +2148,6 @@ define amdgpu_kernel void @test_print_string_literal_1ai8.undef(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.undef, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_literal_1ai8_with_use.undef(i32 %n) {
-; R600-LABEL: @test_print_string_literal_1ai8_with_use.undef(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.undef, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_literal_1ai8_with_use.undef(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 55, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.undef, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_literal_i8.zero(i32 %n) {
@@ -2242,7 +2166,7 @@ define amdgpu_kernel void @test_print_string_literal_i8.zero(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 56, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 54, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2272,7 +2196,7 @@ define i32 @test_print_string_literal_i8_with_use.zero(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 57, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 55, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2304,7 +2228,7 @@ define amdgpu_kernel void @test_print_string_literal_size2(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 58, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 56, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 27, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2334,7 +2258,7 @@ define i32 @test_print_string_literal_size2_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 59, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 57, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 27, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2366,7 +2290,7 @@ define amdgpu_kernel void @test_print_string_literal_size3(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 60, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 58, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 7195, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2396,7 +2320,7 @@ define i32 @test_print_string_literal_size3_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 61, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 59, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 7195, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2428,7 +2352,7 @@ define amdgpu_kernel void @test_print_string_literal_size3_zero(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 62, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 60, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2458,7 +2382,7 @@ define i32 @test_print_string_literal_size3_zero_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 63, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 61, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2490,7 +2414,7 @@ define amdgpu_kernel void @test_print_string_literal_size4(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 64, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 62, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 6513249, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2520,7 +2444,7 @@ define i32 @test_print_string_literal_size4_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 65, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 63, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 6513249, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2552,7 +2476,7 @@ define amdgpu_kernel void @test_print_string_literal_size4_nonull_term(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 66, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 64, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2582,7 +2506,7 @@ define i32 @test_print_string_literal_size4_nonull_term_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 67, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 65, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2614,7 +2538,7 @@ define amdgpu_kernel void @test_print_string_literal_size5(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 68, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 66, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2644,7 +2568,7 @@ define i32 @test_print_string_literal_size5_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 69, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 67, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2676,7 +2600,7 @@ define amdgpu_kernel void @test_print_string_literal_size6(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 70, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 68, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2708,7 +2632,7 @@ define i32 @test_print_string_literal_size6_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 71, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 69, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2742,7 +2666,7 @@ define amdgpu_kernel void @test_print_string_literal_size7(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 72, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 70, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2774,7 +2698,7 @@ define i32 @test_print_string_literal_size7_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 73, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 71, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2808,7 +2732,7 @@ define amdgpu_kernel void @test_print_string_literal_size8(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 74, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 72, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2840,7 +2764,7 @@ define i32 @test_print_string_literal_size8_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 75, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 73, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2874,7 +2798,7 @@ define amdgpu_kernel void @test_print_string_literal_size9(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 76, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 74, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684104548, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2906,7 +2830,7 @@ define i32 @test_print_string_literal_size9_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 77, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 75, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684104548, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2940,7 +2864,7 @@ define amdgpu_kernel void @test_print_string_literal_size16(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 78, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 76, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 909194801, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -2976,7 +2900,7 @@ define i32 @test_print_string_literal_size16_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 79, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 77, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 909194801, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3014,7 +2938,7 @@ define amdgpu_kernel void @test_print_string_literal_size17(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 80, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 78, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 925972273, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3050,7 +2974,7 @@ define i32 @test_print_string_literal_size17_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 81, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 79, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 925972273, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3088,7 +3012,7 @@ define amdgpu_kernel void @test_print_string_literal_size20(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 82, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 80, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3126,7 +3050,7 @@ define i32 @test_print_string_literal_size20_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 83, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 81, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1684234849, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3166,7 +3090,7 @@ define amdgpu_kernel void @test_print_string_literal_size32(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 84, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 82, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3210,7 +3134,7 @@ define i32 @test_print_string_literal_size32_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 85, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 83, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1953722977, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3256,7 +3180,7 @@ define amdgpu_kernel void @test_print_string_not_constant_global(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 86, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 84, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3286,7 +3210,7 @@ define i32 @test_print_string_not_constant_global_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 87, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 85, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3318,7 +3242,7 @@ define amdgpu_kernel void @test_print_string_constant_interposable_global(i32 %n
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 88, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 86, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3348,7 +3272,7 @@ define i32 @test_print_string_constant_interposable_global_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 89, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 87, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3380,7 +3304,7 @@ define amdgpu_kernel void @test_print_string_literal_v4i8(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 90, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 88, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 67305985, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3410,7 +3334,7 @@ define i32 @test_print_string_literal_v4i8_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 91, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 89, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 67305985, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3442,7 +3366,7 @@ define amdgpu_kernel void @test_print_string_literal_v4i32(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 92, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 90, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3472,7 +3396,7 @@ define i32 @test_print_string_literal_v4i32_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 93, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 91, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3504,7 +3428,7 @@ define amdgpu_kernel void @test_print_string_literal_struct(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 94, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 92, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 66, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3534,7 +3458,7 @@ define i32 @test_print_string_literal_struct_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 95, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 93, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 66, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3566,7 +3490,7 @@ define amdgpu_kernel void @test_print_string_undef(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 96, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 94, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3578,38 +3502,6 @@ define amdgpu_kernel void @test_print_string_undef(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_undef_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_undef_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_undef_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 97, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_poison(i32 %n) {
@@ -3628,7 +3520,7 @@ define amdgpu_kernel void @test_print_string_poison(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 98, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 95, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3658,7 +3550,7 @@ define i32 @test_print_string_poison_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 99, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 96, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3690,7 +3582,7 @@ define amdgpu_kernel void @test_print_string_null(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 100, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 97, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3720,7 +3612,7 @@ define i32 @test_print_string_null_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 101, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 98, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3752,7 +3644,7 @@ define amdgpu_kernel void @test_print_string_inttoptr(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 102, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 99, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3782,7 +3674,7 @@ define i32 @test_print_string_inttoptr_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 103, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 100, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 4144959, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3814,7 +3706,7 @@ define amdgpu_kernel void @test_print_string_float_neg0(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 104, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 101, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3844,7 +3736,7 @@ define i32 @test_print_string_float_neg0_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 105, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 102, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3876,7 +3768,7 @@ define amdgpu_kernel void @test_print_string_float_0(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 106, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 103, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3906,7 +3798,7 @@ define i32 @test_print_string_float_0_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 107, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 104, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3938,7 +3830,7 @@ define amdgpu_kernel void @test_print_string_ptr_null(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 108, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 105, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -3968,7 +3860,7 @@ define i32 @test_print_string_ptr_null_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 109, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 106, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -4000,7 +3892,7 @@ define amdgpu_kernel void @test_print_string_ptr_undef(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 110, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 107, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -4012,38 +3904,6 @@ define amdgpu_kernel void @test_print_string_ptr_undef(i32 %n) {
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.undef, i32 %n)
   ret void
-}
-
-define i32 @test_print_string_ptr_undef_with_use(i32 %n) {
-; R600-LABEL: @test_print_string_ptr_undef_with_use(
-; R600-NEXT:  entry:
-; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.undef, i32 [[N:%.*]])
-; R600-NEXT:    ret i32 [[PRINTF]]
-;
-; GCN-LABEL: @test_print_string_ptr_undef_with_use(
-; GCN-NEXT:  entry:
-; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
-; GCN-NEXT:    br label [[ENTRY_SPLIT:%.*]]
-; GCN:       entry.split:
-; GCN-NEXT:    [[TMP0:%.*]] = icmp ne ptr addrspace(1) [[PRINTF_ALLOC_FN]], null
-; GCN-NEXT:    br i1 [[TMP0]], label [[TMP1:%.*]], label [[TMP2:%.*]]
-; GCN:       1:
-; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
-; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 111, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
-; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
-; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
-; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
-; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
-; GCN-NEXT:    br label [[TMP2]]
-; GCN:       2:
-; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
-; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
-; GCN-NEXT:    ret i32 [[PRINTF_RES]]
-;
-entry:
-  %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.undef, i32 %n)
-  ret i32 %printf
 }
 
 define amdgpu_kernel void @test_print_string_indexed(i32 %n) {
@@ -4062,7 +3922,7 @@ define amdgpu_kernel void @test_print_string_indexed(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 112, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 108, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1936875892, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -4098,7 +3958,7 @@ define i32 @test_print_string_indexed_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 113, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 109, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 1936875892, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -4136,7 +3996,7 @@ define amdgpu_kernel void @test_print_string_indexed_oob(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 114, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 110, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -4166,7 +4026,7 @@ define i32 @test_print_string_indexed_oob_with_use(i32 %n) {
 ; GCN:       1:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 115, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 111, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store i32 -256, ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFGEP]], i32 4
@@ -4201,7 +4061,7 @@ define amdgpu_kernel void @test_format_array_i16(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 116, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 112, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -4228,7 +4088,7 @@ define i32 @test_format_array_i16_with_use(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 117, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 113, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -4259,7 +4119,7 @@ define amdgpu_kernel void @test_format_struct(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 118, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 114, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -4286,7 +4146,7 @@ define i32 @test_format_struct_with_use(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 119, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 115, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
@@ -4328,7 +4188,7 @@ define void @printf_printf(i32 %n) {
 ; GCN:       2:
 ; GCN-NEXT:    [[PRINTBUFFID:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 0
 ; GCN-NEXT:    [[PRINTBUFFIDCAST:%.*]] = bitcast ptr addrspace(1) [[PRINTBUFFID]] to ptr addrspace(1)
-; GCN-NEXT:    store i32 120, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
+; GCN-NEXT:    store i32 116, ptr addrspace(1) [[PRINTBUFFIDCAST]], align 4
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    store ptr @printf, ptr addrspace(1) [[PRINTBUFFGEP]], align 8
 ; GCN-NEXT:    br label [[TMP3]]

--- a/llvm/test/CodeGen/AMDGPU/opencl-printf.ll
+++ b/llvm/test/CodeGen/AMDGPU/opencl-printf.ll
@@ -54,11 +54,11 @@
 @format.str.one.ptr = private unnamed_addr addrspace(4) constant [8 x i8] c"arst %p\00", align 1
 
 
-define amdgpu_kernel void @format_str_f(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
+define i32 @format_str_f(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
 ; R600-LABEL: @format_str_f(
 ; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.f, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @format_str_f(
 ; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
@@ -98,18 +98,20 @@ define amdgpu_kernel void @format_str_f(float %f32.0, double %f64, float %f32.1,
 ; GCN-NEXT:    store i32 [[TMP3]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
 ; GCN-NEXT:    br label [[TMP6]]
 ; GCN:       6:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP7:%.*]] = xor i1 [[TMP4]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP7]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %fpext.f32.to.f64 = fpext float %f32.1 to double
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.f, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
-  ret void
+  ret i32 %call1
 }
 
-define amdgpu_kernel void @format_str_F(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
+define i32 @format_str_F(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
 ; R600-LABEL: @format_str_F(
 ; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.F, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @format_str_F(
 ; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
@@ -149,18 +151,20 @@ define amdgpu_kernel void @format_str_F(float %f32.0, double %f64, float %f32.1,
 ; GCN-NEXT:    store i32 [[TMP6]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       6:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP7:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP7]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %fpext.f32.to.f64 = fpext float %f32.1 to double
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.F, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
-  ret void
+  ret i32 %call1
 }
 
-define amdgpu_kernel void @format_str_a(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
+define i32 @format_str_a(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
 ; R600-LABEL: @format_str_a(
 ; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.a, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @format_str_a(
 ; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
@@ -200,18 +204,20 @@ define amdgpu_kernel void @format_str_a(float %f32.0, double %f64, float %f32.1,
 ; GCN-NEXT:    store i32 [[TMP3]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
 ; GCN-NEXT:    br label [[TMP6]]
 ; GCN:       6:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP7:%.*]] = xor i1 [[TMP4]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP7]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %fpext.f32.to.f64 = fpext float %f32.1 to double
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.a, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
-  ret void
+  ret i32 %call1
 }
 
-define amdgpu_kernel void @format_str_A(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
+define i32 @format_str_A(float %f32.0, double %f64, float %f32.1, i16 %i16, i32 %i32, i64 %i64, half %f16) {
 ; R600-LABEL: @format_str_A(
 ; R600-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.A, float [[F32_0:%.*]], double [[F64:%.*]], double [[FPEXT_F32_TO_F64]], float 1.000000e+00, double 2.000000e+00, i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], <2 x float> <float 1.000000e+00, float 2.000000e+00>, <2 x i32> <i32 8, i32 234>, half [[F16:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @format_str_A(
 ; GCN-NEXT:    [[FPEXT_F32_TO_F64:%.*]] = fpext float [[F32_1:%.*]] to double
@@ -251,17 +257,19 @@ define amdgpu_kernel void @format_str_A(float %f32.0, double %f64, float %f32.1,
 ; GCN-NEXT:    store i32 [[TMP6]], ptr addrspace(1) [[PRINTBUFFNEXTPTR9]], align 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       6:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP7:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP7]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %fpext.f32.to.f64 = fpext float %f32.1 to double
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.A, float %f32.0, double %f64, double %fpext.f32.to.f64, float 1.0, double 2.0, i16 %i16, i32 %i32, i64 %i64, <2 x float> <float 1.0, float 2.0>, <2 x i32> <i32 8, i32 234>, half %f16)
-  ret void
+  ret i32 %call1
 }
 
-define void @format_str_ptr(ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspace(1) %ptr.global, ptr addrspace(5) %ptr.stack, ptr addrspace(4) %ptr.const) {
+define i32 @format_str_ptr(ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspace(1) %ptr.global, ptr addrspace(5) %ptr.stack, ptr addrspace(4) %ptr.const) {
 ; R600-LABEL: @format_str_ptr(
 ; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.p, ptr [[PTR_FLAT:%.*]], ptr addrspace(3) [[PTR_LDS:%.*]], ptr addrspace(1) [[PTR_GLOBAL:%.*]], ptr addrspace(5) [[PTR_STACK:%.*]], ptr addrspace(4) [[PTR_CONST:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL]]
 ;
 ; GCN-LABEL: @format_str_ptr(
 ; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 36)
@@ -285,16 +293,18 @@ define void @format_str_ptr(ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrsp
 ; GCN-NEXT:    store ptr addrspace(4) [[PTR_CONST:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 8
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %call = call i32 @printf(ptr addrspace(4) @format.str.p, ptr %ptr.flat, ptr addrspace(3) %ptr.lds, ptr addrspace(1) %ptr.global, ptr addrspace(5) %ptr.stack, ptr addrspace(4) %ptr.const)
-  ret void
+  ret i32 %call
 }
 
-define amdgpu_kernel void @format_str_d(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
+define i32 @format_str_d(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
 ; R600-LABEL: @format_str_d(
 ; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.d, i1 [[I1:%.*]], i4 [[I4:%.*]], i8 [[I8:%.*]], i24 [[I24:%.*]], i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], i96 [[I96:%.*]], i128 [[I128:%.*]], i32 1234)
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL]]
 ;
 ; GCN-LABEL: @format_str_d(
 ; GCN-NEXT:    [[TMP1:%.*]] = sext i1 [[I1:%.*]] to i32
@@ -332,16 +342,18 @@ define amdgpu_kernel void @format_str_d(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i
 ; GCN-NEXT:    store i32 1234, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 4
 ; GCN-NEXT:    br label [[TMP7]]
 ; GCN:       7:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP8:%.*]] = xor i1 [[TMP5]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP8]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %call = call i32 @printf(ptr addrspace(4) @format.str.d, i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128, i32 1234)
-  ret void
+  ret i32 %call
 }
 
-define amdgpu_kernel void @format_str_u(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
+define i32 @format_str_u(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128) {
 ; R600-LABEL: @format_str_u(
 ; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.u, i1 [[I1:%.*]], i4 [[I4:%.*]], i8 [[I8:%.*]], i24 [[I24:%.*]], i16 [[I16:%.*]], i32 [[I32:%.*]], i64 [[I64:%.*]], i96 [[I96:%.*]], i128 [[I128:%.*]], i32 1234)
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL]]
 ;
 ; GCN-LABEL: @format_str_u(
 ; GCN-NEXT:    [[TMP1:%.*]] = zext i1 [[I1:%.*]] to i32
@@ -379,17 +391,19 @@ define amdgpu_kernel void @format_str_u(i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i
 ; GCN-NEXT:    store i32 1234, ptr addrspace(1) [[PRINTBUFFNEXTPTR8]], align 4
 ; GCN-NEXT:    br label [[TMP7]]
 ; GCN:       7:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP8:%.*]] = xor i1 [[TMP5]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP8]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %call = call i32 @printf(ptr addrspace(4) @format.str.u, i1 %i1, i4 %i4, i8 %i8, i24 %i24, i16 %i16, i32 %i32, i64 %i64, i96 %i96, i128 %i128, i32 1234)
-  ret void
+  ret i32 %call
 }
 
-define void @format_str_v1(<1 x float> %v1f32.0, <1 x float> %v1f32.1, <1 x double> %v1f64, <1 x i8> %v1i8, <1 x i16> %v1i16, <1 x i32> %v1i32, <1 x i64> %v1i64,
+define i32 @format_str_v1(<1 x float> %v1f32.0, <1 x float> %v1f32.1, <1 x double> %v1f64, <1 x i8> %v1i8, <1 x i16> %v1i16, <1 x i32> %v1i32, <1 x i64> %v1i64,
 ; R600-LABEL: @format_str_v1(
 ; R600-NEXT:    [[V1F32_1_FPEXT:%.*]] = fpext <1 x float> [[V1F32_1:%.*]] to <1 x double>
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v1, <1 x float> [[V1F32_0:%.*]], <1 x double> [[V1F32_1_FPEXT]], <1 x double> [[V1F64:%.*]], <1 x i8> [[V1I8:%.*]], <1 x i16> [[V1I16:%.*]], <1 x i32> [[V1I32:%.*]], <1 x i64> [[V1I64:%.*]], <1 x ptr addrspace(1)> [[V1P1:%.*]], <1 x ptr addrspace(3)> [[V1P3:%.*]], <1 x half> [[V1F16:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @format_str_v1(
 ; GCN-NEXT:    [[V1F32_1_FPEXT:%.*]] = fpext <1 x float> [[V1F32_1:%.*]] to <1 x double>
@@ -421,20 +435,22 @@ define void @format_str_v1(<1 x float> %v1f32.0, <1 x float> %v1f32.1, <1 x doub
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 8
 ; GCN-NEXT:    br label [[TMP5]]
 ; GCN:       5:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP6:%.*]] = xor i1 [[TMP3]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP6]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   <1 x ptr addrspace(1)> %v1p1, <1 x ptr addrspace(3)> %v1p3, <1 x half> %v1f16) {
   %v1f32.1.fpext = fpext <1 x float> %v1f32.1 to <1 x double>
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.v1, <1 x float> %v1f32.0, <1 x double> %v1f32.1.fpext, <1 x double> %v1f64, <1 x i8> %v1i8, <1 x i16> %v1i16, <1 x i32> %v1i32, <1 x i64> %v1i64,
   <1 x ptr addrspace(1)> %v1p1, <1 x ptr addrspace(3)> %v1p3, <1 x half> %v1f16)
-  ret void
+  ret i32 %call1
 }
 
-define void @format_str_v2(<2 x float> %v2f32.0, <2 x float> %v2f32.1, <2 x double> %v2f64, <2 x i8> %v2i8, <2 x i16> %v2i16, <2 x i32> %v2i32, <2 x i64> %v2i64,
+define i32 @format_str_v2(<2 x float> %v2f32.0, <2 x float> %v2f32.1, <2 x double> %v2f64, <2 x i8> %v2i8, <2 x i16> %v2i16, <2 x i32> %v2i32, <2 x i64> %v2i64,
 ; R600-LABEL: @format_str_v2(
 ; R600-NEXT:    [[V2F32_1_FPEXT:%.*]] = fpext <2 x float> [[V2F32_1:%.*]] to <2 x double>
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v2, <2 x float> [[V2F32_0:%.*]], <2 x double> [[V2F32_1_FPEXT]], <2 x double> [[V2F64:%.*]], <2 x i8> [[V2I8:%.*]], <2 x i16> [[V2I16:%.*]], <2 x i32> [[V2I32:%.*]], <2 x i64> [[V2I64:%.*]], <2 x ptr addrspace(1)> [[V2P1:%.*]], <2 x ptr addrspace(3)> [[V2P3:%.*]], <2 x half> [[V2F16:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @format_str_v2(
 ; GCN-NEXT:    [[V2F32_1_FPEXT:%.*]] = fpext <2 x float> [[V2F32_1:%.*]] to <2 x double>
@@ -465,20 +481,22 @@ define void @format_str_v2(<2 x float> %v2f32.0, <2 x float> %v2f32.1, <2 x doub
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 16
 ; GCN-NEXT:    br label [[TMP4]]
 ; GCN:       4:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP5:%.*]] = xor i1 [[TMP2]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP5]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   <2 x ptr addrspace(1)> %v2p1, <2 x ptr addrspace(3)> %v2p3, <2 x half> %v2f16) {
   %v2f32.1.fpext = fpext <2 x float> %v2f32.1 to <2 x double>
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.v2, <2 x float> %v2f32.0, <2 x double> %v2f32.1.fpext, <2 x double> %v2f64, <2 x i8> %v2i8, <2 x i16> %v2i16, <2 x i32> %v2i32, <2 x i64> %v2i64,
   <2 x ptr addrspace(1)> %v2p1, <2 x ptr addrspace(3)> %v2p3, <2 x half> %v2f16)
-  ret void
+  ret i32 %call1
 }
 
-define void @format_str_v3(<3 x float> %v3f32.0, <3 x float> %v3f32.1, <3 x double> %v3f64, <3 x i8> %v3i8, <3 x i16> %v3i16, <3 x i32> %v3i32, <3 x i64> %v3i64,
+define i32 @format_str_v3(<3 x float> %v3f32.0, <3 x float> %v3f32.1, <3 x double> %v3f64, <3 x i8> %v3i8, <3 x i16> %v3i16, <3 x i32> %v3i32, <3 x i64> %v3i64,
 ; R600-LABEL: @format_str_v3(
 ; R600-NEXT:    [[V3F32_1_FPEXT:%.*]] = fpext <3 x float> [[V3F32_1:%.*]] to <3 x double>
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v3, <3 x float> [[V3F32_0:%.*]], <3 x double> [[V3F32_1_FPEXT]], <3 x double> [[V3F64:%.*]], <3 x i8> [[V3I8:%.*]], <3 x i16> [[V3I16:%.*]], <3 x i32> [[V3I32:%.*]], <3 x i64> [[V3I64:%.*]], <3 x ptr addrspace(1)> [[V3P1:%.*]], <3 x ptr addrspace(3)> [[V3P3:%.*]], <3 x half> [[V3F16:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @format_str_v3(
 ; GCN-NEXT:    [[V3F32_1_FPEXT:%.*]] = fpext <3 x float> [[V3F32_1:%.*]] to <3 x double>
@@ -508,20 +526,22 @@ define void @format_str_v3(<3 x float> %v3f32.0, <3 x float> %v3f32.1, <3 x doub
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 32
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   <3 x ptr addrspace(1)> %v3p1, <3 x ptr addrspace(3)> %v3p3, <3 x half> %v3f16) {
   %v3f32.1.fpext = fpext <3 x float> %v3f32.1 to <3 x double>
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.v3, <3 x float> %v3f32.0, <3 x double> %v3f32.1.fpext, <3 x double> %v3f64, <3 x i8> %v3i8, <3 x i16> %v3i16, <3 x i32> %v3i32, <3 x i64> %v3i64,
   <3 x ptr addrspace(1)> %v3p1, <3 x ptr addrspace(3)> %v3p3, <3 x half> %v3f16)
-  ret void
+  ret i32 %call1
 }
 
-define void @format_str_v4(<4 x float> %v4f32.0, <4 x float> %v4f32.1, <4 x double> %v4f64, <4 x i8> %v4i8, <4 x i16> %v4i16, <4 x i32> %v4i32, <4 x i64> %v4i64,
+define i32 @format_str_v4(<4 x float> %v4f32.0, <4 x float> %v4f32.1, <4 x double> %v4f64, <4 x i8> %v4i8, <4 x i16> %v4i16, <4 x i32> %v4i32, <4 x i64> %v4i64,
 ; R600-LABEL: @format_str_v4(
 ; R600-NEXT:    [[V4F32_1_FPEXT:%.*]] = fpext <4 x float> [[V4F32_1:%.*]] to <4 x double>
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v4, <4 x float> [[V4F32_0:%.*]], <4 x double> [[V4F32_1_FPEXT]], <4 x double> [[V4F64:%.*]], <4 x i8> [[V4I8:%.*]], <4 x i16> [[V4I16:%.*]], <4 x i32> [[V4I32:%.*]], <4 x i64> [[V4I64:%.*]], <4 x ptr addrspace(1)> [[V4P1:%.*]], <4 x ptr addrspace(3)> [[V4P3:%.*]], <4 x half> [[V4F16:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @format_str_v4(
 ; GCN-NEXT:    [[V4F32_1_FPEXT:%.*]] = fpext <4 x float> [[V4F32_1:%.*]] to <4 x double>
@@ -551,20 +571,22 @@ define void @format_str_v4(<4 x float> %v4f32.0, <4 x float> %v4f32.1, <4 x doub
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 32
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   <4 x ptr addrspace(1)> %v4p1, <4 x ptr addrspace(3)> %v4p3, <4 x half> %v4f16) {
   %v4f32.1.fpext = fpext <4 x float> %v4f32.1 to <4 x double>
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.v4, <4 x float> %v4f32.0, <4 x double> %v4f32.1.fpext, <4 x double> %v4f64, <4 x i8> %v4i8, <4 x i16> %v4i16, <4 x i32> %v4i32, <4 x i64> %v4i64,
   <4 x ptr addrspace(1)> %v4p1, <4 x ptr addrspace(3)> %v4p3, <4 x half> %v4f16)
-  ret void
+  ret i32 %call1
 }
 
-define void @format_str_v8(<8 x float> %v8f32.0, <8 x float> %v8f32.1, <8 x double> %v8f64, <8 x i8> %v8i8, <8 x i16> %v8i16, <8 x i32> %v8i32, <8 x i64> %v8i64,
+define i32 @format_str_v8(<8 x float> %v8f32.0, <8 x float> %v8f32.1, <8 x double> %v8f64, <8 x i8> %v8i8, <8 x i16> %v8i16, <8 x i32> %v8i32, <8 x i64> %v8i64,
 ; R600-LABEL: @format_str_v8(
 ; R600-NEXT:    [[V8F32_1_FPEXT:%.*]] = fpext <8 x float> [[V8F32_1:%.*]] to <8 x double>
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v8, <8 x float> [[V8F32_0:%.*]], <8 x double> [[V8F32_1_FPEXT]], <8 x double> [[V8F64:%.*]], <8 x i8> [[V8I8:%.*]], <8 x i16> [[V8I16:%.*]], <8 x i32> [[V8I32:%.*]], <8 x i64> [[V8I64:%.*]], <8 x ptr addrspace(1)> [[V8P1:%.*]], <8 x ptr addrspace(3)> [[V8P3:%.*]], <8 x half> [[V8F16:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @format_str_v8(
 ; GCN-NEXT:    [[V8F32_1_FPEXT:%.*]] = fpext <8 x float> [[V8F32_1:%.*]] to <8 x double>
@@ -594,20 +616,22 @@ define void @format_str_v8(<8 x float> %v8f32.0, <8 x float> %v8f32.1, <8 x doub
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 64
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   <8 x ptr addrspace(1)> %v8p1, <8 x ptr addrspace(3)> %v8p3, <8 x half> %v8f16) {
   %v8f32.1.fpext = fpext <8 x float> %v8f32.1 to <8 x double>
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.v8, <8 x float> %v8f32.0, <8 x double> %v8f32.1.fpext, <8 x double> %v8f64, <8 x i8> %v8i8, <8 x i16> %v8i16, <8 x i32> %v8i32, <8 x i64> %v8i64,
   <8 x ptr addrspace(1)> %v8p1, <8 x ptr addrspace(3)> %v8p3, <8 x half> %v8f16)
-  ret void
+  ret i32 %call1
 }
 
-define void @format_str_v16(<16 x float> %v16f32.0, <16 x float> %v16f32.1, <16 x double> %v16f64, <16 x i8> %v16i8, <16 x i16> %v16i16, <16 x i32> %v16i32, <16 x i64> %v16i64,
+define i32 @format_str_v16(<16 x float> %v16f32.0, <16 x float> %v16f32.1, <16 x double> %v16f64, <16 x i8> %v16i8, <16 x i16> %v16i16, <16 x i32> %v16i32, <16 x i64> %v16i64,
 ; R600-LABEL: @format_str_v16(
 ; R600-NEXT:    [[V16F32_1_FPEXT:%.*]] = fpext <16 x float> [[V16F32_1:%.*]] to <16 x double>
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.v16, <16 x float> [[V16F32_0:%.*]], <16 x double> [[V16F32_1_FPEXT]], <16 x double> [[V16F64:%.*]], <16 x i8> [[V16I8:%.*]], <16 x i16> [[V16I16:%.*]], <16 x i32> [[V16I32:%.*]], <16 x i64> [[V16I64:%.*]], <16 x ptr addrspace(1)> [[V16P1:%.*]], <16 x ptr addrspace(3)> [[V16P3:%.*]], <16 x half> [[V16F16:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @format_str_v16(
 ; GCN-NEXT:    [[V16F32_1_FPEXT:%.*]] = fpext <16 x float> [[V16F32_1:%.*]] to <16 x double>
@@ -637,13 +661,15 @@ define void @format_str_v16(<16 x float> %v16f32.0, <16 x float> %v16f32.1, <16 
 ; GCN-NEXT:    [[PRINTBUFFNEXTPTR6:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTBUFFNEXTPTR5]], i32 128
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   <16 x ptr addrspace(1)> %v16p1, <16 x ptr addrspace(3)> %v16p3, <16 x half> %v16f16) {
   %v16f32.1.fpext = fpext <16 x float> %v16f32.1 to <16 x double>
   %call1 = call i32 @printf(ptr addrspace(4) @format.str.v16, <16 x float> %v16f32.0, <16 x double> %v16f32.1.fpext, <16 x double> %v16f64, <16 x i8> %v16i8, <16 x i16> %v16i16, <16 x i32> %v16i32, <16 x i64> %v16i64,
   <16 x ptr addrspace(1)> %v16p1, <16 x ptr addrspace(3)> %v16p3, <16 x half> %v16f16)
-  ret void
+  ret i32 %call1
 }
 
 define amdgpu_kernel void @test_kernel(i32 %n) {
@@ -679,11 +705,11 @@ entry:
   ret void
 }
 
-define amdgpu_kernel void @test_format_str_no_null_terminator(i32 %n) {
+define i32 @test_format_str_no_null_terminator(i32 %n) {
 ; R600-LABEL: @test_format_str_no_null_terminator(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @format.str.no.null.terminator, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @test_format_str_no_null_terminator(
 ; GCN-NEXT:  entry:
@@ -700,19 +726,21 @@ define amdgpu_kernel void @test_format_str_no_null_terminator(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @format.str.no.null.terminator, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
 
-define amdgpu_kernel void @test_indexed_format_str(i32 %n) {
+define i32 @test_indexed_format_str(i32 %n) {
 ; R600-LABEL: @test_indexed_format_str(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i32 7), i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @test_indexed_format_str(
 ; GCN-NEXT:  entry:
@@ -729,18 +757,20 @@ define amdgpu_kernel void @test_indexed_format_str(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFGEP]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i32 7), i32 %n)
-  ret void
+  ret i32 %call1
 }
 
-define amdgpu_kernel void @test_indexed_format_str_oob(i32 %n) {
+define i32 @test_indexed_format_str_oob(i32 %n) {
 ; R600-LABEL: @test_indexed_format_str_oob(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i64 11), i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @test_indexed_format_str_oob(
 ; GCN-NEXT:  entry:
@@ -756,18 +786,20 @@ define amdgpu_kernel void @test_indexed_format_str_oob(i32 %n) {
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) getelementptr ([11 x i8], ptr addrspace(4) @indexed.format.str, i64 0, i64 11), i32 %n)
-  ret void
+  ret i32 %call1
 }
 
-define amdgpu_kernel void @string_pointee_type(i32 %n) {
+define i32 @string_pointee_type(i32 %n) {
 ; R600-LABEL: @string_pointee_type(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @string_pointee_type(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -786,17 +818,19 @@ define amdgpu_kernel void @string_pointee_type(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(5) %str, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
-define amdgpu_kernel void @string_address_space4(i32 %n, ptr addrspace(4) %str) {
+define i32 @string_address_space4(i32 %n, ptr addrspace(4) %str) {
 ; R600-LABEL: @string_address_space4(
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) [[STR:%.*]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @string_address_space4(
 ; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
@@ -814,16 +848,18 @@ define amdgpu_kernel void @string_address_space4(i32 %n, ptr addrspace(4) %str) 
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) %str, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
-define amdgpu_kernel void @string_address_space1(i32 %n, ptr addrspace(1) %str) {
+define i32 @string_address_space1(i32 %n, ptr addrspace(1) %str) {
 ; R600-LABEL: @string_address_space1(
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(1) [[STR:%.*]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @string_address_space1(
 ; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
@@ -841,16 +877,18 @@ define amdgpu_kernel void @string_address_space1(i32 %n, ptr addrspace(1) %str) 
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(1) %str, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
-define amdgpu_kernel void @string_format_passed_i32(i32 %n, i32 %str) {
+define i32 @string_format_passed_i32(i32 %n, i32 %str) {
 ; R600-LABEL: @string_format_passed_i32(
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, i32 [[STR:%.*]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @string_format_passed_i32(
 ; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
@@ -868,22 +906,24 @@ define amdgpu_kernel void @string_format_passed_i32(i32 %n, i32 %str) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, i32 %str, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
 
 @str.as1 = private unnamed_addr addrspace(1) constant [6 x i8] c"%s:%d\00", align 1
 
-define amdgpu_kernel void @test_kernel_addrspacecasted_format_str(i32 %n) {
+define i32 @test_kernel_addrspacecasted_format_str(i32 %n) {
 ; R600-LABEL: @test_kernel_addrspacecasted_format_str(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[ARRAYDECAY:%.*]] = getelementptr inbounds [9 x i8], ptr addrspace(5) [[STR]], i32 0, i32 0
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) addrspacecast (ptr addrspace(1) @str.as1 to ptr addrspace(4)), ptr addrspace(5) [[ARRAYDECAY]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @test_kernel_addrspacecasted_format_str(
 ; GCN-NEXT:  entry:
@@ -904,67 +944,69 @@ define amdgpu_kernel void @test_kernel_addrspacecasted_format_str(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %str = alloca [9 x i8], align 1, addrspace(5)
   %arraydecay = getelementptr inbounds [9 x i8], ptr addrspace(5) %str, i32 0, i32 0
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) addrspacecast (ptr addrspace(1) @str.as1 to ptr addrspace(4)), ptr addrspace(5) %arraydecay, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
-define amdgpu_kernel void @test_undef_argument(i32 %n) {
+define i32 @test_undef_argument(i32 %n) {
 ; R600-LABEL: @test_undef_argument(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @test_undef_argument(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    ret void
+; GCN-NEXT:    ret i32 0
 ;
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) %str, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
-define amdgpu_kernel void @test_poison_argument(i32 %n) {
+define i32 @test_poison_argument(i32 %n) {
 ; R600-LABEL: @test_poison_argument(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @test_poison_argument(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    ret void
+; GCN-NEXT:    ret i32 0
 ;
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) poison, ptr addrspace(5) %str, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
-define amdgpu_kernel void @test_null_argument(i32 %n) {
+define i32 @test_null_argument(i32 %n) {
 ; R600-LABEL: @test_null_argument(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) null, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @test_null_argument(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
-; GCN-NEXT:    ret void
+; GCN-NEXT:    ret i32 0
 ;
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) null, ptr addrspace(5) %str, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
 @undef.initializer = private unnamed_addr addrspace(4) constant [6 x i8] undef
 
-define amdgpu_kernel void @undef_initializer_gv(i32 %n) {
+define i32 @undef_initializer_gv(i32 %n) {
 ; R600-LABEL: @undef_initializer_gv(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @undef_initializer_gv(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -980,20 +1022,22 @@ define amdgpu_kernel void @undef_initializer_gv(i32 %n) {
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) %str, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
 @poison.initializer = private unnamed_addr addrspace(4) constant [6 x i8] poison
 
-define amdgpu_kernel void @poison_initializer_gv(i32 %n) {
+define i32 @poison_initializer_gv(i32 %n) {
 ; R600-LABEL: @poison_initializer_gv(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @poison_initializer_gv(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -1009,20 +1053,22 @@ define amdgpu_kernel void @poison_initializer_gv(i32 %n) {
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) %str, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
 @zero.initializer = private unnamed_addr addrspace(4) constant [6 x i8] zeroinitializer
 
-define amdgpu_kernel void @zero_initializer_gv(i32 %n) {
+define i32 @zero_initializer_gv(i32 %n) {
 ; R600-LABEL: @zero_initializer_gv(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @zero_initializer_gv(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -1038,18 +1084,20 @@ define amdgpu_kernel void @zero_initializer_gv(i32 %n) {
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @poison.initializer, ptr addrspace(5) %str, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
-define amdgpu_kernel void @test_print_string_literal_size0(i32 %n) {
+define i32 @test_print_string_literal_size0(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size0(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size0, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size0(
 ; GCN-NEXT:  entry:
@@ -1068,18 +1116,20 @@ define amdgpu_kernel void @test_print_string_literal_size0(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size0, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_1ai8.zero(i32 %n) {
+define i32 @test_print_string_literal_1ai8.zero(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_1ai8.zero(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.zero, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_1ai8.zero(
 ; GCN-NEXT:  entry:
@@ -1098,18 +1148,20 @@ define amdgpu_kernel void @test_print_string_literal_1ai8.zero(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.zero, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_1ai8.undef(i32 %n) {
+define i32 @test_print_string_literal_1ai8.undef(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_1ai8.undef(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.undef, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_1ai8.undef(
 ; GCN-NEXT:  entry:
@@ -1128,18 +1180,20 @@ define amdgpu_kernel void @test_print_string_literal_1ai8.undef(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.1ai8.undef, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_i8.zero(i32 %n) {
+define i32 @test_print_string_literal_i8.zero(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_i8.zero(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.i8.zero, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_i8.zero(
 ; GCN-NEXT:  entry:
@@ -1158,18 +1212,20 @@ define amdgpu_kernel void @test_print_string_literal_i8.zero(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.i8.zero, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size2(i32 %n) {
+define i32 @test_print_string_literal_size2(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size2(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size2, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size2(
 ; GCN-NEXT:  entry:
@@ -1188,18 +1244,20 @@ define amdgpu_kernel void @test_print_string_literal_size2(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size2, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size3(i32 %n) {
+define i32 @test_print_string_literal_size3(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size3(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size3(
 ; GCN-NEXT:  entry:
@@ -1218,18 +1276,20 @@ define amdgpu_kernel void @test_print_string_literal_size3(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size3_zero(i32 %n) {
+define i32 @test_print_string_literal_size3_zero(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size3_zero(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3.zero, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size3_zero(
 ; GCN-NEXT:  entry:
@@ -1248,18 +1308,20 @@ define amdgpu_kernel void @test_print_string_literal_size3_zero(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size3.zero, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size4(i32 %n) {
+define i32 @test_print_string_literal_size4(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size4(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size4(
 ; GCN-NEXT:  entry:
@@ -1278,18 +1340,20 @@ define amdgpu_kernel void @test_print_string_literal_size4(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size4_nonull_term(i32 %n) {
+define i32 @test_print_string_literal_size4_nonull_term(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size4_nonull_term(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4.nonull.term, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size4_nonull_term(
 ; GCN-NEXT:  entry:
@@ -1308,18 +1372,20 @@ define amdgpu_kernel void @test_print_string_literal_size4_nonull_term(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size4.nonull.term, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size5(i32 %n) {
+define i32 @test_print_string_literal_size5(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size5(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size5, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size5(
 ; GCN-NEXT:  entry:
@@ -1338,18 +1404,20 @@ define amdgpu_kernel void @test_print_string_literal_size5(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size5, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size6(i32 %n) {
+define i32 @test_print_string_literal_size6(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size6(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size6(
 ; GCN-NEXT:  entry:
@@ -1370,18 +1438,20 @@ define amdgpu_kernel void @test_print_string_literal_size6(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size7(i32 %n) {
+define i32 @test_print_string_literal_size7(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size7(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size7(
 ; GCN-NEXT:  entry:
@@ -1402,18 +1472,20 @@ define amdgpu_kernel void @test_print_string_literal_size7(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size6, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size8(i32 %n) {
+define i32 @test_print_string_literal_size8(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size8(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size8, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size8(
 ; GCN-NEXT:  entry:
@@ -1434,18 +1506,20 @@ define amdgpu_kernel void @test_print_string_literal_size8(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size8, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size9(i32 %n) {
+define i32 @test_print_string_literal_size9(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size9(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size9, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size9(
 ; GCN-NEXT:  entry:
@@ -1466,18 +1540,20 @@ define amdgpu_kernel void @test_print_string_literal_size9(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR1]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size9, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size16(i32 %n) {
+define i32 @test_print_string_literal_size16(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size16(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size16, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size16(
 ; GCN-NEXT:  entry:
@@ -1502,18 +1578,20 @@ define amdgpu_kernel void @test_print_string_literal_size16(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size16, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size17(i32 %n) {
+define i32 @test_print_string_literal_size17(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size17(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size17, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size17(
 ; GCN-NEXT:  entry:
@@ -1538,18 +1616,20 @@ define amdgpu_kernel void @test_print_string_literal_size17(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size17, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size20(i32 %n) {
+define i32 @test_print_string_literal_size20(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size20(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size20, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size20(
 ; GCN-NEXT:  entry:
@@ -1576,18 +1656,20 @@ define amdgpu_kernel void @test_print_string_literal_size20(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR4]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size20, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_size32(i32 %n) {
+define i32 @test_print_string_literal_size32(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_size32(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size32, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_size32(
 ; GCN-NEXT:  entry:
@@ -1620,18 +1702,20 @@ define amdgpu_kernel void @test_print_string_literal_size32(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR7]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.size32, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_not_constant_global(i32 %n) {
+define i32 @test_print_string_not_constant_global(i32 %n) {
 ; R600-LABEL: @test_print_string_not_constant_global(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.not.constant.size4, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_not_constant_global(
 ; GCN-NEXT:  entry:
@@ -1650,18 +1734,20 @@ define amdgpu_kernel void @test_print_string_not_constant_global(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.not.constant.size4, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_constant_interposable_global(i32 %n) {
+define i32 @test_print_string_constant_interposable_global(i32 %n) {
 ; R600-LABEL: @test_print_string_constant_interposable_global(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.interposable.size4, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_constant_interposable_global(
 ; GCN-NEXT:  entry:
@@ -1680,18 +1766,20 @@ define amdgpu_kernel void @test_print_string_constant_interposable_global(i32 %n
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.interposable.size4, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_v4i8(i32 %n) {
+define i32 @test_print_string_literal_v4i8(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_v4i8(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i8, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_v4i8(
 ; GCN-NEXT:  entry:
@@ -1710,18 +1798,20 @@ define amdgpu_kernel void @test_print_string_literal_v4i8(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i8, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_v4i32(i32 %n) {
+define i32 @test_print_string_literal_v4i32(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_v4i32(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i32, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_v4i32(
 ; GCN-NEXT:  entry:
@@ -1740,18 +1830,20 @@ define amdgpu_kernel void @test_print_string_literal_v4i32(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.v4i32, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_literal_struct(i32 %n) {
+define i32 @test_print_string_literal_struct(i32 %n) {
 ; R600-LABEL: @test_print_string_literal_struct(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.struct, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_literal_struct(
 ; GCN-NEXT:  entry:
@@ -1770,18 +1862,20 @@ define amdgpu_kernel void @test_print_string_literal_struct(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.struct, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_undef(i32 %n) {
+define i32 @test_print_string_undef(i32 %n) {
 ; R600-LABEL: @test_print_string_undef(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_undef(
 ; GCN-NEXT:  entry:
@@ -1800,18 +1894,20 @@ define amdgpu_kernel void @test_print_string_undef(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_poison(i32 %n) {
+define i32 @test_print_string_poison(i32 %n) {
 ; R600-LABEL: @test_print_string_poison(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_poison(
 ; GCN-NEXT:  entry:
@@ -1830,18 +1926,20 @@ define amdgpu_kernel void @test_print_string_poison(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) poison, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_null(i32 %n) {
+define i32 @test_print_string_null(i32 %n) {
 ; R600-LABEL: @test_print_string_null(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) null, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_null(
 ; GCN-NEXT:  entry:
@@ -1860,18 +1958,20 @@ define amdgpu_kernel void @test_print_string_null(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) null, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_inttoptr(i32 %n) {
+define i32 @test_print_string_inttoptr(i32 %n) {
 ; R600-LABEL: @test_print_string_inttoptr(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) inttoptr (i64 1234 to ptr addrspace(4)), i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_inttoptr(
 ; GCN-NEXT:  entry:
@@ -1890,18 +1990,20 @@ define amdgpu_kernel void @test_print_string_inttoptr(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) inttoptr (i64 1234 to ptr addrspace(4)), i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_float_neg0(i32 %n) {
+define i32 @test_print_string_float_neg0(i32 %n) {
 ; R600-LABEL: @test_print_string_float_neg0(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_float_neg0(
 ; GCN-NEXT:  entry:
@@ -1920,18 +2022,20 @@ define amdgpu_kernel void @test_print_string_float_neg0(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_float_0(i32 %n) {
+define i32 @test_print_string_float_0(i32 %n) {
 ; R600-LABEL: @test_print_string_float_0(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_float_0(
 ; GCN-NEXT:  entry:
@@ -1950,18 +2054,20 @@ define amdgpu_kernel void @test_print_string_float_0(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.float.0, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_ptr_null(i32 %n) {
+define i32 @test_print_string_ptr_null(i32 %n) {
 ; R600-LABEL: @test_print_string_ptr_null(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.null, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_ptr_null(
 ; GCN-NEXT:  entry:
@@ -1980,18 +2086,20 @@ define amdgpu_kernel void @test_print_string_ptr_null(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.null, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_ptr_undef(i32 %n) {
+define i32 @test_print_string_ptr_undef(i32 %n) {
 ; R600-LABEL: @test_print_string_ptr_undef(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.undef, i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_ptr_undef(
 ; GCN-NEXT:  entry:
@@ -2010,18 +2118,20 @@ define amdgpu_kernel void @test_print_string_ptr_undef(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) @printed.str.ptr.undef, i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_indexed(i32 %n) {
+define i32 @test_print_string_indexed(i32 %n) {
 ; R600-LABEL: @test_print_string_indexed(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 15), i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_indexed(
 ; GCN-NEXT:  entry:
@@ -2046,18 +2156,20 @@ define amdgpu_kernel void @test_print_string_indexed(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR3]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 15), i32 %n)
-  ret void
+  ret i32 %printf
 }
 
-define amdgpu_kernel void @test_print_string_indexed_oob(i32 %n) {
+define i32 @test_print_string_indexed_oob(i32 %n) {
 ; R600-LABEL: @test_print_string_indexed_oob(
 ; R600-NEXT:  entry:
 ; R600-NEXT:    [[PRINTF:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 32), i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[PRINTF]]
 ;
 ; GCN-LABEL: @test_print_string_indexed_oob(
 ; GCN-NEXT:  entry:
@@ -2076,21 +2188,23 @@ define amdgpu_kernel void @test_print_string_indexed_oob(i32 %n) {
 ; GCN-NEXT:    store i32 [[N:%.*]], ptr addrspace(1) [[PRINTBUFFNEXTPTR]], align 4
 ; GCN-NEXT:    br label [[TMP2]]
 ; GCN:       2:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP3:%.*]] = xor i1 [[TMP0]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP3]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
 entry:
   %printf = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @.str, ptr addrspace(4) getelementptr ([32 x i8], ptr addrspace(4) @printed.str.size32, i64 0, i64 32), i32 %n)
-  ret void
+  ret i32 %printf
 }
 
 @array.i16 = private unnamed_addr addrspace(4) constant [6 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6]
 
 ; CHECK: error: <unknown>:0:0: in function test_format_array_i16 void (i32): printf format string must be a trivially resolved constant string global variable
-define amdgpu_kernel void @test_format_array_i16(i32 %n) {
+define i32 @test_format_array_i16(i32 %n) {
 ; R600-LABEL: @test_format_array_i16(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @array.i16, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @test_format_array_i16(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -2106,20 +2220,22 @@ define amdgpu_kernel void @test_format_array_i16(i32 %n) {
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @array.i16, ptr addrspace(5) %str, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
 @struct = private unnamed_addr addrspace(4) constant { [6 x i8] } { [6 x i8] [i8 1, i8 2, i8 3, i8 4, i8 5, i8 6] }
 
-define amdgpu_kernel void @test_format_struct(i32 %n) {
+define i32 @test_format_struct(i32 %n) {
 ; R600-LABEL: @test_format_struct(
 ; R600-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
 ; R600-NEXT:    [[CALL1:%.*]] = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @struct, ptr addrspace(5) [[STR]], i32 [[N:%.*]])
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL1]]
 ;
 ; GCN-LABEL: @test_format_struct(
 ; GCN-NEXT:    [[STR:%.*]] = alloca [9 x i8], align 1, addrspace(5)
@@ -2135,11 +2251,13 @@ define amdgpu_kernel void @test_format_struct(i32 %n) {
 ; GCN-NEXT:    [[PRINTBUFFGEP:%.*]] = getelementptr i8, ptr addrspace(1) [[PRINTF_ALLOC_FN]], i32 4
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %str = alloca [9 x i8], align 1, addrspace(5)
   %call1 = call i32 (ptr addrspace(4), ...) @printf(ptr addrspace(4) @struct, ptr addrspace(5) %str, i32 %n)
-  ret void
+  ret i32 %call1
 }
 
 declare void @func(ptr)
@@ -2157,10 +2275,10 @@ define void @not_call_operand_printf() {
   ret void
 }
 
-define void @printf_printf(i32 %n) {
+define i32 @printf_printf(i32 %n) {
 ; R600-LABEL: @printf_printf(
 ; R600-NEXT:    [[CALL:%.*]] = call i32 @printf(ptr addrspace(4) @format.str.one.ptr, ptr @printf)
-; R600-NEXT:    ret void
+; R600-NEXT:    ret i32 [[CALL]]
 ;
 ; GCN-LABEL: @printf_printf(
 ; GCN-NEXT:    [[PRINTF_ALLOC_FN:%.*]] = call ptr addrspace(1) @__printf_alloc(i32 12)
@@ -2176,10 +2294,12 @@ define void @printf_printf(i32 %n) {
 ; GCN-NEXT:    store ptr @printf, ptr addrspace(1) [[PRINTBUFFGEP]], align 8
 ; GCN-NEXT:    br label [[TMP3]]
 ; GCN:       3:
-; GCN-NEXT:    ret void
+; GCN-NEXT:    [[TMP4:%.*]] = xor i1 [[TMP1]], true
+; GCN-NEXT:    [[PRINTF_RES:%.*]] = sext i1 [[TMP4]] to i32
+; GCN-NEXT:    ret i32 [[PRINTF_RES]]
 ;
   %call = call i32 @printf(ptr addrspace(4) @format.str.one.ptr, ptr @printf)
-  ret void
+  ret i32 %call
 }
 
 declare i32 @printf(ptr addrspace(4), ...)


### PR DESCRIPTION
When handling OpenCL printf calls, the AMDGPU backend replaces the actual function call with a runtime binding. However, this replacement currently assumes that there are no uses of the original call value result. If there are uses, the erasure of the function call leads to errors.
This patch replaces all uses of the original printf call with a 0 value constant, signalling success of the printf operation.