### PR TITLE
[Support] Move loadSystemModuleSecure into Process.inc. NFC.

### DIFF
--- a/llvm/lib/Support/Windows/Process.inc
+++ b/llvm/lib/Support/Windows/Process.inc
@@ -521,3 +521,32 @@ bool llvm::RunningWindows11OrGreater() {
   TerminateProcess(GetCurrentProcess(), RetCode);
   llvm_unreachable("TerminateProcess doesn't return");
 }
+
+namespace llvm::sys::windows {
+HMODULE loadSystemModuleSecure(LPCWSTR lpModuleName) {
+  // Ensure we load indeed a module from system32 path.
+  // As per GetModuleHandle documentation:
+  // "If lpModuleName does not include a path and there is more than one loaded
+  // module with the same base name and extension, you cannot predict which
+  // module handle will be returned.". This mitigates
+  // https://learn.microsoft.com/en-us/security-updates/securityadvisories/2010/2269637
+  SmallVector<wchar_t, MAX_PATH> Buf;
+  size_t Size = MAX_PATH;
+  do {
+    Buf.resize_for_overwrite(Size);
+    SetLastError(NO_ERROR);
+    Size = ::GetSystemDirectoryW(Buf.data(), Buf.size());
+    if (Size == 0)
+      return NULL;
+
+    // Try again with larger buffer.
+  } while (Size > Buf.size());
+
+  Buf.truncate(Size);
+  Buf.push_back(L'\\');
+  Buf.append(lpModuleName, lpModuleName + std::wcslen(lpModuleName));
+  Buf.push_back(0);
+
+  return ::GetModuleHandleW(Buf.data());
+}
+} // namespace llvm::sys::windows

--- a/llvm/lib/Support/Windows/Threading.inc
+++ b/llvm/lib/Support/Windows/Threading.inc
@@ -105,35 +105,6 @@ void llvm::get_thread_name(SmallVectorImpl<char> &Name) {
   Name.clear();
 }
 
-namespace llvm::sys::windows {
-HMODULE loadSystemModuleSecure(LPCWSTR lpModuleName) {
-  // Ensure we load indeed a module from system32 path.
-  // As per GetModuleHandle documentation:
-  // "If lpModuleName does not include a path and there is more than one loaded
-  // module with the same base name and extension, you cannot predict which
-  // module handle will be returned.". This mitigates
-  // https://learn.microsoft.com/en-us/security-updates/securityadvisories/2010/2269637
-  SmallVector<wchar_t, MAX_PATH> Buf;
-  size_t Size = MAX_PATH;
-  do {
-    Buf.resize_for_overwrite(Size);
-    SetLastError(NO_ERROR);
-    Size = ::GetSystemDirectoryW(Buf.data(), Buf.size());
-    if (Size == 0)
-      return NULL;
-
-    // Try again with larger buffer.
-  } while (Size > Buf.size());
-
-  Buf.truncate(Size);
-  Buf.push_back(L'\\');
-  Buf.append(lpModuleName, lpModuleName + std::wcslen(lpModuleName));
-  Buf.push_back(0);
-
-  return ::GetModuleHandleW(Buf.data());
-}
-} // namespace llvm::sys::windows
-
 SetThreadPriorityResult llvm::set_thread_priority(ThreadPriority Priority) {
 #ifdef THREAD_POWER_THROTTLING_CURRENT_VERSION
   HMODULE kernelM = llvm::sys::windows::loadSystemModuleSecure(L"kernel32.dll");


### PR DESCRIPTION
Move Windows-specific function `llvm::sys::windows::loadSystemModuleSecure` from `lib/Support/Windows/Threading.inc` into `lib/Support/Windows/Process.inc`.

This is to fix link problems on Windows, see https://github.com/llvm/llvm-project/pull/169224#issuecomment-3790350128