### PR TITLE
[Clang][CIR][Neon] Add lowering for `vabsh_f16`

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -1245,11 +1245,17 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
 
   assert(!cir::MissingFeatures::neonSISDIntrinsics());
 
+  llvm::SmallVector<mlir::Value, 4> ops;
+  mlir::Location loc = getLoc(expr->getExprLoc());
+
   // Handle non-overloaded intrinsics first.
   switch (builtinID) {
   default:
     break;
-  case NEON::BI__builtin_neon_vabsh_f16:
+  case NEON::BI__builtin_neon_vabsh_f16: {
+    ops.push_back(emitScalarExpr(expr->getArg(0)));
+    return cir::FAbsOp::create(builder, loc, ops);
+  }
   case NEON::BI__builtin_neon_vaddq_p128:
   case NEON::BI__builtin_neon_vldrq_p128:
   case NEON::BI__builtin_neon_vstrq_p128:

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp
@@ -1245,7 +1245,7 @@ CIRGenFunction::emitAArch64BuiltinExpr(unsigned builtinID, const CallExpr *expr,
 
   assert(!cir::MissingFeatures::neonSISDIntrinsics());
 
-  llvm::SmallVector<mlir::Value, 4> ops;
+  llvm::SmallVector<mlir::Value> ops;
   mlir::Location loc = getLoc(expr->getExprLoc());
 
   // Handle non-overloaded intrinsics first.

--- a/clang/test/CIR/CodeGenBuiltins/AArch64/neon/fullfp16.c
+++ b/clang/test/CIR/CodeGenBuiltins/AArch64/neon/fullfp16.c
@@ -1,0 +1,31 @@
+// REQUIRES: aarch64-registered-target
+
+// RUN: %clang_cc1 -triple aarch64 -target-feature +fullfp16 -disable-O0-optnone -Werror -Wall -fclangir -emit-cir  -o - %s                                       | FileCheck %s --check-prefixes=ALL,CIR
+// RUN: %clang_cc1 -triple aarch64 -target-feature +fullfp16 -disable-O0-optnone -Werror -Wall -fclangir -emit-llvm -o - %s |  opt -S -passes=mem2reg,simplifycfg | FileCheck %s --check-prefixes=ALL,LLVM
+// RUN: %clang_cc1 -triple aarch64 -target-feature +fullfp16 -disable-O0-optnone -Werror -Wall           -emit-llvm -o - %s |  opt -S -passes=mem2reg,simplifycfg | FileCheck %s --check-prefixes=ALL,LLVM
+
+
+//=============================================================================
+// NOTES
+//
+// Tests for unconstrained intrinsics that require the fullfp16 extension.
+//
+// As these intrinsics expand to code with multiple compound and declaration
+// stmts, the LLVM output has been simplified with opt. `simplifycfg` was added
+// specifically for the CIR lowering path.
+//
+// TODO: Merge this file with clang/test/CodeGen/AArch64/v8.2a-fp16-intrinsics.c
+// (the source of these tests).
+//=============================================================================
+
+#include <arm_fp16.h>
+
+// ALL-LABEL: @test_vabsh_f16
+float16_t test_vabsh_f16(float16_t a) {
+// CIR: {{%.*}}  = cir.fabs {{%.*}} : !cir.f16
+
+// LLVM-SAME: (half [[A:%.*]])
+// LLVM:  [[ABS:%.*]] =  call half @llvm.fabs.f16(half [[A]])
+// LLVM:  ret half [[ABS]]
+  return vabsh_f16(a);
+}

--- a/clang/test/CIR/CodeGenBuiltins/AArch64/neon/fullfp16.c
+++ b/clang/test/CIR/CodeGenBuiltins/AArch64/neon/fullfp16.c
@@ -14,6 +14,10 @@
 // stmts, the LLVM output has been simplified with opt. `simplifycfg` was added
 // specifically for the CIR lowering path.
 //
+// Minor differences between RUNs (e.g. presence of `noundef` attached to
+// argumens, align` attribute attached to pointers), are matched using
+// catch-alls like {{.*}}.
+//
 // TODO: Merge this file with clang/test/CodeGen/AArch64/v8.2a-fp16-intrinsics.c
 // (the source of these tests).
 //=============================================================================
@@ -24,7 +28,7 @@
 float16_t test_vabsh_f16(float16_t a) {
 // CIR: {{%.*}}  = cir.fabs {{%.*}} : !cir.f16
 
-// LLVM-SAME: (half [[A:%.*]])
+// LLVM-SAME: (half{{.*}} [[A:%.*]])
 // LLVM:  [[ABS:%.*]] =  call half @llvm.fabs.f16(half [[A]])
 // LLVM:  ret half [[ABS]]
   return vabsh_f16(a);


### PR DESCRIPTION
NOTE: This PR upstreams code from
  * https://github.com/llvm/clangir.

This logic was originally implemented by Amr Hesham in
https://github.com/llvm/clangir/pull/1269. Further
modification were made by other ClangIR contributors.

Co-authored-by: Amr Hesham <amr96@programmer.net>
