### PR TITLE
[clang-tidy] Add llvm::accumulate to llvm-use-ranges

### DIFF
--- a/clang-tools-extra/clang-tidy/llvm/UseRangesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/UseRangesCheck.cpp
@@ -55,36 +55,16 @@ utils::UseRangesCheck::ReplacerMap UseRangesCheck::getReplacerMap() const {
       };
 
   // Single range algorithms.
-  AddStdToLLVM(llvm::makeIntrusiveRefCnt<StdToLLVMReplacer>(SingleSig),
-               {"adjacent_find",
-                "all_of",
-                "any_of",
-                "binary_search",
-                "copy",
-                "copy_if",
-                "count",
-                "count_if",
-                "fill",
-                "find",
-                "find_if",
-                "find_if_not",
-                "for_each",
-                "is_sorted",
-                "lower_bound",
-                "max_element",
-                "min_element",
-                "none_of",
-                "partition",
-                "partition_point",
-                "remove_if",
-                "replace",
-                "replace_copy",
-                "replace_copy_if",
-                "stable_sort",
-                "transform",
-                "uninitialized_copy",
-                "unique",
-                "upper_bound"});
+  AddStdToLLVM(
+      llvm::makeIntrusiveRefCnt<StdToLLVMReplacer>(SingleSig),
+      {"accumulate",      "adjacent_find", "all_of",    "any_of",
+       "binary_search",   "copy",          "copy_if",   "count",
+       "count_if",        "fill",          "find",      "find_if",
+       "find_if_not",     "for_each",      "is_sorted", "lower_bound",
+       "max_element",     "min_element",   "none_of",   "partition",
+       "partition_point", "remove_if",     "replace",   "replace_copy",
+       "replace_copy_if", "stable_sort",   "transform", "uninitialized_copy",
+       "unique",          "upper_bound"});
 
   // Two range algorithms.
   AddStdToLLVM(llvm::makeIntrusiveRefCnt<StdToLLVMReplacer>(TwoSig),

--- a/clang-tools-extra/clang-tidy/llvm/UseRangesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/UseRangesCheck.cpp
@@ -54,17 +54,40 @@ utils::UseRangesCheck::ReplacerMap UseRangesCheck::getReplacerMap() const {
           Results.try_emplace(("::std::" + Name).str(), Replacer);
       };
 
-  // Single range algorithms.
-  AddStdToLLVM(
-      llvm::makeIntrusiveRefCnt<StdToLLVMReplacer>(SingleSig),
-      {"accumulate",      "adjacent_find", "all_of",    "any_of",
-       "binary_search",   "copy",          "copy_if",   "count",
-       "count_if",        "fill",          "find",      "find_if",
-       "find_if_not",     "for_each",      "is_sorted", "lower_bound",
-       "max_element",     "min_element",   "none_of",   "partition",
-       "partition_point", "remove_if",     "replace",   "replace_copy",
-       "replace_copy_if", "stable_sort",   "transform", "uninitialized_copy",
-       "unique",          "upper_bound"});
+  // Single range algorithms. One per line, keep sorted.
+  // clang-format off
+  AddStdToLLVM(llvm::makeIntrusiveRefCnt<StdToLLVMReplacer>(SingleSig),
+               {"accumulate",
+                "adjacent_find",
+                "all_of",
+                "any_of",
+                "binary_search",
+                "copy",
+                "copy_if",
+                "count",
+                "count_if",
+                "fill",
+                "find",
+                "find_if",
+                "find_if_not",
+                "for_each",
+                "is_sorted",
+                "lower_bound",
+                "max_element",
+                "min_element",
+                "none_of",
+                "partition",
+                "partition_point",
+                "remove_if",
+                "replace",
+                "replace_copy",
+                "replace_copy_if",
+                "stable_sort",
+                "transform",
+                "uninitialized_copy",
+                "unique",
+                "upper_bound"});
+  // clang-format on
 
   // Two range algorithms.
   AddStdToLLVM(llvm::makeIntrusiveRefCnt<StdToLLVMReplacer>(TwoSig),

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -122,7 +122,8 @@ Changes in existing checks
 
 - Improved :doc:`llvm-use-ranges
   <clang-tidy/checks/llvm/use-ranges>` check by adding support for the following
-  algorithms: ``std::replace_copy`` and ``std::replace_copy_if``.
+  algorithms: ``std::accumulate``, ``std::replace_copy``, and
+  ``std::replace_copy_if``.
 
 - Improved :doc:`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check:

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/use-ranges.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/use-ranges.rst
@@ -27,6 +27,7 @@ Supported algorithms
 
 Calls to the following STL algorithms are checked:
 
+``std::accumulate``,
 ``std::adjacent_find``,
 ``std::all_of``,
 ``std::any_of``,

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/use-ranges.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/use-ranges.cpp
@@ -22,6 +22,12 @@ template <typename T> T* begin(T (&arr)[5]);
 template <typename T> T* end(T (&arr)[5]);
 
 template <class InputIt, class T>
+T accumulate(InputIt first, InputIt last, T init);
+
+template <class InputIt, class T, class BinaryOp>
+T accumulate(InputIt first, InputIt last, T init, BinaryOp op);
+
+template <class InputIt, class T>
 InputIt find(InputIt first, InputIt last, const T &value);
 
 template <class RandomIt>
@@ -78,10 +84,19 @@ OutputIt replace_copy_if(InputIt first, InputIt last, OutputIt d_first,
 
 bool is_even(int x);
 void double_ref(int& x);
+int multiply(int a, int b);
 
 void test_positive() {
   std::vector<int> vec;
   int arr[5] = {1, 2, 3, 4, 5};
+
+  int sum = std::accumulate(vec.begin(), vec.end(), 0);
+  // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: use an LLVM range-based algorithm
+  // CHECK-FIXES: int sum = llvm::accumulate(vec, 0);
+
+  int product = std::accumulate(vec.begin(), vec.end(), 1, multiply);
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use an LLVM range-based algorithm
+  // CHECK-FIXES: int product = llvm::accumulate(vec, 1, multiply);
 
   auto it1 = std::find(vec.begin(), vec.end(), 3);
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: use an LLVM range-based algorithm


### PR DESCRIPTION
I missed this in https://github.com/llvm/llvm-project/pull/177457.

All range wrappers from STLExtras should be covered by llvm-use-ranges now.