### PR TITLE
[clang] Fix assertion failure with malformed destructor in literal type check

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -185,6 +185,7 @@ Bug Fixes to Attribute Support
 Bug Fixes to C++ Support
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed a crash when instantiating ``requires`` expressions involving substitution failures in C++ concepts. (#GH176402)
+- Fixed an assertion failure when checking literal types with malformed destructor declarations. (#GH177894)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -9679,6 +9679,7 @@ bool Sema::RequireLiteralType(SourceLocation Loc, QualType T,
     // destructors. If this class's destructor is non-trivial / non-constexpr,
     // it must be user-declared.
     CXXDestructorDecl *Dtor = RD->getDestructor();
+    // Malformed destructor declarations can leave getDestructor() null.
     if (!Dtor)
       return true;
 

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -9679,7 +9679,6 @@ bool Sema::RequireLiteralType(SourceLocation Loc, QualType T,
     // destructors. If this class's destructor is non-trivial / non-constexpr,
     // it must be user-declared.
     CXXDestructorDecl *Dtor = RD->getDestructor();
-    assert(Dtor && "class has literal fields and bases but no dtor?");
     if (!Dtor)
       return true;
 

--- a/clang/test/SemaCXX/literal-type.cpp
+++ b/clang/test/SemaCXX/literal-type.cpp
@@ -176,3 +176,12 @@ static_assert(__is_literal(UnionWithNonLiteralMemberConstexprDtor2), "fail");
 #endif
 }
 #endif
+
+
+namespace GH177894 {
+struct S {
+  ~S() = (0); // expected-error {{initializer on function does not look like a pure-specifier}}
+};
+
+void bar() { S s; }
+}


### PR DESCRIPTION
Removed an incorrect assertion in RequireLiteralType - it assumed getDestructor() never returns null, but malformed destructors can cause that. The null check after it already handled it.

Fixes #177894.