### PR TITLE
[bazel] dsymutil should link against CF framework on darwin

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -4541,6 +4541,13 @@ cc_library(
         "tools/dsymutil/*.h",
     ]),
     copts = llvm_copts,
+    linkopts = select({
+        "@platforms//os:macos": [
+            "-framework",
+            "CoreFoundation",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         ":AllTargetsCodeGens",
         ":BinaryFormat",


### PR DESCRIPTION
Matches cmake https://github.com/llvm/llvm-project/blob/6de6f7b46bda0fef45b997d05fe57e046f60e4df/llvm/tools/dsymutil/CMakeLists.txt#L48