### PR TITLE
[libc++] Fix realloc bug in ios.cpp

### DIFF
--- a/libcxx/src/ios.cpp
+++ b/libcxx/src/ios.cpp
@@ -180,12 +180,16 @@ void ios_base::register_callback(event_callback fn, int index) {
   if (req_size > __event_cap_) {
     size_t newcap       = __ios_new_cap<event_callback>(req_size, __event_cap_);
     event_callback* fns = static_cast<event_callback*>(realloc(__fn_, newcap * sizeof(event_callback)));
-    if (fns == 0)
+    if (fns == 0) {
       setstate(badbit);
+      return;
+    }
     __fn_      = fns;
     int* indxs = static_cast<int*>(realloc(__index_, newcap * sizeof(int)));
-    if (indxs == 0)
+    if (indxs == 0) {
       setstate(badbit);
+      return;
+    }
     __index_     = indxs;
     __event_cap_ = newcap;
   }


### PR DESCRIPTION
When realloc fails in the function register_callback in `ios.cpp`, the memory will be leaked, then `__fn_` is assigned as `nullptr`, dereferencing `__fn_` causes UB. The fix is quite simple which aligns to `iword & pword` for `realloc`, i.e. return directly if `realloc` fails.

Regarding testing for this bug fix, because `realloc` is a C function that we can't replace, there is no way to exercise that path easily.