### PR TITLE
[flang][cuda] Allow device descriptor in show_descriptor

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -341,8 +341,9 @@ static bool DefersSameTypeParameters(
 // List of intrinsics that are skipped when checking for device actual
 // arguments.
 static const llvm::StringSet<> cudaSkippedIntrinsics = {"__builtin_c_devloc",
-    "__builtin_c_f_pointer", "__builtin_c_loc", "allocated", "associated",
-    "kind", "lbound", "loc", "present", "shape", "size", "sizeof", "ubound"};
+    "__builtin_c_f_pointer", "__builtin_c_loc", "__builtin_show_descriptor",
+    "allocated", "associated", "kind", "lbound", "loc", "present", "shape",
+    "size", "sizeof", "ubound"};
 
 static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
     const std::string &dummyName, evaluate::Expr<evaluate::SomeType> &actual,

--- a/flang/test/Semantics/cuf23.cuf
+++ b/flang/test/Semantics/cuf23.cuf
@@ -77,3 +77,9 @@ subroutine intrinsic_error_size(n)
   x = size(d,dim=1) ! ok
   x = sizeof(d) ! ok
 end subroutine
+
+subroutine intrinsic_error_skip_show_descriptor(n)
+  use flang_debug
+  real(8), allocatable, device :: d(:)
+  call show_descriptor(d) ! ok, descriptore in managed memory
+end subroutine


### PR DESCRIPTION
Descriptor are always in managed memory so it is safe to call show_descriptor for them.