### PR TITLE
[libc] Remove superfluous explicitly defaulted constructors

### DIFF
--- a/libc/config/linux/app.h
+++ b/libc/config/linux/app.h
@@ -76,8 +76,6 @@ struct TLSDescriptor {
   // Note that, dependending the target architecture ABI, it can be the
   // same as |addr| or something else.
   uintptr_t tp = 0;
-
-  constexpr TLSDescriptor() = default;
 };
 
 // Create and initialize the TLS area for the current thread. Should not

--- a/libc/src/__support/threads/fork_callbacks.cpp
+++ b/libc/src/__support/threads/fork_callbacks.cpp
@@ -22,7 +22,6 @@ struct ForkCallbackTriple {
   ForkCallback *prepare = nullptr;
   ForkCallback *parent = nullptr;
   ForkCallback *child = nullptr;
-  constexpr ForkCallbackTriple() = default;
 };
 
 class AtForkCallbackManager {


### PR DESCRIPTION
Any user-defined constructor, even an `= default` one, is
incompatible with aggregate initialization in C++20.

The default constructor does not need to be declared at all in
these cases.  It's implicit.
