### PR TITLE
[AArch64] Add missing GlobalISel patterns to round+convert multiclass

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -6809,6 +6809,21 @@ multiclass FPToIntegerPats<SDNode to_int, SDNode to_int_sat, SDNode to_int_sat_g
   def : Pat<(i64 (to_int_sat (round f64:$Rn), i64)),
             (!cast<Instruction>(INST # UXDr) f64:$Rn)>;
 
+  let Predicates = [HasFullFP16] in {
+  def : Pat<(i32 (to_int_sat_gi (round f16:$Rn))),
+            (!cast<Instruction>(INST # UWHr) f16:$Rn)>;
+  def : Pat<(i64 (to_int_sat_gi (round f16:$Rn))),
+            (!cast<Instruction>(INST # UXHr) f16:$Rn)>;
+  }
+  def : Pat<(i32 (to_int_sat_gi (round f32:$Rn))),
+            (!cast<Instruction>(INST # UWSr) f32:$Rn)>;
+  def : Pat<(i64 (to_int_sat_gi (round f32:$Rn))),
+            (!cast<Instruction>(INST # UXSr) f32:$Rn)>;
+  def : Pat<(i32 (to_int_sat_gi (round f64:$Rn))),
+            (!cast<Instruction>(INST # UWDr) f64:$Rn)>;
+  def : Pat<(i64 (to_int_sat_gi (round f64:$Rn))),
+            (!cast<Instruction>(INST # UXDr) f64:$Rn)>;
+
   // For global-isel we can use register classes to determine
   // which FCVT instruction to use.
   let Predicates = [HasFPRCVT] in {

--- a/llvm/test/CodeGen/AArch64/round-fptosi-sat-scalar.ll
+++ b/llvm/test/CodeGen/AArch64/round-fptosi-sat-scalar.ll
@@ -87,17 +87,8 @@ define i32 @testmswh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testmswh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtms w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testmswh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintm s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.floor.f16(half %a)
   %i = call i32 @llvm.fptosi.sat.i32.f16(half %r)
@@ -130,17 +121,8 @@ define i64 @testmsxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testmsxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtms x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testmsxh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintm s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.floor.f16(half %a)
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
@@ -148,32 +130,10 @@ entry:
 }
 
 define i32 @testmsws(float %a) {
-; CHECK-CVT-LABEL: testmsws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtms w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmsws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtms w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmsws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm s0, s0
-; CHECK-GI-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmsws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testmsws:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintm s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testmsws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtms w0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.floor.f32(float %a)
   %i = call i32 @llvm.fptosi.sat.i32.f32(float %r)
@@ -181,32 +141,10 @@ entry:
 }
 
 define i64 @testmsxs(float %a) {
-; CHECK-CVT-LABEL: testmsxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtms x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmsxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtms x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmsxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm s0, s0
-; CHECK-GI-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmsxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testmsxs:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintm s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testmsxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtms x0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.floor.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
@@ -214,32 +152,10 @@ entry:
 }
 
 define i32 @testmswd(double %a) {
-; CHECK-CVT-LABEL: testmswd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtms w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmswd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtms w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmswd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm d0, d0
-; CHECK-GI-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmswd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testmswd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintm d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testmswd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtms w0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.floor.f64(double %a)
   %i = call i32 @llvm.fptosi.sat.i32.f64(double %r)
@@ -247,32 +163,10 @@ entry:
 }
 
 define i64 @testmsxd(double %a) {
-; CHECK-CVT-LABEL: testmsxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtms x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmsxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtms x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmsxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm d0, d0
-; CHECK-GI-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmsxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testmsxd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintm d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testmsxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtms x0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.floor.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
@@ -351,17 +245,8 @@ define i32 @testpswh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testpswh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtps w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testpswh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintp s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.ceil.f16(half %a)
   %i = call i32 @llvm.fptosi.sat.i32.f16(half %r)
@@ -394,17 +279,8 @@ define i64 @testpsxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testpsxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtps x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testpsxh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintp s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.ceil.f16(half %a)
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
@@ -412,32 +288,10 @@ entry:
 }
 
 define i32 @testpsws(float %a) {
-; CHECK-CVT-LABEL: testpsws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtps w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpsws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtps w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpsws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp s0, s0
-; CHECK-GI-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpsws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testpsws:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintp s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testpsws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtps w0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.ceil.f32(float %a)
   %i = call i32 @llvm.fptosi.sat.i32.f32(float %r)
@@ -445,32 +299,10 @@ entry:
 }
 
 define i64 @testpsxs(float %a) {
-; CHECK-CVT-LABEL: testpsxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtps x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpsxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtps x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpsxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp s0, s0
-; CHECK-GI-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpsxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testpsxs:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintp s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testpsxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtps x0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.ceil.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
@@ -478,32 +310,10 @@ entry:
 }
 
 define i32 @testpswd(double %a) {
-; CHECK-CVT-LABEL: testpswd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtps w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpswd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtps w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpswd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp d0, d0
-; CHECK-GI-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpswd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testpswd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintp d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testpswd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtps w0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.ceil.f64(double %a)
   %i = call i32 @llvm.fptosi.sat.i32.f64(double %r)
@@ -511,32 +321,10 @@ entry:
 }
 
 define i64 @testpsxd(double %a) {
-; CHECK-CVT-LABEL: testpsxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtps x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpsxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtps x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpsxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp d0, d0
-; CHECK-GI-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpsxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testpsxd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintp d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testpsxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtps x0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.ceil.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
@@ -615,17 +403,8 @@ define i32 @testzswh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testzswh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz h0, h0
 ; CHECK-GI-FP16-NEXT:    fcvtzs w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testzswh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintz s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.trunc.f16(half %a)
   %i = call i32 @llvm.fptosi.sat.i32.f16(half %r)
@@ -658,17 +437,8 @@ define i64 @testzsxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testzsxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz h0, h0
 ; CHECK-GI-FP16-NEXT:    fcvtzs x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testzsxh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintz s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.trunc.f16(half %a)
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
@@ -676,32 +446,10 @@ entry:
 }
 
 define i32 @testzsws(float %a) {
-; CHECK-CVT-LABEL: testzsws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzs w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzsws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzs w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzsws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz s0, s0
-; CHECK-GI-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzsws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testzsws:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintz s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testzsws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzs w0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.trunc.f32(float %a)
   %i = call i32 @llvm.fptosi.sat.i32.f32(float %r)
@@ -709,32 +457,10 @@ entry:
 }
 
 define i64 @testzsxs(float %a) {
-; CHECK-CVT-LABEL: testzsxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzs x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzsxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzs x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzsxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz s0, s0
-; CHECK-GI-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzsxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testzsxs:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintz s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testzsxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzs x0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.trunc.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
@@ -742,32 +468,10 @@ entry:
 }
 
 define i32 @testzswd(double %a) {
-; CHECK-CVT-LABEL: testzswd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzs w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzswd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzs w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzswd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz d0, d0
-; CHECK-GI-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzswd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testzswd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintz d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testzswd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzs w0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.trunc.f64(double %a)
   %i = call i32 @llvm.fptosi.sat.i32.f64(double %r)
@@ -775,32 +479,10 @@ entry:
 }
 
 define i64 @testzsxd(double %a) {
-; CHECK-CVT-LABEL: testzsxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzs x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzsxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzs x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzsxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz d0, d0
-; CHECK-GI-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzsxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testzsxd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frintz d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testzsxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzs x0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.trunc.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
@@ -879,17 +561,8 @@ define i32 @testaswh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testaswh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtas w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testaswh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frinta s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.round.f16(half %a)
   %i = call i32 @llvm.fptosi.sat.i32.f16(half %r)
@@ -922,17 +595,8 @@ define i64 @testasxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testasxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtas x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testasxh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frinta s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.round.f16(half %a)
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
@@ -940,32 +604,10 @@ entry:
 }
 
 define i32 @testasws(float %a) {
-; CHECK-CVT-LABEL: testasws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtas w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testasws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtas w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testasws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta s0, s0
-; CHECK-GI-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testasws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testasws:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frinta s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testasws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtas w0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.round.f32(float %a)
   %i = call i32 @llvm.fptosi.sat.i32.f32(float %r)
@@ -973,32 +615,10 @@ entry:
 }
 
 define i64 @testasxs(float %a) {
-; CHECK-CVT-LABEL: testasxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtas x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testasxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtas x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testasxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta s0, s0
-; CHECK-GI-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testasxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testasxs:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frinta s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testasxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtas x0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.round.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
@@ -1006,32 +626,10 @@ entry:
 }
 
 define i32 @testaswd(double %a) {
-; CHECK-CVT-LABEL: testaswd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtas w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testaswd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtas w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testaswd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta d0, d0
-; CHECK-GI-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testaswd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testaswd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frinta d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testaswd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtas w0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.round.f64(double %a)
   %i = call i32 @llvm.fptosi.sat.i32.f64(double %r)
@@ -1039,32 +637,10 @@ entry:
 }
 
 define i64 @testasxd(double %a) {
-; CHECK-CVT-LABEL: testasxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtas x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testasxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtas x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testasxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta d0, d0
-; CHECK-GI-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testasxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testasxd:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    frinta d0, d0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, d0
-; CHECK-GI-NOFP16-NEXT:    ret
+; CHECK-LABEL: testasxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtas x0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.round.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
@@ -1147,14 +723,6 @@ define i32 @testnswh(half %a) {
 ; CHECK-GI-FP16-NEXT:    frintn h0, h0
 ; CHECK-GI-FP16-NEXT:    fcvtzs w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testnswh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintn s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs w0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.roundeven.f16(half %a)
   %i = call i32 @llvm.fptosi.sat.i32.f16(half %r)
@@ -1191,14 +759,6 @@ define i64 @testnsxh(half %a) {
 ; CHECK-GI-FP16-NEXT:    frintn h0, h0
 ; CHECK-GI-FP16-NEXT:    fcvtzs x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
-; CHECK-GI-NOFP16-LABEL: testnsxh:
-; CHECK-GI-NOFP16:       // %bb.0: // %entry
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    frintn s0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt h0, s0
-; CHECK-GI-NOFP16-NEXT:    fcvt s0, h0
-; CHECK-GI-NOFP16-NEXT:    fcvtzs x0, s0
-; CHECK-GI-NOFP16-NEXT:    ret
 entry:
   %r = call half @llvm.roundeven.f16(half %a)
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)

--- a/llvm/test/CodeGen/AArch64/round-fptoui-sat-scalar.ll
+++ b/llvm/test/CodeGen/AArch64/round-fptoui-sat-scalar.ll
@@ -87,8 +87,7 @@ define i32 @testmuwh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testmuwh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtmu w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.floor.f16(half %a)
@@ -122,8 +121,7 @@ define i64 @testmuxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testmuxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtmu x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.floor.f16(half %a)
@@ -132,27 +130,10 @@ entry:
 }
 
 define i32 @testmuws(float %a) {
-; CHECK-CVT-LABEL: testmuws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtmu w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmuws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtmu w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmuws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm s0, s0
-; CHECK-GI-NEXT:    fcvtzu w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmuws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testmuws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtmu w0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.floor.f32(float %a)
   %i = call i32 @llvm.fptoui.sat.i32.f32(float %r)
@@ -160,27 +141,10 @@ entry:
 }
 
 define i64 @testmuxs(float %a) {
-; CHECK-CVT-LABEL: testmuxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtmu x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmuxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtmu x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmuxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm s0, s0
-; CHECK-GI-NEXT:    fcvtzu x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmuxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testmuxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtmu x0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.floor.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
@@ -188,27 +152,10 @@ entry:
 }
 
 define i32 @testmuwd(double %a) {
-; CHECK-CVT-LABEL: testmuwd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtmu w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmuwd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtmu w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmuwd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm d0, d0
-; CHECK-GI-NEXT:    fcvtzu w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmuwd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testmuwd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtmu w0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.floor.f64(double %a)
   %i = call i32 @llvm.fptoui.sat.i32.f64(double %r)
@@ -216,27 +163,10 @@ entry:
 }
 
 define i64 @testmuxd(double %a) {
-; CHECK-CVT-LABEL: testmuxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtmu x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testmuxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtmu x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testmuxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintm d0, d0
-; CHECK-GI-NEXT:    fcvtzu x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testmuxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintm d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testmuxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtmu x0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.floor.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
@@ -315,8 +245,7 @@ define i32 @testpuwh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testpuwh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtpu w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.ceil.f16(half %a)
@@ -350,8 +279,7 @@ define i64 @testpuxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testpuxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtpu x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.ceil.f16(half %a)
@@ -360,27 +288,10 @@ entry:
 }
 
 define i32 @testpuws(float %a) {
-; CHECK-CVT-LABEL: testpuws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtpu w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpuws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtpu w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpuws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp s0, s0
-; CHECK-GI-NEXT:    fcvtzu w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpuws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testpuws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtpu w0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.ceil.f32(float %a)
   %i = call i32 @llvm.fptoui.sat.i32.f32(float %r)
@@ -388,27 +299,10 @@ entry:
 }
 
 define i64 @testpuxs(float %a) {
-; CHECK-CVT-LABEL: testpuxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtpu x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpuxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtpu x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpuxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp s0, s0
-; CHECK-GI-NEXT:    fcvtzu x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpuxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testpuxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtpu x0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.ceil.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
@@ -416,27 +310,10 @@ entry:
 }
 
 define i32 @testpuwd(double %a) {
-; CHECK-CVT-LABEL: testpuwd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtpu w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpuwd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtpu w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpuwd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp d0, d0
-; CHECK-GI-NEXT:    fcvtzu w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpuwd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testpuwd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtpu w0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.ceil.f64(double %a)
   %i = call i32 @llvm.fptoui.sat.i32.f64(double %r)
@@ -444,27 +321,10 @@ entry:
 }
 
 define i64 @testpuxd(double %a) {
-; CHECK-CVT-LABEL: testpuxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtpu x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testpuxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtpu x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testpuxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintp d0, d0
-; CHECK-GI-NEXT:    fcvtzu x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testpuxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintp d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testpuxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtpu x0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.ceil.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
@@ -543,7 +403,6 @@ define i32 @testzuwh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testzuwh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz h0, h0
 ; CHECK-GI-FP16-NEXT:    fcvtzu w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
@@ -578,7 +437,6 @@ define i64 @testzuxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testzuxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz h0, h0
 ; CHECK-GI-FP16-NEXT:    fcvtzu x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
@@ -588,27 +446,10 @@ entry:
 }
 
 define i32 @testzuws(float %a) {
-; CHECK-CVT-LABEL: testzuws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzu w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzuws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzu w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzuws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz s0, s0
-; CHECK-GI-NEXT:    fcvtzu w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzuws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testzuws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzu w0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.trunc.f32(float %a)
   %i = call i32 @llvm.fptoui.sat.i32.f32(float %r)
@@ -616,27 +457,10 @@ entry:
 }
 
 define i64 @testzuxs(float %a) {
-; CHECK-CVT-LABEL: testzuxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzu x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzuxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzu x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzuxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz s0, s0
-; CHECK-GI-NEXT:    fcvtzu x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzuxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testzuxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzu x0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.trunc.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
@@ -644,27 +468,10 @@ entry:
 }
 
 define i32 @testzuwd(double %a) {
-; CHECK-CVT-LABEL: testzuwd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzu w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzuwd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzu w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzuwd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz d0, d0
-; CHECK-GI-NEXT:    fcvtzu w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzuwd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testzuwd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzu w0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.trunc.f64(double %a)
   %i = call i32 @llvm.fptoui.sat.i32.f64(double %r)
@@ -672,27 +479,10 @@ entry:
 }
 
 define i64 @testzuxd(double %a) {
-; CHECK-CVT-LABEL: testzuxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtzu x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testzuxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtzu x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testzuxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frintz d0, d0
-; CHECK-GI-NEXT:    fcvtzu x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testzuxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintz d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testzuxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtzu x0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.trunc.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)
@@ -771,8 +561,7 @@ define i32 @testauwh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testauwh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtau w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.round.f16(half %a)
@@ -806,8 +595,7 @@ define i64 @testauxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testauxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtau x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.round.f16(half %a)
@@ -816,27 +604,10 @@ entry:
 }
 
 define i32 @testauws(float %a) {
-; CHECK-CVT-LABEL: testauws:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtau w0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testauws:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtau w0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testauws:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta s0, s0
-; CHECK-GI-NEXT:    fcvtzu w0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testauws:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testauws:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtau w0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.round.f32(float %a)
   %i = call i32 @llvm.fptoui.sat.i32.f32(float %r)
@@ -844,27 +615,10 @@ entry:
 }
 
 define i64 @testauxs(float %a) {
-; CHECK-CVT-LABEL: testauxs:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtau x0, s0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testauxs:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtau x0, s0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testauxs:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta s0, s0
-; CHECK-GI-NEXT:    fcvtzu x0, s0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testauxs:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta s0, s0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, s0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testauxs:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtau x0, s0
+; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.round.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
@@ -872,27 +626,10 @@ entry:
 }
 
 define i32 @testauwd(double %a) {
-; CHECK-CVT-LABEL: testauwd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtau w0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testauwd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtau w0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testauwd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta d0, d0
-; CHECK-GI-NEXT:    fcvtzu w0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testauwd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testauwd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtau w0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.round.f64(double %a)
   %i = call i32 @llvm.fptoui.sat.i32.f64(double %r)
@@ -900,27 +637,10 @@ entry:
 }
 
 define i64 @testauxd(double %a) {
-; CHECK-CVT-LABEL: testauxd:
-; CHECK-CVT:       // %bb.0: // %entry
-; CHECK-CVT-NEXT:    fcvtau x0, d0
-; CHECK-CVT-NEXT:    ret
-;
-; CHECK-FP16-LABEL: testauxd:
-; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    fcvtau x0, d0
-; CHECK-FP16-NEXT:    ret
-;
-; CHECK-GI-LABEL: testauxd:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    frinta d0, d0
-; CHECK-GI-NEXT:    fcvtzu x0, d0
-; CHECK-GI-NEXT:    ret
-;
-; CHECK-GI-FP16-LABEL: testauxd:
-; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frinta d0, d0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, d0
-; CHECK-GI-FP16-NEXT:    ret
+; CHECK-LABEL: testauxd:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    fcvtau x0, d0
+; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.round.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)


### PR DESCRIPTION
This allows GlobalISel to fuse floating point round+convert operations in the same way as SelectionDAG.