### PR TITLE
[InstCombine] Replace getAllocatedType() with getAllocationSize()

### DIFF
--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -64,6 +64,9 @@ static cl::opt<bool> DisableI2pP2iOpt(
 std::optional<TypeSize>
 AllocaInst::getAllocationSize(const DataLayout &DL) const {
   TypeSize Size = DL.getTypeAllocSize(getAllocatedType());
+  // Zero-sized types can return early since 0 * N = 0 for any array size N.
+  if (Size.isZero())
+    return Size;
   if (isArrayAllocation()) {
     auto *C = dyn_cast<ConstantInt>(getArraySize());
     if (!C)


### PR DESCRIPTION
Replace uses of getAllocatedType() with the more semantic
getAllocationSize() method in the alloca dereferenceability check
and zero-size alloca merging logic.

This simplifies the code by:
- Eliminating manual isArrayAllocation() checks (handled by getAllocationSize)
- Eliminating superfluous isSized() checks (the verifier rejects them already)
- Using TypeSize::isScalable() for scalable vector handling (before casting to uint64_t)
- Using TypeSize::isZero() for zero-size checks