### PR TITLE
[NFC] Fix "FIMXE" typos to "FIXME"

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/Record.cpp
+++ b/clang-tools-extra/include-cleaner/lib/Record.cpp
@@ -424,7 +424,7 @@ toFileEntries(llvm::ArrayRef<StringRef> FileNames, FileManager &FM) {
   llvm::SmallVector<FileEntryRef> Results;
 
   for (auto FName : FileNames) {
-    // FIMXE: log the failing cases?
+    // FIXME: log the failing cases?
     if (auto FE = FM.getOptionalFileRef(FName))
       Results.push_back(*FE);
   }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/invalid-enum-default-initialization.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/invalid-enum-default-initialization.cpp
@@ -42,7 +42,7 @@ Enum2 E2_2 = Enum2();
 // CHECK-NOTES: :14:6: note: enum is defined here
 
 void f1() {
-  static Enum1 S; // FIMXE: warn for this?
+  static Enum1 S; // FIXME: warn for this?
   Enum1 A;
   Enum1 B = Enum1();
   // CHECK-NOTES: :[[@LINE-1]]:13: warning: enum value of type 'Enum1' initialized with invalid value of 0, enum doesn't have a zero-value enumerator
@@ -62,7 +62,7 @@ void f2() {
   // CHECK-NOTES: :9:12: note: enum is defined here
   // CHECK-NOTES: :[[@LINE-3]]:17: warning: enum value of type 'Enum1' initialized with invalid value of 0, enum doesn't have a zero-value enumerator
   // CHECK-NOTES: :9:12: note: enum is defined here
-  Enum1 D[5] = {}; // FIMXE: warn for this?
+  Enum1 D[5] = {}; // FIXME: warn for this?
   // CHECK-NOTES: :[[@LINE-1]]:16: warning: enum value of type 'Enum1' initialized with invalid value of 0, enum doesn't have a zero-value enumerator
   // CHECK-NOTES: :9:12: note: enum is defined here
 }

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -2783,7 +2783,7 @@ DEF_TRAVERSE_STMT(CXXNewExpr, {
 DEF_TRAVERSE_STMT(OffsetOfExpr, {
   // The child-iterator will pick up the expression representing
   // the field.
-  // FIMXE: for code like offsetof(Foo, a.b.c), should we get
+  // FIXME: for code like offsetof(Foo, a.b.c), should we get
   // making a MemberExpr callbacks for Foo.a, Foo.a.b, and Foo.a.b.c?
   TRY_TO(TraverseTypeLoc(S->getTypeSourceInfo()->getTypeLoc()));
 })

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15466,7 +15466,7 @@ void Sema::ActOnDocumentableDecls(ArrayRef<Decl *> Group) {
     }
   }
 
-  // FIMXE: We assume every Decl in the group is in the same file.
+  // FIXME: We assume every Decl in the group is in the same file.
   // This is false when preprocessor constructs the group from decls in
   // different files (e. g. macros or #include).
   Context.attachCommentsToJustParsedDecls(Group, &getPreprocessor());

--- a/llvm/lib/Target/AVR/AVRInstrInfo.td
+++ b/llvm/lib/Target/AVR/AVRInstrInfo.td
@@ -1685,7 +1685,7 @@ def : Pat<(AVRcall(i16 tglobaladdr:$dst)), (RCALLk tglobaladdr:$dst)>;
 def : Pat<(AVRcall(i16 texternalsym:$dst)), (RCALLk texternalsym:$dst)>;
 
 // `anyext`
-// FIMXE: Using INSERT_SUBREG is more efficient, but leads to issue #132203.
+// FIXME: Using INSERT_SUBREG is more efficient, but leads to issue #132203.
 def : Pat<(i16(anyext i8:$src)),
 //        (INSERT_SUBREG(i16(IMPLICIT_DEF)), i8:$src, sub_lo)>;
           (ZEXT i8:$src)>;

--- a/llvm/test/CodeGen/RISCV/GlobalISel/rv32zbkb.ll
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/rv32zbkb.ll
@@ -143,7 +143,7 @@ define i32 @packh_i32_2(i32 %a, i32 %b) nounwind {
   ret i32 %or
 }
 
-; FIMXE: Use packh
+; FIXME: Use packh
 define i64 @packh_i64(i64 %a, i64 %b) nounwind {
 ; CHECK-LABEL: packh_i64:
 ; CHECK:       # %bb.0:


### PR DESCRIPTION
Replace common typo "FIMXE" with the intended "FIXME" across the codebase.