### PR TITLE
[SSAF] Add SerializationFormat interface

### DIFF
--- a/clang/include/clang/Analysis/Scalable/Serialization/SerializationFormat.h
+++ b/clang/include/clang/Analysis/Scalable/Serialization/SerializationFormat.h
@@ -1,0 +1,65 @@
+//===- SerializationFormat.h ------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Abstract SerializationFormat interface for reading and writing
+// TUSummary and LinkUnitResolution data.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_ANALYSIS_SCALABLE_SERIALIZATION_SERIALIZATION_FORMAT_H
+#define CLANG_ANALYSIS_SCALABLE_SERIALIZATION_SERIALIZATION_FORMAT_H
+
+#include "clang/Analysis/Scalable/Model/BuildNamespace.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+#include <string>
+#include <vector>
+
+namespace clang {
+namespace ssaf {
+
+class TUSummary;
+class EntityIdTable;
+class EntityName;
+class EntityId;
+class TUSummaryData;
+
+/// Abstract base class for serialization formats.
+class SerializationFormat {
+protected:
+  // Helpers providing access to implementation details of basic data structures
+  // for efficient serialization/deserialization.
+  static EntityIdTable &getIdTableForDeserialization(TUSummary &S);
+  static NestedBuildNamespace &
+  getCommonNamespaceForDeserialization(TUSummary &S);
+  static const EntityIdTable &getIdTable(const TUSummary &S);
+  static const NestedBuildNamespace &getCommonNamespace(const TUSummary &S);
+
+  static BuildNamespaceKind getBuildNamespaceKind(const BuildNamespace &BN);
+  static const std::string &getBuildNamespaceName(const BuildNamespace &BN);
+  static const std::vector<BuildNamespace> &
+  getNestedBuildNamespaces(const NestedBuildNamespace &NBN);
+
+  static const std::string &getEntityNameUSR(const EntityName &EN);
+  static const llvm::SmallString<16> &getEntityNameSuffix(const EntityName &EN);
+  static const NestedBuildNamespace &
+  getEntityNameNamespace(const EntityName &EN);
+
+public:
+  virtual ~SerializationFormat() = default;
+
+  virtual TUSummary readTUSummary(const std::string &Path) = 0;
+
+  virtual void writeTUSummary(const TUSummary &Summary,
+                              llvm::StringRef OutputDir) = 0;
+};
+
+} // namespace ssaf
+} // namespace clang
+
+#endif // CLANG_ANALYSIS_SCALABLE_SERIALIZATION_SERIALIZATION_FORMAT_H


### PR DESCRIPTION
We want to support multiple serialization formats. This is PR adds common interface of a serialization format.
Separately we will develop a serialization format registry similar to [TUSummaryExtractorRegistry](https://github.com/llvm/llvm-project/pull/173290) and implementation of a JSON-based serialization format.