### PR TITLE
[lldb] Fix test_chained_frame_providers on 32-bit Arm

### DIFF
--- a/lldb/test/API/functionalities/scripted_frame_provider/TestScriptedFrameProvider.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/TestScriptedFrameProvider.py
@@ -706,7 +706,7 @@ class ScriptedFrameProviderTestCase(TestBase):
             "baz",
             "Frame 0 should be 'baz' from last provider in chain",
         )
-        self.assertEqual(frame0.GetPC(), 0xBAD)
+        self.assertEqual(frame0.GetPC(), 0xBAC)
 
         frame1 = thread.GetFrameAtIndex(1)
         self.assertIsNotNone(frame1)
@@ -715,7 +715,7 @@ class ScriptedFrameProviderTestCase(TestBase):
             "bar",
             "Frame 1 should be 'bar' from second provider in chain",
         )
-        self.assertEqual(frame1.GetPC(), 0xBAB)
+        self.assertEqual(frame1.GetPC(), 0xBAA)
 
         frame2 = thread.GetFrameAtIndex(2)
         self.assertIsNotNone(frame2)

--- a/lldb/test/API/functionalities/scripted_frame_provider/test_frame_providers.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/test_frame_providers.py
@@ -427,7 +427,7 @@ class AddBarFrameProvider(ScriptedFrameProvider):
     def get_frame_at_index(self, index):
         if index == 0:
             # Return synthetic "bar" frame
-            return CustomScriptedFrame(self.thread, 0, 0xBAB, "bar")
+            return CustomScriptedFrame(self.thread, 0, 0xBAA, "bar")
         elif index - 1 < len(self.input_frames):
             # Pass through input frames (shifted by 1)
             return index - 1
@@ -453,7 +453,7 @@ class AddBazFrameProvider(ScriptedFrameProvider):
     def get_frame_at_index(self, index):
         if index == 0:
             # Return synthetic "baz" frame
-            return CustomScriptedFrame(self.thread, 0, 0xBAD, "baz")
+            return CustomScriptedFrame(self.thread, 0, 0xBAC, "baz")
         elif index - 1 < len(self.input_frames):
             # Pass through input frames (shifted by 1)
             return index - 1


### PR DESCRIPTION
PC addresses must always be 16-bit aligned on 32-bit Arm CPUs.

Fixes #177666
