### PR TITLE
[clang] Fix a crash when default argument is passed to an explicit object parameter

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -232,6 +232,7 @@ Bug Fixes to Attribute Support
 Bug Fixes to C++ Support
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed a crash when instantiating ``requires`` expressions involving substitution failures in C++ concepts. (#GH176402)
+- Fixed a crash when a default argument is passed to an explicit object parameter. (#GH176639)
 - Fixed a crash when diagnosing an invalid static member function with an explicit object parameter (#GH177741)
 
 Bug Fixes to AST Handling

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -11600,6 +11600,7 @@ void Sema::CheckExplicitObjectMemberFunction(Declarator &D,
     Diag(ExplicitObjectParam->getLocation(),
          diag::err_explicit_object_default_arg)
         << ExplicitObjectParam->getSourceRange();
+    D.setInvalidType();
   }
 
   if (D.getDeclSpec().getStorageClassSpec() == DeclSpec::SCS_static ||

--- a/clang/test/SemaCXX/cxx2b-deducing-this.cpp
+++ b/clang/test/SemaCXX/cxx2b-deducing-this.cpp
@@ -1431,6 +1431,30 @@ namespace ConstexprBacktrace {
                           // expected-note {{in call to}}
 }
 
+namespace GH176639 {
+
+struct S {
+  void operator()(this S =) // expected-error {{the explicit object parameter cannot have a default argument}}
+          // expected-error@-1 {{expected ';' at end of declaration list}}
+          // expected-error@-2 {{expected expression}}
+};
+
+void foo() {
+  S s{};
+  s(0); // expected-error {{no matching function for call to object of type 'S'}}
+}
+
+struct S2 {
+  void operator()(this S2 = S2 {}){} // expected-error {{the explicit object parameter cannot have a default argument}}
+};
+
+void foo2() {
+  S2 s{};
+  s(0); // expected-error {{no matching function for call to object of type 'S2'}}
+}
+
+}
+
 namespace GH177741 {
 
 struct S {


### PR DESCRIPTION
This is an invalid usecase and we should mark it as such after emitting a Diagnostic. Fixes #176639.