### PR TITLE
Cleanup: Remove SmallVector hacks

### DIFF
--- a/mlir/include/mlir/Support/LLVM.h
+++ b/mlir/include/mlir/Support/LLVM.h
@@ -26,14 +26,6 @@
 // it anyway.
 #include "llvm/Support/LogicalResult.h"
 
-// Workaround for clang-5 (PR41549)
-#if defined(__clang_major__)
-#if __clang_major__ <= 5
-#include "llvm/ADT/DenseMapInfo.h"
-#include "llvm/ADT/SmallVector.h"
-#endif
-#endif
-
 // Forward declarations.
 namespace llvm {
 // String types


### PR DESCRIPTION
We no longer support any platform that uses Clang 5. This was a workaround for older clang versions where template arguments weren't merged between forward declarations and definitions correctly.

Since we don't support anything this old anymore, we can drop this workaround.

Note: I do not have merge permissions.