### PR TITLE
[Clang][Sema] Only call PerformDependentDiagnostics for dependent contexts

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -322,6 +322,7 @@ Bug Fixes in This Version
 - Fixed a crash when parsing ``#pragma clang attribute`` arguments for attributes that forbid arguments. (#GH182122)
 - Fixed a bug with multiple-include optimization (MIOpt) state not being preserved in some cases during lexing, which could suppress header-guard mismatch diagnostics and interfere with include-guard optimization. (#GH180155)
 - Fixed a crash when normalizing constraints involving concept template parameters whose index coincided with non-concept template parameters in the same parameter mapping.
+- Fixed a crash caused by accessing dependent diagnostics of a non-dependent context.
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -5969,7 +5969,8 @@ void Sema::InstantiateFunctionDefinition(SourceLocation PointOfInstantiation,
 
     checkReferenceToTULocalFromOtherTU(Function, PointOfInstantiation);
 
-    PerformDependentDiagnostics(PatternDecl, TemplateArgs);
+    if (PatternDecl->isDependentContext())
+      PerformDependentDiagnostics(PatternDecl, TemplateArgs);
 
     if (auto *Listener = getASTMutationListener())
       Listener->FunctionDefinitionInstantiated(Function);

--- a/clang/test/SemaTemplate/GH176155.cpp
+++ b/clang/test/SemaTemplate/GH176155.cpp
@@ -3,6 +3,11 @@
 template <int> struct bad {
   template <class T, auto =
                          [] { // #lambda
+                           // expected-note@#lambda {{while substituting into a lambda expression here}}
+                           // expected-note@#lambda 2{{capture 'i' by value}}
+                           // expected-note@#lambda 2{{capture 'i' by reference}}
+                           // expected-note@#lambda 2{{default capture by value}}
+                           // expected-note@#lambda 2{{default capture by reference}}
                            for (int i = 0; i < 100; ++i) { // #i
                              // expected-error@-1 {{variable 'i' cannot be implicitly captured in a lambda with no capture-default specified}}
                              // expected-note@#i {{'i' declared here}}

--- a/clang/test/SemaTemplate/GH176155.cpp
+++ b/clang/test/SemaTemplate/GH176155.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+template <int> struct bad {
+  template <class T, auto =
+                         [] { // #lambda
+                           for (int i = 0; i < 100; ++i) { // #i
+                             // expected-error@-1 {{variable 'i' cannot be implicitly captured in a lambda with no capture-default specified}}
+                             // expected-note@#i {{'i' declared here}}
+                             // expected-note@#lambda {{lambda expression begins here}}
+                             // expected-error@-4 {{variable 'i' cannot be implicitly captured in a lambda with no capture-default specified}}
+                             // expected-note@#i {{'i' declared here}}
+                             // expected-note@#lambda {{lambda expression begins here}}
+                             struct LoopHelper {
+                               static constexpr void process() {}
+                             };
+                           }
+                         }>
+  static void f(T) {} // expected-note {{in instantiation of default argument for 'f<int>' required here}}
+};
+
+int main() { bad<0>::f(0); } // expected-note {{while substituting deduced template arguments into function template 'f'}}


### PR DESCRIPTION
`DeclContext::ddiags` should only be called on a dependent `DeclContext`. This patch adds the missing `isDependentContext` check before calling `ddiags`. 

Fixes #176155