### PR TITLE
[orc-rt] Fix some Session::shutdown bugs.

### DIFF
--- a/orc-rt/unittests/SessionTest.cpp
+++ b/orc-rt/unittests/SessionTest.cpp
@@ -464,3 +464,14 @@ TEST(ControllerAccessTest, CallFromController) {
 
   S.waitForShutdown();
 }
+
+TEST(ControllerAccessTest, RedundantAsyncShutdown) {
+  // Check that redundant calls to shutdown have their callbacks run.
+  std::deque<std::unique_ptr<Task>> Tasks;
+  Session S(std::make_unique<EnqueueingDispatcher>(Tasks), noErrors);
+  S.waitForShutdown();
+
+  bool RedundantCallbackRan = false;
+  S.shutdown([&]() { RedundantCallbackRan = true; });
+  EXPECT_TRUE(RedundantCallbackRan);
+}


### PR DESCRIPTION
All calls to Session::shutdown were enquing their on-shutdown-complete callbacks in Session's ShutdownInfo struct, but this queue is only drained once by the thread that initiates shutdown. After the queue is drained, subsequent calls to Session::shutdown were enquing their callbacks in a queue that would never be drained.

This patch updates Session::shutdown to check whether shutdown has completed already and, if so, run the on-shutdown-complete immediately.

This patch also fixes a concurrency bug: Session::shutdownComplete was accessing SI->OnCompletes outside the session mutex, but this could lead to corruption of SI->OnCompletes if a concurrent call to Session::shutdown tried to enqueue a new callback to SI->OnCompletes concurrently. This has been fixed by moving the SI->OnCompletes queue to a new variable under the Session mutex, then draining the new queue outside the mutex. (No testcase yet: this was discovered by observation, and replicating the bug would depend on timing).