### PR TITLE
[HIP] Provide implicit include to ROCm library directory

### DIFF
--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -867,6 +867,11 @@ void Linux::addOffloadRTLibs(unsigned ActiveKinds, const ArgList &Args,
     llvm::sys::path::append(p, Library);
     CmdArgs.push_back(Args.MakeArgString(p));
   }
+
+  // FIXME: The ROCm builds implicitly depends on this being present.
+  if (ActiveKinds & Action::OFK_HIP)
+    CmdArgs.push_back(
+        Args.MakeArgString(StringRef("-L") + RocmInstallation->getLibPath()));
 }
 
 void Linux::AddIAMCUIncludeArgs(const ArgList &DriverArgs,

--- a/clang/test/Driver/hip-runtime-libs-linux.hip
+++ b/clang/test/Driver/hip-runtime-libs-linux.hip
@@ -58,7 +58,7 @@
 // RUN:   --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=ROCM-PATH %s
 
-// ROCM-PATH: "{{.*/Inputs/rocm/lib/libamdhip64.so}}"
+// ROCM-PATH: "{{.*/Inputs/rocm/lib/libamdhip64.so}}" "-L[[HIPRT:.*/Inputs/rocm/lib]]"
 // ROCM-RPATH: "-rpath" "{{.*/Inputs/rocm/lib}}"
 // ROCM-RPATH-CANONICAL: "-rpath" "{{.*/rocm/lib}}"
 // ROCM-REL: "{{.*/opt/rocm-3.10.0/lib/libamdhip64.so}}"


### PR DESCRIPTION
Summary:
It's more correct to directly link the HIP runtime if we know the path,
however some users were relying on the old `-L` to pass in some other
non-standard HIP libraries. Put that part back in for now.
