### PR TITLE
[clang-tidy] Add llvm-use-vector-utils

### DIFF
--- a/clang-tools-extra/clang-tidy/llvm/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/llvm/CMakeLists.txt
@@ -13,6 +13,7 @@ add_clang_library(clangTidyLLVMModule STATIC
   TwineLocalCheck.cpp
   UseNewMLIROpBuilderCheck.cpp
   UseRangesCheck.cpp
+  UseVectorUtilsCheck.cpp
 
   LINK_LIBS
   clangTidy

--- a/clang-tools-extra/clang-tidy/llvm/LLVMTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/LLVMTidyModule.cpp
@@ -19,6 +19,7 @@
 #include "TwineLocalCheck.h"
 #include "UseNewMLIROpBuilderCheck.h"
 #include "UseRangesCheck.h"
+#include "UseVectorUtilsCheck.h"
 
 namespace clang::tidy {
 namespace llvm_check {
@@ -45,6 +46,7 @@ public:
     CheckFactories.registerCheck<UseNewMlirOpBuilderCheck>(
         "llvm-use-new-mlir-op-builder");
     CheckFactories.registerCheck<UseRangesCheck>("llvm-use-ranges");
+    CheckFactories.registerCheck<UseVectorUtilsCheck>("llvm-use-vector-utils");
   }
 
   ClangTidyOptions getModuleOptions() override {

--- a/clang-tools-extra/clang-tidy/llvm/UseVectorUtilsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/UseVectorUtilsCheck.cpp
@@ -1,0 +1,128 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "UseVectorUtilsCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Lex/Lexer.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::llvm_check {
+
+UseVectorUtilsCheck::UseVectorUtilsCheck(StringRef Name,
+                                         ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context),
+      Inserter(Options.getLocalOrGlobal("IncludeStyle",
+                                        utils::IncludeSorter::IS_LLVM),
+               areDiagsSelfContained()) {}
+
+void UseVectorUtilsCheck::registerPPCallbacks(const SourceManager &SM,
+                                              Preprocessor *PP,
+                                              Preprocessor *ModuleExpanderPP) {
+  Inserter.registerPreprocessor(PP);
+}
+
+void UseVectorUtilsCheck::registerMatchers(MatchFinder *Finder) {
+  // Match `llvm::to_vector(llvm::map_range(X, F))`.
+  Finder->addMatcher(
+      callExpr(
+          callee(functionDecl(hasName("::llvm::to_vector"))),
+          hasArgument(
+              0, callExpr(callee(functionDecl(hasName("::llvm::map_range"))))
+                     .bind("inner_call")))
+          .bind("map_range_call"),
+      this);
+
+  // Match `llvm::to_vector(llvm::make_filter_range(X, Pred))`.
+  Finder->addMatcher(
+      callExpr(
+          callee(functionDecl(hasName("::llvm::to_vector"))),
+          hasArgument(0, callExpr(callee(functionDecl(
+                                      hasName("::llvm::make_filter_range"))))
+                             .bind("inner_call")))
+          .bind("filter_range_call"),
+      this);
+}
+
+void UseVectorUtilsCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MapRangeCall =
+      Result.Nodes.getNodeAs<CallExpr>("map_range_call");
+  const auto *FilterRangeCall =
+      Result.Nodes.getNodeAs<CallExpr>("filter_range_call");
+  if (!MapRangeCall && !FilterRangeCall)
+    return;
+
+  const auto *InnerCall = Result.Nodes.getNodeAs<CallExpr>("inner_call");
+  assert(InnerCall && "inner_call must be bound if map_range_call or "
+                      "filter_range_call matched");
+  // Only handle the 2-argument overloads of `map_range`/`make_filter_range`, to
+  // future-proof against additional overloads.
+  if (InnerCall->getNumArgs() != 2)
+    return;
+
+  const CallExpr *OuterCall = MapRangeCall ? MapRangeCall : FilterRangeCall;
+
+  const SourceManager &SM = *Result.SourceManager;
+  const LangOptions &LangOpts = getLangOpts();
+
+  // Determine the base replacement function name.
+  const StringRef ReplacementFuncBase =
+      MapRangeCall ? "llvm::map_to_vector" : "llvm::filter_to_vector";
+  const StringRef InnerFuncName =
+      MapRangeCall ? "llvm::map_range" : "llvm::make_filter_range";
+
+  // Check if `to_vector` was called with an explicit size template argument.
+  std::string SizeTemplateArg;
+  if (const auto *DRE =
+          dyn_cast<DeclRefExpr>(OuterCall->getCallee()->IgnoreImplicit())) {
+    if (DRE->hasExplicitTemplateArgs()) {
+      // Extract the template argument text (e.g., `<4>`).
+      const auto TemplateArgsCharRange = CharSourceRange::getTokenRange(
+          DRE->getLAngleLoc(), DRE->getRAngleLoc());
+      SizeTemplateArg =
+          Lexer::getSourceText(TemplateArgsCharRange, SM, LangOpts).str();
+    }
+  }
+
+  const std::string ReplacementFunc =
+      (ReplacementFuncBase + SizeTemplateArg).str();
+  const std::string ToVectorFunc = "llvm::to_vector" + SizeTemplateArg;
+
+  // Build the replacement: Replace the whole expression with the new function
+  // and the arguments from the inner call.
+  auto Diag = diag(OuterCall->getBeginLoc(),
+                   "use '%0' instead of '%1(%2(...))'")
+              << ReplacementFunc << ToVectorFunc << InnerFuncName;
+
+  // Get the range argument.
+  const SourceRange RangeArgRange = InnerCall->getArg(0)->getSourceRange();
+  const auto RangeArgCharRange = CharSourceRange::getTokenRange(RangeArgRange);
+  const StringRef RangeArgText =
+      Lexer::getSourceText(RangeArgCharRange, SM, LangOpts);
+
+  // Get the function/predicate argument.
+  const SourceRange FuncArgRange = InnerCall->getArg(1)->getSourceRange();
+  const auto FuncArgCharRange = CharSourceRange::getTokenRange(FuncArgRange);
+  const StringRef FuncArgText =
+      Lexer::getSourceText(FuncArgCharRange, SM, LangOpts);
+
+  // Create the replacement text.
+  const std::string Replacement =
+      (ReplacementFunc + "(" + RangeArgText + ", " + FuncArgText + ")").str();
+
+  Diag << FixItHint::CreateReplacement(OuterCall->getSourceRange(), Replacement);
+
+  // Add include for `SmallVectorExtras.h` if needed.
+  if (auto IncludeFixit = Inserter.createIncludeInsertion(
+          SM.getFileID(OuterCall->getBeginLoc()),
+          "llvm/ADT/SmallVectorExtras.h"))
+    Diag << *IncludeFixit;
+}
+
+} // namespace clang::tidy::llvm_check

--- a/clang-tools-extra/clang-tidy/llvm/UseVectorUtilsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/UseVectorUtilsCheck.cpp
@@ -67,7 +67,12 @@ void UseVectorUtilsCheck::check(const MatchFinder::MatchResult &Result) {
 
   // Replace the outer function name (preserving qualifier and template args),
   // and then remove the inner call's callee and opening paren and closing
-  // paren.
+  // paren. Example:
+  // ```
+  // llvm::to_vector<4>(llvm::map_range(X, F))
+  //       ^replace~^   ^----remove-----^   ^
+  //                                      remove
+  // ```
   Diag << FixItHint::CreateReplacement(
               OuterCallee->getNameInfo().getSourceRange(), ReplacementFuncName)
        << FixItHint::CreateRemoval(CharSourceRange::getCharRange(

--- a/clang-tools-extra/clang-tidy/llvm/UseVectorUtilsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvm/UseVectorUtilsCheck.cpp
@@ -18,9 +18,7 @@ namespace clang::tidy::llvm_check {
 UseVectorUtilsCheck::UseVectorUtilsCheck(StringRef Name,
                                          ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
-      Inserter(Options.getLocalOrGlobal("IncludeStyle",
-                                        utils::IncludeSorter::IS_LLVM),
-               areDiagsSelfContained()) {}
+      Inserter(utils::IncludeSorter::IS_LLVM, areDiagsSelfContained()) {}
 
 void UseVectorUtilsCheck::registerPPCallbacks(const SourceManager &SM,
                                               Preprocessor *PP,
@@ -29,94 +27,72 @@ void UseVectorUtilsCheck::registerPPCallbacks(const SourceManager &SM,
 }
 
 void UseVectorUtilsCheck::registerMatchers(MatchFinder *Finder) {
-  // Match `llvm::to_vector(llvm::map_range(X, F))`.
+  // Match `llvm::to_vector(llvm::map_range(X, F))` or
+  // `llvm::to_vector(llvm::make_filter_range(X, Pred))`.
   Finder->addMatcher(
       callExpr(callee(functionDecl(hasName("::llvm::to_vector"))),
-               hasArgument(0, callExpr(callee(functionDecl(
-                                           hasName("::llvm::map_range"))))
-                                  .bind("inner_call")))
-          .bind("map_range_call"),
-      this);
-
-  // Match `llvm::to_vector(llvm::make_filter_range(X, Pred))`.
-  Finder->addMatcher(
-      callExpr(callee(functionDecl(hasName("::llvm::to_vector"))),
-               hasArgument(0, callExpr(callee(functionDecl(hasName(
-                                           "::llvm::make_filter_range"))))
-                                  .bind("inner_call")))
-          .bind("filter_range_call"),
+               hasArgument(0, callExpr(callee(functionDecl(hasAnyName(
+                                           "::llvm::map_range",
+                                           "::llvm::make_filter_range"))),
+                                       argumentCountIs(2))
+                                  .bind("inner_call")),
+               argumentCountIs(1))
+          .bind("outer_call"),
       this);
 }
 
+// Returns the original qualifier spelling (e.g., `llvm::` or `::llvm::`) for
+// the diagnostic message.
+static StringRef getQualifierSpelling(const DeclRefExpr *DeclRef,
+                                      const MatchFinder::MatchResult &Result) {
+  if (const auto QualifierLoc = DeclRef->getQualifierLoc()) {
+    return Lexer::getSourceText(
+        CharSourceRange::getTokenRange(QualifierLoc.getSourceRange()),
+        *Result.SourceManager, Result.Context->getLangOpts());
+  }
+  return "";
+}
+
 void UseVectorUtilsCheck::check(const MatchFinder::MatchResult &Result) {
-  const auto *MapRangeCall = Result.Nodes.getNodeAs<CallExpr>("map_range_call");
-  const auto *FilterRangeCall =
-      Result.Nodes.getNodeAs<CallExpr>("filter_range_call");
-  if (!MapRangeCall && !FilterRangeCall)
-    return;
+  const auto *OuterCall = Result.Nodes.getNodeAs<CallExpr>("outer_call");
+  assert(OuterCall);
 
   const auto *InnerCall = Result.Nodes.getNodeAs<CallExpr>("inner_call");
-  assert(InnerCall && "inner_call must be bound if map_range_call or "
-                      "filter_range_call matched");
-  // Only handle the 2-argument overloads of `map_range`/`make_filter_range`, to
-  // future-proof against additional overloads.
-  if (InnerCall->getNumArgs() != 2)
-    return;
+  assert(InnerCall);
 
-  const CallExpr *OuterCall = MapRangeCall ? MapRangeCall : FilterRangeCall;
+  const auto *OuterCallee =
+      cast<DeclRefExpr>(OuterCall->getCallee()->IgnoreImplicit());
+  const auto *InnerCallee =
+      cast<DeclRefExpr>(InnerCall->getCallee()->IgnoreImplicit());
 
-  const SourceManager &SM = *Result.SourceManager;
-  const LangOptions &LangOpts = getLangOpts();
-
-  // Determine the base replacement function name.
-  const StringRef ReplacementFuncBase =
-      MapRangeCall ? "llvm::map_to_vector" : "llvm::filter_to_vector";
   const StringRef InnerFuncName =
-      MapRangeCall ? "llvm::map_range" : "llvm::make_filter_range";
+      cast<NamedDecl>(InnerCallee->getDecl())->getName();
 
-  // Check if `to_vector` was called with an explicit size template argument.
-  std::string SizeTemplateArg;
-  if (const auto *DRE =
-          dyn_cast<DeclRefExpr>(OuterCall->getCallee()->IgnoreImplicit())) {
-    if (DRE->hasExplicitTemplateArgs()) {
-      // Extract the template argument text (e.g., `<4>`).
-      const auto TemplateArgsCharRange = CharSourceRange::getTokenRange(
-          DRE->getLAngleLoc(), DRE->getRAngleLoc());
-      SizeTemplateArg =
-          Lexer::getSourceText(TemplateArgsCharRange, SM, LangOpts).str();
-    }
-  }
+  // Determine the replacement function name (unqualified).
+  const llvm::SmallDenseMap<StringRef, StringRef, 2>
+      InnerFuncNameToReplacementFuncName = {
+          {"map_range", "map_to_vector"},
+          {"make_filter_range", "filter_to_vector"},
+      };
+  const StringRef ReplacementFuncName =
+      InnerFuncNameToReplacementFuncName.lookup(InnerFuncName);
+  assert(!ReplacementFuncName.empty() && "Unhandled function?");
 
-  const std::string ReplacementFunc =
-      (ReplacementFuncBase + SizeTemplateArg).str();
-  const std::string ToVectorFunc = "llvm::to_vector" + SizeTemplateArg;
+  auto Diag = diag(OuterCall->getBeginLoc(), "use '%0%1'")
+              << getQualifierSpelling(OuterCallee, Result)
+              << ReplacementFuncName;
 
-  // Build the replacement: Replace the whole expression with the new function
-  // and the arguments from the inner call.
-  auto Diag =
-      diag(OuterCall->getBeginLoc(), "use '%0' instead of '%1(%2(...))'")
-      << ReplacementFunc << ToVectorFunc << InnerFuncName;
-
-  // Get the range argument.
-  const SourceRange RangeArgRange = InnerCall->getArg(0)->getSourceRange();
-  const auto RangeArgCharRange = CharSourceRange::getTokenRange(RangeArgRange);
-  const StringRef RangeArgText =
-      Lexer::getSourceText(RangeArgCharRange, SM, LangOpts);
-
-  // Get the function/predicate argument.
-  const SourceRange FuncArgRange = InnerCall->getArg(1)->getSourceRange();
-  const auto FuncArgCharRange = CharSourceRange::getTokenRange(FuncArgRange);
-  const StringRef FuncArgText =
-      Lexer::getSourceText(FuncArgCharRange, SM, LangOpts);
-
-  // Create the replacement text.
-  const std::string Replacement =
-      (ReplacementFunc + "(" + RangeArgText + ", " + FuncArgText + ")").str();
-
-  Diag << FixItHint::CreateReplacement(OuterCall->getSourceRange(),
-                                       Replacement);
+  // Replace only the unqualified function name, preserving qualifier and
+  // template arguments.
+  const auto InnerCallUntilFirstArg = CharSourceRange::getCharRange(
+      InnerCall->getBeginLoc(), InnerCall->getArg(0)->getBeginLoc());
+  Diag << FixItHint::CreateReplacement(
+              OuterCallee->getNameInfo().getSourceRange(), ReplacementFuncName)
+       << FixItHint::CreateRemoval(InnerCallUntilFirstArg)
+       << FixItHint::CreateRemoval(InnerCall->getRParenLoc());
 
   // Add include for `SmallVectorExtras.h` if needed.
+  const SourceManager &SM = *Result.SourceManager;
   if (auto IncludeFixit = Inserter.createIncludeInsertion(
           SM.getFileID(OuterCall->getBeginLoc()),
           "llvm/ADT/SmallVectorExtras.h"))

--- a/clang-tools-extra/clang-tidy/llvm/UseVectorUtilsCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/UseVectorUtilsCheck.h
@@ -24,13 +24,14 @@ namespace clang::tidy::llvm_check {
 class UseVectorUtilsCheck : public ClangTidyCheck {
 public:
   UseVectorUtilsCheck(StringRef Name, ClangTidyContext *Context);
-  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
-    return LangOpts.CPlusPlus;
-  }
   void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
                            Preprocessor *ModuleExpanderPP) override;
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus;
+  }
 
 private:
   utils::IncludeInserter Inserter;

--- a/clang-tools-extra/clang-tidy/llvm/UseVectorUtilsCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/UseVectorUtilsCheck.h
@@ -16,7 +16,8 @@ namespace clang::tidy::llvm_check {
 
 /// Finds calls to `llvm::to_vector(llvm::map_range(...))` and
 /// `llvm::to_vector(llvm::make_filter_range(...))` that can be replaced with
-/// `llvm::map_to_vector` and `llvm::filter_to_vector` from `SmallVectorExtras.h`.
+/// `llvm::map_to_vector` and `llvm::filter_to_vector` from
+/// `SmallVectorExtras.h`.
 ///
 /// For the user-facing documentation see:
 /// https://clang.llvm.org/extra/clang-tidy/checks/llvm/use-vector-utils.html
@@ -38,4 +39,3 @@ private:
 } // namespace clang::tidy::llvm_check
 
 #endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_USEVECTORUTILSCHECK_H
-

--- a/clang-tools-extra/clang-tidy/llvm/UseVectorUtilsCheck.h
+++ b/clang-tools-extra/clang-tidy/llvm/UseVectorUtilsCheck.h
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_USEVECTORUTILSCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_USEVECTORUTILSCHECK_H
+
+#include "../ClangTidyCheck.h"
+#include "../utils/IncludeInserter.h"
+
+namespace clang::tidy::llvm_check {
+
+/// Finds calls to `llvm::to_vector(llvm::map_range(...))` and
+/// `llvm::to_vector(llvm::make_filter_range(...))` that can be replaced with
+/// `llvm::map_to_vector` and `llvm::filter_to_vector` from `SmallVectorExtras.h`.
+///
+/// For the user-facing documentation see:
+/// https://clang.llvm.org/extra/clang-tidy/checks/llvm/use-vector-utils.html
+class UseVectorUtilsCheck : public ClangTidyCheck {
+public:
+  UseVectorUtilsCheck(StringRef Name, ClangTidyContext *Context);
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus;
+  }
+  void registerPPCallbacks(const SourceManager &SM, Preprocessor *PP,
+                           Preprocessor *ModuleExpanderPP) override;
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+
+private:
+  utils::IncludeInserter Inserter;
+};
+
+} // namespace clang::tidy::llvm_check
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_LLVM_USEVECTORUTILSCHECK_H
+

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -97,6 +97,13 @@ Improvements to clang-tidy
 New checks
 ^^^^^^^^^^
 
+- New :doc:`llvm-use-vector-utils
+  <clang-tidy/checks/llvm/use-vector-utils>` check.
+
+  Finds calls to ``llvm::to_vector(llvm::map_range(...))`` and
+  ``llvm::to_vector(llvm::make_filter_range(...))`` that can be replaced with
+  ``llvm::map_to_vector`` and ``llvm::filter_to_vector``.
+
 - New :doc:`modernize-use-string-view
   <clang-tidy/checks/modernize/use-string-view>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -258,6 +258,7 @@ Clang-Tidy Checks
    :doc:`llvm-twine-local <llvm/twine-local>`, "Yes"
    :doc:`llvm-use-new-mlir-op-builder <llvm/use-new-mlir-op-builder>`, "Yes"
    :doc:`llvm-use-ranges <llvm/use-ranges>`, "Yes"
+   :doc:`llvm-use-vector-utils <llvm/use-vector-utils>`, "Yes"
    :doc:`llvmlibc-callee-namespace <llvmlibc/callee-namespace>`,
    :doc:`llvmlibc-implementation-in-namespace <llvmlibc/implementation-in-namespace>`,
    :doc:`llvmlibc-inline-function-decl <llvmlibc/inline-function-decl>`, "Yes"

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/use-vector-utils.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/use-vector-utils.rst
@@ -1,0 +1,32 @@
+.. title:: clang-tidy - llvm-use-vector-utils
+
+llvm-use-vector-utils
+=====================
+
+Finds calls to ``llvm::to_vector`` with ``llvm::map_range`` or
+``llvm::make_filter_range`` that can be replaced with the more concise
+``llvm::map_to_vector`` and ``llvm::filter_to_vector`` utilities from
+``llvm/ADT/SmallVectorExtras.h``.
+
+The check will add the necessary ``#include "llvm/ADT/SmallVectorExtras.h"``
+directive when applying fixes.
+
+Example
+-------
+
+.. code-block:: c++
+
+  auto v1 = llvm::to_vector(llvm::map_range(container, func));
+  auto v2 = llvm::to_vector(llvm::make_filter_range(container, pred));
+  auto v3 = llvm::to_vector<4>(llvm::map_range(container, func));
+  auto v4 = llvm::to_vector<4>(llvm::make_filter_range(container, pred));
+
+Transforms to:
+
+.. code-block:: c++
+
+  auto v1 = llvm::map_to_vector(container, func);
+  auto v2 = llvm::filter_to_vector(container, pred);
+  auto v3 = llvm::map_to_vector<4>(container, func);
+  auto v4 = llvm::filter_to_vector<4>(container, pred);
+

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/use-vector-utils.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/use-vector-utils.rst
@@ -29,4 +29,3 @@ Transforms to:
   auto v2 = llvm::filter_to_vector(container, pred);
   auto v3 = llvm::map_to_vector<4>(container, func);
   auto v4 = llvm::filter_to_vector<4>(container, pred);
-

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/use-vector-utils.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/use-vector-utils.cpp
@@ -77,6 +77,16 @@ void test_map_range() {
   auto result_comment4 = llvm::to_vector</*keep_me*/ 7>(llvm::map_range(vec, transform));
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: use 'map_to_vector'
   // CHECK-FIXES: auto result_comment4 = llvm::map_to_vector</*keep_me*/ 7>(vec, transform);
+
+  // Check that whitespace between callee and `(` is handled correctly.
+  auto result_whitespace1 = llvm::to_vector(llvm::map_range  (vec, transform));
+  // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: use 'map_to_vector'
+  // CHECK-FIXES: auto result_whitespace1 = llvm::map_to_vector(vec, transform);
+
+  // Check that comments between callee and `(` are handled correctly.
+  auto result_whitespace2 = llvm::to_vector(llvm::map_range /*weird but ok*/ (vec, transform));
+  // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: use 'map_to_vector'
+  // CHECK-FIXES: auto result_whitespace2 = llvm::map_to_vector(vec, transform);
 }
 
 void test_filter_range() {
@@ -103,6 +113,18 @@ void test_inside_llvm_namespace() {
 }
 
 } // namespace llvm
+
+// Check that an empty macro between callee and `(` is handled.
+void test_macro() {
+  llvm::SmallVector<int> vec;
+
+#define EMPTY
+  // No fix-it when a macro appears between callee and `(`.
+  auto result = llvm::to_vector(llvm::map_range EMPTY (vec, transform));
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use 'map_to_vector'
+
+#undef EMPTY
+}
 
 void test_negative() {
   llvm::SmallVector<int> vec;

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/use-vector-utils.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/use-vector-utils.cpp
@@ -47,23 +47,27 @@ void test_map_range() {
   llvm::SmallVector<int> vec;
 
   auto result = llvm::to_vector(llvm::map_range(vec, transform));
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use 'llvm::map_to_vector' instead of 'llvm::to_vector(llvm::map_range(...))'
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use 'llvm::map_to_vector'
   // CHECK-FIXES: auto result = llvm::map_to_vector(vec, transform);
 
   auto result_sized = llvm::to_vector<4>(llvm::map_range(vec, transform));
-  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: use 'llvm::map_to_vector<4>' instead of 'llvm::to_vector<4>(llvm::map_range(...))'
+  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: use 'llvm::map_to_vector'
   // CHECK-FIXES: auto result_sized = llvm::map_to_vector<4>(vec, transform);
+
+  auto result_global = ::llvm::to_vector(::llvm::map_range(vec, transform));
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: use '::llvm::map_to_vector'
+  // CHECK-FIXES: auto result_global = ::llvm::map_to_vector(vec, transform);
 }
 
 void test_filter_range() {
   llvm::SmallVector<int> vec;
 
   auto result = llvm::to_vector(llvm::make_filter_range(vec, is_even));
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use 'llvm::filter_to_vector' instead of 'llvm::to_vector(llvm::make_filter_range(...))'
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use 'llvm::filter_to_vector'
   // CHECK-FIXES: auto result = llvm::filter_to_vector(vec, is_even);
 
   auto result_sized = llvm::to_vector<6>(llvm::make_filter_range(vec, is_even));
-  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: use 'llvm::filter_to_vector<6>' instead of 'llvm::to_vector<6>(llvm::make_filter_range(...))'
+  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: use 'llvm::filter_to_vector'
   // CHECK-FIXES: auto result_sized = llvm::filter_to_vector<6>(vec, is_even);
 }
 
@@ -74,8 +78,8 @@ void test_inside_llvm_namespace() {
 
   // Unprefixed calls inside the `llvm` namespace should also be detected.
   auto result = to_vector(map_range(vec, transform));
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use 'llvm::map_to_vector' instead of 'llvm::to_vector(llvm::map_range(...))'
-  // CHECK-FIXES: auto result = llvm::map_to_vector(vec, transform);
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use 'map_to_vector'
+  // CHECK-FIXES: auto result = map_to_vector(vec, transform);
 }
 
 } // namespace llvm

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/use-vector-utils.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/use-vector-utils.cpp
@@ -72,6 +72,11 @@ void test_map_range() {
   auto result_comment3 = llvm::to_vector(llvm::map_range(/*keep_me*/ vec, transform));
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: use 'map_to_vector'
   // CHECK-FIXES: auto result_comment3 = llvm::map_to_vector(/*keep_me*/ vec, transform);
+
+  // Check that comments inside explicit template argument are preserved.
+  auto result_comment4 = llvm::to_vector</*keep_me*/ 7>(llvm::map_range(vec, transform));
+  // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: use 'map_to_vector'
+  // CHECK-FIXES: auto result_comment4 = llvm::map_to_vector</*keep_me*/ 7>(vec, transform);
 }
 
 void test_filter_range() {

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/use-vector-utils.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/use-vector-utils.cpp
@@ -57,6 +57,21 @@ void test_map_range() {
   auto result_global = ::llvm::to_vector(::llvm::map_range(vec, transform));
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: use 'map_to_vector'
   // CHECK-FIXES: auto result_global = ::llvm::map_to_vector(vec, transform);
+
+  // Check that comments between `to_vector(` and `map_range(` are preserved.
+  auto result_comment1 = llvm::to_vector(/*keep_me*/ llvm::map_range(vec, transform));
+  // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: use 'map_to_vector'
+  // CHECK-FIXES: auto result_comment1 = llvm::map_to_vector(/*keep_me*/ vec, transform);
+
+  // Check that comments between `to_vector<9>(` and `map_range(` are preserved.
+  auto result_comment2 = llvm::to_vector<9>(/*keep_me*/ llvm::map_range(vec, transform));
+  // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: use 'map_to_vector'
+  // CHECK-FIXES: auto result_comment2 = llvm::map_to_vector<9>(/*keep_me*/ vec, transform);
+
+  // Check that comments inside `map_range(` are also preserved.
+  auto result_comment3 = llvm::to_vector(llvm::map_range(/*keep_me*/ vec, transform));
+  // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: use 'map_to_vector'
+  // CHECK-FIXES: auto result_comment3 = llvm::map_to_vector(/*keep_me*/ vec, transform);
 }
 
 void test_filter_range() {

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/use-vector-utils.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/use-vector-utils.cpp
@@ -47,15 +47,15 @@ void test_map_range() {
   llvm::SmallVector<int> vec;
 
   auto result = llvm::to_vector(llvm::map_range(vec, transform));
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use 'llvm::map_to_vector'
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use 'map_to_vector'
   // CHECK-FIXES: auto result = llvm::map_to_vector(vec, transform);
 
   auto result_sized = llvm::to_vector<4>(llvm::map_range(vec, transform));
-  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: use 'llvm::map_to_vector'
+  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: use 'map_to_vector'
   // CHECK-FIXES: auto result_sized = llvm::map_to_vector<4>(vec, transform);
 
   auto result_global = ::llvm::to_vector(::llvm::map_range(vec, transform));
-  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: use '::llvm::map_to_vector'
+  // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: use 'map_to_vector'
   // CHECK-FIXES: auto result_global = ::llvm::map_to_vector(vec, transform);
 }
 
@@ -63,11 +63,11 @@ void test_filter_range() {
   llvm::SmallVector<int> vec;
 
   auto result = llvm::to_vector(llvm::make_filter_range(vec, is_even));
-  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use 'llvm::filter_to_vector'
+  // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use 'filter_to_vector'
   // CHECK-FIXES: auto result = llvm::filter_to_vector(vec, is_even);
 
   auto result_sized = llvm::to_vector<6>(llvm::make_filter_range(vec, is_even));
-  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: use 'llvm::filter_to_vector'
+  // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: use 'filter_to_vector'
   // CHECK-FIXES: auto result_sized = llvm::filter_to_vector<6>(vec, is_even);
 }
 


### PR DESCRIPTION
This new check suggests the following replacements:
*  `llvm::to_vector(llvm::map_range(X, Fn))` -> `llvm::map_to_vector(X, Fn)`
*  `llvm::to_vector(llvm::make_filter_range(X, Fn))` -> `llvm::filter_to_vector(X, Fn)`
and add the `SmallVectorExtras.h` include when necessary.

The check is called `vector-utils` because we may want to handle more cases in the future, like turning explicit calls to SmallVector constructor to `llvm::to_vector` (which lives in `SmallVector.h`, not `SmallVectorExtras.h`).

Assisted-by: claude