### PR TITLE
[IRMover] Use signature for exact definition

### DIFF
--- a/llvm/test/Transforms/FunctionImport/Inputs/attr_fixup_dae_noundef.ll
+++ b/llvm/test/Transforms/FunctionImport/Inputs/attr_fixup_dae_noundef.ll
@@ -1,0 +1,14 @@
+; This file contains the post-"deadargelim" IR.
+
+define void @outer(i32 noundef %arg) {
+  ; The parameter was originally `noundef %arg`, changed to `poison` by "deadargelim".
+  call void @inner(i32 poison)
+  ret void
+}
+
+; %arg was originally `noundef`, removed by "deadargelim".
+define void @inner(i32 %arg) #0 {
+  ret void
+}
+
+attributes #0 = { noinline }

--- a/llvm/test/Transforms/FunctionImport/Inputs/attr_fixup_dae_noundef.ll
+++ b/llvm/test/Transforms/FunctionImport/Inputs/attr_fixup_dae_noundef.ll
@@ -3,11 +3,16 @@
 define void @outer(i32 noundef %arg) {
   ; The parameter was originally `noundef %arg`, changed to `poison` by "deadargelim".
   call void @inner(i32 poison)
+  call void @inner2(i32 poison)
   ret void
 }
 
 ; %arg was originally `noundef`, removed by "deadargelim".
 define void @inner(i32 %arg) #0 {
+  ret void
+}
+
+define void @inner2(i32 %arg) #0 {
   ret void
 }
 

--- a/llvm/test/Transforms/FunctionImport/attr_fixup_dae_noundef.ll
+++ b/llvm/test/Transforms/FunctionImport/attr_fixup_dae_noundef.ll
@@ -17,6 +17,9 @@
 define void @main()  {
   call void @outer(i32 noundef 1)
   call void @inner(i32 noundef 1)
+  ; This call is UB due to signature mismatch with the actual definition.
+  ; Make sure it does not lead to a crash.
+  call void @inner2()
   ret void
 }
 
@@ -30,3 +33,6 @@ declare void @outer(i32 noundef)
 ; not have the `noundef` attribute.
 ; CHECK: declare void @inner(i32)
 declare void @inner(i32 noundef)
+
+; CHECK: declare void @inner2(i32)
+declare void @inner2()

--- a/llvm/test/Transforms/FunctionImport/attr_fixup_dae_noundef.ll
+++ b/llvm/test/Transforms/FunctionImport/attr_fixup_dae_noundef.ll
@@ -1,0 +1,31 @@
+; Test to ensure that if a definition is imported, already-present declarations
+; are updated as necessary: Definitions from the same module may be optimized
+; together. Thus care must be taken when importing only a subset of the
+; definitions from a module (because other referenced definitions from that
+; module may have been changed by the optimizer and may no longer match
+; declarations already present in the module being imported into).
+
+; Generate bitcode and index, and run the function import.
+; `Inputs/attr_fixup_dae_noundef.ll` contains the post-"Dead Argument Elimination" IR, which
+; removed the `noundef` from `@inner`.
+; RUN: opt -module-summary %p/Inputs/attr_fixup_dae_noundef.ll -o %t.inputs.attr_fixup_dae_noundef.bc
+; RUN: opt -module-summary %s -o %t.main.bc
+; RUN: llvm-lto -thinlto -o %t.summary %t.main.bc %t.inputs.attr_fixup_dae_noundef.bc
+; RUN: opt -passes=function-import -summary-file %t.summary.thinlto.bc %t.main.bc -S 2>&1 \
+; RUN:   | FileCheck %s
+
+define void @main()  {
+  call void @outer(i32 noundef 1)
+  call void @inner(i32 noundef 1)
+  ret void
+}
+
+; Because `@inner` is `noinline`, it should not get imported. However, the
+; `noundef` should be removed.
+; CHECK: declare void @inner(i32)
+declare void @inner(i32 noundef)
+
+; `@outer` should get imported.
+; CHECK: define available_externally void @outer(i32 noundef %arg)
+; CHECK-NEXT: call void @inner(i32 poison)
+declare void @outer(i32 noundef)


### PR DESCRIPTION
It is possible for optimizations to modify attributes on exact definitions. In particular, DeadArgumentElimination may find that a certain argument is dead, and replace arguments in calls with `poison`. This requires dropping the `noundef` attribute on the argument.

When ThinLTO import is performed, the destination module already has a declaration for the function, and the definition is not imported (e.g. because it is noinline), we currently simply retain the original declaration. This is incorrect if call with poison arguments were imported, as the calls become immediate UB.

There was a previous attempt to address this in https://reviews.llvm.org/D139209. What that patch did was to fix up the attributes of the declaration after the fact, dropping UB implying attributes that are not present on the definition. It was reverted because it made an incorrect assumption that the signature between the declaration and definition must match.

In this PR, I propose to fix the issue in a different way: If the source module holds an exact definition (which are the ones that can be, in limited ways, modified by optimizations), then even if we don't import the definition, we should still import a declaration based on it. This ensures that we respect any dropped attributes. (It's probably also useful for optimization purposes, because we also see more inferred attributes.)

Fixes https://github.com/llvm/llvm-project/issues/58976.