### PR TITLE
[libc][math] Refactor ffmaf128 implementation to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -61,6 +61,7 @@
 #include "math/expm1f16.h"
 #include "math/f16fma.h"
 #include "math/f16fmal.h"
+#include "math/ffmaf128.h"
 #include "math/frexpf.h"
 #include "math/frexpf128.h"
 #include "math/frexpf16.h"

--- a/libc/shared/math/ffmaf128.h
+++ b/libc/shared/math/ffmaf128.h
@@ -1,0 +1,29 @@
+//===-- Shared ffmaf128 function --------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_MATH_FFMAF128_H
+#define LLVM_LIBC_SHARED_MATH_FFMAF128_H
+
+#include "include/llvm-libc-types/float128.h"
+#include "shared/libc_common.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "src/__support/math/ffmaf128.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace shared {
+
+using math::ffmaf128;
+
+} // namespace shared
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SHARED_MATH_FFMAF128_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -611,6 +611,15 @@ add_header_library(
 )
 
 add_header_library(
+  ffmaf128
+  HDRS
+    ffmaf128.h
+  DEPENDS
+    libc.src.__support.FPUtil.fma
+)
+
+
+add_header_library(
   inv_trigf_utils
   HDRS
     inv_trigf_utils.h

--- a/libc/src/__support/math/ffmaf128.h
+++ b/libc/src/__support/math/ffmaf128.h
@@ -1,0 +1,33 @@
+//===-- Implementation header for ffmaf128 ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FFMAF128_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_FFMAF128_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
+#include "src/__support/FPUtil/FMA.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE static constexpr float128 ffmaf128(float128 x, float128 y,
+                                               float128 z) {
+  return fputil::fma<float128>(x, y, z);
+}
+
+} // namespace math
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_FFMAF128_H

--- a/libc/src/math/ffmaf128.h
+++ b/libc/src/math/ffmaf128.h
@@ -14,7 +14,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-float ffmaf128(float128 x, float128 y, float128 z);
+float128 ffmaf128(float128 x, float128 y, float128 z);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -3373,7 +3373,7 @@ add_entrypoint_object(
     ../ffmaf128.h
   DEPENDS
     libc.src.__support.macros.properties.types
-    libc.src.__support.FPUtil.fma
+    libc.src.__support.math.ffmaf128
 )
 
 add_entrypoint_object(

--- a/libc/src/math/generic/ffmaf128.cpp
+++ b/libc/src/math/generic/ffmaf128.cpp
@@ -7,14 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/ffmaf128.h"
-#include "src/__support/FPUtil/FMA.h"
-#include "src/__support/common.h"
-#include "src/__support/macros/config.h"
+#include "src/__support/math/ffmaf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(float, ffmaf128, (float128 x, float128 y, float128 z)) {
-  return fputil::fma<float>(x, y, z);
+LLVM_LIBC_FUNCTION(float128, ffmaf128, (float128 x, float128 y, float128 z)) {
+  return math::ffmaf128(x, y, z);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -57,6 +57,7 @@ add_fp_unittest(
     libc.src.__support.math.expf16
     libc.src.__support.math.f16fma
     libc.src.__support.math.f16fmal
+    libc.src.__support.math.ffmaf128
     libc.src.__support.math.frexpf
     libc.src.__support.math.frexpf128
     libc.src.__support.math.frexpf16

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -127,6 +127,9 @@ TEST(LlvmLibcSharedMathTest, AllFloat128) {
   EXPECT_FP_EQ(float128(0x0p+0),
                LIBC_NAMESPACE::shared::atan2f128(float128(0.0), float128(0.0)));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::fsqrtf128(float128(1.0f)));
+  EXPECT_FP_EQ(float128(0x0p+0),
+               LIBC_NAMESPACE::shared::ffmaf128(float128(0.0), float128(0.0),
+                                                float128(0.0)));
   EXPECT_FP_EQ_ALL_ROUNDING(float128(0.75), LIBC_NAMESPACE::shared::frexpf128(
                                                 float128(24), &exponent));
   EXPECT_EQ(exponent, 5);

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2916,6 +2916,14 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_ffmaf128",
+    hdrs = ["src/__support/math/ffmaf128.h"],
+    deps = [
+        ":__support_fputil_fma",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_inv_trigf_utils",
     hdrs = ["src/__support/math/inv_trigf_utils.h"],
     deps = [
@@ -4309,7 +4317,7 @@ libc_math_function(
 libc_math_function(
     name = "ffmaf128",
     additional_deps = [
-        ":__support_fputil_fma",
+        ":__support_math_ffmaf128",
     ],
 )
 


### PR DESCRIPTION
Closes #175325
Part of https://github.com/llvm/llvm-project/issues/147386

in preparation for: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450

CC:@bassiounix 