### PR TITLE
Fix bazel lldb

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3483,6 +3483,7 @@ libc_support_library(
     name = "__support_math_tan",
     hdrs = ["src/__support/math/tan.h"],
     deps = [
+        ":__support_fputil_except_value_utils",
         ":__support_fputil_multiply_add",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",

--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -582,6 +582,7 @@ cc_library(
     deps = [
         ":Headers",
         ":UtilityHeaders",
+        "//llvm:DebugInfoDWARF",
         "//llvm:Object",
         "//llvm:Support",
         "//llvm:TargetParser",
@@ -767,6 +768,7 @@ cc_library(
         ":TargetHeaders",
         ":UtilityPrivateHeaders",
         "//llvm:BinaryFormat",
+        "//llvm:DebugInfoDWARF",
         "//llvm:Support",
         "//llvm:TargetParser",
         "//llvm:config",


### PR DESCRIPTION
PR #177309 introduced some new dependencies on DebugInfo/DWARF. This updates the bazel file for lldb accordingly.