### PR TITLE
[LoopPeel] change `peelLoop`'s return type from `bool` to `void`

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/LoopPeel.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopPeel.h
@@ -30,7 +30,7 @@ bool canPeelLastIteration(const Loop &L, ScalarEvolution &SE);
 /// instructions in the last peeled-off iteration. If \p PeelLast is true, peel
 /// off the last \p PeelCount iterations from \p L (canPeelLastIteration must be
 /// true for \p L), otherwise peel off the first \p PeelCount iterations.
-bool peelLoop(Loop *L, unsigned PeelCount, bool PeelLast, LoopInfo *LI,
+void peelLoop(Loop *L, unsigned PeelCount, bool PeelLast, LoopInfo *LI,
               ScalarEvolution *SE, DominatorTree &DT, AssumptionCache *AC,
               bool PreserveLCSSA, ValueToValueMapTy &VMap);
 

--- a/llvm/lib/Transforms/Scalar/LoopFuse.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopFuse.cpp
@@ -791,62 +791,60 @@ private:
                       << " iterations of the first loop. \n");
 
     ValueToValueMapTy VMap;
-    FC0.Peeled =
-        peelLoop(FC0.L, PeelCount, false, &LI, &SE, DT, &AC, true, VMap);
-    if (FC0.Peeled) {
-      LLVM_DEBUG(dbgs() << "Done Peeling\n");
+    peelLoop(FC0.L, PeelCount, false, &LI, &SE, DT, &AC, true, VMap);
+    FC0.Peeled = true;
+    LLVM_DEBUG(dbgs() << "Done Peeling\n");
 
 #ifndef NDEBUG
-      auto IdenticalTripCount = haveIdenticalTripCounts(FC0, FC1);
+    auto IdenticalTripCount = haveIdenticalTripCounts(FC0, FC1);
 
-      assert(IdenticalTripCount.first && *IdenticalTripCount.second == 0 &&
-             "Loops should have identical trip counts after peeling");
+    assert(IdenticalTripCount.first && *IdenticalTripCount.second == 0 &&
+           "Loops should have identical trip counts after peeling");
 #endif
 
-      FC0.PP.PeelCount += PeelCount;
+    FC0.PP.PeelCount += PeelCount;
 
-      // Peeling does not update the PDT
-      PDT.recalculate(*FC0.Preheader->getParent());
+    // Peeling does not update the PDT
+    PDT.recalculate(*FC0.Preheader->getParent());
 
-      FC0.updateAfterPeeling();
+    FC0.updateAfterPeeling();
 
-      // In this case the iterations of the loop are constant, so the first
-      // loop will execute completely (will not jump from one of
-      // the peeled blocks to the second loop). Here we are updating the
-      // branch conditions of each of the peeled blocks, such that it will
-      // branch to its successor which is not the preheader of the second loop
-      // in the case of unguarded loops, or the succesors of the exit block of
-      // the first loop otherwise. Doing this update will ensure that the entry
-      // block of the first loop dominates the entry block of the second loop.
-      BasicBlock *BB =
-          FC0.GuardBranch ? FC0.ExitBlock->getUniqueSuccessor() : FC1.Preheader;
-      if (BB) {
-        SmallVector<DominatorTree::UpdateType, 8> TreeUpdates;
-        SmallVector<Instruction *, 8> WorkList;
-        for (BasicBlock *Pred : predecessors(BB)) {
-          if (Pred != FC0.ExitBlock) {
-            WorkList.emplace_back(Pred->getTerminator());
-            TreeUpdates.emplace_back(
-                DominatorTree::UpdateType(DominatorTree::Delete, Pred, BB));
-          }
+    // In this case the iterations of the loop are constant, so the first
+    // loop will execute completely (will not jump from one of
+    // the peeled blocks to the second loop). Here we are updating the
+    // branch conditions of each of the peeled blocks, such that it will
+    // branch to its successor which is not the preheader of the second loop
+    // in the case of unguarded loops, or the succesors of the exit block of
+    // the first loop otherwise. Doing this update will ensure that the entry
+    // block of the first loop dominates the entry block of the second loop.
+    BasicBlock *BB =
+        FC0.GuardBranch ? FC0.ExitBlock->getUniqueSuccessor() : FC1.Preheader;
+    if (BB) {
+      SmallVector<DominatorTree::UpdateType, 8> TreeUpdates;
+      SmallVector<Instruction *, 8> WorkList;
+      for (BasicBlock *Pred : predecessors(BB)) {
+        if (Pred != FC0.ExitBlock) {
+          WorkList.emplace_back(Pred->getTerminator());
+          TreeUpdates.emplace_back(
+              DominatorTree::UpdateType(DominatorTree::Delete, Pred, BB));
         }
-        // Cannot modify the predecessors inside the above loop as it will cause
-        // the iterators to be nullptrs, causing memory errors.
-        for (Instruction *CurrentBranch : WorkList) {
-          BasicBlock *Succ = CurrentBranch->getSuccessor(0);
-          if (Succ == BB)
-            Succ = CurrentBranch->getSuccessor(1);
-          ReplaceInstWithInst(CurrentBranch, BranchInst::Create(Succ));
-        }
-
-        DTU.applyUpdates(TreeUpdates);
-        DTU.flush();
       }
-      LLVM_DEBUG(
+      // Cannot modify the predecessors inside the above loop as it will cause
+      // the iterators to be nullptrs, causing memory errors.
+      for (Instruction *CurrentBranch : WorkList) {
+        BasicBlock *Succ = CurrentBranch->getSuccessor(0);
+        if (Succ == BB)
+          Succ = CurrentBranch->getSuccessor(1);
+        ReplaceInstWithInst(CurrentBranch, BranchInst::Create(Succ));
+      }
+
+      DTU.applyUpdates(TreeUpdates);
+      DTU.flush();
+    }
+    LLVM_DEBUG(
           dbgs() << "Sucessfully peeled " << FC0.PP.PeelCount
                  << " iterations from the first loop.\n"
                     "Both Loops have the same number of iterations now.\n");
-    }
   }
 
   /// Walk each set of control flow equivalent fusion candidates and attempt to

--- a/llvm/lib/Transforms/Scalar/LoopFuse.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopFuse.cpp
@@ -842,9 +842,9 @@ private:
       DTU.flush();
     }
     LLVM_DEBUG(
-          dbgs() << "Sucessfully peeled " << FC0.PP.PeelCount
-                 << " iterations from the first loop.\n"
-                    "Both Loops have the same number of iterations now.\n");
+        dbgs() << "Sucessfully peeled " << FC0.PP.PeelCount
+               << " iterations from the first loop.\n"
+                  "Both Loops have the same number of iterations now.\n");
   }
 
   /// Walk each set of control flow equivalent fusion candidates and attempt to

--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -1314,16 +1314,14 @@ tryToUnrollLoop(Loop *L, DominatorTree &DT, LoopInfo *LI, ScalarEvolution &SE,
     });
 
     ValueToValueMapTy VMap;
-    if (peelLoop(L, PP.PeelCount, PP.PeelLast, LI, &SE, DT, &AC, PreserveLCSSA,
-                 VMap)) {
-      simplifyLoopAfterUnroll(L, true, LI, &SE, &DT, &AC, &TTI, nullptr);
-      // If the loop was peeled, we already "used up" the profile information
-      // we had, so we don't want to unroll or peel again.
-      if (PP.PeelProfiledIterations)
-        L->setLoopAlreadyUnrolled();
-      return LoopUnrollResult::PartiallyUnrolled;
-    }
-    return LoopUnrollResult::Unmodified;
+    peelLoop(L, PP.PeelCount, PP.PeelLast, LI, &SE, DT, &AC, PreserveLCSSA,
+             VMap);
+    simplifyLoopAfterUnroll(L, true, LI, &SE, &DT, &AC, &TTI, nullptr);
+    // If the loop was peeled, we already "used up" the profile information
+    // we had, so we don't want to unroll or peel again.
+    if (PP.PeelProfiledIterations)
+      L->setLoopAlreadyUnrolled();
+    return LoopUnrollResult::PartiallyUnrolled;
   }
 
   // Do not attempt partial/runtime unrolling in FullLoopUnrolling

--- a/llvm/lib/Transforms/Utils/LoopPeel.cpp
+++ b/llvm/lib/Transforms/Utils/LoopPeel.cpp
@@ -1170,7 +1170,7 @@ llvm::gatherPeelingPreferences(Loop *L, ScalarEvolution &SE,
 /// this provides a benefit, since the peeled off iterations, which account
 /// for the bulk of dynamic execution, can be further simplified by scalar
 /// optimizations.
-bool llvm::peelLoop(Loop *L, unsigned PeelCount, bool PeelLast, LoopInfo *LI,
+void llvm::peelLoop(Loop *L, unsigned PeelCount, bool PeelLast, LoopInfo *LI,
                     ScalarEvolution *SE, DominatorTree &DT, AssumptionCache *AC,
                     bool PreserveLCSSA, ValueToValueMapTy &LVMap) {
   assert(PeelCount > 0 && "Attempt to peel out zero iterations?");
@@ -1453,6 +1453,4 @@ bool llvm::peelLoop(Loop *L, unsigned PeelCount, bool PeelLast, LoopInfo *LI,
 
   NumPeeled++;
   NumPeeledEnd += PeelLast;
-
-  return true;
 }


### PR DESCRIPTION
`peelLoop` never returns `false`, so this PR changes the return type of `peelLoop` to `void`. 