### PR TITLE
[clang] Clarify SourceLocation and (Char)SourceRange docs

### DIFF
--- a/clang/include/clang/Basic/SourceLocation.h
+++ b/clang/include/clang/Basic/SourceLocation.h
@@ -108,7 +108,7 @@ private:
   enum : UIntTy { MacroIDBit = 1ULL << (8 * sizeof(UIntTy) - 1) };
 
 public:
-  bool isFileID() const { return (ID & MacroIDBit) == 0; }
+  bool isFileID() const  { return (ID & MacroIDBit) == 0; }
   bool isMacroID() const { return (ID & MacroIDBit) != 0; }
 
   /// Return true if this is a valid SourceLocation object.
@@ -141,9 +141,9 @@ public:
   /// Return a source location with the specified offset from this
   /// SourceLocation.
   SourceLocation getLocWithOffset(IntTy Offset) const {
-    assert(((getOffset() + Offset) & MacroIDBit) == 0 && "offset overflow");
+    assert(((getOffset()+Offset) & MacroIDBit) == 0 && "offset overflow");
     SourceLocation L;
-    L.ID = ID + Offset;
+    L.ID = ID+Offset;
     return L;
   }
 
@@ -169,10 +169,10 @@ public:
   ///
   /// This should only be passed to SourceLocation::getFromPtrEncoding, it
   /// should not be inspected directly.
-  void *getPtrEncoding() const {
+  void* getPtrEncoding() const {
     // Double cast to avoid a warning "cast to pointer from integer of different
     // size".
-    return (void *)(uintptr_t)getRawEncoding();
+    return (void*)(uintptr_t)getRawEncoding();
   }
 
   /// Turn a pointer encoding of a SourceLocation object back
@@ -239,9 +239,13 @@ public:
   bool isValid() const { return B.isValid() && E.isValid(); }
   bool isInvalid() const { return !isValid(); }
 
-  bool operator==(const SourceRange &X) const { return B == X.B && E == X.E; }
+  bool operator==(const SourceRange &X) const {
+    return B == X.B && E == X.E;
+  }
 
-  bool operator!=(const SourceRange &X) const { return B != X.B || E != X.E; }
+  bool operator!=(const SourceRange &X) const {
+    return B != X.B || E != X.E;
+  }
 
   // Returns true iff other is wholly contained within this range.
   bool fullyContains(const SourceRange &other) const {
@@ -460,7 +464,7 @@ public:
 
   /// Comparison function class, useful for sorting FullSourceLocs.
   struct BeforeThanCompare {
-    bool operator()(const FullSourceLoc &lhs, const FullSourceLoc &rhs) const {
+    bool operator()(const FullSourceLoc& lhs, const FullSourceLoc& rhs) const {
       return lhs.isBeforeInTranslationUnitThan(rhs);
     }
   };
@@ -470,12 +474,14 @@ public:
   /// This is useful for debugging.
   void dump() const;
 
-  friend bool operator==(const FullSourceLoc &LHS, const FullSourceLoc &RHS) {
+  friend bool
+  operator==(const FullSourceLoc &LHS, const FullSourceLoc &RHS) {
     return LHS.getRawEncoding() == RHS.getRawEncoding() &&
-           LHS.SrcMgr == RHS.SrcMgr;
+          LHS.SrcMgr == RHS.SrcMgr;
   }
 
-  friend bool operator!=(const FullSourceLoc &LHS, const FullSourceLoc &RHS) {
+  friend bool
+  operator!=(const FullSourceLoc &LHS, const FullSourceLoc &RHS) {
     return !(LHS == RHS);
   }
 };
@@ -484,68 +490,73 @@ public:
 
 namespace llvm {
 
-/// Define DenseMapInfo so that FileID's can be used as keys in DenseMap and
-/// DenseSets.
-template <> struct DenseMapInfo<clang::FileID, void> {
-  static clang::FileID getEmptyKey() { return {}; }
+  /// Define DenseMapInfo so that FileID's can be used as keys in DenseMap and
+  /// DenseSets.
+  template <>
+  struct DenseMapInfo<clang::FileID, void> {
+    static clang::FileID getEmptyKey() {
+      return {};
+    }
 
-  static clang::FileID getTombstoneKey() {
-    return clang::FileID::getSentinel();
-  }
+    static clang::FileID getTombstoneKey() {
+      return clang::FileID::getSentinel();
+    }
 
-  static unsigned getHashValue(clang::FileID S) { return S.getHashValue(); }
+    static unsigned getHashValue(clang::FileID S) {
+      return S.getHashValue();
+    }
 
-  static bool isEqual(clang::FileID LHS, clang::FileID RHS) {
-    return LHS == RHS;
-  }
-};
+    static bool isEqual(clang::FileID LHS, clang::FileID RHS) {
+      return LHS == RHS;
+    }
+  };
 
-/// Define DenseMapInfo so that SourceLocation's can be used as keys in
-/// DenseMap and DenseSet. This trait class is eqivalent to
-/// DenseMapInfo<unsigned> which uses SourceLocation::ID is used as a key.
-template <> struct DenseMapInfo<clang::SourceLocation, void> {
-  static clang::SourceLocation getEmptyKey() {
-    constexpr clang::SourceLocation::UIntTy Zero = 0;
-    return clang::SourceLocation::getFromRawEncoding(~Zero);
-  }
+  /// Define DenseMapInfo so that SourceLocation's can be used as keys in
+  /// DenseMap and DenseSet. This trait class is eqivalent to
+  /// DenseMapInfo<unsigned> which uses SourceLocation::ID is used as a key.
+  template <> struct DenseMapInfo<clang::SourceLocation, void> {
+    static clang::SourceLocation getEmptyKey() {
+      constexpr clang::SourceLocation::UIntTy Zero = 0;
+      return clang::SourceLocation::getFromRawEncoding(~Zero);
+    }
 
-  static clang::SourceLocation getTombstoneKey() {
-    constexpr clang::SourceLocation::UIntTy Zero = 0;
-    return clang::SourceLocation::getFromRawEncoding(~Zero - 1);
-  }
+    static clang::SourceLocation getTombstoneKey() {
+      constexpr clang::SourceLocation::UIntTy Zero = 0;
+      return clang::SourceLocation::getFromRawEncoding(~Zero - 1);
+    }
 
-  static unsigned getHashValue(clang::SourceLocation Loc) {
-    return Loc.getHashValue();
-  }
+    static unsigned getHashValue(clang::SourceLocation Loc) {
+      return Loc.getHashValue();
+    }
 
-  static bool isEqual(clang::SourceLocation LHS, clang::SourceLocation RHS) {
-    return LHS == RHS;
-  }
-};
+    static bool isEqual(clang::SourceLocation LHS, clang::SourceLocation RHS) {
+      return LHS == RHS;
+    }
+  };
 
-// Allow calling FoldingSetNodeID::Add with SourceLocation object as parameter
-template <> struct FoldingSetTrait<clang::SourceLocation, void> {
-  static void Profile(const clang::SourceLocation &X, FoldingSetNodeID &ID);
-};
+  // Allow calling FoldingSetNodeID::Add with SourceLocation object as parameter
+  template <> struct FoldingSetTrait<clang::SourceLocation, void> {
+    static void Profile(const clang::SourceLocation &X, FoldingSetNodeID &ID);
+  };
 
-template <> struct DenseMapInfo<clang::SourceRange> {
-  static clang::SourceRange getEmptyKey() {
-    return DenseMapInfo<clang::SourceLocation>::getEmptyKey();
-  }
+  template <> struct DenseMapInfo<clang::SourceRange> {
+    static clang::SourceRange getEmptyKey() {
+      return DenseMapInfo<clang::SourceLocation>::getEmptyKey();
+    }
 
-  static clang::SourceRange getTombstoneKey() {
-    return DenseMapInfo<clang::SourceLocation>::getTombstoneKey();
-  }
+    static clang::SourceRange getTombstoneKey() {
+      return DenseMapInfo<clang::SourceLocation>::getTombstoneKey();
+    }
 
-  static unsigned getHashValue(clang::SourceRange Range) {
-    return detail::combineHashValue(Range.getBegin().getHashValue(),
-                                    Range.getEnd().getHashValue());
-  }
+    static unsigned getHashValue(clang::SourceRange Range) {
+      return detail::combineHashValue(Range.getBegin().getHashValue(),
+                                      Range.getEnd().getHashValue());
+    }
 
-  static bool isEqual(clang::SourceRange LHS, clang::SourceRange RHS) {
-    return LHS == RHS;
-  }
-};
+    static bool isEqual(clang::SourceRange LHS, clang::SourceRange RHS) {
+      return LHS == RHS;
+    }
+  };
 
 } // namespace llvm
 

--- a/clang/include/clang/Basic/SourceLocation.h
+++ b/clang/include/clang/Basic/SourceLocation.h
@@ -86,9 +86,9 @@ using FileIDAndOffset = std::pair<FileID, unsigned>;
 /// In addition, one bit of SourceLocation is used for quick access to the
 /// information whether the location is in a file or a macro expansion.
 ///
-/// SourceLocation operates on a character level, i.e. offsets describe
-/// character distances, but in most cases, they are used on a token level,
-/// where a SourceLocation points to the first character of a lexer token.
+/// SourceLocation operates on a byte level, i.e. offsets describe
+/// byte distances, but in most cases, they are used on a token level,
+/// where a SourceLocation points to the first byte of a lexer token.
 ///
 /// It is important that this type remains small. It is currently 32 bits wide.
 class SourceLocation {
@@ -219,8 +219,8 @@ inline bool operator>=(const SourceLocation &LHS, const SourceLocation &RHS) {
 ///
 /// When referring to tokens, a SourceRange is an inclusive range [begin, end]
 /// that contains its endpoints, its begin SourceLocation points to the first
-/// character of the first token and its end SourceLocation points to the first
-/// character of the last token.
+/// byte of the first token and its end SourceLocation points to the first byte
+/// of the last token.
 class SourceRange {
   SourceLocation B;
   SourceLocation E;
@@ -253,9 +253,9 @@ public:
   void dump(const SourceManager &SM) const;
 };
 
-/// Represents a character-granular source range.
+/// Represents a byte-granular source range.
 ///
-/// The underlying SourceRange can either specify the starting/ending character
+/// The underlying SourceRange can either specify the starting/ending byte
 /// of the range, or it can specify the start of the range and the start of the
 /// last token of the range (a "token range").  In the token range case, the
 /// size of the last token must be measured to determine the actual end of the
@@ -266,7 +266,7 @@ public:
 /// For a TokenRange, the range contains the endpoint, i.e. the token containing
 /// the end SourceLocation.
 /// For a CharRange, the range doesn't contain the endpoint, i.e. it ends at the
-/// character before the end SourceLocation. This allows representing a point
+/// byte before the end SourceLocation. This allows representing a point
 /// CharRange [begin, begin) that points at the empty range right in front of
 /// the begin SourceLocation.
 class CharSourceRange {
@@ -294,8 +294,8 @@ public:
   }
 
   /// Return true if the end of this range specifies the start of
-  /// the last token.  Return false if the end of this range specifies the last
-  /// character in the range.
+  /// the last token.  Return false if the end of this range specifies the first
+  /// byte after the range.
   bool isTokenRange() const { return IsTokenRange; }
   bool isCharRange() const { return !IsTokenRange; }
 

--- a/clang/include/clang/Basic/SourceLocation.h
+++ b/clang/include/clang/Basic/SourceLocation.h
@@ -217,10 +217,10 @@ inline bool operator>=(const SourceLocation &LHS, const SourceLocation &RHS) {
 
 /// A trivial tuple used to represent a source range.
 ///
-/// SourceRange is an inclusive range [begin, end] that contains its endpoints,
-/// and when referring to tokens, its begin SourceLocation usually points to
-/// the first character of the first token and its end SourceLocation points to
-/// the last character of the last token.
+/// When referring to tokens, a SourceRange is an inclusive range [begin, end]
+/// that contains its endpoints, its begin SourceLocation points to the first
+/// character of the first token and its end SourceLocation points to the first
+/// character of the last token.
 class SourceRange {
   SourceLocation B;
   SourceLocation E;

--- a/clang/include/clang/Basic/SourceLocation.h
+++ b/clang/include/clang/Basic/SourceLocation.h
@@ -86,6 +86,10 @@ using FileIDAndOffset = std::pair<FileID, unsigned>;
 /// In addition, one bit of SourceLocation is used for quick access to the
 /// information whether the location is in a file or a macro expansion.
 ///
+/// SourceLocation operates on a character level, i.e. offsets describe
+/// character distances, but in most cases, they are used on a token level,
+/// where a SourceLocation points to the first character of a lexer token.
+///
 /// It is important that this type remains small. It is currently 32 bits wide.
 class SourceLocation {
   friend class ASTReader;
@@ -212,6 +216,11 @@ inline bool operator>=(const SourceLocation &LHS, const SourceLocation &RHS) {
 }
 
 /// A trivial tuple used to represent a source range.
+///
+/// SourceRange is an inclusive range [begin, end] that contains its endpoints,
+/// and when referring to tokens, its begin SourceLocation usually points to
+/// the first character of the first token and its end SourceLocation points to
+/// the last character of the last token.
 class SourceRange {
   SourceLocation B;
   SourceLocation E;
@@ -251,6 +260,15 @@ public:
 /// last token of the range (a "token range").  In the token range case, the
 /// size of the last token must be measured to determine the actual end of the
 /// range.
+///
+/// CharSourceRange is interpreted differently depending on whether it is a
+/// TokenRange or a CharRange.
+/// For a TokenRange, the range contains the endpoint, i.e. the token containing
+/// the end SourceLocation.
+/// For a CharRange, the range doesn't contain the endpoint, i.e. it ends at the
+/// character before the end SourceLocation. This allows representing a point
+/// CharRange [begin, begin) that points at the empty range right in front of
+/// the begin SourceLocation.
 class CharSourceRange {
   SourceRange Range;
   bool IsTokenRange = false;

--- a/clang/include/clang/Basic/SourceLocation.h
+++ b/clang/include/clang/Basic/SourceLocation.h
@@ -104,7 +104,7 @@ private:
   enum : UIntTy { MacroIDBit = 1ULL << (8 * sizeof(UIntTy) - 1) };
 
 public:
-  bool isFileID() const  { return (ID & MacroIDBit) == 0; }
+  bool isFileID() const { return (ID & MacroIDBit) == 0; }
   bool isMacroID() const { return (ID & MacroIDBit) != 0; }
 
   /// Return true if this is a valid SourceLocation object.
@@ -137,9 +137,9 @@ public:
   /// Return a source location with the specified offset from this
   /// SourceLocation.
   SourceLocation getLocWithOffset(IntTy Offset) const {
-    assert(((getOffset()+Offset) & MacroIDBit) == 0 && "offset overflow");
+    assert(((getOffset() + Offset) & MacroIDBit) == 0 && "offset overflow");
     SourceLocation L;
-    L.ID = ID+Offset;
+    L.ID = ID + Offset;
     return L;
   }
 
@@ -165,10 +165,10 @@ public:
   ///
   /// This should only be passed to SourceLocation::getFromPtrEncoding, it
   /// should not be inspected directly.
-  void* getPtrEncoding() const {
+  void *getPtrEncoding() const {
     // Double cast to avoid a warning "cast to pointer from integer of different
     // size".
-    return (void*)(uintptr_t)getRawEncoding();
+    return (void *)(uintptr_t)getRawEncoding();
   }
 
   /// Turn a pointer encoding of a SourceLocation object back
@@ -230,13 +230,9 @@ public:
   bool isValid() const { return B.isValid() && E.isValid(); }
   bool isInvalid() const { return !isValid(); }
 
-  bool operator==(const SourceRange &X) const {
-    return B == X.B && E == X.E;
-  }
+  bool operator==(const SourceRange &X) const { return B == X.B && E == X.E; }
 
-  bool operator!=(const SourceRange &X) const {
-    return B != X.B || E != X.E;
-  }
+  bool operator!=(const SourceRange &X) const { return B != X.B || E != X.E; }
 
   // Returns true iff other is wholly contained within this range.
   bool fullyContains(const SourceRange &other) const {
@@ -446,7 +442,7 @@ public:
 
   /// Comparison function class, useful for sorting FullSourceLocs.
   struct BeforeThanCompare {
-    bool operator()(const FullSourceLoc& lhs, const FullSourceLoc& rhs) const {
+    bool operator()(const FullSourceLoc &lhs, const FullSourceLoc &rhs) const {
       return lhs.isBeforeInTranslationUnitThan(rhs);
     }
   };
@@ -456,14 +452,12 @@ public:
   /// This is useful for debugging.
   void dump() const;
 
-  friend bool
-  operator==(const FullSourceLoc &LHS, const FullSourceLoc &RHS) {
+  friend bool operator==(const FullSourceLoc &LHS, const FullSourceLoc &RHS) {
     return LHS.getRawEncoding() == RHS.getRawEncoding() &&
-          LHS.SrcMgr == RHS.SrcMgr;
+           LHS.SrcMgr == RHS.SrcMgr;
   }
 
-  friend bool
-  operator!=(const FullSourceLoc &LHS, const FullSourceLoc &RHS) {
+  friend bool operator!=(const FullSourceLoc &LHS, const FullSourceLoc &RHS) {
     return !(LHS == RHS);
   }
 };
@@ -472,73 +466,68 @@ public:
 
 namespace llvm {
 
-  /// Define DenseMapInfo so that FileID's can be used as keys in DenseMap and
-  /// DenseSets.
-  template <>
-  struct DenseMapInfo<clang::FileID, void> {
-    static clang::FileID getEmptyKey() {
-      return {};
-    }
+/// Define DenseMapInfo so that FileID's can be used as keys in DenseMap and
+/// DenseSets.
+template <> struct DenseMapInfo<clang::FileID, void> {
+  static clang::FileID getEmptyKey() { return {}; }
 
-    static clang::FileID getTombstoneKey() {
-      return clang::FileID::getSentinel();
-    }
+  static clang::FileID getTombstoneKey() {
+    return clang::FileID::getSentinel();
+  }
 
-    static unsigned getHashValue(clang::FileID S) {
-      return S.getHashValue();
-    }
+  static unsigned getHashValue(clang::FileID S) { return S.getHashValue(); }
 
-    static bool isEqual(clang::FileID LHS, clang::FileID RHS) {
-      return LHS == RHS;
-    }
-  };
+  static bool isEqual(clang::FileID LHS, clang::FileID RHS) {
+    return LHS == RHS;
+  }
+};
 
-  /// Define DenseMapInfo so that SourceLocation's can be used as keys in
-  /// DenseMap and DenseSet. This trait class is eqivalent to
-  /// DenseMapInfo<unsigned> which uses SourceLocation::ID is used as a key.
-  template <> struct DenseMapInfo<clang::SourceLocation, void> {
-    static clang::SourceLocation getEmptyKey() {
-      constexpr clang::SourceLocation::UIntTy Zero = 0;
-      return clang::SourceLocation::getFromRawEncoding(~Zero);
-    }
+/// Define DenseMapInfo so that SourceLocation's can be used as keys in
+/// DenseMap and DenseSet. This trait class is eqivalent to
+/// DenseMapInfo<unsigned> which uses SourceLocation::ID is used as a key.
+template <> struct DenseMapInfo<clang::SourceLocation, void> {
+  static clang::SourceLocation getEmptyKey() {
+    constexpr clang::SourceLocation::UIntTy Zero = 0;
+    return clang::SourceLocation::getFromRawEncoding(~Zero);
+  }
 
-    static clang::SourceLocation getTombstoneKey() {
-      constexpr clang::SourceLocation::UIntTy Zero = 0;
-      return clang::SourceLocation::getFromRawEncoding(~Zero - 1);
-    }
+  static clang::SourceLocation getTombstoneKey() {
+    constexpr clang::SourceLocation::UIntTy Zero = 0;
+    return clang::SourceLocation::getFromRawEncoding(~Zero - 1);
+  }
 
-    static unsigned getHashValue(clang::SourceLocation Loc) {
-      return Loc.getHashValue();
-    }
+  static unsigned getHashValue(clang::SourceLocation Loc) {
+    return Loc.getHashValue();
+  }
 
-    static bool isEqual(clang::SourceLocation LHS, clang::SourceLocation RHS) {
-      return LHS == RHS;
-    }
-  };
+  static bool isEqual(clang::SourceLocation LHS, clang::SourceLocation RHS) {
+    return LHS == RHS;
+  }
+};
 
-  // Allow calling FoldingSetNodeID::Add with SourceLocation object as parameter
-  template <> struct FoldingSetTrait<clang::SourceLocation, void> {
-    static void Profile(const clang::SourceLocation &X, FoldingSetNodeID &ID);
-  };
+// Allow calling FoldingSetNodeID::Add with SourceLocation object as parameter
+template <> struct FoldingSetTrait<clang::SourceLocation, void> {
+  static void Profile(const clang::SourceLocation &X, FoldingSetNodeID &ID);
+};
 
-  template <> struct DenseMapInfo<clang::SourceRange> {
-    static clang::SourceRange getEmptyKey() {
-      return DenseMapInfo<clang::SourceLocation>::getEmptyKey();
-    }
+template <> struct DenseMapInfo<clang::SourceRange> {
+  static clang::SourceRange getEmptyKey() {
+    return DenseMapInfo<clang::SourceLocation>::getEmptyKey();
+  }
 
-    static clang::SourceRange getTombstoneKey() {
-      return DenseMapInfo<clang::SourceLocation>::getTombstoneKey();
-    }
+  static clang::SourceRange getTombstoneKey() {
+    return DenseMapInfo<clang::SourceLocation>::getTombstoneKey();
+  }
 
-    static unsigned getHashValue(clang::SourceRange Range) {
-      return detail::combineHashValue(Range.getBegin().getHashValue(),
-                                      Range.getEnd().getHashValue());
-    }
+  static unsigned getHashValue(clang::SourceRange Range) {
+    return detail::combineHashValue(Range.getBegin().getHashValue(),
+                                    Range.getEnd().getHashValue());
+  }
 
-    static bool isEqual(clang::SourceRange LHS, clang::SourceRange RHS) {
-      return LHS == RHS;
-    }
-  };
+  static bool isEqual(clang::SourceRange LHS, clang::SourceRange RHS) {
+    return LHS == RHS;
+  }
+};
 
 } // namespace llvm
 


### PR DESCRIPTION
The current documentation leaves some questions unanswered to me, which I'm trying to clarify here.
1. It was unclear how SourceLocation differed when referring to the character level vs. the token level. Turns out there is no such difference, and SourceLocation always refers to characters. This should be made explicit in the docs.
2. It was unclear in which cases (Char)SourceRange is inclusive (containing the endpoint) or exclusive (ending before the endpoint). From my reading of the docs and investigating the behavior of different AST nodes' `getSourceLoc()` result and  `Lexer::getSourceText()`, SourceRange is always inclusive and CharSourceRange is inclusive only as a TokenRange, and exclusive as a CharRange. This is also consistent matches with the documentation of the clang::transformer::after() function in RangeSelector.h, where the question of inclusive/exclusive ranges came up first for me.