### PR TITLE
[HIP] Make `--no-offloadlib` not link HIP's RT

### DIFF
--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -847,7 +847,9 @@ void Linux::AddHIPIncludeArgs(const ArgList &DriverArgs,
 
 void Linux::addOffloadRTLibs(unsigned ActiveKinds, const ArgList &Args,
                              ArgStringList &CmdArgs) const {
-  if (Args.hasArg(options::OPT_nostdlib) ||
+  if (!Args.hasFlag(options::OPT_offloadlib, options::OPT_no_offloadlib,
+                    true) ||
+      Args.hasArg(options::OPT_nostdlib) ||
       Args.hasArg(options::OPT_no_hip_rt) || Args.hasArg(options::OPT_r))
     return;
 

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -518,7 +518,9 @@ void MSVCToolChain::addSYCLIncludeArgs(const ArgList &DriverArgs,
 
 void MSVCToolChain::addOffloadRTLibs(unsigned ActiveKinds, const ArgList &Args,
                                      ArgStringList &CmdArgs) const {
-  if (Args.hasArg(options::OPT_no_hip_rt) || Args.hasArg(options::OPT_r))
+  if (!Args.hasFlag(options::OPT_offloadlib, options::OPT_no_offloadlib,
+                    true) ||
+      Args.hasArg(options::OPT_no_hip_rt) || Args.hasArg(options::OPT_r))
     return;
 
   if (ActiveKinds & Action::OFK_HIP) {

--- a/clang/test/Driver/hip-runtime-libs-linux.hip
+++ b/clang/test/Driver/hip-runtime-libs-linux.hip
@@ -47,6 +47,9 @@
 // RUN: %clang -### --hip-link -no-hip-rt --target=x86_64-linux-gnu \
 // RUN:   --rocm-path=%S/Inputs/rocm %t.o 2>&1 \
 // RUN:   | FileCheck -check-prefixes=NOHIPRT %s
+// RUN: %clang -### --hip-link --no-offloadlib --target=x86_64-linux-gnu \
+// RUN:   --rocm-path=%S/Inputs/rocm %t.o 2>&1 \
+// RUN:   | FileCheck -check-prefixes=NOHIPRT %s
 
 // Test HIP runtime lib is not linked with -r.
 // RUN: %clang -### --hip-link -r --target=x86_64-linux-gnu \
@@ -54,8 +57,8 @@
 // RUN:   | FileCheck -check-prefixes=NOHIPRT %s
 
 // Test HIP runtime lib is linked without hip-link if there is HIP input file.
-// RUN: %clang -### --target=x86_64-linux-gnu -nogpuinc -nogpulib \
-// RUN:   --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN: %clang -### --target=x86_64-linux-gnu -nogpuinc \
+// RUN:   --offload-arch=gfx908 --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=ROCM-PATH %s
 
 // ROCM-PATH: "{{.*/Inputs/rocm/lib/libamdhip64.so}}" "-L[[HIPRT:.*/Inputs/rocm/lib]]"

--- a/clang/test/Driver/hip-runtime-libs-msvc.hip
+++ b/clang/test/Driver/hip-runtime-libs-msvc.hip
@@ -6,15 +6,15 @@
 // RUN:   | FileCheck %s
 
 // Test HIP runtime lib is linked without --hip-link when there is HIP input file.
-// RUN: %clang -### --target=x86_64-pc-windows-msvc -nogpuinc -nogpulib \
-// RUN:   --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN: %clang -### --target=x86_64-pc-windows-msvc -nogpuinc \
+// RUN:   --offload-arch=gfx908 --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck %s
 
 // Test HIP runtime lib is linked even if -nostdlib is specified when the input
 // is a HIP file. This is important when composing with e.g. the UCRT or other
 // non glibc-like implementations of the C standard library.
-// RUN: %clang -### --target=x86_64-pc-windows-msvc -nogpuinc -nogpulib \
-// RUN:   -nostdlib --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN: %clang -### --target=x86_64-pc-windows-msvc -nogpuinc \
+// RUN:   --offload-arch=gfx908 -nostdlib --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck %s
 
 // CHECK: "-libpath:{{.*Inputs.*rocm.*lib}}" "amdhip64.lib"


### PR DESCRIPTION
Summary:
Right now we have `--no-hip-rt` to suppress the implicit linking of the
HIP runtime. However, we already have a flag for `--no-offloadlib` which
seems to imply this. However, this one currently only applies to the
device-side library. More targets will likely use this soon, so it would
be nice to unify the behavior here.

The impact of this change is that `-nogpulib` which is commonly used to
suppress the ROCm device libraries will now also suppress this, and
`--no-hip-rt` will suppress the ROCm device libraries. This is a
functional change, but I'm not sure if anyone truly relies on this
distinction in the wild. Functionally, one turns off the host runtime,
the other the device. This PR makes both do both at the same time. Since
these are libraries we should be able to just get users to pass them
manually if needed.
