### PR TITLE
[MLIR] [SPIR-V] Verify element type in SPIR-V's vector-type verifier

### DIFF
--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
@@ -188,8 +188,7 @@ static Type parseAndVerifyType(SPIRVDialect const &dialect,
     }
     if (!isa<ScalarType>(t.getElementType())) {
       parser.emitError(typeLoc,
-                       "vector element type has to be SPIR-V compatible "
-                       "integer, float or boolean but found ")
+                       "vector element type has to be SPIR-V scalar but found ")
           << t.getElementType();
       return Type();
     }

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
@@ -186,6 +186,13 @@ static Type parseAndVerifyType(SPIRVDialect const &dialect,
       parser.emitError(typeLoc, "only 1-D vector allowed but found ") << t;
       return Type();
     }
+    if (!isa<ScalarType>(t.getElementType())) {
+      parser.emitError(typeLoc,
+                       "vector element type has to be SPIR-V compatible "
+                       "integer, float or boolean but found ")
+          << t.getElementType();
+      return Type();
+    }
     if (t.getNumElements() > 4) {
       parser.emitError(
           typeLoc, "vector length has to be less than or equal to 4 but found ")

--- a/mlir/test/Dialect/SPIRV/IR/invalid.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/invalid.mlir
@@ -41,3 +41,11 @@ func.func @aligned_store_non_power_of_two(%arg0 : f32) -> () {
   spirv.Store "Function" %0, %arg0 ["Aligned", 3] : f32
   return
 }
+
+// -----
+
+func.func @vector_with_non_spirv_scalar_element_type() -> () {
+  // expected-error@below {{vector element type has to be SPIR-V scalar but found 'index'}}
+  %0 = spirv.Variable : !spirv.ptr<vector<1xindex>, Function>
+  return
+}


### PR DESCRIPTION
Add a check in the SPIR-V vector-type verifier to make sure the element type is a SPIR-V `ScalarType`.

This is intended to "fix" the following bug: https://github.com/llvm/llvm-project/issues/177775 by making the verifier fail on disallowed vector-types which is causing the crash.

Important to mention: the size of vectors might need to be updated in the verifier but I didn't add it since I figured there was an inconsistency between the doc, the current verifier, the CompositeType::isValid method and I don't know which of those make sense since I am not very knowledgable with regard to SPIR-V