### PR TITLE
[clang][analyzer] Suppress false positives in std::stable_sort and st…

### DIFF
--- a/clang/test/Analysis/diagnostics/implicit-cxx-std-suppression.cpp
+++ b/clang/test/Analysis/diagnostics/implicit-cxx-std-suppression.cpp
@@ -37,3 +37,13 @@ void testSuppression_std_shared_pointer() {
 
   p = nullptr; // no-warning
 }
+
+void testSuppression_stable_sort() {
+  int arr[5];
+  std::stable_sort(arr, arr + 5); // no-warning
+}
+
+void testSuppression_inplace_merge() {
+  int arr[5];
+  std::inplace_merge(arr, arr + 2, arr + 5); // no-warning
+}


### PR DESCRIPTION
…d::inplace_merge

The analyzer reports false positives in `std::stable_sort` and `std::inplace_merge` due to complex move semantics in `__uninitialized_construct_buf_dispatch::__ucr`.

Add suppression for this STL internal function, following the pattern of existing suppressions for `std::basic_string` and `std::shared_ptr`.