### PR TITLE
[NFCI][AMDGPU] Add `FeatureMadMacF32Insts` to all R600 processors

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.h
@@ -26,9 +26,6 @@
 //   bool HasXXX = false;                      // member declaration
 //   bool hasXXX() const { return HasXXX; }    // getter
 //
-// AMDGPU_SUBTARGET_HAS_FEATURE_MEMBER_ONLY: Features with member only
-//   bool HasXXX = false;                      // member declaration only
-//
 // AMDGPU_SUBTARGET_ENABLE_FEATURE_MEMBER_ONLY: Features with member only
 //   bool EnableXXX = false;                   // member declaration only
 //
@@ -46,12 +43,11 @@
 // to GCNSubtarget.h instead.
 //===----------------------------------------------------------------------===//
 
-#define AMDGPU_SUBTARGET_HAS_FEATURE_MEMBER_ONLY(X) X(MadMacF32Insts)
-
 #define AMDGPU_SUBTARGET_HAS_FEATURE(X)                                        \
   X(16BitInsts)                                                                \
   X(FastFMAF32)                                                                \
   X(Inv2PiInlineImm)                                                           \
+  X(MadMacF32Insts)                                                            \
   X(SDWA)                                                                      \
   X(True16BitInsts)                                                            \
   X(VOP3PInsts)
@@ -97,7 +93,6 @@ protected:
 
 #define DECL_HAS_MEMBER(Name) bool Has##Name = false;
   AMDGPU_SUBTARGET_HAS_FEATURE(DECL_HAS_MEMBER)
-  AMDGPU_SUBTARGET_HAS_FEATURE_MEMBER_ONLY(DECL_HAS_MEMBER)
 #undef DECL_HAS_MEMBER
 #undef AMDGPU_SUBTARGET_HAS_FEATURE_MEMBER_ONLY
 
@@ -254,10 +249,6 @@ public:
   bool useRealTrue16Insts() const;
 
   bool hasD16Writes32BitVgpr() const;
-
-  bool hasMadMacF32Insts() const {
-    return HasMadMacF32Insts || !isGCN();
-  }
 
   bool hasMulI24() const {
     return HasMulI24;

--- a/llvm/lib/Target/AMDGPU/R600Processors.td
+++ b/llvm/lib/Target/AMDGPU/R600Processors.td
@@ -40,26 +40,32 @@ def FeatureCFALUBug : SubtargetFeature<"cfalubug",
   "GPU has CF_ALU bug"
 >;
 
+def FeatureMadMacF32Insts : SubtargetFeature<"mad-mac-f32-insts",
+  "HasMadMacF32Insts",
+  "true",
+  "Has v_mad_f32/v_mac_f32/v_madak_f32/v_madmk_f32 instructions"
+>;
+
 class R600SubtargetFeatureGeneration <string Value, string FeatureName,
                                   list<SubtargetFeature> Implies> :
         SubtargetFeatureGeneration <Value, FeatureName, "R600Subtarget", Implies>;
 
 def FeatureR600 : R600SubtargetFeatureGeneration<"R600", "r600",
-  [FeatureR600ALUInst, FeatureFetchLimit8]
+  [FeatureR600ALUInst, FeatureFetchLimit8, FeatureMadMacF32Insts]
 >;
 
 def FeatureR700 : R600SubtargetFeatureGeneration<"R700", "r700",
-  [FeatureFetchLimit16]
+  [FeatureFetchLimit16, FeatureMadMacF32Insts]
 >;
 
 def FeatureEvergreen : R600SubtargetFeatureGeneration<"EVERGREEN", "evergreen",
-  [FeatureFetchLimit16, FeatureAddressableLocalMemorySize32768]
+  [FeatureFetchLimit16, FeatureAddressableLocalMemorySize32768, FeatureMadMacF32Insts]
 >;
 
 def FeatureNorthernIslands : R600SubtargetFeatureGeneration<"NORTHERN_ISLANDS",
   "northern-islands",
   [FeatureFetchLimit16, FeatureWavefrontSize64,
-   FeatureAddressableLocalMemorySize32768]
+   FeatureAddressableLocalMemorySize32768, FeatureMadMacF32Insts]
 >;
 
 


### PR DESCRIPTION
In this way, we don't need to use a custom getter in `hasMadMacF32Insts`.