### PR TITLE
[InstCombine] Combine `select(C0, select(C1, b, a), b)` -> `select(C0&&!C1, a, b)`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -4515,23 +4515,27 @@ Instruction *InstCombinerImpl::visitSelectInst(SelectInst &SI) {
               *TrueSI, CondVal, /*CondIsTrue=*/true, DL))
         return replaceOperand(SI, 1, V);
 
-      // select(C0, select(C1, a, b), b) -> select(C0&C1, a, b)
       // We choose this as normal form to enable folding on the And and
       // shortening paths for the values (this helps getUnderlyingObjects() for
       // example).
-      if (TrueSI->getFalseValue() == FalseVal && TrueSI->hasOneUse()) {
-        Value *And = Builder.CreateLogicalAnd(CondVal, TrueSI->getCondition());
-        replaceOperand(SI, 0, And);
-        replaceOperand(SI, 1, TrueSI->getTrueValue());
-        return &SI;
-      }
-      // select(C0, select(C1, b, a), b) -> select(C0&!C1, a, b)
-      if (TrueSI->getTrueValue() == FalseVal && TrueSI->hasOneUse()) {
-        Value *Negation = Builder.CreateNot(TrueSI->getCondition());
-        Value *And = Builder.CreateLogicalAnd(CondVal, Negation);
-        replaceOperand(SI, 0, And);
-        replaceOperand(SI, 1, TrueSI->getFalseValue());
-        return &SI;
+      if (TrueSI->hasOneUse()) {
+        Value *And = nullptr, *OtherVal = nullptr;
+        // select(C0, select(C1, a, b), b) -> select(C0&C1, a, b)
+        if (TrueSI->getFalseValue() == FalseVal) {
+          And = Builder.CreateLogicalAnd(CondVal, TrueSI->getCondition());
+          OtherVal = TrueSI->getTrueValue();
+        }
+        // select(C0, select(C1, b, a), b) -> select(C0&!C1, a, b)
+        else if (TrueSI->getTrueValue() == FalseVal) {
+          Value *Negation = Builder.CreateNot(TrueSI->getCondition());
+          And = Builder.CreateLogicalAnd(CondVal, Negation);
+          OtherVal = TrueSI->getFalseValue();
+        }
+        if (And && OtherVal) {
+          replaceOperand(SI, 0, And);
+          replaceOperand(SI, 1, OtherVal);
+          return &SI;
+        }
       }
     }
   }
@@ -4543,20 +4547,24 @@ Instruction *InstCombinerImpl::visitSelectInst(SelectInst &SI) {
               *FalseSI, CondVal, /*CondIsTrue=*/false, DL))
         return replaceOperand(SI, 2, V);
 
-      // select(C0, a, select(C1, a, b)) -> select(C0|C1, a, b)
-      if (FalseSI->getTrueValue() == TrueVal && FalseSI->hasOneUse()) {
-        Value *Or = Builder.CreateLogicalOr(CondVal, FalseSI->getCondition());
-        replaceOperand(SI, 0, Or);
-        replaceOperand(SI, 2, FalseSI->getFalseValue());
-        return &SI;
-      }
-      // select(C0, a, select(C1, b, a)) -> select(C0|!C1, a, b)
-      if (FalseSI->getFalseValue() == TrueVal && FalseSI->hasOneUse()) {
-        Value *Negation = Builder.CreateNot(FalseSI->getCondition());
-        Value *Or = Builder.CreateLogicalOr(CondVal, Negation);
-        replaceOperand(SI, 0, Or);
-        replaceOperand(SI, 2, FalseSI->getTrueValue());
-        return &SI;
+      if (FalseSI->hasOneUse()) {
+        Value *Or = nullptr, *OtherVal = nullptr;
+        // select(C0, a, select(C1, a, b)) -> select(C0|C1, a, b)
+        if (FalseSI->getTrueValue() == TrueVal) {
+          Or = Builder.CreateLogicalOr(CondVal, FalseSI->getCondition());
+          OtherVal = FalseSI->getFalseValue();
+        }
+        // select(C0, a, select(C1, b, a)) -> select(C0|!C1, a, b)
+        else if (FalseSI->getFalseValue() == TrueVal) {
+          Value *Negation = Builder.CreateNot(FalseSI->getCondition());
+          Or = Builder.CreateLogicalOr(CondVal, Negation);
+          OtherVal = FalseSI->getTrueValue();
+        }
+        if (Or && OtherVal) {
+          replaceOperand(SI, 0, Or);
+          replaceOperand(SI, 2, OtherVal);
+          return &SI;
+        }
       }
     }
   }

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -4527,8 +4527,8 @@ Instruction *InstCombinerImpl::visitSelectInst(SelectInst &SI) {
         }
         // select(C0, select(C1, b, a), b) -> select(C0&!C1, a, b)
         else if (TrueSI->getTrueValue() == FalseVal) {
-          Value *Negation = Builder.CreateNot(TrueSI->getCondition());
-          And = Builder.CreateLogicalAnd(CondVal, Negation);
+          Value *InvertedCond = Builder.CreateNot(TrueSI->getCondition());
+          And = Builder.CreateLogicalAnd(CondVal, InvertedCond);
           OtherVal = TrueSI->getFalseValue();
         }
         if (And && OtherVal) {
@@ -4556,8 +4556,8 @@ Instruction *InstCombinerImpl::visitSelectInst(SelectInst &SI) {
         }
         // select(C0, a, select(C1, b, a)) -> select(C0|!C1, a, b)
         else if (FalseSI->getFalseValue() == TrueVal) {
-          Value *Negation = Builder.CreateNot(FalseSI->getCondition());
-          Or = Builder.CreateLogicalOr(CondVal, Negation);
+          Value *InvertedCond = Builder.CreateNot(FalseSI->getCondition());
+          Or = Builder.CreateLogicalOr(CondVal, InvertedCond);
           OtherVal = FalseSI->getTrueValue();
         }
         if (Or && OtherVal) {

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -4520,12 +4520,12 @@ Instruction *InstCombinerImpl::visitSelectInst(SelectInst &SI) {
       // example).
       if (TrueSI->hasOneUse()) {
         Value *And = nullptr, *OtherVal = nullptr;
-        // select(C0, select(C1, a, b), b) -> select(C0&C1, a, b)
+        // select(C0, select(C1, a, b), b) -> select(C0&&C1, a, b)
         if (TrueSI->getFalseValue() == FalseVal) {
           And = Builder.CreateLogicalAnd(CondVal, TrueSI->getCondition());
           OtherVal = TrueSI->getTrueValue();
         }
-        // select(C0, select(C1, b, a), b) -> select(C0&!C1, a, b)
+        // select(C0, select(C1, b, a), b) -> select(C0&&!C1, a, b)
         else if (TrueSI->getTrueValue() == FalseVal) {
           Value *InvertedCond = Builder.CreateNot(TrueSI->getCondition());
           And = Builder.CreateLogicalAnd(CondVal, InvertedCond);
@@ -4549,12 +4549,12 @@ Instruction *InstCombinerImpl::visitSelectInst(SelectInst &SI) {
 
       if (FalseSI->hasOneUse()) {
         Value *Or = nullptr, *OtherVal = nullptr;
-        // select(C0, a, select(C1, a, b)) -> select(C0|C1, a, b)
+        // select(C0, a, select(C1, a, b)) -> select(C0||C1, a, b)
         if (FalseSI->getTrueValue() == TrueVal) {
           Or = Builder.CreateLogicalOr(CondVal, FalseSI->getCondition());
           OtherVal = FalseSI->getFalseValue();
         }
-        // select(C0, a, select(C1, b, a)) -> select(C0|!C1, a, b)
+        // select(C0, a, select(C1, b, a)) -> select(C0||!C1, a, b)
         else if (FalseSI->getFalseValue() == TrueVal) {
           Value *InvertedCond = Builder.CreateNot(FalseSI->getCondition());
           Or = Builder.CreateLogicalOr(CondVal, InvertedCond);

--- a/llvm/test/Transforms/InstCombine/pr63791.ll
+++ b/llvm/test/Transforms/InstCombine/pr63791.ll
@@ -15,7 +15,7 @@ define void @y() {
 ; CHECK-NEXT:    store i1 true, ptr poison, align 1
 ; CHECK-NEXT:    br i1 poison, label [[FOR_COND_I]], label [[FOR_COND5_PREHEADER_I]]
 ; CHECK:       for.cond5.preheader.i:
-; CHECK-NEXT:    br i1 false, label [[FOR_INC19_I:%.*]], label [[FOR_COND1_LOOPEXIT_I:%.*]]
+; CHECK-NEXT:    br i1 true, label [[FOR_COND1_LOOPEXIT_I:%.*]], label [[FOR_INC19_I:%.*]]
 ; CHECK:       for.inc19.i:
 ; CHECK-NEXT:    br i1 poison, label [[FOR_INC19_I]], label [[FOR_COND1_LOOPEXIT_I]]
 ;

--- a/llvm/test/Transforms/InstCombine/select-of-symmetric-selects.ll
+++ b/llvm/test/Transforms/InstCombine/select-of-symmetric-selects.ll
@@ -15,8 +15,9 @@ define i32 @select_of_symmetric_selects(i32 %a, i32 %b, i1 %c1, i1 %c2) {
 
 define i32 @select_of_symmetric_selects_negative1(i32 %a, i32 %b, i1 %c1, i1 %c2) {
 ; CHECK-LABEL: @select_of_symmetric_selects_negative1(
-; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[C1:%.*]], i32 [[A:%.*]], i32 [[B:%.*]]
-; CHECK-NEXT:    [[RET:%.*]] = select i1 [[C2:%.*]], i32 [[SEL1]], i32 [[A]]
+; CHECK-NEXT:    [[TMP1:%.*]] = xor i1 [[C1:%.*]], true
+; CHECK-NEXT:    [[C2:%.*]] = select i1 [[C3:%.*]], i1 [[TMP1]], i1 false
+; CHECK-NEXT:    [[RET:%.*]] = select i1 [[C2]], i32 [[SEL1:%.*]], i32 [[A:%.*]]
 ; CHECK-NEXT:    ret i32 [[RET]]
 ;
   %sel1 = select i1 %c1, i32 %a, i32 %b

--- a/llvm/test/Transforms/InstCombine/select-select.ll
+++ b/llvm/test/Transforms/InstCombine/select-select.ll
@@ -531,7 +531,7 @@ define <2 x i8> @strong_order_cmp_eq_ugt_vector_poison3(<2 x i32> %a, <2 x i32> 
   ret <2 x i8> %sel.gt
 }
 
-; Minimal code that triigers the optimizations.
+; Minimal code that triggers the optimizations.
 
 define i32 @selectSelect11(i1 %cond1, i1 %cond2, i32 %var, i32 %defaultVal) {
 ; CHECK-LABEL: @selectSelect11(

--- a/llvm/test/Transforms/InstCombine/select.ll
+++ b/llvm/test/Transforms/InstCombine/select.ll
@@ -1400,10 +1400,10 @@ define i128 @test86(i1 %flag) {
 define i32 @test_select_select0(i32 %a, i32 %r0, i32 %r1, i32 %v1, i32 %v2) {
 ; CHECK-LABEL: define i32 @test_select_select0(
 ; CHECK-SAME: i32 [[A:%.*]], i32 [[R0:%.*]], i32 [[R1:%.*]], i32 [[V1:%.*]], i32 [[V2:%.*]]) {
-; CHECK-NEXT:    [[C0_NOT:%.*]] = icmp slt i32 [[A]], [[V1]]
-; CHECK-NEXT:    [[S0:%.*]] = select i1 [[C0_NOT]], i32 [[R1]], i32 [[R0]]
+; CHECK-NEXT:    [[C0_NOT:%.*]] = icmp sge i32 [[A]], [[V1]]
 ; CHECK-NEXT:    [[C1:%.*]] = icmp slt i32 [[A]], [[V2]]
-; CHECK-NEXT:    [[S1:%.*]] = select i1 [[C1]], i32 [[S0]], i32 [[R1]]
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[C1]], i1 [[C0_NOT]], i1 false
+; CHECK-NEXT:    [[S1:%.*]] = select i1 [[TMP1]], i32 [[R0]], i32 [[R1]]
 ; CHECK-NEXT:    ret i32 [[S1]]
 ;
   %c0 = icmp sge i32 %a, %v1
@@ -1416,10 +1416,10 @@ define i32 @test_select_select0(i32 %a, i32 %r0, i32 %r1, i32 %v1, i32 %v2) {
 define i32 @test_select_select1(i32 %a, i32 %r0, i32 %r1, i32 %v1, i32 %v2) {
 ; CHECK-LABEL: define i32 @test_select_select1(
 ; CHECK-SAME: i32 [[A:%.*]], i32 [[R0:%.*]], i32 [[R1:%.*]], i32 [[V1:%.*]], i32 [[V2:%.*]]) {
-; CHECK-NEXT:    [[C0_NOT:%.*]] = icmp slt i32 [[A]], [[V1]]
-; CHECK-NEXT:    [[S0:%.*]] = select i1 [[C0_NOT]], i32 [[R1]], i32 [[R0]]
+; CHECK-NEXT:    [[C0_NOT:%.*]] = icmp sge i32 [[A]], [[V1]]
 ; CHECK-NEXT:    [[C1:%.*]] = icmp slt i32 [[A]], [[V2]]
-; CHECK-NEXT:    [[S1:%.*]] = select i1 [[C1]], i32 [[R0]], i32 [[S0]]
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[C1]], i1 true, i1 [[C0_NOT]]
+; CHECK-NEXT:    [[S1:%.*]] = select i1 [[TMP1]], i32 [[R0]], i32 [[R1]]
 ; CHECK-NEXT:    ret i32 [[S1]]
 ;
   %c0 = icmp sge i32 %a, %v1


### PR DESCRIPTION
Fixes #82350

Address cases like:
```
select(C0, select(C1, b, a), b) -> select(C0&!C1, a, b)
select(C0, a, select(C1, b, a)) -> select(C0|!C1, a, b)
```
    
It seem that it generates better code for the real world examples for the few targets I have checked: https://godbolt.org/z/KeEMd9b8E .
On the most generic case it generates the same assembly code for the sources and targets for all targets, expect RISC-V, where the targets seem shoretr and better (less branching): https://godbolt.org/z/3has1Td5G So I did not experience any regression on any target in no scenario.

Proofs: https://alive2.llvm.org/ce/z/DoL3zQ

For reviewers:
This PR consists of 3 commits:
- The first one introduces just the tests, so later the change in behaviour can be seen (29ada10e4cdfbf8edeed8c08245b4a79ec6659af)
- Second is the most straigh forward solution (aa9ead9b233d3ec3a6ff14bb53018c7e62e69c66)
- The third modifies the second one to a more elegant solution with no code duplication (9ad7bdcfbae3dad6e79aa9ed7fb61b7be3a75fee)

I prefer the 3rd one, the latest version, even if it means a bit more line changed, but if you like the second one more I can go with that.