### PR TITLE
[HLSL] Make  frac, tanh, degrees overload tests stricter. NFC

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/degrees-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/degrees-overloads.hlsl
@@ -1,93 +1,113 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm\
 // RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)" -DTARGET=dx
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm\
 // RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" -DTARGET=spv
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].degrees.f32(
-// CHECK: ret float %hlsl.degrees
+// CHECK: define [[FNATTRS]] float @_Z19test_degrees_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLDEGREESI]]
 float test_degrees_double(double p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].degrees.v2f32
-// CHECK: ret <2 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <2 x float> @_Z20test_degrees_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLDEGREESI]]
 float2 test_degrees_double2(double2 p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].degrees.v3f32
-// CHECK: ret <3 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <3 x float> @_Z20test_degrees_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLDEGREESI]]
 float3 test_degrees_double3(double3 p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].degrees.v4f32
-// CHECK: ret <4 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <4 x float> @_Z20test_degrees_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLDEGREESI]]
 float4 test_degrees_double4(double4 p0) { return degrees(p0); }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].degrees.f32(
-// CHECK: ret float %hlsl.degrees
+// CHECK: define [[FNATTRS]] float @_Z16test_degrees_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLDEGREESI]]
 float test_degrees_int(int p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].degrees.v2f32
-// CHECK: ret <2 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_degrees_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLDEGREESI]]
 float2 test_degrees_int2(int2 p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].degrees.v3f32
-// CHECK: ret <3 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_degrees_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLDEGREESI]]
 float3 test_degrees_int3(int3 p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].degrees.v4f32
-// CHECK: ret <4 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_degrees_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLDEGREESI]]
 float4 test_degrees_int4(int4 p0) { return degrees(p0); }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].degrees.f32(
-// CHECK: ret float %hlsl.degrees
+// CHECK: define [[FNATTRS]] float @_Z17test_degrees_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLDEGREESI]]
 float test_degrees_uint(uint p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].degrees.v2f32
-// CHECK: ret <2 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_degrees_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLDEGREESI]]
 float2 test_degrees_uint2(uint2 p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].degrees.v3f32
-// CHECK: ret <3 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_degrees_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLDEGREESI]]
 float3 test_degrees_uint3(uint3 p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].degrees.v4f32
-// CHECK: ret <4 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_degrees_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLDEGREESI]]
 float4 test_degrees_uint4(uint4 p0) { return degrees(p0); }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].degrees.f32(
-// CHECK: ret float %hlsl.degrees
+// CHECK: define [[FNATTRS]] float @_Z20test_degrees_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLDEGREESI]]
 float test_degrees_int64_t(int64_t p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].degrees.v2f32
-// CHECK: ret <2 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <2 x float> @_Z21test_degrees_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLDEGREESI]]
 float2 test_degrees_int64_t2(int64_t2 p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].degrees.v3f32
-// CHECK: ret <3 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <3 x float> @_Z21test_degrees_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLDEGREESI]]
 float3 test_degrees_int64_t3(int64_t3 p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].degrees.v4f32
-// CHECK: ret <4 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <4 x float> @_Z21test_degrees_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLDEGREESI]]
 float4 test_degrees_int64_t4(int64_t4 p0) { return degrees(p0); }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].degrees.f32(
-// CHECK: ret float %hlsl.degrees
+// CHECK: define [[FNATTRS]] float @_Z21test_degrees_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLDEGREESI]]
 float test_degrees_uint64_t(uint64_t p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].degrees.v2f32
-// CHECK: ret <2 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <2 x float> @_Z22test_degrees_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLDEGREESI]]
 float2 test_degrees_uint64_t2(uint64_t2 p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].degrees.v3f32
-// CHECK: ret <3 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <3 x float> @_Z22test_degrees_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLDEGREESI]]
 float3 test_degrees_uint64_t3(uint64_t3 p0) { return degrees(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].degrees.v4f32
-// CHECK: ret <4 x float> %hlsl.degrees
+// CHECK: define [[FNATTRS]] <4 x float> @_Z22test_degrees_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLDEGREESI]]
 float4 test_degrees_uint64_t4(uint64_t4 p0) { return degrees(p0); }

--- a/clang/test/CodeGenHLSL/builtins/degrees-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/degrees-overloads.hlsl
@@ -1,113 +1,137 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm\
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)" -DTARGET=dx
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm\
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" -DTARGET=spv
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z19test_degrees_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x 64 bit API lowering for degrees is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float test_degrees_double(double p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z20test_degrees_double2Dv2_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x 64 bit API lowering for degrees is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float2 test_degrees_double2(double2 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z20test_degrees_double3Dv3_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x 64 bit API lowering for degrees is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float3 test_degrees_double3(double3 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z20test_degrees_double4Dv4_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x 64 bit API lowering for degrees is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float4 test_degrees_double4(double4 p0) { return degrees(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z16test_degrees_inti(
 // CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float test_degrees_int(int p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_degrees_int2Dv2_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float2 test_degrees_int2(int2 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_degrees_int3Dv3_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float3 test_degrees_int3(int3 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_degrees_int4Dv4_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float4 test_degrees_int4(int4 p0) { return degrees(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_degrees_uintj(
 // CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float test_degrees_uint(uint p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_degrees_uint2Dv2_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float2 test_degrees_uint2(uint2 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_degrees_uint3Dv3_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float3 test_degrees_uint3(uint3 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_degrees_uint4Dv4_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float4 test_degrees_uint4(uint4 p0) { return degrees(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z20test_degrees_int64_tl(
 // CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float test_degrees_int64_t(int64_t p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z21test_degrees_int64_t2Dv2_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float2 test_degrees_int64_t2(int64_t2 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z21test_degrees_int64_t3Dv3_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float3 test_degrees_int64_t3(int64_t3 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z21test_degrees_int64_t4Dv4_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float4 test_degrees_int64_t4(int64_t4 p0) { return degrees(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z21test_degrees_uint64_tm(
 // CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float test_degrees_uint64_t(uint64_t p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z22test_degrees_uint64_t2Dv2_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float2 test_degrees_uint64_t2(uint64_t2 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z22test_degrees_uint64_t3Dv3_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float3 test_degrees_uint64_t3(uint64_t3 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z22test_degrees_uint64_t4Dv4_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLDEGREESI]]
+// expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float4 test_degrees_uint64_t4(uint64_t4 p0) { return degrees(p0); }

--- a/clang/test/CodeGenHLSL/builtins/frac-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/frac-overloads.hlsl
@@ -1,93 +1,113 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
 // RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)" -DTARGET=dx
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
 // RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" -DTARGET=spv
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].frac.f32(
-// CHECK: ret float %hlsl.frac
+// CHECK: define [[FNATTRS]] float @_Z16test_frac_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLFRACI]]
 float test_frac_double(double p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].frac.v2f32
-// CHECK: ret <2 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_frac_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLFRACI]]
 float2 test_frac_double2(double2 p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].frac.v3f32
-// CHECK: ret <3 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_frac_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLFRACI]]
 float3 test_frac_double3(double3 p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].frac.v4f32
-// CHECK: ret <4 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_frac_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLFRACI]]
 float4 test_frac_double4(double4 p0) { return frac(p0); }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].frac.f32(
-// CHECK: ret float %hlsl.frac
+// CHECK: define [[FNATTRS]] float @_Z13test_frac_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLFRACI]]
 float test_frac_int(int p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].frac.v2f32
-// CHECK: ret <2 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_frac_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLFRACI]]
 float2 test_frac_int2(int2 p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].frac.v3f32
-// CHECK: ret <3 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_frac_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLFRACI]]
 float3 test_frac_int3(int3 p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].frac.v4f32
-// CHECK: ret <4 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_frac_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLFRACI]]
 float4 test_frac_int4(int4 p0) { return frac(p0); }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].frac.f32(
-// CHECK: ret float %hlsl.frac
+// CHECK: define [[FNATTRS]] float @_Z14test_frac_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLFRACI]]
 float test_frac_uint(uint p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].frac.v2f32
-// CHECK: ret <2 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_frac_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLFRACI]]
 float2 test_frac_uint2(uint2 p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].frac.v3f32
-// CHECK: ret <3 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_frac_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLFRACI]]
 float3 test_frac_uint3(uint3 p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].frac.v4f32
-// CHECK: ret <4 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_frac_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLFRACI]]
 float4 test_frac_uint4(uint4 p0) { return frac(p0); }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].frac.f32(
-// CHECK: ret float %hlsl.frac
+// CHECK: define [[FNATTRS]] float @_Z17test_frac_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLFRACI]]
 float test_frac_int64_t(int64_t p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].frac.v2f32
-// CHECK: ret <2 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_frac_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLFRACI]]
 float2 test_frac_int64_t2(int64_t2 p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].frac.v3f32
-// CHECK: ret <3 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_frac_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLFRACI]]
 float3 test_frac_int64_t3(int64_t3 p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].frac.v4f32
-// CHECK: ret <4 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_frac_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLFRACI]]
 float4 test_frac_int64_t4(int64_t4 p0) { return frac(p0); }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].frac.f32(
-// CHECK: ret float %hlsl.frac
+// CHECK: define [[FNATTRS]] float @_Z18test_frac_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLFRACI]]
 float test_frac_uint64_t(uint64_t p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].frac.v2f32
-// CHECK: ret <2 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_frac_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLFRACI]]
 float2 test_frac_uint64_t2(uint64_t2 p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].frac.v3f32
-// CHECK: ret <3 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_frac_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLFRACI]]
 float3 test_frac_uint64_t3(uint64_t3 p0) { return frac(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].frac.v4f32
-// CHECK: ret <4 x float> %hlsl.frac
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_frac_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLFRACI]]
 float4 test_frac_uint64_t4(uint64_t4 p0) { return frac(p0); }

--- a/clang/test/CodeGenHLSL/builtins/frac-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/frac-overloads.hlsl
@@ -1,113 +1,137 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)" -DTARGET=dx
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" -DTARGET=spv
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z16test_frac_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x 64 bit API lowering for frac is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float test_frac_double(double p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_frac_double2Dv2_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x 64 bit API lowering for frac is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float2 test_frac_double2(double2 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_frac_double3Dv3_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x 64 bit API lowering for frac is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float3 test_frac_double3(double3 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_frac_double4Dv4_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x 64 bit API lowering for frac is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float4 test_frac_double4(double4 p0) { return frac(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_frac_inti(
 // CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float test_frac_int(int p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_frac_int2Dv2_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float2 test_frac_int2(int2 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_frac_int3Dv3_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float3 test_frac_int3(int3 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_frac_int4Dv4_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float4 test_frac_int4(int4 p0) { return frac(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_frac_uintj(
 // CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float test_frac_uint(uint p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_frac_uint2Dv2_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float2 test_frac_uint2(uint2 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_frac_uint3Dv3_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float3 test_frac_uint3(uint3 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_frac_uint4Dv4_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float4 test_frac_uint4(uint4 p0) { return frac(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_frac_int64_tl(
 // CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float test_frac_int64_t(int64_t p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_frac_int64_t2Dv2_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float2 test_frac_int64_t2(int64_t2 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_frac_int64_t3Dv3_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float3 test_frac_int64_t3(int64_t3 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_frac_int64_t4Dv4_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float4 test_frac_int64_t4(int64_t4 p0) { return frac(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_frac_uint64_tm(
 // CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float test_frac_uint64_t(uint64_t p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_frac_uint64_t2Dv2_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float2 test_frac_uint64_t2(uint64_t2 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_frac_uint64_t3Dv3_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float3 test_frac_uint64_t3(uint64_t3 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_frac_uint64_t4Dv4_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLFRACI]]
+// expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float4 test_frac_uint64_t4(uint64_t4 p0) { return frac(p0); }

--- a/clang/test/CodeGenHLSL/builtins/tanh-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/tanh-overloads.hlsl
@@ -1,123 +1,163 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
 
-// CHECK-LABEL: test_tanh_double
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.tanh.f32
+// CHECK: define [[FNATTRS]] float @_Z16test_tanh_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_tanh_double ( double p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_double2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.tanh.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_tanh_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_double2 ( double2 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_double3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.tanh.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_tanh_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_double3 ( double3 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_double4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.tanh.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_tanh_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_double4 ( double4 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_int
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.tanh.f32
+// CHECK: define [[FNATTRS]] float @_Z13test_tanh_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_tanh_int ( int p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_int2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.tanh.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_tanh_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_int2 ( int2 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_int3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.tanh.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_tanh_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_int3 ( int3 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_int4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.tanh.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_tanh_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_int4 ( int4 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_uint
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.tanh.f32
+// CHECK: define [[FNATTRS]] float @_Z14test_tanh_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_tanh_uint ( uint p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_uint2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.tanh.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_tanh_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_uint2 ( uint2 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_uint3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.tanh.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_tanh_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_uint3 ( uint3 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_uint4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.tanh.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_tanh_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_uint4 ( uint4 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_int64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.tanh.f32
+// CHECK: define [[FNATTRS]] float @_Z17test_tanh_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_tanh_int64_t ( int64_t p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_int64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.tanh.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_tanh_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_int64_t2 ( int64_t2 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_int64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.tanh.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_tanh_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_int64_t3 ( int64_t3 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_int64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.tanh.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_tanh_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_int64_t4 ( int64_t4 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_uint64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.tanh.f32
+// CHECK: define [[FNATTRS]] float @_Z18test_tanh_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_tanh_uint64_t ( uint64_t p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_uint64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.tanh.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_tanh_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_uint64_t2 ( uint64_t2 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_uint64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.tanh.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_tanh_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_uint64_t3 ( uint64_t3 p0 ) {
   return tanh ( p0 );
 }
 
-// CHECK-LABEL: test_tanh_uint64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.tanh.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_tanh_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_uint64_t4 ( uint64_t4 p0 ) {
   return tanh ( p0 );
 }

--- a/clang/test/CodeGenHLSL/builtins/tanh-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/tanh-overloads.hlsl
@@ -1,12 +1,16 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" -DTARGET=spv
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z16test_tanh_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tanh_double ( double p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x 64 bit API lowering for tanh is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return tanh ( p0 );
 }
 
@@ -15,6 +19,7 @@ float test_tanh_double ( double p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_double2 ( double2 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x 64 bit API lowering for tanh is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return tanh ( p0 );
 }
 
@@ -23,6 +28,7 @@ float2 test_tanh_double2 ( double2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_double3 ( double3 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x 64 bit API lowering for tanh is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return tanh ( p0 );
 }
 
@@ -31,6 +37,7 @@ float3 test_tanh_double3 ( double3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_double4 ( double4 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x 64 bit API lowering for tanh is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return tanh ( p0 );
 }
 
@@ -39,6 +46,7 @@ float4 test_tanh_double4 ( double4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tanh_int ( int p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -47,6 +55,7 @@ float test_tanh_int ( int p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_int2 ( int2 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -55,6 +64,7 @@ float2 test_tanh_int2 ( int2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_int3 ( int3 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -63,6 +73,7 @@ float3 test_tanh_int3 ( int3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_int4 ( int4 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -71,6 +82,7 @@ float4 test_tanh_int4 ( int4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tanh_uint ( uint p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -79,6 +91,7 @@ float test_tanh_uint ( uint p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_uint2 ( uint2 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -87,6 +100,7 @@ float2 test_tanh_uint2 ( uint2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_uint3 ( uint3 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -95,6 +109,7 @@ float3 test_tanh_uint3 ( uint3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_uint4 ( uint4 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -103,6 +118,7 @@ float4 test_tanh_uint4 ( uint4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tanh_int64_t ( int64_t p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -111,6 +127,7 @@ float test_tanh_int64_t ( int64_t p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_int64_t2 ( int64_t2 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -119,6 +136,7 @@ float2 test_tanh_int64_t2 ( int64_t2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_int64_t3 ( int64_t3 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -127,6 +145,7 @@ float3 test_tanh_int64_t3 ( int64_t3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_int64_t4 ( int64_t4 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -135,6 +154,7 @@ float4 test_tanh_int64_t4 ( int64_t4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tanh_uint64_t ( uint64_t p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -143,6 +163,7 @@ float test_tanh_uint64_t ( uint64_t p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_uint64_t2 ( uint64_t2 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -151,6 +172,7 @@ float2 test_tanh_uint64_t2 ( uint64_t2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_uint64_t3 ( uint64_t3 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }
 
@@ -159,5 +181,6 @@ float3 test_tanh_uint64_t3 ( uint64_t3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_uint64_t4 ( uint64_t4 p0 ) {
+// expected-warning@+1 {{'tanh' is deprecated: In 202x int lowering for tanh is deprecated. Explicitly cast parameters to float types.}}
   return tanh ( p0 );
 }


### PR DESCRIPTION
This patch changes the run lines for frac, tanh, degrees overload test to use -O1 instead of -disable-llvm-passes and rewrite the tests to actually look at the whole function.

This work is part of https://github.com/llvm/llvm-project/issues/138016.