### PR TITLE
[clang] add transformer range selector for spelled ranges

### DIFF
--- a/clang/include/clang/Tooling/Transformer/RangeSelector.h
+++ b/clang/include/clang/Tooling/Transformer/RangeSelector.h
@@ -111,6 +111,11 @@ RangeSelector elseBranch(std::string ID);
 /// source), if `S` is an expansion, and `S` itself, otherwise.  Corresponds to
 /// `SourceManager::getExpansionRange`.
 RangeSelector expansion(RangeSelector S);
+
+/// Selects the spelling range of `S` if it is spelled inside a macro
+/// definition, and `S` itself, otherwise. Corresponds to calling
+/// `SourceManager::getSpellingLoc` on both endpoints.
+RangeSelector spelled(RangeSelector S);
 } // namespace transformer
 } // namespace clang
 

--- a/clang/lib/Tooling/Transformer/RangeSelector.cpp
+++ b/clang/lib/Tooling/Transformer/RangeSelector.cpp
@@ -444,16 +444,9 @@ RangeSelector transformer::spelled(RangeSelector S) {
     Expected<CharSourceRange> SRange = S(Result);
     if (!SRange)
       return SRange.takeError();
-    if (!SRange->isTokenRange()) {
-      return invalidArgumentError("spelled: only supports token ranges");
-    }
     const auto &SM = *Result.SourceManager;
     const auto B = SRange->getBegin();
     const auto E = SRange->getEnd();
-    if (SM.getFileID(B) != SM.getFileID(E)) {
-      return invalidArgumentError(
-          "spelled: range crosses file/macro boundaries");
-    }
     return CharSourceRange(
         SourceRange(SM.getSpellingLoc(B), SM.getSpellingLoc(E)),
         SRange->isTokenRange());

--- a/clang/lib/Tooling/Transformer/RangeSelector.cpp
+++ b/clang/lib/Tooling/Transformer/RangeSelector.cpp
@@ -405,8 +405,7 @@ RangeSelector transformer::constructExprArgs(std::string ID) {
 namespace {
 // Returns the range of the elements of the initializer list. Includes all
 // source between the braces.
-CharSourceRange getElementsRange(const MatchResult &,
-                                 const InitListExpr &E) {
+CharSourceRange getElementsRange(const MatchResult &, const InitListExpr &E) {
   return CharSourceRange::getCharRange(E.getLBraceLoc().getLocWithOffset(1),
                                        E.getRBraceLoc());
 }

--- a/clang/unittests/Tooling/RangeSelectorTest.cpp
+++ b/clang/unittests/Tooling/RangeSelectorTest.cpp
@@ -173,7 +173,7 @@ TEST(RangeSelectorTest, AfterOp) {
   )cc";
   StringRef Call = "call";
   TestMatch Match = matchCode(Code, callExpr().bind(Call));
-  const auto* E = Match.Result.Nodes.getNodeAs<Expr>(Call);
+  const auto *E = Match.Result.Nodes.getNodeAs<Expr>(Call);
   assert(E != nullptr);
   const SourceRange Range = E->getSourceRange();
   // The end token, a right paren, is one character wide, so advance by one,

--- a/clang/unittests/Tooling/RangeSelectorTest.cpp
+++ b/clang/unittests/Tooling/RangeSelectorTest.cpp
@@ -940,20 +940,6 @@ TEST(RangeSelectorTest, SpelledWithArgumentInMacro) {
                        HasValue("void foo(T t)"));
 }
 
-TEST(RangeSelectorTest, SpelledPartiallyInMacro) {
-  StringRef Code = R"cc(
-    #define MACRO(T) foo(T t); int i;
-    void MACRO(int);
-  )cc";
-  const char *ID = "id";
-  TestMatch Match = matchCode(Code, functionDecl().bind(ID));
-  EXPECT_THAT_EXPECTED(
-      select(spelled(node(ID)), Match),
-      Failed<StringError>(testing::Property(
-          &StringError::getMessage,
-          HasSubstr("spelled: range crosses file/macro boundaries"))));
-}
-
 TEST(RangeSelectorTest, IfBoundOpBound) {
   StringRef Code = R"cc(
     int f() {

--- a/clang/unittests/Tooling/RangeSelectorTest.cpp
+++ b/clang/unittests/Tooling/RangeSelectorTest.cpp
@@ -583,19 +583,14 @@ TEST(RangeSelectorTest, NameOpDeclInMacroArg) {
   EXPECT_THAT_EXPECTED(select(name(ID), Match), HasValue("x"));
 }
 
-TEST(RangeSelectorTest, NameOpDeclInMacroBodyError) {
+TEST(RangeSelectorTest, NameSpelledInMacro) {
   StringRef Code = R"cc(
-  #define MACRO int x;
-  MACRO
+  #define NAME foo;
+  int NAME;
   )cc";
   const char *ID = "id";
   TestMatch Match = matchCode(Code, varDecl().bind(ID));
-  EXPECT_THAT_EXPECTED(
-      name(ID)(Match.Result),
-      Failed<StringError>(testing::Property(
-          &StringError::getMessage,
-          AllOf(HasSubstr("range selected by name(node id="),
-                HasSubstr("' is different from decl name 'x'")))));
+  EXPECT_THAT_EXPECTED(select(name(ID), Match), HasValue("foo"));
 }
 
 TEST(RangeSelectorTest, CallArgsOp) {
@@ -922,6 +917,41 @@ TEST(RangeSelectorTest, ExpansionOpPartial) {
   TestMatch Match = matchCode(Code, returnStmt().bind(Ret));
   EXPECT_THAT_EXPECTED(select(expansion(node(Ret)), Match),
                        HasValue("BADDECL(x * x)"));
+}
+
+TEST(RangeSelectorTest, SpelledFullyInMacro) {
+  StringRef Code = R"cc(
+    #define MACRO int i;
+    MACRO
+  )cc";
+  const char *ID = "id";
+  TestMatch Match = matchCode(Code, varDecl().bind(ID));
+  EXPECT_THAT_EXPECTED(select(spelled(node(ID)), Match), HasValue("int i"));
+}
+
+TEST(RangeSelectorTest, SpelledWithArgumentInMacro) {
+  StringRef Code = R"cc(
+    #define MACRO(T) void foo(T t);
+    MACRO(int)
+  )cc";
+  const char *ID = "id";
+  TestMatch Match = matchCode(Code, functionDecl().bind(ID));
+  EXPECT_THAT_EXPECTED(select(spelled(node(ID)), Match),
+                       HasValue("void foo(T t)"));
+}
+
+TEST(RangeSelectorTest, SpelledPartiallyInMacro) {
+  StringRef Code = R"cc(
+    #define MACRO(T) foo(T t); int i;
+    void MACRO(int);
+  )cc";
+  const char *ID = "id";
+  TestMatch Match = matchCode(Code, functionDecl().bind(ID));
+  EXPECT_THAT_EXPECTED(
+      select(spelled(node(ID)), Match),
+      Failed<StringError>(testing::Property(
+          &StringError::getMessage,
+          HasSubstr("spelled: range crosses file/macro boundaries"))));
 }
 
 TEST(RangeSelectorTest, IfBoundOpBound) {


### PR DESCRIPTION
Previously, it was impossible to use clang-tidy Transformer checks to make changes to macro definitions.
This PR adds the ability to match against the spelled range corresponding to a range that is fully inside a macro definition using the new `spelled` range selector, as well as retrieving the name of a declaration inside a macro definition with the existing `name` range selector.

There are still some edge-case questions to resolve, mainly around source ranges that end at the macro boundaries, and thus may not be resolved to their spelled location properly, as well as character ranges, which I didn't support right now for the same reason. Stepping backwards in the expanded source and forwards in the spelled source again lead to the expanded source being one character longer than the spelled source, the reason for which I couldn't track down yet.