### PR TITLE
Revert "Enable using threads on z/OS (#171847)"

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -597,7 +597,12 @@ option(LLVM_ENABLE_LIBEDIT "Use libedit if available." ON)
 
 option(LLVM_ENABLE_LIBPFM "Use libpfm for performance counters if available." ON)
 
-option(LLVM_ENABLE_THREADS "Use threads if available." ON)
+# On z/OS, threads cannot be used because TLS is not supported.
+if (CMAKE_SYSTEM_NAME MATCHES "OS390")
+  option(LLVM_ENABLE_THREADS "Use threads if available." OFF)
+else()
+  option(LLVM_ENABLE_THREADS "Use threads if available." ON)
+endif()
 
 set(LLVM_ENABLE_ICU "OFF" CACHE STRING "Use ICU for text encoding conversion support if available. Can be ON, OFF, or FORCE_ON")
 

--- a/llvm/include/llvm/Support/thread.h
+++ b/llvm/include/llvm/Support/thread.h
@@ -51,11 +51,7 @@ class thread {
 public:
 #ifdef LLVM_ON_UNIX
   using native_handle_type = pthread_t;
-#ifdef __MVS__
-  using id = unsigned long long;
-#else
   using id = pthread_t;
-#endif
   using start_routine_type = void *(*)(void *);
 
   template <typename CalleeTuple> static void *ThreadProxy(void *Ptr) {
@@ -101,7 +97,7 @@ public:
     return *this;
   }
 
-  bool joinable() const noexcept { return get_id() != 0; }
+  bool joinable() const noexcept { return Thread != native_handle_type(); }
 
   inline id get_id() const noexcept;
 
@@ -137,7 +133,7 @@ thread::thread(std::optional<unsigned> StackSizeInBytes, Function &&f,
 
   Thread = llvm_execute_on_thread_impl(ThreadProxy<CalleeTuple>, Callee.get(),
                                        StackSizeInBytes);
-  if (joinable())
+  if (Thread != native_handle_type())
     Callee.release();
 }
 

--- a/llvm/lib/Support/Parallel.cpp
+++ b/llvm/lib/Support/Parallel.cpp
@@ -128,6 +128,8 @@ private:
     // first successful tryAcquire() in a process. This guarantees forward
     // progress without requiring a dedicated "always-on" thread here.
 
+    static thread_local std::unique_ptr<ExponentialBackoff> Backoff;
+
     while (true) {
       if (TheJobserver) {
         // Jobserver-mode scheduling:

--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -119,17 +119,9 @@ void llvm_thread_join_impl(pthread_t Thread) {
   }
 }
 
-llvm::thread::id llvm_thread_get_id_impl(pthread_t Thread) {
-#ifdef __MVS__
-  return Thread.__;
-#else
-  return Thread;
-#endif
-}
+pthread_t llvm_thread_get_id_impl(pthread_t Thread) { return Thread; }
 
-llvm::thread::id llvm_thread_get_current_id_impl() {
-  return llvm_thread_get_id_impl(::pthread_self());
-}
+pthread_t llvm_thread_get_current_id_impl() { return ::pthread_self(); }
 
 } // namespace llvm
 
@@ -156,8 +148,6 @@ uint64_t llvm::get_threadid() {
   return uint64_t(syscall(__NR_gettid));
 #elif defined(_AIX)
   return uint64_t(thread_self());
-#elif defined(__MVS__)
-  return llvm_thread_get_id_impl(pthread_self());
 #else
   return uint64_t(pthread_self());
 #endif


### PR DESCRIPTION
This reverts commit 64be34c562a23761dcb48a0a6a0b3ef0576c14c4.

The commit is causing build failures on FreeBSD.