### PR TITLE
[lldb] Improve error and docs for repeating "memory region"

### DIFF
--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -1651,12 +1651,18 @@ public:
   };
 
   CommandObjectMemoryRegion(CommandInterpreter &interpreter)
-      : CommandObjectParsed(interpreter, "memory region",
-                            "Get information on the memory region containing "
-                            "an address in the current target process.",
-                            "memory region <address-expression> (or --all)",
-                            eCommandRequiresProcess | eCommandTryTargetAPILock |
-                                eCommandProcessMustBeLaunched) {
+      : CommandObjectParsed(
+            interpreter, "memory region",
+            "Get information on the memory region containing "
+            "an address in the current target process.\n"
+            "If this command is given an <address-expression> once "
+            "and then repeated without options, it will try to print "
+            "the memory region that follows the previously printed "
+            "region. The command can be repeated until the end of "
+            "the address range is reached.",
+            "memory region <address-expression> (or --all)",
+            eCommandRequiresProcess | eCommandTryTargetAPILock |
+                eCommandProcessMustBeLaunched) {
     // Address in option set 1.
     m_arguments.push_back(CommandArgumentEntry{CommandArgumentData(
         eArgTypeAddressOrExpression, eArgRepeatPlain, LLDB_OPT_SET_1)});
@@ -1747,8 +1753,9 @@ protected:
             // we must be at the end of the mappable range.
             (abi && (abi->FixAnyAddress(load_addr) != load_addr))) {
           result.AppendErrorWithFormat(
-              "'%s' takes one argument or \"--all\" option:\nUsage: %s\n",
-              m_cmd_name.c_str(), m_cmd_syntax.c_str());
+              "No next region address set: one address expression argument or "
+              "\"--all\" option required:\nUsage: %s\n",
+              m_cmd_syntax.c_str());
           return;
         }
       }

--- a/lldb/test/API/functionalities/memory-region/TestMemoryRegion.py
+++ b/lldb/test/API/functionalities/memory-region/TestMemoryRegion.py
@@ -54,7 +54,7 @@ class MemoryCommandRegion(TestBase):
         self.assertFalse(result.Succeeded())
         self.assertEqual(
             result.GetError(),
-            "error: 'memory region' takes one argument or \"--all\" option:\n"
+            'error: No next region address set: one address expression argument or "--all" option required:\n'
             "Usage: memory region <address-expression> (or --all)\n",
         )
 

--- a/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
+++ b/lldb/test/API/tools/lldb-dap/completions/TestDAP_completions.py
@@ -162,10 +162,15 @@ class TestDAP_completions(lldbdap_testcase.DAPTestCaseBase):
                     ),
                     CompletionItem(
                         label="region",
-                        detail="Get information on the memory region containing an address in the current target process.",
+                        detail="Get information on the memory region containing an address "
+                        "in the current target process.\nIf this command is given an "
+                        "<address-expression> once and then repeated without options, "
+                        "it will try to print the memory region that follows the "
+                        "previously printed region. The command can be repeated "
+                        "until the end of the address range is reached.",
                     ),
                 },
-            )
+            ),
         )
 
         # Provides completions for parameter values of commands


### PR DESCRIPTION
"memory region" can be given an address once and then when repeated,
it will try to find a region just beyond the last one it printed.
This continues until the end of the address space.

Then it gives you an error showing the usage, which is odd because
you just saw a bunch of "memory region" with no options work.

So I've improved the error a bit to imply its to do with the repetition.
Then described the repeating behaviour in the help text.