### PR TITLE
[clang][bytecode] Fix crash caused by overflow of Casting float number to integer

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2628,8 +2628,9 @@ static inline bool CastFloatingIntegralAP(InterpState &S, CodePtr OpPC,
   auto Status = F.convertToInteger(Result);
 
   // Float-to-Integral overflow check.
-  if ((Status & APFloat::opStatus::opInvalidOp) && F.isFinite())
-    return handleOverflow(S, OpPC, F.getAPFloat());
+  if ((Status & APFloat::opStatus::opInvalidOp) && F.isFinite() &&
+      !handleOverflow(S, OpPC, F.getAPFloat()))
+    return false;
 
   FPOptions FPO = FPOptions::getFromOpaqueInt(FPOI);
 
@@ -2649,8 +2650,9 @@ static inline bool CastFloatingIntegralAPS(InterpState &S, CodePtr OpPC,
   auto Status = F.convertToInteger(Result);
 
   // Float-to-Integral overflow check.
-  if ((Status & APFloat::opStatus::opInvalidOp) && F.isFinite())
-    return handleOverflow(S, OpPC, F.getAPFloat());
+  if ((Status & APFloat::opStatus::opInvalidOp) && F.isFinite() &&
+      !handleOverflow(S, OpPC, F.getAPFloat()))
+    return false;
 
   FPOptions FPO = FPOptions::getFromOpaqueInt(FPOI);
 

--- a/clang/test/AST/ByteCode/floats.cpp
+++ b/clang/test/AST/ByteCode/floats.cpp
@@ -224,3 +224,16 @@ namespace nan {
                                                            // expected-error {{must be initialized by a constant expression}} \
                                                            // expected-note {{produces a NaN}}
 }
+
+namespace ConvertToIntOverflow {
+  // should not crash
+  enum { E = (__uint128_t)-1. }; // ref-error {{expression is not an integral constant expression}} \
+                                 // ref-note {{outside the range of representable values of type}} \
+                                 // expected-error {{expression is not an integral constant expression}} \
+                                 // expected-note {{outside the range of representable values of type}}
+
+  enum { F = (__int128)(3.0e38) }; // ref-error {{expression is not an integral constant expression}} \
+                                   // ref-note {{outside the range of representable values of type}} \
+                                   // expected-error {{expression is not an integral constant expression}} \
+                                   // expected-note {{outside the range of representable values of type}}
+}

--- a/clang/test/AST/ByteCode/floats.cpp
+++ b/clang/test/AST/ByteCode/floats.cpp
@@ -225,6 +225,7 @@ namespace nan {
                                                            // expected-note {{produces a NaN}}
 }
 
+#ifdef __SIZEOF_INT128__
 namespace ConvertToIntOverflow {
   // should not crash
   enum { E = (__uint128_t)-1. }; // ref-error {{expression is not an integral constant expression}} \
@@ -237,3 +238,4 @@ namespace ConvertToIntOverflow {
                                    // expected-error {{expression is not an integral constant expression}} \
                                    // expected-note {{outside the range of representable values of type}}
 }
+#endif


### PR DESCRIPTION
Before this PR evaluation process will stop immediately regradless of whether it's set to handle overflow,

this will prevent us getting value from stack, which leads to crash(with or without assertion).

Closes  #177751.