### PR TITLE
[clang][HeaderSearch] Treat permission-denied include paths as non-fatal

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -389,6 +389,7 @@ def err_unable_to_rename_temp : Error<
   "unable to rename temporary '%0' to output file '%1': '%2'">;
 def err_unable_to_make_temp : Error<
   "unable to make temporary file: %0">;
+def warn_cannot_access_file : Warning<"cannot access file '%0': %1">;
 def remark_sloc_usage : Remark<
   "source manager location address space usage:">,
   InGroup<DiagGroup<"sloc-usage">>, DefaultRemark, ShowInSystemHeader;

--- a/clang/lib/Lex/HeaderSearch.cpp
+++ b/clang/lib/Lex/HeaderSearch.cpp
@@ -453,6 +453,13 @@ OptionalFileEntryRef HeaderSearch::getFileAndSuggestModule(
     // For rare, surprising errors (e.g. "out of file handles"), diag the EC
     // message.
     std::error_code EC = llvm::errorToErrorCode(File.takeError());
+
+    if (EC == llvm::errc::permission_denied) {
+      Diags.Report(IncludeLoc, diag::warn_cannot_access_file)
+          << FileName << EC.message();
+      return std::nullopt;
+    }
+
     if (EC != llvm::errc::no_such_file_or_directory &&
         EC != llvm::errc::invalid_argument &&
         EC != llvm::errc::is_a_directory && EC != llvm::errc::not_a_directory) {

--- a/clang/test/Preprocessor/non-accessible-include.c
+++ b/clang/test/Preprocessor/non-accessible-include.c
@@ -1,0 +1,9 @@
+// Needs chmod
+// UNSUPPORTED: system-windows
+//
+// RUN: chmod -R 755 %t; rm -rf %t && mkdir -p %t/noaccess %t/haveaccess
+// RUN: echo "int test();" > %t/haveaccess/test.h
+// RUN: chmod 000 %t/noaccess
+// RUN: %clang_cc1 -fsyntax-only -I %t/noaccess -I %t/haveaccess -verify %s
+
+#include "test.h" // expected-warning {{cannot access file}}


### PR DESCRIPTION
If part of the -I search path cannot be accessed due to permissions, Clang no longer treats this as a fatal error. Instead, it emits a warning pointing to the exact path that cannot be accessed while continuing the search in subsequent search path elements.

Based on the original patch by Axel Naumann.