### PR TITLE
[SelectionDAG] Add very basic computeKnownBits support for ISD::CLMUL.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -3913,6 +3913,16 @@ KnownBits SelectionDAG::computeKnownBits(SDValue Op, const APInt &DemandedElts,
     Known.Zero.setBitsFrom(1);
     break;
   }
+  case ISD::CLMUL: {
+    Known = computeKnownBits(Op.getOperand(1), DemandedElts, Depth + 1);
+    Known2 = computeKnownBits(Op.getOperand(0), DemandedElts, Depth + 1);
+    // TODO: Trailing zeros, known LSBs.
+    unsigned ActiveBits = std::min(
+        BitWidth, Known.countMaxActiveBits() + Known2.countMaxActiveBits() - 1);
+    Known.Zero = APInt::getBitsSetFrom(BitWidth, ActiveBits);
+    Known.One.clearAllBits();
+    break;
+  }
   case ISD::MGATHER:
   case ISD::MLOAD: {
     ISD::LoadExtType ETy =

--- a/llvm/test/CodeGen/RISCV/clmul.ll
+++ b/llvm/test/CodeGen/RISCV/clmul.ll
@@ -1576,65 +1576,34 @@ define i4 @clmulr_i4_bitreverse(i4 %a, i4 %b) nounwind {
 }
 
 define i8 @clmulr_i8(i8 %a, i8 %b) nounwind {
-; RV32IM-LABEL: clmulr_i8:
-; RV32IM:       # %bb.0:
-; RV32IM-NEXT:    zext.b a0, a0
-; RV32IM-NEXT:    andi a2, a1, 2
-; RV32IM-NEXT:    andi a3, a1, 1
-; RV32IM-NEXT:    andi a4, a1, 4
-; RV32IM-NEXT:    andi a5, a1, 8
-; RV32IM-NEXT:    mul a2, a0, a2
-; RV32IM-NEXT:    mul a3, a0, a3
-; RV32IM-NEXT:    xor a2, a3, a2
-; RV32IM-NEXT:    andi a3, a1, 16
-; RV32IM-NEXT:    mul a4, a0, a4
-; RV32IM-NEXT:    mul a5, a0, a5
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    andi a5, a1, 32
-; RV32IM-NEXT:    mul a3, a0, a3
-; RV32IM-NEXT:    mul a5, a0, a5
-; RV32IM-NEXT:    xor a3, a3, a5
-; RV32IM-NEXT:    xor a2, a2, a4
-; RV32IM-NEXT:    andi a4, a1, 64
-; RV32IM-NEXT:    andi a1, a1, 128
-; RV32IM-NEXT:    mul a4, a0, a4
-; RV32IM-NEXT:    xor a3, a3, a4
-; RV32IM-NEXT:    xor a2, a2, a3
-; RV32IM-NEXT:    mul a0, a0, a1
-; RV32IM-NEXT:    xor a0, a2, a0
-; RV32IM-NEXT:    slli a0, a0, 17
-; RV32IM-NEXT:    srli a0, a0, 24
-; RV32IM-NEXT:    ret
-;
-; RV64IM-LABEL: clmulr_i8:
-; RV64IM:       # %bb.0:
-; RV64IM-NEXT:    zext.b a0, a0
-; RV64IM-NEXT:    andi a2, a1, 2
-; RV64IM-NEXT:    andi a3, a1, 1
-; RV64IM-NEXT:    andi a4, a1, 4
-; RV64IM-NEXT:    andi a5, a1, 8
-; RV64IM-NEXT:    mul a2, a0, a2
-; RV64IM-NEXT:    mul a3, a0, a3
-; RV64IM-NEXT:    xor a2, a3, a2
-; RV64IM-NEXT:    andi a3, a1, 16
-; RV64IM-NEXT:    mul a4, a0, a4
-; RV64IM-NEXT:    mul a5, a0, a5
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    andi a5, a1, 32
-; RV64IM-NEXT:    mul a3, a0, a3
-; RV64IM-NEXT:    mul a5, a0, a5
-; RV64IM-NEXT:    xor a3, a3, a5
-; RV64IM-NEXT:    xor a2, a2, a4
-; RV64IM-NEXT:    andi a4, a1, 64
-; RV64IM-NEXT:    andi a1, a1, 128
-; RV64IM-NEXT:    mul a4, a0, a4
-; RV64IM-NEXT:    xor a3, a3, a4
-; RV64IM-NEXT:    xor a2, a2, a3
-; RV64IM-NEXT:    mul a0, a0, a1
-; RV64IM-NEXT:    xor a0, a2, a0
-; RV64IM-NEXT:    slli a0, a0, 49
-; RV64IM-NEXT:    srli a0, a0, 56
-; RV64IM-NEXT:    ret
+; CHECK-LABEL: clmulr_i8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.b a0, a0
+; CHECK-NEXT:    andi a2, a1, 2
+; CHECK-NEXT:    andi a3, a1, 1
+; CHECK-NEXT:    andi a4, a1, 4
+; CHECK-NEXT:    andi a5, a1, 8
+; CHECK-NEXT:    mul a2, a0, a2
+; CHECK-NEXT:    mul a3, a0, a3
+; CHECK-NEXT:    xor a2, a3, a2
+; CHECK-NEXT:    andi a3, a1, 16
+; CHECK-NEXT:    mul a4, a0, a4
+; CHECK-NEXT:    mul a5, a0, a5
+; CHECK-NEXT:    xor a4, a4, a5
+; CHECK-NEXT:    andi a5, a1, 32
+; CHECK-NEXT:    mul a3, a0, a3
+; CHECK-NEXT:    mul a5, a0, a5
+; CHECK-NEXT:    xor a3, a3, a5
+; CHECK-NEXT:    xor a2, a2, a4
+; CHECK-NEXT:    andi a4, a1, 64
+; CHECK-NEXT:    andi a1, a1, 128
+; CHECK-NEXT:    mul a4, a0, a4
+; CHECK-NEXT:    xor a3, a3, a4
+; CHECK-NEXT:    xor a2, a2, a3
+; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    xor a0, a2, a0
+; CHECK-NEXT:    srli a0, a0, 7
+; CHECK-NEXT:    ret
   %a.ext = zext i8 %a to i16
   %b.ext = zext i8 %b to i16
   %clmul = call i16 @llvm.clmul.i16(i16 %a.ext, i16 %b.ext)
@@ -1701,8 +1670,7 @@ define i16 @clmulr_i16(i16 %a, i16 %b) nounwind {
 ; RV32IM-NEXT:    xor a1, a1, a2
 ; RV32IM-NEXT:    mul a0, a0, a3
 ; RV32IM-NEXT:    xor a0, a1, a0
-; RV32IM-NEXT:    slli a0, a0, 1
-; RV32IM-NEXT:    srli a0, a0, 16
+; RV32IM-NEXT:    srli a0, a0, 15
 ; RV32IM-NEXT:    ret
 ;
 ; RV64IM-LABEL: clmulr_i16:
@@ -1762,8 +1730,7 @@ define i16 @clmulr_i16(i16 %a, i16 %b) nounwind {
 ; RV64IM-NEXT:    xor a1, a1, a2
 ; RV64IM-NEXT:    mul a0, a0, a3
 ; RV64IM-NEXT:    xor a0, a1, a0
-; RV64IM-NEXT:    slli a0, a0, 33
-; RV64IM-NEXT:    srli a0, a0, 48
+; RV64IM-NEXT:    srli a0, a0, 15
 ; RV64IM-NEXT:    ret
   %a.ext = zext i16 %a to i32
   %b.ext = zext i16 %b to i32
@@ -2195,8 +2162,7 @@ define i32 @clmulr_i32(i32 %a, i32 %b) nounwind {
 ; RV64IM-NEXT:    xor a0, a0, a2
 ; RV64IM-NEXT:    xor a1, a7, a1
 ; RV64IM-NEXT:    xor a0, a0, a1
-; RV64IM-NEXT:    slli a0, a0, 1
-; RV64IM-NEXT:    srli a0, a0, 32
+; RV64IM-NEXT:    srli a0, a0, 31
 ; RV64IM-NEXT:    ld ra, 120(sp) # 8-byte Folded Reload
 ; RV64IM-NEXT:    ld s0, 112(sp) # 8-byte Folded Reload
 ; RV64IM-NEXT:    ld s1, 104(sp) # 8-byte Folded Reload
@@ -2266,65 +2232,34 @@ define i4 @clmulh_i4_bitreverse(i4 %a, i4 %b) nounwind {
 
 
 define i8 @clmulh_i8(i8 %a, i8 %b) nounwind {
-; RV32IM-LABEL: clmulh_i8:
-; RV32IM:       # %bb.0:
-; RV32IM-NEXT:    zext.b a0, a0
-; RV32IM-NEXT:    andi a2, a1, 2
-; RV32IM-NEXT:    andi a3, a1, 1
-; RV32IM-NEXT:    andi a4, a1, 4
-; RV32IM-NEXT:    andi a5, a1, 8
-; RV32IM-NEXT:    mul a2, a0, a2
-; RV32IM-NEXT:    mul a3, a0, a3
-; RV32IM-NEXT:    xor a2, a3, a2
-; RV32IM-NEXT:    andi a3, a1, 16
-; RV32IM-NEXT:    mul a4, a0, a4
-; RV32IM-NEXT:    mul a5, a0, a5
-; RV32IM-NEXT:    xor a4, a4, a5
-; RV32IM-NEXT:    andi a5, a1, 32
-; RV32IM-NEXT:    mul a3, a0, a3
-; RV32IM-NEXT:    mul a5, a0, a5
-; RV32IM-NEXT:    xor a3, a3, a5
-; RV32IM-NEXT:    xor a2, a2, a4
-; RV32IM-NEXT:    andi a4, a1, 64
-; RV32IM-NEXT:    andi a1, a1, 128
-; RV32IM-NEXT:    mul a4, a0, a4
-; RV32IM-NEXT:    xor a3, a3, a4
-; RV32IM-NEXT:    xor a2, a2, a3
-; RV32IM-NEXT:    mul a0, a0, a1
-; RV32IM-NEXT:    xor a0, a2, a0
-; RV32IM-NEXT:    slli a0, a0, 16
-; RV32IM-NEXT:    srli a0, a0, 24
-; RV32IM-NEXT:    ret
-;
-; RV64IM-LABEL: clmulh_i8:
-; RV64IM:       # %bb.0:
-; RV64IM-NEXT:    zext.b a0, a0
-; RV64IM-NEXT:    andi a2, a1, 2
-; RV64IM-NEXT:    andi a3, a1, 1
-; RV64IM-NEXT:    andi a4, a1, 4
-; RV64IM-NEXT:    andi a5, a1, 8
-; RV64IM-NEXT:    mul a2, a0, a2
-; RV64IM-NEXT:    mul a3, a0, a3
-; RV64IM-NEXT:    xor a2, a3, a2
-; RV64IM-NEXT:    andi a3, a1, 16
-; RV64IM-NEXT:    mul a4, a0, a4
-; RV64IM-NEXT:    mul a5, a0, a5
-; RV64IM-NEXT:    xor a4, a4, a5
-; RV64IM-NEXT:    andi a5, a1, 32
-; RV64IM-NEXT:    mul a3, a0, a3
-; RV64IM-NEXT:    mul a5, a0, a5
-; RV64IM-NEXT:    xor a3, a3, a5
-; RV64IM-NEXT:    xor a2, a2, a4
-; RV64IM-NEXT:    andi a4, a1, 64
-; RV64IM-NEXT:    andi a1, a1, 128
-; RV64IM-NEXT:    mul a4, a0, a4
-; RV64IM-NEXT:    xor a3, a3, a4
-; RV64IM-NEXT:    xor a2, a2, a3
-; RV64IM-NEXT:    mul a0, a0, a1
-; RV64IM-NEXT:    xor a0, a2, a0
-; RV64IM-NEXT:    slli a0, a0, 48
-; RV64IM-NEXT:    srli a0, a0, 56
-; RV64IM-NEXT:    ret
+; CHECK-LABEL: clmulh_i8:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    zext.b a0, a0
+; CHECK-NEXT:    andi a2, a1, 2
+; CHECK-NEXT:    andi a3, a1, 1
+; CHECK-NEXT:    andi a4, a1, 4
+; CHECK-NEXT:    andi a5, a1, 8
+; CHECK-NEXT:    mul a2, a0, a2
+; CHECK-NEXT:    mul a3, a0, a3
+; CHECK-NEXT:    xor a2, a3, a2
+; CHECK-NEXT:    andi a3, a1, 16
+; CHECK-NEXT:    mul a4, a0, a4
+; CHECK-NEXT:    mul a5, a0, a5
+; CHECK-NEXT:    xor a4, a4, a5
+; CHECK-NEXT:    andi a5, a1, 32
+; CHECK-NEXT:    mul a3, a0, a3
+; CHECK-NEXT:    mul a5, a0, a5
+; CHECK-NEXT:    xor a3, a3, a5
+; CHECK-NEXT:    xor a2, a2, a4
+; CHECK-NEXT:    andi a4, a1, 64
+; CHECK-NEXT:    andi a1, a1, 128
+; CHECK-NEXT:    mul a4, a0, a4
+; CHECK-NEXT:    xor a3, a3, a4
+; CHECK-NEXT:    xor a2, a2, a3
+; CHECK-NEXT:    mul a0, a0, a1
+; CHECK-NEXT:    xor a0, a2, a0
+; CHECK-NEXT:    srli a0, a0, 8
+; CHECK-NEXT:    ret
   %a.ext = zext i8 %a to i16
   %b.ext = zext i8 %b to i16
   %clmul = call i16 @llvm.clmul.i16(i16 %a.ext, i16 %b.ext)
@@ -2451,7 +2386,7 @@ define i16 @clmulh_i16(i16 %a, i16 %b) nounwind {
 ; RV64IM-NEXT:    xor a1, a1, a2
 ; RV64IM-NEXT:    mul a0, a0, a3
 ; RV64IM-NEXT:    xor a0, a1, a0
-; RV64IM-NEXT:    srliw a0, a0, 16
+; RV64IM-NEXT:    srli a0, a0, 16
 ; RV64IM-NEXT:    ret
   %a.ext = zext i16 %a to i32
   %b.ext = zext i16 %b to i32

--- a/llvm/test/CodeGen/RISCV/rv64zbc-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbc-intrinsic.ll
@@ -58,8 +58,7 @@ define i32 @llvm_clmulr_i32(i32 %a, i32 %b) nounwind {
 ; RV64ZBC-NEXT:    srli a1, a1, 32
 ; RV64ZBC-NEXT:    srli a0, a0, 32
 ; RV64ZBC-NEXT:    clmul a0, a0, a1
-; RV64ZBC-NEXT:    slli a0, a0, 1
-; RV64ZBC-NEXT:    srli a0, a0, 32
+; RV64ZBC-NEXT:    srli a0, a0, 31
 ; RV64ZBC-NEXT:    ret
   %tmp1 = zext i32 %a to i64
   %tmp2 = zext i32 %b to i64

--- a/llvm/test/CodeGen/X86/clmul-vector.ll
+++ b/llvm/test/CodeGen/X86/clmul-vector.ll
@@ -1692,7 +1692,6 @@ define <16 x i8> @clmulr_v16i8(<16 x i8> %a, <16 x i8> %b) nounwind {
 ; AVX2-NEXT:    vpmullw %ymm1, %ymm0, %ymm0
 ; AVX2-NEXT:    vpxor %ymm0, %ymm2, %ymm0
 ; AVX2-NEXT:    vpsrlw $7, %ymm0, %ymm0
-; AVX2-NEXT:    vpand {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm0, %ymm0
 ; AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; AVX2-NEXT:    vpackuswb %xmm1, %xmm0, %xmm0
 ; AVX2-NEXT:    vzeroupper
@@ -2034,9 +2033,8 @@ define <8 x i16> @clmulr_v8i16(<8 x i16> %a, <8 x i16> %b) nounwind {
 ; AVX2-NEXT:    vpxor %ymm0, %ymm3, %ymm0
 ; AVX2-NEXT:    vpxor %ymm0, %ymm2, %ymm0
 ; AVX2-NEXT:    vpsrld $15, %ymm0, %ymm0
-; AVX2-NEXT:    vpshufb {{.*#+}} ymm0 = ymm0[0,1,4,5,8,9,12,13,u,u,u,u,u,u,u,u,16,17,20,21,24,25,28,29,u,u,u,u,u,u,u,u]
-; AVX2-NEXT:    vpermq {{.*#+}} ymm0 = ymm0[0,2,2,3]
-; AVX2-NEXT:    # kill: def $xmm0 killed $xmm0 killed $ymm0
+; AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
+; AVX2-NEXT:    vpackusdw %xmm1, %xmm0, %xmm0
 ; AVX2-NEXT:    vzeroupper
 ; AVX2-NEXT:    retq
 ;


### PR DESCRIPTION
This implements leading zero count support so we can remove some unnecessary ANDs.