### PR TITLE
[libc] Fix character converter in C++20

### DIFF
--- a/libc/src/__support/wchar/character_converter.h
+++ b/libc/src/__support/wchar/character_converter.h
@@ -77,7 +77,8 @@ LIBC_INLINE bool CharacterConverter::isValidState() {
 }
 
 LIBC_INLINE int CharacterConverter::push(char8_t utf8_byte) {
-  uint8_t num_ones = static_cast<uint8_t>(cpp::countl_one(utf8_byte));
+  uint8_t num_ones =
+      static_cast<uint8_t>(cpp::countl_one(static_cast<uint8_t>(utf8_byte)));
   // Checking the first byte if first push
   if (isEmpty()) {
     // UTF-8 char has 1 byte total


### PR DESCRIPTION
Internally character converter uses char8_t to represent a character.
Before C++20 we provide a typedef for it, but since C++20 it's a
keyword. The keyword version isn't listed in our is_integral, causing
countl to reject it as an invalid type. This patch just casts from
char8_t to int8_t to sidestep the issue, but in future we may want to
add char8_t, char16_t, and char32_t to our is_integral.
