### PR TITLE
[llvm-gsymutil]: print gsym function names for duplicates

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
@@ -304,8 +304,8 @@ llvm::Error GsymCreator::finalize(OutputAggregator &Out) {
                     [&](raw_ostream &OS) {
                       OS << "warning: same address range contains "
                             "different debug "
-                         << "info. Removing:\n"
-                         << Prev << "\nIn favor of this one:\n"
+                         << "info. Removing [" << getString(Prev.Name) << "]:\n"
+                         << Prev << "\nIn favor of this one [" << getString(Curr.Name) << "]:\n"
                          << Curr << "\n";
                     });
 


### PR DESCRIPTION
This makes it easier to see what is traded off for what:

```
$ llvm-gsymutil --convert ... --out-file /tmp/libc.gsym | grep '^\[0x0000000000110790' -B1
warning: same address range contains different debug info. Removing [__clone3]:
[0x0000000000110790 - 0x00000000001107d3): Name=0x00014838
--
In favor of this one [__GI___clone3]:
[0x0000000000110790 - 0x00000000001107d3): Name=0x00014923
```

I rediscovered #122921 on LLVM 19 and this seemed like a helpful addition.
