### PR TITLE
[lldb] Unconditionally setup posix spawn responsible flag

### DIFF
--- a/lldb/source/Host/macosx/objcxx/PosixSpawnResponsible.h
+++ b/lldb/source/Host/macosx/objcxx/PosixSpawnResponsible.h
@@ -11,21 +11,17 @@
 
 #include <spawn.h>
 
-#if __has_include(<responsibility.h>)
 #include <dispatch/dispatch.h>
 #include <dlfcn.h>
+#if __has_include(<responsibility.h>)
 #include <responsibility.h>
+#endif
 
-// Older SDKs  have responsibility.h but not this particular function. Let's
-// include the prototype here.
 errno_t responsibility_spawnattrs_setdisclaim(posix_spawnattr_t *attrs,
                                               bool disclaim);
 
-#endif
-
 static inline int setup_posix_spawn_responsible_flag(posix_spawnattr_t *attr) {
   if (@available(macOS 10.14, *)) {
-#if __has_include(<responsibility.h>)
     static __typeof__(responsibility_spawnattrs_setdisclaim)
         *responsibility_spawnattrs_setdisclaim_ptr;
     static dispatch_once_t pred;
@@ -36,7 +32,6 @@ static inline int setup_posix_spawn_responsible_flag(posix_spawnattr_t *attr) {
     });
     if (responsibility_spawnattrs_setdisclaim_ptr)
       return responsibility_spawnattrs_setdisclaim_ptr(attr, true);
-#endif
   }
   return 0;
 }

--- a/lldb/source/Host/macosx/objcxx/PosixSpawnResponsible.h
+++ b/lldb/source/Host/macosx/objcxx/PosixSpawnResponsible.h
@@ -13,26 +13,21 @@
 
 #include <dispatch/dispatch.h>
 #include <dlfcn.h>
-#if __has_include(<responsibility.h>)
-#include <responsibility.h>
-#endif
 
 errno_t responsibility_spawnattrs_setdisclaim(posix_spawnattr_t *attrs,
                                               bool disclaim);
 
 static inline int setup_posix_spawn_responsible_flag(posix_spawnattr_t *attr) {
-  if (@available(macOS 10.14, *)) {
-    static __typeof__(responsibility_spawnattrs_setdisclaim)
-        *responsibility_spawnattrs_setdisclaim_ptr;
-    static dispatch_once_t pred;
-    dispatch_once(&pred, ^{
-      responsibility_spawnattrs_setdisclaim_ptr =
-          reinterpret_cast<__typeof__(&responsibility_spawnattrs_setdisclaim)>
-          (dlsym(RTLD_DEFAULT, "responsibility_spawnattrs_setdisclaim"));
-    });
-    if (responsibility_spawnattrs_setdisclaim_ptr)
-      return responsibility_spawnattrs_setdisclaim_ptr(attr, true);
-  }
+  static __typeof__(responsibility_spawnattrs_setdisclaim)
+      *responsibility_spawnattrs_setdisclaim_ptr;
+  static dispatch_once_t pred;
+  dispatch_once(&pred, ^{
+    responsibility_spawnattrs_setdisclaim_ptr =
+        reinterpret_cast<__typeof__(&responsibility_spawnattrs_setdisclaim)>(
+            dlsym(RTLD_DEFAULT, "responsibility_spawnattrs_setdisclaim"));
+  });
+  if (responsibility_spawnattrs_setdisclaim_ptr)
+    return responsibility_spawnattrs_setdisclaim_ptr(attr, true);
   return 0;
 }
 


### PR DESCRIPTION
# Problem

The TCC support in LLDB was added by https://github.com/llvm/llvm-project/commit/041c7b84a4b925476d1e21ed302786033bb6035f.

However, on newer macOS machines, when launching and debugging an Catalyst app on macOS (see [Host.mm](https://github.com/llvm/llvm-project/blob/1286de408cc4a3ba1bd6cb6fed7d9517c0429462/lldb/source/Host/macosx/objcxx/Host.mm#L1208-L1219)), the TCC doesn't work as expected. This is because, even though the launch info doesn't specify `eLaunchFlagInheritTCCFromParent`, the app is still launched to inherit TCC from its parent (the LLDB). This prevents the user from granting privacy access to the Catalyst app, which is usually reflected in macOS' "Privacy & Security" settings.

For example, in the following screenshot, even when the microphone access has already been granted to WhatsApp, trying to use it will still cause a prompt (as if it's not granted already).

<img width="1786" height="779" alt="Screenshot 2026-01-22 at 12 03 23 PM" src="https://github.com/user-attachments/assets/4a7fb7c5-e79d-4a2d-a044-a4cd73052fa3" />


# Fix

On newer macOS versions, the code which was originally inside the `#if __has_include(<responsibility.h>)` actually works. So the fix is to unwrap them from the `#if`.

Also, since we already forward declare the type and dlsym the symbol, the `#include <responsibility.h>` can be removed. Same for the `@available` check, since the original code handles `dlsym` failure.


# Test

Tested manually. In the following screenshots:
* When access hasn't been grant, using the microphone prompts for access.
* When access has been grant, the microphone can be used as normal.

<img width="1758" height="773" alt="Screenshot 2026-01-22 at 1 34 33 PM" src="https://github.com/user-attachments/assets/1c63d2e4-dc6e-49f3-98b2-b0bbffea179a" />

<img width="1759" height="774" alt="Screenshot 2026-01-22 at 1 42 44 PM" src="https://github.com/user-attachments/assets/f64ca9f0-53f8-409a-ad8b-58c36ce9be50" />

I'm not sure how to test this automatically, as it involves verifying the Settings in macOS.

