### PR TITLE
[DebugInfo][test] Remove irrelevant problematic lines.

### DIFF
--- a/llvm/test/DebugInfo/MIR/X86/no-cfi-loc.mir
+++ b/llvm/test/DebugInfo/MIR/X86/no-cfi-loc.mir
@@ -48,10 +48,6 @@ legalized:       false
 regBankSelected: false
 selected:        false
 tracksRegLiveness: true
-calleeSavedRegisters: [ '$bh', '$bl', '$bp', '$bpl', '$bx', '$ebp', '$ebx', 
-                        '$rbp', '$rbx', '$r12', '$r13', '$r14', '$r15', 
-                        '$r12b', '$r13b', '$r14b', '$r15b', '$r12d', '$r13d', 
-                        '$r14d', '$r15d', '$r12w', '$r13w', '$r14w', '$r15w' ]
 frameInfo:       
   isFrameAddressTaken: false
   isReturnAddressTaken: false


### PR DESCRIPTION
Previously the test declared that `bh` register is callee-saved, but `bh` register does not have a dwarf register number. This will cause problems for future work on `CFIInstrInserter`.