### PR TITLE
[HLSL] Make log, asin, acos overload tests stricter. NFC

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/acos-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/acos-overloads.hlsl
@@ -1,123 +1,163 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
 
-// CHECK-LABEL: test_acos_double
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.acos.f32
+// CHECK: define [[FNATTRS]] float @_Z16test_acos_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_acos_double ( double p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_double2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.acos.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_acos_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_double2 ( double2 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_double3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.acos.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_acos_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_double3 ( double3 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_double4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.acos.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_acos_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_double4 ( double4 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_int
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.acos.f32
+// CHECK: define [[FNATTRS]] float @_Z13test_acos_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_acos_int ( int p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_int2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.acos.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_acos_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_int2 ( int2 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_int3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.acos.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_acos_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_int3 ( int3 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_int4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.acos.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_acos_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_int4 ( int4 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_uint
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.acos.f32
+// CHECK: define [[FNATTRS]] float @_Z14test_acos_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_acos_uint ( uint p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_uint2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.acos.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_acos_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_uint2 ( uint2 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_uint3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.acos.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_acos_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_uint3 ( uint3 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_uint4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.acos.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_acos_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_uint4 ( uint4 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_int64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.acos.f32
+// CHECK: define [[FNATTRS]] float @_Z17test_acos_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_acos_int64_t ( int64_t p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_int64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.acos.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_acos_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_int64_t2 ( int64_t2 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_int64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.acos.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_acos_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_int64_t3 ( int64_t3 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_int64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.acos.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_acos_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_int64_t4 ( int64_t4 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_uint64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.acos.f32
+// CHECK: define [[FNATTRS]] float @_Z18test_acos_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_acos_uint64_t ( uint64_t p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_uint64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.acos.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_acos_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_uint64_t2 ( uint64_t2 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_uint64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.acos.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_acos_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_uint64_t3 ( uint64_t3 p0 ) {
   return acos ( p0 );
 }
 
-// CHECK-LABEL: test_acos_uint64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.acos.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_acos_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_uint64_t4 ( uint64_t4 p0 ) {
   return acos ( p0 );
 }

--- a/clang/test/CodeGenHLSL/builtins/acos-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/acos-overloads.hlsl
@@ -1,163 +1,206 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z16test_acos_doubled(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_acos_double ( double p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x 64 bit API lowering for acos is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_acos_double2Dv2_d(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_double2 ( double2 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x 64 bit API lowering for acos is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_acos_double3Dv3_d(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_double3 ( double3 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x 64 bit API lowering for acos is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_acos_double4Dv4_d(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_double4 ( double4 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x 64 bit API lowering for acos is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_acos_inti(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_acos_int ( int p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_acos_int2Dv2_i(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_int2 ( int2 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_acos_int3Dv3_i(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_int3 ( int3 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_acos_int4Dv4_i(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_int4 ( int4 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_acos_uintj(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_acos_uint ( uint p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_acos_uint2Dv2_j(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_uint2 ( uint2 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_acos_uint3Dv3_j(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_uint3 ( uint3 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_acos_uint4Dv4_j(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_uint4 ( uint4 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_acos_int64_tl(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_acos_int64_t ( int64_t p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_acos_int64_t2Dv2_l(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_int64_t2 ( int64_t2 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_acos_int64_t3Dv3_l(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_int64_t3 ( int64_t3 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_acos_int64_t4Dv4_l(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_int64_t4 ( int64_t4 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_acos_uint64_tm(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_acos_uint64_t ( uint64_t p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_acos_uint64_t2Dv2_m(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_uint64_t2 ( uint64_t2 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_acos_uint64_t3Dv3_m(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_uint64_t3 ( uint64_t3 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_acos_uint64_t4Dv4_m(
+// CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_uint64_t4 ( uint64_t4 p0 ) {
+// expected-warning@+1 {{'acos' is deprecated: In 202x int lowering for acos is deprecated. Explicitly cast parameters to float types.}}
   return acos ( p0 );
 }

--- a/clang/test/CodeGenHLSL/builtins/asin-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/asin-overloads.hlsl
@@ -1,12 +1,16 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm  \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z16test_asin_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_asin_double ( double p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x 64 bit API lowering for asin is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return asin ( p0 );
 }
 
@@ -15,6 +19,7 @@ float test_asin_double ( double p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_double2 ( double2 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x 64 bit API lowering for asin is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return asin ( p0 );
 }
 
@@ -23,6 +28,7 @@ float2 test_asin_double2 ( double2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_double3 ( double3 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x 64 bit API lowering for asin is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return asin ( p0 );
 }
 
@@ -31,6 +37,7 @@ float3 test_asin_double3 ( double3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_double4 ( double4 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x 64 bit API lowering for asin is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return asin ( p0 );
 }
 
@@ -39,6 +46,7 @@ float4 test_asin_double4 ( double4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_asin_int ( int p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -47,6 +55,7 @@ float test_asin_int ( int p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_int2 ( int2 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -55,6 +64,7 @@ float2 test_asin_int2 ( int2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_int3 ( int3 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -63,6 +73,7 @@ float3 test_asin_int3 ( int3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_int4 ( int4 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -71,6 +82,7 @@ float4 test_asin_int4 ( int4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_asin_uint ( uint p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -79,6 +91,7 @@ float test_asin_uint ( uint p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_uint2 ( uint2 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -87,6 +100,7 @@ float2 test_asin_uint2 ( uint2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_uint3 ( uint3 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -95,6 +109,7 @@ float3 test_asin_uint3 ( uint3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_uint4 ( uint4 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -103,6 +118,7 @@ float4 test_asin_uint4 ( uint4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_asin_int64_t ( int64_t p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -111,6 +127,7 @@ float test_asin_int64_t ( int64_t p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_int64_t2 ( int64_t2 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -119,6 +136,7 @@ float2 test_asin_int64_t2 ( int64_t2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_int64_t3 ( int64_t3 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -127,6 +145,7 @@ float3 test_asin_int64_t3 ( int64_t3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_int64_t4 ( int64_t4 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -135,6 +154,7 @@ float4 test_asin_int64_t4 ( int64_t4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_asin_uint64_t ( uint64_t p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -143,6 +163,7 @@ float test_asin_uint64_t ( uint64_t p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_uint64_t2 ( uint64_t2 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -151,6 +172,7 @@ float2 test_asin_uint64_t2 ( uint64_t2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_uint64_t3 ( uint64_t3 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }
 
@@ -159,5 +181,6 @@ float3 test_asin_uint64_t3 ( uint64_t3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_uint64_t4 ( uint64_t4 p0 ) {
+// expected-warning@+1 {{'asin' is deprecated: In 202x int lowering for asin is deprecated. Explicitly cast parameters to float types.}}
   return asin ( p0 );
 }

--- a/clang/test/CodeGenHLSL/builtins/asin-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/asin-overloads.hlsl
@@ -1,123 +1,163 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm  \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
 
-// CHECK-LABEL: test_asin_double
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.asin.f32
+// CHECK: define [[FNATTRS]] float @_Z16test_asin_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_asin_double ( double p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_double2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.asin.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_asin_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_double2 ( double2 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_double3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.asin.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_asin_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_double3 ( double3 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_double4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.asin.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_asin_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_double4 ( double4 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_int
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.asin.f32
+// CHECK: define [[FNATTRS]] float @_Z13test_asin_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_asin_int ( int p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_int2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.asin.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_asin_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_int2 ( int2 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_int3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.asin.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_asin_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_int3 ( int3 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_int4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.asin.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_asin_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_int4 ( int4 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_uint
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.asin.f32
+// CHECK: define [[FNATTRS]] float @_Z14test_asin_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_asin_uint ( uint p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_uint2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.asin.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_asin_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_uint2 ( uint2 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_uint3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.asin.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_asin_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_uint3 ( uint3 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_uint4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.asin.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_asin_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_uint4 ( uint4 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_int64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.asin.f32
+// CHECK: define [[FNATTRS]] float @_Z17test_asin_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_asin_int64_t ( int64_t p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_int64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.asin.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_asin_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_int64_t2 ( int64_t2 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_int64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.asin.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_asin_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_int64_t3 ( int64_t3 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_int64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.asin.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_asin_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_int64_t4 ( int64_t4 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_uint64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.asin.f32
+// CHECK: define [[FNATTRS]] float @_Z18test_asin_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_asin_uint64_t ( uint64_t p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_uint64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.asin.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_asin_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_uint64_t2 ( uint64_t2 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_uint64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.asin.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_asin_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_uint64_t3 ( uint64_t3 p0 ) {
   return asin ( p0 );
 }
 
-// CHECK-LABEL: test_asin_uint64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.asin.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_asin_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_uint64_t4 ( uint64_t4 p0 ) {
   return asin ( p0 );
 }

--- a/clang/test/CodeGenHLSL/builtins/log-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log-overloads.hlsl
@@ -1,68 +1,108 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -disable-llvm-passes -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK
+// RUN:  -emit-llvm -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)"
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_log_double
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log.f32(
+// CHECK: define [[FNATTRS]] float @_Z15test_log_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_log_double(double p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_log_double2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z16test_log_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_log_double2(double2 p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_log_double3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z16test_log_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_log_double3(double3 p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_log_double4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z16test_log_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_log_double4(double4 p0) { return log(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_log_int
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log.f32(
+// CHECK: define [[FNATTRS]] float @_Z12test_log_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_log_int(int p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_log_int2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z13test_log_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_log_int2(int2 p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_log_int3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z13test_log_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_log_int3(int3 p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_log_int4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z13test_log_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_log_int4(int4 p0) { return log(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_log_uint
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log.f32(
+// CHECK: define [[FNATTRS]] float @_Z13test_log_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_log_uint(uint p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_log_uint2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_log_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_log_uint2(uint2 p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_log_uint3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_log_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_log_uint3(uint3 p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_log_uint4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_log_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_log_uint4(uint4 p0) { return log(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_log_int64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log.f32(
+// CHECK: define [[FNATTRS]] float @_Z16test_log_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_log_int64_t(int64_t p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_log_int64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_log_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_log_int64_t2(int64_t2 p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_log_int64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_log_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_log_int64_t3(int64_t3 p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_log_int64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_log_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_log_int64_t4(int64_t4 p0) { return log(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_log_uint64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log.f32(
+// CHECK: define [[FNATTRS]] float @_Z17test_log_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_log_uint64_t(uint64_t p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_log_uint64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_log_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_log_uint64_t2(uint64_t2 p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_log_uint64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_log_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_log_uint64_t3(uint64_t3 p0) { return log(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_log_uint64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_log_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_log_uint64_t4(uint64_t4 p0) { return log(p0); }

--- a/clang/test/CodeGenHLSL/builtins/log-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log-overloads.hlsl
@@ -1,108 +1,131 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z15test_log_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x 64 bit API lowering for log is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float test_log_double(double p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z16test_log_double2Dv2_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x 64 bit API lowering for log is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float2 test_log_double2(double2 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z16test_log_double3Dv3_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x 64 bit API lowering for log is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float3 test_log_double3(double3 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z16test_log_double4Dv4_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x 64 bit API lowering for log is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float4 test_log_double4(double4 p0) { return log(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z12test_log_inti(
 // CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float test_log_int(int p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z13test_log_int2Dv2_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log_int2(int2 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z13test_log_int3Dv3_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log_int3(int3 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z13test_log_int4Dv4_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log_int4(int4 p0) { return log(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_log_uintj(
 // CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float test_log_uint(uint p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_log_uint2Dv2_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log_uint2(uint2 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_log_uint3Dv3_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log_uint3(uint3 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_log_uint4Dv4_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log_uint4(uint4 p0) { return log(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z16test_log_int64_tl(
 // CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float test_log_int64_t(int64_t p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_log_int64_t2Dv2_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log_int64_t2(int64_t2 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_log_int64_t3Dv3_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log_int64_t3(int64_t3 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_log_int64_t4Dv4_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log_int64_t4(int64_t4 p0) { return log(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_log_uint64_tm(
 // CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float test_log_uint64_t(uint64_t p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_log_uint64_t2Dv2_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log_uint64_t2(uint64_t2 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_log_uint64_t3Dv3_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log_uint64_t3(uint64_t3 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_log_uint64_t4Dv4_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log_uint64_t4(uint64_t4 p0) { return log(p0); }


### PR DESCRIPTION
This patch changes the run lines for log, asin, acos overload test to use -O1 instead of -disable-llvm-passes and rewrite the tests to actually look at the whole function.

This work is part of https://github.com/llvm/llvm-project/issues/138016.