### PR TITLE
[Flan][OpenMP] Implement TODO support for compatible defaultmap types for implicit mappers

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -2766,10 +2766,9 @@ genTargetOp(lower::AbstractConverter &converter, lower::SymMap &symTable,
               firOpBuilder, converter, defaultMaps, eleType, loc, sym);
 
       mlir::FlatSymbolRefAttr mapperId;
-      if (defaultMaps.empty()) {
-        // TODO: Honor user-provided defaultmap clauses (aggregates/pointers)
-        // instead of blanket-disabling implicit mapper generation whenever any
-        // explicit default map is present.
+      auto defaultmapBehaviour = getDefaultmapIfPresent(defaultMaps, eleType);
+      if (defaultmapBehaviour ==
+          clause::Defaultmap::ImplicitBehavior::Default) {
         const semantics::DerivedTypeSpec *typeSpec =
             sym.GetType() ? sym.GetType()->AsDerived() : nullptr;
         if (typeSpec) {

--- a/flang/test/Lower/OpenMP/defaultmap.f90
+++ b/flang/test/Lower/OpenMP/defaultmap.f90
@@ -106,3 +106,25 @@ subroutine defaultmap_dtype_aggregate_to()
 
     return
 end subroutine
+
+subroutine defaultmap_scalar_implicit_mapper()
+    implicit none
+    type :: dtype
+        integer(4) :: array_i(10)
+        integer(4) :: k
+    end type dtype
+
+    type(dtype), allocatable :: obj
+
+! CHECK-LABEL: func.func @_QPdefaultmap_scalar_implicit_mapper
+! CHECK: %[[BASE_MAP:.*]] = omp.map.info {{.*}} map_clauses(implicit, tofrom) capture(ByRef) {{.*}} mapper(@{{.*}}) -> {{.*}} {name = ""}
+! CHECK: %[[DESC_MAP:.*]] = omp.map.info {{.*}} map_clauses(always, implicit, to) capture(ByRef) members(%[[BASE_MAP]] : [0] : {{.*}}) -> {{.*}} {name = "obj"}
+! CHECK: omp.target map_entries(%[[DESC_MAP]] -> {{.*}}, %[[BASE_MAP]] -> {{.*}})
+    allocate(obj)
+    !$omp target defaultmap(tofrom: scalar)
+        obj%k = 40
+        obj%array_i(1) = 50
+    !$omp end target
+
+    return
+end subroutine

--- a/offload/test/offloading/fortran/target-defaultmap-implicit-mapper.f90
+++ b/offload/test/offloading/fortran/target-defaultmap-implicit-mapper.f90
@@ -1,0 +1,49 @@
+! Offload test that ensures defaultmap(scalar: tofrom) does not suppress
+! implicit default mapper generation for allocatable derived types.
+! REQUIRES: flang, amdgpu
+
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+program defaultmap_implicit_mapper
+  implicit none
+
+  type :: payload_t
+    integer, allocatable :: arr(:)
+  end type payload_t
+
+  type(payload_t), allocatable :: obj
+  integer, parameter :: n = 8
+  integer :: i
+  integer :: scalar
+  logical :: ok
+
+  allocate(obj)
+  allocate(obj%arr(n))
+  obj%arr = 1
+  scalar = 2
+
+  !$omp target defaultmap(tofrom: scalar)
+    do i = 1, n
+      obj%arr(i) = obj%arr(i) + scalar
+    end do
+    scalar = 7
+  !$omp end target
+
+  ok = .true.
+  do i = 1, n
+    if (obj%arr(i) /= 3) ok = .false.
+  end do
+  if (scalar /= 7) ok = .false.
+
+  if (ok) then
+    print *, "Test passed!"
+  else
+    print *, "Test failed!"
+    print *, obj%arr
+    print *, scalar
+  end if
+
+  deallocate(obj%arr)
+  deallocate(obj)
+end program defaultmap_implicit_mapper
+
+! CHECK: Test passed!

--- a/offload/test/offloading/fortran/target-defaultmap-implicit-mapper.f90
+++ b/offload/test/offloading/fortran/target-defaultmap-implicit-mapper.f90
@@ -1,4 +1,4 @@
-! Offload test that ensures defaultmap(scalar: tofrom) does not suppress
+! Offload test that ensures defaultmap(tofrom: scalar) does not suppress
 ! implicit default mapper generation for allocatable derived types.
 ! REQUIRES: flang, amdgpu
 


### PR DESCRIPTION
Make implicit default mapper generation respect defaultmap categories so unrelated defaultmap clauses no longer suppress mappers for derived types.
Added related tests.