### PR TITLE
[X86] SimplifyDemandedBitsForTargetNode: add X86ISD::BZHI handling

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -45698,15 +45698,14 @@ bool X86TargetLowering::SimplifyDemandedBitsForTargetNode(
 
       MaxMask8 = MaskedVal1;
     } else {
-      unsigned MaskBW = Op1.getValueType().getSizeInBits();
-      APInt MaskDemand = APInt::getLowBitsSet(MaskBW, 8);
+      APInt MaskDemand = APInt::getLowBitsSet(BitWidth, 8);
 
       KnownBits Known1;
       if (SimplifyDemandedBits(Op1, MaskDemand, Known1, TLO, Depth + 1))
         return true;
 
       // Compute an upper bound on mask[7:0].
-      KnownBits MaskBits = Known1.extractBits(8, 0);
+      KnownBits MaskBits = Known1.trunc(8);
       MaxMask8 = MaskBits.getMaxValue().getZExtValue();
     }
 

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -45675,6 +45675,64 @@ bool X86TargetLowering::SimplifyDemandedBitsForTargetNode(
 
     break;
   }
+case X86ISD::BZHI: {
+  SDValue Op0 = Op.getOperand(0); // src
+  SDValue Op1 = Op.getOperand(1); // mask
+
+  // Rule 1: Only the bottom 8 bits of the mask are required.
+  // Track an upper bound on mask[7:0] so we can apply Rule 2.
+  uint64_t MaxMask8 = 255;
+
+  if (auto *Cst1 = dyn_cast<ConstantSDNode>(Op1)) {
+    // NOTE: SimplifyDemandedBits won't do this for constants.
+    uint64_t Val1 = Cst1->getZExtValue();
+    uint64_t MaskedVal1 = Val1 & 0xFF;
+
+    if (MaskedVal1 != Val1) {
+      SDLoc DL(Op);
+      EVT MaskVT = Op1.getValueType();
+      SDValue NewMask = TLO.DAG.getConstant(MaskedVal1, DL, MaskVT);
+      return TLO.CombineTo(Op, TLO.DAG.getNode(X86ISD::BZHI, DL, VT, Op0, NewMask));
+    }
+
+    MaxMask8 = MaskedVal1;
+  } else {
+    unsigned MaskBW = Op1.getValueType().getSizeInBits();
+    APInt MaskDemand = APInt::getLowBitsSet(MaskBW, 8);
+
+    KnownBits Known1;
+    if (SimplifyDemandedBits(Op1, MaskDemand, Known1, TLO, Depth + 1))
+      return true;
+
+    // Compute an upper bound on mask[7:0].
+    KnownBits MaskBits = Known1.extractBits(8, 0);
+    MaxMask8 = MaskBits.getMaxValue().getZExtValue();
+  }
+
+  // Rule 2: If mask[7:0] is known to be < BitWidth, then bits at/above
+  // getMaxValue are always zero and thus not demanded; likewise src bits.
+  APInt SrcDemanded = OriginalDemandedBits;
+  if (MaxMask8 < BitWidth) {
+    unsigned Cut = (unsigned)MaxMask8;
+    SrcDemanded.clearBits(Cut, BitWidth);
+  }
+
+  
+  KnownBits KnownSrc;
+  if (SimplifyDemandedBits(Op0, SrcDemanded, KnownSrc, TLO, Depth + 1))
+    return true;
+
+  
+  Known.One.clearAllBits();
+  Known.Zero.clearAllBits();
+  if (MaxMask8 < BitWidth) {
+    unsigned Cut = (unsigned)MaxMask8;
+    Known.Zero.setBits(Cut, BitWidth);
+    }
+
+  break;
+  }
+
   case X86ISD::PDEP: {
     SDValue Op0 = Op.getOperand(0);
     SDValue Op1 = Op.getOperand(1);

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -45675,62 +45675,61 @@ bool X86TargetLowering::SimplifyDemandedBitsForTargetNode(
 
     break;
   }
-case X86ISD::BZHI: {
-  SDValue Op0 = Op.getOperand(0); // src
-  SDValue Op1 = Op.getOperand(1); // mask
+  case X86ISD::BZHI: {
+    SDValue Op0 = Op.getOperand(0); // src
+    SDValue Op1 = Op.getOperand(1); // mask
 
-  // Rule 1: Only the bottom 8 bits of the mask are required.
-  // Track an upper bound on mask[7:0] so we can apply Rule 2.
-  uint64_t MaxMask8 = 255;
+    // Rule 1: Only the bottom 8 bits of the mask are required.
+    // Track an upper bound on mask[7:0] so we can apply Rule 2.
+    uint64_t MaxMask8 = 255;
 
-  if (auto *Cst1 = dyn_cast<ConstantSDNode>(Op1)) {
-    // NOTE: SimplifyDemandedBits won't do this for constants.
-    uint64_t Val1 = Cst1->getZExtValue();
-    uint64_t MaskedVal1 = Val1 & 0xFF;
+    if (auto *Cst1 = dyn_cast<ConstantSDNode>(Op1)) {
+      // NOTE: SimplifyDemandedBits won't do this for constants.
+      uint64_t Val1 = Cst1->getZExtValue();
+      uint64_t MaskedVal1 = Val1 & 0xFF;
 
-    if (MaskedVal1 != Val1) {
-      SDLoc DL(Op);
-      EVT MaskVT = Op1.getValueType();
-      SDValue NewMask = TLO.DAG.getConstant(MaskedVal1, DL, MaskVT);
-      return TLO.CombineTo(Op, TLO.DAG.getNode(X86ISD::BZHI, DL, VT, Op0, NewMask));
+      if (MaskedVal1 != Val1) {
+        SDLoc DL(Op);
+        EVT MaskVT = Op1.getValueType();
+        SDValue NewMask = TLO.DAG.getConstant(MaskedVal1, DL, MaskVT);
+        return TLO.CombineTo(
+            Op, TLO.DAG.getNode(X86ISD::BZHI, DL, VT, Op0, NewMask));
+      }
+
+      MaxMask8 = MaskedVal1;
+    } else {
+      unsigned MaskBW = Op1.getValueType().getSizeInBits();
+      APInt MaskDemand = APInt::getLowBitsSet(MaskBW, 8);
+
+      KnownBits Known1;
+      if (SimplifyDemandedBits(Op1, MaskDemand, Known1, TLO, Depth + 1))
+        return true;
+
+      // Compute an upper bound on mask[7:0].
+      KnownBits MaskBits = Known1.extractBits(8, 0);
+      MaxMask8 = MaskBits.getMaxValue().getZExtValue();
     }
 
-    MaxMask8 = MaskedVal1;
-  } else {
-    unsigned MaskBW = Op1.getValueType().getSizeInBits();
-    APInt MaskDemand = APInt::getLowBitsSet(MaskBW, 8);
+    // Rule 2: If mask[7:0] is known to be < BitWidth, then bits at/above
+    // getMaxValue are always zero and thus not demanded; likewise src bits.
+    APInt SrcDemanded = OriginalDemandedBits;
+    if (MaxMask8 < BitWidth) {
+      unsigned Cut = (unsigned)MaxMask8;
+      SrcDemanded.clearBits(Cut, BitWidth);
+    }
 
-    KnownBits Known1;
-    if (SimplifyDemandedBits(Op1, MaskDemand, Known1, TLO, Depth + 1))
+    KnownBits KnownSrc;
+    if (SimplifyDemandedBits(Op0, SrcDemanded, KnownSrc, TLO, Depth + 1))
       return true;
 
-    // Compute an upper bound on mask[7:0].
-    KnownBits MaskBits = Known1.extractBits(8, 0);
-    MaxMask8 = MaskBits.getMaxValue().getZExtValue();
-  }
-
-  // Rule 2: If mask[7:0] is known to be < BitWidth, then bits at/above
-  // getMaxValue are always zero and thus not demanded; likewise src bits.
-  APInt SrcDemanded = OriginalDemandedBits;
-  if (MaxMask8 < BitWidth) {
-    unsigned Cut = (unsigned)MaxMask8;
-    SrcDemanded.clearBits(Cut, BitWidth);
-  }
-
-  
-  KnownBits KnownSrc;
-  if (SimplifyDemandedBits(Op0, SrcDemanded, KnownSrc, TLO, Depth + 1))
-    return true;
-
-  
-  Known.One.clearAllBits();
-  Known.Zero.clearAllBits();
-  if (MaxMask8 < BitWidth) {
-    unsigned Cut = (unsigned)MaxMask8;
-    Known.Zero.setBits(Cut, BitWidth);
+    Known.One.clearAllBits();
+    Known.Zero.clearAllBits();
+    if (MaxMask8 < BitWidth) {
+      unsigned Cut = (unsigned)MaxMask8;
+      Known.Zero.setBits(Cut, BitWidth);
     }
 
-  break;
+    break;
   }
 
   case X86ISD::PDEP: {

--- a/llvm/test/CodeGen/X86/combine-bzhi.ll
+++ b/llvm/test/CodeGen/X86/combine-bzhi.ll
@@ -81,3 +81,51 @@ define i64 @test_bzhi64_range(i64 %arg) nounwind readnone {
   %4 = tail call i64 @llvm.x86.bmi.bzhi.64(i64 30064771240, i64 %3)
   ret i64 %4
 }
+
+define i32 @test_bzhi32_mask_const_highbits(i32 %a) nounwind {
+; CHECK-LABEL: test_bzhi32_mask_const_highbits:
+; CHECK-NOT:   $257
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    movl $1, %eax
+; CHECK-NEXT:    bzhil
+; CHECK-NEXT:    retq
+  %1 = tail call i32 @llvm.x86.bmi.bzhi.32(i32 %a, i32 257)
+  ret i32 %1
+}
+
+define i64 @test_bzhi64_mask_const_highbits(i64 %a) nounwind {
+; CHECK-LABEL: test_bzhi64_mask_const_highbits:
+; CHECK-NOT:   $257
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    movl $1, %eax
+; CHECK-NEXT:    bzhiq
+; CHECK-NEXT:    retq
+  %1 = tail call i64 @llvm.x86.bmi.bzhi.64(i64 %a, i64 257)
+  ret i64 %1
+}
+
+define i32 @test_bzhi32_rule2_mask_max31_kills_topbit(i32 %a, i32 %m) nounwind {
+; CHECK-LABEL: test_bzhi32_rule2_mask_max31_kills_topbit:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andl $31, %esi
+; CHECK-NEXT:    bzhil
+; CHECK-NEXT:    retq
+  %mask = and i32 %m, 31
+  %hi  = shl i32 %a, 31
+  %src = or i32 %a, %hi
+  %r = tail call i32 @llvm.x86.bmi.bzhi.32(i32 %src, i32 %mask)
+  ret i32 %r
+}
+
+define i64 @test_bzhi64_rule2_mask_max63_kills_topbit(i64 %a, i64 %m) nounwind {
+; CHECK-LABEL: test_bzhi64_rule2_mask_max63_kills_topbit:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andl $63, %esi
+; CHECK-NEXT:    bzhiq
+; CHECK-NEXT:    retq
+  %mask = and i64 %m, 63
+  %hi  = shl i64 %a, 63
+  %src = or i64 %a, %hi
+  %r = tail call i64 @llvm.x86.bmi.bzhi.64(i64 %src, i64 %mask)
+  ret i64 %r
+}


### PR DESCRIPTION
This patch adds SimplifyDemandedBitsForTargetNode support for X86ISD::BZHI.

For BZHI, only the low 8 bits of the mask operand are semantically relevant.
This change teaches SimplifyDemandedBitsForTargetNode to:

* Limit demanded bits of the mask operand to mask[7:0]
* Use KnownBits information to compute an upper bound on mask[7:0]
* When the maximum possible value of mask[7:0] is less than the operand
  bitwidth, treat result bits at and above that bound as always zero and
  mark the corresponding source bits as not demanded

Tests are added to combine-bzhi.ll.

Closes #177369
