### PR TITLE
[libclang/python] Add deprecation warnings to CompletionChunk.isKind methods

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3160,7 +3160,7 @@ class CompletionChunk:
     __deprecation_message = (
         "'CompletionChunk.{}' will be removed in a future release. "
         "All uses of 'CompletionChunk.{}' should be replaced by checking "
-        "if the 'CompletionChunk's kind is 'CompletionChunkKind.{}'."
+        "if 'CompletionChunk.kind` is equal to 'CompletionChunkKind.{}'."
     )
 
     def isKindOptional(self) -> bool:

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3157,19 +3157,55 @@ class CompletionChunk:
             return None
         return CompletionString(res)
 
+    __deprecation_message = (
+        "'CompletionChunk.{}' will be removed in a future release. "
+        "All uses of 'CompletionChunk.{}' should be replaced by checking "
+        "if the 'CompletionChunk's kind is 'CompletionChunkKind.{}'."
+    )
+
     def isKindOptional(self) -> bool:
+        deprecation_message = self.__deprecation_message.format(
+            "isKindOptional",
+            "isKindOptional",
+            "OPTIONAL",
+        )
+        warnings.warn(deprecation_message, DeprecationWarning)
         return self.kind == CompletionChunkKind.OPTIONAL
 
     def isKindTypedText(self) -> bool:
+        deprecation_message = self.__deprecation_message.format(
+            "isKindTypedText",
+            "isKindTypedText",
+            "TYPED_TEXT",
+        )
+        warnings.warn(deprecation_message, DeprecationWarning)
         return self.kind == CompletionChunkKind.TYPED_TEXT
 
     def isKindPlaceHolder(self) -> bool:
+        deprecation_message = self.__deprecation_message.format(
+            "isKindPlaceHolder",
+            "isKindPlaceHolder",
+            "PLACEHOLDER",
+        )
+        warnings.warn(deprecation_message, DeprecationWarning)
         return self.kind == CompletionChunkKind.PLACEHOLDER
 
     def isKindInformative(self) -> bool:
+        deprecation_message = self.__deprecation_message.format(
+            "isKindInformative",
+            "isKindInformative",
+            "INFORMATIVE",
+        )
+        warnings.warn(deprecation_message, DeprecationWarning)
         return self.kind == CompletionChunkKind.INFORMATIVE
 
     def isKindResultType(self) -> bool:
+        deprecation_message = self.__deprecation_message.format(
+            "isKindResultType",
+            "isKindResultType",
+            "RESULT_TYPE",
+        )
+        warnings.warn(deprecation_message, DeprecationWarning)
         return self.kind == CompletionChunkKind.RESULT_TYPE
 
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -307,6 +307,9 @@ Python Binding Changes
   to directly compare equality of the ``CompletionChunk`` kind with
   the corresponding ``CompletionChunkKind`` variant.
 
+  Affected methods: ``isKindOptional``, ``isKindTypedText``, ``isKindPlaceHolder``,
+  ``isKindInformative`` and ``isKindResultType``.
+
 OpenMP Support
 --------------
 - Added support for ``transparent`` clause in task and taskloop directives.

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -302,6 +302,10 @@ Sanitizers
 
 Python Binding Changes
 ----------------------
+- Add deprecation warnings to ``CompletionChunk.isKind...`` methods.
+  These will be removed in a future release. Existing uses should be adapted
+  to directly compare equality of the ``CompletionChunk`` kind with
+  the corresponding ``CompletionChunkKind`` variant.
 
 OpenMP Support
 --------------


### PR DESCRIPTION
This adresses point 3 from https://github.com/llvm/llvm-project/issues/156680.