### PR TITLE
[llvm-ir2vec] vocab read refactor

### DIFF
--- a/llvm/include/llvm/Analysis/IR2Vec.h
+++ b/llvm/include/llvm/Analysis/IR2Vec.h
@@ -77,6 +77,7 @@ LLVM_ABI extern cl::opt<float> OpcWeight;
 LLVM_ABI extern cl::opt<float> TypeWeight;
 LLVM_ABI extern cl::opt<float> ArgWeight;
 LLVM_ABI extern cl::opt<IR2VecKind> IR2VecEmbeddingKind;
+LLVM_ABI extern cl::opt<std::string> VocabFile;
 
 /// Embedding is a datatype that wraps std::vector<double>. It provides
 /// additional functionality for arithmetic and comparison operations.

--- a/llvm/lib/Analysis/IR2Vec.cpp
+++ b/llvm/lib/Analysis/IR2Vec.cpp
@@ -40,7 +40,7 @@ namespace ir2vec {
 cl::OptionCategory IR2VecCategory("IR2Vec Options");
 
 // FIXME: Use a default vocab when not specified
-static cl::opt<std::string>
+cl::opt<std::string>
     VocabFile("ir2vec-vocab-path", cl::Optional,
               cl::desc("Path to the vocabulary file for IR2Vec"), cl::init(""),
               cl::cat(IR2VecCategory));

--- a/llvm/test/tools/llvm-ir2vec/error-handling.ll
+++ b/llvm/test/tools/llvm-ir2vec/error-handling.ll
@@ -2,6 +2,7 @@
 
 ; RUN: not llvm-ir2vec embeddings %s 2>&1 | FileCheck %s -check-prefix=CHECK-NO-VOCAB
 ; RUN: not llvm-ir2vec embeddings --function=nonexistent --ir2vec-vocab-path=%ir2vec_test_vocab_dir/dummy_3D_nonzero_opc_vocab.json %s 2>&1 | FileCheck %s -check-prefix=CHECK-FUNC-NOT-FOUND
+; RUN: not llvm-ir2vec embeddings --function=nonexistent --ir2vec-vocab-path=%ir2vec_test_vocab_dir/incorrect_vocab1.json %s 2>&1 | FileCheck %s -check-prefix=CHECK-FUNC-INCORRECT-VOCAB
 
 ; Simple test function for valid IR
 define i32 @test_func(i32 %a) {
@@ -11,3 +12,4 @@ entry:
 
 ; CHECK-NO-VOCAB: error: IR2Vec vocabulary file path not specified; You may need to set it using --ir2vec-vocab-path
 ; CHECK-FUNC-NOT-FOUND: error: Function 'nonexistent' not found
+; CHECK-FUNC-INCORRECT-VOCAB: error: Missing 'Opcodes' section in vocabulary file

--- a/llvm/tools/llvm-ir2vec/lib/Utils.cpp
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.cpp
@@ -51,7 +51,7 @@ Error IR2VecTool::initializeVocabulary(StringRef VocabPath) {
 
   if (!Vocab->isValid())
     return createStringError(errc::invalid_argument,
-                            "Failed to initialize IR2Vec vocabulary");
+                             "Failed to initialize IR2Vec vocabulary");
   return Error::success();
 }
 

--- a/llvm/tools/llvm-ir2vec/lib/Utils.cpp
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.cpp
@@ -41,14 +41,16 @@ namespace llvm {
 
 namespace ir2vec {
 
-bool IR2VecTool::initializeVocabulary() {
-  // Register and run the IR2Vec vocabulary analysis
-  // The vocabulary file path is specified via --ir2vec-vocab-path global
-  // option
-  MAM.registerPass([&] { return PassInstrumentationAnalysis(); });
-  MAM.registerPass([&] { return IR2VecVocabAnalysis(); });
-  // This will throw an error if vocab is not found or invalid
-  Vocab = &MAM.getResult<IR2VecVocabAnalysis>(M);
+bool IR2VecTool::initializeVocabulary(StringRef VocabPath) {
+  auto VocabOrErr = Vocabulary::fromFile(VocabPath);
+
+  if (!VocabOrErr) {
+    llvm::errs() << "Failed to load vocabulary: "
+                 << toString(VocabOrErr.takeError()) << "\n";
+    return false;
+  }
+
+  Vocab = std::make_unique<Vocabulary>(std::move(*VocabOrErr));
   return Vocab->isValid();
 }
 

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -87,13 +87,13 @@ class IR2VecTool {
 private:
   Module &M;
   ModuleAnalysisManager MAM;
-  const Vocabulary *Vocab = nullptr;
+  std::unique_ptr<Vocabulary> Vocab;
 
 public:
   explicit IR2VecTool(Module &M) : M(M) {}
 
   /// Initialize the IR2Vec vocabulary analysis
-  bool initializeVocabulary();
+  bool initializeVocabulary(StringRef VocabPath);
 
   /// Generate triplets for a single function
   /// Returns a TripletResult with:

--- a/llvm/tools/llvm-ir2vec/lib/Utils.h
+++ b/llvm/tools/llvm-ir2vec/lib/Utils.h
@@ -92,8 +92,8 @@ private:
 public:
   explicit IR2VecTool(Module &M) : M(M) {}
 
-  /// Initialize the IR2Vec vocabulary analysis
-  bool initializeVocabulary(StringRef VocabPath);
+  /// Initialize the IR2Vec vocabulary from the specified file path.
+  Error initializeVocabulary(StringRef VocabPath);
 
   /// Generate triplets for a single function
   /// Returns a TripletResult with:

--- a/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
+++ b/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
@@ -160,9 +160,9 @@ static Error processModule(Module &M, raw_ostream &OS) {
           "IR2Vec vocabulary file path not specified; "
           "You may need to set it using --ir2vec-vocab-path");
     }
-    auto VocabStatus = Tool.initializeVocabulary(VocabFile);
-    assert(VocabStatus && "Failed to initialize IR2Vec vocabulary");
-    (void)VocabStatus;
+
+    if (Error Err = Tool.initializeVocabulary(VocabFile))
+      return Err;
 
     if (!FunctionName.empty()) {
       // Process single function

--- a/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
+++ b/llvm/tools/llvm-ir2vec/llvm-ir2vec.cpp
@@ -153,7 +153,14 @@ static Error processModule(Module &M, raw_ostream &OS) {
   if (EmbeddingsSubCmd) {
     // Initialize vocabulary for embedding generation
     // Note: Requires --ir2vec-vocab-path option to be set
-    auto VocabStatus = Tool.initializeVocabulary();
+    // and this value will be populated in the var VocabFile
+    if (VocabFile.empty()) {
+      return createStringError(
+          errc::invalid_argument,
+          "IR2Vec vocabulary file path not specified; "
+          "You may need to set it using --ir2vec-vocab-path");
+    }
+    auto VocabStatus = Tool.initializeVocabulary(VocabFile);
     assert(VocabStatus && "Failed to initialize IR2Vec vocabulary");
     (void)VocabStatus;
 


### PR DESCRIPTION
Modifying llvm-ir2vec vocab reading pipeline to use Vocabulary::fromFile instead of a full pass invocation

Addresses - [comment]( https://github.com/llvm/llvm-project/pull/177092#pullrequestreview-3687563016) and is a follow up of the patch [here](https://github.com/llvm/llvm-project/pull/177348)