### PR TITLE
[libc] Add Elf32_Xword type

### DIFF
--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -294,6 +294,7 @@ add_gen_header(
     libc.include.llvm-libc-types.Elf32_Verneed
     libc.include.llvm-libc-types.Elf32_Versym
     libc.include.llvm-libc-types.Elf32_Word
+    libc.include.llvm-libc-types.Elf32_Xword
     libc.include.llvm-libc-types.Elf64_Addr
     libc.include.llvm-libc-types.Elf64_Chdr
     libc.include.llvm-libc-types.Elf64_Dyn

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -649,6 +649,14 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  Elf32_Xword
+  HDRS
+  Elf32_Xword.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.Elf32_Xword
+)
+
+add_proxy_header_library(
   Elf64_Addr
   HDRS
     Elf64_Addr.h

--- a/libc/hdr/types/Elf32_Xword.h
+++ b/libc/hdr/types/Elf32_Xword.h
@@ -1,0 +1,22 @@
+//===-- Proxy for Elf32_Xword ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_ELF32_XWORD_H
+#define LLVM_LIBC_HDR_TYPES_ELF32_XWORD_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/Elf32_Xword.h"
+
+#else // Overlay mode
+
+#include <elf.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_ELF32_XWORD_H

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -497,6 +497,7 @@ add_header_macro(
     .llvm-libc-types.Elf32_Verneed
     .llvm-libc-types.Elf32_Versym
     .llvm-libc-types.Elf32_Word
+    .llvm-libc-types.Elf32_Xword
     .llvm-libc-types.Elf64_Addr
     .llvm-libc-types.Elf64_Chdr
     .llvm-libc-types.Elf64_Dyn
@@ -800,7 +801,7 @@ add_header_macro(
   ../libc/include/wctype.yaml
   wctype.h
   DEPENDS
-    .llvm_libc_common_h    
+    .llvm_libc_common_h
     .llvm-libc-types.wint_t
 )
 

--- a/libc/include/elf.yaml
+++ b/libc/include/elf.yaml
@@ -461,6 +461,7 @@ types:
   - type_name: Elf32_Verneed
   - type_name: Elf32_Versym
   - type_name: Elf32_Word
+  - type_name: Elf32_Xword
   - type_name: Elf64_Addr
   - type_name: Elf64_Chdr
   - type_name: Elf64_Dyn

--- a/libc/include/llvm-libc-macros/link-macros.h
+++ b/libc/include/llvm-libc-macros/link-macros.h
@@ -24,6 +24,7 @@
 #include "../llvm-libc-types/Elf32_Sword.h"
 #include "../llvm-libc-types/Elf32_Sym.h"
 #include "../llvm-libc-types/Elf32_Word.h"
+#include "../llvm-libc-types/Elf32_Xword.h"
 #include "../llvm-libc-types/Elf64_Addr.h"
 #include "../llvm-libc-types/Elf64_Chdr.h"
 #include "../llvm-libc-types/Elf64_Dyn.h"

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -194,6 +194,7 @@ add_header(Elf32_Lword HDR Elf32_Lword.h DEPENDS libc.include.llvm-libc-macros.s
 add_header(Elf32_Off HDR Elf32_Off.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
 add_header(Elf32_Sword HDR Elf32_Sword.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
 add_header(Elf32_Word HDR Elf32_Word.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
+add_header(Elf32_Xword HDR Elf32_Xword.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
 add_header(
   Elf32_Chdr
   HDR

--- a/libc/include/llvm-libc-types/Elf32_Xword.h
+++ b/libc/include/llvm-libc-types/Elf32_Xword.h
@@ -1,0 +1,16 @@
+//===-- Definition of Elf32_Xword type ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_ELF32_XWORD_H
+#define LLVM_LIBC_TYPES_ELF32_XWORD_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+
+typedef uint64_t Elf32_Xword;
+
+#endif // LLVM_LIBC_TYPES_ELF32_XWORD_H


### PR DESCRIPTION
In a recent PR (https://github.com/llvm/llvm-project/pull/174772), we introduced GnuPropertySection using ElfW(Xword). Since we are currently missing Elf32_Xword, this is failing on 32bit architectures.

This commit adds the missing Elf32_Xword type that should always hold 64bit even on 32bit architectures.