### PR TITLE
[clangd] Fix SIGSEGV crash when receiving a textDocument/didOpen request with the URI pointing to a directory

### DIFF
--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -731,8 +731,10 @@ void ClangdLSPServer::onSync(const NoParams &, Callback<std::nullptr_t> Reply) {
 void ClangdLSPServer::onDocumentDidOpen(
     const DidOpenTextDocumentParams &Params) {
   PathRef File = Params.textDocument.uri.file();
-  if (llvm::sys::fs::is_directory(File))
+  if (llvm::sys::fs::is_directory(File)) {
+    elog("Ignoring didOpen for directory: {0}", File);
     return;
+  }
 
   const std::string &Contents = Params.textDocument.text;
 
@@ -1030,9 +1032,6 @@ flattenSymbolHierarchy(llvm::ArrayRef<DocumentSymbol> Symbols,
 void ClangdLSPServer::onDocumentSymbol(const DocumentSymbolParams &Params,
                                        Callback<llvm::json::Value> Reply) {
   URIForFile FileURI = Params.textDocument.uri;
-  if (llvm::sys::fs::is_directory(FileURI.file()))
-    return Reply(llvm::make_error<LSPError>("URI is a directory",
-                                            ErrorCode::InvalidParams));
   Server->documentSymbols(
       Params.textDocument.uri.file(),
       [this, FileURI, Reply = std::move(Reply)](

--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -731,9 +731,8 @@ void ClangdLSPServer::onSync(const NoParams &, Callback<std::nullptr_t> Reply) {
 void ClangdLSPServer::onDocumentDidOpen(
     const DidOpenTextDocumentParams &Params) {
   PathRef File = Params.textDocument.uri.file();
-  if (llvm::sys::fs::is_directory(File)) {
+  if (llvm::sys::fs::is_directory(File))
     return;
-  }
 
   const std::string &Contents = Params.textDocument.text;
 
@@ -1031,10 +1030,9 @@ flattenSymbolHierarchy(llvm::ArrayRef<DocumentSymbol> Symbols,
 void ClangdLSPServer::onDocumentSymbol(const DocumentSymbolParams &Params,
                                        Callback<llvm::json::Value> Reply) {
   URIForFile FileURI = Params.textDocument.uri;
-  if (llvm::sys::fs::is_directory(FileURI.file())) {
+  if (llvm::sys::fs::is_directory(FileURI.file()))
     return Reply(llvm::make_error<LSPError>("URI is a directory",
                                             ErrorCode::InvalidParams));
-  }
   Server->documentSymbols(
       Params.textDocument.uri.file(),
       [this, FileURI, Reply = std::move(Reply)](

--- a/clang-tools-extra/clangd/test/directory-uri.test
+++ b/clang-tools-extra/clangd/test/directory-uri.test
@@ -1,0 +1,42 @@
+# RUN: not --crash clangd -lit-test < %s 2> %t.err
+# RUN: FileCheck %s < %t.err
+# RUN: not --crash clangd -lit-test -sync=0 < %s 2> %t.async.err
+# RUN: FileCheck %s < %t.async.err
+
+{"jsonrpc":"2.0","id":0,"method":"initialize","params":{}}
+---
+{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{
+  "uri":"file:///",
+  "languageId":"c",
+  "version":1,
+  "text":""
+}}}
+#      CHECK: I[{{.*}}] Ignoring didOpen for directory: /
+---
+{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{
+  "uri":"file:///tmp",
+  "languageId":"cpp",
+  "version":1,
+  "text":"int main() {}"
+}}}
+#      CHECK: I[{{.*}}] Ignoring didOpen for directory: /tmp
+---
+{"jsonrpc":"2.0","id":1,"method":"textDocument/documentSymbol","params":{"textDocument":{"uri":"file:///"}}}
+#      CHECK: "error": {
+# CHECK-NEXT:   "code": -32602,
+# CHECK-NEXT:   "message": "URI is a directory"
+# CHECK-NEXT: },
+# CHECK-NEXT: "id": 1,
+# CHECK-NEXT: "jsonrpc": "2.0"
+---
+{"jsonrpc":"2.0","id":2,"method":"textDocument/documentSymbol","params":{"textDocument":{"uri":"file:///tmp"}}}
+#      CHECK: "error": {
+# CHECK-NEXT:   "code": -32602,
+# CHECK-NEXT:   "message": "URI is a directory"
+# CHECK-NEXT: },
+# CHECK-NEXT: "id": 2,
+# CHECK-NEXT: "jsonrpc": "2.0"
+---
+{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+---
+{"jsonrpc":"2.0","method":"exit"}

--- a/clang-tools-extra/clangd/test/directory-uri.test
+++ b/clang-tools-extra/clangd/test/directory-uri.test
@@ -21,22 +21,6 @@
 }}}
 #      CHECK: I[{{.*}}] Ignoring didOpen for directory: /tmp
 ---
-{"jsonrpc":"2.0","id":1,"method":"textDocument/documentSymbol","params":{"textDocument":{"uri":"file:///"}}}
-#      CHECK: "error": {
-# CHECK-NEXT:   "code": -32602,
-# CHECK-NEXT:   "message": "URI is a directory"
-# CHECK-NEXT: },
-# CHECK-NEXT: "id": 1,
-# CHECK-NEXT: "jsonrpc": "2.0"
----
-{"jsonrpc":"2.0","id":2,"method":"textDocument/documentSymbol","params":{"textDocument":{"uri":"file:///tmp"}}}
-#      CHECK: "error": {
-# CHECK-NEXT:   "code": -32602,
-# CHECK-NEXT:   "message": "URI is a directory"
-# CHECK-NEXT: },
-# CHECK-NEXT: "id": 2,
-# CHECK-NEXT: "jsonrpc": "2.0"
----
 {"jsonrpc":"2.0","id":3,"method":"shutdown"}
 ---
 {"jsonrpc":"2.0","method":"exit"}

--- a/clang-tools-extra/clangd/test/directory-uri.test
+++ b/clang-tools-extra/clangd/test/directory-uri.test
@@ -1,6 +1,5 @@
-# RUN: not --crash clangd -lit-test < %s 2> %t.err
+# RUN: clangd -lit-test < %s | FileCheck %s
 # RUN: FileCheck %s < %t.err
-# RUN: not --crash clangd -lit-test -sync=0 < %s 2> %t.async.err
 # RUN: FileCheck %s < %t.async.err
 
 {"jsonrpc":"2.0","id":0,"method":"initialize","params":{}}
@@ -19,7 +18,7 @@
   "version":1,
   "text":"int main() {}"
 }}}
-#      CHECK: I[{{.*}}] Ignoring didOpen for directory: /tmp
+#      CHECK: E[{{.*}}] Ignoring didOpen for directory: /tmp
 ---
 {"jsonrpc":"2.0","id":3,"method":"shutdown"}
 ---


### PR DESCRIPTION
Prevents a SIGSEGV crash when a client sends a URI that points to a directory instead of a file in `textDocument/didOpen` and `textDocument/documentSymbol` requests.

Closes #177466 