### PR TITLE
[KnownBits] Make `clmul` optimal

### DIFF
--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -3200,8 +3200,8 @@ APInt llvm::APIntOps::fshr(const APInt &Hi, const APInt &Lo,
 }
 
 APInt llvm::APIntOps::clmul(const APInt &LHS, const APInt &RHS) {
-  assert(LHS.getBitWidth() == RHS.getBitWidth());
   unsigned BW = LHS.getBitWidth();
+  assert(BW == RHS.getBitWidth() && "Operand mismatch");
   APInt Result(BW, 0);
   for (unsigned I : seq(std::min(RHS.getActiveBits(), BW - LHS.countr_zero())))
     if (RHS[I])

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -3203,9 +3203,9 @@ APInt llvm::APIntOps::clmul(const APInt &LHS, const APInt &RHS) {
   assert(LHS.getBitWidth() == RHS.getBitWidth());
   unsigned BW = LHS.getBitWidth();
   APInt Result(BW, 0);
-  for (unsigned I : seq<unsigned>(BW))
+  for (unsigned I : seq(std::min(RHS.getActiveBits(), BW - LHS.countr_zero())))
     if (RHS[I])
-      Result ^= LHS.shl(I);
+      Result ^= LHS << I;
   return Result;
 }
 

--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -610,8 +610,8 @@ KnownBits KnownBits::clmul(const KnownBits &LHS, const KnownBits &RHS) {
   // This is the same operation as clmul except it accumulates the result with
   // an OR instead of an XOR.
   auto ClMulOr = [](const APInt &LHS, const APInt &RHS) {
-    assert(LHS.getBitWidth() == RHS.getBitWidth());
     unsigned BW = LHS.getBitWidth();
+    assert(BW == RHS.getBitWidth() && "Operand mismatch");
     APInt Result(BW, 0);
     for (unsigned I :
          seq(std::min(RHS.getActiveBits(), BW - LHS.countr_zero())))

--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -610,12 +610,14 @@ KnownBits KnownBits::clmul(const KnownBits &LHS, const KnownBits &RHS) {
   // This is the same operation as clmul except it accumulates the result with
   // an OR instead of an XOR.
   auto ClMulOr = [](const APInt &LHS, const APInt &RHS) {
-    APInt Res(LHS.getBitWidth(), 0);
-    for (unsigned I : seq(LHS.getBitWidth())) {
-      if (LHS[I])
-        Res |= RHS << I;
-    }
-    return Res;
+    assert(LHS.getBitWidth() == RHS.getBitWidth());
+    unsigned BW = LHS.getBitWidth();
+    APInt Result(BW, 0);
+    for (unsigned I :
+         seq(std::min(RHS.getActiveBits(), BW - LHS.countr_zero())))
+      if (RHS[I])
+        Result |= LHS << I;
+    return Result;
   };
 
   // Bits in the result are known if, for every corresponding pair of input

--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/Sequence.h"
 #include "llvm/Support/KnownBits.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -603,38 +604,26 @@ KnownBits KnownBits::ashr(const KnownBits &LHS, const KnownBits &RHS,
 }
 
 KnownBits KnownBits::clmul(const KnownBits &LHS, const KnownBits &RHS) {
-  unsigned BitWidth = LHS.getBitWidth();
+  KnownBits Res = makeConstant(APIntOps::clmul(LHS.getMinValue(),
+                                               RHS.getMinValue()));
 
-  // An m*n result will always fit in m+n-1 bits since there are no carries.
-  // If either input is to be zero, the result is zero.
-  unsigned ActiveBitsLHS = LHS.countMaxActiveBits();
-  unsigned ActiveBitsRHS = RHS.countMaxActiveBits();
-  unsigned ActiveBits;
-  if (ActiveBitsLHS == 0 || ActiveBitsRHS == 0)
-    ActiveBits = 0;
-  else
-    ActiveBits = std::min(BitWidth, ActiveBitsLHS + ActiveBitsRHS - 1);
+  // This is the same operation as clmul except it accumulates the result with
+  // an OR instead of an XOR.
+  auto ClMulOr = [](const APInt &LHS, const APInt &RHS){
+    APInt Res(LHS.getBitWidth(), 0);
+    for (unsigned I : seq(LHS.getBitWidth())) {
+      if (LHS[I])
+        Res |= RHS << I;
+    }
+    return Res;
+  };
 
-  // The result of the bottom bits of a clmul can be inferred by looking at the
-  // bottom bits of both operands and carryless multiplying them together. The
-  // number of bits we can determine follows the same logic as KnownBits::mul.
-  unsigned TrailBitsKnownLHS = (LHS.Zero | LHS.One).countr_one();
-  unsigned TrailBitsKnownRHS = (RHS.Zero | RHS.One).countr_one();
-  unsigned TrailZeroLHS = LHS.countMinTrailingZeros();
-  unsigned TrailZeroRHS = RHS.countMinTrailingZeros();
-  unsigned TrailZ = TrailZeroLHS + TrailZeroRHS;
-
-  // Figure out the fewest known-bits operand.
-  unsigned SmallestOperand = std::min(TrailBitsKnownLHS - TrailZeroLHS,
-                                      TrailBitsKnownRHS - TrailZeroRHS);
-  unsigned ResultBitsKnown = std::min(SmallestOperand + TrailZ, BitWidth);
-
-  APInt BottomKnown = APIntOps::clmul(LHS.One, RHS.One);
-
-  KnownBits Res(BitWidth);
-  Res.Zero.setBitsFrom(ActiveBits);
-  Res.Zero |= (~BottomKnown).getLoBits(ResultBitsKnown);
-  Res.One = BottomKnown.getLoBits(ResultBitsKnown);
+  // Bits in the result are known if, for every corresponding pair of input
+  // bits, both input bits are known or either input bit is known to be zero.
+  APInt Known = ~(ClMulOr(~LHS.Zero & ~LHS.One, ~RHS.Zero) |
+                  ClMulOr(~LHS.Zero, ~RHS.Zero & ~RHS.One));
+  Res.Zero &= Known;
+  Res.One &= Known;
 
   return Res;
 }

--- a/llvm/lib/Support/KnownBits.cpp
+++ b/llvm/lib/Support/KnownBits.cpp
@@ -11,8 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/ADT/Sequence.h"
 #include "llvm/Support/KnownBits.h"
+#include "llvm/ADT/Sequence.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
@@ -604,12 +604,12 @@ KnownBits KnownBits::ashr(const KnownBits &LHS, const KnownBits &RHS,
 }
 
 KnownBits KnownBits::clmul(const KnownBits &LHS, const KnownBits &RHS) {
-  KnownBits Res = makeConstant(APIntOps::clmul(LHS.getMinValue(),
-                                               RHS.getMinValue()));
+  KnownBits Res =
+      makeConstant(APIntOps::clmul(LHS.getMinValue(), RHS.getMinValue()));
 
   // This is the same operation as clmul except it accumulates the result with
   // an OR instead of an XOR.
-  auto ClMulOr = [](const APInt &LHS, const APInt &RHS){
+  auto ClMulOr = [](const APInt &LHS, const APInt &RHS) {
     APInt Res(LHS.getBitWidth(), 0);
     for (unsigned I : seq(LHS.getBitWidth())) {
       if (LHS[I])

--- a/llvm/unittests/Support/KnownBitsTest.cpp
+++ b/llvm/unittests/Support/KnownBitsTest.cpp
@@ -568,8 +568,7 @@ TEST(KnownBitsTest, BinaryExhaustive) {
 
   testBinaryOpExhaustive("avgCeilS", KnownBits::avgCeilS, APIntOps::avgCeilS);
 
-  testBinaryOpExhaustive("clmul", KnownBits::clmul, APIntOps::clmul,
-                         /*CheckOptimality=*/false);
+  testBinaryOpExhaustive("clmul", KnownBits::clmul, APIntOps::clmul);
 }
 
 TEST(KnownBitsTest, UnaryExhaustive) {


### PR DESCRIPTION
Normally I would push back on implementations that take O(BitWidth)
steps, but since the corresponding APInt function already takes
O(BitWidth) steps, this KnownBits function is no worse in that regard.

Also add the same early-out optimization to both the APInt function and the KnownBits function.
