### PR TITLE
[RISCV] Set vm=0 on vadc/vsbc/vmerge. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
@@ -474,7 +474,9 @@ class VALUVV<bits<6> funct6, RISCVVFormat opv, string opcodestr>
 class VALUmVV<bits<6> funct6, RISCVVFormat opv, string opcodestr>
     : RVInstVV<funct6, opv, (outs VR:$vd),
                 (ins VR:$vs2, VR:$vs1, VMaskCarryInOp:$vm),
-                opcodestr, "$vd, $vs2, $vs1, $vm">;
+                opcodestr, "$vd, $vs2, $vs1, $vm"> {
+  let vm = 0;
+}
 
 // op vd, vs1, vs2, vm (reverse the order of vs1 and vs2)
 class VMACVV<bits<6> funct6, RISCVVFormat opv, string opcodestr,
@@ -504,7 +506,9 @@ class VALUVX<bits<6> funct6, RISCVVFormat opv, string opcodestr>
 class VALUmVX<bits<6> funct6, RISCVVFormat opv, string opcodestr>
     : RVInstVX<funct6, opv, (outs VR:$vd),
                 (ins VR:$vs2, GPR:$rs1, VMaskCarryInOp:$vm),
-                opcodestr, "$vd, $vs2, $rs1, $vm">;
+                opcodestr, "$vd, $vs2, $rs1, $vm"> {
+  let vm = 0;
+}
 
 // op vd, rs1, vs2, vm (reverse the order of rs1 and vs2)
 class VMACVX<bits<6> funct6, RISCVVFormat opv, string opcodestr,
@@ -534,7 +538,9 @@ class VALUVI<bits<6> funct6, string opcodestr, Operand optype = simm5>
 class VALUmVI<bits<6> funct6, string opcodestr, Operand optype = simm5>
     : RVInstIVI<funct6, (outs VR:$vd),
                 (ins VR:$vs2, optype:$imm, VMaskCarryInOp:$vm),
-                opcodestr, "$vd, $vs2, $imm, $vm">;
+                opcodestr, "$vd, $vs2, $imm, $vm"> {
+  let vm = 0;
+}
 
 // op vd, vs2, imm
 class VALUVINoVm<bits<6> funct6, string opcodestr, Operand optype = simm5>
@@ -1488,7 +1494,9 @@ let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
 def VFMERGE_VFM : RVInstVX<0b010111, OPFVF, (outs VR:$vd),
                            (ins VR:$vs2, FPR32:$rs1, VMaskCarryInOp:$vm),
                            "vfmerge.vfm", "$vd, $vs2, $rs1, $vm">,
-                  SchedBinaryMC<"WriteVFMergeV", "ReadVFMergeV", "ReadVFMergeF">;
+                  SchedBinaryMC<"WriteVFMergeV", "ReadVFMergeV", "ReadVFMergeF"> {
+  let vm = 0;
+}
 
 // Vector Floating-Point Move Instruction
 let RVVConstraint = NoConstraint in


### PR DESCRIPTION
The instructions have an explicit v0 operand that is always present so vm is always 0. We can mark it explicitly instead of relying on DecodeVMV0RegisterClass rejecting it.

This makes it easier to validate LLVM against the RISC-V unified-db.