### PR TITLE
[HLSL] Make atan, sin, sqrt overload tests stricter. NFC

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/atan-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/atan-overloads.hlsl
@@ -1,123 +1,163 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
-// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm -disable-llvm-passes \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK
+// RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
+// RUN:   -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
 
-// CHECK-LABEL: test_atan_double
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.atan.f32
+// CHECK: define [[FNATTRS]] float @_Z16test_atan_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_atan_double ( double p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_double2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.atan.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_atan_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_double2 ( double2 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_double3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.atan.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_atan_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_double3 ( double3 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_double4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.atan.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_atan_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_double4 ( double4 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_int
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.atan.f32
+// CHECK: define [[FNATTRS]] float @_Z13test_atan_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_atan_int ( int p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_int2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.atan.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_atan_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_int2 ( int2 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_int3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.atan.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_atan_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_int3 ( int3 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_int4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.atan.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_atan_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_int4 ( int4 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_uint
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.atan.f32
+// CHECK: define [[FNATTRS]] float @_Z14test_atan_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_atan_uint ( uint p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_uint2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.atan.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_atan_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_uint2 ( uint2 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_uint3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.atan.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_atan_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_uint3 ( uint3 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_uint4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.atan.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_atan_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_uint4 ( uint4 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_int64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.atan.f32
+// CHECK: define [[FNATTRS]] float @_Z17test_atan_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_atan_int64_t ( int64_t p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_int64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.atan.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_atan_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_int64_t2 ( int64_t2 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_int64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.atan.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_atan_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_int64_t3 ( int64_t3 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_int64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.atan.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_atan_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_int64_t4 ( int64_t4 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_uint64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.atan.f32
+// CHECK: define [[FNATTRS]] float @_Z18test_atan_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
+// CHECK:    ret float [[V3]]
 float test_atan_uint64_t ( uint64_t p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_uint64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.atan.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_atan_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_uint64_t2 ( uint64_t2 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_uint64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.atan.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_atan_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_uint64_t3 ( uint64_t3 p0 ) {
   return atan ( p0 );
 }
 
-// CHECK-LABEL: test_atan_uint64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.atan.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_atan_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_uint64_t4 ( uint64_t4 p0 ) {
   return atan ( p0 );
 }

--- a/clang/test/CodeGenHLSL/builtins/atan-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/atan-overloads.hlsl
@@ -1,12 +1,16 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
 // RUN:   spirv-unknown-vulkan-compute %s -emit-llvm \
-// RUN:   -o - | FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden spir_func noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple spirv-unknown-vulkan-compute %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z16test_atan_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_atan_double ( double p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x 64 bit API lowering for atan is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return atan ( p0 );
 }
 
@@ -15,6 +19,7 @@ float test_atan_double ( double p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_double2 ( double2 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x 64 bit API lowering for atan is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return atan ( p0 );
 }
 
@@ -23,6 +28,7 @@ float2 test_atan_double2 ( double2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_double3 ( double3 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x 64 bit API lowering for atan is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return atan ( p0 );
 }
 
@@ -31,6 +37,7 @@ float3 test_atan_double3 ( double3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_double4 ( double4 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x 64 bit API lowering for atan is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
   return atan ( p0 );
 }
 
@@ -39,6 +46,7 @@ float4 test_atan_double4 ( double4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_atan_int ( int p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -47,6 +55,7 @@ float test_atan_int ( int p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_int2 ( int2 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -55,6 +64,7 @@ float2 test_atan_int2 ( int2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_int3 ( int3 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -63,6 +73,7 @@ float3 test_atan_int3 ( int3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_int4 ( int4 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -71,6 +82,7 @@ float4 test_atan_int4 ( int4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_atan_uint ( uint p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -79,6 +91,7 @@ float test_atan_uint ( uint p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_uint2 ( uint2 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -87,6 +100,7 @@ float2 test_atan_uint2 ( uint2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_uint3 ( uint3 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -95,6 +109,7 @@ float3 test_atan_uint3 ( uint3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_uint4 ( uint4 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -103,6 +118,7 @@ float4 test_atan_uint4 ( uint4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_atan_int64_t ( int64_t p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -111,6 +127,7 @@ float test_atan_int64_t ( int64_t p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_int64_t2 ( int64_t2 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -119,6 +136,7 @@ float2 test_atan_int64_t2 ( int64_t2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_int64_t3 ( int64_t3 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -127,6 +145,7 @@ float3 test_atan_int64_t3 ( int64_t3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_int64_t4 ( int64_t4 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -135,6 +154,7 @@ float4 test_atan_int64_t4 ( int64_t4 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_atan_uint64_t ( uint64_t p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -143,6 +163,7 @@ float test_atan_uint64_t ( uint64_t p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_uint64_t2 ( uint64_t2 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -151,6 +172,7 @@ float2 test_atan_uint64_t2 ( uint64_t2 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_uint64_t3 ( uint64_t3 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }
 
@@ -159,5 +181,6 @@ float3 test_atan_uint64_t3 ( uint64_t3 p0 ) {
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_uint64_t4 ( uint64_t4 p0 ) {
+// expected-warning@+1 {{'atan' is deprecated: In 202x int lowering for atan is deprecated. Explicitly cast parameters to float types.}}
   return atan ( p0 );
 }

--- a/clang/test/CodeGenHLSL/builtins/round-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/round-overloads.hlsl
@@ -1,88 +1,92 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -disable-llvm-passes -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK
+// RUN:  -emit-llvm -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)"
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_double
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
-// CHECK: ret float [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] float @_Z17test_round_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.roundeven.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_round_double(double p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_double2
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
-// CHECK: ret <2 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_round_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.roundeven.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_round_double2(double2 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_double3
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
-// CHECK: ret <3 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_round_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.roundeven.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_round_double3(double3 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_double4
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
-// CHECK: ret <4 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_round_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.roundeven.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_round_double4(double4 p0) { return round(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_int
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
-// CHECK: ret float [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] float @_Z14test_round_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
 float test_round_int(int p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_int2
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
-// CHECK: ret <2 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_round_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
 float2 test_round_int2(int2 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_int3
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
-// CHECK: ret <3 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_round_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
 float3 test_round_int3(int3 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_int4
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
-// CHECK: ret <4 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_round_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
 float4 test_round_int4(int4 p0) { return round(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_uint
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
-// CHECK: ret float [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] float @_Z15test_round_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
 float test_round_uint(uint p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_uint2
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
-// CHECK: ret <2 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z16test_round_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
 float2 test_round_uint2(uint2 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_uint3
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
-// CHECK: ret <3 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z16test_round_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
 float3 test_round_uint3(uint3 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_uint4
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
-// CHECK: ret <4 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z16test_round_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
 float4 test_round_uint4(uint4 p0) { return round(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_int64_t
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
-// CHECK: ret float [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] float @_Z18test_round_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
 float test_round_int64_t(int64_t p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_int64_t2
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
-// CHECK: ret <2 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_round_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
 float2 test_round_int64_t2(int64_t2 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_int64_t3
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
-// CHECK: ret <3 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_round_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
 float3 test_round_int64_t3(int64_t3 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_int64_t4
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
-// CHECK: ret <4 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_round_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
 float4 test_round_int64_t4(int64_t4 p0) { return round(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_uint64_t
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
-// CHECK: ret float [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] float @_Z19test_round_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    ret float [[CONVI]]
 float test_round_uint64_t(uint64_t p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_uint64_t2
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
-// CHECK: ret <2 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <2 x float> @_Z20test_round_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    ret <2 x float> [[CONVI]]
 float2 test_round_uint64_t2(uint64_t2 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_uint64_t3
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
-// CHECK: ret <3 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <3 x float> @_Z20test_round_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    ret <3 x float> [[CONVI]]
 float3 test_round_uint64_t3(uint64_t3 p0) { return round(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_uint64_t4
-// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
-// CHECK: ret <4 x float> [[ROUNDEVEN]]
+// CHECK: define [[FNATTRS]] <4 x float> @_Z20test_round_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    ret <4 x float> [[CONVI]]
 float4 test_round_uint64_t4(uint64_t4 p0) { return round(p0); }

--- a/clang/test/CodeGenHLSL/builtins/round-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/round-overloads.hlsl
@@ -1,92 +1,88 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN:  -emit-llvm -disable-llvm-passes -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK
 
-// CHECK: define [[FNATTRS]] float @_Z17test_round_doubled(
-// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
-// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.roundeven.f32(float [[CONVI]])
-// CHECK:    ret float [[V2]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_double
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
+// CHECK: ret float [[ROUNDEVEN]]
 float test_round_double(double p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_round_double2Dv2_d(
-// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
-// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.roundeven.v2f32(<2 x float> [[CONVI]])
-// CHECK:    ret <2 x float> [[V2]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_double2
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
+// CHECK: ret <2 x float> [[ROUNDEVEN]]
 float2 test_round_double2(double2 p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_round_double3Dv3_d(
-// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
-// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.roundeven.v3f32(<3 x float> [[CONVI]])
-// CHECK:    ret <3 x float> [[V2]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_double3
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
+// CHECK: ret <3 x float> [[ROUNDEVEN]]
 float3 test_round_double3(double3 p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_round_double4Dv4_d(
-// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
-// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.roundeven.v4f32(<4 x float> [[CONVI]])
-// CHECK:    ret <4 x float> [[V2]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_double4
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
+// CHECK: ret <4 x float> [[ROUNDEVEN]]
 float4 test_round_double4(double4 p0) { return round(p0); }
 
-// CHECK: define [[FNATTRS]] float @_Z14test_round_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
-// CHECK:    ret float [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_int
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
+// CHECK: ret float [[ROUNDEVEN]]
 float test_round_int(int p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_round_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
-// CHECK:    ret <2 x float> [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_int2
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
+// CHECK: ret <2 x float> [[ROUNDEVEN]]
 float2 test_round_int2(int2 p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_round_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
-// CHECK:    ret <3 x float> [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_int3
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
+// CHECK: ret <3 x float> [[ROUNDEVEN]]
 float3 test_round_int3(int3 p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_round_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
-// CHECK:    ret <4 x float> [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_int4
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
+// CHECK: ret <4 x float> [[ROUNDEVEN]]
 float4 test_round_int4(int4 p0) { return round(p0); }
 
-// CHECK: define [[FNATTRS]] float @_Z15test_round_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
-// CHECK:    ret float [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_uint
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
+// CHECK: ret float [[ROUNDEVEN]]
 float test_round_uint(uint p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @_Z16test_round_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
-// CHECK:    ret <2 x float> [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_uint2
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
+// CHECK: ret <2 x float> [[ROUNDEVEN]]
 float2 test_round_uint2(uint2 p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @_Z16test_round_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
-// CHECK:    ret <3 x float> [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_uint3
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
+// CHECK: ret <3 x float> [[ROUNDEVEN]]
 float3 test_round_uint3(uint3 p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @_Z16test_round_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
-// CHECK:    ret <4 x float> [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_uint4
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
+// CHECK: ret <4 x float> [[ROUNDEVEN]]
 float4 test_round_uint4(uint4 p0) { return round(p0); }
 
-// CHECK: define [[FNATTRS]] float @_Z18test_round_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
-// CHECK:    ret float [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_int64_t
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
+// CHECK: ret float [[ROUNDEVEN]]
 float test_round_int64_t(int64_t p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_round_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
-// CHECK:    ret <2 x float> [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_int64_t2
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
+// CHECK: ret <2 x float> [[ROUNDEVEN]]
 float2 test_round_int64_t2(int64_t2 p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_round_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
-// CHECK:    ret <3 x float> [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_int64_t3
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
+// CHECK: ret <3 x float> [[ROUNDEVEN]]
 float3 test_round_int64_t3(int64_t3 p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_round_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
-// CHECK:    ret <4 x float> [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_int64_t4
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
+// CHECK: ret <4 x float> [[ROUNDEVEN]]
 float4 test_round_int64_t4(int64_t4 p0) { return round(p0); }
 
-// CHECK: define [[FNATTRS]] float @_Z19test_round_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
-// CHECK:    ret float [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_round_uint64_t
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
+// CHECK: ret float [[ROUNDEVEN]]
 float test_round_uint64_t(uint64_t p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <2 x float> @_Z20test_round_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
-// CHECK:    ret <2 x float> [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_uint64_t2
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
+// CHECK: ret <2 x float> [[ROUNDEVEN]]
 float2 test_round_uint64_t2(uint64_t2 p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <3 x float> @_Z20test_round_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
-// CHECK:    ret <3 x float> [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_uint64_t3
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
+// CHECK: ret <3 x float> [[ROUNDEVEN]]
 float3 test_round_uint64_t3(uint64_t3 p0) { return round(p0); }
-// CHECK: define [[FNATTRS]] <4 x float> @_Z20test_round_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
-// CHECK:    ret <4 x float> [[CONVI]]
+// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_uint64_t4
+// CHECK: [[ROUNDEVEN:%.*]] = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
+// CHECK: ret <4 x float> [[ROUNDEVEN]]
 float4 test_round_uint64_t4(uint64_t4 p0) { return round(p0); }

--- a/clang/test/CodeGenHLSL/builtins/sin-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sin-overloads.hlsl
@@ -1,68 +1,108 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -disable-llvm-passes -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK
+// RUN:  -emit-llvm -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)"
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_sin_double
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.sin.f32(
+// CHECK: define [[FNATTRS]] float @_Z15test_sin_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_sin_double(double p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_sin_double2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sin.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z16test_sin_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_sin_double2(double2 p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_sin_double3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sin.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z16test_sin_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_sin_double3(double3 p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_sin_double4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sin.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z16test_sin_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_sin_double4(double4 p0) { return sin(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_sin_int
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.sin.f32(
+// CHECK: define [[FNATTRS]] float @_Z12test_sin_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_sin_int(int p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_sin_int2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sin.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z13test_sin_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_sin_int2(int2 p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_sin_int3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sin.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z13test_sin_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_sin_int3(int3 p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_sin_int4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sin.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z13test_sin_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_sin_int4(int4 p0) { return sin(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_sin_uint
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.sin.f32(
+// CHECK: define [[FNATTRS]] float @_Z13test_sin_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_sin_uint(uint p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_sin_uint2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sin.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_sin_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_sin_uint2(uint2 p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_sin_uint3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sin.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_sin_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_sin_uint3(uint3 p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_sin_uint4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sin.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_sin_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_sin_uint4(uint4 p0) { return sin(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_sin_int64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.sin.f32(
+// CHECK: define [[FNATTRS]] float @_Z16test_sin_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_sin_int64_t(int64_t p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_sin_int64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sin.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_sin_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_sin_int64_t2(int64_t2 p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_sin_int64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sin.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_sin_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_sin_int64_t3(int64_t3 p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_sin_int64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sin.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_sin_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_sin_int64_t4(int64_t4 p0) { return sin(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_sin_uint64_t
-// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.sin.f32(
+// CHECK: define [[FNATTRS]] float @_Z17test_sin_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_sin_uint64_t(uint64_t p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_sin_uint64_t2
-// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sin.v2f32
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_sin_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_sin_uint64_t2(uint64_t2 p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_sin_uint64_t3
-// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sin.v3f32
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_sin_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_sin_uint64_t3(uint64_t3 p0) { return sin(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_sin_uint64_t4
-// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sin.v4f32
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_sin_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_sin_uint64_t4(uint64_t4 p0) { return sin(p0); }

--- a/clang/test/CodeGenHLSL/builtins/sin-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sin-overloads.hlsl
@@ -1,108 +1,131 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z15test_sin_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x 64 bit API lowering for sin is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float test_sin_double(double p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z16test_sin_double2Dv2_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x 64 bit API lowering for sin is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float2 test_sin_double2(double2 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z16test_sin_double3Dv3_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x 64 bit API lowering for sin is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float3 test_sin_double3(double3 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z16test_sin_double4Dv4_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x 64 bit API lowering for sin is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float4 test_sin_double4(double4 p0) { return sin(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z12test_sin_inti(
 // CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float test_sin_int(int p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z13test_sin_int2Dv2_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sin_int2(int2 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z13test_sin_int3Dv3_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sin_int3(int3 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z13test_sin_int4Dv4_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sin_int4(int4 p0) { return sin(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_sin_uintj(
 // CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float test_sin_uint(uint p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_sin_uint2Dv2_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sin_uint2(uint2 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_sin_uint3Dv3_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sin_uint3(uint3 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_sin_uint4Dv4_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sin_uint4(uint4 p0) { return sin(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z16test_sin_int64_tl(
 // CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float test_sin_int64_t(int64_t p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_sin_int64_t2Dv2_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sin_int64_t2(int64_t2 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_sin_int64_t3Dv3_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sin_int64_t3(int64_t3 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_sin_int64_t4Dv4_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sin_int64_t4(int64_t4 p0) { return sin(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_sin_uint64_tm(
 // CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float test_sin_uint64_t(uint64_t p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_sin_uint64_t2Dv2_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sin_uint64_t2(uint64_t2 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_sin_uint64_t3Dv3_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sin_uint64_t3(uint64_t3 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_sin_uint64_t4Dv4_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sin_uint64_t4(uint64_t4 p0) { return sin(p0); }

--- a/clang/test/CodeGenHLSL/builtins/sqrt-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sqrt-overloads.hlsl
@@ -1,108 +1,131 @@
-// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -emit-llvm \
+// RUN:   -Wdeprecated-declarations -Wconversion -o - | FileCheck %s --check-prefixes=CHECK \
+// RUN:   -DFNATTRS="hidden noundef nofpclass(nan inf)"
+// RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -verify -verify-ignore-unexpected=note
 
 // CHECK: define [[FNATTRS]] float @_Z16test_sqrt_doubled(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x 64 bit API lowering for sqrt is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float test_sqrt_double(double p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_sqrt_double2Dv2_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x 64 bit API lowering for sqrt is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float2 test_sqrt_double2(double2 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_sqrt_double3Dv3_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x 64 bit API lowering for sqrt is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float3 test_sqrt_double3(double3 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_sqrt_double4Dv4_d(
 // CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x 64 bit API lowering for sqrt is deprecated. Explicitly cast parameters to 32 or 16 bit types.}}
 float4 test_sqrt_double4(double4 p0) { return sqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_sqrt_inti(
 // CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_sqrt_int(int p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_sqrt_int2Dv2_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sqrt_int2(int2 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_sqrt_int3Dv3_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sqrt_int3(int3 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_sqrt_int4Dv4_i(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sqrt_int4(int4 p0) { return sqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_sqrt_uintj(
 // CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_sqrt_uint(uint p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_sqrt_uint2Dv2_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sqrt_uint2(uint2 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_sqrt_uint3Dv3_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sqrt_uint3(uint3 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_sqrt_uint4Dv4_j(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sqrt_uint4(uint4 p0) { return sqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_sqrt_int64_tl(
 // CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_sqrt_int64_t(int64_t p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_sqrt_int64_t2Dv2_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sqrt_int64_t2(int64_t2 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_sqrt_int64_t3Dv3_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sqrt_int64_t3(int64_t3 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_sqrt_int64_t4Dv4_l(
 // CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sqrt_int64_t4(int64_t4 p0) { return sqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_sqrt_uint64_tm(
 // CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_sqrt_uint64_t(uint64_t p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_sqrt_uint64_t2Dv2_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sqrt_uint64_t2(uint64_t2 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_sqrt_uint64_t3Dv3_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sqrt_uint64_t3(uint64_t3 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_sqrt_uint64_t4Dv4_m(
 // CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
+// expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sqrt_uint64_t4(uint64_t4 p0) { return sqrt(p0); }

--- a/clang/test/CodeGenHLSL/builtins/sqrt-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sqrt-overloads.hlsl
@@ -1,88 +1,108 @@
 // RUN: %clang_cc1 -std=hlsl202x -finclude-default-header -triple dxil-pc-shadermodel6.3-library %s \
-// RUN:  -emit-llvm -disable-llvm-passes -o - | \
-// RUN:  FileCheck %s --check-prefixes=CHECK
+// RUN:  -emit-llvm -o - | \
+// RUN:  FileCheck %s --check-prefixes=CHECK -DFNATTRS="hidden noundef nofpclass(nan inf)"
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_sqrt_double
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn float @llvm.sqrt.f32(
-// CHECK: ret float %{{.*}}
+// CHECK: define [[FNATTRS]] float @_Z16test_sqrt_doubled(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} double %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_sqrt_double(double p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_sqrt_double2
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sqrt.v2f32
-// CHECK: ret <2 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <2 x float> @_Z17test_sqrt_double2Dv2_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <2 x double> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_sqrt_double2(double2 p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_sqrt_double3
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sqrt.v3f32
-// CHECK: ret <3 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <3 x float> @_Z17test_sqrt_double3Dv3_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <3 x double> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_sqrt_double3(double3 p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_sqrt_double4
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sqrt.v4f32
-// CHECK: ret <4 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <4 x float> @_Z17test_sqrt_double4Dv4_d(
+// CHECK:    [[CONVI:%.*]] = fptrunc {{.*}} <4 x double> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_sqrt_double4(double4 p0) { return sqrt(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_sqrt_int
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn float @llvm.sqrt.f32(
-// CHECK: ret float %{{.*}}
+// CHECK: define [[FNATTRS]] float @_Z13test_sqrt_inti(
+// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_sqrt_int(int p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_sqrt_int2
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sqrt.v2f32
-// CHECK: ret <2 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <2 x float> @_Z14test_sqrt_int2Dv2_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_sqrt_int2(int2 p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_sqrt_int3
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sqrt.v3f32
-// CHECK: ret <3 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <3 x float> @_Z14test_sqrt_int3Dv3_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_sqrt_int3(int3 p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_sqrt_int4
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sqrt.v4f32
-// CHECK: ret <4 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <4 x float> @_Z14test_sqrt_int4Dv4_i(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_sqrt_int4(int4 p0) { return sqrt(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_sqrt_uint
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn float @llvm.sqrt.f32(
-// CHECK: ret float %{{.*}}
+// CHECK: define [[FNATTRS]] float @_Z14test_sqrt_uintj(
+// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_sqrt_uint(uint p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_sqrt_uint2
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sqrt.v2f32
-// CHECK: ret <2 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <2 x float> @_Z15test_sqrt_uint2Dv2_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_sqrt_uint2(uint2 p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_sqrt_uint3
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sqrt.v3f32
-// CHECK: ret <3 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <3 x float> @_Z15test_sqrt_uint3Dv3_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_sqrt_uint3(uint3 p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_sqrt_uint4
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sqrt.v4f32
-// CHECK: ret <4 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <4 x float> @_Z15test_sqrt_uint4Dv4_j(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_sqrt_uint4(uint4 p0) { return sqrt(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_sqrt_int64_t
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn float @llvm.sqrt.f32(
-// CHECK: ret float %{{.*}}
+// CHECK: define [[FNATTRS]] float @_Z17test_sqrt_int64_tl(
+// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_sqrt_int64_t(int64_t p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_sqrt_int64_t2
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sqrt.v2f32
-// CHECK: ret <2 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <2 x float> @_Z18test_sqrt_int64_t2Dv2_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_sqrt_int64_t2(int64_t2 p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_sqrt_int64_t3
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sqrt.v3f32
-// CHECK: ret <3 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <3 x float> @_Z18test_sqrt_int64_t3Dv3_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_sqrt_int64_t3(int64_t3 p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_sqrt_int64_t4
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sqrt.v4f32
-// CHECK: ret <4 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <4 x float> @_Z18test_sqrt_int64_t4Dv4_l(
+// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_sqrt_int64_t4(int64_t4 p0) { return sqrt(p0); }
 
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_sqrt_uint64_t
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn float @llvm.sqrt.f32(
-// CHECK: ret float %{{.*}}
+// CHECK: define [[FNATTRS]] float @_Z18test_sqrt_uint64_tm(
+// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
+// CHECK:    ret float [[V2]]
 float test_sqrt_uint64_t(uint64_t p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_sqrt_uint64_t2
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sqrt.v2f32
-// CHECK: ret <2 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <2 x float> @_Z19test_sqrt_uint64_t2Dv2_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
+// CHECK:    ret <2 x float> [[V2]]
 float2 test_sqrt_uint64_t2(uint64_t2 p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_sqrt_uint64_t3
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sqrt.v3f32
-// CHECK: ret <3 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <3 x float> @_Z19test_sqrt_uint64_t3Dv3_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
+// CHECK:    ret <3 x float> [[V2]]
 float3 test_sqrt_uint64_t3(uint64_t3 p0) { return sqrt(p0); }
-// CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_sqrt_uint64_t4
-// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sqrt.v4f32
-// CHECK: ret <4 x float> %{{.*}}
+// CHECK: define [[FNATTRS]] <4 x float> @_Z19test_sqrt_uint64_t4Dv4_m(
+// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
+// CHECK:    ret <4 x float> [[V2]]
 float4 test_sqrt_uint64_t4(uint64_t4 p0) { return sqrt(p0); }


### PR DESCRIPTION
This patch changes the run lines for atan, sin, sqrt overload test to use -O1 instead of -disable-llvm-passes and rewrite the tests to actually look at the whole function.

This work is part of https://github.com/llvm/llvm-project/issues/138016.