### PR TITLE
[CIR][CUDA][HIP] Add NVPTX target info and CUDA/HIP global emission filtering

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -382,15 +382,7 @@ template <typename AttrT> static bool hasImplicitAttr(const ValueDecl *decl) {
   return decl->isImplicit();
 }
 
-// This function returns true if M is a specialization, a template,
-// or a non-generic lambda call operator.
-inline bool isLambdaCallOperator(const CXXMethodDecl *MD) {
-  const CXXRecordDecl *LambdaClass = MD->getParent();
-  if (!LambdaClass || !LambdaClass->isLambda())
-    return false;
-  return MD->getOverloadedOperator() == OO_Call;
-}
-
+// TODO(cir): This should be shared with OG Codegen.
 bool CIRGenModule::shouldEmitCUDAGlobalVar(const VarDecl *global) const {
   assert(langOpts.CUDA && "Should not be called by non-CUDA languages");
   // We need to emit host-side 'shadows' for all global
@@ -427,6 +419,7 @@ void CIRGenModule::emitGlobal(clang::GlobalDecl gd) {
     if (const auto *varDecl = dyn_cast<VarDecl>(global)) {
       if (!shouldEmitCUDAGlobalVar(varDecl))
         return;
+    // TODO(cir): This should be shared with OG Codegen.
     } else if (langOpts.CUDAIsDevice) {
       const auto *functionDecl = dyn_cast<FunctionDecl>(global);
       if ((!global->hasAttr<CUDADeviceAttr>() ||

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -419,7 +419,7 @@ void CIRGenModule::emitGlobal(clang::GlobalDecl gd) {
     if (const auto *varDecl = dyn_cast<VarDecl>(global)) {
       if (!shouldEmitCUDAGlobalVar(varDecl))
         return;
-    // TODO(cir): This should be shared with OG Codegen.
+      // TODO(cir): This should be shared with OG Codegen.
     } else if (langOpts.CUDAIsDevice) {
       const auto *functionDecl = dyn_cast<FunctionDecl>(global);
       if ((!global->hasAttr<CUDADeviceAttr>() ||

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -17,8 +17,8 @@
 #include "CIRGenFunction.h"
 
 #include "clang/AST/ASTContext.h"
-#include "clang/AST/DeclBase.h"
 #include "clang/AST/ASTLambda.h"
+#include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclOpenACC.h"
 #include "clang/AST/GlobalDecl.h"
 #include "clang/AST/RecordLayout.h"
@@ -386,7 +386,8 @@ template <typename AttrT> static bool hasImplicitAttr(const ValueDecl *decl) {
 // or a non-generic lambda call operator.
 inline bool isLambdaCallOperator(const CXXMethodDecl *MD) {
   const CXXRecordDecl *LambdaClass = MD->getParent();
-  if (!LambdaClass || !LambdaClass->isLambda()) return false;
+  if (!LambdaClass || !LambdaClass->isLambda())
+    return false;
   return MD->getOverloadedOperator() == OO_Call;
 }
 
@@ -2060,8 +2061,6 @@ bool CIRGenModule::mayBeEmittedEagerly(const ValueDecl *global) {
          "Only FunctionDecl and VarDecl should hit this path so far.");
   return true;
 }
-
-
 
 static bool shouldAssumeDSOLocal(const CIRGenModule &cgm,
                                  cir::CIRGlobalValueInterface gv) {

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -567,6 +567,10 @@ public:
 
   static void setInitializer(cir::GlobalOp &op, mlir::Attribute value);
 
+  // Whether a global variable should be emitted by CUDA/HIP host/device
+  // related attributes.
+  bool shouldEmitCUDAGlobalVar(const VarDecl *global) const;
+
   void replaceUsesOfNonProtoTypeWithRealFunction(mlir::Operation *old,
                                                  cir::FuncOp newFn);
 

--- a/clang/lib/CIR/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CIR/CodeGen/TargetInfo.cpp
@@ -56,6 +56,25 @@ public:
 
 } // namespace
 
+namespace {
+
+class NVPTXABIInfo : public ABIInfo {
+public:
+  NVPTXABIInfo(CIRGenTypes &cgt) : ABIInfo(cgt) {}
+};
+
+class NVPTXTargetCIRGenInfo : public TargetCIRGenInfo {
+public:
+  NVPTXTargetCIRGenInfo(CIRGenTypes &cgt)
+      : TargetCIRGenInfo(std::make_unique<NVPTXABIInfo>(cgt)) {}
+};
+} // namespace
+
+std::unique_ptr<TargetCIRGenInfo>
+clang::CIRGen::createNVPTXTargetCIRGenInfo(CIRGenTypes &cgt) {
+  return std::make_unique<NVPTXTargetCIRGenInfo>(cgt);
+}
+
 std::unique_ptr<TargetCIRGenInfo>
 clang::CIRGen::createX8664TargetCIRGenInfo(CIRGenTypes &cgt) {
   return std::make_unique<X8664TargetCIRGenInfo>(cgt);

--- a/clang/lib/CIR/CodeGen/TargetInfo.h
+++ b/clang/lib/CIR/CodeGen/TargetInfo.h
@@ -124,6 +124,8 @@ public:
 
 std::unique_ptr<TargetCIRGenInfo> createX8664TargetCIRGenInfo(CIRGenTypes &cgt);
 
+std::unique_ptr<TargetCIRGenInfo> createNVPTXTargetCIRGenInfo(CIRGenTypes &cgt);
+
 } // namespace clang::CIRGen
 
 #endif // LLVM_CLANG_LIB_CIR_TARGETINFO_H

--- a/clang/test/CIR/CodeGenCUDA/filter-decl.cu
+++ b/clang/test/CIR/CodeGenCUDA/filter-decl.cu
@@ -1,37 +1,55 @@
 // Based on clang/test/CodeGenCUDA/filter-decl.cu tailored for CIR current capabilities.
 // Tests that host/device functions are emitted only on the appropriate side.
 
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x cuda \
-// RUN:   -I%S/../inputs -emit-cir %s -o %t.host.cir
-// RUN: FileCheck --input-file=%t.host.cir %s --check-prefix=CHECK-HOST
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -target-sdk-version=9.2 \
+// RUN:   -x cuda -I%S/../inputs -emit-cir %s -o %t.host.cir
+// RUN: FileCheck --input-file=%t.host.cir %s --check-prefix=CIR-HOST
 
 // RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda \
 // RUN:   -I%S/../inputs -fcuda-is-device -emit-cir %s -o %t.device.cir
-// RUN: FileCheck --input-file=%t.device.cir %s --check-prefix=CHECK-DEVICE
+// RUN: FileCheck --input-file=%t.device.cir %s --check-prefix=CIR-DEVICE
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -target-sdk-version=9.2 \
+// RUN:   -x cuda -I%S/../inputs -emit-llvm %s -o %t.host.ll
+// RUN: FileCheck --input-file=%t.host.ll %s --check-prefix=OGCG-HOST
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda \
+// RUN:   -I%S/../inputs -fcuda-is-device -emit-llvm %s -o %t.device.ll
+// RUN: FileCheck --input-file=%t.device.ll %s --check-prefix=OGCG-DEVICE
 
 #include "cuda.h"
 
 // Implicit host function (no attribute) — host only
-// CHECK-HOST: cir.func {{.*}} @_Z20implicithostonlyfuncv()
-// CHECK-DEVICE-NOT: @_Z20implicithostonlyfuncv
+// CIR-HOST: cir.func {{.*}} @_Z20implicithostonlyfuncv()
+// CIR-DEVICE-NOT: @_Z20implicithostonlyfuncv
+// OGCG-HOST: define{{.*}} void @_Z20implicithostonlyfuncv()
+// OGCG-DEVICE-NOT: @_Z20implicithostonlyfuncv
 void implicithostonlyfunc(void) {}
 
 // Explicit __host__ function — host only
-// CHECK-HOST: cir.func {{.*}} @_Z20explicithostonlyfuncv()
-// CHECK-DEVICE-NOT: @_Z20explicithostonlyfuncv
+// CIR-HOST: cir.func {{.*}} @_Z20explicithostonlyfuncv()
+// CIR-DEVICE-NOT: @_Z20explicithostonlyfuncv
+// OGCG-HOST: define{{.*}} void @_Z20explicithostonlyfuncv()
+// OGCG-DEVICE-NOT: @_Z20explicithostonlyfuncv
 __host__ void explicithostonlyfunc(void) {}
 
 // __device__ function — device only
-// CHECK-HOST-NOT: @_Z14deviceonlyfuncv
-// CHECK-DEVICE: cir.func {{.*}} @_Z14deviceonlyfuncv()
+// CIR-HOST-NOT: @_Z14deviceonlyfuncv
+// CIR-DEVICE: cir.func {{.*}} @_Z14deviceonlyfuncv()
+// OGCG-HOST-NOT: @_Z14deviceonlyfuncv
+// OGCG-DEVICE: define{{.*}} void @_Z14deviceonlyfuncv()
 __device__ void deviceonlyfunc(void) {}
 
 // __host__ __device__ function — both sides
-// CHECK-HOST: cir.func {{.*}} @_Z14hostdevicefuncv()
-// CHECK-DEVICE: cir.func {{.*}} @_Z14hostdevicefuncv()
+// CIR-HOST: cir.func {{.*}} @_Z14hostdevicefuncv()
+// CIR-DEVICE: cir.func {{.*}} @_Z14hostdevicefuncv()
+// OGCG-HOST: define{{.*}} void @_Z14hostdevicefuncv()
+// OGCG-DEVICE: define{{.*}} void @_Z14hostdevicefuncv()
 __host__ __device__ void hostdevicefunc(void) {}
 
 // __global__ kernel — both sides (stub on host, kernel on device)
-// CHECK-HOST: cir.func {{.*}} @_Z25__device_stub__globalfuncv()
-// CHECK-DEVICE: cir.func {{.*}} @_Z10globalfuncv()
+// CIR-HOST: cir.func {{.*}} @_Z25__device_stub__globalfuncv()
+// CIR-DEVICE: cir.func {{.*}} @_Z10globalfuncv()
+// OGCG-HOST: define{{.*}} void @_Z25__device_stub__globalfuncv()
+// OGCG-DEVICE: define{{.*}} void @_Z10globalfuncv()
 __global__ void globalfunc(void) {}

--- a/clang/test/CIR/CodeGenCUDA/filter-decl.cu
+++ b/clang/test/CIR/CodeGenCUDA/filter-decl.cu
@@ -1,0 +1,37 @@
+// Based on clang/test/CodeGenCUDA/filter-decl.cu tailored for CIR current capabilities.
+// Tests that host/device functions are emitted only on the appropriate side.
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x cuda \
+// RUN:   -I%S/../inputs -emit-cir %s -o %t.host.cir
+// RUN: FileCheck --input-file=%t.host.cir %s --check-prefix=CHECK-HOST
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda \
+// RUN:   -I%S/../inputs -fcuda-is-device -emit-cir %s -o %t.device.cir
+// RUN: FileCheck --input-file=%t.device.cir %s --check-prefix=CHECK-DEVICE
+
+#include "cuda.h"
+
+// Implicit host function (no attribute) — host only
+// CHECK-HOST: cir.func {{.*}} @_Z20implicithostonlyfuncv()
+// CHECK-DEVICE-NOT: @_Z20implicithostonlyfuncv
+void implicithostonlyfunc(void) {}
+
+// Explicit __host__ function — host only
+// CHECK-HOST: cir.func {{.*}} @_Z20explicithostonlyfuncv()
+// CHECK-DEVICE-NOT: @_Z20explicithostonlyfuncv
+__host__ void explicithostonlyfunc(void) {}
+
+// __device__ function — device only
+// CHECK-HOST-NOT: @_Z14deviceonlyfuncv
+// CHECK-DEVICE: cir.func {{.*}} @_Z14deviceonlyfuncv()
+__device__ void deviceonlyfunc(void) {}
+
+// __host__ __device__ function — both sides
+// CHECK-HOST: cir.func {{.*}} @_Z14hostdevicefuncv()
+// CHECK-DEVICE: cir.func {{.*}} @_Z14hostdevicefuncv()
+__host__ __device__ void hostdevicefunc(void) {}
+
+// __global__ kernel — both sides (stub on host, kernel on device)
+// CHECK-HOST: cir.func {{.*}} @__device_stub__globalfunc()
+// CHECK-DEVICE: cir.func {{.*}} @_Z10globalfuncv()
+__global__ void globalfunc(void) {}

--- a/clang/test/CIR/CodeGenCUDA/filter-decl.cu
+++ b/clang/test/CIR/CodeGenCUDA/filter-decl.cu
@@ -32,6 +32,6 @@ __device__ void deviceonlyfunc(void) {}
 __host__ __device__ void hostdevicefunc(void) {}
 
 // __global__ kernel — both sides (stub on host, kernel on device)
-// CHECK-HOST: cir.func {{.*}} @__device_stub__globalfunc()
+// CHECK-HOST: cir.func {{.*}} @_Z25__device_stub__globalfuncv()
 // CHECK-DEVICE: cir.func {{.*}} @_Z10globalfuncv()
 __global__ void globalfunc(void) {}

--- a/clang/test/CIR/CodeGenCUDA/filter-decl.cu
+++ b/clang/test/CIR/CodeGenCUDA/filter-decl.cu
@@ -2,22 +2,22 @@
 // Tests that host/device functions are emitted only on the appropriate side.
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -target-sdk-version=9.2 \
-// RUN:   -x cuda -I%S/../Inputs -emit-cir %s -o %t.host.cir
+// RUN:   -x cuda -emit-cir %s -o %t.host.cir
 // RUN: FileCheck --input-file=%t.host.cir %s --check-prefix=CIR-HOST
 
 // RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda \
-// RUN:   -I%S/../Inputs -fcuda-is-device -emit-cir %s -o %t.device.cir
+// RUN:  -fcuda-is-device -emit-cir %s -o %t.device.cir
 // RUN: FileCheck --input-file=%t.device.cir %s --check-prefix=CIR-DEVICE
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -target-sdk-version=9.2 \
-// RUN:   -x cuda -I%S/../Inputs -emit-llvm %s -o %t.host.ll
+// RUN:   -x cuda -emit-llvm %s -o %t.host.ll
 // RUN: FileCheck --input-file=%t.host.ll %s --check-prefix=OGCG-HOST
 
 // RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda \
-// RUN:   -I%S/../Inputs -fcuda-is-device -emit-llvm %s -o %t.device.ll
+// RUN:   -fcuda-is-device -emit-llvm %s -o %t.device.ll
 // RUN: FileCheck --input-file=%t.device.ll %s --check-prefix=OGCG-DEVICE
 
-#include "cuda.h"
+#include "Inputs/cuda.h"
 
 // Implicit host function (no attribute) — host only
 // CIR-HOST: cir.func {{.*}} @_Z20implicithostonlyfuncv()

--- a/clang/test/CIR/CodeGenCUDA/filter-decl.cu
+++ b/clang/test/CIR/CodeGenCUDA/filter-decl.cu
@@ -2,19 +2,19 @@
 // Tests that host/device functions are emitted only on the appropriate side.
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -target-sdk-version=9.2 \
-// RUN:   -x cuda -I%S/../inputs -emit-cir %s -o %t.host.cir
+// RUN:   -x cuda -I%S/../Inputs -emit-cir %s -o %t.host.cir
 // RUN: FileCheck --input-file=%t.host.cir %s --check-prefix=CIR-HOST
 
 // RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda \
-// RUN:   -I%S/../inputs -fcuda-is-device -emit-cir %s -o %t.device.cir
+// RUN:   -I%S/../Inputs -fcuda-is-device -emit-cir %s -o %t.device.cir
 // RUN: FileCheck --input-file=%t.device.cir %s --check-prefix=CIR-DEVICE
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -target-sdk-version=9.2 \
-// RUN:   -x cuda -I%S/../inputs -emit-llvm %s -o %t.host.ll
+// RUN:   -x cuda -I%S/../Inputs -emit-llvm %s -o %t.host.ll
 // RUN: FileCheck --input-file=%t.host.ll %s --check-prefix=OGCG-HOST
 
 // RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda \
-// RUN:   -I%S/../inputs -fcuda-is-device -emit-llvm %s -o %t.device.ll
+// RUN:   -I%S/../Inputs -fcuda-is-device -emit-llvm %s -o %t.device.ll
 // RUN: FileCheck --input-file=%t.device.ll %s --check-prefix=OGCG-DEVICE
 
 #include "cuda.h"

--- a/clang/test/CIR/CodeGenCUDA/nvptx-basic.cu
+++ b/clang/test/CIR/CodeGenCUDA/nvptx-basic.cu
@@ -2,10 +2,10 @@
 // Tests basic device-side compilation with NVPTX target.
 
 // RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda \
-// RUN:   -I%S/../Inputs -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN:   -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
-#include "cuda.h"
+#include "Inputs/cuda.h"
 
 // CHECK: cir.func {{.*}} @device_function()
 extern "C"

--- a/clang/test/CIR/CodeGenCUDA/nvptx-basic.cu
+++ b/clang/test/CIR/CodeGenCUDA/nvptx-basic.cu
@@ -2,7 +2,7 @@
 // Tests basic device-side compilation with NVPTX target.
 
 // RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda \
-// RUN:   -I%S/../inputs -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN:   -I%S/../Inputs -fcuda-is-device -emit-cir %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
 #include "cuda.h"

--- a/clang/test/CIR/CodeGenCUDA/nvptx-basic.cu
+++ b/clang/test/CIR/CodeGenCUDA/nvptx-basic.cu
@@ -1,0 +1,30 @@
+// Based on clang/test/CodeGenCUDA/ptx-kernels.cu tailored for CIR current capabilities.
+// Tests basic device-side compilation with NVPTX target.
+
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -x cuda \
+// RUN:   -I%S/../inputs -fcuda-is-device -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+#include "cuda.h"
+
+// CHECK: cir.func {{.*}} @device_function()
+extern "C"
+__device__ void device_function() {}
+
+// CHECK: cir.func {{.*}} @global_function()
+// CHECK:   cir.call @device_function()
+extern "C"
+__global__ void global_function() {
+  device_function();
+}
+
+// Template kernel with explicit instantiation
+template <typename T> __global__ void templated_kernel(T param) {}
+template __global__ void templated_kernel<int>(int);
+// CHECK: cir.func {{.*}} @_Z16templated_kernelIiEvT_
+
+// Anonymous namespace kernel
+namespace {
+__global__ void anonymous_ns_kernel() {}
+// CHECK: cir.func {{.*}} @_ZN12_GLOBAL__N_119anonymous_ns_kernelEv
+}


### PR DESCRIPTION
related: #175871 

This patch adds foundational infra for device-side CUDA/HIP compilation by introducing NVPTX target info and implementing the global emission filtering logic.


  NVPTX Target Info to allows us to compile against that triple:
  - Add NVPTXABIInfo and NVPTXTargetCIRGenInfo classes
  - Wire up nvptx and nvptx64 triples in getTargetCIRGenInfo()
  - Add createNVPTXTargetCIRGenInfo() factory function

  CUDA/HIP Global Emission Filtering (most of this is boilerplate from the AST) This basically narrows down to:
  - Skip host-only functions (no `__device__` attribute) when `-fcuda-is-device`
   - Skip device-only functions (device without  host) on host side
   - Always emit ` __global__` kernels and `__host__` `__device__` functions on both sides
  - Add `shouldEmitCUDAGlobalVar()` to handle variable emission (device/constant/shared variables)
  - Handle special cases: implicit host/device templates, lambda call operators
