### PR TITLE
[mlir][bufferization] Drop equivalent buffer results - modify public functions option

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.h
@@ -182,8 +182,15 @@ LogicalResult
 promoteBufferResultsToOutParams(ModuleOp module,
                                 const BufferResultsToOutParamsOpts &options);
 
+/// Options for dropping equivalent memref buffer results.
+struct DropBufferResultsOpts {
+  /// If true, signatures of public functions are modified.
+  bool modifyPublicFunctions = false;
+};
+
 /// Drop all memref function results that are equivalent to a function argument.
-LogicalResult dropEquivalentBufferResults(ModuleOp module);
+LogicalResult dropEquivalentBufferResults(
+    ModuleOp module, DropBufferResultsOpts options = DropBufferResultsOpts());
 
 /// Creates a pass that promotes heap-based allocations to stack-based ones.
 /// Only buffers smaller with `isSmallAlloc(alloc) == true` are promoted.

--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.td
@@ -276,6 +276,11 @@ def DropEquivalentBufferResultsPass
     Note: If a bbArg buffer is not returned directly but casted to beforehand,
     the buffer is still considered equivalent.
   }];
+  let options = [
+    Option<"modifyPublicFunctions", "modify-public-functions", "bool",
+           /*default=*/"false", "Modify function signatures of public "
+           "functions.">,
+  ];
   let dependentDialects = ["memref::MemRefDialect"];
 }
 

--- a/mlir/test/Dialect/Bufferization/Transforms/drop-equivalent-buffer-results.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/drop-equivalent-buffer-results.mlir
@@ -12,6 +12,18 @@ func.func private @single_buffer_return(%buf: !type, %val: f32, %idx: index) -> 
   return %buf : !type
 }
 
+// CHECK-LABEL: func @caller(
+// CHECK-SAME:     %[[BUF:.+]]: memref<?xf32, strided<[?], offset: ?>>,
+// CHECK: call @single_buffer_return(%[[BUF]]{{.*}}-> ()
+// CHECK: %[[LOADED:.+]] = memref.load %[[BUF]]
+// CHECK: return %[[LOADED]]
+
+func.func @caller(%buf: !type, %val: f32, %idx: index) -> f32 {
+  %0 = call @single_buffer_return(%buf, %val, %idx) : (!type, f32, index) -> (!type)
+  %1 = memref.load %0[%idx] : !type
+  return %1 : f32
+}
+
 // -----
 
 // CHECK-LABEL: func private @multiple_buffer_returns({{.*}}) {
@@ -61,6 +73,24 @@ func.func @public_function(
     %buf: !type, %val: f32, %idx: index) -> !type {
   memref.store %val, %buf[%idx] : !type
   return %buf : !type
+}
+
+// CHECK-LABEL: func @caller(
+// CHECK-SAME:     %[[IN_BUF:.+]]: memref<?xf32, strided<[?], offset: ?>>,
+// CHECK: %[[RET_VAL:.+]] = call @public_function(%[[IN_BUF]]{{.*}}-> memref
+// CHECK: %[[LOADED:.+]] = memref.load %[[RET_VAL]]
+// CHECK: return %[[LOADED]]
+
+// MODIFY-PUBLIC-LABEL: func @caller(
+// MODIFY-PUBLIC-SAME:    %[[IN_BUF:.+]]: memref<?xf32, strided<[?], offset: ?>>,
+// MODIFY-PUBLIC: call @public_function(%[[IN_BUF]]{{.*}}-> ()
+// MODIFY-PUBLIC: %[[LOADED:.*]] = memref.load %[[IN_BUF]]
+// MODIFY-PUBLIC: return %[[LOADED]]
+
+func.func @caller(%buf: !type, %val: f32, %idx: index) -> f32 {
+  %0 = call @public_function(%buf, %val, %idx) : (!type, f32, index) -> (!type)
+  %1 = memref.load %0[%idx] : !type
+  return %1 : f32
 }
 
 // -----

--- a/mlir/test/Transforms/drop-equivalent-buffer-results.mlir
+++ b/mlir/test/Transforms/drop-equivalent-buffer-results.mlir
@@ -1,0 +1,76 @@
+// RUN: mlir-opt -drop-equivalent-buffer-results -split-input-file %s | FileCheck %s
+// RUN: mlir-opt -drop-equivalent-buffer-results=modify-public-functions=1 -split-input-file %s | \
+// RUN:   FileCheck %s --check-prefix=MODIFY-PUBLIC
+
+
+// CHECK-LABEL: func private @single_buffer_return({{.*}}) {
+// CHECK: return
+
+!type = memref<?xf32, strided<[?], offset: ?>>
+func.func private @single_buffer_return(%buf: !type, %val: f32, %idx: index) -> !type {
+  memref.store %val, %buf[%idx] : !type
+  return %buf : !type
+}
+
+// -----
+
+// CHECK-LABEL: func private @multiple_buffer_returns({{.*}}) {
+// CHECK: return
+
+!type = memref<?xf32, strided<[?], offset: ?>>
+!type1 = memref<?x?xf32>
+func.func private @multiple_buffer_returns(
+    %buf: !type, %buf1: !type1, %val: f32, %idx: index) -> (!type1, !type) {
+  memref.store %val, %buf[%idx] : !type
+  memref.store %val, %buf1[%idx, %idx] : !type1
+  return %buf1, %buf : !type1, !type
+}
+
+// -----
+
+// CHECK-LABEL: func private @multiple_mixed_returns({{.*}}) -> i32 {
+// CHECK: %[[CST:.+]] = arith.constant 1 : i32
+// CHECK: return %[[CST]] : i32
+
+!type = memref<?xf32, strided<[?], offset: ?>>
+!type1 = memref<?x?xf32>
+func.func private @multiple_mixed_returns(
+    %buf: !type, %buf1: !type1, %val: f32, %idx: index) -> (!type1, i32, !type) {
+  memref.store %val, %buf[%idx] : !type
+  memref.store %val, %buf1[%idx, %idx] : !type1
+  %cst = arith.constant 1 : i32
+  return %buf1, %cst, %buf : !type1, i32, !type
+}
+
+// -----
+
+// Ensure public functions remain unchanged by default.
+// CHECK-LABEL: func @public_function(
+// CHECK-SAME:    %[[BUF:.+]]: memref<?xf32, strided<[?], offset: ?>>,
+// CHECK-SAME:    ) -> memref<?xf32, strided<[?], offset: ?>> {
+// CHECK: return %[[BUF]]
+
+// When explicitly requested, public functions can be modified.
+// MODIFY-PUBLIC-LABEL: func @public_function(
+// MODIFY-PUBLIC-SAME:    %[[BUF:.+]]: memref<?xf32, strided<[?], offset: ?>>,
+// MODIFY-PUBLIC-SAME:    ) {
+// MODIFY-PUBLIC: return
+
+!type = memref<?xf32, strided<[?], offset: ?>>
+func.func @public_function(
+    %buf: !type, %val: f32, %idx: index) -> !type {
+  memref.store %val, %buf[%idx] : !type
+  return %buf : !type
+}
+
+// -----
+
+// CHECK-LABEL: func private @negative_external_function(
+// CHECK-SAME:    -> memref<?xf32, strided<[?], offset: ?>>
+
+// Ensure external function remains unchanged.
+// MODIFY-PUBLIC-LABEL: func private @negative_external_function(
+// MODIFY-PUBLIC-SAME:    -> memref<?xf32, strided<[?], offset: ?>>
+
+!type = memref<?xf32, strided<[?], offset: ?>>
+func.func private @negative_external_function(%arg0: !type) -> !type


### PR DESCRIPTION
Adds an option to allow modification of public functions to the drop equivalent buffer results API and the respective pass.
A new standalone test for the pass is also added.

https://github.com/llvm/llvm-project/pull/163001 modified the default behavior by disallowing rewriting public function. This PR preserves the new behavior and only adds an opt-in flag to reenable changing public function.

The extra flag aligns dropping equivalent function results with another bufferization API `promoteBufferResultsToOutParams` which also allows opt-in public function rewriting.