### PR TITLE
[NFCI][AMDGPU] Refine `AMDGPUSubtarget.h`

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.h
@@ -19,6 +19,47 @@
 #include "llvm/Support/Alignment.h"
 #include "llvm/TargetParser/Triple.h"
 
+//===----------------------------------------------------------------------===//
+// X-Macros for simple subtarget features.
+//
+// AMDGPU_SUBTARGET_HAS_FEATURE: Features with both member and getter
+//   bool HasXXX = false;                      // member declaration
+//   bool hasXXX() const { return HasXXX; }    // getter
+//
+// AMDGPU_SUBTARGET_HAS_FEATURE_MEMBER_ONLY: Features with member only
+//   bool HasXXX = false;                      // member declaration only
+//
+// AMDGPU_SUBTARGET_ENABLE_FEATURE_MEMBER_ONLY: Features with member only
+//   bool EnableXXX = false;                   // member declaration only
+//
+// To add a new simple feature:
+//   1. Add X(FeatureName) to the appropriate macro below
+//   2. Remove the manual bool HasFeatureName declaration from protected section
+//   3. If using AMDGPU_SUBTARGET_HAS_FEATURE, also remove the manual getter
+//   4. If using AMDGPU_SUBTARGET_ENABLE_FEATURE_MEMBER_ONLY, also remove the
+//      manual getter
+//
+// Note: The features are ordered alphabetically for convenience. Unlike
+// GCNSubtarget.h, we do not use TableGen-generated features here. We
+// intentionally keep the feature set here minimal. For any new feature, unless
+// it needs to be queried via an AMDGPUSubtarget reference, it should be added
+// to GCNSubtarget.h instead.
+//===----------------------------------------------------------------------===//
+
+#define AMDGPU_SUBTARGET_HAS_FEATURE_MEMBER_ONLY(X) X(MadMacF32Insts)
+
+#define AMDGPU_SUBTARGET_HAS_FEATURE(X)                                        \
+  X(16BitInsts)                                                                \
+  X(FastFMAF32)                                                                \
+  X(Inv2PiInlineImm)                                                           \
+  X(SDWA)                                                                      \
+  X(True16BitInsts)                                                            \
+  X(VOP3PInsts)
+
+#define AMDGPU_SUBTARGET_ENABLE_FEATURE_MEMBER_ONLY(X)                         \
+  X(RealTrue16Insts)                                                           \
+  X(D16Writes32BitVgpr)
+
 namespace llvm {
 
 enum AMDGPUDwarfFlavour : unsigned;
@@ -48,34 +89,23 @@ private:
   Triple TargetTriple;
 
 protected:
-  bool GCN3Encoding = false;
-  bool Has16BitInsts = false;
-  bool HasTrue16BitInsts = false;
-  bool HasFP8ConversionScaleInsts = false;
-  bool HasBF8ConversionScaleInsts = false;
-  bool HasFP4ConversionScaleInsts = false;
-  bool HasFP6BF6ConversionScaleInsts = false;
-  bool HasF16BF16ToFP6BF6ConversionScaleInsts = false;
-  bool HasCvtPkF16F32Inst = false;
-  bool HasF32ToF16BF16ConversionSRInsts = false;
-  bool EnableRealTrue16Insts = false;
-  bool EnableD16Writes32BitVgpr = false;
-  bool HasBF16TransInsts = false;
-  bool HasBF16ConversionInsts = false;
-  bool HasBF16PackedInsts = false;
-  bool HasMadMixInsts = false;
-  bool HasMadMacF32Insts = false;
-  bool HasDsSrc2Insts = false;
-  bool HasSDWA = false;
-  bool HasVOP3PInsts = false;
   bool HasMulI24 = true;
   bool HasMulU24 = true;
   bool HasSMulHi = false;
-  bool HasInv2PiInlineImm = false;
-  bool HasFminFmaxLegacy = true;
   bool EnablePromoteAlloca = false;
-  bool HasTrigReducedRange = false;
-  bool HasFastFMAF32 = false;
+  bool HasFminFmaxLegacy = true;
+
+#define DECL_HAS_MEMBER(Name) bool Has##Name = false;
+  AMDGPU_SUBTARGET_HAS_FEATURE(DECL_HAS_MEMBER)
+  AMDGPU_SUBTARGET_HAS_FEATURE_MEMBER_ONLY(DECL_HAS_MEMBER)
+#undef DECL_HAS_MEMBER
+#undef AMDGPU_SUBTARGET_HAS_FEATURE_MEMBER_ONLY
+
+#define DECL_ENABLE_MEMBER(Name) bool Enable##Name = false;
+  AMDGPU_SUBTARGET_ENABLE_FEATURE_MEMBER_ONLY(DECL_ENABLE_MEMBER)
+#undef DECL_ENABLE_MEMBER
+#undef AMDGPU_SUBTARGET_ENABLE_FEATURE_MEMBER_ONLY
+
   unsigned EUsPerCU = 4;
   unsigned MaxWavesPerEU = 10;
   unsigned LocalMemorySize = 0;
@@ -206,16 +236,12 @@ public:
 
   bool isGCN() const { return TargetTriple.isAMDGCN(); }
 
-  bool isGCN3Encoding() const {
-    return GCN3Encoding;
-  }
-
-  bool has16BitInsts() const {
-    return Has16BitInsts;
-  }
-
-  /// Return true if the subtarget supports True16 instructions.
-  bool hasTrue16BitInsts() const { return HasTrue16BitInsts; }
+  // Simple subtarget feature getters - auto-generated from X-macro.
+#define DECL_HAS_GETTER(Name)                                                  \
+  bool has##Name() const { return Has##Name; }
+  AMDGPU_SUBTARGET_HAS_FEATURE(DECL_HAS_GETTER)
+#undef DECL_HAS_GETTER
+#undef AMDGPU_SUBTARGET_HAS_FEATURE
 
   /// Return true if real (non-fake) variants of True16 instructions using
   /// 16-bit registers should be code-generated. Fake True16 instructions are
@@ -227,52 +253,8 @@ public:
 
   bool hasD16Writes32BitVgpr() const;
 
-  bool hasBF16TransInsts() const { return HasBF16TransInsts; }
-
-  bool hasBF16ConversionInsts() const {
-    return HasBF16ConversionInsts;
-  }
-
-  bool hasBF16PackedInsts() const { return HasBF16PackedInsts; }
-
-  bool hasMadMixInsts() const {
-    return HasMadMixInsts;
-  }
-
-  bool hasFP8ConversionScaleInsts() const { return HasFP8ConversionScaleInsts; }
-
-  bool hasBF8ConversionScaleInsts() const { return HasBF8ConversionScaleInsts; }
-
-  bool hasFP4ConversionScaleInsts() const { return HasFP4ConversionScaleInsts; }
-
-  bool hasFP6BF6ConversionScaleInsts() const {
-    return HasFP6BF6ConversionScaleInsts;
-  }
-
-  bool hasF16BF16ToFP6BF6ConversionScaleInsts() const {
-    return HasF16BF16ToFP6BF6ConversionScaleInsts;
-  }
-
-  bool hasCvtPkF16F32Inst() const { return HasCvtPkF16F32Inst; }
-
-  bool hasF32ToF16BF16ConversionSRInsts() const {
-    return HasF32ToF16BF16ConversionSRInsts;
-  }
-
   bool hasMadMacF32Insts() const {
     return HasMadMacF32Insts || !isGCN();
-  }
-
-  bool hasDsSrc2Insts() const {
-    return HasDsSrc2Insts;
-  }
-
-  bool hasSDWA() const {
-    return HasSDWA;
-  }
-
-  bool hasVOP3PInsts() const {
-    return HasVOP3PInsts;
   }
 
   bool hasMulI24() const {
@@ -287,19 +269,9 @@ public:
     return HasSMulHi;
   }
 
-  bool hasInv2PiInlineImm() const {
-    return HasInv2PiInlineImm;
-  }
-
   bool hasFminFmaxLegacy() const {
     return HasFminFmaxLegacy;
   }
-
-  bool hasTrigReducedRange() const {
-    return HasTrigReducedRange;
-  }
-
-  bool hasFastFMAF32() const { return HasFastFMAF32; }
 
   bool isPromoteAllocaEnabled() const {
     return EnablePromoteAlloca;

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -71,7 +71,6 @@
   X(1_5xVGPRs)                                                                 \
   X(1024AddressableVGPRs)                                                      \
   X(45BitNumRecordsBufferResource)                                             \
-  X(AutoWaitcntBeforeBarrier)                                                  \
   X(64BitLiterals)                                                             \
   X(A16)                                                                       \
   X(AddMinMaxInsts)                                                            \
@@ -95,13 +94,19 @@
   X(AtomicFMinFMaxF64FlatInsts)                                                \
   X(AtomicFMinFMaxF64GlobalInsts)                                              \
   X(AtomicGlobalPkAddBF16Inst)                                                 \
+  X(AutoWaitcntBeforeBarrier)                                                  \
   X(BackOffBarrier)                                                            \
+  X(BF16ConversionInsts)                                                       \
+  X(BF16PackedInsts)                                                           \
+  X(BF16TransInsts)                                                            \
+  X(BF8ConversionScaleInsts)                                                   \
   X(BitOp3Insts)                                                               \
   X(BVHDualAndBVH8Insts)                                                       \
   X(Clusters)                                                                  \
   X(CubeInsts)                                                                 \
   X(CvtFP8VOP1Bug)                                                             \
   X(CvtNormInsts)                                                              \
+  X(CvtPkF16F32Inst)                                                           \
   X(CvtPkNormVOP2Insts)                                                        \
   X(CvtPkNormVOP3Insts)                                                        \
   X(DefaultComponentBroadcast)                                                 \
@@ -124,8 +129,11 @@
   X(DPP)                                                                       \
   X(DPP8)                                                                      \
   X(DPPSrc1SGPR)                                                               \
+  X(DsSrc2Insts)                                                               \
   X(EmulatedSystemScopeAtomics)                                                \
   X(ExtendedImageInsts)                                                        \
+  X(F16BF16ToFP6BF6ConversionScaleInsts)                                       \
+  X(F32ToF16BF16ConversionSRInsts)                                             \
   X(FlatAddressSpace)                                                          \
   X(FlatAtomicFaddF32Inst)                                                     \
   X(FlatBufferGlobalAtomicFaddF64Inst)                                         \
@@ -138,8 +146,11 @@
   X(FmacF64Inst)                                                               \
   X(FmaMixBF16Insts)                                                           \
   X(FmaMixInsts)                                                               \
+  X(FP4ConversionScaleInsts)                                                   \
   X(FP64)                                                                      \
+  X(FP6BF6ConversionScaleInsts)                                                \
   X(FP8ConversionInsts)                                                        \
+  X(FP8ConversionScaleInsts)                                                   \
   X(FP8E5M3Insts)                                                              \
   X(FP8Insts)                                                                  \
   X(FullRate64Ops)                                                             \
@@ -168,6 +179,7 @@
   X(LerpInst)                                                                  \
   X(LshlAddU64Inst)                                                            \
   X(MADIntraFwdBug)                                                            \
+  X(MadMixInsts)                                                               \
   X(MadU32Inst)                                                                \
   X(MAIInsts)                                                                  \
   X(McastLoadInsts)                                                            \
@@ -230,6 +242,7 @@
   X(TensorCvtLutInsts)                                                         \
   X(TransposeLoadF4F6Insts)                                                    \
   X(TrapHandler)                                                               \
+  X(TrigReducedRange)                                                          \
   X(UnalignedAccessMode)                                                       \
   X(UnalignedDSAccess)                                                         \
   X(UnpackedD16VMem)                                                           \


### PR DESCRIPTION
This PR is to move code around to pave the path for using `GET_SUBTARGETINFO_MACRO` in `GCNSubtarget.h`.