### PR TITLE
[LLVM] Move CodeGen test to proper subdirectory.

### DIFF
--- a/llvm/test/CodeGen/AArch64/fptoi-256.ll
+++ b/llvm/test/CodeGen/AArch64/fptoi-256.ll
@@ -1,4 +1,3 @@
-; REQUIRES: aarch64-registered-target
 ; RUN: llc -mtriple=aarch64 < %s
 
 define i256 @doubletosi256(double %a) {


### PR DESCRIPTION
PR #176851 put an AArch64 test directly in the llvm/test/CodeGen directory. This moves the test to the proper subdirectory.