### PR TITLE
[llvm] Fix illumos header macro conflicts.

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -14,6 +14,11 @@
 #ifndef LLVM_ADT_SMALLVECTOR_H
 #define LLVM_ADT_SMALLVECTOR_H
 
+// Fix conflict with illumos CS macro in sys/regset.h.
+#ifdef __sun
+#undef CS
+#endif
+
 #include "llvm/ADT/ADL.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/Support/Compiler.h"

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -19,6 +19,11 @@
 #ifndef LLVM_SUPPORT_COMMANDLINE_H
 #define LLVM_SUPPORT_COMMANDLINE_H
 
+// Fix conflict with illumos FS macro in sys/regset.h.
+#ifdef __sun
+#undef FS
+#endif
+
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"

--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -13,6 +13,11 @@
 #ifndef LLVM_TARGET_TARGETMACHINE_H
 #define LLVM_TARGET_TARGETMACHINE_H
 
+// Fix conflict with illumos FS macro in sys/regset.h.
+#ifdef __sun
+#undef FS
+#endif
+
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/PassManager.h"


### PR DESCRIPTION
On illumos, sys/regset.h defines `CS` and `FS` as macros (x86 segment registers), conflicting with identifier names in llvm headers. This patch adds #undef directives to fix the conflicts.