### PR TITLE
[StaticDataLayout] Temporarily undo diagnostic warning when the data access profile payload is not available

### DIFF
--- a/llvm/lib/ProfileData/MemProfSummary.cpp
+++ b/llvm/lib/ProfileData/MemProfSummary.cpp
@@ -26,10 +26,10 @@ void MemProfSummary::printSummaryYaml(raw_ostream &OS) const {
   OS << "#   Maximum warm context total size: " << MaxWarmTotalSize << "\n";
   OS << "#   Maximum hot context total size: " << MaxHotTotalSize << "\n";
   if (HasDataAccessProfile) {
-    OS << "# Num hot symbols and string literals: "
+    OS << "#   Num hot symbols and string literals: "
        << NumHotSymbolsAndStringLiterals << "\n";
-    OS << "# Num known cold symbols: " << NumKnownColdSymbols << "\n";
-    OS << "# Num known cold string literals: " << NumKnownColdStringLiterals
+    OS << "#   Num known cold symbols: " << NumKnownColdSymbols << "\n";
+    OS << "#   Num known cold string literals: " << NumKnownColdStringLiterals
        << "\n";
   }
 }

--- a/llvm/lib/ProfileData/MemProfSummary.cpp
+++ b/llvm/lib/ProfileData/MemProfSummary.cpp
@@ -26,10 +26,10 @@ void MemProfSummary::printSummaryYaml(raw_ostream &OS) const {
   OS << "#   Maximum warm context total size: " << MaxWarmTotalSize << "\n";
   OS << "#   Maximum hot context total size: " << MaxHotTotalSize << "\n";
   if (HasDataAccessProfile) {
-    OS << "#   Num hot symbols and string literals: "
+    OS << "# Num hot symbols and string literals: "
        << NumHotSymbolsAndStringLiterals << "\n";
-    OS << "#   Num known cold symbols: " << NumKnownColdSymbols << "\n";
-    OS << "#   Num known cold string literals: " << NumKnownColdStringLiterals
+    OS << "# Num known cold symbols: " << NumKnownColdSymbols << "\n";
+    OS << "# Num known cold string literals: " << NumKnownColdStringLiterals
        << "\n";
   }
 }

--- a/llvm/lib/Transforms/Instrumentation/MemProfUse.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfUse.cpp
@@ -910,11 +910,8 @@ bool MemProfUsePass::annotateGlobalVariables(
 
   if (!DataAccessProf) {
     M.addModuleFlag(Module::Warning, "EnableDataAccessProf", 0U);
-    M.getContext().diagnose(DiagnosticInfoPGOProfile(
-        MemoryProfileFileName.data(),
-        StringRef("Data access profiles not found in memprof. Ignore "
-                  "-memprof-annotate-static-data-prefix."),
-        DS_Warning));
+    // FIXME: Add a diagnostic message without failing the compilation when
+    // data access profile payload is not available.
     return false;
   }
   M.addModuleFlag(Module::Warning, "EnableDataAccessProf", 1U);


### PR DESCRIPTION
Added a FIXME to add it back later after figuring out how to make it a non-error like the PGO profile mismatch one.