### PR TITLE
[clang] Add myself as an additional offloading driver maintainer

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -179,6 +179,9 @@ Offloading driver
 | Joseph Huber
 | joseph.huber\@amd.com (email), jhuber6 (GitHub)
 
+| Nick Sarnie
+| nick.sarnie\@intel.com (email), sarnex (GitHub)
+
 
 Driver parts not covered by someone else
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I've worked in the offloading driver a decent amount both directly here and in Intel's downstream forks and I feel I have the judgement to consider the needs of the project overall as well as the bandwidth to properly carry out the role.