### PR TITLE
[DTU] fix dominator tree update eliding reachable nodes

### DIFF
--- a/llvm/include/llvm/Support/GenericDomTreeConstruction.h
+++ b/llvm/include/llvm/Support/GenericDomTreeConstruction.h
@@ -1110,9 +1110,12 @@ struct SemiNCAInfo {
     SNCA.clear();
 
     // Identify nodes that remain in the affected subtree.
-    auto DescendBelow = [MinLevel, &DT](NodePtr, NodePtr To) {
+    auto DescendBelow = [MinLevel, &DT](NodePtr R, NodePtr To) {
       const TreeNodePtr ToTN = DT.getNode(To);
-      return ToTN && ToTN->getLevel() > MinLevel;
+      if (ToTN)
+        return ToTN->getLevel() > MinLevel;
+      DT.createNode(To, DT.getNode(R));
+      return true;
     };
     SNCA.runDFS(MinNode->getBlock(), 0, DescendBelow, 0);
 


### PR DESCRIPTION
The initial CFG looks like this:

![initial_graph.png](https://app.graphite.com/user-attachments/assets/1e3109c5-7c02-4c81-b9b3-fa6a25964e00.png)

After inlining, it looks like this:

![after_inlining.png](https://app.graphite.com/user-attachments/assets/10906dc6-1865-4125-8cd5-c2af69191858.png)

It should be sufficient to add and remove the edges shown in the test, i.e.:
- add: `bb3->bb1.i` and `bb3->bb2.i`
- remove: `bb3->bb4`, `bb3->bb5` and `bb5->bb8`

New nodes, like `bb5.body`, get discovered when adding bb3->bb2.i. See the "StepByStep" variant of the test). Without the fix in this patch, however, `bb5.body` gets elided when the deleted edges get taken into account, and `DT` is left invalid.