### PR TITLE
[clang][ExprConst] Fix rendering of explicit this parameters

### DIFF
--- a/clang/lib/AST/ByteCode/InterpFrame.cpp
+++ b/clang/lib/AST/ByteCode/InterpFrame.cpp
@@ -198,9 +198,10 @@ void InterpFrame::describe(llvm::raw_ostream &OS) const {
   Off += Func->hasRVO() ? primSize(PT_Ptr) : 0;
   Off += Func->hasThisPointer() ? primSize(PT_Ptr) : 0;
   llvm::ListSeparator Comma;
-  for (unsigned I = ExplicitInstanceParam, N = F->getNumParams(); I != N; ++I) {
+  for (const ParmVarDecl *Param :
+       F->parameters().slice(ExplicitInstanceParam)) {
     OS << Comma;
-    QualType Ty = F->getParamDecl(I)->getType();
+    QualType Ty = Param->getType();
     PrimType PrimTy = S.Ctx.classify(Ty).value_or(PT_Ptr);
 
     TYPE_SWITCH(PrimTy, print(OS, stackRef<T>(Off), S.getASTContext(), Ty));

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -2009,17 +2009,14 @@ void CallStackFrame::describe(raw_ostream &Out) const {
     }
     Callee->getNameForDiagnostic(Out, Info.Ctx.getPrintingPolicy(),
                                  /*Qualified=*/false);
-    IsMemberCall = false;
   }
 
   Out << '(';
 
   llvm::ListSeparator Comma;
-  for (unsigned ArgIndex = ExplicitInstanceParam, N = Callee->getNumParams();
-       ArgIndex != N; ++ArgIndex) {
+  for (const ParmVarDecl *Param :
+       Callee->parameters().slice(ExplicitInstanceParam)) {
     Out << Comma;
-
-    const ParmVarDecl *Param = Callee->getParamDecl(ArgIndex);
     const APValue *V = Info.getParamSlot(Arguments, Param);
     if (V)
       V->printPretty(Out, Info.Ctx, Param->getType());

--- a/clang/test/SemaCXX/cxx2b-deducing-this.cpp
+++ b/clang/test/SemaCXX/cxx2b-deducing-this.cpp
@@ -1400,3 +1400,33 @@ a void Bar(this int) { // expected-note {{candidate function}}
 }
 
 }
+
+namespace ConstexprBacktrace {
+  struct S {
+    constexpr int foo(this const S& self, int b) {
+      (void)(1/b); // expected-note {{division by zero}}
+      return 0;
+    }
+    constexpr int foo2(this const S& self) {
+      (void)(1/0); // expected-note {{division by zero}} \
+                   // expected-warning {{division by zero is undefined}}
+      return 0;
+    }
+  };
+
+  constexpr bool test() {
+    S s;
+    s.foo(0); // expected-note {{in call to 's.foo(0)'}}
+    return true;
+  }
+  static_assert(test()); // expected-error {{not an integral constant expression}} \
+                         // expected-note {{in call to}}
+
+  constexpr bool test2() {
+    S s;
+    s.foo2(); // expected-note {{in call to 's.foo2()'}}
+    return true;
+  }
+  static_assert(test2()); // expected-error {{not an integral constant expression}} \
+                          // expected-note {{in call to}}
+}


### PR DESCRIPTION
in compile-time backtraces.

The two test cases used to be rendered as `foo(s, 0)` and `foo2(s)`.