### PR TITLE
[RISCV] Replace RISCVISD::CLMUL* with ISD::CLMUL*.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -490,6 +490,11 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
     setOperationAction(ISD::SSHLSAT, MVT::i32, Legal);
   }
 
+  if (Subtarget.hasStdExtZbc() || Subtarget.hasStdExtZbkc())
+    setOperationAction({ISD::CLMUL, ISD::CLMULH}, XLenVT, Legal);
+  if (Subtarget.hasStdExtZbc())
+    setOperationAction(ISD::CLMULR, XLenVT, Legal);
+
   static const unsigned FPLegalNodeTypes[] = {
       ISD::FMINNUM,       ISD::FMAXNUM,        ISD::FMINIMUMNUM,
       ISD::FMAXIMUMNUM,   ISD::LRINT,          ISD::LLRINT,
@@ -11366,12 +11371,11 @@ SDValue RISCVTargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
                        Op.getOperand(2), Op.getOperand(3));
   }
   case Intrinsic::riscv_clmul:
-    return DAG.getNode(RISCVISD::CLMUL, DL, XLenVT, Op.getOperand(1),
+    return DAG.getNode(ISD::CLMUL, DL, XLenVT, Op.getOperand(1),
                        Op.getOperand(2));
   case Intrinsic::riscv_clmulh:
   case Intrinsic::riscv_clmulr: {
-    unsigned Opc =
-        IntNo == Intrinsic::riscv_clmulh ? RISCVISD::CLMULH : RISCVISD::CLMULR;
+    unsigned Opc = IntNo == Intrinsic::riscv_clmulh ? ISD::CLMULH : ISD::CLMULR;
     return DAG.getNode(Opc, DL, XLenVT, Op.getOperand(1), Op.getOperand(2));
   }
   case Intrinsic::experimental_get_vector_length:
@@ -15553,7 +15557,7 @@ void RISCVTargetLowering::ReplaceNodeResults(SDNode *N,
           DAG.getNode(ISD::ANY_EXTEND, DL, MVT::i64, N->getOperand(1));
       SDValue NewOp1 =
           DAG.getNode(ISD::ANY_EXTEND, DL, MVT::i64, N->getOperand(2));
-      SDValue Res = DAG.getNode(RISCVISD::CLMUL, DL, MVT::i64, NewOp0, NewOp1);
+      SDValue Res = DAG.getNode(ISD::CLMUL, DL, MVT::i64, NewOp0, NewOp1);
       Results.push_back(DAG.getNode(ISD::TRUNCATE, DL, MVT::i32, Res));
       return;
     }
@@ -15579,8 +15583,8 @@ void RISCVTargetLowering::ReplaceNodeResults(SDNode *N,
                            DAG.getConstant(32, DL, MVT::i64));
       NewOp1 = DAG.getNode(ISD::SHL, DL, MVT::i64, NewOp1,
                            DAG.getConstant(32, DL, MVT::i64));
-      unsigned Opc = IntNo == Intrinsic::riscv_clmulh ? RISCVISD::CLMULH
-                                                      : RISCVISD::CLMULR;
+      unsigned Opc =
+          IntNo == Intrinsic::riscv_clmulh ? ISD::CLMULH : ISD::CLMULR;
       SDValue Res = DAG.getNode(Opc, DL, MVT::i64, NewOp0, NewOp1);
       Res = DAG.getNode(ISD::SRL, DL, MVT::i64, Res,
                         DAG.getConstant(32, DL, MVT::i64));

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
@@ -53,11 +53,6 @@ def riscv_unzip   : RVSDNode<"UNZIP",   SDTIntUnaryOp>;
 // RV64IZbb absolute value for i32. Expanded to (max (negw X), X) during isel.
 def riscv_negw_max : RVSDNode<"NEGW_MAX",    SDTIntUnaryOp>;
 
-// Scalar cryptography
-def riscv_clmul   : RVSDNode<"CLMUL",   SDTIntBinOp>;
-def riscv_clmulh  : RVSDNode<"CLMULH",  SDTIntBinOp>;
-def riscv_clmulr  : RVSDNode<"CLMULR",  SDTIntBinOp>;
-
 def BCLRXForm : SDNodeXForm<imm, [{
   // Find the lowest 0.
   return CurDAG->getTargetConstant(llvm::countr_one(N->getZExtValue()),
@@ -860,12 +855,12 @@ def : Sh3AddPat<SH3ADD>;
 } // Predicates = [HasStdExtZba, IsRV64]
 
 let Predicates = [HasStdExtZbcOrZbkc] in {
-def : PatGprGpr<riscv_clmul, CLMUL>;
-def : PatGprGpr<riscv_clmulh, CLMULH>;
+def : PatGprGpr<clmul, CLMUL>;
+def : PatGprGpr<clmulh, CLMULH>;
 } // Predicates = [HasStdExtZbcOrZbkc]
 
 let Predicates = [HasStdExtZbc] in
-def : PatGprGpr<riscv_clmulr, CLMULR>;
+def : PatGprGpr<clmulr, CLMULR>;
 
 let Predicates = [HasStdExtZbkx] in {
 def : PatGprGpr<int_riscv_xperm4, XPERM4>;

--- a/llvm/test/CodeGen/RISCV/rv32zbc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zbc-intrinsic.ll
@@ -10,3 +10,16 @@ define i32 @clmul32r(i32 %a, i32 %b) nounwind {
   %tmp = call i32 @llvm.riscv.clmulr.i32(i32 %a, i32 %b)
   ret i32 %tmp
 }
+
+define i32 @llvm_clmulr_i32(i32 %a, i32 %b) nounwind {
+; RV32ZBC-LABEL: llvm_clmulr_i32:
+; RV32ZBC:       # %bb.0:
+; RV32ZBC-NEXT:    clmulr a0, a0, a1
+; RV32ZBC-NEXT:    ret
+  %tmp1 = zext i32 %a to i64
+  %tmp2 = zext i32 %b to i64
+  %tmp3 = call i64 @llvm.clmul.i64(i64 %tmp1, i64 %tmp2)
+  %tmp4 = lshr i64 %tmp3, 31
+  %tmp5 = trunc i64 %tmp4 to i32
+  ret i32 %tmp5
+}

--- a/llvm/test/CodeGen/RISCV/rv32zbc-zbkc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zbc-zbkc-intrinsic.ll
@@ -21,3 +21,25 @@ define i32 @clmul32h(i32 %a, i32 %b) nounwind {
   %tmp = call i32 @llvm.riscv.clmulh.i32(i32 %a, i32 %b)
   ret i32 %tmp
 }
+
+define i32 @llvm_clmul_i32(i32 %a, i32 %b) nounwind {
+; RV32ZBC-ZBKC-LABEL: llvm_clmul_i32:
+; RV32ZBC-ZBKC:       # %bb.0:
+; RV32ZBC-ZBKC-NEXT:    clmul a0, a0, a1
+; RV32ZBC-ZBKC-NEXT:    ret
+  %tmp = call i32 @llvm.clmul.i32(i32 %a, i32 %b)
+  ret i32 %tmp
+}
+
+define i32 @llvm_clmulh_i32(i32 %a, i32 %b) nounwind {
+; RV32ZBC-ZBKC-LABEL: llvm_clmulh_i32:
+; RV32ZBC-ZBKC:       # %bb.0:
+; RV32ZBC-ZBKC-NEXT:    clmulh a0, a0, a1
+; RV32ZBC-ZBKC-NEXT:    ret
+  %tmp1 = zext i32 %a to i64
+  %tmp2 = zext i32 %b to i64
+  %tmp3 = call i64 @llvm.clmul.i64(i64 %tmp1, i64 %tmp2)
+  %tmp4 = lshr i64 %tmp3, 32
+  %tmp5 = trunc i64 %tmp4 to i32
+  ret i32 %tmp5
+}

--- a/llvm/test/CodeGen/RISCV/rv64zbc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbc-intrinsic.ll
@@ -36,3 +36,35 @@ define signext i32 @clmul32r_zext(i32 zeroext %a, i32 zeroext %b) nounwind {
   %tmp = call i32 @llvm.riscv.clmulr.i32(i32 %a, i32 %b)
   ret i32 %tmp
 }
+
+define i64 @llvm_clmulr_i64(i64 %a, i64 %b) nounwind {
+; RV64ZBC-LABEL: llvm_clmulr_i64:
+; RV64ZBC:       # %bb.0:
+; RV64ZBC-NEXT:    clmulr a0, a0, a1
+; RV64ZBC-NEXT:    ret
+  %tmp1 = zext i64 %a to i128
+  %tmp2 = zext i64 %b to i128
+  %tmp3 = call i128 @llvm.clmul.i128(i128 %tmp1, i128 %tmp2)
+  %tmp4 = lshr i128 %tmp3, 63
+  %tmp5 = trunc i128 %tmp4 to i64
+  ret i64 %tmp5
+}
+
+define i32 @llvm_clmulr_i32(i32 %a, i32 %b) nounwind {
+; RV64ZBC-LABEL: llvm_clmulr_i32:
+; RV64ZBC:       # %bb.0:
+; RV64ZBC-NEXT:    slli a1, a1, 32
+; RV64ZBC-NEXT:    slli a0, a0, 32
+; RV64ZBC-NEXT:    srli a1, a1, 32
+; RV64ZBC-NEXT:    srli a0, a0, 32
+; RV64ZBC-NEXT:    clmul a0, a0, a1
+; RV64ZBC-NEXT:    slli a0, a0, 1
+; RV64ZBC-NEXT:    srli a0, a0, 32
+; RV64ZBC-NEXT:    ret
+  %tmp1 = zext i32 %a to i64
+  %tmp2 = zext i32 %b to i64
+  %tmp3 = call i64 @llvm.clmul.i64(i64 %tmp1, i64 %tmp2)
+  %tmp4 = lshr i64 %tmp3, 31
+  %tmp5 = trunc i64 %tmp4 to i32
+  ret i32 %tmp5
+}

--- a/llvm/test/CodeGen/RISCV/rv64zbc-zbkc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbc-zbkc-intrinsic.ll
@@ -57,3 +57,52 @@ define signext i32 @clmul32h_zext(i32 zeroext %a, i32 zeroext %b) nounwind {
   %tmp = call i32 @llvm.riscv.clmulh.i32(i32 %a, i32 %b)
   ret i32 %tmp
 }
+
+define i64 @llvm_clmul_i64(i64 %a, i64 %b) nounwind {
+; RV64ZBC-ZBKC-LABEL: llvm_clmul_i64:
+; RV64ZBC-ZBKC:       # %bb.0:
+; RV64ZBC-ZBKC-NEXT:    clmul a0, a0, a1
+; RV64ZBC-ZBKC-NEXT:    ret
+  %tmp = call i64 @llvm.clmul.i64(i64 %a, i64 %b)
+  ret i64 %tmp
+}
+
+define i64 @llvm_clmulh_i64(i64 %a, i64 %b) nounwind {
+; RV64ZBC-ZBKC-LABEL: llvm_clmulh_i64:
+; RV64ZBC-ZBKC:       # %bb.0:
+; RV64ZBC-ZBKC-NEXT:    clmulh a0, a0, a1
+; RV64ZBC-ZBKC-NEXT:    ret
+  %tmp1 = zext i64 %a to i128
+  %tmp2 = zext i64 %b to i128
+  %tmp3 = call i128 @llvm.clmul.i128(i128 %tmp1, i128 %tmp2)
+  %tmp4 = lshr i128 %tmp3, 64
+  %tmp5 = trunc i128 %tmp4 to i64
+  ret i64 %tmp5
+}
+
+define i32 @llvm_clmul_i32(i32 %a, i32 %b) nounwind {
+; RV64ZBC-ZBKC-LABEL: llvm_clmul_i32:
+; RV64ZBC-ZBKC:       # %bb.0:
+; RV64ZBC-ZBKC-NEXT:    clmul a0, a0, a1
+; RV64ZBC-ZBKC-NEXT:    ret
+  %tmp = call i32 @llvm.clmul.i32(i32 %a, i32 %b)
+  ret i32 %tmp
+}
+
+define i32 @llvm_clmulh_i32(i32 %a, i32 %b) nounwind {
+; RV64ZBC-ZBKC-LABEL: llvm_clmulh_i32:
+; RV64ZBC-ZBKC:       # %bb.0:
+; RV64ZBC-ZBKC-NEXT:    slli a1, a1, 32
+; RV64ZBC-ZBKC-NEXT:    slli a0, a0, 32
+; RV64ZBC-ZBKC-NEXT:    srli a1, a1, 32
+; RV64ZBC-ZBKC-NEXT:    srli a0, a0, 32
+; RV64ZBC-ZBKC-NEXT:    clmul a0, a0, a1
+; RV64ZBC-ZBKC-NEXT:    srli a0, a0, 32
+; RV64ZBC-ZBKC-NEXT:    ret
+  %tmp1 = zext i32 %a to i64
+  %tmp2 = zext i32 %b to i64
+  %tmp3 = call i64 @llvm.clmul.i64(i64 %tmp1, i64 %tmp2)
+  %tmp4 = lshr i64 %tmp3, 32
+  %tmp5 = trunc i64 %tmp4 to i32
+  ret i32 %tmp5
+}


### PR DESCRIPTION
This patch does the minimum to remove RISCVISD::CLMUL*. It does not remove existing intrinsics.

There's some missed optimizations for i32 CLMULH/CLMULR on RV64, but those may be generic issues.

I've put the test cases in the existing files so it's more obvious what the missed optimizations are by comparing within the file.