### PR TITLE
[MLIR] Support dynamic traits in `DynamicDialect`

### DIFF
--- a/mlir/test/IR/dynamic.mlir
+++ b/mlir/test/IR/dynamic.mlir
@@ -125,6 +125,50 @@ func.func @customOpParserPrinter() {
   return
 }
 
+// -----
+
+func.func @failedDynamicGenericOpNoTerminator() {
+  // expected-error@+1 {{empty block: expect at least a terminator}}
+  "test.dynamic_generic"() ({
+    ^bb1:
+  }) : () -> ()
+  return
+}
+
+// -----
+
+func.func @dynamicTerminatorOp() {
+  // CHECK: "test.dynamic_generic"()
+  "test.dynamic_generic"() ({
+    ^bb1:
+      // CHECK: test.dynamic_terminator"()
+      "test.dynamic_terminator"() : () -> ()
+  }) : () -> ()
+  return
+}
+
+// -----
+
+func.func @failedDynamicTerminatorOp() {
+  "test.dynamic_generic"() ({
+    ^bb1:
+      // expected-error@+1 {{'test.dynamic_terminator' op must be the last operation in the parent block}}
+      "test.dynamic_terminator"() : () -> ()
+      "test.dynamic_generic"() : () -> ()
+  }) : () -> ()
+  return
+}
+
+// -----
+
+func.func @dynamicNoTerminatorOp() {
+  // CHECK: "test.dynamic_noterminator"()
+  "test.dynamic_noterminator"() ({
+    ^bb1:
+  }) : () -> ()
+  return
+}
+
 //===----------------------------------------------------------------------===//
 // Dynamic dialect
 //===----------------------------------------------------------------------===//

--- a/mlir/test/lib/Dialect/Test/TestDialect.cpp
+++ b/mlir/test/lib/Dialect/Test/TestDialect.cpp
@@ -42,6 +42,7 @@
 #include "mlir/Reducer/ReductionPatternInterface.h"
 #include "mlir/Transforms/InliningUtils.h"
 #include <cstdint>
+#include <memory>
 #include <numeric>
 #include <optional>
 
@@ -243,6 +244,24 @@ getDynamicGenericOp(TestDialect *dialect) {
 }
 
 static std::unique_ptr<DynamicOpDefinition>
+getDynamicTerminatorOp(TestDialect *dialect) {
+  auto def = DynamicOpDefinition::get(
+      "dynamic_terminator", dialect, [](Operation *op) { return success(); },
+      [](Operation *op) { return success(); });
+  def->addTrait(std::make_unique<DynamicOpTraits::IsTerminator>());
+  return def;
+}
+
+static std::unique_ptr<DynamicOpDefinition>
+getDynamicNoTerminatorOp(TestDialect *dialect) {
+  auto def = DynamicOpDefinition::get(
+      "dynamic_noterminator", dialect, [](Operation *op) { return success(); },
+      [](Operation *op) { return success(); });
+  def->addTrait(std::make_unique<DynamicOpTraits::NoTerminator>());
+  return def;
+}
+
+static std::unique_ptr<DynamicOpDefinition>
 getDynamicOneOperandTwoResultsOp(TestDialect *dialect) {
   return DynamicOpDefinition::get(
       "dynamic_one_operand_two_results", dialect,
@@ -329,6 +348,8 @@ void TestDialect::initialize() {
   addOperations<ManualCppOpWithFold>();
   registerTestDialectOperations(this);
   registerDynamicOp(getDynamicGenericOp(this));
+  registerDynamicOp(getDynamicTerminatorOp(this));
+  registerDynamicOp(getDynamicNoTerminatorOp(this));
   registerDynamicOp(getDynamicOneOperandTwoResultsOp(this));
   registerDynamicOp(getDynamicCustomParserPrinterOp(this));
   registerInterfaces();


### PR DESCRIPTION
Unlike Interfaces, Traits in MLIR are static: they are defined via CRTP templates and used as base classes of an `Op`, which makes them difficult to attach to an op dynamically.

However, in IRDL and the Python bindings, we define operations dynamically through `DynamicDialect`, which means the traditional static traits cannot be applied to them. Traits are important, for example, they are how MLIR marks an op as a terminator or a non-terminator.

If `DynamicDialect` does not support traits, then even though we can define an op with regions, we cannot define new terminators or mark an op as a non-terminator. This makes `DynamicDialect` very limited in region-related scenarios.

In this PR, we introduce a `DynamicOpTrait` type that “dynamizes” `OpTrait`, enabling traits to be attached to ops in `DynamicDialect`. The key design goal is that existing checks in the MLIR codebase such as `op->hasTrait<XXX>()` work seamlessly on ops defined by `DynamicOpDefinition`, without requiring any changes.

Note that currently only two traits `IsTerminator` and `NoTerminator` are supported in this PR.

This PR aims to lay the groundwork for adding support for traits in IRDL and python bindings (and maybe other bindings) in the future.

Related to #158066.