### PR TITLE
[lldb] Avoid redundant calls to `std::shared_ptr::get` (NFC)

### DIFF
--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -854,7 +854,7 @@ size_t ObjectFileELF::SectionIndex(const SectionHeaderCollConstIter &I) const {
 
 bool ObjectFileELF::ParseHeader() {
   lldb::offset_t offset = 0;
-  return m_header.Parse(*m_data_nsp.get(), &offset);
+  return m_header.Parse(*m_data_nsp, &offset);
 }
 
 UUID ObjectFileELF::GetUUID() {
@@ -890,7 +890,7 @@ UUID ObjectFileELF::GetUUID() {
         return UUID();
 
       core_notes_crc =
-          CalculateELFNotesSegmentsCRC32(m_program_headers, *m_data_nsp.get());
+          CalculateELFNotesSegmentsCRC32(m_program_headers, *m_data_nsp);
 
       if (core_notes_crc) {
         // Use 8 bytes - first 4 bytes for *magic* prefix, mainly to make it
@@ -901,7 +901,7 @@ UUID ObjectFileELF::GetUUID() {
       }
     } else {
       if (!m_gnu_debuglink_crc)
-        m_gnu_debuglink_crc = calc_crc32(0, *m_data_nsp.get());
+        m_gnu_debuglink_crc = calc_crc32(0, *m_data_nsp);
       if (m_gnu_debuglink_crc) {
         // Use 4 bytes of crc from the .gnu_debuglink section.
         u32le data(m_gnu_debuglink_crc);
@@ -1087,8 +1087,7 @@ size_t ObjectFileELF::GetProgramHeaderInfo(ProgramHeaderColl &program_headers,
 
 // ParseProgramHeaders
 bool ObjectFileELF::ParseProgramHeaders() {
-  return GetProgramHeaderInfo(m_program_headers, *m_data_nsp.get(), m_header) !=
-         0;
+  return GetProgramHeaderInfo(m_program_headers, *m_data_nsp, m_header) != 0;
 }
 
 lldb_private::Status
@@ -1678,8 +1677,8 @@ ObjectFileELF::StripLinkerSymbolAnnotations(llvm::StringRef symbol_name) const {
 
 // ParseSectionHeaders
 size_t ObjectFileELF::ParseSectionHeaders() {
-  return GetSectionHeaderInfo(m_section_headers, *m_data_nsp.get(), m_header,
-                              m_uuid, m_gnu_debuglink_file, m_gnu_debuglink_crc,
+  return GetSectionHeaderInfo(m_section_headers, *m_data_nsp, m_header, m_uuid,
+                              m_gnu_debuglink_file, m_gnu_debuglink_crc,
                               m_arch_spec);
 }
 
@@ -3689,8 +3688,7 @@ ArchSpec ObjectFileELF::GetArchitecture() {
       if (H.p_type != PT_NOTE || H.p_offset == 0 || H.p_filesz == 0)
         continue;
       DataExtractor data;
-      if (data.SetData(*m_data_nsp.get(), H.p_offset, H.p_filesz) ==
-          H.p_filesz) {
+      if (data.SetData(*m_data_nsp, H.p_offset, H.p_filesz) == H.p_filesz) {
         UUID uuid;
         RefineModuleDetailsFromNote(data, m_arch_spec, uuid);
       }
@@ -3848,7 +3846,7 @@ DataExtractor ObjectFileELF::GetSegmentData(const ELFProgramHeader &H) {
   // Try and read the program header from our cached m_data_nsp which can come
   // from the file on disk being mmap'ed or from the initial part of the ELF
   // file we read from memory and cached.
-  DataExtractor data = DataExtractor(*m_data_nsp.get(), H.p_offset, H.p_filesz);
+  DataExtractor data = DataExtractor(*m_data_nsp, H.p_offset, H.p_filesz);
   if (data.GetByteSize() == H.p_filesz)
     return data;
   if (IsInMemory()) {

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -1058,7 +1058,7 @@ bool ObjectFileMachO::ParseHeader() {
 
     ModuleSpecList all_specs;
     ModuleSpec base_spec;
-    GetAllArchSpecs(m_header, *m_data_nsp.get(),
+    GetAllArchSpecs(m_header, *m_data_nsp,
                     MachHeaderSizeFromMagic(m_header.magic), base_spec,
                     all_specs);
 
@@ -2493,9 +2493,9 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
       exports_trie_load_command.dataoff += linkedit_slide;
     }
 
-    nlist_data.SetData(*m_data_nsp.get(), symtab_load_command.symoff,
+    nlist_data.SetData(*m_data_nsp, symtab_load_command.symoff,
                        nlist_data_byte_size);
-    strtab_data.SetData(*m_data_nsp.get(), symtab_load_command.stroff,
+    strtab_data.SetData(*m_data_nsp, symtab_load_command.stroff,
                         strtab_data_byte_size);
 
     // We shouldn't have exports data from both the LC_DYLD_INFO command
@@ -2503,21 +2503,19 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     lldbassert(!((dyld_info.export_size > 0)
                  && (exports_trie_load_command.datasize > 0)));
     if (dyld_info.export_size > 0) {
-      dyld_trie_data.SetData(*m_data_nsp.get(), dyld_info.export_off,
+      dyld_trie_data.SetData(*m_data_nsp, dyld_info.export_off,
                              dyld_info.export_size);
     } else if (exports_trie_load_command.datasize > 0) {
-      dyld_trie_data.SetData(*m_data_nsp.get(),
-                             exports_trie_load_command.dataoff,
+      dyld_trie_data.SetData(*m_data_nsp, exports_trie_load_command.dataoff,
                              exports_trie_load_command.datasize);
     }
 
     if (dysymtab.nindirectsyms != 0) {
-      indirect_symbol_index_data.SetData(*m_data_nsp.get(),
-                                         dysymtab.indirectsymoff,
+      indirect_symbol_index_data.SetData(*m_data_nsp, dysymtab.indirectsymoff,
                                          dysymtab.nindirectsyms * 4);
     }
     if (function_starts_load_command.cmd) {
-      function_starts_data.SetData(*m_data_nsp.get(),
+      function_starts_data.SetData(*m_data_nsp,
                                    function_starts_load_command.dataoff,
                                    function_starts_load_command.datasize);
     }
@@ -4570,7 +4568,7 @@ void ObjectFileMachO::Dump(Stream *s) {
     *s << ", file = '" << m_file;
     ModuleSpecList all_specs;
     ModuleSpec base_spec;
-    GetAllArchSpecs(m_header, *m_data_nsp.get(),
+    GetAllArchSpecs(m_header, *m_data_nsp,
                     MachHeaderSizeFromMagic(m_header.magic), base_spec,
                     all_specs);
     for (unsigned i = 0, e = all_specs.GetSize(); i != e; ++i) {
@@ -4878,7 +4876,7 @@ UUID ObjectFileMachO::GetUUID() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
     lldb::offset_t offset = MachHeaderSizeFromMagic(m_header.magic);
-    return GetUUID(m_header, *m_data_nsp.get(), offset);
+    return GetUUID(m_header, *m_data_nsp, offset);
   }
   return UUID();
 }
@@ -5549,8 +5547,7 @@ ObjectFileMachO::GetThreadContextAtIndex(uint32_t idx,
         m_thread_context_offsets.GetEntryAtIndex(idx);
     if (thread_context_file_range) {
 
-      DataExtractor data(*m_data_nsp.get(),
-                         thread_context_file_range->GetRangeBase(),
+      DataExtractor data(*m_data_nsp, thread_context_file_range->GetRangeBase(),
                          thread_context_file_range->GetByteSize());
 
       switch (m_header.cputype) {
@@ -5722,7 +5719,7 @@ ArchSpec ObjectFileMachO::GetArchitecture() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
 
-    return GetArchitecture(module_sp, m_header, *m_data_nsp.get(),
+    return GetArchitecture(module_sp, m_header, *m_data_nsp,
                            MachHeaderSizeFromMagic(m_header.magic));
   }
   return arch;
@@ -5893,16 +5890,14 @@ static llvm::VersionTuple FindMinimumVersionInfo(DataExtractor &data,
 llvm::VersionTuple ObjectFileMachO::GetMinimumOSVersion() {
   if (!m_min_os_version)
     m_min_os_version = FindMinimumVersionInfo(
-        *m_data_nsp.get(), MachHeaderSizeFromMagic(m_header.magic),
-        m_header.ncmds);
+        *m_data_nsp, MachHeaderSizeFromMagic(m_header.magic), m_header.ncmds);
   return *m_min_os_version;
 }
 
 llvm::VersionTuple ObjectFileMachO::GetSDKVersion() {
   if (!m_sdk_versions)
     m_sdk_versions = FindMinimumVersionInfo(
-        *m_data_nsp.get(), MachHeaderSizeFromMagic(m_header.magic),
-        m_header.ncmds);
+        *m_data_nsp, MachHeaderSizeFromMagic(m_header.magic), m_header.ncmds);
   return *m_sdk_versions;
 }
 

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -449,12 +449,12 @@ bool ObjectFilePECOFF::ParseHeader() {
     m_data_nsp->SetByteOrder(eByteOrderLittle);
     lldb::offset_t offset = 0;
 
-    if (ParseDOSHeader(*m_data_nsp.get(), m_dos_header)) {
+    if (ParseDOSHeader(*m_data_nsp, m_dos_header)) {
       offset = m_dos_header.e_lfanew;
       uint32_t pe_signature = m_data_nsp->GetU32(&offset);
       if (pe_signature != IMAGE_NT_SIGNATURE)
         return false;
-      if (ParseCOFFHeader(*m_data_nsp.get(), &offset, m_coff_header)) {
+      if (ParseCOFFHeader(*m_data_nsp, &offset, m_coff_header)) {
         if (m_coff_header.hdrsize > 0)
           ParseCOFFOptionalHeader(&offset);
         ParseSectionHeaders(offset);
@@ -695,7 +695,7 @@ DataExtractor ObjectFilePECOFF::ReadImageData(uint32_t offset, size_t size) {
     return {};
 
   if (m_data_nsp->ValidOffsetForDataOfSize(offset, size))
-    return DataExtractor(*m_data_nsp.get(), offset, size);
+    return DataExtractor(*m_data_nsp, offset, size);
 
   ProcessSP process_sp(m_process_wp.lock());
   DataExtractor data;

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -494,7 +494,7 @@ size_t ObjectFile::GetData(lldb::offset_t offset, size_t length,
                            DataExtractor &data) const {
   // The entire file has already been mmap'ed into m_data_nsp, so just copy from
   // there as the back mmap buffer will be shared with shared pointers.
-  return data.SetData(*m_data_nsp.get(), offset, length);
+  return data.SetData(*m_data_nsp, offset, length);
 }
 
 size_t ObjectFile::CopyData(lldb::offset_t offset, size_t length,


### PR DESCRIPTION
Avoid redundant calls to `std::shared_ptr::get()`. The class provides a dereference operator and using that is the standard, idiomatic way to access the underlying object.