### PR TITLE
[libc++] do not redefine _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION 

### DIFF
--- a/libcxx/include/__configuration/availability.h
+++ b/libcxx/include/__configuration/availability.h
@@ -295,15 +295,6 @@
 #define _LIBCPP_AVAILABILITY_HAS_BAD_FUNCTION_CALL_GOOD_WHAT_MESSAGE _LIBCPP_INTRODUCED_IN_LLVM_21
 // No attribute, since we've had bad_function_call::what() in the headers before
 
-// Define availability attributes that depend on both
-// _LIBCPP_HAS_EXCEPTIONS and _LIBCPP_HAS_RTTI.
-#if !_LIBCPP_HAS_EXCEPTIONS || !_LIBCPP_HAS_RTTI
-#  undef _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION
-#  undef _LIBCPP_AVAILABILITY_INIT_PRIMARY_EXCEPTION
-#  define _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION 0
-#  define _LIBCPP_AVAILABILITY_INIT_PRIMARY_EXCEPTION
-#endif
-
 // Only define a bunch of symbols in the dylib if we need to be compatible with LLVM 7 headers or older
 #  if defined(_LIBCPP_BUILDING_LIBRARY) && _LIBCPP_AVAILABILITY_MINIMUM_HEADER_VERSION < 8
 #    define _LIBCPP_HIDE_FROM_ABI_SINCE_LLVM8

--- a/libcxx/include/__exception/exception_ptr.h
+++ b/libcxx/include/__exception/exception_ptr.h
@@ -31,7 +31,7 @@ _LIBCPP_PUSH_MACROS
 
 #ifndef _LIBCPP_ABI_MICROSOFT
 
-#  if _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION
+#  if _LIBCPP_HAS_EXCEPTIONS && _LIBCPP_HAS_RTTI && _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION
 
 namespace __cxxabiv1 {
 
@@ -113,7 +113,7 @@ inline _LIBCPP_HIDE_FROM_ABI void swap(exception_ptr& __x, exception_ptr& __y) _
 }
 
 #  if _LIBCPP_HAS_EXCEPTIONS
-#    if _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION
+#    if _LIBCPP_HAS_RTTI && _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION
 template <class _Ep>
 _LIBCPP_HIDE_FROM_ABI exception_ptr __make_exception_ptr_explicit(_Ep& __e) _NOEXCEPT {
   using _Ep2 = __decay_t<_Ep>;
@@ -164,7 +164,7 @@ _LIBCPP_HIDE_FROM_ABI exception_ptr make_exception_ptr(_Ep __e) _NOEXCEPT {
     return std::__make_exception_ptr_via_throw(__e);
   }
 
-#    if _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION && !defined(_LIBCPP_CXX03_LANG)
+#    if _LIBCPP_HAS_RTTI && _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION && !defined(_LIBCPP_CXX03_LANG)
   return std::__make_exception_ptr_explicit(__e);
 #    else
   return std::__make_exception_ptr_via_throw(__e);

--- a/libcxx/include/__exception/exception_ptr.h
+++ b/libcxx/include/__exception/exception_ptr.h
@@ -55,9 +55,9 @@ _LIBCPP_OVERRIDABLE_FUNC_VIS __cxa_exception* __cxa_init_primary_exception(
 
 } // namespace __cxxabiv1
 
-#  endif
+#  endif // _LIBCPP_HAS_EXCEPTIONS && _LIBCPP_HAS_RTTI && _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION
 
-#endif
+#endif // !defined(_LIBCPP_ABI_MICROSOFT)
 
 _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 
@@ -136,7 +136,7 @@ _LIBCPP_HIDE_FROM_ABI exception_ptr __make_exception_ptr_explicit(_Ep& __e) _NOE
     return current_exception();
   }
 }
-#    endif
+#    endif // _LIBCPP_HAS_RTTI && _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION
 
 template <class _Ep>
 _LIBCPP_HIDE_FROM_ABI exception_ptr __make_exception_ptr_via_throw(_Ep& __e) _NOEXCEPT {
@@ -177,7 +177,7 @@ _LIBCPP_HIDE_FROM_ABI exception_ptr make_exception_ptr(_Ep) _NOEXCEPT {
 }
 #  endif // _LIBCPP_HAS_EXCEPTIONS
 
-#else // _LIBCPP_ABI_MICROSOFT
+#else // defined(_LIBCPP_ABI_MICROSOFT)
 
 class _LIBCPP_EXPORTED_FROM_ABI exception_ptr {
   _LIBCPP_DIAGNOSTIC_PUSH
@@ -218,7 +218,7 @@ _LIBCPP_HIDE_FROM_ABI exception_ptr make_exception_ptr(_Ep __e) _NOEXCEPT {
   return __copy_exception_ptr(std::addressof(__e), __GetExceptionInfo(__e));
 }
 
-#endif // _LIBCPP_ABI_MICROSOFT
+#endif // defined(_LIBCPP_ABI_MICROSOFT)
 _LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS


### PR DESCRIPTION
Review in #176857 asked to:

> In the same vein as Nikolas is suggesting, let's make a pre-requisite PR that removes this block. This can be done by replacing uses of `_LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION` in the code by
> 
> ```
> _LIBCPP_HAS_EXCEPTIONS && _LIBCPP_HAS_RTTI && _LIBCPP_AVAILABILITY_HAS_INIT_PRIMARY_EXCEPTION
> ```
> 
> Then this patch will be a clearer re-ordering.

Second commit is cosmetic, but IMO helpful.