### PR TITLE
[HLSL] Make  step, isinf, rsqrt overload tests stricter. NFC 

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/isinf-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/isinf-overloads.hlsl
@@ -1,20 +1,29 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm\
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \ 
+// RUN:   -DFNATTRS="hidden noundef" -DTARGET=dx
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden spir_func noundef" -DTARGET=spv
 
-// CHECK: define hidden noundef i1 @
-// CHECK: %hlsl.isinf = call i1 @llvm.dx.isinf.f32(
-// CHECK: ret i1 %hlsl.isinf
+// CHECK: define [[FNATTRS]] i1 @_Z17test_isinf_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[HLSLISINFI:%.*]] = call noundef i1 @llvm.[[TARGET]].isinf.f32(float [[CONVI]])
+// CHECK:    ret i1 [[HLSLISINFI]]
 bool test_isinf_double(double p0) { return isinf(p0); }
-// CHECK: define hidden noundef <2 x i1> @
-// CHECK: %hlsl.isinf = call <2 x i1> @llvm.dx.isinf.v2f32
-// CHECK: ret <2 x i1> %hlsl.isinf
+// CHECK: define [[FNATTRS]] <2 x i1> @_Z18test_isinf_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLISINFI:%.*]] = call noundef <2 x i1> @llvm.[[TARGET]].isinf.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x i1> [[HLSLISINFI]]
 bool2 test_isinf_double2(double2 p0) { return isinf(p0); }
-// CHECK: define hidden noundef <3 x i1> @
-// CHECK: %hlsl.isinf = call <3 x i1> @llvm.dx.isinf.v3f32
-// CHECK: ret <3 x i1> %hlsl.isinf
+// CHECK: define [[FNATTRS]] <3 x i1> @_Z18test_isinf_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLISINFI:%.*]] = call noundef <3 x i1> @llvm.[[TARGET]].isinf.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x i1> [[HLSLISINFI]]
 bool3 test_isinf_double3(double3 p0) { return isinf(p0); }
-// CHECK: define hidden noundef <4 x i1> @
-// CHECK: %hlsl.isinf = call <4 x i1> @llvm.dx.isinf.v4f32
-// CHECK: ret <4 x i1> %hlsl.isinf
+// CHECK: define [[FNATTRS]] <4 x i1> @_Z18test_isinf_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLISINFI:%.*]] = call noundef <4 x i1> @llvm.[[TARGET]].isinf.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x i1> [[HLSLISINFI]]
 bool4 test_isinf_double4(double4 p0) { return isinf(p0); }

--- a/clang/test/CodeGenHLSL/builtins/isinf-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/isinf-overloads.hlsl
@@ -1,29 +1,37 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm\
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \ 
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden noundef" -DTARGET=dx
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden spir_func noundef" -DTARGET=spv
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] i1 @_Z17test_isinf_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[HLSLISINFI:%.*]] = call noundef i1 @llvm.[[TARGET]].isinf.f32(float [[CONVI]])
 // CHECK:    ret i1 [[HLSLISINFI]]
+// expected-warning@+1 {{'isinf' is deprecated: In 202x 64 bit API lowering for fn is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 bool test_isinf_double(double p0) { return isinf(p0); }
 // CHECK: define [[FNATTRS]] <2 x i1> @_Z18test_isinf_double2Dv2_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLISINFI:%.*]] = call noundef <2 x i1> @llvm.[[TARGET]].isinf.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x i1> [[HLSLISINFI]]
+// expected-warning@+1 {{'isinf' is deprecated: In 202x 64 bit API lowering for fn is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 bool2 test_isinf_double2(double2 p0) { return isinf(p0); }
 // CHECK: define [[FNATTRS]] <3 x i1> @_Z18test_isinf_double3Dv3_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLISINFI:%.*]] = call noundef <3 x i1> @llvm.[[TARGET]].isinf.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x i1> [[HLSLISINFI]]
+// expected-warning@+1 {{'isinf' is deprecated: In 202x 64 bit API lowering for fn is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 bool3 test_isinf_double3(double3 p0) { return isinf(p0); }
 // CHECK: define [[FNATTRS]] <4 x i1> @_Z18test_isinf_double4Dv4_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLISINFI:%.*]] = call noundef <4 x i1> @llvm.[[TARGET]].isinf.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x i1> [[HLSLISINFI]]
+// expected-warning@+1 {{'isinf' is deprecated: In 202x 64 bit API lowering for fn is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 bool4 test_isinf_double4(double4 p0) { return isinf(p0); }

--- a/clang/test/CodeGenHLSL/builtins/rsqrt-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/rsqrt-overloads.hlsl
@@ -1,93 +1,113 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
 // RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)" -DTARGET=dx
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
 // RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" -DTARGET=spv
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].rsqrt.f32(
-// CHECK: ret float %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] float @_Z17test_rsqrt_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLRSQRTI]]
 float test_rsqrt_double(double p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].rsqrt.v2f32
-// CHECK: ret <2 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_rsqrt_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLRSQRTI]]
 float2 test_rsqrt_double2(double2 p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].rsqrt.v3f32
-// CHECK: ret <3 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_rsqrt_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLRSQRTI]]
 float3 test_rsqrt_double3(double3 p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].rsqrt.v4f32
-// CHECK: ret <4 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_rsqrt_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLRSQRTI]]
 float4 test_rsqrt_double4(double4 p0) { return rsqrt(p0); }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].rsqrt.f32(
-// CHECK: ret float %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] float @_Z14test_rsqrt_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLRSQRTI]]
 float test_rsqrt_int(int p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].rsqrt.v2f32
-// CHECK: ret <2 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_rsqrt_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLRSQRTI]]
 float2 test_rsqrt_int2(int2 p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].rsqrt.v3f32
-// CHECK: ret <3 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_rsqrt_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLRSQRTI]]
 float3 test_rsqrt_int3(int3 p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].rsqrt.v4f32
-// CHECK: ret <4 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_rsqrt_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLRSQRTI]]
 float4 test_rsqrt_int4(int4 p0) { return rsqrt(p0); }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].rsqrt.f32(
-// CHECK: ret float %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] float @_Z15test_rsqrt_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLRSQRTI]]
 float test_rsqrt_uint(uint p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].rsqrt.v2f32
-// CHECK: ret <2 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <2 x float> @_Z16test_rsqrt_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLRSQRTI]]
 float2 test_rsqrt_uint2(uint2 p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].rsqrt.v3f32
-// CHECK: ret <3 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <3 x float> @_Z16test_rsqrt_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLRSQRTI]]
 float3 test_rsqrt_uint3(uint3 p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].rsqrt.v4f32
-// CHECK: ret <4 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <4 x float> @_Z16test_rsqrt_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLRSQRTI]]
 float4 test_rsqrt_uint4(uint4 p0) { return rsqrt(p0); }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].rsqrt.f32(
-// CHECK: ret float %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] float @_Z18test_rsqrt_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLRSQRTI]]
 float test_rsqrt_int64_t(int64_t p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].rsqrt.v2f32
-// CHECK: ret <2 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_rsqrt_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLRSQRTI]]
 float2 test_rsqrt_int64_t2(int64_t2 p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].rsqrt.v3f32
-// CHECK: ret <3 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_rsqrt_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLRSQRTI]]
 float3 test_rsqrt_int64_t3(int64_t3 p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].rsqrt.v4f32
-// CHECK: ret <4 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_rsqrt_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLRSQRTI]]
 float4 test_rsqrt_int64_t4(int64_t4 p0) { return rsqrt(p0); }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].rsqrt.f32(
-// CHECK: ret float %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] float @_Z19test_rsqrt_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
+// CHECK:    ret float [[HLSLRSQRTI]]
 float test_rsqrt_uint64_t(uint64_t p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].rsqrt.v2f32
-// CHECK: ret <2 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <2 x float> @_Z20test_rsqrt_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[HLSLRSQRTI]]
 float2 test_rsqrt_uint64_t2(uint64_t2 p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].rsqrt.v3f32
-// CHECK: ret <3 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <3 x float> @_Z20test_rsqrt_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[HLSLRSQRTI]]
 float3 test_rsqrt_uint64_t3(uint64_t3 p0) { return rsqrt(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].rsqrt.v4f32
-// CHECK: ret <4 x float> %hlsl.rsqrt
+// CHECK: define [[FNATTRS]] <4 x float> @_Z20test_rsqrt_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[HLSLRSQRTI]]
 float4 test_rsqrt_uint64_t4(uint64_t4 p0) { return rsqrt(p0); }

--- a/clang/test/CodeGenHLSL/builtins/rsqrt-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/rsqrt-overloads.hlsl
@@ -1,113 +1,137 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)" -DTARGET=dx
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" -DTARGET=spv
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z17test_rsqrt_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x 64 bit API lowering for rsqrt is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float test_rsqrt_double(double p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_rsqrt_double2Dv2_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x 64 bit API lowering for rsqrt is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float2 test_rsqrt_double2(double2 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_rsqrt_double3Dv3_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x 64 bit API lowering for rsqrt is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float3 test_rsqrt_double3(double3 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_rsqrt_double4Dv4_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x 64 bit API lowering for rsqrt is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float4 test_rsqrt_double4(double4 p0) { return rsqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_rsqrt_inti(
 // CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_rsqrt_int(int p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_rsqrt_int2Dv2_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_rsqrt_int2(int2 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_rsqrt_int3Dv3_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_rsqrt_int3(int3 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_rsqrt_int4Dv4_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_rsqrt_int4(int4 p0) { return rsqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z15test_rsqrt_uintj(
 // CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_rsqrt_uint(uint p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z16test_rsqrt_uint2Dv2_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_rsqrt_uint2(uint2 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z16test_rsqrt_uint3Dv3_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_rsqrt_uint3(uint3 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z16test_rsqrt_uint4Dv4_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_rsqrt_uint4(uint4 p0) { return rsqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_rsqrt_int64_tl(
 // CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_rsqrt_int64_t(int64_t p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_rsqrt_int64_t2Dv2_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_rsqrt_int64_t2(int64_t2 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_rsqrt_int64_t3Dv3_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_rsqrt_int64_t3(int64_t3 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_rsqrt_int64_t4Dv4_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_rsqrt_int64_t4(int64_t4 p0) { return rsqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z19test_rsqrt_uint64_tm(
 // CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_rsqrt_uint64_t(uint64_t p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z20test_rsqrt_uint64_t2Dv2_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_rsqrt_uint64_t2(uint64_t2 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z20test_rsqrt_uint64_t3Dv3_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_rsqrt_uint64_t3(uint64_t3 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z20test_rsqrt_uint64_t4Dv4_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRSQRTI]]
+// expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_rsqrt_uint64_t4(uint64_t4 p0) { return rsqrt(p0); }

--- a/clang/test/CodeGenHLSL/builtins/step-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/step-overloads.hlsl
@@ -1,152 +1,192 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm -disable-llvm-passes \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
 // RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)" -DTARGET=dx
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
 // RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" -DTARGET=spv
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].step.f32(float
-// CHECK: ret float
+// CHECK: define [[FNATTRS]] float @_Z16test_step_doubledd(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} float @llvm.[[TARGET]].step.f32(float [[CONVI]], float [[CONV1I]])
+// CHECK:    ret float [[HLSLSTEPI]]
 float test_step_double(double p0, double p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].step.v2f32(
-// CHECK: ret <2 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_step_double2Dv2_dS_(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].step.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
+// CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_double2(double2 p0, double2 p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].step.v3f32(
-// CHECK: ret <3 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_step_double3Dv3_dS_(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].step.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
+// CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_double3(double3 p0, double3 p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].step.v4f32(
-// CHECK: ret <4 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_step_double4Dv4_dS_(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].step.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
+// CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_double4(double4 p0, double4 p1)
 {
     return step(p0, p1);
 }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].step.f32(float
-// CHECK: ret float
+// CHECK: define [[FNATTRS]] float @_Z13test_step_intii(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} float @llvm.[[TARGET]].step.f32(float [[CONVI]], float [[CONV1I]])
+// CHECK:    ret float [[HLSLSTEPI]]
 float test_step_int(int p0, int p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].step.v2f32(
-// CHECK: ret <2 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_step_int2Dv2_iS_(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].step.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
+// CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_int2(int2 p0, int2 p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].step.v3f32(
-// CHECK: ret <3 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_step_int3Dv3_iS_(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].step.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
+// CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_int3(int3 p0, int3 p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].step.v4f32(
-// CHECK: ret <4 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_step_int4Dv4_iS_(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].step.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
+// CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_int4(int4 p0, int4 p1)
 {
     return step(p0, p1);
 }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].step.f32(float
-// CHECK: ret float
+// CHECK: define [[FNATTRS]] float @_Z14test_step_uintjj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} float @llvm.[[TARGET]].step.f32(float [[CONVI]], float [[CONV1I]])
+// CHECK:    ret float [[HLSLSTEPI]]
 float test_step_uint(uint p0, uint p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].step.v2f32(
-// CHECK: ret <2 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_step_uint2Dv2_jS_(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].step.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
+// CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_uint2(uint2 p0, uint2 p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].step.v3f32(
-// CHECK: ret <3 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_step_uint3Dv3_jS_(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].step.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
+// CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_uint3(uint3 p0, uint3 p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].step.v4f32(
-// CHECK: ret <4 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_step_uint4Dv4_jS_(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].step.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
+// CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_uint4(uint4 p0, uint4 p1)
 {
     return step(p0, p1);
 }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].step.f32(float
-// CHECK: ret float
+// CHECK: define [[FNATTRS]] float @_Z17test_step_int64_tll(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} float @llvm.[[TARGET]].step.f32(float [[CONVI]], float [[CONV1I]])
+// CHECK:    ret float [[HLSLSTEPI]]
 float test_step_int64_t(int64_t p0, int64_t p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].step.v2f32(
-// CHECK: ret <2 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_step_int64_t2Dv2_lS_(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].step.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
+// CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_int64_t2(int64_t2 p0, int64_t2 p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].step.v3f32(
-// CHECK: ret <3 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_step_int64_t3Dv3_lS_(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].step.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
+// CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_int64_t3(int64_t3 p0, int64_t3 p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].step.v4f32(
-// CHECK: ret <4 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_step_int64_t4Dv4_lS_(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].step.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
+// CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_int64_t4(int64_t4 p0, int64_t4 p1)
 {
     return step(p0, p1);
 }
 
-// CHECK: define [[FNATTRS]] float @
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].step.f32(float
-// CHECK: ret float
+// CHECK: define [[FNATTRS]] float @_Z18test_step_uint64_tmm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} float @llvm.[[TARGET]].step.f32(float [[CONVI]], float [[CONV1I]])
+// CHECK:    ret float [[HLSLSTEPI]]
 float test_step_uint64_t(uint64_t p0, uint64_t p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <2 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].step.v2f32(
-// CHECK: ret <2 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_step_uint64_t2Dv2_mS_(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].step.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
+// CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_uint64_t2(uint64_t2 p0, uint64_t2 p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <3 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].step.v3f32(
-// CHECK: ret <3 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_step_uint64_t3Dv3_mS_(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].step.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
+// CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_uint64_t3(uint64_t3 p0, uint64_t3 p1)
 {
     return step(p0, p1);
 }
-// CHECK: define [[FNATTRS]] <4 x float> @
-// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].step.v4f32(
-// CHECK: ret <4 x float> %hlsl.step
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_step_uint64_t4Dv4_mS_(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].step.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
+// CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_uint64_t4(uint64_t4 p0, uint64_t4 p1)
 {
     return step(p0, p1);

--- a/clang/test/CodeGenHLSL/builtins/step-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/step-overloads.hlsl
@@ -1,11 +1,15 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)" -DTARGET=dx
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
 // RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" -DTARGET=spv
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z16test_step_doubledd(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
@@ -14,6 +18,7 @@
 // CHECK:    ret float [[HLSLSTEPI]]
 float test_step_double(double p0, double p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x 64 bit API lowering for step is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_step_double2Dv2_dS_(
@@ -23,6 +28,7 @@ float test_step_double(double p0, double p1)
 // CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_double2(double2 p0, double2 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x 64 bit API lowering for step is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_step_double3Dv3_dS_(
@@ -32,6 +38,7 @@ float2 test_step_double2(double2 p0, double2 p1)
 // CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_double3(double3 p0, double3 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x 64 bit API lowering for step is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_step_double4Dv4_dS_(
@@ -41,6 +48,7 @@ float3 test_step_double3(double3 p0, double3 p1)
 // CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_double4(double4 p0, double4 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x 64 bit API lowering for step is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
     return step(p0, p1);
 }
 
@@ -51,6 +59,7 @@ float4 test_step_double4(double4 p0, double4 p1)
 // CHECK:    ret float [[HLSLSTEPI]]
 float test_step_int(int p0, int p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_step_int2Dv2_iS_(
@@ -60,6 +69,7 @@ float test_step_int(int p0, int p1)
 // CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_int2(int2 p0, int2 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_step_int3Dv3_iS_(
@@ -69,6 +79,7 @@ float2 test_step_int2(int2 p0, int2 p1)
 // CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_int3(int3 p0, int3 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_step_int4Dv4_iS_(
@@ -78,6 +89,7 @@ float3 test_step_int3(int3 p0, int3 p1)
 // CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_int4(int4 p0, int4 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 
@@ -88,6 +100,7 @@ float4 test_step_int4(int4 p0, int4 p1)
 // CHECK:    ret float [[HLSLSTEPI]]
 float test_step_uint(uint p0, uint p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_step_uint2Dv2_jS_(
@@ -97,6 +110,7 @@ float test_step_uint(uint p0, uint p1)
 // CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_uint2(uint2 p0, uint2 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_step_uint3Dv3_jS_(
@@ -106,6 +120,7 @@ float2 test_step_uint2(uint2 p0, uint2 p1)
 // CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_uint3(uint3 p0, uint3 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_step_uint4Dv4_jS_(
@@ -115,6 +130,7 @@ float3 test_step_uint3(uint3 p0, uint3 p1)
 // CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_uint4(uint4 p0, uint4 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 
@@ -125,6 +141,7 @@ float4 test_step_uint4(uint4 p0, uint4 p1)
 // CHECK:    ret float [[HLSLSTEPI]]
 float test_step_int64_t(int64_t p0, int64_t p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_step_int64_t2Dv2_lS_(
@@ -134,6 +151,7 @@ float test_step_int64_t(int64_t p0, int64_t p1)
 // CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_int64_t2(int64_t2 p0, int64_t2 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_step_int64_t3Dv3_lS_(
@@ -143,6 +161,7 @@ float2 test_step_int64_t2(int64_t2 p0, int64_t2 p1)
 // CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_int64_t3(int64_t3 p0, int64_t3 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_step_int64_t4Dv4_lS_(
@@ -152,6 +171,7 @@ float3 test_step_int64_t3(int64_t3 p0, int64_t3 p1)
 // CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_int64_t4(int64_t4 p0, int64_t4 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 
@@ -162,6 +182,7 @@ float4 test_step_int64_t4(int64_t4 p0, int64_t4 p1)
 // CHECK:    ret float [[HLSLSTEPI]]
 float test_step_uint64_t(uint64_t p0, uint64_t p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_step_uint64_t2Dv2_mS_(
@@ -171,6 +192,7 @@ float test_step_uint64_t(uint64_t p0, uint64_t p1)
 // CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_uint64_t2(uint64_t2 p0, uint64_t2 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_step_uint64_t3Dv3_mS_(
@@ -180,6 +202,7 @@ float2 test_step_uint64_t2(uint64_t2 p0, uint64_t2 p1)
 // CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_uint64_t3(uint64_t3 p0, uint64_t3 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_step_uint64_t4Dv4_mS_(
@@ -189,5 +212,6 @@ float3 test_step_uint64_t3(uint64_t3 p0, uint64_t3 p1)
 // CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_uint64_t4(uint64_t4 p0, uint64_t4 p1)
 {
+// expected-warning@+1 {{'step' is deprecated: In 202x int lowering for step is deprecated. Explicitly cast parameters to float types.}}
     return step(p0, p1);
 }


### PR DESCRIPTION
This patch changes the run lines for step, isinf, rsqrt overload test to use -O1 instead of -disable-llvm-passes and rewrite the tests to actually look at the whole function.

This work is part of https://github.com/llvm/llvm-project/issues/138016.