### PR TITLE
[NFCI][AMDGPU] Move more attributes from `AMDGPUSubtarget` to `GCNSubtarget`

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -529,9 +529,7 @@ def FeatureRealTrue16Insts : SubtargetFeature<"real-true16",
   "Use true 16-bit registers"
 >;
 
-def FeatureD16Writes32BitVgpr : SubtargetFeature<"d16-write-vgpr32",
-  "EnableD16Writes32BitVgpr",
-  "true",
+defm D16Writes32BitVgpr : AMDGPUSubtargetFeature<"d16-write-vgpr32",
   "D16 instructions potentially have 32-bit data dependencies"
 >;
 
@@ -2380,8 +2378,6 @@ def UseFakeTrue16Insts : True16PredicateClass<"Subtarget->hasTrue16BitInsts() &&
 def UseTrue16WithSramECC : True16PredicateClass<"Subtarget->useRealTrue16Insts() && "
                                                 "!Subtarget->d16PreservesUnusedBits()">;
 
-def HasD16Writes32BitVgpr: Predicate<"Subtarget->hasD16Writes32BitVgpr()">,
-  AssemblerPredicate<(all_of FeatureTrue16BitInsts, FeatureRealTrue16Insts, FeatureD16Writes32BitVgpr)>;
 def NotHasD16Writes32BitVgpr: Predicate<"!Subtarget->hasD16Writes32BitVgpr()">,
   AssemblerPredicate<(all_of FeatureTrue16BitInsts, FeatureRealTrue16Insts, (not FeatureD16Writes32BitVgpr))>;
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.cpp
@@ -34,14 +34,6 @@ using namespace llvm;
 
 AMDGPUSubtarget::AMDGPUSubtarget(Triple TT) : TargetTriple(std::move(TT)) {}
 
-bool AMDGPUSubtarget::useRealTrue16Insts() const {
-  return hasTrue16BitInsts() && EnableRealTrue16Insts;
-}
-
-bool AMDGPUSubtarget::hasD16Writes32BitVgpr() const {
-  return EnableD16Writes32BitVgpr;
-}
-
 // Returns the maximum per-workgroup LDS allocation size (in bytes) that still
 // allows the given function to achieve an occupancy of NWaves waves per
 // SIMD / EU, taking into account only the function's *maximum* workgroup size.

--- a/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.h
@@ -26,15 +26,10 @@
 //   bool HasXXX = false;                      // member declaration
 //   bool hasXXX() const { return HasXXX; }    // getter
 //
-// AMDGPU_SUBTARGET_ENABLE_FEATURE_MEMBER_ONLY: Features with member only
-//   bool EnableXXX = false;                   // member declaration only
-//
 // To add a new simple feature:
 //   1. Add X(FeatureName) to the appropriate macro below
 //   2. Remove the manual bool HasFeatureName declaration from protected section
 //   3. If using AMDGPU_SUBTARGET_HAS_FEATURE, also remove the manual getter
-//   4. If using AMDGPU_SUBTARGET_ENABLE_FEATURE_MEMBER_ONLY, also remove the
-//      manual getter
 //
 // Note: The features are ordered alphabetically for convenience. Unlike
 // GCNSubtarget.h, we do not use TableGen-generated features here. We
@@ -49,12 +44,7 @@
   X(Inv2PiInlineImm)                                                           \
   X(MadMacF32Insts)                                                            \
   X(SDWA)                                                                      \
-  X(True16BitInsts)                                                            \
   X(VOP3PInsts)
-
-#define AMDGPU_SUBTARGET_ENABLE_FEATURE_MEMBER_ONLY(X)                         \
-  X(RealTrue16Insts)                                                           \
-  X(D16Writes32BitVgpr)
 
 namespace llvm {
 
@@ -95,11 +85,6 @@ protected:
   AMDGPU_SUBTARGET_HAS_FEATURE(DECL_HAS_MEMBER)
 #undef DECL_HAS_MEMBER
 #undef AMDGPU_SUBTARGET_HAS_FEATURE_MEMBER_ONLY
-
-#define DECL_ENABLE_MEMBER(Name) bool Enable##Name = false;
-  AMDGPU_SUBTARGET_ENABLE_FEATURE_MEMBER_ONLY(DECL_ENABLE_MEMBER)
-#undef DECL_ENABLE_MEMBER
-#undef AMDGPU_SUBTARGET_ENABLE_FEATURE_MEMBER_ONLY
 
   unsigned EUsPerCU = 4;
   unsigned MaxWavesPerEU = 10;
@@ -237,16 +222,6 @@ public:
   AMDGPU_SUBTARGET_HAS_FEATURE(DECL_HAS_GETTER)
 #undef DECL_HAS_GETTER
 #undef AMDGPU_SUBTARGET_HAS_FEATURE
-
-  /// Return true if real (non-fake) variants of True16 instructions using
-  /// 16-bit registers should be code-generated. Fake True16 instructions are
-  /// identical to non-fake ones except that they take 32-bit registers as
-  /// operands and always use their low halves.
-  // TODO: Remove and use hasTrue16BitInsts() instead once True16 is fully
-  // supported and the support for fake True16 instructions is removed.
-  bool useRealTrue16Insts() const;
-
-  bool hasD16Writes32BitVgpr() const;
 
   bool hasMulI24() const {
     return HasMulI24;

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -64,6 +64,7 @@
   X(LDSMisalignedBug)                                                          \
   X(UnalignedBufferAccess)                                                     \
   X(UnalignedScratchAccess)                                                    \
+  X(RealTrue16Insts)                                                           \
   X(UserSGPRInit16Bug)
 
 // Features with both member and getter.
@@ -109,6 +110,7 @@
   X(CvtPkF16F32Inst)                                                           \
   X(CvtPkNormVOP2Insts)                                                        \
   X(CvtPkNormVOP3Insts)                                                        \
+  X(D16Writes32BitVgpr)                                                        \
   X(DefaultComponentBroadcast)                                                 \
   X(DefaultComponentZero)                                                      \
   X(DLInsts)                                                                   \
@@ -243,6 +245,7 @@
   X(TransposeLoadF4F6Insts)                                                    \
   X(TrapHandler)                                                               \
   X(TrigReducedRange)                                                          \
+  X(True16BitInsts)                                                            \
   X(UnalignedAccessMode)                                                       \
   X(UnalignedDSAccess)                                                         \
   X(UnpackedD16VMem)                                                           \
@@ -320,6 +323,7 @@ protected:
   bool EnableLoadStoreOpt = false;
   bool EnablePreciseMemory = false;
   bool EnablePRTStrictNull = false;
+  bool EnableRealTrue16Insts = false;
   bool EnableSIScheduler = false;
   // This should not be used directly. 'TargetID' tracks the dynamic settings
   // for SRAMECC.
@@ -1279,6 +1283,16 @@ public:
     return (getGeneration() <= AMDGPUSubtarget::GFX9 ||
             getGeneration() == AMDGPUSubtarget::GFX12) ||
            isWave32();
+  }
+
+  /// Return true if real (non-fake) variants of True16 instructions using
+  /// 16-bit registers should be code-generated. Fake True16 instructions are
+  /// identical to non-fake ones except that they take 32-bit registers as
+  /// operands and always use their low halves.
+  // TODO: Remove and use hasTrue16BitInsts() instead once True16 is fully
+  // supported and the support for fake True16 instructions is removed.
+  bool useRealTrue16Insts() const {
+    return hasTrue16BitInsts() && EnableRealTrue16Insts;
   }
 };
 


### PR DESCRIPTION
They are simply not used by `AMDGPUSubtarget &` but directly via `GCNSubtarget &`.