### PR TITLE
[HLSL] Make log2, tan overload tests stricter. NFC 

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/log2-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log2-overloads.hlsl
@@ -1,108 +1,131 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)" 
+/// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z16test_log2_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x 64 bit API lowering for log2 is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float test_log2_double(double p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_log2_double2Dv2_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x 64 bit API lowering for log2 is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float2 test_log2_double2(double2 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_log2_double3Dv3_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x 64 bit API lowering for log2 is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float3 test_log2_double3(double3 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_log2_double4Dv4_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x 64 bit API lowering for log2 is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float4 test_log2_double4(double4 p0) { return log2(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_log2_inti(
 // CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float test_log2_int(int p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_log2_int2Dv2_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log2_int2(int2 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_log2_int3Dv3_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log2_int3(int3 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_log2_int4Dv4_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log2_int4(int4 p0) { return log2(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_log2_uintj(
 // CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float test_log2_uint(uint p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_log2_uint2Dv2_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log2_uint2(uint2 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_log2_uint3Dv3_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log2_uint3(uint3 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_log2_uint4Dv4_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log2_uint4(uint4 p0) { return log2(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_log2_int64_tl(
 // CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float test_log2_int64_t(int64_t p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_log2_int64_t2Dv2_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log2_int64_t2(int64_t2 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_log2_int64_t3Dv3_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log2_int64_t3(int64_t3 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_log2_int64_t4Dv4_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log2_int64_t4(int64_t4 p0) { return log2(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_log2_uint64_tm(
 // CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float test_log2_uint64_t(uint64_t p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_log2_uint64_t2Dv2_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log2_uint64_t2(uint64_t2 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_log2_uint64_t3Dv3_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log2_uint64_t3(uint64_t3 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_log2_uint64_t4Dv4_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log2_uint64_t4(uint64_t4 p0) { return log2(p0); }

--- a/clang/test/CodeGenHLSL/builtins/log2-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log2-overloads.hlsl
@@ -1,68 +1,108 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -disable-llvm-passes -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK
+// RUN:  -emit-llvm -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)" 
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_log2_double
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log2.f32(
+// CHECK: define [[FNATTRS]] float @_Z16test_log2_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_log2_double(double p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_log2_double2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log2.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_log2_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_log2_double2(double2 p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_log2_double3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log2.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_log2_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_log2_double3(double3 p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_log2_double4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log2.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_log2_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_log2_double4(double4 p0) { return log2(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_log2_int
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log2.f32(
+// CHECK: define [[FNATTRS]] float @_Z13test_log2_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_log2_int(int p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_log2_int2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log2.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_log2_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_log2_int2(int2 p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_log2_int3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log2.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_log2_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_log2_int3(int3 p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_log2_int4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log2.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_log2_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_log2_int4(int4 p0) { return log2(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_log2_uint
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log2.f32(
+// CHECK: define [[FNATTRS]] float @_Z14test_log2_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_log2_uint(uint p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_log2_uint2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log2.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_log2_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_log2_uint2(uint2 p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_log2_uint3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log2.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_log2_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_log2_uint3(uint3 p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_log2_uint4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log2.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_log2_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_log2_uint4(uint4 p0) { return log2(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_log2_int64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log2.f32(
+// CHECK: define [[FNATTRS]] float @_Z17test_log2_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_log2_int64_t(int64_t p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_log2_int64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log2.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_log2_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_log2_int64_t2(int64_t2 p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_log2_int64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log2.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_log2_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_log2_int64_t3(int64_t3 p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_log2_int64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log2.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_log2_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_log2_int64_t4(int64_t4 p0) { return log2(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_log2_uint64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log2.f32(
+// CHECK: define [[FNATTRS]] float @_Z18test_log2_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_log2_uint64_t(uint64_t p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_log2_uint64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log2.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_log2_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_log2_uint64_t2(uint64_t2 p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_log2_uint64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log2.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_log2_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_log2_uint64_t3(uint64_t3 p0) { return log2(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_log2_uint64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log2.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_log2_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_log2_uint64_t4(uint64_t4 p0) { return log2(p0); }

--- a/clang/test/CodeGenHLSL/builtins/tan-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/tan-overloads.hlsl
@@ -1,123 +1,163 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm  \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" 
 
-// CHECK-LABEL: test_tan_double
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.tan.f32
+// CHECK: define [[FNATTRS]] float @_Z15test_tan_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_tan_double ( double p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_double2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.tan.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z16test_tan_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_double2 ( double2 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_double3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.tan.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z16test_tan_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_double3 ( double3 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_double4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.tan.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z16test_tan_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_double4 ( double4 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_int
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.tan.f32
+// CHECK: define [[FNATTRS]] float @_Z12test_tan_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_tan_int ( int p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_int2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.tan.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z13test_tan_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_int2 ( int2 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_int3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.tan.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z13test_tan_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_int3 ( int3 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_int4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.tan.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z13test_tan_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_int4 ( int4 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_uint
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.tan.f32
+// CHECK: define [[FNATTRS]] float @_Z13test_tan_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_tan_uint ( uint p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_uint2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.tan.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_tan_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_uint2 ( uint2 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_uint3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.tan.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_tan_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_uint3 ( uint3 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_uint4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.tan.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_tan_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_uint4 ( uint4 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_int64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.tan.f32
+// CHECK: define [[FNATTRS]] float @_Z16test_tan_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_tan_int64_t ( int64_t p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_int64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.tan.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_tan_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_int64_t2 ( int64_t2 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_int64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.tan.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_tan_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_int64_t3 ( int64_t3 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_int64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.tan.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_tan_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_int64_t4 ( int64_t4 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_uint64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.tan.f32
+// CHECK: define [[FNATTRS]] float @_Z17test_tan_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_tan_uint64_t ( uint64_t p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_uint64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.tan.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_tan_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_uint64_t2 ( uint64_t2 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_uint64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.tan.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_tan_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_uint64_t3 ( uint64_t3 p0 ) {
   return tan ( p0 );
 }
 
-// CHECK-LABEL: test_tan_uint64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.tan.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_tan_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_uint64_t4 ( uint64_t4 p0 ) {
   return tan ( p0 );
 }

--- a/clang/test/CodeGenHLSL/builtins/tan-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/tan-overloads.hlsl
@@ -1,12 +1,16 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm  \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)" 
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z15test_tan_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tan_double ( double p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x 64 bit API lowering for tan is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return tan ( p0 );
 }
 
@@ -15,6 +19,7 @@ float test_tan_double ( double p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_double2 ( double2 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x 64 bit API lowering for tan is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return tan ( p0 );
 }
 
@@ -23,6 +28,7 @@ float2 test_tan_double2 ( double2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_double3 ( double3 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x 64 bit API lowering for tan is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return tan ( p0 );
 }
 
@@ -31,6 +37,7 @@ float3 test_tan_double3 ( double3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_double4 ( double4 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x 64 bit API lowering for tan is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return tan ( p0 );
 }
 
@@ -39,6 +46,7 @@ float4 test_tan_double4 ( double4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tan_int ( int p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -47,6 +55,7 @@ float test_tan_int ( int p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_int2 ( int2 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -55,6 +64,7 @@ float2 test_tan_int2 ( int2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_int3 ( int3 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -63,6 +73,7 @@ float3 test_tan_int3 ( int3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_int4 ( int4 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -71,6 +82,7 @@ float4 test_tan_int4 ( int4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tan_uint ( uint p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -79,6 +91,7 @@ float test_tan_uint ( uint p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_uint2 ( uint2 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -87,6 +100,7 @@ float2 test_tan_uint2 ( uint2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_uint3 ( uint3 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -95,6 +109,7 @@ float3 test_tan_uint3 ( uint3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_uint4 ( uint4 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -103,6 +118,7 @@ float4 test_tan_uint4 ( uint4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tan_int64_t ( int64_t p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -111,6 +127,7 @@ float test_tan_int64_t ( int64_t p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_int64_t2 ( int64_t2 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -119,6 +136,7 @@ float2 test_tan_int64_t2 ( int64_t2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_int64_t3 ( int64_t3 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -127,6 +145,7 @@ float3 test_tan_int64_t3 ( int64_t3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_int64_t4 ( int64_t4 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -135,6 +154,7 @@ float4 test_tan_int64_t4 ( int64_t4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tan_uint64_t ( uint64_t p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -143,6 +163,7 @@ float test_tan_uint64_t ( uint64_t p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_uint64_t2 ( uint64_t2 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -151,6 +172,7 @@ float2 test_tan_uint64_t2 ( uint64_t2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_uint64_t3 ( uint64_t3 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }
 
@@ -159,5 +181,6 @@ float3 test_tan_uint64_t3 ( uint64_t3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_uint64_t4 ( uint64_t4 p0 ) {
+// expected-warning@+1 {{'tan' is deprecated: In 202x int lowering for tan is deprecated. Explicitly cast parameters to float types.}}
   return tan ( p0 );
 }


### PR DESCRIPTION
This patch changes the run lines for log2, tan overload test to use -O1 instead of -disable-llvm-passes and rewrite the tests to actually look at the whole function.

This work is part of https://github.com/llvm/llvm-project/issues/138016.