### PR TITLE
[HLSL] Make  cosh, exp, normalize overload tests stricter. NFC

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/cosh-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/cosh-overloads.hlsl
@@ -1,12 +1,16 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z16test_cosh_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_cosh_double ( double p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x 64 bit API lowering for cosh is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return cosh ( p0 );
 }
 
@@ -15,6 +19,7 @@ float test_cosh_double ( double p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_double2 ( double2 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x 64 bit API lowering for cosh is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return cosh ( p0 );
 }
 
@@ -23,6 +28,7 @@ float2 test_cosh_double2 ( double2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_double3 ( double3 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x 64 bit API lowering for cosh is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return cosh ( p0 );
 }
 
@@ -31,6 +37,7 @@ float3 test_cosh_double3 ( double3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_double4 ( double4 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x 64 bit API lowering for cosh is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return cosh ( p0 );
 }
 
@@ -39,6 +46,7 @@ float4 test_cosh_double4 ( double4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_cosh_int ( int p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -47,6 +55,7 @@ float test_cosh_int ( int p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_int2 ( int2 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -55,6 +64,7 @@ float2 test_cosh_int2 ( int2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_int3 ( int3 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -63,6 +73,7 @@ float3 test_cosh_int3 ( int3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_int4 ( int4 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -71,6 +82,7 @@ float4 test_cosh_int4 ( int4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_cosh_uint ( uint p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -79,6 +91,7 @@ float test_cosh_uint ( uint p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_uint2 ( uint2 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -87,6 +100,7 @@ float2 test_cosh_uint2 ( uint2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_uint3 ( uint3 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -95,6 +109,7 @@ float3 test_cosh_uint3 ( uint3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_uint4 ( uint4 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -103,6 +118,7 @@ float4 test_cosh_uint4 ( uint4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_cosh_int64_t ( int64_t p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -111,6 +127,7 @@ float test_cosh_int64_t ( int64_t p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_int64_t2 ( int64_t2 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -119,6 +136,7 @@ float2 test_cosh_int64_t2 ( int64_t2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_int64_t3 ( int64_t3 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -127,6 +145,7 @@ float3 test_cosh_int64_t3 ( int64_t3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_int64_t4 ( int64_t4 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -135,6 +154,7 @@ float4 test_cosh_int64_t4 ( int64_t4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_cosh_uint64_t ( uint64_t p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -143,6 +163,7 @@ float test_cosh_uint64_t ( uint64_t p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_uint64_t2 ( uint64_t2 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -151,6 +172,7 @@ float2 test_cosh_uint64_t2 ( uint64_t2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_uint64_t3 ( uint64_t3 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }
 
@@ -159,5 +181,6 @@ float3 test_cosh_uint64_t3 ( uint64_t3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_uint64_t4 ( uint64_t4 p0 ) {
+// expected-warning@+1 {{'cosh' is deprecated: In 202x int lowering for cosh is deprecated. Explicitly cast parameters to float types.}}
   return cosh ( p0 );
 }

--- a/clang/test/CodeGenHLSL/builtins/cosh-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/cosh-overloads.hlsl
@@ -1,123 +1,163 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
 
-// CHECK-LABEL: test_cosh_double
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.cosh.f32
+// CHECK: define [[FNATTRS]] float @_Z16test_cosh_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_cosh_double ( double p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_double2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.cosh.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_cosh_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_double2 ( double2 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_double3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.cosh.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_cosh_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_double3 ( double3 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_double4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.cosh.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_cosh_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_double4 ( double4 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_int
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.cosh.f32
+// CHECK: define [[FNATTRS]] float @_Z13test_cosh_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_cosh_int ( int p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_int2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.cosh.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_cosh_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_int2 ( int2 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_int3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.cosh.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_cosh_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_int3 ( int3 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_int4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.cosh.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_cosh_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_int4 ( int4 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_uint
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.cosh.f32
+// CHECK: define [[FNATTRS]] float @_Z14test_cosh_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_cosh_uint ( uint p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_uint2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.cosh.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_cosh_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_uint2 ( uint2 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_uint3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.cosh.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_cosh_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_uint3 ( uint3 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_uint4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.cosh.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_cosh_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_uint4 ( uint4 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_int64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.cosh.f32
+// CHECK: define [[FNATTRS]] float @_Z17test_cosh_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_cosh_int64_t ( int64_t p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_int64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.cosh.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_cosh_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_int64_t2 ( int64_t2 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_int64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.cosh.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_cosh_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_int64_t3 ( int64_t3 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_int64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.cosh.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_cosh_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_int64_t4 ( int64_t4 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_uint64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.cosh.f32
+// CHECK: define [[FNATTRS]] float @_Z18test_cosh_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_cosh_uint64_t ( uint64_t p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_uint64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.cosh.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_cosh_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_uint64_t2 ( uint64_t2 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_uint64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.cosh.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_cosh_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_uint64_t3 ( uint64_t3 p0 ) {
   return cosh ( p0 );
 }
 
-// CHECK-LABEL: test_cosh_uint64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.cosh.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_cosh_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_uint64_t4 ( uint64_t4 p0 ) {
   return cosh ( p0 );
 }

--- a/clang/test/CodeGenHLSL/builtins/exp-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/exp-overloads.hlsl
@@ -1,88 +1,108 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -disable-llvm-passes -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK
+// RUN:  -emit-llvm -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)"
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_exp_double
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.exp.f32(
-// CHECK: ret float [[EXP]]
+// CHECK: define [[FNATTRS]] float @_Z15test_exp_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_exp_double(double p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_exp_double2
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.exp.v2f32
-// CHECK: ret <2 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z16test_exp_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_exp_double2(double2 p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_exp_double3
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.exp.v3f32
-// CHECK: ret <3 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z16test_exp_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_exp_double3(double3 p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_exp_double4
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.exp.v4f32
-// CHECK: ret <4 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z16test_exp_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_exp_double4(double4 p0) { return exp(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_exp_int
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.exp.f32(
-// CHECK: ret float [[EXP]]
+// CHECK: define [[FNATTRS]] float @_Z12test_exp_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_exp_int(int p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_exp_int2
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.exp.v2f32
-// CHECK: ret <2 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z13test_exp_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_exp_int2(int2 p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_exp_int3
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.exp.v3f32
-// CHECK: ret <3 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z13test_exp_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_exp_int3(int3 p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_exp_int4
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.exp.v4f32
-// CHECK: ret <4 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z13test_exp_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_exp_int4(int4 p0) { return exp(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_exp_uint
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.exp.f32(
-// CHECK: ret float [[EXP]]
+// CHECK: define [[FNATTRS]] float @_Z13test_exp_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_exp_uint(uint p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_exp_uint2
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.exp.v2f32
-// CHECK: ret <2 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_exp_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_exp_uint2(uint2 p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_exp_uint3
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.exp.v3f32
-// CHECK: ret <3 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_exp_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_exp_uint3(uint3 p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_exp_uint4
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.exp.v4f32
-// CHECK: ret <4 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_exp_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_exp_uint4(uint4 p0) { return exp(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_exp_int64_t
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.exp.f32(
-// CHECK: ret float [[EXP]]
+// CHECK: define [[FNATTRS]] float @_Z16test_exp_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_exp_int64_t(int64_t p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_exp_int64_t2
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.exp.v2f32
-// CHECK: ret <2 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_exp_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_exp_int64_t2(int64_t2 p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_exp_int64_t3
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.exp.v3f32
-// CHECK: ret <3 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_exp_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_exp_int64_t3(int64_t3 p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_exp_int64_t4
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.exp.v4f32
-// CHECK: ret <4 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_exp_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_exp_int64_t4(int64_t4 p0) { return exp(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_exp_uint64_t
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.exp.f32(
-// CHECK: ret float [[EXP]]
+// CHECK: define [[FNATTRS]] float @_Z17test_exp_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_exp_uint64_t(uint64_t p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_exp_uint64_t2
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.exp.v2f32
-// CHECK: ret <2 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_exp_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_exp_uint64_t2(uint64_t2 p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_exp_uint64_t3
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.exp.v3f32
-// CHECK: ret <3 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_exp_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_exp_uint64_t3(uint64_t3 p0) { return exp(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_exp_uint64_t4
-// CHECK: [[EXP:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.exp.v4f32
-// CHECK: ret <4 x float> [[EXP]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_exp_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_exp_uint64_t4(uint64_t4 p0) { return exp(p0); }

--- a/clang/test/CodeGenHLSL/builtins/exp-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/exp-overloads.hlsl
@@ -1,108 +1,130 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN:   -Wdeprecated-declarations -Wconversion  -emit-llvm -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z15test_exp_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x 64 bit API lowering for exp is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float test_exp_double(double p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z16test_exp_double2Dv2_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x 64 bit API lowering for exp is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float2 test_exp_double2(double2 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z16test_exp_double3Dv3_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x 64 bit API lowering for exp is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float3 test_exp_double3(double3 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z16test_exp_double4Dv4_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x 64 bit API lowering for exp is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float4 test_exp_double4(double4 p0) { return exp(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z12test_exp_inti(
 // CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float test_exp_int(int p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z13test_exp_int2Dv2_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float2 test_exp_int2(int2 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z13test_exp_int3Dv3_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float3 test_exp_int3(int3 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z13test_exp_int4Dv4_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float4 test_exp_int4(int4 p0) { return exp(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_exp_uintj(
 // CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float test_exp_uint(uint p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_exp_uint2Dv2_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float2 test_exp_uint2(uint2 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_exp_uint3Dv3_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float3 test_exp_uint3(uint3 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_exp_uint4Dv4_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float4 test_exp_uint4(uint4 p0) { return exp(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z16test_exp_int64_tl(
 // CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float test_exp_int64_t(int64_t p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_exp_int64_t2Dv2_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float2 test_exp_int64_t2(int64_t2 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_exp_int64_t3Dv3_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float3 test_exp_int64_t3(int64_t3 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_exp_int64_t4Dv4_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float4 test_exp_int64_t4(int64_t4 p0) { return exp(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_exp_uint64_tm(
 // CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float test_exp_uint64_t(uint64_t p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_exp_uint64_t2Dv2_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float2 test_exp_uint64_t2(uint64_t2 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_exp_uint64_t3Dv3_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float3 test_exp_uint64_t3(uint64_t3 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_exp_uint64_t4Dv4_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float4 test_exp_uint64_t4(uint64_t4 p0) { return exp(p0); }

--- a/clang/test/CodeGenHLSL/builtins/normalize-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/normalize-overloads.hlsl
@@ -1,11 +1,15 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)" -DTARGET=dx
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" -DTARGET=spv
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z21test_normalize_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
@@ -13,6 +17,7 @@
 // CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_double(double p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x 64 bit API lowering for normalize is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z22test_normalize_double2Dv2_d(
@@ -21,6 +26,7 @@ float test_normalize_double(double p0)
 // CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_double2(double2 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x 64 bit API lowering for normalize is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z22test_normalize_double3Dv3_d(
@@ -29,6 +35,7 @@ float2 test_normalize_double2(double2 p0)
 // CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_double3(double3 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x 64 bit API lowering for normalize is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_length_double4Dv4_d(
@@ -37,6 +44,7 @@ float3 test_normalize_double3(double3 p0)
 // CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_double4(double4 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x 64 bit API lowering for normalize is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
     return normalize(p0);
 }
 
@@ -46,6 +54,7 @@ float4 test_length_double4(double4 p0)
 // CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_int(int p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_normalize_int2Dv2_i(
@@ -54,6 +63,7 @@ float test_normalize_int(int p0)
 // CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_int2(int2 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_normalize_int3Dv3_i(
@@ -62,6 +72,7 @@ float2 test_normalize_int2(int2 p0)
 // CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_int3(int3 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z16test_length_int4Dv4_i(
@@ -70,6 +81,7 @@ float3 test_normalize_int3(int3 p0)
 // CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_int4(int4 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 
@@ -79,6 +91,7 @@ float4 test_length_int4(int4 p0)
 // CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_uint(uint p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 
@@ -88,6 +101,7 @@ float test_normalize_uint(uint p0)
 // CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_uint2(uint2 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z20test_normalize_uint3Dv3_j(
@@ -96,6 +110,7 @@ float2 test_normalize_uint2(uint2 p0)
 // CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_uint3(uint3 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_length_uint4Dv4_j(
@@ -104,6 +119,7 @@ float3 test_normalize_uint3(uint3 p0)
 // CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_uint4(uint4 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 
@@ -113,6 +129,7 @@ float4 test_length_uint4(uint4 p0)
 // CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_int64_t(int64_t p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 
@@ -122,6 +139,7 @@ float test_normalize_int64_t(int64_t p0)
 // CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_int64_t2(int64_t2 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z23test_normalize_int64_t3Dv3_l(
@@ -130,6 +148,7 @@ float2 test_normalize_int64_t2(int64_t2 p0)
 // CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_int64_t3(int64_t3 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z20test_length_int64_t4Dv4_l(
@@ -138,6 +157,7 @@ float3 test_normalize_int64_t3(int64_t3 p0)
 // CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_int64_t4(int64_t4 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 
@@ -147,6 +167,7 @@ float4 test_length_int64_t4(int64_t4 p0)
 // CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_uint64_t(uint64_t p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 
@@ -156,6 +177,7 @@ float test_normalize_uint64_t(uint64_t p0)
 // CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_uint64_t2(uint64_t2 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z24test_normalize_uint64_t3Dv3_m(
@@ -164,6 +186,7 @@ float2 test_normalize_uint64_t2(uint64_t2 p0)
 // CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_uint64_t3(uint64_t3 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z21test_length_uint64_t4Dv4_m(
@@ -172,5 +195,6 @@ float3 test_normalize_uint64_t3(uint64_t3 p0)
 // CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_uint64_t4(uint64_t4 p0)
 {
+// expected-warning@+1 {{'normalize' is deprecated: In 202x int lowering for normalize is deprecated. Explicitly cast parameters to float types.}}
     return normalize(p0);
 }

--- a/clang/test/CodeGenHLSL/builtins/normalize-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/normalize-overloads.hlsl
@@ -1,155 +1,175 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
 // RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)" -DTARGET=dx
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
 // RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" -DTARGET=spv
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].normalize.f32(float
-// CHECK: ret float
+// CHECK: define [[FNATTRS]] float @_Z21test_normalize_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} float @llvm.[[TARGET]].normalize.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_double(double p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float>
-// CHECK: ret <2 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <2 x float> @_Z22test_normalize_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_double2(double2 p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].normalize.v3f32(
-// CHECK: ret <3 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <3 x float> @_Z22test_normalize_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].normalize.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_double3(double3 p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].normalize.v4f32(
-// CHECK: ret <4 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_length_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].normalize.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_double4(double4 p0)
 {
     return normalize(p0);
 }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].normalize.f32(float
-// CHECK: ret float
+// CHECK: define [[FNATTRS]] float @_Z18test_normalize_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} float @llvm.[[TARGET]].normalize.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_int(int p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float>
-// CHECK: ret <2 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_normalize_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_int2(int2 p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].normalize.v3f32(
-// CHECK: ret <3 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_normalize_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].normalize.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_int3(int3 p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].normalize.v4f32(
-// CHECK: ret <4 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <4 x float> @_Z16test_length_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].normalize.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_int4(int4 p0)
 {
     return normalize(p0);
 }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].normalize.f32(float
-// CHECK: ret float
+// CHECK: define [[FNATTRS]] float @_Z19test_normalize_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} float @llvm.[[TARGET]].normalize.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_uint(uint p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float>
 
-// CHECK: ret <2 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <2 x float> @_Z20test_normalize_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_uint2(uint2 p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].normalize.v3f32(
-// CHECK: ret <3 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <3 x float> @_Z20test_normalize_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].normalize.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_uint3(uint3 p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].normalize.v4f32(
-// CHECK: ret <4 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_length_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].normalize.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_uint4(uint4 p0)
 {
     return normalize(p0);
 }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].normalize.f32(float
-// CHECK: ret float
+// CHECK: define [[FNATTRS]] float @_Z22test_normalize_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} float @llvm.[[TARGET]].normalize.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_int64_t(int64_t p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float>
 
-// CHECK: ret <2 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <2 x float> @_Z23test_normalize_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_int64_t2(int64_t2 p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].normalize.v3f32(
-// CHECK: ret <3 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <3 x float> @_Z23test_normalize_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].normalize.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_int64_t3(int64_t3 p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].normalize.v4f32(
-// CHECK: ret <4 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <4 x float> @_Z20test_length_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].normalize.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_int64_t4(int64_t4 p0)
 {
     return normalize(p0);
 }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].normalize.f32(float
-// CHECK: ret float
+// CHECK: define [[FNATTRS]] float @_Z23test_normalize_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} float @llvm.[[TARGET]].normalize.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_uint64_t(uint64_t p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float>
 
-// CHECK: ret <2 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <2 x float> @_Z24test_normalize_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_uint64_t2(uint64_t2 p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].normalize.v3f32(
-// CHECK: ret <3 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <3 x float> @_Z24test_normalize_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].normalize.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_uint64_t3(uint64_t3 p0)
 {
     return normalize(p0);
 }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].normalize.v4f32(
-// CHECK: ret <4 x float> %hlsl.normalize
+// CHECK: define [[FNATTRS]] <4 x float> @_Z21test_length_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].normalize.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_uint64_t4(uint64_t4 p0)
 {
     return normalize(p0);


### PR DESCRIPTION
This patch changes the run lines for cosh, exp, normalize overload test to use -O1 instead of -disable-llvm-passes and rewrite the tests to actually look at the whole function.

This work is part of https://github.com/llvm/llvm-project/issues/138016.