### PR TITLE
Early exit if compares are not using the same register (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
@@ -506,6 +506,12 @@ bool AArch64ConditionOptimizer::optimizeCrossBlock(MachineBasicBlock &HBB) {
     return false;
   }
 
+  // Both compares must use the same register for CSE to be possible.
+  if (HeadCmpMI->getOperand(1).getReg() != TrueCmpMI->getOperand(1).getReg()) {
+    LLVM_DEBUG(dbgs() << "Compares use different registers, skipping\n");
+    return false;
+  }
+
   AArch64CC::CondCode HeadCmp;
   if (HeadCond.empty() || !parseCond(HeadCond, HeadCmp)) {
     return false;


### PR DESCRIPTION
No codegen change, since this will be checked later on, but this is an early exit.