### PR TITLE
[clang][bytecode][NFC] Move some opcode impls to the source file

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -118,6 +118,9 @@ bool CheckBitCast(InterpState &S, CodePtr OpPC, bool HasIndeterminateBits,
 bool CheckBCPResult(InterpState &S, const Pointer &Ptr);
 bool CheckDestructor(InterpState &S, CodePtr OpPC, const Pointer &Ptr);
 bool CheckFunctionDecl(InterpState &S, CodePtr OpPC, const FunctionDecl *FD);
+bool CheckBitCast(InterpState &S, CodePtr OpPC, const Type *TargetType,
+                  bool SrcIsVoidPtr);
+bool InvalidCast(InterpState &S, CodePtr OpPC, CastKind Kind, bool Fatal);
 
 bool handleFixedPointOverflow(InterpState &S, CodePtr OpPC,
                               const FixedPoint &FP);
@@ -211,6 +214,8 @@ bool CheckFloatResult(InterpState &S, CodePtr OpPC, const Floating &Result,
 
 /// Checks why the given DeclRefExpr is invalid.
 bool CheckDeclRef(InterpState &S, CodePtr OpPC, const DeclRefExpr *DR);
+bool InvalidDeclRef(InterpState &S, CodePtr OpPC, const DeclRefExpr *DR,
+                    bool InitializerFailed);
 
 enum class ArithOp { Add, Sub };
 
@@ -3271,6 +3276,7 @@ inline bool StartSpeculation(InterpState &S, CodePtr OpPC) {
   S.getEvalStatus().Diag = nullptr;
   return true;
 }
+
 inline bool EndSpeculation(InterpState &S, CodePtr OpPC) {
   assert(S.SpeculationDepth != 0);
   --S.SpeculationDepth;
@@ -3307,89 +3313,6 @@ inline bool CtorCheck(InterpState &S, CodePtr OpPC) {
   return true;
 }
 
-inline bool CheckBitCast(InterpState &S, CodePtr OpPC, const Type *TargetType,
-                         bool SrcIsVoidPtr) {
-  const auto &Ptr = S.Stk.peek<Pointer>();
-  if (Ptr.isZero())
-    return true;
-  if (!Ptr.isBlockPointer())
-    return true;
-
-  if (TargetType->isIntegerType())
-    return true;
-
-  if (SrcIsVoidPtr && S.getLangOpts().CPlusPlus) {
-    bool HasValidResult = !Ptr.isZero();
-
-    if (HasValidResult) {
-      if (S.getStdAllocatorCaller("allocate"))
-        return true;
-
-      const auto &E = cast<CastExpr>(S.Current->getExpr(OpPC));
-      if (S.getLangOpts().CPlusPlus26 &&
-          S.getASTContext().hasSimilarType(Ptr.getType(),
-                                           QualType(TargetType, 0)))
-        return true;
-
-      S.CCEDiag(E, diag::note_constexpr_invalid_void_star_cast)
-          << E->getSubExpr()->getType() << S.getLangOpts().CPlusPlus26
-          << Ptr.getType().getCanonicalType() << E->getType()->getPointeeType();
-    } else if (!S.getLangOpts().CPlusPlus26) {
-      const SourceInfo &E = S.Current->getSource(OpPC);
-      S.CCEDiag(E, diag::note_constexpr_invalid_cast)
-          << diag::ConstexprInvalidCastKind::CastFrom << "'void *'"
-          << S.Current->getRange(OpPC);
-    }
-  }
-
-  QualType PtrType = Ptr.getType();
-  if (PtrType->isRecordType() &&
-      PtrType->getAsRecordDecl() != TargetType->getAsRecordDecl()) {
-    S.CCEDiag(S.Current->getSource(OpPC), diag::note_constexpr_invalid_cast)
-        << diag::ConstexprInvalidCastKind::ThisConversionOrReinterpret
-        << S.getLangOpts().CPlusPlus << S.Current->getRange(OpPC);
-    return false;
-  }
-  return true;
-}
-
-/// Same here, but only for casts.
-inline bool InvalidCast(InterpState &S, CodePtr OpPC, CastKind Kind,
-                        bool Fatal) {
-  const SourceLocation &Loc = S.Current->getLocation(OpPC);
-
-  switch (Kind) {
-  case CastKind::Reinterpret:
-    S.CCEDiag(Loc, diag::note_constexpr_invalid_cast)
-        << diag::ConstexprInvalidCastKind::Reinterpret
-        << S.Current->getRange(OpPC);
-    return !Fatal;
-  case CastKind::ReinterpretLike:
-    S.CCEDiag(Loc, diag::note_constexpr_invalid_cast)
-        << diag::ConstexprInvalidCastKind::ThisConversionOrReinterpret
-        << S.getLangOpts().CPlusPlus << S.Current->getRange(OpPC);
-    return !Fatal;
-  case CastKind::Volatile:
-    if (!S.checkingPotentialConstantExpression()) {
-      const auto *E = cast<CastExpr>(S.Current->getExpr(OpPC));
-      if (S.getLangOpts().CPlusPlus)
-        S.FFDiag(E, diag::note_constexpr_access_volatile_type)
-            << AK_Read << E->getSubExpr()->getType();
-      else
-        S.FFDiag(E);
-    }
-
-    return false;
-  case CastKind::Dynamic:
-    assert(!S.getLangOpts().CPlusPlus20);
-    S.CCEDiag(Loc, diag::note_constexpr_invalid_cast)
-        << diag::ConstexprInvalidCastKind::Dynamic;
-    return true;
-  }
-  llvm_unreachable("Unhandled CastKind");
-  return false;
-}
-
 inline bool InvalidStore(InterpState &S, CodePtr OpPC, const Type *T) {
   if (S.getLangOpts().CPlusPlus) {
     QualType VolatileType = QualType(T, 0).withVolatile();
@@ -3400,21 +3323,6 @@ inline bool InvalidStore(InterpState &S, CodePtr OpPC, const Type *T) {
     S.FFDiag(S.Current->getSource(OpPC));
   }
   return false;
-}
-
-inline bool InvalidDeclRef(InterpState &S, CodePtr OpPC, const DeclRefExpr *DR,
-                           bool InitializerFailed) {
-  assert(DR);
-
-  if (InitializerFailed) {
-    const SourceInfo &Loc = S.Current->getSource(OpPC);
-    const auto *VD = cast<VarDecl>(DR->getDecl());
-    S.FFDiag(Loc, diag::note_constexpr_var_init_non_constant, 1) << VD;
-    S.Note(VD->getLocation(), diag::note_declared_at);
-    return false;
-  }
-
-  return CheckDeclRef(S, OpPC, DR);
 }
 
 inline bool SizelessVectorElementSize(InterpState &S, CodePtr OpPC) {


### PR DESCRIPTION
They aren't templated, so move them to Interp.cpp to make the header file a bit shorter.