### PR TITLE
[APINotes] Support overloaded operators

### DIFF
--- a/clang/test/APINotes/Inputs/Headers/Methods.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/Methods.apinotes
@@ -9,6 +9,12 @@ Tags:
   - Name: getDecremented
     Availability: none
     AvailabilityMsg: "this should have no effect"
+  - Name: operator+
+    Availability: none
+    AvailabilityMsg: "oh no, this is an operator"
+  - Name: operator*
+    Availability: none
+    AvailabilityMsg: "oh no, this is an operator star"
 - Name: IntWrapper2
   Methods:
   - Name: getIncremented

--- a/clang/test/APINotes/Inputs/Headers/Methods.h
+++ b/clang/test/APINotes/Inputs/Headers/Methods.h
@@ -4,6 +4,8 @@ struct IntWrapper {
   IntWrapper getIncremented() const { return {value + 1}; }
 
   IntWrapper operator+(const IntWrapper& RHS) const { return {value + RHS.value}; }
+
+  const int& operator*() const { return value; }
 };
 
 extern "C++" {

--- a/clang/test/APINotes/methods.cpp
+++ b/clang/test/APINotes/methods.cpp
@@ -1,6 +1,8 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Methods -fdisable-module-hash -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -x c++
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Methods -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter IntWrapper::getIncremented -x c++ | FileCheck --check-prefix=CHECK-METHOD %s
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Methods -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter IntWrapper::operator+ -x c++ | FileCheck --check-prefix=CHECK-OPERATOR-PLUS %s
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Methods -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter IntWrapper::operator* -x c++ | FileCheck --check-prefix=CHECK-OPERATOR-STAR %s
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Methods -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter IntWrapper2::getIncremented -x c++ | FileCheck --check-prefix=CHECK-METHOD-2 %s
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Methods -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter IntWrapper3::getIncremented -x c++ | FileCheck --check-prefix=CHECK-METHOD-3 %s
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Methods -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter Outer::Inner::getDecremented -x c++ | FileCheck --check-prefix=CHECK-DEEP-METHOD %s
@@ -10,6 +12,14 @@
 // CHECK-METHOD: Dumping IntWrapper::getIncremented:
 // CHECK-METHOD-NEXT: CXXMethodDecl {{.+}} getIncremented
 // CHECK-METHOD: UnavailableAttr {{.+}} <<invalid sloc>> "oh no"
+
+// CHECK-OPERATOR-PLUS: Dumping IntWrapper::operator+:
+// CHECK-OPERATOR-PLUS-NEXT: CXXMethodDecl {{.+}} operator+
+// CHECK-OPERATOR-PLUS: UnavailableAttr {{.+}} <<invalid sloc>> "oh no, this is an operator"
+
+// CHECK-OPERATOR-STAR: Dumping IntWrapper::operator*:
+// CHECK-OPERATOR-STAR-NEXT: CXXMethodDecl {{.+}} operator*
+// CHECK-OPERATOR-STAR: UnavailableAttr {{.+}} <<invalid sloc>> "oh no, this is an operator star"
 
 // CHECK-METHOD-2: Dumping IntWrapper2::getIncremented:
 // CHECK-METHOD-2-NEXT: CXXMethodDecl {{.+}} getIncremented


### PR DESCRIPTION
This adds support for annotating C++ operators via API Notes. For instance:
```
Tags:
- Name: MyTag
  Methods:
  - Name: operator+
    Availability: none
```

At the moment only operators that are declared as methods of C++ records can be annotated.

rdar://148534260