### PR TITLE
[SECURITY.md] add pointers to "what is a security issue"

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,3 +3,12 @@
 To report security issues in LLVM, please follow the steps outlined on the
 [LLVM Security Group](https://llvm.org/docs/Security.html#how-to-report-a-security-issue)
 page.
+
+## Security Issue Scope
+
+Many of LLVM's tools are explicitly **not** considered to be hardened against
+malicious input. Bugs in LLVM tools like buffer overreads or crashes are
+valuable to report [as Issues](https://github.com/llvm/llvm-project/issues),
+but aren't always seen as security vulnerabilities. Please see
+[our documentation](https://llvm.org/docs/Security.html#what-is-considered-a-security-issue)
+for a more precise definition of a security issue in this repository.


### PR DESCRIPTION
Over the years, the security group has received a decent number of reports of malicious input causing e.g., Clang to crash.

While these reports are valuable, it seems useful to clarify that many of them are considered bugs, rather than security issues.