### PR TITLE
[AArch64] Fuse froundeven+convert into single instruction

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -6864,14 +6864,16 @@ multiclass FPToIntegerPats<SDNode to_int, SDNode to_int_sat, SDNode to_int_sat_g
             (!cast<Instruction>(INST # v1i64) f64:$Rn)>;
 }
 
-defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, fceil,  "FCVTPS">;
-defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, fceil,  "FCVTPU">;
-defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, ffloor, "FCVTMS">;
-defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, ffloor, "FCVTMU">;
-defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, ftrunc, "FCVTZS">;
-defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, ftrunc, "FCVTZU">;
-defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, fround, "FCVTAS">;
-defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, fround, "FCVTAU">;
+defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, fceil,      "FCVTPS">;
+defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, fceil,      "FCVTPU">;
+defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, ffloor,     "FCVTMS">;
+defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, ffloor,     "FCVTMU">;
+defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, ftrunc,     "FCVTZS">;
+defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, ftrunc,     "FCVTZU">;
+defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, fround,     "FCVTAS">;
+defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, fround,     "FCVTAU">;
+defm : FPToIntegerPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, froundeven, "FCVTNS">;
+defm : FPToIntegerPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, froundeven, "FCVTNU">;
 
 // For global-isel we can use register classes to determine
 // which FCVT instruction to use.

--- a/llvm/test/CodeGen/AArch64/arm64-cvt-simd-fptoi.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-cvt-simd-fptoi.ll
@@ -546,15 +546,13 @@ define double @fcvtau_dd_round_simd(double %a) {
 define double @fcvtns_ds_roundeven_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_ds_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs x8, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtns x8, s0
 ; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_ds_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs d0, s0
+; CHECK-NEXT:    fcvtns d0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = fptosi float %r to i64
@@ -565,15 +563,13 @@ define double @fcvtns_ds_roundeven_simd(float %a) {
 define float @fcvtns_sd_roundeven_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_sd_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs w8, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtns w8, d0
 ; CHECK-NOFPRCVT-NEXT:    fmov s0, w8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_sd_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs s0, d0
+; CHECK-NEXT:    fcvtns s0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = fptosi double %r to i32
@@ -584,14 +580,12 @@ define float @fcvtns_sd_roundeven_simd(double %a) {
 define float @fcvtns_ss_roundeven_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_ss_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs s0, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtns s0, s0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_ss_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs s0, s0
+; CHECK-NEXT:    fcvtns s0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = fptosi float %r to i32
@@ -602,14 +596,12 @@ define float @fcvtns_ss_roundeven_simd(float %a) {
 define double @fcvtns_dd_roundeven_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_dd_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs d0, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtns d0, d0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_dd_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs d0, d0
+; CHECK-NEXT:    fcvtns d0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = fptosi double %r to i64
@@ -621,15 +613,13 @@ define double @fcvtns_dd_roundeven_simd(double %a) {
 define double @fcvtnu_ds_roundeven_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_ds_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu x8, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu x8, s0
 ; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_ds_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu d0, s0
+; CHECK-NEXT:    fcvtnu d0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = fptoui float %r to i64
@@ -640,15 +630,13 @@ define double @fcvtnu_ds_roundeven_simd(float %a) {
 define float @fcvtnu_sd_roundeven_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_sd_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu w8, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu w8, d0
 ; CHECK-NOFPRCVT-NEXT:    fmov s0, w8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_sd_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu s0, d0
+; CHECK-NEXT:    fcvtnu s0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = fptoui double %r to i32
@@ -659,14 +647,12 @@ define float @fcvtnu_sd_roundeven_simd(double %a) {
 define float @fcvtnu_ss_roundeven_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_ss_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu s0, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu s0, s0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_ss_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu s0, s0
+; CHECK-NEXT:    fcvtnu s0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = fptoui float %r to i32
@@ -677,14 +663,12 @@ define float @fcvtnu_ss_roundeven_simd(float %a) {
 define double @fcvtnu_dd_roundeven_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_dd_roundeven_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu d0, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu d0, d0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_dd_roundeven_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu d0, d0
+; CHECK-NEXT:    fcvtnu d0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = fptoui double %r to i64
@@ -1493,15 +1477,13 @@ define double @fcvtau_dd_simd(double %a) {
 define float @fcvtns_sh_simd(half %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_sh_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn h0, h0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs w8, h0
+; CHECK-NOFPRCVT-NEXT:    fcvtns w8, h0
 ; CHECK-NOFPRCVT-NEXT:    fmov s0, w8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_sh_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn h0, h0
-; CHECK-NEXT:    fcvtzs s0, h0
+; CHECK-NEXT:    fcvtns s0, h0
 ; CHECK-NEXT:    ret
   %r = call half @llvm.roundeven.f16(half %a)
   %i = call i32 @llvm.fptosi.sat.i32.f16(half %r)
@@ -1512,15 +1494,13 @@ define float @fcvtns_sh_simd(half %a) {
 define double @fcvtns_dh_simd(half %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_dh_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn h0, h0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs x8, h0
+; CHECK-NOFPRCVT-NEXT:    fcvtns x8, h0
 ; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_dh_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn h0, h0
-; CHECK-NEXT:    fcvtzs d0, h0
+; CHECK-NEXT:    fcvtns d0, h0
 ; CHECK-NEXT:    ret
   %r = call half @llvm.roundeven.f16(half %a)
   %i = call i64 @llvm.fptosi.sat.i64.f16(half %r)
@@ -1531,15 +1511,13 @@ define double @fcvtns_dh_simd(half %a) {
 define double @fcvtns_ds_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_ds_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs x8, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtns x8, s0
 ; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_ds_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs d0, s0
+; CHECK-NEXT:    fcvtns d0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = call i64 @llvm.fptosi.sat.i64.f32(float %r)
@@ -1550,15 +1528,13 @@ define double @fcvtns_ds_simd(float %a) {
 define float @fcvtns_sd_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_sd_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs w8, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtns w8, d0
 ; CHECK-NOFPRCVT-NEXT:    fmov s0, w8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_sd_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs s0, d0
+; CHECK-NEXT:    fcvtns s0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = call i32 @llvm.fptosi.sat.i32.f64(double %r)
@@ -1569,14 +1545,12 @@ define float @fcvtns_sd_simd(double %a) {
 define float @fcvtns_ss_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_ss_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs s0, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtns s0, s0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_ss_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs s0, s0
+; CHECK-NEXT:    fcvtns s0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = call i32 @llvm.fptosi.sat.i32.f32(float %r)
@@ -1587,14 +1561,12 @@ define float @fcvtns_ss_simd(float %a) {
 define double @fcvtns_dd_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtns_dd_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzs d0, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtns d0, d0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtns_dd_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs d0, d0
+; CHECK-NEXT:    fcvtns d0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = call i64 @llvm.fptosi.sat.i64.f64(double %r)
@@ -1605,15 +1577,13 @@ define double @fcvtns_dd_simd(double %a) {
 define float @fcvtnu_sh_simd(half %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_sh_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn h0, h0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu w8, h0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu w8, h0
 ; CHECK-NOFPRCVT-NEXT:    fmov s0, w8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_sh_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn h0, h0
-; CHECK-NEXT:    fcvtzu s0, h0
+; CHECK-NEXT:    fcvtnu s0, h0
 ; CHECK-NEXT:    ret
   %r = call half @llvm.roundeven.f16(half %a)
   %i = call i32 @llvm.fptoui.sat.i32.f16(half %r)
@@ -1624,15 +1594,13 @@ define float @fcvtnu_sh_simd(half %a) {
 define double @fcvtnu_dh_simd(half %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_dh_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn h0, h0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu x8, h0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu x8, h0
 ; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_dh_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn h0, h0
-; CHECK-NEXT:    fcvtzu d0, h0
+; CHECK-NEXT:    fcvtnu d0, h0
 ; CHECK-NEXT:    ret
   %r = call half @llvm.roundeven.f16(half %a)
   %i = call i64 @llvm.fptoui.sat.i64.f16(half %r)
@@ -1643,15 +1611,13 @@ define double @fcvtnu_dh_simd(half %a) {
 define double @fcvtnu_ds_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_ds_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu x8, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu x8, s0
 ; CHECK-NOFPRCVT-NEXT:    fmov d0, x8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_ds_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu d0, s0
+; CHECK-NEXT:    fcvtnu d0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = call i64 @llvm.fptoui.sat.i64.f32(float %r)
@@ -1662,15 +1628,13 @@ define double @fcvtnu_ds_simd(float %a) {
 define float @fcvtnu_sd_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_sd_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu w8, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu w8, d0
 ; CHECK-NOFPRCVT-NEXT:    fmov s0, w8
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_sd_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu s0, d0
+; CHECK-NEXT:    fcvtnu s0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = call i32 @llvm.fptoui.sat.i32.f64(double %r)
@@ -1681,14 +1645,12 @@ define float @fcvtnu_sd_simd(double %a) {
 define float @fcvtnu_ss_simd(float %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_ss_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn s0, s0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu s0, s0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu s0, s0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_ss_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu s0, s0
+; CHECK-NEXT:    fcvtnu s0, s0
 ; CHECK-NEXT:    ret
   %r = call float @llvm.roundeven.f32(float %a)
   %i = call i32 @llvm.fptoui.sat.i32.f32(float %r)
@@ -1699,14 +1661,12 @@ define float @fcvtnu_ss_simd(float %a) {
 define double @fcvtnu_dd_simd(double %a) {
 ; CHECK-NOFPRCVT-LABEL: fcvtnu_dd_simd:
 ; CHECK-NOFPRCVT:       // %bb.0:
-; CHECK-NOFPRCVT-NEXT:    frintn d0, d0
-; CHECK-NOFPRCVT-NEXT:    fcvtzu d0, d0
+; CHECK-NOFPRCVT-NEXT:    fcvtnu d0, d0
 ; CHECK-NOFPRCVT-NEXT:    ret
 ;
 ; CHECK-LABEL: fcvtnu_dd_simd:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu d0, d0
+; CHECK-NEXT:    fcvtnu d0, d0
 ; CHECK-NEXT:    ret
   %r = call double @llvm.roundeven.f64(double %a)
   %i = call i64 @llvm.fptoui.sat.i64.f64(double %r)

--- a/llvm/test/CodeGen/AArch64/round-conv.ll
+++ b/llvm/test/CodeGen/AArch64/round-conv.ll
@@ -280,8 +280,7 @@ entry:
 define i32 @testnsws(float %a) {
 ; CHECK-LABEL: testnsws:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs w0, s0
+; CHECK-NEXT:    fcvtns w0, s0
 ; CHECK-NEXT:    ret
 entry:
   %call = call float @llvm.roundeven.f32(float %a)
@@ -303,8 +302,7 @@ entry:
 define i64 @testnsxs(float %a) {
 ; CHECK-LABEL: testnsxs:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs x0, s0
+; CHECK-NEXT:    fcvtns x0, s0
 ; CHECK-NEXT:    ret
 entry:
   %call = call float @llvm.roundeven.f32(float %a)
@@ -326,8 +324,7 @@ entry:
 define i32 @testnswd(double %a) {
 ; CHECK-LABEL: testnswd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs w0, d0
+; CHECK-NEXT:    fcvtns w0, d0
 ; CHECK-NEXT:    ret
 entry:
   %call = call double @llvm.roundeven.f64(double %a)
@@ -349,8 +346,7 @@ entry:
 define i64 @testnsxd(double %a) {
 ; CHECK-LABEL: testnsxd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs x0, d0
+; CHECK-NEXT:    fcvtns x0, d0
 ; CHECK-NEXT:    ret
 entry:
   %call = call double @llvm.roundeven.f64(double %a)
@@ -372,8 +368,7 @@ entry:
 define i32 @testnuws(float %a) {
 ; CHECK-LABEL: testnuws:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu w0, s0
+; CHECK-NEXT:    fcvtnu w0, s0
 ; CHECK-NEXT:    ret
 entry:
   %call = call float @llvm.roundeven.f32(float %a)
@@ -395,8 +390,7 @@ entry:
 define i64 @testnuxs(float %a) {
 ; CHECK-LABEL: testnuxs:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu x0, s0
+; CHECK-NEXT:    fcvtnu x0, s0
 ; CHECK-NEXT:    ret
 entry:
   %call = call float @llvm.roundeven.f32(float %a)
@@ -418,8 +412,7 @@ entry:
 define i32 @testnuwd(double %a) {
 ; CHECK-LABEL: testnuwd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu w0, d0
+; CHECK-NEXT:    fcvtnu w0, d0
 ; CHECK-NEXT:    ret
 entry:
   %call = call double @llvm.roundeven.f64(double %a)
@@ -441,8 +434,7 @@ entry:
 define i64 @testnuxd(double %a) {
 ; CHECK-LABEL: testnuxd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu x0, d0
+; CHECK-NEXT:    fcvtnu x0, d0
 ; CHECK-NEXT:    ret
 entry:
   %call = call double @llvm.roundeven.f64(double %a)

--- a/llvm/test/CodeGen/AArch64/round-fptosi-sat-scalar.ll
+++ b/llvm/test/CodeGen/AArch64/round-fptosi-sat-scalar.ll
@@ -705,8 +705,7 @@ define i32 @testnswh(half %a) {
 ;
 ; CHECK-FP16-LABEL: testnswh:
 ; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    frintn h0, h0
-; CHECK-FP16-NEXT:    fcvtzs w0, h0
+; CHECK-FP16-NEXT:    fcvtns w0, h0
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: testnswh:
@@ -720,8 +719,7 @@ define i32 @testnswh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testnswh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintn h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtns w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.roundeven.f16(half %a)
@@ -741,8 +739,7 @@ define i64 @testnsxh(half %a) {
 ;
 ; CHECK-FP16-LABEL: testnsxh:
 ; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    frintn h0, h0
-; CHECK-FP16-NEXT:    fcvtzs x0, h0
+; CHECK-FP16-NEXT:    fcvtns x0, h0
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: testnsxh:
@@ -756,8 +753,7 @@ define i64 @testnsxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testnsxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintn h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzs x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtns x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.roundeven.f16(half %a)
@@ -768,8 +764,7 @@ entry:
 define i32 @testnsws(float %a) {
 ; CHECK-LABEL: testnsws:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs w0, s0
+; CHECK-NEXT:    fcvtns w0, s0
 ; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.roundeven.f32(float %a)
@@ -780,8 +775,7 @@ entry:
 define i64 @testnsxs(float %a) {
 ; CHECK-LABEL: testnsxs:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzs x0, s0
+; CHECK-NEXT:    fcvtns x0, s0
 ; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.roundeven.f32(float %a)
@@ -792,8 +786,7 @@ entry:
 define i32 @testnswd(double %a) {
 ; CHECK-LABEL: testnswd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs w0, d0
+; CHECK-NEXT:    fcvtns w0, d0
 ; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.roundeven.f64(double %a)
@@ -804,8 +797,7 @@ entry:
 define i64 @testnsxd(double %a) {
 ; CHECK-LABEL: testnsxd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzs x0, d0
+; CHECK-NEXT:    fcvtns x0, d0
 ; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.roundeven.f64(double %a)

--- a/llvm/test/CodeGen/AArch64/round-fptoui-sat-scalar.ll
+++ b/llvm/test/CodeGen/AArch64/round-fptoui-sat-scalar.ll
@@ -705,8 +705,7 @@ define i32 @testnuwh(half %a) {
 ;
 ; CHECK-FP16-LABEL: testnuwh:
 ; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    frintn h0, h0
-; CHECK-FP16-NEXT:    fcvtzu w0, h0
+; CHECK-FP16-NEXT:    fcvtnu w0, h0
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: testnuwh:
@@ -720,8 +719,7 @@ define i32 @testnuwh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testnuwh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintn h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu w0, h0
+; CHECK-GI-FP16-NEXT:    fcvtnu w0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.roundeven.f16(half %a)
@@ -741,8 +739,7 @@ define i64 @testnuxh(half %a) {
 ;
 ; CHECK-FP16-LABEL: testnuxh:
 ; CHECK-FP16:       // %bb.0: // %entry
-; CHECK-FP16-NEXT:    frintn h0, h0
-; CHECK-FP16-NEXT:    fcvtzu x0, h0
+; CHECK-FP16-NEXT:    fcvtnu x0, h0
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: testnuxh:
@@ -756,8 +753,7 @@ define i64 @testnuxh(half %a) {
 ;
 ; CHECK-GI-FP16-LABEL: testnuxh:
 ; CHECK-GI-FP16:       // %bb.0: // %entry
-; CHECK-GI-FP16-NEXT:    frintn h0, h0
-; CHECK-GI-FP16-NEXT:    fcvtzu x0, h0
+; CHECK-GI-FP16-NEXT:    fcvtnu x0, h0
 ; CHECK-GI-FP16-NEXT:    ret
 entry:
   %r = call half @llvm.roundeven.f16(half %a)
@@ -768,8 +764,7 @@ entry:
 define i32 @testnuws(float %a) {
 ; CHECK-LABEL: testnuws:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu w0, s0
+; CHECK-NEXT:    fcvtnu w0, s0
 ; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.roundeven.f32(float %a)
@@ -780,8 +775,7 @@ entry:
 define i64 @testnuxs(float %a) {
 ; CHECK-LABEL: testnuxs:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn s0, s0
-; CHECK-NEXT:    fcvtzu x0, s0
+; CHECK-NEXT:    fcvtnu x0, s0
 ; CHECK-NEXT:    ret
 entry:
   %r = call float @llvm.roundeven.f32(float %a)
@@ -792,8 +786,7 @@ entry:
 define i32 @testnuwd(double %a) {
 ; CHECK-LABEL: testnuwd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu w0, d0
+; CHECK-NEXT:    fcvtnu w0, d0
 ; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.roundeven.f64(double %a)
@@ -804,8 +797,7 @@ entry:
 define i64 @testnuxd(double %a) {
 ; CHECK-LABEL: testnuxd:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    frintn d0, d0
-; CHECK-NEXT:    fcvtzu x0, d0
+; CHECK-NEXT:    fcvtnu x0, d0
 ; CHECK-NEXT:    ret
 entry:
   %r = call double @llvm.roundeven.f64(double %a)


### PR DESCRIPTION
Stacked on https://github.com/llvm/llvm-project/pull/177799.

We're already able to fuse `fceil`, `ffloor`, `ftrunc`, and `fround` followed by a float-to-int conversion into a single "rounded conversion" instruction. However, we were not doing this for `froundeven`, even though there's a "convert to integer, rounding to even" instruction (`FCVTNS`/`FCVTNU`).