### PR TITLE
[mlir][memref]-Add verification for MemRef::ViewOp bounds

### DIFF
--- a/mlir/test/Conversion/XeGPUToXeVM/loadstore_matrix.mlir
+++ b/mlir/test/Conversion/XeGPUToXeVM/loadstore_matrix.mlir
@@ -35,9 +35,9 @@ gpu.module @test_kernel [#xevm.target<chip = "pvc">] {
   }
 
   //CHECK-LABEL: load_store_matrix_plain_2d_input
-  gpu.func @load_store_matrix_plain_2d_input(%arg0: memref<1024xi8, 3>) -> f32 {
+  gpu.func @load_store_matrix_plain_2d_input(%arg0: memref<8192xi8, 3>) -> f32 {
     %c0 = arith.constant 0 : index
-    %view = memref.view %arg0[%c0][]: memref<1024xi8, 3> to memref<64x32xf32, 3>
+    %view = memref.view %arg0[%c0][]: memref<8192xi8, 3> to memref<64x32xf32, 3>
 
     %subview = memref.subview %view[32, 0] [32, 32] [1, 1] : memref<64x32xf32, 3> to memref<32x32xf32, strided<[32, 1], offset: 1024>, 3>
 

--- a/mlir/test/Dialect/MemRef/canonicalize.mlir
+++ b/mlir/test/Dialect/MemRef/canonicalize.mlir
@@ -1574,13 +1574,13 @@ func.func @fold_view_same_source_result_types(%0: memref<128xi8>) -> memref<128x
 // -----
 
 // CHECK-LABEL: func @non_fold_view_non_zero_offset
-//  CHECK-SAME:   (%[[ARG:.*]]: memref<128xi8>)
-func.func @non_fold_view_non_zero_offset(%0: memref<128xi8>) -> memref<128xi8> {
+//  CHECK-SAME:   (%[[ARG:.*]]: memref<129xi8>)
+func.func @non_fold_view_non_zero_offset(%0: memref<129xi8>) -> memref<128xi8> {
   %c1 = arith.constant 1 : index
   // CHECK: %[[C1:.*]] = arith.constant 1 : index
-  // CHECK: %[[RES:.*]] = memref.view %[[ARG]][%[[C1]]][] : memref<128xi8> to memref<128xi8>
+  // CHECK: %[[RES:.*]] = memref.view %[[ARG]][%[[C1]]][] : memref<129xi8> to memref<128xi8>
   // CHECK: return %[[RES]]
-  %res = memref.view %0[%c1][] : memref<128xi8> to memref<128xi8>
+  %res = memref.view %0[%c1][] : memref<129xi8> to memref<128xi8>
   return %res : memref<128xi8>
 }
 

--- a/mlir/test/Dialect/MemRef/invalid.mlir
+++ b/mlir/test/Dialect/MemRef/invalid.mlir
@@ -632,6 +632,35 @@ func.func @invalid_view(%arg0 : index, %arg1 : index, %arg2 : index) {
 
 // -----
 
+func.func @invalid_view_out_of_bounds() {
+  %0 = memref.alloc() : memref<64xi8>
+  %c0 = arith.constant 0 : index
+  // expected-error@+1 {{view total elements in bytes with shift is greater than base total elements in bytes}}
+  %1 = memref.view %0[%c0][] : memref<64xi8> to memref<32xf32>
+  return
+}
+
+// -----
+
+func.func @invalid_view_out_of_bounds_with_dynamic_shift_in_bytes(%shift: index) {
+  %0 = memref.alloc() : memref<64xi8>
+  // expected-error@+1 {{view total elements in bytes with shift is greater than base total elements in bytes}}
+  %1 = memref.view %0[%shift][] : memref<64xi8> to memref<32xf32>
+  return
+}
+
+// -----
+
+func.func @invalid_view_out_of_bounds_with_shift() {
+  %0 = memref.alloc() : memref<128xi8>
+  %c8 = arith.constant 8 : index
+  // expected-error@+1 {{view total elements in bytes with shift is greater than base total elements in bytes}}
+  %1 = memref.view %0[%c8][] : memref<128xi8> to memref<32xf32>
+  return
+}
+
+// -----
+
 func.func @invalid_subview(%input: memref<4x1024xf32>) -> memref<2x256xf32, strided<[1024, 1], offset: 2304>> {
   // expected-error@+1 {{expected offsets to be non-negative, but got -1}}
   %0 = memref.subview %input[-1, 256] [2, 256] [1, 1] : memref<4x1024xf32> to memref<2x256xf32, strided<[1024, 1], offset: 2304>>


### PR DESCRIPTION
- Added static bounds checking for ViewOp, Verifies that the view result size (in bytes) plus the byte shift does not exceed the source buffer size when both memrefs have static shapes.

- Added new invalid lit tests and fixed existing test which has failed on the new verification.