### PR TITLE
Don't skip storing stack arguments in case of size mismatch (#177360)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -8833,7 +8833,7 @@ static bool shouldLowerTailCallStackArg(const MachineFunction &MF,
       if (CallOffset != MFI.getObjectOffset(FI))
         return true;
       uint64_t SizeInBits = LoadNode->getMemoryVT().getFixedSizeInBits();
-      if (SizeInBits / 8 != MFI.getObjectSize(FI))
+      if (SizeInBits != VA.getValVT().getSizeInBits())
         return true;
       return false;
     }

--- a/llvm/test/CodeGen/AArch64/tail-call-stack-args.ll
+++ b/llvm/test/CodeGen/AArch64/tail-call-stack-args.ll
@@ -65,3 +65,16 @@ define void @wrapper_func_i8(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32
   tail call void @func_signext_i1(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h, i32 %i, i1 signext %j)
   ret void
 }
+
+declare void @func_i64(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h, i32 %i, i64 %j)
+
+define void @wrapper_func_i64(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h, i32 %i, i32 %j) {
+; CHECK-LABEL: wrapper_func_i64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ldr w8, [sp, #8]
+; CHECK-NEXT:    str x8, [sp, #8]
+; CHECK-NEXT:    b func_i64
+  %conv = zext i32 %j to i64
+  tail call void @func_i64(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h, i32 %i, i64 %conv)
+  ret void
+}


### PR DESCRIPTION
Wnen argument on stack needs to be zero extended, we can't omit ld/st pair, because we may get an undefined value in certain conditions. (e.g the code below will print 0xFFFFFFFF00000042 instead of 0x42)

```
[[gnu::noinline]]
void baz(int, int, int, int, int, int, int, int, long v)
{
    printf("Value of v: %#lx\n", v);
}

[[gnu::noinline]]
void bar(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8, unsigned v)
{
    baz(i1, i2, i3, i4, i5, i6, i7, i8, v);
}

[[gnu::noinline]]
void foo(int=1, int=2, int=3, int=4, int=5, int=6, int=7, int=8, uint64_t dummy=-1ULL)
{
  bar(1, 2, 3, 4, 5, 6, 7, 8, 0x42)
}
```