### PR TITLE
[MLIR][XeGPU] Add more OCP micro scaling format types.

### DIFF
--- a/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUTypes.td
+++ b/mlir/include/mlir/Dialect/XeGPU/IR/XeGPUTypes.td
@@ -15,7 +15,8 @@ include "mlir/IR/BuiltinTypes.td"
 
 def XeGPU_IntType : AnyTypeOf<[I1, I<4>, I8, I16, I32, I64, SI1, SI8, SI16,
                                SI32, SI64, UI1, UI8, UI16, UI32, UI64]>;
-def XeGPU_FloatType : AnyTypeOf<[F8E4M3FN, F8E5M2, F16, F32, F64, BF16, TF32]>;
+def XeGPU_FloatType : AnyTypeOf<[F4E2M1FN, F8E4M3FN, F8E5M2, F8E8M0FNU, F16,
+                                 F32, F64, BF16, TF32]>;
 def XeGPU_ScalarType: AnyTypeOf<[XeGPU_IntType, XeGPU_FloatType]>;
 def XeGPU_PointerType : AnyTypeOf<[UI64, UI32, I64, I32]>;
 def XeGPU_BaseAddrType


### PR DESCRIPTION
Add fp4 - e2m1 and fp8 - e8m0 data type.