### PR TITLE
[LLVM] Inline asserts-only variable into assert

### DIFF
--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -1225,7 +1225,7 @@ struct DSEState {
     auto IBounded = InvisibleToCallerAfterRetBounded.find(V);
     if (IBounded != InvisibleToCallerAfterRetBounded.end()) {
       int64_t ValueOffset;
-      const Value *BaseValue =
+      [[maybe_unused]] const Value *BaseValue =
           GetPointerBaseWithConstantOffset(Ptr, ValueOffset, DL);
       assert(BaseValue == V);
       // This store is only invisible after return if we are in bounds of the

--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -1225,9 +1225,7 @@ struct DSEState {
     auto IBounded = InvisibleToCallerAfterRetBounded.find(V);
     if (IBounded != InvisibleToCallerAfterRetBounded.end()) {
       int64_t ValueOffset;
-      [[maybe_unused]] const Value *BaseValue =
-          GetPointerBaseWithConstantOffset(Ptr, ValueOffset, DL);
-      assert(BaseValue == V);
+      assert(GetPointerBaseWithConstantOffset(Ptr, ValueOffset, DL) == V);
       // This store is only invisible after return if we are in bounds of the
       // range marked dead.
       if (StoreSize.hasValue() &&


### PR DESCRIPTION
Remove the variable definition and move the function call directly into the assert statement. Otherwise builds with -Werror that don't use asserts would fail.