### PR TITLE
[FunctionSpecialization] Remove getAllocatedType() type check

### DIFF
--- a/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionSpecialization.cpp
@@ -544,18 +544,19 @@ Constant *FunctionSpecializer::getPromotableAlloca(AllocaInst *Alloca,
 
 // A constant stack value is an AllocaInst that has a single constant
 // value stored to it. Return this constant if such an alloca stack value
-// is a function argument.
+// is a function argument and the value is an integer.
 Constant *FunctionSpecializer::getConstantStackValue(CallInst *Call,
                                                      Value *Val) {
   if (!Val)
     return nullptr;
   Val = Val->stripPointerCasts();
-  if (auto *ConstVal = dyn_cast<ConstantInt>(Val))
-    return ConstVal;
   auto *Alloca = dyn_cast<AllocaInst>(Val);
-  if (!Alloca || !Alloca->getAllocatedType()->isIntegerTy())
+  if (!Alloca)
     return nullptr;
-  return getPromotableAlloca(Alloca, Call);
+  Constant *C = getPromotableAlloca(Alloca, Call);
+  if (!C || !C->getType()->isIntegerTy())
+    return nullptr;
+  return C;
 }
 
 // To support specializing recursive functions, it is important to propagate


### PR DESCRIPTION
Change getConstantStackValue() to check the type of the promoted constant rather than the alloca's declared type. This is more correct semantically since we're interested in the actual stored value's type, not what the alloca was declared as.

The change also handles type punning cases more conservatively - if an alloca is declared as i64 but stores a float, the old code would pass the integer type check but potentially return a non-integer constant. The new code correctly rejects such cases.

Also remove a bit of dead code, since the argument is a pointer type, it cannot also have been a constant integer (and this code would be wrong if it was reachable). Originally introduced as dead code in https://reviews.llvm.org/D106426 30fbb06979077740961ebc46853e28ab1f999f9d.