### PR TITLE
[NFC][OpenMP] Mark new mapper test as XFAIL on intelgpu.

### DIFF
--- a/offload/test/mapping/declare_mapper_target_checks.cpp
+++ b/offload/test/mapping/declare_mapper_target_checks.cpp
@@ -1,4 +1,6 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// XFAIL: intelgpu
+
 #include <omp.h>
 #include <stdio.h>
 


### PR DESCRIPTION
Other tests in the directory already do this. The new test was added in #177059.