### PR TITLE
[RISCV] Remove decodeRTZArg. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -430,16 +430,6 @@ static DecodeStatus decodeFRMArg(MCInst &Inst, uint32_t Imm, int64_t Address,
   return MCDisassembler::Success;
 }
 
-static DecodeStatus decodeRTZArg(MCInst &Inst, uint32_t Imm, int64_t Address,
-                                 const MCDisassembler *Decoder) {
-  assert(isUInt<3>(Imm) && "Invalid immediate");
-  if (Imm != RISCVFPRndMode::RTZ)
-    return MCDisassembler::Fail;
-
-  Inst.addOperand(MCOperand::createImm(Imm));
-  return MCDisassembler::Success;
-}
-
 static DecodeStatus decodeZcmpRlist(MCInst &Inst, uint32_t Imm,
                                     uint64_t Address,
                                     const MCDisassembler *Decoder) {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZfa.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZfa.td
@@ -52,7 +52,7 @@ def RTZArg : AsmOperandClass {
 def rtzarg : Operand<XLenVT> {
   let ParserMatchClass = RTZArg;
   let PrintMethod = "printFRMArg";
-  let DecoderMethod = "decodeRTZArg";
+  let DecoderMethod = "decodeFRMArg";
   let OperandType = "OPERAND_RTZARG";
   let OperandNamespace = "RISCVOp";
 }
@@ -86,6 +86,7 @@ class FPUnaryOp_r_rtz<bits<7> funct7, bits<5> rs2val, DAGOperand rdty,
                  (ins rs1ty:$rs1, rtzarg:$frm), opcodestr,
                   "$rd, $rs1$frm"> {
   let rs2 = rs2val;
+  let frm = FRM_RTZ;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
We can set the frm field in tablegen class which make the disassembler only accept that fixed value without neding to reject it with decodeRTZArg.