### PR TITLE
[AArch64] Add vector floating-point round+convert patterns

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -5849,6 +5849,57 @@ multiclass SIMDTwoVectorFPToIntSatPats<SDNode to_int_sat, SDNode to_int_sat_gi, 
 defm : SIMDTwoVectorFPToIntSatPats<fp_to_sint_sat, fp_to_sint_sat_gi, "FCVTZS">;
 defm : SIMDTwoVectorFPToIntSatPats<fp_to_uint_sat, fp_to_uint_sat_gi, "FCVTZU">;
 
+// Fused round + convert to int patterns for vectors
+multiclass SIMDTwoVectorFPToIntRoundPats<SDNode to_int, SDNode to_int_sat, SDNode to_int_sat_gi, SDNode round, string INST> {
+  let Predicates = [HasFullFP16] in {
+    def : Pat<(v4i16 (to_int (round v4f16:$Rn))),
+              (!cast<Instruction>(INST # v4f16) v4f16:$Rn)>;
+    def : Pat<(v8i16 (to_int (round v8f16:$Rn))),
+              (!cast<Instruction>(INST # v8f16) v8f16:$Rn)>;
+
+    def : Pat<(v4i16 (to_int_sat (round v4f16:$Rn), i16)),
+              (!cast<Instruction>(INST # v4f16) v4f16:$Rn)>;
+    def : Pat<(v8i16 (to_int_sat (round v8f16:$Rn), i16)),
+              (!cast<Instruction>(INST # v8f16) v8f16:$Rn)>;
+
+    def : Pat<(v4i16 (to_int_sat_gi (round v4f16:$Rn))),
+              (!cast<Instruction>(INST # v4f16) v4f16:$Rn)>;
+    def : Pat<(v8i16 (to_int_sat_gi (round v8f16:$Rn))),
+              (!cast<Instruction>(INST # v8f16) v8f16:$Rn)>;
+  }
+  def : Pat<(v2i32 (to_int (round v2f32:$Rn))),
+            (!cast<Instruction>(INST # v2f32) v2f32:$Rn)>;
+  def : Pat<(v4i32 (to_int (round v4f32:$Rn))),
+            (!cast<Instruction>(INST # v4f32) v4f32:$Rn)>;
+  def : Pat<(v2i64 (to_int (round v2f64:$Rn))),
+            (!cast<Instruction>(INST # v2f64) v2f64:$Rn)>;
+
+  def : Pat<(v2i32 (to_int_sat (round v2f32:$Rn), i32)),
+            (!cast<Instruction>(INST # v2f32) v2f32:$Rn)>;
+  def : Pat<(v4i32 (to_int_sat (round v4f32:$Rn), i32)),
+            (!cast<Instruction>(INST # v4f32) v4f32:$Rn)>;
+  def : Pat<(v2i64 (to_int_sat (round v2f64:$Rn), i64)),
+            (!cast<Instruction>(INST # v2f64) v2f64:$Rn)>;
+
+  def : Pat<(v2i32 (to_int_sat_gi (round v2f32:$Rn))),
+            (!cast<Instruction>(INST # v2f32) v2f32:$Rn)>;
+  def : Pat<(v4i32 (to_int_sat_gi (round v4f32:$Rn))),
+            (!cast<Instruction>(INST # v4f32) v4f32:$Rn)>;
+  def : Pat<(v2i64 (to_int_sat_gi (round v2f64:$Rn))),
+            (!cast<Instruction>(INST # v2f64) v2f64:$Rn)>;
+}
+
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, fceil,      "FCVTPS">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, fceil,      "FCVTPU">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, ffloor,     "FCVTMS">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, ffloor,     "FCVTMU">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, ftrunc,     "FCVTZS">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, ftrunc,     "FCVTZU">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, fround,     "FCVTAS">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, fround,     "FCVTAU">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_sint, fp_to_sint_sat, fp_to_sint_sat_gi, froundeven, "FCVTNS">;
+defm : SIMDTwoVectorFPToIntRoundPats<fp_to_uint, fp_to_uint_sat, fp_to_uint_sat_gi, froundeven, "FCVTNU">;
+
 def : Pat<(v4i16 (int_aarch64_neon_fcvtzs v4f16:$Rn)), (FCVTZSv4f16 $Rn)>;
 def : Pat<(v8i16 (int_aarch64_neon_fcvtzs v8f16:$Rn)), (FCVTZSv8f16 $Rn)>;
 def : Pat<(v2i32 (int_aarch64_neon_fcvtzs v2f32:$Rn)), (FCVTZSv2f32 $Rn)>;

--- a/llvm/test/CodeGen/AArch64/arm64-vcvt-fptoi.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-vcvt-fptoi.ll
@@ -15,8 +15,7 @@
 define <2 x i32> @fcvtas_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtas_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtas v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.round.v2f32(<2 x float> %A)
   %tmp2 = fptosi <2 x float> %tmp1 to <2 x i32>
@@ -26,8 +25,7 @@ define <2 x i32> @fcvtas_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtas_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtas_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtas v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.round.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -38,8 +36,7 @@ define <2 x i32> @fcvtas_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtas_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtas_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtas v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.round.v4f32(<4 x float> %A)
   %tmp2 = fptosi <4 x float> %tmp1 to <4 x i32>
@@ -49,8 +46,7 @@ define <4 x i32> @fcvtas_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtas_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtas_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtas v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.round.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptosi.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -61,8 +57,7 @@ define <4 x i32> @fcvtas_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtas_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtas_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtas v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.round.v2f64(<2 x double> %A)
   %tmp2 = fptosi <2 x double> %tmp1 to <2 x i64>
@@ -72,8 +67,7 @@ define <2 x i64> @fcvtas_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtas_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtas_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtas v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.round.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptosi.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -88,8 +82,7 @@ define <2 x i64> @fcvtas_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtau_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtau_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtau v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.round.v2f32(<2 x float> %A)
   %tmp2 = fptoui <2 x float> %tmp1 to <2 x i32>
@@ -99,8 +92,7 @@ define <2 x i32> @fcvtau_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtau_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtau_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtau v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.round.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptoui.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -111,8 +103,7 @@ define <2 x i32> @fcvtau_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtau_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtau_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtau v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.round.v4f32(<4 x float> %A)
   %tmp2 = fptoui <4 x float> %tmp1 to <4 x i32>
@@ -122,8 +113,7 @@ define <4 x i32> @fcvtau_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtau_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtau_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtau v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.round.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptoui.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -134,8 +124,7 @@ define <4 x i32> @fcvtau_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtau_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtau_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtau v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.round.v2f64(<2 x double> %A)
   %tmp2 = fptoui <2 x double> %tmp1 to <2 x i64>
@@ -145,8 +134,7 @@ define <2 x i64> @fcvtau_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtau_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtau_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frinta v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtau v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.round.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptoui.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -161,8 +149,7 @@ define <2 x i64> @fcvtau_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtns_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtns_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtns v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.roundeven.v2f32(<2 x float> %A)
   %tmp2 = fptosi <2 x float> %tmp1 to <2 x i32>
@@ -172,8 +159,7 @@ define <2 x i32> @fcvtns_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtns_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtns_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtns v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.roundeven.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -184,8 +170,7 @@ define <2 x i32> @fcvtns_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtns_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtns_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtns v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.roundeven.v4f32(<4 x float> %A)
   %tmp2 = fptosi <4 x float> %tmp1 to <4 x i32>
@@ -195,8 +180,7 @@ define <4 x i32> @fcvtns_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtns_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtns_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtns v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.roundeven.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptosi.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -207,8 +191,7 @@ define <4 x i32> @fcvtns_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtns_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtns_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtns v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.roundeven.v2f64(<2 x double> %A)
   %tmp2 = fptosi <2 x double> %tmp1 to <2 x i64>
@@ -218,8 +201,7 @@ define <2 x i64> @fcvtns_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtns_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtns_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtns v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.roundeven.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptosi.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -234,8 +216,7 @@ define <2 x i64> @fcvtns_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtnu_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtnu_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtnu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.roundeven.v2f32(<2 x float> %A)
   %tmp2 = fptoui <2 x float> %tmp1 to <2 x i32>
@@ -245,8 +226,7 @@ define <2 x i32> @fcvtnu_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtnu_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtnu_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtnu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.roundeven.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptoui.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -257,8 +237,7 @@ define <2 x i32> @fcvtnu_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtnu_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtnu_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtnu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.roundeven.v4f32(<4 x float> %A)
   %tmp2 = fptoui <4 x float> %tmp1 to <4 x i32>
@@ -268,8 +247,7 @@ define <4 x i32> @fcvtnu_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtnu_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtnu_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtnu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.roundeven.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptoui.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -280,8 +258,7 @@ define <4 x i32> @fcvtnu_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtnu_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtnu_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtnu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.roundeven.v2f64(<2 x double> %A)
   %tmp2 = fptoui <2 x double> %tmp1 to <2 x i64>
@@ -291,8 +268,7 @@ define <2 x i64> @fcvtnu_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtnu_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtnu_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintn v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtnu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.roundeven.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptoui.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -307,8 +283,7 @@ define <2 x i64> @fcvtnu_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtms_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtms_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtms v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.floor.v2f32(<2 x float> %A)
   %tmp2 = fptosi <2 x float> %tmp1 to <2 x i32>
@@ -318,8 +293,7 @@ define <2 x i32> @fcvtms_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtms_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtms_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtms v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.floor.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -330,8 +304,7 @@ define <2 x i32> @fcvtms_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtms_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtms_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtms v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.floor.v4f32(<4 x float> %A)
   %tmp2 = fptosi <4 x float> %tmp1 to <4 x i32>
@@ -341,8 +314,7 @@ define <4 x i32> @fcvtms_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtms_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtms_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtms v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.floor.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptosi.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -353,8 +325,7 @@ define <4 x i32> @fcvtms_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtms_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtms_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtms v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.floor.v2f64(<2 x double> %A)
   %tmp2 = fptosi <2 x double> %tmp1 to <2 x i64>
@@ -364,8 +335,7 @@ define <2 x i64> @fcvtms_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtms_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtms_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtms v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.floor.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptosi.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -380,8 +350,7 @@ define <2 x i64> @fcvtms_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtmu_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtmu_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtmu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.floor.v2f32(<2 x float> %A)
   %tmp2 = fptoui <2 x float> %tmp1 to <2 x i32>
@@ -391,8 +360,7 @@ define <2 x i32> @fcvtmu_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtmu_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtmu_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtmu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.floor.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptoui.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -403,8 +371,7 @@ define <2 x i32> @fcvtmu_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtmu_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtmu_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtmu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.floor.v4f32(<4 x float> %A)
   %tmp2 = fptoui <4 x float> %tmp1 to <4 x i32>
@@ -414,8 +381,7 @@ define <4 x i32> @fcvtmu_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtmu_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtmu_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtmu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.floor.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptoui.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -426,8 +392,7 @@ define <4 x i32> @fcvtmu_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtmu_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtmu_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtmu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.floor.v2f64(<2 x double> %A)
   %tmp2 = fptoui <2 x double> %tmp1 to <2 x i64>
@@ -437,8 +402,7 @@ define <2 x i64> @fcvtmu_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtmu_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtmu_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtmu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.floor.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptoui.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -453,8 +417,7 @@ define <2 x i64> @fcvtmu_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtps_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtps_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtps v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.ceil.v2f32(<2 x float> %A)
   %tmp2 = fptosi <2 x float> %tmp1 to <2 x i32>
@@ -464,8 +427,7 @@ define <2 x i32> @fcvtps_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtps_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtps_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
+; CHECK-NEXT:    fcvtps v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.ceil.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptosi.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -476,8 +438,7 @@ define <2 x i32> @fcvtps_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtps_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtps_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtps v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.ceil.v4f32(<4 x float> %A)
   %tmp2 = fptosi <4 x float> %tmp1 to <4 x i32>
@@ -487,8 +448,7 @@ define <4 x i32> @fcvtps_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtps_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtps_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
+; CHECK-NEXT:    fcvtps v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.ceil.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptosi.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -499,8 +459,7 @@ define <4 x i32> @fcvtps_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtps_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtps_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtps v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.ceil.v2f64(<2 x double> %A)
   %tmp2 = fptosi <2 x double> %tmp1 to <2 x i64>
@@ -510,8 +469,7 @@ define <2 x i64> @fcvtps_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtps_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtps_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
+; CHECK-NEXT:    fcvtps v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.ceil.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptosi.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -526,8 +484,7 @@ define <2 x i64> @fcvtps_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtpu_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtpu_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtpu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.ceil.v2f32(<2 x float> %A)
   %tmp2 = fptoui <2 x float> %tmp1 to <2 x i32>
@@ -537,8 +494,7 @@ define <2 x i32> @fcvtpu_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtpu_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtpu_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2s, v0.2s
-; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
+; CHECK-NEXT:    fcvtpu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.ceil.v2f32(<2 x float> %A)
   %tmp2 = call <2 x i32> @llvm.fptoui.sat.v2i32.v2f32(<2 x float> %tmp1)
@@ -549,8 +505,7 @@ define <2 x i32> @fcvtpu_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtpu_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtpu_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtpu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.ceil.v4f32(<4 x float> %A)
   %tmp2 = fptoui <4 x float> %tmp1 to <4 x i32>
@@ -560,8 +515,7 @@ define <4 x i32> @fcvtpu_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtpu_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtpu_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.4s, v0.4s
-; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
+; CHECK-NEXT:    fcvtpu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.ceil.v4f32(<4 x float> %A)
   %tmp2 = call <4 x i32> @llvm.fptoui.sat.v4i32.v4f32(<4 x float> %tmp1)
@@ -572,8 +526,7 @@ define <4 x i32> @fcvtpu_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtpu_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtpu_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtpu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.ceil.v2f64(<2 x double> %A)
   %tmp2 = fptoui <2 x double> %tmp1 to <2 x i64>
@@ -583,8 +536,7 @@ define <2 x i64> @fcvtpu_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtpu_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtpu_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintp v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
+; CHECK-NEXT:    fcvtpu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.ceil.v2f64(<2 x double> %A)
   %tmp2 = call <2 x i64> @llvm.fptoui.sat.v2i64.v2f64(<2 x double> %tmp1)
@@ -599,7 +551,6 @@ define <2 x i64> @fcvtpu_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtzs_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzs_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2s, v0.2s
 ; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.trunc.v2f32(<2 x float> %A)
@@ -610,7 +561,6 @@ define <2 x i32> @fcvtzs_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtzs_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzs_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2s, v0.2s
 ; CHECK-NEXT:    fcvtzs v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.trunc.v2f32(<2 x float> %A)
@@ -622,7 +572,6 @@ define <2 x i32> @fcvtzs_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtzs_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzs_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.4s, v0.4s
 ; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.trunc.v4f32(<4 x float> %A)
@@ -633,7 +582,6 @@ define <4 x i32> @fcvtzs_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtzs_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzs_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.4s, v0.4s
 ; CHECK-NEXT:    fcvtzs v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.trunc.v4f32(<4 x float> %A)
@@ -645,7 +593,6 @@ define <4 x i32> @fcvtzs_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtzs_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtzs_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2d, v0.2d
 ; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.trunc.v2f64(<2 x double> %A)
@@ -656,7 +603,6 @@ define <2 x i64> @fcvtzs_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtzs_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtzs_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2d, v0.2d
 ; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.trunc.v2f64(<2 x double> %A)
@@ -672,7 +618,6 @@ define <2 x i64> @fcvtzs_2d_sat(<2 x double> %A) nounwind {
 define <2 x i32> @fcvtzu_2s(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzu_2s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2s, v0.2s
 ; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.trunc.v2f32(<2 x float> %A)
@@ -683,7 +628,6 @@ define <2 x i32> @fcvtzu_2s(<2 x float> %A) nounwind {
 define <2 x i32> @fcvtzu_2s_sat(<2 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzu_2s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2s, v0.2s
 ; CHECK-NEXT:    fcvtzu v0.2s, v0.2s
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x float> @llvm.trunc.v2f32(<2 x float> %A)
@@ -695,7 +639,6 @@ define <2 x i32> @fcvtzu_2s_sat(<2 x float> %A) nounwind {
 define <4 x i32> @fcvtzu_4s(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzu_4s:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.4s, v0.4s
 ; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.trunc.v4f32(<4 x float> %A)
@@ -706,7 +649,6 @@ define <4 x i32> @fcvtzu_4s(<4 x float> %A) nounwind {
 define <4 x i32> @fcvtzu_4s_sat(<4 x float> %A) nounwind {
 ; CHECK-LABEL: fcvtzu_4s_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.4s, v0.4s
 ; CHECK-NEXT:    fcvtzu v0.4s, v0.4s
 ; CHECK-NEXT:    ret
   %tmp1 = call <4 x float> @llvm.trunc.v4f32(<4 x float> %A)
@@ -718,7 +660,6 @@ define <4 x i32> @fcvtzu_4s_sat(<4 x float> %A) nounwind {
 define <2 x i64> @fcvtzu_2d(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtzu_2d:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2d, v0.2d
 ; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.trunc.v2f64(<2 x double> %A)
@@ -729,7 +670,6 @@ define <2 x i64> @fcvtzu_2d(<2 x double> %A) nounwind {
 define <2 x i64> @fcvtzu_2d_sat(<2 x double> %A) nounwind {
 ; CHECK-LABEL: fcvtzu_2d_sat:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintz v0.2d, v0.2d
 ; CHECK-NEXT:    fcvtzu v0.2d, v0.2d
 ; CHECK-NEXT:    ret
   %tmp1 = call <2 x double> @llvm.trunc.v2f64(<2 x double> %A)
@@ -755,8 +695,7 @@ define <4 x i16> @fcvtas_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtas_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtas v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtas_4h:
@@ -771,8 +710,7 @@ define <4 x i16> @fcvtas_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtas_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtas v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.round.v4f16(<4 x half> %A)
   %tmp2 = fptosi <4 x half> %tmp1 to <4 x i16>
@@ -792,8 +730,7 @@ define <4 x i16> @fcvtas_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtas_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtas v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtas_4h_sat:
@@ -808,8 +745,7 @@ define <4 x i16> @fcvtas_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtas_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtas v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.round.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptosi.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -835,8 +771,7 @@ define <8 x i16> @fcvtas_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtas_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtas v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtas_8h:
@@ -856,8 +791,7 @@ define <8 x i16> @fcvtas_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtas_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtas v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.round.v8f16(<8 x half> %A)
   %tmp2 = fptosi <8 x half> %tmp1 to <8 x i16>
@@ -883,8 +817,7 @@ define <8 x i16> @fcvtas_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtas_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtas v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtas_8h_sat:
@@ -905,8 +838,7 @@ define <8 x i16> @fcvtas_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtas_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtas v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.round.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptosi.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -927,8 +859,7 @@ define <4 x i16> @fcvtau_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtau_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtau v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtau_4h:
@@ -943,8 +874,7 @@ define <4 x i16> @fcvtau_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtau_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtau v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.round.v4f16(<4 x half> %A)
   %tmp2 = fptoui <4 x half> %tmp1 to <4 x i16>
@@ -964,8 +894,7 @@ define <4 x i16> @fcvtau_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtau_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtau v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtau_4h_sat:
@@ -980,8 +909,7 @@ define <4 x i16> @fcvtau_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtau_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtau v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.round.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptoui.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -1007,8 +935,7 @@ define <8 x i16> @fcvtau_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtau_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtau v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtau_8h:
@@ -1028,8 +955,7 @@ define <8 x i16> @fcvtau_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtau_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtau v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.round.v8f16(<8 x half> %A)
   %tmp2 = fptoui <8 x half> %tmp1 to <8 x i16>
@@ -1055,8 +981,7 @@ define <8 x i16> @fcvtau_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtau_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtau v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtau_8h_sat:
@@ -1077,8 +1002,7 @@ define <8 x i16> @fcvtau_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtau_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frinta v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtau v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.round.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptoui.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -1099,8 +1023,7 @@ define <4 x i16> @fcvtns_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtns_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtns v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtns_4h:
@@ -1115,8 +1038,7 @@ define <4 x i16> @fcvtns_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtns_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtns v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.roundeven.v4f16(<4 x half> %A)
   %tmp2 = fptosi <4 x half> %tmp1 to <4 x i16>
@@ -1136,8 +1058,7 @@ define <4 x i16> @fcvtns_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtns_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtns v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtns_4h_sat:
@@ -1152,8 +1073,7 @@ define <4 x i16> @fcvtns_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtns_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtns v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.roundeven.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptosi.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -1179,8 +1099,7 @@ define <8 x i16> @fcvtns_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtns_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtns v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtns_8h:
@@ -1200,8 +1119,7 @@ define <8 x i16> @fcvtns_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtns_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtns v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.roundeven.v8f16(<8 x half> %A)
   %tmp2 = fptosi <8 x half> %tmp1 to <8 x i16>
@@ -1227,8 +1145,7 @@ define <8 x i16> @fcvtns_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtns_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtns v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtns_8h_sat:
@@ -1249,8 +1166,7 @@ define <8 x i16> @fcvtns_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtns_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtns v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.roundeven.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptosi.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -1271,8 +1187,7 @@ define <4 x i16> @fcvtnu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtnu_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtnu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtnu_4h:
@@ -1287,8 +1202,7 @@ define <4 x i16> @fcvtnu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtnu_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtnu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.roundeven.v4f16(<4 x half> %A)
   %tmp2 = fptoui <4 x half> %tmp1 to <4 x i16>
@@ -1308,8 +1222,7 @@ define <4 x i16> @fcvtnu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtnu_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtnu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtnu_4h_sat:
@@ -1324,8 +1237,7 @@ define <4 x i16> @fcvtnu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtnu_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtnu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.roundeven.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptoui.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -1351,8 +1263,7 @@ define <8 x i16> @fcvtnu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtnu_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtnu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtnu_8h:
@@ -1372,8 +1283,7 @@ define <8 x i16> @fcvtnu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtnu_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtnu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.roundeven.v8f16(<8 x half> %A)
   %tmp2 = fptoui <8 x half> %tmp1 to <8 x i16>
@@ -1399,8 +1309,7 @@ define <8 x i16> @fcvtnu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtnu_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtnu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtnu_8h_sat:
@@ -1421,8 +1330,7 @@ define <8 x i16> @fcvtnu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtnu_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintn v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtnu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.roundeven.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptoui.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -1443,8 +1351,7 @@ define <4 x i16> @fcvtms_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtms_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtms v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtms_4h:
@@ -1459,8 +1366,7 @@ define <4 x i16> @fcvtms_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtms_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtms v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.floor.v4f16(<4 x half> %A)
   %tmp2 = fptosi <4 x half> %tmp1 to <4 x i16>
@@ -1480,8 +1386,7 @@ define <4 x i16> @fcvtms_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtms_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtms v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtms_4h_sat:
@@ -1496,8 +1401,7 @@ define <4 x i16> @fcvtms_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtms_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtms v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.floor.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptosi.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -1523,8 +1427,7 @@ define <8 x i16> @fcvtms_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtms_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtms v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtms_8h:
@@ -1544,8 +1447,7 @@ define <8 x i16> @fcvtms_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtms_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtms v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.floor.v8f16(<8 x half> %A)
   %tmp2 = fptosi <8 x half> %tmp1 to <8 x i16>
@@ -1571,8 +1473,7 @@ define <8 x i16> @fcvtms_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtms_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtms v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtms_8h_sat:
@@ -1593,8 +1494,7 @@ define <8 x i16> @fcvtms_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtms_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtms v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.floor.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptosi.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -1615,8 +1515,7 @@ define <4 x i16> @fcvtmu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtmu_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtmu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtmu_4h:
@@ -1631,8 +1530,7 @@ define <4 x i16> @fcvtmu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtmu_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtmu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.floor.v4f16(<4 x half> %A)
   %tmp2 = fptoui <4 x half> %tmp1 to <4 x i16>
@@ -1652,8 +1550,7 @@ define <4 x i16> @fcvtmu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtmu_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtmu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtmu_4h_sat:
@@ -1668,8 +1565,7 @@ define <4 x i16> @fcvtmu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtmu_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtmu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.floor.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptoui.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -1695,8 +1591,7 @@ define <8 x i16> @fcvtmu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtmu_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtmu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtmu_8h:
@@ -1716,8 +1611,7 @@ define <8 x i16> @fcvtmu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtmu_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtmu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.floor.v8f16(<8 x half> %A)
   %tmp2 = fptoui <8 x half> %tmp1 to <8 x i16>
@@ -1743,8 +1637,7 @@ define <8 x i16> @fcvtmu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtmu_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtmu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtmu_8h_sat:
@@ -1765,8 +1658,7 @@ define <8 x i16> @fcvtmu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtmu_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintm v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtmu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.floor.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptoui.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -1787,8 +1679,7 @@ define <4 x i16> @fcvtps_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtps_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtps v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtps_4h:
@@ -1803,8 +1694,7 @@ define <4 x i16> @fcvtps_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtps_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtps v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.ceil.v4f16(<4 x half> %A)
   %tmp2 = fptosi <4 x half> %tmp1 to <4 x i16>
@@ -1824,8 +1714,7 @@ define <4 x i16> @fcvtps_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtps_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtps v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtps_4h_sat:
@@ -1840,8 +1729,7 @@ define <4 x i16> @fcvtps_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtps_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtps v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.ceil.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptosi.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -1867,8 +1755,7 @@ define <8 x i16> @fcvtps_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtps_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtps v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtps_8h:
@@ -1888,8 +1775,7 @@ define <8 x i16> @fcvtps_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtps_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtps v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.ceil.v8f16(<8 x half> %A)
   %tmp2 = fptosi <8 x half> %tmp1 to <8 x i16>
@@ -1915,8 +1801,7 @@ define <8 x i16> @fcvtps_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtps_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtps v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtps_8h_sat:
@@ -1937,8 +1822,7 @@ define <8 x i16> @fcvtps_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtps_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtps v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.ceil.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptosi.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -1959,8 +1843,7 @@ define <4 x i16> @fcvtpu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtpu_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtpu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtpu_4h:
@@ -1975,8 +1858,7 @@ define <4 x i16> @fcvtpu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtpu_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtpu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.ceil.v4f16(<4 x half> %A)
   %tmp2 = fptoui <4 x half> %tmp1 to <4 x i16>
@@ -1996,8 +1878,7 @@ define <4 x i16> @fcvtpu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtpu_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-FP16-NEXT:    fcvtpu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtpu_4h_sat:
@@ -2012,8 +1893,7 @@ define <4 x i16> @fcvtpu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtpu_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.4h, v0.4h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
+; CHECK-GI-FP16-NEXT:    fcvtpu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.ceil.v4f16(<4 x half> %A)
   %tmp2 = call <4 x i16> @llvm.fptoui.sat.v4i16.v4f16(<4 x half> %tmp1)
@@ -2039,8 +1919,7 @@ define <8 x i16> @fcvtpu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtpu_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtpu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtpu_8h:
@@ -2060,8 +1939,7 @@ define <8 x i16> @fcvtpu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtpu_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtpu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.ceil.v8f16(<8 x half> %A)
   %tmp2 = fptoui <8 x half> %tmp1 to <8 x i16>
@@ -2087,8 +1965,7 @@ define <8 x i16> @fcvtpu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtpu_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fcvtpu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
 ; CHECK-GI-NO16-LABEL: fcvtpu_8h_sat:
@@ -2109,8 +1986,7 @@ define <8 x i16> @fcvtpu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtpu_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintp v0.8h, v0.8h
-; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
+; CHECK-GI-FP16-NEXT:    fcvtpu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.ceil.v8f16(<8 x half> %A)
   %tmp2 = call <8 x i16> @llvm.fptoui.sat.v8i16.v8f16(<8 x half> %tmp1)
@@ -2131,7 +2007,6 @@ define <4 x i16> @fcvtzs_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzs_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2147,7 +2022,6 @@ define <4 x i16> @fcvtzs_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzs_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.trunc.v4f16(<4 x half> %A)
@@ -2168,7 +2042,6 @@ define <4 x i16> @fcvtzs_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzs_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    fcvtzs v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2184,7 +2057,6 @@ define <4 x i16> @fcvtzs_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzs_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    fcvtzs v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.trunc.v4f16(<4 x half> %A)
@@ -2211,7 +2083,6 @@ define <8 x i16> @fcvtzs_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzs_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2232,7 +2103,6 @@ define <8 x i16> @fcvtzs_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzs_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.trunc.v8f16(<8 x half> %A)
@@ -2259,7 +2129,6 @@ define <8 x i16> @fcvtzs_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzs_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    fcvtzs v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2281,7 +2150,6 @@ define <8 x i16> @fcvtzs_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzs_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    fcvtzs v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.trunc.v8f16(<8 x half> %A)
@@ -2303,7 +2171,6 @@ define <4 x i16> @fcvtzu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzu_4h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2319,7 +2186,6 @@ define <4 x i16> @fcvtzu_4h(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzu_4h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.trunc.v4f16(<4 x half> %A)
@@ -2340,7 +2206,6 @@ define <4 x i16> @fcvtzu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzu_4h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    fcvtzu v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2356,7 +2221,6 @@ define <4 x i16> @fcvtzu_4h_sat(<4 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzu_4h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    fcvtzu v0.4h, v0.4h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <4 x half> @llvm.trunc.v4f16(<4 x half> %A)
@@ -2383,7 +2247,6 @@ define <8 x i16> @fcvtzu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzu_8h:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2404,7 +2267,6 @@ define <8 x i16> @fcvtzu_8h(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzu_8h:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.trunc.v8f16(<8 x half> %A)
@@ -2431,7 +2293,6 @@ define <8 x i16> @fcvtzu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-FP16-LABEL: fcvtzu_8h_sat:
 ; CHECK-FP16:       // %bb.0:
-; CHECK-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    fcvtzu v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
 ;
@@ -2453,7 +2314,6 @@ define <8 x i16> @fcvtzu_8h_sat(<8 x half> %A) nounwind {
 ;
 ; CHECK-GI-FP16-LABEL: fcvtzu_8h_sat:
 ; CHECK-GI-FP16:       // %bb.0:
-; CHECK-GI-FP16-NEXT:    frintz v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    fcvtzu v0.8h, v0.8h
 ; CHECK-GI-FP16-NEXT:    ret
   %tmp1 = call <8 x half> @llvm.trunc.v8f16(<8 x half> %A)

--- a/llvm/test/CodeGen/AArch64/shuffle-tbl34.ll
+++ b/llvm/test/CodeGen/AArch64/shuffle-tbl34.ll
@@ -700,23 +700,15 @@ define <16 x i8> @insert4_v16i8(<8 x i8> %a, <16 x i8> %b, <8 x i8> %c, <16 x i8
 define <16 x i16> @test(<2 x double> %l213, <2 x double> %l231, <2 x double> %l249, <2 x double> %l267, <2 x double> %l285, <2 x double> %l303, <2 x double> %l321, <2 x double> %l339) {
 ; CHECK-LABEL: test:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    frintm v0.2d, v0.2d
-; CHECK-NEXT:    frintm v4.2d, v4.2d
+; CHECK-NEXT:    fcvtms v0.2d, v0.2d
+; CHECK-NEXT:    fcvtms v4.2d, v4.2d
 ; CHECK-NEXT:    adrp x8, .LCPI16_0
-; CHECK-NEXT:    frintm v1.2d, v1.2d
-; CHECK-NEXT:    frintm v5.2d, v5.2d
-; CHECK-NEXT:    frintm v2.2d, v2.2d
-; CHECK-NEXT:    frintm v6.2d, v6.2d
-; CHECK-NEXT:    frintm v3.2d, v3.2d
-; CHECK-NEXT:    frintm v7.2d, v7.2d
-; CHECK-NEXT:    fcvtzs v0.2d, v0.2d
-; CHECK-NEXT:    fcvtzs v4.2d, v4.2d
-; CHECK-NEXT:    fcvtzs v1.2d, v1.2d
-; CHECK-NEXT:    fcvtzs v5.2d, v5.2d
-; CHECK-NEXT:    fcvtzs v2.2d, v2.2d
-; CHECK-NEXT:    fcvtzs v6.2d, v6.2d
-; CHECK-NEXT:    fcvtzs v3.2d, v3.2d
-; CHECK-NEXT:    fcvtzs v7.2d, v7.2d
+; CHECK-NEXT:    fcvtms v1.2d, v1.2d
+; CHECK-NEXT:    fcvtms v5.2d, v5.2d
+; CHECK-NEXT:    fcvtms v2.2d, v2.2d
+; CHECK-NEXT:    fcvtms v6.2d, v6.2d
+; CHECK-NEXT:    fcvtms v3.2d, v3.2d
+; CHECK-NEXT:    fcvtms v7.2d, v7.2d
 ; CHECK-NEXT:    xtn v16.2s, v0.2d
 ; CHECK-NEXT:    xtn v20.2s, v4.2d
 ; CHECK-NEXT:    ldr q0, [x8, :lo12:.LCPI16_0]


### PR DESCRIPTION
Stacked on https://github.com/llvm/llvm-project/pull/177800.

We were previously able to fuse *scalar* floating-point round + convert to integer sequences into a single "rounding conversion" instruction. This PR extends that to vectors.