### PR TITLE
[RISCV] Put VL before VTYPE in XAndes and XSfmm instruction Defs/Uses. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXAndes.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXAndes.td
@@ -379,7 +379,7 @@ class NDSRVInstVSINTLN<bits<5> funct5, string opcodestr>
   let hasSideEffects = 0;
   let mayLoad = 1;
   let mayStore = 0;
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
 }
 
 class NDSRVInstVSINTCvt<bits<5> fucnt5, string opcodestr>
@@ -498,7 +498,7 @@ class NDSRVInstVLN<bits<5> funct5, string opcodestr>
   let mayLoad = 1;
   let mayStore = 0;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = VMConstraint;
 }
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXSfmm.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXSfmm.td
@@ -48,7 +48,7 @@ class SFInstSetSingle<dag outs, dag ins, bits<5> rs2, string opcodestr,
   let Inst{11-7} = rd;
   let Inst{6-0} = OPC_OP_V.Value;
 
-  let Defs = [VTYPE, VL];
+  let Defs = [VL, VTYPE];
 }
 
 class SFInstTileMemOp<dag outs, dag ins, bits<3> nf, RISCVOpcode opcode,
@@ -67,7 +67,7 @@ class SFInstTileMemOp<dag outs, dag ins, bits<3> nf, RISCVOpcode opcode,
   let Inst{11-7} = 0b00000;
   let Inst{6-0} = opcode.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let ReadsPastVL = 1;
 }
 
@@ -97,7 +97,7 @@ class SFInstTileMoveOp<bits<6> funct6, dag outs, dag ins, string opcodestr,
   let Inst{11-7} = vd;
   let Inst{6-0} = OPC_OP_V.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let ReadsPastVL = 1;
 }
 
@@ -117,7 +117,7 @@ class SFInstMatmulF<dag outs, dag ins, string opcodestr, string argstr>
   let Inst{8-7} = 0b00;
   let Inst{6-0} = OPC_OP_VE.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let ReadsPastVL = 1;
 }
 
@@ -140,7 +140,7 @@ class SFInstMatmulF8<bit a, bit b, dag outs, dag ins,
   let Inst{7} = b;
   let Inst{6-0} = OPC_OP_VE.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let ReadsPastVL = 1;
 }
 
@@ -173,7 +173,7 @@ class SFInstMatmulI8<bit funct6_1, bit a, bit b, dag outs, dag ins,
   let Inst{7} = b;
   let Inst{6-0} = OPC_OP_VE.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let ReadsPastVL = 1;
 }
 
@@ -201,7 +201,7 @@ class SFInstSetZero<dag outs, dag ins, string opcodestr, string argstr>
   let Inst{7} = 0;
   let Inst{6-0} = OPC_OP_V.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
 }
 
 let hasSideEffects = 1, mayLoad = 0, mayStore = 0 in


### PR DESCRIPTION
This is the order we use for standard vector instructions.