### PR TITLE
[compiler-rt] remove unused argument in interceptor

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_signal_interceptors.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_signal_interceptors.inc
@@ -63,9 +63,9 @@ INTERCEPTOR(uptr, signal, int signum, uptr handler) {
     // sigaction().
     return (uptr) nullptr;
 
-  uptr ret = +[](auto signal, int signum, uptr handler) {
+  uptr ret = +[](int signum, uptr handler) {
     SIGNAL_INTERCEPTOR_SIGNAL_IMPL(signal, signum, handler);
-  }(signal, signum, handler);
+  }(signum, handler);
 
   if (ret != sig_err && SetSignalHandlerFromSanitizer(signum, false))
     // If the user sets a signal handler, it becomes uncloaked, even if they


### PR DESCRIPTION
The `SIGNAL_INTERCEPTOR_SIGNAL_IMPL` macro expands to use the `REAL` macro, thus eventually becoming the line
`return __interception::real_signal(signum, handler)`, so we don't need to pass signal in here.