### PR TITLE
[LangRef] Mention allocation elision

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2080,7 +2080,7 @@ For example:
 
     Calls to functions annotated with ``allockind`` are subject to allocation
     elision: Calls to allocator functions can be removed, and the allocation
-    served from a virtual allocator instead. Notably, this is allowed even if
+    served from a "virtual" allocator instead. Notably, this is allowed even if
     the allocator calls have side-effects. In other words, for each allocation
     there is a non-deterministic choice between calling the allocator as usual,
     or using a virtual, side-effect-free allocator instead.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2085,7 +2085,8 @@ For example:
 
     If multiple allocation functions operate on the same allocation (for
     example, an "alloc" followed by "free"), allocation elision is only allowed
-    if all involved functions have the same ``"alloc-family"``.
+    if all involved functions have the same ``"alloc-family"``. In this case,
+    either all operations have to be elided or none of them.
 ``"alloc-variant-zeroed"="FUNCTION"``
     This attribute indicates that another function is equivalent to an allocator function,
     but returns zeroed memory. The function must have "zeroed" allocation behavior,

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2081,7 +2081,9 @@ For example:
     Calls to functions annotated with ``allockind`` are subject to allocation
     elision: Calls to allocator functions can be removed, and the allocation
     served from a virtual allocator instead. Notably, this is allowed even if
-    the allocator calls have side-effects.
+    the allocator calls have side-effects. In other words, for each allocation
+    there there is a non-deterministic choice between calling the allocator as
+    usual, or using a virtual, side-effect-free allocator instead.
 
     If multiple allocation functions operate on the same allocation,
     allocation elision is only allowed for pairs of "alloc" and "free" with the

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2082,8 +2082,8 @@ For example:
     elision: Calls to allocator functions can be removed, and the allocation
     served from a virtual allocator instead. Notably, this is allowed even if
     the allocator calls have side-effects. In other words, for each allocation
-    there there is a non-deterministic choice between calling the allocator as
-    usual, or using a virtual, side-effect-free allocator instead.
+    there is a non-deterministic choice between calling the allocator as usual,
+    or using a virtual, side-effect-free allocator instead.
 
     If multiple allocation functions operate on the same allocation,
     allocation elision is only allowed for pairs of "alloc" and "free" with the

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2085,8 +2085,14 @@ For example:
 
     If multiple allocation functions operate on the same allocation (for
     example, an "alloc" followed by "free"), allocation elision is only allowed
-    if all involved functions have the same ``"alloc-family"``. In this case,
-    either all operations have to be elided or none of them.
+    if all involved functions have the same ``"alloc-family"``. The following
+    transforms can be performed, or combinations thereof:
+
+    * An "alloc" that is leaked (no "free"/"realloc") can be elided.
+    * An "alloc" and "free" pair can be elided.
+    * A "realloc" and "free" pair can be converted into a "free" of the original
+      allocation.
+    * An "alloc" and "realloc" pair can be converted into an "alloc".
 ``"alloc-variant-zeroed"="FUNCTION"``
     This attribute indicates that another function is equivalent to an allocator function,
     but returns zeroed memory. The function must have "zeroed" allocation behavior,

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2077,6 +2077,15 @@ For example:
     The first three options are mutually exclusive, and the remaining options
     describe more details of how the function behaves. The remaining options
     are invalid for "free"-type functions.
+
+    Calls to functions annotated with ``allockind`` are subject to allocation
+    elision: Calls to allocator functions can be removed, and the allocation
+    served from a virtual allocator instead. Notably, this is allowed even if
+    the allocator calls have side-effects.
+
+    If multiple allocation functions operate on the same allocation (for
+    example, an "alloc" followed by "free"), allocation elision is only allowed
+    if all involved functions have the same ``"alloc-family"``.
 ``"alloc-variant-zeroed"="FUNCTION"``
     This attribute indicates that another function is equivalent to an allocator function,
     but returns zeroed memory. The function must have "zeroed" allocation behavior,

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2083,16 +2083,11 @@ For example:
     served from a virtual allocator instead. Notably, this is allowed even if
     the allocator calls have side-effects.
 
-    If multiple allocation functions operate on the same allocation (for
-    example, an "alloc" followed by "free"), allocation elision is only allowed
-    if all involved functions have the same ``"alloc-family"``. The following
-    transforms can be performed, or combinations thereof:
-
-    * An "alloc" that is leaked (no "free"/"realloc") can be elided.
-    * An "alloc" and "free" pair can be elided.
-    * A "realloc" and "free" pair can be converted into a "free" of the original
-      allocation.
-    * An "alloc" and "realloc" pair can be converted into an "alloc".
+    If multiple allocation functions operate on the same allocation,
+    allocation elision is only allowed for pairs of "alloc" and "free" with the
+    same ``"alloc-family"`` attribute. For this purpose, a "realloc" call may
+    be decomposed into "alloc" and "free" operations, as long as at least one
+    of them will be elided.
 ``"alloc-variant-zeroed"="FUNCTION"``
     This attribute indicates that another function is equivalent to an allocator function,
     but returns zeroed memory. The function must have "zeroed" allocation behavior,


### PR DESCRIPTION
allockind / alloc-family enable allocation elision, but this was not previously mentioned by LangRef.

Related discussion: https://discourse.llvm.org/t/rfc-clarifying-semantic-assumptions-for-custom-allocators/89469

cc @RalfJung 

I've documented this in terms of optimization, but if desired I could define this more operationally with non-determinism.