### PR TITLE
[AArch64] Stop using TargetFlags as RegState for LOADgot

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -1430,7 +1430,7 @@ bool AArch64ExpandPseudo::expandMI(MachineBasicBlock &MBB,
       if (MF.getSubtarget<AArch64Subtarget>().isTargetILP32()) {
         auto TRI = MBB.getParent()->getSubtarget().getRegisterInfo();
         unsigned Reg32 = TRI->getSubReg(DstReg, AArch64::sub_32);
-        unsigned DstFlags = MI.getOperand(0).getTargetFlags();
+        unsigned DstFlags = getRegState(MI.getOperand(0));
         MIB2 = BuildMI(MBB, MBBI, MI.getDebugLoc(), TII->get(AArch64::LDRWui))
                    .addDef(Reg32)
                    .addReg(DstReg, RegState::Kill)

--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -1430,11 +1430,10 @@ bool AArch64ExpandPseudo::expandMI(MachineBasicBlock &MBB,
       if (MF.getSubtarget<AArch64Subtarget>().isTargetILP32()) {
         auto TRI = MBB.getParent()->getSubtarget().getRegisterInfo();
         unsigned Reg32 = TRI->getSubReg(DstReg, AArch64::sub_32);
-        unsigned DstFlags = getRegState(MI.getOperand(0));
         MIB2 = BuildMI(MBB, MBBI, MI.getDebugLoc(), TII->get(AArch64::LDRWui))
                    .addDef(Reg32)
                    .addReg(DstReg, RegState::Kill)
-                   .addReg(DstReg, DstFlags | RegState::Implicit);
+                   .addReg(DstReg, RegState::Implicit);
       } else {
         Register DstReg = MI.getOperand(0).getReg();
         MIB2 = BuildMI(MBB, MBBI, DL, TII->get(AArch64::LDRXui))


### PR DESCRIPTION
The register state flags have been represented using `unsigned`, but we intend to make this an `enum class` in llvm/llvm-project#177090.

That change has shown there is some strange behaviour in this AArch64 function, which uses operand TargetFlags (usually used for representing some abstract form of relocation information to clarify global accesses, also represented with `unsigned`) to initialise the register state flags (used for representing how the register operand is used by an instruction). These TargetFlags are always 0 in the tests, so remove the variable and assignment.
