### PR TITLE
[KnownBits] Rename variables and simplify KnownBits::mul. NFC

### DIFF
--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -1021,24 +1021,22 @@ KnownBits KnownBits::mul(const KnownBits &LHS, const KnownBits &RHS,
   // Where C5, C6 describe the known bits of %a, %b
   // C1, C2 describe the known bottom bits of %a, %b.
   // C7 describes the mask of the known bits of the result.
-  const APInt &Bottom0 = LHS.One;
-  const APInt &Bottom1 = RHS.One;
 
   // How many times we'd be able to divide each argument by 2 (shr by 1).
   // This gives us the number of trailing zeros on the multiplication result.
-  unsigned TrailBitsKnown0 = (LHS.Zero | LHS.One).countr_one();
-  unsigned TrailBitsKnown1 = (RHS.Zero | RHS.One).countr_one();
-  unsigned TrailZero0 = LHS.countMinTrailingZeros();
-  unsigned TrailZero1 = RHS.countMinTrailingZeros();
-  unsigned TrailZ = TrailZero0 + TrailZero1;
+  unsigned TrailBitsKnownLHS = (LHS.Zero | LHS.One).countr_one();
+  unsigned TrailBitsKnownRHS = (RHS.Zero | RHS.One).countr_one();
+  unsigned TrailZeroLHS = LHS.countMinTrailingZeros();
+  unsigned TrailZeroRHS = RHS.countMinTrailingZeros();
+  unsigned TrailZ = TrailZeroLHS + TrailZeroRHS;
 
   // Figure out the fewest known-bits operand.
-  unsigned SmallestOperand =
-      std::min(TrailBitsKnown0 - TrailZero0, TrailBitsKnown1 - TrailZero1);
+  unsigned SmallestOperand = std::min(TrailBitsKnownLHS - TrailZeroLHS,
+                                      TrailBitsKnownRHS - TrailZeroRHS);
   unsigned ResultBitsKnown = std::min(SmallestOperand + TrailZ, BitWidth);
 
-  APInt BottomKnown =
-      Bottom0.getLoBits(TrailBitsKnown0) * Bottom1.getLoBits(TrailBitsKnown1);
+  // The lower ResultBitsKnown bits of this are known.
+  APInt BottomKnown = LHS.One * RHS.One;
 
   KnownBits Res(BitWidth);
   Res.Zero.setHighBits(LeadZ);
@@ -1047,13 +1045,13 @@ KnownBits KnownBits::mul(const KnownBits &LHS, const KnownBits &RHS,
 
   if (NoUndefSelfMultiply) {
     // If X has at least TZ trailing zeroes, then bit (2 * TZ + 1) must be zero.
-    unsigned TwoTZP1 = 2 * TrailZero0 + 1;
+    unsigned TwoTZP1 = 2 * TrailZeroLHS + 1;
     if (TwoTZP1 < BitWidth)
       Res.Zero.setBit(TwoTZP1);
 
     // If X has exactly TZ trailing zeros, then bit (2 * TZ + 2) must also be
     // zero.
-    if (TrailZero0 < BitWidth && LHS.One[TrailZero0]) {
+    if (TrailZeroLHS < BitWidth && LHS.One[TrailZeroLHS]) {
       unsigned TwoTZP2 = TwoTZP1 + 1;
       if (TwoTZP2 < BitWidth)
         Res.Zero.setBit(TwoTZP2);


### PR DESCRIPTION
Replace 0/1 with LHS/RHS to match arguments. Remove unneeded calls to getLoBits. Remove unneeded references to LHS/RHS.One.