### PR TITLE
[RISC-V][Mach-O] Add assembler support for Mach-O relocations.

### DIFF
--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -245,7 +245,7 @@ public:
     Inst.setOpcode(Opcode);
     Inst.clear();
     Inst.addOperand(MCOperand::createExpr(MCSpecifierExpr::create(
-        MCSymbolRefExpr::create(Target, *Ctx), ELF::R_RISCV_CALL_PLT, *Ctx)));
+        MCSymbolRefExpr::create(Target, *Ctx), RISCV::S_CALL_PLT, *Ctx)));
   }
 
   void createCall(MCInst &Inst, const MCSymbol *Target,
@@ -433,7 +433,7 @@ public:
     case ELF::R_RISCV_TLS_GD_HI20:
       // The GOT is reused so no need to create GOT relocations
     case ELF::R_RISCV_PCREL_HI20:
-      return MCSpecifierExpr::create(Expr, ELF::R_RISCV_PCREL_HI20, Ctx);
+      return MCSpecifierExpr::create(Expr, RISCV::S_PCREL_HI, Ctx);
     case ELF::R_RISCV_PCREL_LO12_I:
     case ELF::R_RISCV_PCREL_LO12_S:
       return MCSpecifierExpr::create(Expr, RISCV::S_PCREL_LO, Ctx);
@@ -443,9 +443,9 @@ public:
     case ELF::R_RISCV_LO12_S:
       return MCSpecifierExpr::create(Expr, RISCV::S_LO, Ctx);
     case ELF::R_RISCV_CALL:
-      return MCSpecifierExpr::create(Expr, ELF::R_RISCV_CALL_PLT, Ctx);
+      return MCSpecifierExpr::create(Expr, RISCV::S_CALL_PLT, Ctx);
     case ELF::R_RISCV_CALL_PLT:
-      return MCSpecifierExpr::create(Expr, ELF::R_RISCV_CALL_PLT, Ctx);
+      return MCSpecifierExpr::create(Expr, RISCV::S_CALL_PLT, Ctx);
     }
   }
 

--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -470,6 +470,7 @@ public:
     switch (cast<MCSpecifierExpr>(ImmExpr)->getSpecifier()) {
     default:
       return false;
+    case RISCV::S_CALL_PLT:
     case ELF::R_RISCV_CALL_PLT:
       return true;
     }

--- a/llvm/include/llvm/BinaryFormat/MachO.h
+++ b/llvm/include/llvm/BinaryFormat/MachO.h
@@ -517,7 +517,10 @@ enum RelocationInfoType {
   // AUIPC.  r_pcrel=0 means this is paired with a LUI.
   RISCV_RELOC_GOT_HI20 = 5,
   // Low 12 bits of GOT slot. r_pcrel=1 means this is paired with an
-  // AUIPC.  r_pcrel=0 means this is paired with a LUI.
+  // AUIPC.  r_pcrel=0 means this is paired with a LUI (the compiler
+  // may emit a @got reloc for a reference to anything outside the
+  // translation unit, then the linker elides the @got if the target
+  // is in range).
   RISCV_RELOC_GOT_LO12 = 6,
   // For pointers to GOT slots. To be used by C++ exception handling,
   // in the Language Specific Data Area (LSDA, __gcc_except_tab

--- a/llvm/include/llvm/BinaryFormat/MachO.h
+++ b/llvm/include/llvm/BinaryFormat/MachO.h
@@ -494,11 +494,11 @@ enum RelocationInfoType {
   //    .word _a - _b
   //    .end_data_region
   RISCV_RELOC_SUBTRACTOR = 1,
-  // A B/BL instruction with 21-bit displacement. For example, a
+  // A jal/j instruction with 21-bit displacement. For example, a
   // function call:
   //
   //    _foo:
-  //          call _bar
+  //          jal _bar
   RISCV_RELOC_BRANCH21 = 2,
   // High 20 bits of pointer. r_pcrel=1 means this is paired with an
   // AUIPC.  r_pcrel=0 means this is paired with a LUI.

--- a/llvm/include/llvm/BinaryFormat/MachO.h
+++ b/llvm/include/llvm/BinaryFormat/MachO.h
@@ -508,7 +508,10 @@ enum RelocationInfoType {
   // r_pcrel=0 means this is paired with a LUI (llvm currently does
   // not support no-PIC). Note: the compiler places the distance to
   // the paired AUIPC in the imm12 (e.g. if previous instruction is
-  // the AUIPC, the imm12 is -4 or 0xFFC).
+  // the AUIPC, the imm12 is -4 or 0xFFC).  NOTE: this mean that the
+  // separation between hi/lo has to fit in (signed) 12 bits. FIXME:
+  // this needs addressing for code models that go beyond 4k
+  // functions.
   RISCV_RELOC_LO12 = 4,
   // High 20 bits of GOT slot. r_pcrel=1 means this is paired with an
   // AUIPC.  r_pcrel=0 means this is paired with a LUI.

--- a/llvm/include/llvm/BinaryFormat/MachO.h
+++ b/llvm/include/llvm/BinaryFormat/MachO.h
@@ -477,6 +477,56 @@ enum RelocationInfoType {
   // An authenticated pointer.
   ARM64_RELOC_AUTHENTICATED_POINTER = 11,
 
+  // For pointers. For example, for a .word directive in assembly
+  // representing a memory location where data is stored:
+  //      .word: _bar
+  RISCV_RELOC_UNSIGNED = 0,
+  // Subtractor operand. Must be followed by a RISCV_RELOC_UNSIGNED,
+  // which is the pointer from which to subtract the subtractor. For
+  // example:
+  //
+  //          .global _a
+  //          .global _b
+  //    _a: ...
+  //    _b: ...
+  //
+  //    .data_region
+  //    .word _a - _b
+  //    .end_data_region
+  RISCV_RELOC_SUBTRACTOR = 1,
+  // A B/BL instruction with 21-bit displacement. For example, a
+  // function call:
+  //
+  //    _foo:
+  //          call _bar
+  RISCV_RELOC_BRANCH21 = 2,
+  // High 20 bits of pointer. r_pcrel=1 means this is paired with an
+  // AUIPC.  r_pcrel=0 means this is paired with a LUI.
+  RISCV_RELOC_HI20 = 3,
+  // An ADDI or LW/SW instruction that requires low 12 bits to be
+  // adjusted. r_pcrel=1 means this is paired with an AUIPC.
+  // r_pcrel=0 means this is paired with a LUI (llvm currently does
+  // not support no-PIC). Note: the compiler places the distance to
+  // the paired AUIPC in the imm12 (e.g. if previous instruction is
+  // the AUIPC, the imm12 is -4 or 0xFFC).
+  RISCV_RELOC_LO12 = 4,
+  // High 20 bits of GOT slot. r_pcrel=1 means this is paired with an
+  // AUIPC.  r_pcrel=0 means this is paired with a LUI.
+  RISCV_RELOC_GOT_HI20 = 5,
+  // Low 12 bits of GOT slot. r_pcrel=1 means this is paired with an
+  // AUIPC.  r_pcrel=0 means this is paired with a LUI.
+  RISCV_RELOC_GOT_LO12 = 6,
+  // For pointers to GOT slots. To be used by C++ exception handling,
+  // in the Language Specific Data Area (LSDA, __gcc_except_tab
+  // section). Not currently used, but added for completeness.
+  RISCV_RELOC_POINTER_TO_GOT = 7,
+  // Adds a static offset to a relocation.  Must be followed by
+  // RISCV_RELOC_PCREL_HI or RISCV_RELOC_BRANCH21. For example, the 16
+  // bytes offset in:
+  //
+  //         auipc a0, %pcrel_hi(var+16)
+  RISCV_RELOC_ADDEND = 8,
+
   // Constant values for the r_type field in an x86_64 architecture
   // llvm::MachO::relocation_info or llvm::MachO::scattered_relocation_info
   // structure

--- a/llvm/include/llvm/BinaryFormat/MachO.h
+++ b/llvm/include/llvm/BinaryFormat/MachO.h
@@ -514,7 +514,10 @@ enum RelocationInfoType {
   // functions.
   RISCV_RELOC_LO12 = 4,
   // High 20 bits of GOT slot. r_pcrel=1 means this is paired with an
-  // AUIPC.  r_pcrel=0 means this is paired with a LUI.
+  // AUIPC.  r_pcrel=0 means this is paired with a LUI (the compiler
+  // may emit a @got reloc for a reference to anything outside the
+  // translation unit, then the linker elides the @got if the target
+  // is in range).
   RISCV_RELOC_GOT_HI20 = 5,
   // Low 12 bits of GOT slot. r_pcrel=1 means this is paired with an
   // AUIPC.  r_pcrel=0 means this is paired with a LUI.

--- a/llvm/include/llvm/BinaryFormat/MachO.h
+++ b/llvm/include/llvm/BinaryFormat/MachO.h
@@ -517,10 +517,7 @@ enum RelocationInfoType {
   // AUIPC.  r_pcrel=0 means this is paired with a LUI.
   RISCV_RELOC_GOT_HI20 = 5,
   // Low 12 bits of GOT slot. r_pcrel=1 means this is paired with an
-  // AUIPC.  r_pcrel=0 means this is paired with a LUI (the compiler
-  // may emit a @got reloc for a reference to anything outside the
-  // translation unit, then the linker elides the @got if the target
-  // is in range).
+  // AUIPC.  r_pcrel=0 means this is paired with a LUI.
   RISCV_RELOC_GOT_LO12 = 6,
   // For pointers to GOT slots. To be used by C++ exception handling,
   // in the Language Specific Data Area (LSDA, __gcc_except_tab

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -2398,6 +2398,30 @@ void MachOObjectFile::getRelocationTypeName(
         res = Table[RType];
       break;
     }
+    case Triple::riscv32: {
+      static const char *const Table[] = {
+          "RISCV_RELOC_UNSIGNED", "RISCV_RELOC_SUBTRACTOR",
+          "RISCV_RELOC_BRANCH21", "RISCV_RELOC_HI20",
+          "RISCV_RELOC_LO12",     "RISCV_RELOC_GOT_HI20",
+          "RISCV_RELOC_GOT_LO12", "RISCV_RELOC_POINTER_TO_GOT",
+          "RISCV_RELOC_ADDEND",
+      };
+
+      if (RType >= std::size(Table))
+        res = "Unknown";
+      else
+        res = Table[RType];
+      Result.append(res.begin(), res.end());
+      if ((RType == MachO::RISCV_RELOC_HI20 ||
+           RType == MachO::RISCV_RELOC_GOT_HI20 ||
+           RType == MachO::RISCV_RELOC_LO12 ||
+           RType == MachO::RISCV_RELOC_GOT_LO12) &&
+          getAnyRelocationPCRel(getRelocation(Rel))) {
+        StringRef PCRel("(pcrel)");
+        Result.append(PCRel.begin(), PCRel.end());
+      }
+      return;
+    }
     case Triple::UnknownArch:
       res = "Unknown";
       break;

--- a/llvm/lib/Target/RISCV/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/CMakeLists.txt
@@ -19,7 +19,7 @@ add_llvm_component_library(LLVMRISCVDesc
   RISCVInfo
   Support
   TargetParser
-  
+
   ADD_TO_COMPONENT
   RISCV
 )

--- a/llvm/lib/Target/RISCV/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/CMakeLists.txt
@@ -19,7 +19,7 @@ add_llvm_component_library(LLVMRISCVDesc
   RISCVInfo
   Support
   TargetParser
-
+  
   ADD_TO_COMPONENT
   RISCV
 )

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.h
@@ -41,8 +41,8 @@ public:
 
   std::optional<bool> evaluateFixup(const MCFragment &, MCFixup &, MCValue &,
                                     uint64_t &) override;
-  bool addReloc(const MCFragment &, const MCFixup &, const MCValue &,
-                uint64_t &FixedValue, bool IsResolved);
+  virtual bool addReloc(const MCFragment &, const MCFixup &, const MCValue &,
+                        uint64_t &FixedValue, bool IsResolved);
 
   void maybeAddVendorReloc(const MCFragment &, const MCFixup &);
 

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
@@ -51,7 +51,7 @@ const MCExpr *RISCVMCAsmInfo::getExprForFDESymbol(const MCSymbol *Sym,
 void RISCVMCAsmInfo::printSpecifierExpr(raw_ostream &OS,
                                         const MCSpecifierExpr &Expr) const {
   auto S = Expr.getSpecifier();
-  bool HasSpecifier = S != 0 && S != RISCV::S_CALL_PLT;
+  bool HasSpecifier = S != RISCV::S_None && S != RISCV::S_CALL_PLT;
   if (HasSpecifier)
     OS << '%' << RISCV::getSpecifierName(S) << '(';
   printExpr(OS, *Expr.getSubExpr());
@@ -76,7 +76,7 @@ RISCVMCAsmInfoDarwin::RISCVMCAsmInfoDarwin() {
 void RISCVMCAsmInfoDarwin::printSpecifierExpr(
     raw_ostream &OS, const MCSpecifierExpr &Expr) const {
   auto S = Expr.getSpecifier();
-  bool HasSpecifier = S != 0 && S != RISCV::S_CALL_PLT;
+  bool HasSpecifier = S != RISCV::S_None && S != RISCV::S_CALL_PLT;
   if (HasSpecifier)
     OS << '%' << RISCV::getSpecifierName(S) << '(';
   printExpr(OS, *Expr.getSubExpr());

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
@@ -51,7 +51,7 @@ const MCExpr *RISCVMCAsmInfo::getExprForFDESymbol(const MCSymbol *Sym,
 void RISCVMCAsmInfo::printSpecifierExpr(raw_ostream &OS,
                                         const MCSpecifierExpr &Expr) const {
   auto S = Expr.getSpecifier();
-  bool HasSpecifier = S != 0 && S != ELF::R_RISCV_CALL_PLT;
+  bool HasSpecifier = S != 0 && S != RISCV::S_CALL_PLT;
   if (HasSpecifier)
     OS << '%' << RISCV::getSpecifierName(S) << '(';
   printExpr(OS, *Expr.getSubExpr());
@@ -67,7 +67,19 @@ RISCVMCAsmInfoDarwin::RISCVMCAsmInfoDarwin() {
   CommentString = ";";
   AlignmentIsInBytes = false;
   SupportsDebugInformation = true;
+  UseDataRegionDirectives = true;
   ExceptionsType = ExceptionHandling::DwarfCFI;
   Data16bitsDirective = "\t.half\t";
   Data32bitsDirective = "\t.word\t";
+}
+
+void RISCVMCAsmInfoDarwin::printSpecifierExpr(
+    raw_ostream &OS, const MCSpecifierExpr &Expr) const {
+  auto S = Expr.getSpecifier();
+  bool HasSpecifier = S != 0 && S != RISCV::S_CALL_PLT;
+  if (HasSpecifier)
+    OS << '%' << RISCV::getSpecifierName(S) << '(';
+  printExpr(OS, *Expr.getSubExpr());
+  if (HasSpecifier)
+    OS << ')';
 }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.h
@@ -41,7 +41,10 @@ enum {
   // Specifiers mapping to distinct relocation types.
   S_LO = FirstTargetFixupKind,
   S_PCREL_LO,
+  S_PCREL_HI,
   S_TPREL_LO,
+  S_CALL_PLT,
+  S_GOT_HI,
   // Vendor-specific relocation types might conflict across vendors.
   // Refer to them using Specifier constants.
   S_QC_ABS20,
@@ -54,6 +57,8 @@ StringRef getSpecifierName(Specifier Kind);
 class RISCVMCAsmInfoDarwin : public MCAsmInfoDarwin {
 public:
   explicit RISCVMCAsmInfoDarwin();
+  void printSpecifierExpr(raw_ostream &OS,
+                          const MCSpecifierExpr &Expr) const override;
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCExpr.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCExpr.cpp
@@ -25,8 +25,8 @@ RISCV::Specifier RISCV::parseSpecifierName(StringRef name) {
       .Case("lo", RISCV::S_LO)
       .Case("hi", ELF::R_RISCV_HI20)
       .Case("pcrel_lo", RISCV::S_PCREL_LO)
-      .Case("pcrel_hi", ELF::R_RISCV_PCREL_HI20)
-      .Case("got_pcrel_hi", ELF::R_RISCV_GOT_HI20)
+      .Case("pcrel_hi", RISCV::S_PCREL_HI)
+      .Case("got_pcrel_hi", RISCV::S_GOT_HI)
       .Case("tprel_lo", RISCV::S_TPREL_LO)
       .Case("tprel_hi", ELF::R_RISCV_TPREL_HI20)
       .Case("tprel_add", ELF::R_RISCV_TPREL_ADD)
@@ -53,9 +53,9 @@ StringRef RISCV::getSpecifierName(Specifier S) {
     return "hi";
   case RISCV::S_PCREL_LO:
     return "pcrel_lo";
-  case ELF::R_RISCV_PCREL_HI20:
+  case RISCV::S_PCREL_HI:
     return "pcrel_hi";
-  case ELF::R_RISCV_GOT_HI20:
+  case RISCV::S_GOT_HI:
     return "got_pcrel_hi";
   case RISCV::S_TPREL_LO:
     return "tprel_lo";
@@ -75,7 +75,7 @@ StringRef RISCV::getSpecifierName(Specifier S) {
     return "tlsdesc_call";
   case ELF::R_RISCV_TLS_GD_HI20:
     return "tls_gd_pcrel_hi";
-  case ELF::R_RISCV_CALL_PLT:
+  case RISCV::S_CALL_PLT:
     return "call_plt";
   case ELF::R_RISCV_32_PCREL:
     return "32_pcrel";

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h
@@ -24,6 +24,7 @@ class MCContext;
 class MCInstrInfo;
 class MCObjectTargetWriter;
 class MCRegisterInfo;
+class MCRelocationInfo;
 class MCSubtargetInfo;
 class Target;
 
@@ -38,7 +39,6 @@ std::unique_ptr<MCObjectTargetWriter> createRISCVELFObjectWriter(uint8_t OSABI,
                                                                  bool Is64Bit);
 std::unique_ptr<MCObjectTargetWriter>
 createRISCVMachObjectWriter(uint32_t CPUType, uint32_t CPUSubtype);
-
 } // namespace llvm
 
 // Defines symbolic names for RISC-V registers.

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMachObjectWriter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMachObjectWriter.cpp
@@ -8,10 +8,12 @@
 
 #include "MCTargetDesc/RISCVFixupKinds.h"
 #include "MCTargetDesc/RISCVMCTargetDesc.h"
+#include "RISCVMCAsmInfo.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCAsmInfoDarwin.h"
 #include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCExpr.h"
@@ -31,6 +33,10 @@ using namespace llvm;
 namespace {
 
 class RISCVMachObjectWriter : public MCMachObjectTargetWriter {
+  bool getRISCVFixupKindMachOInfo(const MCFixup &Fixup, unsigned &RelocType,
+                                  const MCValue Sym, unsigned &Log2Size,
+                                  const MCAssembler &Asm);
+
 public:
   RISCVMachObjectWriter(uint32_t CPUType, uint32_t CPUSubtype)
       : MCMachObjectTargetWriter(false, CPUType, CPUSubtype) {}
@@ -42,10 +48,377 @@ public:
 
 } // end anonymous namespace
 
+bool RISCVMachObjectWriter::getRISCVFixupKindMachOInfo(const MCFixup &Fixup,
+                                                       unsigned &RelocType,
+                                                       const MCValue Sym,
+                                                       unsigned &Log2Size,
+                                                       const MCAssembler &Asm) {
+  RelocType = unsigned(MachO::RISCV_RELOC_UNSIGNED);
+  Log2Size = ~0U;
+
+  if (Sym.getSpecifier() == RISCV::S_GOT_HI) {
+    Log2Size = Log2_32(4);
+    RelocType = unsigned(MachO::RISCV_RELOC_GOT_HI20);
+    return true;
+  }
+
+  switch (Fixup.getKind()) {
+  default:
+    return false;
+
+  case FK_Data_1:
+    Log2Size = Log2_32(1);
+    return true;
+  case FK_Data_2:
+    Log2Size = Log2_32(2);
+    return true;
+  case FK_Data_4:
+    Log2Size = Log2_32(4);
+    return true;
+  case FK_Data_8:
+    Log2Size = Log2_32(8);
+    return true;
+  case RISCV::fixup_riscv_pcrel_lo12_i:
+  case RISCV::fixup_riscv_pcrel_lo12_s:
+    llvm_unreachable("lo12 fixups should have been resolved elsewhere");
+  case RISCV::fixup_riscv_lo12_i:
+  case RISCV::fixup_riscv_lo12_s:
+    Log2Size = Log2_32(4);
+    RelocType = MachO::RISCV_RELOC_LO12;
+    return true;
+  case RISCV::fixup_riscv_pcrel_hi20:
+    Log2Size = Log2_32(4);
+    if (Sym.getSpecifier() != RISCV::S_PCREL_HI) {
+      Asm.getContext().reportError(Fixup.getLoc(),
+                                   "unknown AUIPC relocation kind");
+      return false;
+    }
+    RelocType = unsigned(MachO::RISCV_RELOC_HI20);
+    return true;
+  case RISCV::fixup_riscv_hi20:
+    Log2Size = Log2_32(4);
+    RelocType = unsigned(MachO::RISCV_RELOC_HI20);
+    return true;
+  case RISCV::fixup_riscv_call:
+  case RISCV::fixup_riscv_call_plt:
+  case RISCV::fixup_riscv_jal:
+    Log2Size = Log2_32(4);
+    RelocType = unsigned(MachO::RISCV_RELOC_BRANCH21);
+    return true;
+  }
+}
+
+static bool canUseLocalRelocation(const MCSectionMachO &Section,
+                                  const MCSymbol &Symbol, unsigned Log2Size) {
+  // Debug info sections can use local relocations.
+  if (Section.hasAttribute(MachO::S_ATTR_DEBUG))
+    return true;
+
+  // Otherwise, only pointer sized relocations are supported.
+  if (Log2Size != 2)
+    return false;
+
+  // But only if they don't point to a few forbidden sections.
+  if (!Symbol.isInSection())
+    return true;
+  const MCSectionMachO &RefSec =
+      static_cast<const MCSectionMachO &>(Symbol.getSection());
+  if (RefSec.getType() == MachO::S_CSTRING_LITERALS)
+    return false;
+
+  if (RefSec.getSegmentName() == "__DATA" &&
+      RefSec.getName() == "__objc_classrefs")
+    return false;
+
+  return true;
+}
+
+static void emitRelocation(MachObjectWriter *Writer, const MCFragment *Fragment,
+                           uint32_t FixupOffset, const MCSymbol *RelSymbol,
+                           unsigned Index, bool IsPCRel, unsigned Log2Size,
+                           unsigned Type) {
+
+  assert(isUInt<2>(Log2Size) && "Invalid Log2Size");
+  assert(isUInt<4>(Type) && "Invalid type");
+  assert(isUInt<24>(Index) && "Invalid Index");
+  MachO::any_relocation_info MRE;
+  MRE.r_word0 = FixupOffset;
+  MRE.r_word1 =
+      (Index << 0) | (IsPCRel << 24) | (Log2Size << 25) | (Type << 28);
+  Writer->addRelocation(RelSymbol, Fragment->getParent(), MRE);
+}
+
+static bool checkSymbolBase(const MCSymbol *Base, const MCSymbol *Symbol,
+                            const MCFixup &Fixup, MCAssembler &Asm) {
+  if (!Base) {
+    Asm.getContext().reportError(
+        Fixup.getLoc(),
+        "unsupported relocation of local symbol '" + Symbol->getName() +
+            "'. Must have non-local symbol earlier in section.");
+    return false;
+  }
+  return true;
+}
+
+template <unsigned Bits>
+static bool isValidInt(const uint64_t &FixedValue, const char *Msg,
+                       MCAssembler &Asm, const SMLoc Loc) {
+  const bool IsValid = isInt<Bits>(FixedValue);
+  if (!IsValid)
+    Asm.getContext().reportError(Loc, Msg);
+  return IsValid;
+}
+
+extern const MCFixup *getPCRelHiFixup(const MCSpecifierExpr &Expr,
+                                      const MCFragment **DFOut);
+
 void RISCVMachObjectWriter::recordRelocation(
     MachObjectWriter *Writer, MCAssembler &Asm, const MCFragment *Fragment,
     const MCFixup &Fixup, MCValue Target, uint64_t &FixedValue) {
-  llvm_unreachable("unimplemented");
+  const bool IsPCRel =
+      Fixup.isPCRel() || Target.getSpecifier() == RISCV::S_GOT_HI;
+
+  // See <reloc.h>.
+  uint32_t FixupOffset = Asm.getFragmentOffset(*Fragment);
+  unsigned Log2Size = 0;
+  int64_t Value = 0;
+  unsigned Index = 0;
+  unsigned Type = 0;
+  const unsigned Kind = Fixup.getKind();
+  const MCSymbol *RelSymbol = nullptr;
+
+  FixupOffset += Fixup.getOffset();
+
+  // RISC-V pcrel relocation addends do not include the section offset.
+  if (IsPCRel)
+    FixedValue += FixupOffset;
+
+  // AUIPC fixups use relocations for the whole symbol value and only
+  // put the addend in the instruction itself. Clear out any value the
+  // generic code figured out from the symbol definition.
+  if (Kind == RISCV::fixup_riscv_pcrel_hi20)
+    FixedValue = 0;
+
+  // %pcrel_lo relocations directly target the same symbol as the
+  // corresponding AUIPC, and encode (inline) an offset to that AUIPC
+  // in the immediate field of the instruction itself.
+  if (Kind == RISCV::fixup_riscv_pcrel_lo12_i ||
+      Kind == RISCV::fixup_riscv_pcrel_lo12_s) {
+    const MCFragment *AUIPCDF;
+    const MCFixup *AUIPCFixup =
+        getPCRelHiFixup(cast<MCSpecifierExpr>(*Fixup.getValue()), &AUIPCDF);
+    assert(AUIPCFixup);
+
+    // Calculate the offset from this fixup to the AUIPC it references, this
+    // will be put into the instruction itself.
+    FixedValue =
+        Asm.getFragmentOffset(*AUIPCDF) + AUIPCFixup->getOffset() - FixupOffset;
+    if (!isValidInt<12>(
+            FixedValue,
+            "AUIPC out of range of corresponding %pcrel_lo instruction", Asm,
+            Fixup.getLoc()))
+      return;
+
+    // Retarget the rest of this function to reference the AUIPC's symbol.
+    MCValue RealTarget;
+    if (!AUIPCFixup->getValue()->evaluateAsValue(RealTarget, Asm)) {
+      Asm.getContext().reportError(AUIPCFixup->getLoc(),
+                                   "cannot understand AUIPC target");
+      return;
+    }
+    if (RealTarget.getSubSym()) {
+      Asm.getContext().reportError(AUIPCFixup->getLoc(),
+                                   "AUIPC target with symbol difference");
+      return;
+    }
+
+    Target = MCValue::get(RealTarget.getAddSym(), nullptr /*SymB*/,
+                          RealTarget.getConstant(), RISCV::S_PCREL_LO);
+
+    Log2Size = Log2_32(4);
+    const auto Spec = RealTarget.getSpecifier();
+    Type = Spec == RISCV::S_GOT_HI ? MachO::RISCV_RELOC_GOT_LO12
+                                   : MachO::RISCV_RELOC_LO12;
+  } else if (!getRISCVFixupKindMachOInfo(Fixup, Type, Target, Log2Size, Asm)) {
+    Asm.getContext().reportError(Fixup.getLoc(), "unknown RISC-V fixup kind");
+    return;
+  }
+
+  // imm19 relocations are for conditional branches, which require
+  // assembler local symbols. If we got here, that's not what we have,
+  // so report an error.
+  if (Kind == RISCV::fixup_riscv_branch ||
+      Kind == RISCV::fixup_riscv_rvc_jump ||
+      Kind == RISCV::fixup_riscv_rvc_branch) {
+    Asm.getContext().reportError(
+        Fixup.getLoc(), "conditional branch requires assembler-local"
+                        " label. '" +
+                            Target.getAddSym()->getName() + "' is external.");
+    return;
+  }
+
+  Value = Target.getConstant();
+
+  // Only .word and %pcrel_lo instructions inline the pc-relative
+  // offset in the instruction.
+  if (Type != MachO::RISCV_RELOC_UNSIGNED && Type != MachO::RISCV_RELOC_LO12 &&
+      Type != MachO::RISCV_RELOC_GOT_LO12)
+    FixedValue = 0;
+
+  // Emit relocations.
+
+  // Constants.
+  if (Target.isAbsolute()) {
+    // FIXME: Should this always be extern?
+    // SymbolNum of 0 indicates the absolute section.
+    if (IsPCRel) {
+      Asm.getContext().reportError(Fixup.getLoc(),
+                                   "PC relative absolute relocation!");
+      return;
+    }
+    emitRelocation(Writer, Fragment, FixupOffset, RelSymbol, Index,
+                   false /*IsPCRel*/, ~0U /*Log2Size*/,
+                   MachO::RISCV_RELOC_UNSIGNED /*Type*/);
+    return;
+  }
+
+  // A - B + constant
+  if (const MCSymbol *B = Target.getSubSym()) {
+    const MCSymbol *A = Target.getAddSym();
+    const MCSymbol *A_Base = Writer->getAtom(*A);
+    const MCSymbol *B_Base = Writer->getAtom(*B);
+
+    // We don't support PCrel relocations of differences.
+    if (IsPCRel) {
+      Asm.getContext().reportError(Fixup.getLoc(),
+                                   "unsupported pc-relative relocation of "
+                                   "difference");
+      return;
+    }
+
+    // Ensure both symbols have base atoms for external relocations.
+    if (!checkSymbolBase(A_Base, A, Fixup, Asm) ||
+        !checkSymbolBase(B_Base, B, Fixup, Asm))
+      return;
+
+    if (A_Base && A_Base == B_Base) {
+      Asm.getContext().reportError(
+          Fixup.getLoc(), "unsupported relocation with identical base");
+      return;
+    }
+
+    Value +=
+        (!A->getFragment() ? 0 : Writer->getSymbolAddress(*A)) -
+        (!A_Base || !A_Base->getFragment() ? 0
+                                           : Writer->getSymbolAddress(*A_Base));
+    Value -=
+        (!B->getFragment() ? 0 : Writer->getSymbolAddress(*B)) -
+        (!B_Base || !B_Base->getFragment() ? 0
+                                           : Writer->getSymbolAddress(*B_Base));
+
+    // If there's any addend left to handle, inline it in the instruction's
+    // immediate.
+    FixedValue = Value;
+    if (!isValidInt<12>(
+            FixedValue,
+            "AUIPC out of range of corresponding %pcrel_lo instruction", Asm,
+            Fixup.getLoc()))
+      return;
+
+    emitRelocation(Writer, Fragment, FixupOffset, A_Base /*RelSymbol*/, Index,
+                   IsPCRel, Log2Size, MachO::RISCV_RELOC_UNSIGNED /*Type*/);
+    // struct relocation_info (8 bytes)
+    emitRelocation(Writer, Fragment, FixupOffset, B_Base /*RelSymbol*/, Index,
+                   IsPCRel, Log2Size, MachO::RISCV_RELOC_SUBTRACTOR /*Type*/);
+    return;
+  }
+
+  // A + constant
+  if (const MCSymbol *Symbol = Target.getAddSym()) {
+    assert(!Target.getSubSym() && "invalid expression");
+    const MCSectionMachO &Section =
+        static_cast<const MCSectionMachO &>(*Fragment->getParent());
+
+    const bool CanUseLocalRelocation =
+        canUseLocalRelocation(Section, *Symbol, Log2Size);
+    if (Symbol->isTemporary() && (Value || !CanUseLocalRelocation)) {
+      if (!Symbol->isInSection()) {
+        checkSymbolBase(nullptr, Symbol, Fixup, Asm);
+        return;
+      }
+      const MCSection &Sec = Symbol->getSection();
+      if (!MCAsmInfoDarwin::isSectionAtomizableBySymbols(Sec))
+        Symbol->setUsedInReloc();
+    }
+
+    const MCSymbol *Base = Writer->getAtom(*Symbol);
+    // If the symbol is a variable it can either be in a section and
+    // we have a base or it is absolute and should have been expanded.
+    assert(!Symbol->isVariable() || Base);
+
+    // Relocations inside debug sections always use local relocations when
+    // possible. This seems to be done because the debugger doesn't fully
+    // understand relocation entries and expects to find values that
+    // have already been fixed up.
+    if (Symbol->isInSection()) {
+      if (Section.hasAttribute(MachO::S_ATTR_DEBUG))
+        Base = nullptr;
+    }
+
+    // RISC-V uses external relocations as much as possible. For debug
+    // sections, and for pointer-sized relocations (.quad), we allow section
+    // relocations.  It's code sections that run into trouble.
+    if (Base) {
+      RelSymbol = Base;
+
+      // Add the local offset, if needed.
+      if (Base != Symbol)
+        Value += Asm.getSymbolOffset(*Symbol) - Asm.getSymbolOffset(*Base);
+    } else if (Symbol->isInSection()) {
+      if (!CanUseLocalRelocation) {
+        checkSymbolBase(nullptr, Symbol, Fixup, Asm);
+        return;
+      }
+      // Adjust the relocation to be section-relative.
+      // The index is the section ordinal (1-based).
+      const MCSection &Sec = Symbol->getSection();
+      Index = Sec.getOrdinal() + 1;
+      Value += Writer->getSymbolAddress(*Symbol);
+
+      if (IsPCRel)
+        Value -= Writer->getFragmentAddress(Asm, Fragment) + Fixup.getOffset();
+    } else {
+      llvm_unreachable(
+          "This constant variable should have been expanded during evaluation");
+    }
+    if (Type == MachO::RISCV_RELOC_UNSIGNED) {
+      // If there's any addend left to handle, encode it in the instruction.
+      FixedValue = Value;
+      // struct relocation_info (8 bytes)
+      emitRelocation(Writer, Fragment, FixupOffset, RelSymbol, Index,
+                     false /*IsPCRel*/, Log2Size,
+                     MachO::RISCV_RELOC_UNSIGNED /*Type*/);
+      return;
+    }
+    // We have an addend offset that is encoded in the relocation
+    // record, not inlined in the instruction.
+    if (Value) {
+      if (!isValidInt<24>(Value, "addend too big for relocation", Asm,
+                          Fixup.getLoc()))
+        return;
+
+      emitRelocation(Writer, Fragment, FixupOffset, RelSymbol, Index, IsPCRel,
+                     Log2Size, Type);
+      // Now set up the Addend relocation.
+      emitRelocation(Writer, Fragment, FixupOffset, nullptr /*RelSymbol*/,
+                     Value & 0xffffff, false /*IsPCRel*/, 2 /*Log2Size*/,
+                     MachO::RISCV_RELOC_ADDEND /*Type*/);
+      return;
+    }
+
+    emitRelocation(Writer, Fragment, FixupOffset, RelSymbol, Index, IsPCRel,
+                   Log2Size, Type);
+  }
 }
 
 std::unique_ptr<MCObjectTargetWriter>

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMachObjectWriter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMachObjectWriter.cpp
@@ -232,7 +232,7 @@ void RISCVMachObjectWriter::recordRelocation(
       return;
     }
 
-    Target = MCValue::get(RealTarget.getAddSym(), nullptr /*SymB*/,
+    Target = MCValue::get(RealTarget.getAddSym(), /*SymB*/ nullptr,
                           RealTarget.getConstant(), RISCV::S_PCREL_LO);
 
     Log2Size = Log2_32(4);
@@ -277,8 +277,8 @@ void RISCVMachObjectWriter::recordRelocation(
       return;
     }
     emitRelocation(Writer, Fragment, FixupOffset, RelSymbol, Index,
-                   false /*IsPCRel*/, ~0U /*Log2Size*/,
-                   MachO::RISCV_RELOC_UNSIGNED /*Type*/);
+                   /*IsPCRel*/ false, /*Log2Size*/ ~0U,
+                   /*Type*/ MachO::RISCV_RELOC_UNSIGNED);
     return;
   }
 
@@ -325,11 +325,11 @@ void RISCVMachObjectWriter::recordRelocation(
             Fixup.getLoc()))
       return;
 
-    emitRelocation(Writer, Fragment, FixupOffset, A_Base /*RelSymbol*/, Index,
-                   IsPCRel, Log2Size, MachO::RISCV_RELOC_UNSIGNED /*Type*/);
+    emitRelocation(Writer, Fragment, FixupOffset, /*RelSymbol*/ A_Base, Index,
+                   IsPCRel, Log2Size, /*Type*/ MachO::RISCV_RELOC_UNSIGNED);
     // struct relocation_info (8 bytes)
-    emitRelocation(Writer, Fragment, FixupOffset, B_Base /*RelSymbol*/, Index,
-                   IsPCRel, Log2Size, MachO::RISCV_RELOC_SUBTRACTOR /*Type*/);
+    emitRelocation(Writer, Fragment, FixupOffset, /*RelSymbol*/ B_Base, Index,
+                   IsPCRel, Log2Size, /*Type*/ MachO::RISCV_RELOC_SUBTRACTOR);
     return;
   }
 
@@ -396,8 +396,8 @@ void RISCVMachObjectWriter::recordRelocation(
       FixedValue = Value;
       // struct relocation_info (8 bytes)
       emitRelocation(Writer, Fragment, FixupOffset, RelSymbol, Index,
-                     false /*IsPCRel*/, Log2Size,
-                     MachO::RISCV_RELOC_UNSIGNED /*Type*/);
+                     /*IsPCRel*/ false, Log2Size,
+                     /*Type*/ MachO::RISCV_RELOC_UNSIGNED);
       return;
     }
     // We have an addend offset that is encoded in the relocation
@@ -410,9 +410,9 @@ void RISCVMachObjectWriter::recordRelocation(
       emitRelocation(Writer, Fragment, FixupOffset, RelSymbol, Index, IsPCRel,
                      Log2Size, Type);
       // Now set up the Addend relocation.
-      emitRelocation(Writer, Fragment, FixupOffset, nullptr /*RelSymbol*/,
-                     Value & 0xffffff, false /*IsPCRel*/, 2 /*Log2Size*/,
-                     MachO::RISCV_RELOC_ADDEND /*Type*/);
+      emitRelocation(Writer, Fragment, FixupOffset, /*RelSymbol*/ nullptr,
+                     Value & 0xffffff, /*IsPCRel*/ false, /*Log2Size*/ 2,
+                     /*Type*/ MachO::RISCV_RELOC_ADDEND);
       return;
     }
 

--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -638,7 +638,7 @@ void RISCVAsmPrinter::LowerHWASAN_CHECK_MEMACCESS(const MachineInstr &MI) {
     Sym = OutContext.getOrCreateSymbol(SymName);
   }
   auto Res = MCSymbolRefExpr::create(Sym, OutContext);
-  auto Expr = MCSpecifierExpr::create(Res, ELF::R_RISCV_CALL_PLT, OutContext);
+  auto Expr = MCSpecifierExpr::create(Res, RISCV::S_CALL_PLT, OutContext);
 
   EmitToStreamer(*OutStreamer, MCInstBuilder(RISCV::PseudoCALL).addExpr(Expr));
 }
@@ -749,8 +749,8 @@ void RISCVAsmPrinter::EmitHwasanMemaccessSymbols(Module &M) {
 
   const MCSymbolRefExpr *HwasanTagMismatchV2Ref =
       MCSymbolRefExpr::create(HwasanTagMismatchV2Sym, OutContext);
-  auto Expr = MCSpecifierExpr::create(HwasanTagMismatchV2Ref,
-                                      ELF::R_RISCV_CALL_PLT, OutContext);
+  auto Expr = MCSpecifierExpr::create(HwasanTagMismatchV2Ref, RISCV::S_CALL_PLT,
+                                      OutContext);
 
   for (auto &P : HwasanMemaccessSymbols) {
     unsigned Reg = std::get<0>(P.first);
@@ -975,7 +975,7 @@ static MCOperand lowerSymbolOperand(const MachineOperand &MO, MCSymbol *Sym,
     Kind = RISCV::S_None;
     break;
   case RISCVII::MO_CALL:
-    Kind = ELF::R_RISCV_CALL_PLT;
+    Kind = RISCV::S_CALL_PLT;
     break;
   case RISCVII::MO_LO:
     Kind = RISCV::S_LO;
@@ -987,10 +987,10 @@ static MCOperand lowerSymbolOperand(const MachineOperand &MO, MCSymbol *Sym,
     Kind = RISCV::S_PCREL_LO;
     break;
   case RISCVII::MO_PCREL_HI:
-    Kind = ELF::R_RISCV_PCREL_HI20;
+    Kind = RISCV::S_PCREL_HI;
     break;
   case RISCVII::MO_GOT_HI:
-    Kind = ELF::R_RISCV_GOT_HI20;
+    Kind = RISCV::S_GOT_HI;
     break;
   case RISCVII::MO_TPREL_LO:
     Kind = RISCV::S_TPREL_LO;

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -149,7 +149,11 @@ extern "C" LLVM_ABI LLVM_EXTERNAL_VISIBILITY void LLVMInitializeRISCVTarget() {
   initializeRISCVPromoteConstantPass(*PR);
 }
 
-static Reloc::Model getEffectiveRelocModel(std::optional<Reloc::Model> RM) {
+static Reloc::Model getEffectiveRelocModel(const Triple &TT,
+                                           std::optional<Reloc::Model> RM) {
+  if (TT.isOSBinFormatMachO())
+    return RM.value_or(Reloc::PIC_);
+
   return RM.value_or(Reloc::Static);
 }
 
@@ -167,7 +171,7 @@ RISCVTargetMachine::RISCVTargetMachine(const Target &T, const Triple &TT,
                                        CodeGenOptLevel OL, bool JIT)
     : CodeGenTargetMachineImpl(
           T, TT.computeDataLayout(Options.MCOptions.getABIName()), TT, CPU, FS,
-          Options, getEffectiveRelocModel(RM),
+          Options, getEffectiveRelocModel(TT, RM),
           getEffectiveCodeModel(CM, CodeModel::Small), OL),
       TLOF(createTLOF(TT)) {
   initAsmInfo();

--- a/llvm/test/MC/RISCV/Relocations/mc-dump.s
+++ b/llvm/test/MC/RISCV/Relocations/mc-dump.s
@@ -7,7 +7,7 @@
 # CHECK-NEXT:  Align:4 Fill:0 FillLen:1 MaxBytesToEmit:4 Nops
 # CHECK-NEXT:  Symbol @0 .text
 # CHECK-NEXT:0 Data LinkerRelaxable Size:8 [97,00,00,00,e7,80,00,00]
-# CHECK-NEXT:  Fixup @0 Value:specifier(19,ext) Kind:4023 LinkerRelaxable
+# CHECK-NEXT:  Fixup @0 Value:specifier(4014,ext) Kind:4023 LinkerRelaxable
 # CHECK-NEXT:  Symbol @0 $x
 # CHECK-NEXT:8 Align LinkerRelaxable Size:0+6 []
 # CHECK-NEXT:  Align:8 Fill:0 FillLen:1 MaxBytesToEmit:8 Nops

--- a/llvm/test/MC/RISCV/macho.s
+++ b/llvm/test/MC/RISCV/macho.s
@@ -17,9 +17,9 @@ foo:
 ; CHECK-DIS: file format mach-o 32-bit risc-v
 ; CHECK-DIS: Disassembly of section __TEXT,__text:
 ; CHECK-DIS: nop
-; CHECK-DIS: 002a <unknown>
-; CHECK-DIS: 002a <unknown>
-; CHECK-DIS: 0000 <unknown>
+; CHECK-DIS: 002a 
+; CHECK-DIS: 002a
+; CHECK-DIS: 0000
 
 ; CHECK-SYMS-NOT: Lfoo
 ; CHECK-SYMS: foo

--- a/llvm/test/MC/RISCV/riscv-relocs-macho-data.s
+++ b/llvm/test/MC/RISCV/riscv-relocs-macho-data.s
@@ -1,0 +1,80 @@
+; RUN: llvm-mc -triple riscv32-apple-macho -filetype=obj %s -o %t.o
+; RUN: llvm-objdump -dr --section __data --full-contents %t.o | FileCheck %s --check-prefix=CHECK
+; RUN: llvm-otool -Vtr %t.o | FileCheck %s --check-prefix=OTOOL
+
+; Data section relocations
+        .data
+; CHECK:  0000 2a000000 0c000000 00000000 04000000  *...............
+; CHECK-NEXT:  0010 00000000 02000000                    ........
+
+; Plain integer, no relocation needed.
+        .global _a
+; CHECK-LABEL: 00000000 <ltmp1>:
+; CHECK-NEXT:        0: 002a            <unknown>
+; CHECK-NEXT:        2: 0000            <unknown>
+_a:
+        .word 42
+
+; Plain integer, no relocation needed.
+        .global _b
+; CHECK-LABEL: 00000004 <_b>:
+; CHECK-NEXT:        4: 000c            <unknown>
+; CHECK-NEXT:        6: 0000            <unknown>
+_b:
+        .word 12
+
+; Pointer to symbol, require relocation. The 2 chunks of 2 bytes
+; each at PC=8 and PC=a are filled with 0 as a placeholder.
+        .global _ref
+; CHECK-LABEL: 00000008 <_ref>:
+; CHECK-NEXT:        8: 0000            <unknown>
+; CHECK-NEXT:                   00000008:  RISCV_RELOC_UNSIGNED _b
+; CHECK-NEXT:        a: 0000            <unknown>
+_ref:
+        .word _b
+
+; Same as the previous example of pointer to symnbol, but with
+; offset. The placeholder data is storing the offset (00000004).
+        .global _ref_offset
+; CHECK-LABEL: 0000000c <_ref_offset>:
+; CHECK-NEXT:        c: 0004            <unknown>
+; CHECK-NEXT:                   0000000c:  RISCV_RELOC_UNSIGNED _b
+; CHECK-NEXT:        e: 0000            <unknown>
+_ref_offset:
+        .word _b + 4
+
+        .global _sub
+; Difference of addresses to symbols. The linker will take care of
+; replacing the 4 bytes 00000000 with the difference of the address
+; of _ref minus the addresss of _elsewhere.
+_sub:
+; CHECK-LABEL: 00000010 <_sub>:
+; CHECK-NEXT:       10: 0000            <unknown>
+; CHECK-NEXT:                   00000010:  RISCV_RELOC_SUBTRACTOR       _elsewhere
+; CHECK-NEXT:                   00000010:  RISCV_RELOC_UNSIGNED _ref
+; CHECK-NEXT:       12: 0000            <unknown>
+        .word _ref - _elsewhere
+
+
+; Same as before, but an additional offset is stored in the
+; placeholder 4 bytes to be used as the addend in the expression.
+        .global _sub_add
+_sub_add:
+; CHECK-LABEL: 00000014 <_sub_add>:
+; CHECK-NEXT:       14: 0002            <unknown>
+; CHECK-NEXT:                   00000014:  RISCV_RELOC_SUBTRACTOR       _elsewhere
+; CHECK-NEXT:                   00000014:  RISCV_RELOC_UNSIGNED _ref
+; CHECK-NEXT:       16: 0000            <unknown>
+.word _ref - _elsewhere + 2
+; CHECK-NOT: {{.}}
+
+; OTOOL-LABEL: Relocation information (__DATA,__data) 6 entries
+; OTOOL-NEXT:  address  pcrel length extern type    scattered symbolnum/value
+; OTOOL-NEXT:  00000014 False long   True   1       False     _elsewhere
+; OTOOL-NEXT:  00000014 False long   True   0       False     _ref
+; OTOOL-NEXT:  00000010 False long   True   1       False     _elsewhere
+; OTOOL-NEXT:  00000010 False long   True   0       False     _ref
+; OTOOL-NEXT:  0000000c False long   True   0       False     _b
+; OTOOL-NEXT:  00000008 False long   True   0       False     _b
+; OTOOL-NEXT:  Contents of (__TEXT,__text) section
+; OTOOL-NOT: {{.}}

--- a/llvm/test/MC/RISCV/riscv-relocs-macho.s
+++ b/llvm/test/MC/RISCV/riscv-relocs-macho.s
@@ -1,0 +1,184 @@
+; RUN: llvm-mc -triple riscv32-apple-macho -filetype=obj %s -o %t.o
+; RUN: llvm-objdump -dr %t.o | FileCheck %s
+; RUN: llvm-otool -Vtr %t.o | FileCheck %s --check-prefix=OTOOL
+
+; hi20/low12 offsets of var are relative to the PC at Ltmp0
+; (computed by auipc). Final value in a0:
+;
+;      a0 = PC_at_Ltmp0 + hi20_offset(var) + lo12_offset(var)
+;
+; The -0x4 offset of the auipc w.r.t the addi is inlined in the lw
+; instruction.
+;
+; CHECK-LABEL: 00000000 <ltmp0>:
+; CHECK-NEXT: 0: 00000517            auipc   a0, 0
+; CHECK-NEXT:                        00000000:  RISCV_RELOC_HI20(pcrel)      var
+; CHECK-NEXT: 4: ffc50513            addi    a0, a0, -0x4
+; CHECK-NEXT:                        00000004:  RISCV_RELOC_LO12(pcrel)      var
+Ltmp0:
+        auipc a0, %pcrel_hi(var)
+        addi a0, a0, %pcrel_lo(Ltmp0)
+
+; hi20/low12 offsets of var+16 are relative to the PC at Ltmp1
+; (computed by auipc). The relative offset is computed for an
+; additional offset of 16 bytes from var.  Final value in a0:
+;
+;      a0 = PC_at_Ltmp1 + hi20_offset(var) + lo12_offset(var)
+;
+; The -0x4 offset of the auipc w.r.t the addi is inlined in the lw
+; instruction.
+;
+; CHECK-NEXT: 8: 00000517            auipc   a0, 0
+; CHECK-NEXT:                        00000008:  RISCV_RELOC_ADDEND   0x10
+; CHECK-NEXT:                        00000008:  RISCV_RELOC_HI20(pcrel)      var
+; CHECK-NEXT: c: ffc50513 	        addi a0, a0, -0x4
+; CHECK-NEXT:                        0000000c: RISCV_RELOC_ADDEND 0x10
+; CHECK-NEXT:                        0000000c: RISCV_RELOC_LO12(pcrel) var
+Ltmp1:
+        auipc a0, %pcrel_hi(var+16)
+        addi a0, a0, %pcrel_lo(Ltmp1)
+
+; This is a GOT-based address loading sequence, used for accessing
+; global variables in shared libraries or position-independent
+; executables (PIE). Uses indirection through the Global Offset
+; Table (GOT).
+;
+; a0 = PC at Ltmp2 + high 20 bits of the offset of GOT entry for var (offset is relative to the PC)
+;   auipc a0, %got_pcrel_hi(var)
+; a0 = load from [a0 (computed previously with auipc) + the low 12 bits of offset of the GOT entry for var (relative to PC at Ltmp2)]
+;   lw a0, %pcrel_lo(Ltmp2)(a0)
+;
+; The -0x4 offset of the auipc w.r.t the lw is inlined in the lw instruction.
+; CHECK-NEXT: 10: 00000517           auipc   a0, 0
+; CHECK-NEXT:                        00000010:  RISCV_RELOC_GOT_HI20(pcrel)  var
+; CHECK-NEXT: 14: ffc52503           lw      a0, -0x4(a0)
+; CHECK-NEXT:                        00000014:  RISCV_RELOC_GOT_LO12(pcrel)  var
+Ltmp2:
+        auipc a0, %got_pcrel_hi(var)
+        lw a0, %pcrel_lo(Ltmp2)(a0)
+
+; Same as the first example. This time, though, there is code in
+; between the two relocations, which means that the low 12 bits
+; needs to be shifted by the correct amount that takes the address
+; computation relative to the PC at auipc (8 bytes before).
+;
+; CHECK-NEXT: 18: 00000517           auipc   a0, 0
+; CHECK-NEXT:                        00000018:  RISCV_RELOC_HI20(pcrel)      var
+; CHECK-NEXT:  1c: 00000013          nop
+; CHECK-NEXT:  20: ff850513          addi    a0, a0, -0x8
+; CHECK-NEXT:                        00000020:  RISCV_RELOC_LO12(pcrel)      var
+Ltmp3:
+        auipc a0, %pcrel_hi(var)
+        nop
+        addi a0, a0, %pcrel_lo(Ltmp3)
+
+; Relocations for function calls. The jal instruction is patched
+; with the relative offset of _bar to the PC (limited to 21 bits)
+
+; CHECK-NEXT: [[PC_call:[0-9a-f]+]]:{{.*}}jal 0x[[PC_call]] <ltmp0+0x[[PC_call]]>
+; CHECK-NEXT:                       RISCV_RELOC_BRANCH21 _bar
+        call _bar
+
+; CHECK-NEXT: [[PC_tail:[0-9a-f]+]]:{{.*}}j 0x[[PC_tail]] <ltmp0+0x[[PC_tail]]>
+; CHECK-NEXT:                        RISCV_RELOC_BRANCH21 _bar
+        tail _bar
+
+; Non PIC/PIE code, used for baremetal, where absolute addresses are
+; expected.
+;
+; a0 = (address_of_var[31:12] << 12) & 0xfffff000
+; a0 = a0 + address_of_var[11:0] = address_of_var
+;
+; CHECK-NEXT: 2c: 00000537           lui     a0, 0
+; CHECK-NEXT:                      0000002c: RISCV_RELOC_HI20 _var
+; CHECK-NEXT: 30: 00050513           mv      a0, a0
+; CHECK-NEXT:                      00000030:  RISCV_RELOC_LO12       _var
+        lui a0, %hi(_var)
+        addi a0, a0, %lo(_var)
+
+
+; Data directives inside .text, with relocation checks:
+;
+        .data_region
+
+; Absolute address. The linker will fill PC 32 and 34 with the 4
+; bytes of the address of _bar.
+;
+; CHECK-NEXT: 34: 0000             <unknown>
+; CHECK-NEXT:                      00000034:  RISCV_RELOC_UNSIGNED   _bar
+; CHECK-NEXT: 36: 0000             <unknown>
+        .word _bar
+
+; Absolute address as before, but with an additional 42 bytes
+; offset. The linker will see the offset stored @PC36 and use it as
+; an addend to the address of _bar. The resulting value will be
+; stored in the PCs at 36 and 38.
+;
+; CHECK-NEXT: 38: 002a             <unknown>
+; CHECK-NEXT:                      00000038:  RISCV_RELOC_UNSIGNED   _bar
+; CHECK-NEXT: 3a: 0000             <unknown>
+        .word _bar + 42
+
+; Subtraction expression. The 4 bytes at PCs 3a and 3c will be
+; replaced with the subtraction of the address of _a and the
+; address of _b.
+;
+; CHECK-NEXT: 3c: 0000             <unknown>
+; CHECK-NEXT:                      0000003c:  RISCV_RELOC_SUBTRACTOR       _b
+; CHECK-NEXT:                      0000003c:  RISCV_RELOC_UNSIGNED   _a
+; CHECK-NEXT: 3e: 0000             <unknown>
+        .word _a - _b
+
+; Same as before, but the offset between _a and _b is shifted by 42
+; bytes. The shift amount is stored in the 2 bytes at 3e.
+;
+; CHECK-NEXT: 40: 002a             <unknown>
+; CHECK-NEXT:                      00000040:  RISCV_RELOC_SUBTRACTOR         _b
+; CHECK-NEXT:                      00000040:  RISCV_RELOC_UNSIGNED   _a
+; CHECK-NEXT: 42: 0000             <unknown>
+        .word _a - _b + 42
+        .end_data_region
+; No more relocation directive past this line.
+; CHECK-NOT: {{.}}
+
+; OTOOL-LABEL: Relocation information (__TEXT,__text) 20 entries 
+; OTOOL-NEXT:  address  pcrel length extern type    scattered symbolnum/value
+; OTOOL-NEXT:  00000040 False long   True   1       False     _b
+; OTOOL-NEXT:  00000040 False long   True   0       False     _a
+; OTOOL-NEXT:  0000003c False long   True   1       False     _b
+; OTOOL-NEXT:  0000003c False long   True   0       False     _a
+; OTOOL-NEXT:  00000038 False long   True   0       False     _bar
+; OTOOL-NEXT:  00000034 False long   True   0       False     _bar
+; OTOOL-NEXT:  00000030 False long   True   4       False     _var
+; OTOOL-NEXT:  0000002c False long   True   3       False     _var
+; OTOOL-NEXT:  00000028 True  long   True   2       False     _bar
+; OTOOL-NEXT:  00000024 True  long   True   2       False     _bar
+; OTOOL-NEXT:  00000020 True  long   True   4       False     var
+; OTOOL-NEXT:  00000018 True  long   True   3       False     var
+; OTOOL-NEXT:  00000014 True  long   True   6       False     var
+; OTOOL-NEXT:  00000010 True  long   True   5       False     var
+; OTOOL-NEXT:  0000000c False long   False  8       False     addend = 0x000010
+; OTOOL-NEXT:  0000000c True  long   True   4       False     var
+; OTOOL-NEXT:  00000008 False long   False  8       False     addend = 0x000010
+; OTOOL-NEXT:  00000008 True  long   True   3       False     var
+; OTOOL-NEXT:  00000004 True  long   True   4       False     var
+; OTOOL-NEXT:  00000000 True  long   True   3       False     var
+; OTOOL-NEXT:  Contents of (__TEXT,__text) section
+; OTOOL-NEXT:  00000000	auipc	a0, 0x0
+; OTOOL-NEXT:  00000004	addi	a0, a0, -0x4
+; OTOOL-NEXT:  00000008	auipc	a0, 0x0
+; OTOOL-NEXT:  0000000c	addi	a0, a0, -0x4
+; OTOOL-NEXT:  00000010	auipc	a0, 0x0
+; OTOOL-NEXT:  00000014	lw	a0, -0x4(a0)
+; OTOOL-NEXT:  00000018	auipc	a0, 0x0
+; OTOOL-NEXT:  0000001c	nop
+; OTOOL-NEXT:  00000020	addi	a0, a0, -0x8
+; OTOOL-NEXT:  00000024	jal	0x0
+; OTOOL-NEXT:  00000028	j	0x0
+; OTOOL-NEXT:  0000002c	lui	a0, 0x0
+; OTOOL-NEXT:  00000030	mv	a0, a0
+; OTOOL-NEXT:  	.long 0	@ KIND_DATA
+; OTOOL-NEXT:  	.long 42	@ KIND_DATA
+; OTOOL-NEXT:  	.long 0	@ KIND_DATA
+; OTOOL-NEXT:  	.long 42	@ KIND_DATA
+; OTOOL-NOT: {{.}}

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -388,6 +388,12 @@ static void printRelocationTargetName(const MachOObjectFile *O,
     return;
   }
 
+  if (O->getAnyRelocationType(RE) == MachO::RISCV_RELOC_ADDEND &&
+      O->getArch() == Triple::riscv32) {
+    Fmt << format("0x%0" PRIx64, Val);
+    return;
+  }
+
   if (isExtern) {
     symbol_iterator SI = O->symbol_begin();
     std::advance(SI, Val);
@@ -928,6 +934,9 @@ static void PrintRelocationEntries(const MachOObjectFile *O,
           else if ((cputype == MachO::CPU_TYPE_ARM64 ||
                     cputype == MachO::CPU_TYPE_ARM64_32) &&
                    r_type == MachO::ARM64_RELOC_ADDEND)
+            outs() << format("addend = 0x%06x\n", (unsigned int)r_symbolnum);
+          else if (cputype == MachO::CPU_TYPE_RISCV &&
+                   r_type == MachO::RISCV_RELOC_ADDEND)
             outs() << format("addend = 0x%06x\n", (unsigned int)r_symbolnum);
           else {
             outs() << format("%d ", r_symbolnum);


### PR DESCRIPTION
This patch adds comprehensive assembler (MC layer) support for the Mach-O object file format on RISC-V targets, enabling assembly and disassembly of RISC-V code targeting Apple platforms.

Key changes:

- Define RISC-V-specific Mach-O relocation types in BinaryFormat/MachO.h
- Implement RISCVMachObjectWriter with full relocation handling for:
  - PCREL_HI/LO pairs for PC-relative addressing
  - GOT relocations for external symbols
  - Branch relocations (CALL, unconditional/conditional branches)
  - Data section relocations

Test files include llvm-otool dumps to verify the generated relocations.

This code is based on code originally written by Tim Northover.