### PR TITLE
fuzzer: modernize FuzzedDataProvider conversions

### DIFF
--- a/compiler-rt/include/fuzzer/FuzzedDataProvider.h
+++ b/compiler-rt/include/fuzzer/FuzzedDataProvider.h
@@ -380,13 +380,13 @@ TS FuzzedDataProvider::ConvertUnsignedToSigned(TU value) {
   static_assert(!std::numeric_limits<TU>::is_signed,
                 "Source type must be unsigned.");
 
-  // TODO(Dor1s): change to `if constexpr` once C++17 becomes mainstream.
-  if (std::numeric_limits<TS>::is_modulo)
+  if constexpr (std::numeric_limits<TS>::is_modulo)
     return static_cast<TS>(value);
 
   // Avoid using implementation-defined unsigned to signed conversions.
   // To learn more, see https://stackoverflow.com/questions/13150449.
-  if (value <= std::numeric_limits<TS>::max()) {
+  constexpr auto TS_max = static_cast<TU>(std::numeric_limits<TS>::max());
+  if (value <= TS_max) {
     return static_cast<TS>(value);
   } else {
     constexpr auto TS_min = std::numeric_limits<TS>::min();


### PR DESCRIPTION
This change modernizes FuzzedDataProvider.h now that C++17+ is standard in LLVM.
Replace the runtime if with if constexpr in ConvertUnsignedToSigned
Make the unsigned/signed comparison explicit by casting TS::max() to TU

Tests: not run (header-only change)