### PR TITLE
[CIR][X86] Implement generic fallback for x86 builtins

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -391,8 +391,7 @@ std::optional<mlir::Value> CIRGenFunction::emitGenericBuiltinIntrinsic(
   SmallVector<mlir::Value> callArgs(ops.begin(), ops.end());
   coerceCallArgsToASTTypes(callArgs, expr);
 
-  return emitIntrinsicCallOp(
-      builder, loc, intrinsicName, retTy, callArgs);
+  return emitIntrinsicCallOp(builder, loc, intrinsicName, retTy, callArgs);
 }
 
 static bool shouldCIREmitFPMathIntrinsic(CIRGenFunction &cgf, const CallExpr *e,
@@ -1948,7 +1947,8 @@ emitTargetArchBuiltinExpr(CIRGenFunction *cgf, unsigned builtinID,
     for (auto [idx, arg] : llvm::enumerate(e->arguments()))
       ops.push_back(cgf->emitScalarOrConstFoldImmArg(iceArguments, idx, arg));
 
-    if (std::optional<mlir::Value> maybeRes = cgf->emitGenericBuiltinIntrinsic(builtinID, e, ops))
+    if (std::optional<mlir::Value> maybeRes =
+            cgf->emitGenericBuiltinIntrinsic(builtinID, e, ops))
       return *maybeRes;
 
     return std::nullopt;

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1873,12 +1873,12 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
       // CIR dialect operations may have no results, no values will be returned
       // even if it executes successfully.
       if (!v)
-        return RValue::get(nullptr);
+        return RValue::getIgnored();
 
       switch (evalKind) {
       case cir::TEK_Scalar:
         if (mlir::isa<cir::VoidType>(v.getType()))
-          return RValue::get(nullptr);
+          return RValue::getIgnored();
         return RValue::get(v);
       case cir::TEK_Aggregate:
         cgm.errorNYI(e->getSourceRange(),

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -787,8 +787,8 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
   case X86::BI_m_prefetchw:
     return emitPrefetch(*this, builtinID, expr, ops);
   case X86::BI__rdtsc:
-    return emitIntrinsicCallOp(builder, getLoc(expr->getExprLoc()), "x86.rdtsc",
-                               builder.getUInt64Ty());
+    return builder.emitIntrinsicCallOp(getLoc(expr->getExprLoc()), "x86.rdtsc",
+                                       builder.getUInt64Ty());
   case X86::BI__builtin_ia32_rdtscp: {
     mlir::Location loc = getLoc(expr->getExprLoc());
 
@@ -797,8 +797,7 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
         &getMLIRContext(), {builder.getUInt64Ty(), builder.getUInt32Ty()},
         /*packed=*/false, /*padded*/ false,
         cir::RecordType::RecordKind::Struct);
-    mlir::Value call =
-        emitIntrinsicCallOp(builder, loc, "x86.rdtscp", recordTy);
+    mlir::Value call = builder.emitIntrinsicCallOp(loc, "x86.rdtscp", recordTy);
 
     // Aux (i32) -> store to pointer arg ops[0]
     mlir::Value aux = cir::ExtractMemberOp::create(

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -33,6 +33,27 @@ CIRGenFunction::CIRGenFunction(CIRGenModule &cgm, CIRGenBuilderTy &builder,
 
 CIRGenFunction::~CIRGenFunction() {}
 
+std::optional<std::string> CIRGenFunction::getIntrinsicNameForBuiltin(unsigned builtinID) {
+  // First try explicit mappings for known builtins.
+  switch (builtinID) {
+  case X86::BI__builtin_ia32_rdpmc:
+    return std::string("x86.rdpmc");
+  default:
+    break;
+  }
+
+  // As a fallback, match common builtin names to avoid depending on the exact
+  // enum variant emitted by TableGen (e.g., "rdpmc" vs "__builtin_ia32_rdpmc").
+  std::string name = getContext().BuiltinInfo.getName(builtinID);
+
+  
+  if (name.size() >= 5 && name.compare(name.size() - 5, 5, "rdpmc") == 0) {
+    return std::string("x86.rdpmc");
+  }
+
+  return std::nullopt;
+}
+
 // This is copied from clang/lib/CodeGen/CodeGenFunction.cpp
 cir::TypeEvaluationKind CIRGenFunction::getEvaluationKind(QualType type) {
   type = type.getCanonicalType();

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -33,7 +33,8 @@ CIRGenFunction::CIRGenFunction(CIRGenModule &cgm, CIRGenBuilderTy &builder,
 
 CIRGenFunction::~CIRGenFunction() {}
 
-std::optional<std::string> CIRGenFunction::getIntrinsicNameForBuiltin(unsigned builtinID) {
+std::optional<std::string>
+CIRGenFunction::getIntrinsicNameForBuiltin(unsigned builtinID) {
   // First try explicit mappings for known builtins.
   switch (builtinID) {
   case X86::BI__builtin_ia32_rdpmc:
@@ -46,7 +47,6 @@ std::optional<std::string> CIRGenFunction::getIntrinsicNameForBuiltin(unsigned b
   // enum variant emitted by TableGen (e.g., "rdpmc" vs "__builtin_ia32_rdpmc").
   std::string name = getContext().BuiltinInfo.getName(builtinID);
 
-  
   if (name.size() >= 5 && name.compare(name.size() - 5, 5, "rdpmc") == 0) {
     return std::string("x86.rdpmc");
   }

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1882,8 +1882,7 @@ public:
   /// Returns std::nullopt if the builtin is not handled by the generic
   /// intrinsic fallback.
   std::optional<mlir::Value>
-  emitGenericBuiltinIntrinsic(unsigned builtinID,
-                              const clang::CallExpr *expr,
+  emitGenericBuiltinIntrinsic(unsigned builtinID, const clang::CallExpr *expr,
                               llvm::ArrayRef<mlir::Value> ops);
 
   /// Given a value and its clang type, returns the value casted to its memory

--- a/clang/test/CIR/CodeGenBuiltins/X86/rd-builtins.c
+++ b/clang/test/CIR/CodeGenBuiltins/X86/rd-builtins.c
@@ -1,0 +1,66 @@
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang -target x86_64-unknown-linux-gnu -fclangir -S -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang -target x86_64-unknown-linux-gnu -S -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+#include <x86intrin.h>
+
+unsigned long long test_rdpmc(int a) {
+// CIR-LABEL: test_rdpmc
+// CIR: %{{.*}} = cir.call @__rdpmc(%{{.*}}) : (!s32i) -> !u64i
+// CIR: cir.store %{{.*}} : !u64i, !cir.ptr<!u64i>
+// CIR: cir.return %{{.*}} : !u64i
+
+// LLVM-LABEL: test_rdpmc
+// LLVM: %{{.*}} = call i64 @llvm.x86.rdpmc(i32 %{{.*}})
+// LLVM: store i64 %{{.*}}, ptr %{{.*}}
+// LLVM: ret i64 %{{.*}}
+
+// OGCG-LABEL: test_rdpmc
+// OGCG: %{{.*}} = call i64 @llvm.x86.rdpmc(i32 %{{.*}})
+// OGCG: ret i64 %{{.*}}
+  return _rdpmc(a);
+}
+
+int test_rdtsc(void) {
+// CIR-LABEL: test_rdtsc
+// CIR: cir.call_llvm_intrinsic "x86.rdtsc"
+// CIR: cir.cast integral %{{.*}} : !u64i -> !s32i
+// CIR: cir.return %{{.*}} : !u64i
+
+// LLVM-LABEL: test_rdtsc
+// LLVM: %{{.*}} = call i64 @llvm.x86.rdtsc()
+// LLVM: %{{.*}} = trunc i64 %{{.*}} to i32
+// LLVM: ret i32 %{{.*}}
+
+// OGCG-LABEL: test_rdtsc
+// OGCG: %{{.*}} = call i64 @llvm.x86.rdtsc()
+// OGCG: %{{.*}} = trunc i64 %{{.*}} to i32
+// OGCG: ret i32 %{{.*}}
+
+  return _rdtsc();
+}
+
+unsigned long long test_rdtscp(unsigned int *a) {
+// CIR-LABEL: test_rdtscp
+// CIR: %{{.*}} = cir.call @__rdtscp(%{{.*}}) : (!cir.ptr<!u32i>) -> !u64i
+// CIR: cir.store %{{.*}} : !u64i, !cir.ptr<!u64i>
+// CIR: cir.return %{{.*}} : !u64i
+
+// LLVM-LABEL: test_rdtscp
+// LLVM: %{{.*}} = call { i64, i32 } @llvm.x86.rdtscp()
+// LLVM: %{{.*}} = extractvalue { i64, i32 } %{{.*}}, 1
+// LLVM: store i32 %{{.*}}, ptr %{{.*}}
+// LLVM: %{{.*}} = extractvalue { i64, i32 } %{{.*}}, 0
+// LLVM: ret i64 %{{.*}}
+
+// OGCG-LABEL: test_rdtscp
+// OGCG: %{{.*}} = call { i64, i32 } @llvm.x86.rdtscp()
+// OGCG: %{{.*}} = extractvalue { i64, i32 } %{{.*}}, 1
+// OGCG: store i32 %{{.*}}, ptr %{{.*}}
+// OGCG: %{{.*}} = extractvalue { i64, i32 } %{{.*}}, 0
+// OGCG: ret i64 %{{.*}}
+  return __rdtscp(a);
+}


### PR DESCRIPTION
This PR implements generic fallback for the builtins that are not handled in `CIRGenBuiltinX86.cpp`. It also adds the infrastructure to implement similar fallback for other architectures that currently returns `std::nullopt`to make simple builtins for that architecture that map to LLVM intrinsics start working. It implements `rdpmc` builtin to test the implementation(support for `rdtsc/rdtscp` are also added).