### PR TITLE
[libc] Clean up cpp::is_unsigned

### DIFF
--- a/libc/src/__support/CPP/type_traits/is_unsigned.h
+++ b/libc/src/__support/CPP/type_traits/is_unsigned.h
@@ -37,7 +37,7 @@ private:
 
 public:
   LIBC_INLINE_VAR static constexpr bool value =
-      (is_arithmetic_v<T> && (T(-1) > T(0))) ||
+      (is_integral_v<T> && (T(-1) > T(0))) ||
       __is_unqualified_any_of<T, unsigned short fract, unsigned fract,
                               unsigned long fract, unsigned short accum,
                               unsigned accum, unsigned long accum,

--- a/libc/src/__support/CPP/type_traits/is_unsigned.h
+++ b/libc/src/__support/CPP/type_traits/is_unsigned.h
@@ -10,7 +10,7 @@
 
 #include "include/llvm-libc-macros/stdfix-macros.h"
 #include "src/__support/CPP/type_traits/bool_constant.h"
-#include "src/__support/CPP/type_traits/is_arithmetic.h"
+#include "src/__support/CPP/type_traits/is_integral.h"
 #include "src/__support/CPP/type_traits/is_same.h"
 #include "src/__support/CPP/type_traits/remove_cv.h"
 #include "src/__support/macros/attributes.h"
@@ -23,7 +23,7 @@ namespace cpp {
 
 #ifndef LIBC_COMPILER_HAS_FIXED_POINT
 template <typename T>
-struct is_unsigned : bool_constant<(is_arithmetic_v<T> && (T(-1) > T(0)))> {
+struct is_unsigned : bool_constant<(is_integral_v<T> && (T(-1) > T(0)))> {
   LIBC_INLINE constexpr operator bool() const { return is_unsigned::value; }
   LIBC_INLINE constexpr bool operator()() const { return is_unsigned::value; }
 };


### PR DESCRIPTION
There are no unsigned floating-point types, so make it a
subset of is_integral instead of is_arithmetic.
