### PR TITLE
AArch64: Use poison more in legalization

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -4809,7 +4809,7 @@ SDValue AArch64TargetLowering::LowerFP_ROUND(SDValue Op,
       // Round to float without introducing rounding errors and try again.
       SDValue Pg = getPredicateForVector(DAG, DL, MVT::nxv2f32);
       Narrow = DAG.getNode(AArch64ISD::FCVTX_MERGE_PASSTHRU, DL, MVT::nxv2f32,
-                           Pg, SrcVal, DAG.getUNDEF(MVT::nxv2f32));
+                           Pg, SrcVal, DAG.getPOISON(MVT::nxv2f32));
 
       SmallVector<SDValue, 3> NewOps;
       if (IsStrict)
@@ -7283,12 +7283,12 @@ static SDValue LowerTruncateVectorStore(SDLoc DL, StoreSDNode *ST,
   //   xtn  v0.8b, v0.8h
   //   str  s0, [x0]
 
-  SDValue Undef = DAG.getUNDEF(MVT::i16);
-  SDValue UndefVec = DAG.getBuildVector(MVT::v4i16, DL,
-                                        {Undef, Undef, Undef, Undef});
+  SDValue Poison = DAG.getPOISON(MVT::i16);
+  SDValue PoisonVec =
+      DAG.getBuildVector(MVT::v4i16, DL, {Poison, Poison, Poison, Poison});
 
-  SDValue TruncExt = DAG.getNode(ISD::CONCAT_VECTORS, DL, MVT::v8i16,
-                                 Value, UndefVec);
+  SDValue TruncExt =
+      DAG.getNode(ISD::CONCAT_VECTORS, DL, MVT::v8i16, Value, PoisonVec);
   SDValue Trunc = DAG.getNode(ISD::TRUNCATE, DL, MVT::v8i8, TruncExt);
 
   Trunc = DAG.getNode(ISD::BITCAST, DL, MVT::v2i32, Trunc);
@@ -7721,9 +7721,9 @@ static SDValue LowerFLDEXP(SDValue Op, SelectionDAG &DAG) {
 
   SDValue Zero = DAG.getConstant(0, DL, MVT::i64);
   SDValue VX =
-      DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, XVT, DAG.getUNDEF(XVT), X, Zero);
+      DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, XVT, DAG.getPOISON(XVT), X, Zero);
   SDValue VExp = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, ExpVT,
-                             DAG.getUNDEF(ExpVT), Exp, Zero);
+                             DAG.getPOISON(ExpVT), Exp, Zero);
   SDValue VPg = DAG.getConstant(
       1, DL, XVT.changeVectorElementType(*DAG.getContext(), MVT::i1));
   SDValue FScale = DAG.getNode(
@@ -11543,15 +11543,14 @@ SDValue AArch64TargetLowering::LowerFCOPYSIGN(SDValue Op,
       return SDValue();
     EVT SVT = getPackedSVEVectorVT(VT);
 
+    SDValue Poison = DAG.getPOISON(SVT);
+    SDValue Zero = DAG.getConstant(0, DL, MVT::i64);
     SDValue Ins1 =
-        DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, SVT, DAG.getUNDEF(SVT), In1,
-                    DAG.getConstant(0, DL, MVT::i64));
+        DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, SVT, Poison, In1, Zero);
     SDValue Ins2 =
-        DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, SVT, DAG.getUNDEF(SVT), In2,
-                    DAG.getConstant(0, DL, MVT::i64));
+        DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, SVT, Poison, In2, Zero);
     SDValue FCS = DAG.getNode(ISD::FCOPYSIGN, DL, SVT, Ins1, Ins2);
-    return DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, VT, FCS,
-                       DAG.getConstant(0, DL, MVT::i64));
+    return DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, VT, FCS, Zero);
   }
 
   auto BitCast = [this](EVT VT, SDValue Op, SelectionDAG &DAG) {
@@ -11565,10 +11564,9 @@ SDValue AArch64TargetLowering::LowerFCOPYSIGN(SDValue Op,
   EVT VecVT;
   auto SetVecVal = [&](int Idx = -1) {
     if (!VT.isVector()) {
-      VecVal1 =
-          DAG.getTargetInsertSubreg(Idx, DL, VecVT, DAG.getUNDEF(VecVT), In1);
-      VecVal2 =
-          DAG.getTargetInsertSubreg(Idx, DL, VecVT, DAG.getUNDEF(VecVT), In2);
+      SDValue Poison = DAG.getPOISON(VecVT);
+      VecVal1 = DAG.getTargetInsertSubreg(Idx, DL, VecVT, Poison, In1);
+      VecVal2 = DAG.getTargetInsertSubreg(Idx, DL, VecVT, Poison, In2);
     } else {
       VecVal1 = BitCast(VecVT, In1, DAG);
       VecVal2 = BitCast(VecVT, In2, DAG);
@@ -11639,7 +11637,7 @@ SDValue AArch64TargetLowering::LowerCTPOP_PARITY(SDValue Op,
     if (VT == MVT::i32 || VT == MVT::i64) {
       EVT ContainerVT = VT == MVT::i32 ? MVT::nxv4i32 : MVT::nxv2i64;
       Val = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, ContainerVT,
-                        DAG.getUNDEF(ContainerVT), Val,
+                        DAG.getPOISON(ContainerVT), Val,
                         DAG.getVectorIdxConstant(0, DL));
       Val = DAG.getNode(ISD::CTPOP, DL, ContainerVT, Val);
       Val = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, VT, Val,
@@ -12061,7 +12059,7 @@ static SDValue emitVectorComparison(SDValue LHS, SDValue RHS,
           EVT::getVectorVT(*DAG.getContext(), VT, 128 / VT.getSizeInBits());
       SDValue Zero = DAG.getConstant(0, DL, MVT::i64);
       SDValue MaskVec = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, VecVT,
-                                    DAG.getUNDEF(VecVT), Fcmeq, Zero);
+                                    DAG.getPOISON(VecVT), Fcmeq, Zero);
       SDValue InvertedMask = DAG.getNOT(DL, MaskVec, VecVT);
       return DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, VT, InvertedMask, Zero);
     }
@@ -12144,11 +12142,10 @@ static SDValue emitFloatCompareMask(SDValue LHS, SDValue RHS, SDValue TVal,
 
   EVT VecVT = EVT::getVectorVT(*DAG.getContext(), VT, 128 / VT.getSizeInBits());
   SDValue Zero = DAG.getConstant(0, DL, MVT::i64);
-  Cmp = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, VecVT, DAG.getUNDEF(VecVT), Cmp,
-                    Zero);
+  SDValue Poison = DAG.getPOISON(VecVT);
+  Cmp = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, VecVT, Poison, Cmp, Zero);
   if (Cmp2) {
-    Cmp2 = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, VecVT, DAG.getUNDEF(VecVT),
-                       Cmp2, Zero);
+    Cmp2 = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, VecVT, Poison, Cmp2, Zero);
     Cmp = DAG.getNode(ISD::OR, DL, VecVT, Cmp, Cmp2);
   }
   if (ShouldInvert)
@@ -12554,10 +12551,9 @@ SDValue AArch64TargetLowering::LowerSELECT(SDValue Op,
   // If we are lowering a f16 and we do not have fullf16, convert to a f32 in
   // order to use FCSELSrrr
   if ((Ty == MVT::f16 || Ty == MVT::bf16) && !Subtarget->hasFullFP16()) {
-    TVal = DAG.getTargetInsertSubreg(AArch64::hsub, DL, MVT::f32,
-                                     DAG.getUNDEF(MVT::f32), TVal);
-    FVal = DAG.getTargetInsertSubreg(AArch64::hsub, DL, MVT::f32,
-                                     DAG.getUNDEF(MVT::f32), FVal);
+    SDValue Poison = DAG.getPOISON(MVT::f32);
+    TVal = DAG.getTargetInsertSubreg(AArch64::hsub, DL, MVT::f32, Poison, TVal);
+    FVal = DAG.getTargetInsertSubreg(AArch64::hsub, DL, MVT::f32, Poison, FVal);
   }
 
   SDValue Res = LowerSELECT_CC(CC, LHS, RHS, TVal, FVal, Op->users(),
@@ -13766,7 +13762,7 @@ static SDValue WidenVector(SDValue V64Reg, SelectionDAG &DAG) {
   MVT WideTy = MVT::getVectorVT(EltTy, 2 * NarrowSize);
   SDLoc DL(V64Reg);
 
-  return DAG.getNode(ISD::INSERT_SUBVECTOR, DL, WideTy, DAG.getUNDEF(WideTy),
+  return DAG.getNode(ISD::INSERT_SUBVECTOR, DL, WideTy, DAG.getPOISON(WideTy),
                      V64Reg, DAG.getConstant(0, DL, MVT::i64));
 }
 
@@ -13856,7 +13852,7 @@ SDValue ReconstructShuffleWithRuntimeMask(SDValue Op, SelectionDAG &DAG) {
   // of elements in the source, or we would have an out-of-bounds access.
   if (NumElts == 8)
     SourceVec = DAG.getNode(ISD::CONCAT_VECTORS, DL, MVT::v16i8, SourceVec,
-                            DAG.getUNDEF(VT));
+                            DAG.getPOISON(VT));
 
   // Preconditions met, so we can use a vector (AND +) TBL to build this vector.
   if (!AndMaskConstants.empty())
@@ -13977,7 +13973,7 @@ SDValue AArch64TargetLowering::ReconstructShuffle(SDValue Op,
              "Expected a legally typed vector");
       if (SrcVT.is64BitVector())
         Src = DAG.getNode(ISD::CONCAT_VECTORS, DL, MVT::v16i8, Src,
-                          DAG.getUNDEF(MVT::v8i8));
+                          DAG.getPOISON(MVT::v8i8));
       TBLOperands.push_back(Src);
     }
 
@@ -14039,7 +14035,7 @@ SDValue AArch64TargetLowering::ReconstructShuffle(SDValue Op,
       // shuffle...
       Src.ShuffleVec =
           DAG.getNode(ISD::CONCAT_VECTORS, DL, DestVT, Src.ShuffleVec,
-                      DAG.getUNDEF(Src.ShuffleVec.getValueType()));
+                      DAG.getPOISON(Src.ShuffleVec.getValueType()));
       continue;
     }
 
@@ -14150,7 +14146,8 @@ SDValue AArch64TargetLowering::ReconstructShuffle(SDValue Op,
     return SDValue();
   }
 
-  SDValue ShuffleOps[] = { DAG.getUNDEF(ShuffleVT), DAG.getUNDEF(ShuffleVT) };
+  SDValue Poison = DAG.getPOISON(ShuffleVT);
+  SDValue ShuffleOps[] = {Poison, Poison};
   for (unsigned i = 0; i < Sources.size(); ++i)
     ShuffleOps[i] = Sources[i].ShuffleVec;
 
@@ -15783,7 +15780,9 @@ static SDValue NormalizeBuildVector(SDValue Op,
       Lane = DAG.getConstant(
           CstLane->getAPIntValue().trunc(EltTy.getSizeInBits()).getZExtValue(),
           DL, MVT::i32);
-    } else if (Lane.getNode()->isUndef()) {
+    } else if (Lane.getOpcode() == ISD::POISON) {
+      Lane = DAG.getPOISON(MVT::i32);
+    } else if (Lane.getOpcode() == ISD::UNDEF) {
       Lane = DAG.getUNDEF(MVT::i32);
     } else {
       assert(Lane.getValueType() == MVT::i32 &&
@@ -15926,10 +15925,10 @@ SDValue AArch64TargetLowering::LowerFixedLengthBuildVectorToSVE(
   // Lower (pow2) BUILD_VECTORS that are <= 128-bit to a sequence of ZIP1s.
   SDValue ZeroI64 = DAG.getConstant(0, DL, MVT::i64);
   SmallVector<SDValue, 16> Intermediates = map_to_vector<16>(
-      Op->op_values(), [&, Undef = DAG.getUNDEF(ContainerVT)](SDValue Op) {
-        return Op.isUndef() ? Undef
+      Op->op_values(), [&, Poison = DAG.getPOISON(ContainerVT)](SDValue Op) {
+        return Op.isUndef() ? Poison
                             : DAG.getNode(ISD::INSERT_VECTOR_ELT, DL,
-                                          ContainerVT, Undef, Op, ZeroI64);
+                                          ContainerVT, Poison, Op, ZeroI64);
       });
 
   ElementCount ZipEC = ContainerVT.getVectorElementCount();
@@ -16352,7 +16351,7 @@ SDValue AArch64TargetLowering::LowerBUILD_VECTOR(SDValue Op,
         dbgs() << "LowerBUILD_VECTOR: alternatives failed, creating sequence "
                   "of INSERT_VECTOR_ELT\n");
 
-    SDValue Vec = DAG.getUNDEF(VT);
+    SDValue Vec = DAG.getPOISON(VT);
     SDValue Op0 = Op.getOperand(0);
     unsigned i = 0;
 
@@ -16558,7 +16557,7 @@ SDValue AArch64TargetLowering::LowerEXTRACT_SUBVECTOR(SDValue Op,
     if (PackedVT != InVT) {
       // Pack input into the bottom part of an SVE register and try again.
       SDValue Container = DAG.getNode(ISD::INSERT_SUBVECTOR, DL, PackedVT,
-                                      DAG.getUNDEF(PackedVT), Vec,
+                                      DAG.getPOISON(PackedVT), Vec,
                                       DAG.getVectorIdxConstant(0, DL));
       return DAG.getNode(ISD::EXTRACT_SUBVECTOR, DL, VT, Container, Idx);
     }
@@ -19953,7 +19952,7 @@ static SDValue performBuildShuffleExtendCombine(SDValue BV, SelectionDAG &DAG) {
         PreExtendType.getScalarSizeInBits() < 32 ? MVT::i32 : PreExtendType;
     SmallVector<SDValue, 8> NewOps;
     for (SDValue Op : BV->ops())
-      NewOps.push_back(Op.isUndef() ? DAG.getUNDEF(PreExtendLegalType)
+      NewOps.push_back(Op.isUndef() ? DAG.getPOISON(PreExtendLegalType)
                                     : DAG.getAnyExtOrTrunc(Op.getOperand(0), DL,
                                                            PreExtendLegalType));
     NBV = DAG.getNode(ISD::BUILD_VECTOR, DL, PreExtendVT, NewOps);
@@ -19962,7 +19961,7 @@ static SDValue performBuildShuffleExtendCombine(SDValue BV, SelectionDAG &DAG) {
                                                  PreExtendType.getScalarType());
     NBV = DAG.getVectorShuffle(PreExtendVT, DL, BV.getOperand(0).getOperand(0),
                                BV.getOperand(1).isUndef()
-                                   ? DAG.getUNDEF(PreExtendVT)
+                                   ? DAG.getPOISON(PreExtendVT)
                                    : BV.getOperand(1).getOperand(0),
                                cast<ShuffleVectorSDNode>(BV)->getMask());
   }
@@ -20467,7 +20466,7 @@ tryToReplaceScalarFPConversionWithSVE(SDNode *N, SelectionDAG &DAG,
   SDLoc DL(N);
   SDValue ZeroIdx = DAG.getVectorIdxConstant(0, DL);
   SDValue Vec = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, SrcVecTy,
-                            DAG.getUNDEF(SrcVecTy), SrcVal, ZeroIdx);
+                            DAG.getPOISON(SrcVecTy), SrcVal, ZeroIdx);
   SDValue Convert = DAG.getNode(N->getOpcode(), DL, DestVecTy, Vec);
   return DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, DestTy, Convert, ZeroIdx);
 }
@@ -21468,9 +21467,9 @@ static SDValue performConcatVectorsCombine(SDNode *N,
       N1Opc == AArch64ISD::ZIP2 && N0.getOperand(0) == N1.getOperand(0) &&
       N0.getOperand(1) == N1.getOperand(1)) {
     SDValue E0 = DAG.getNode(ISD::CONCAT_VECTORS, DL, VT, N0.getOperand(0),
-                             DAG.getUNDEF(N0.getValueType()));
+                             DAG.getPOISON(N0.getValueType()));
     SDValue E1 = DAG.getNode(ISD::CONCAT_VECTORS, DL, VT, N0.getOperand(1),
-                             DAG.getUNDEF(N0.getValueType()));
+                             DAG.getPOISON(N0.getValueType()));
     return DAG.getNode(AArch64ISD::ZIP1, DL, VT, E0, E1);
   }
 
@@ -23318,7 +23317,7 @@ static SDValue combineSVEReductionOrderedFP(SDNode *N, unsigned Opc,
   // reduction's initial value.
   SDValue Zero = DAG.getConstant(0, DL, MVT::i64);
   InitVal = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, ReduceVT,
-                        DAG.getUNDEF(ReduceVT), InitVal, Zero);
+                        DAG.getPOISON(ReduceVT), InitVal, Zero);
 
   SDValue Reduce = DAG.getNode(Opc, DL, ReduceVT, Pred, InitVal, VecToReduce);
 
@@ -24057,16 +24056,16 @@ static SDValue performLDNT1Combine(SDNode *N, SelectionDAG &DAG) {
 
   auto *MINode = cast<MemIntrinsicSDNode>(N);
   SDValue PassThru = DAG.getConstant(0, DL, LoadVT);
-  SDValue L = DAG.getMaskedLoad(LoadVT, DL, MINode->getChain(),
-                                MINode->getOperand(3), DAG.getUNDEF(PtrTy),
-                                MINode->getOperand(2), PassThru,
-                                MINode->getMemoryVT(), MINode->getMemOperand(),
-                                ISD::UNINDEXED, ISD::NON_EXTLOAD, false);
+  SDValue L =
+      DAG.getMaskedLoad(LoadVT, DL, MINode->getChain(), MINode->getOperand(3),
+                        DAG.getPOISON(PtrTy), MINode->getOperand(2), PassThru,
+                        MINode->getMemoryVT(), MINode->getMemOperand(),
+                        ISD::UNINDEXED, ISD::NON_EXTLOAD, false);
 
-   if (VT.isFloatingPoint()) {
-     SDValue Ops[] = { DAG.getNode(ISD::BITCAST, DL, VT, L), L.getValue(1) };
-     return DAG.getMergeValues(Ops, DL);
-   }
+  if (VT.isFloatingPoint()) {
+    SDValue Ops[] = {DAG.getNode(ISD::BITCAST, DL, VT, L), L.getValue(1)};
+    return DAG.getMergeValues(Ops, DL);
+  }
 
   return L;
 }
@@ -24131,7 +24130,7 @@ static SDValue performSTNT1Combine(SDNode *N, SelectionDAG &DAG) {
 
   auto *MINode = cast<MemIntrinsicSDNode>(N);
   return DAG.getMaskedStore(MINode->getChain(), DL, Data, MINode->getOperand(4),
-                            DAG.getUNDEF(PtrTy), MINode->getOperand(3),
+                            DAG.getPOISON(PtrTy), MINode->getOperand(3),
                             MINode->getMemoryVT(), MINode->getMemOperand(),
                             ISD::UNINDEXED, false, false);
 }
@@ -24516,7 +24515,7 @@ static SDValue performUzpCombine(SDNode *N, SelectionDAG &DAG,
       EVT OpVT = Op0.getOperand(1).getValueType();
       EVT WidenedResVT = ResVT.getDoubleNumVectorElementsVT(*DAG.getContext());
       SDValue Uzp = DAG.getNode(N->getOpcode(), DL, WidenedResVT, SourceVec,
-                                DAG.getUNDEF(WidenedResVT));
+                                DAG.getPOISON(WidenedResVT));
       return DAG.getNode(ISD::EXTRACT_SUBVECTOR, DL, ResVT, Uzp,
                          DAG.getConstant(0, DL, OpVT));
     }
@@ -24549,7 +24548,7 @@ static SDValue performUzpCombine(SDNode *N, SelectionDAG &DAG,
       SDValue BC = DAG.getBitcast(BCVT, Op0);
       SDValue Trunc = DAG.getNode(ISD::TRUNCATE, DL, HalfVT, BC);
       return DAG.getNode(ISD::CONCAT_VECTORS, DL, ResVT, Trunc,
-                         DAG.getUNDEF(HalfVT));
+                         DAG.getPOISON(HalfVT));
     }
   }
 
@@ -25085,11 +25084,11 @@ static SDValue performLOADCombine(SDNode *N,
       DAG.getLoad(RemainingVT, DL, Chain, NewPtr,
                   LD->getPointerInfo().getWithOffset(PtrOffset), NewAlign,
                   LD->getMemOperand()->getFlags(), LD->getAAInfo());
-  SDValue UndefVector = DAG.getUNDEF(NewVT);
+  SDValue PoisonVector = DAG.getPOISON(NewVT);
   SDValue InsertIdx = DAG.getVectorIdxConstant(0, DL);
   SDValue ExtendedRemainingLoad =
       DAG.getNode(ISD::INSERT_SUBVECTOR, DL, NewVT,
-                  {UndefVector, RemainingLoad, InsertIdx});
+                  {PoisonVector, RemainingLoad, InsertIdx});
   LoadOps.push_back(ExtendedRemainingLoad);
   LoadOpsChain.push_back(SDValue(cast<SDNode>(RemainingLoad), 1));
   EVT ConcatVT =
@@ -25322,10 +25321,10 @@ static SDValue combineI8TruncStore(StoreSDNode *ST, SelectionDAG &DAG,
   auto WideVT = EVT::getVectorVT(
       *DAG.getContext(),
       Value->getOperand(0).getValueType().getVectorElementType(), 4);
-  SDValue UndefVector = DAG.getUNDEF(WideVT);
+  SDValue PoisonVector = DAG.getPOISON(WideVT);
   SDValue WideTrunc = DAG.getNode(
       ISD::INSERT_SUBVECTOR, DL, WideVT,
-      {UndefVector, Value->getOperand(0), DAG.getVectorIdxConstant(0, DL)});
+      {PoisonVector, Value->getOperand(0), DAG.getVectorIdxConstant(0, DL)});
   SDValue Cast = DAG.getNode(
       ISD::BITCAST, DL, WideVT.getSizeInBits() == 64 ? MVT::v8i8 : MVT::v16i8,
       WideTrunc);
@@ -25499,7 +25498,7 @@ static SDValue performSTORECombine(SDNode *N,
                                 Value.getValueType(), Vector, ExtIdx);
       SDValue Zero = DAG.getVectorIdxConstant(0, DL);
       ExtVector = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, VectorVT,
-                              DAG.getUNDEF(VectorVT), Ext, Zero);
+                              DAG.getPOISON(VectorVT), Ext, Zero);
     }
 
     EVT FPMemVT = MemVT == MVT::i8
@@ -27379,7 +27378,7 @@ static SDValue performDUPCombine(SDNode *N,
                                       128 / ElemVT.getSizeInBits());
       SDValue Zero = DCI.DAG.getConstant(0, DL, MVT::i64);
       SDValue Vec = DCI.DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, ExpandedVT,
-                                    DCI.DAG.getUNDEF(ExpandedVT), Op, Zero);
+                                    DCI.DAG.getPOISON(ExpandedVT), Op, Zero);
       return DCI.DAG.getNode(getDUPLANEOp(ElemVT), DL, VT, Vec, Zero);
     }
 
@@ -28126,7 +28125,7 @@ static SDValue performDupLane128Combine(SDNode *N, SelectionDAG &DAG) {
   SDLoc DL(N);
   SDValue NewInsert =
       DAG.getNode(ISD::INSERT_SUBVECTOR, DL, NewSubvecVT,
-                  DAG.getUNDEF(NewSubvecVT), Subvec, Insert->getOperand(2));
+                  DAG.getPOISON(NewSubvecVT), Subvec, Insert->getOperand(2));
   SDValue NewDuplane128 = DAG.getNode(AArch64ISD::DUPLANE128, DL, NewSubvecVT,
                                       NewInsert, N->getOperand(1));
   return DAG.getNode(ISD::BITCAST, DL, VT, NewDuplane128);
@@ -28237,7 +28236,7 @@ static SDValue tryCombineMULLWithUZP1(SDNode *N,
   EVT TruncHighVT = TruncHigh.getValueType();
   EVT UZP1VT = TruncHighVT.getDoubleNumVectorElementsVT(*DAG.getContext());
   SDValue TruncLowOp =
-      HasFoundMULLow ? TruncLow.getOperand(0) : DAG.getUNDEF(UZP1VT);
+      HasFoundMULLow ? TruncLow.getOperand(0) : DAG.getPOISON(UZP1VT);
   EVT TruncLowOpVT = TruncLowOp.getValueType();
   if (HasFoundMULLow && (TruncLowOp.getOpcode() == AArch64ISD::DUP ||
                          DAG.isSplatValue(TruncLowOp, false)))
@@ -29119,7 +29118,7 @@ void AArch64TargetLowering::ReplaceBITCASTResults(
     return;
 
   Op = DAG.getTargetInsertSubreg(AArch64::hsub, DL, MVT::f32,
-                                 DAG.getUNDEF(MVT::i32), Op);
+                                 DAG.getPOISON(MVT::i32), Op);
   Op = DAG.getNode(ISD::BITCAST, DL, MVT::i32, Op);
   Results.push_back(DAG.getNode(ISD::TRUNCATE, DL, MVT::i16, Op));
 }
@@ -29165,11 +29164,11 @@ static void ReplaceAddWithADDP(SDNode *N, SmallVectorImpl<SDValue> &Results,
     NMask.push_back(I);
     NMask.push_back(I);
   }
-  Results.push_back(
-      DAG.getVectorShuffle(VT, DL,
-                           DAG.getNode(ISD::CONCAT_VECTORS, DL, VT, Addp,
-                                       DAG.getUNDEF(LoHi.first.getValueType())),
-                           DAG.getUNDEF(VT), NMask));
+  Results.push_back(DAG.getVectorShuffle(
+      VT, DL,
+      DAG.getNode(ISD::CONCAT_VECTORS, DL, VT, Addp,
+                  DAG.getPOISON(LoHi.first.getValueType())),
+      DAG.getPOISON(VT), NMask));
 }
 
 static void ReplaceReductionResults(SDNode *N,
@@ -30602,7 +30601,7 @@ static SDValue convertToScalableVector(SelectionDAG &DAG, EVT VT, SDValue V) {
          "Expected a fixed length vector operand!");
   SDLoc DL(V);
   SDValue Zero = DAG.getConstant(0, DL, MVT::i64);
-  return DAG.getNode(ISD::INSERT_SUBVECTOR, DL, VT, DAG.getUNDEF(VT), V, Zero);
+  return DAG.getNode(ISD::INSERT_SUBVECTOR, DL, VT, DAG.getPOISON(VT), V, Zero);
 }
 
 // Shrink V so it's just big enough to maintain a VT's worth of data.
@@ -30636,7 +30635,7 @@ SDValue AArch64TargetLowering::LowerFixedLengthVectorLoadToSVE(
 
   SDValue NewLoad = DAG.getMaskedLoad(
       LoadVT, DL, Load->getChain(), Load->getBasePtr(), Load->getOffset(), Pg,
-      DAG.getUNDEF(LoadVT), MemVT, Load->getMemOperand(),
+      DAG.getPOISON(LoadVT), MemVT, Load->getMemOperand(),
       Load->getAddressingMode(), Load->getExtensionType());
 
   SDValue Result = NewLoad;
@@ -30646,7 +30645,7 @@ SDValue AArch64TargetLowering::LowerFixedLengthVectorLoadToSVE(
 
     Result = getSVESafeBitCast(ExtendVT, Result, DAG);
     Result = DAG.getNode(AArch64ISD::FP_EXTEND_MERGE_PASSTHRU, DL, ContainerVT,
-                         Pg, Result, DAG.getUNDEF(ContainerVT));
+                         Pg, Result, DAG.getPOISON(ContainerVT));
   } else if (VT.isFloatingPoint()) {
     Result = DAG.getNode(ISD::BITCAST, DL, ContainerVT, Result);
   }
@@ -30763,7 +30762,7 @@ SDValue AArch64TargetLowering::LowerFixedLengthVectorStoreToSVE(
     MemVT = MemVT.changeTypeToInteger();
     NewValue = DAG.getNode(AArch64ISD::FP_ROUND_MERGE_PASSTHRU, DL, TruncVT, Pg,
                            NewValue, DAG.getTargetConstant(0, DL, MVT::i64),
-                           DAG.getUNDEF(TruncVT));
+                           DAG.getPOISON(TruncVT));
     NewValue =
         getSVESafeBitCast(ContainerVT.changeTypeToInteger(), NewValue, DAG);
   } else if (VT.isFloatingPoint()) {
@@ -31038,7 +31037,7 @@ SDValue AArch64TargetLowering::LowerToPredicatedOp(SDValue Op,
     }
 
     if (isMergePassthruOpcode(NewOp))
-      Operands.push_back(DAG.getUNDEF(ContainerVT));
+      Operands.push_back(DAG.getPOISON(ContainerVT));
 
     auto ScalableRes = DAG.getNode(NewOp, DL, ContainerVT, Operands);
     return convertFromScalableVector(DAG, VT, ScalableRes);
@@ -31055,7 +31054,7 @@ SDValue AArch64TargetLowering::LowerToPredicatedOp(SDValue Op,
   }
 
   if (isMergePassthruOpcode(NewOp))
-    Operands.push_back(DAG.getUNDEF(VT));
+    Operands.push_back(DAG.getPOISON(VT));
 
   return DAG.getNode(NewOp, DL, VT, Operands, Op->getFlags());
 }
@@ -31111,7 +31110,7 @@ SDValue AArch64TargetLowering::LowerVECREDUCE_SEQ_FADD(SDValue ScalarOp,
 
   // Convert operands to Scalable.
   AccOp = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, ContainerVT,
-                      DAG.getUNDEF(ContainerVT), AccOp, Zero);
+                      DAG.getPOISON(ContainerVT), AccOp, Zero);
 
   // Perform reduction.
   SDValue Rdx = DAG.getNode(AArch64ISD::FADDA_PRED, DL, ContainerVT,
@@ -31339,8 +31338,8 @@ AArch64TargetLowering::LowerFixedLengthFPExtendToSVE(SDValue Op,
 
   Val = convertToScalableVector(DAG, ContainerVT.changeTypeToInteger(), Val);
   Val = getSVESafeBitCast(ExtendVT, Val, DAG);
-  Val = DAG.getNode(AArch64ISD::FP_EXTEND_MERGE_PASSTHRU, DL, ContainerVT,
-                    Pg, Val, DAG.getUNDEF(ContainerVT));
+  Val = DAG.getNode(AArch64ISD::FP_EXTEND_MERGE_PASSTHRU, DL, ContainerVT, Pg,
+                    Val, DAG.getPOISON(ContainerVT));
 
   return convertFromScalableVector(DAG, VT, Val);
 }
@@ -31361,7 +31360,7 @@ AArch64TargetLowering::LowerFixedLengthFPRoundToSVE(SDValue Op,
 
   Val = convertToScalableVector(DAG, ContainerSrcVT, Val);
   Val = DAG.getNode(AArch64ISD::FP_ROUND_MERGE_PASSTHRU, DL, RoundVT, Pg, Val,
-                    Op.getOperand(1), DAG.getUNDEF(RoundVT));
+                    Op.getOperand(1), DAG.getPOISON(RoundVT));
   Val = getSVESafeBitCast(ContainerSrcVT.changeTypeToInteger(), Val, DAG);
   Val = convertFromScalableVector(DAG, SrcVT.changeTypeToInteger(), Val);
 
@@ -31396,7 +31395,7 @@ AArch64TargetLowering::LowerFixedLengthIntToFPToSVE(SDValue Op,
     Val =
         convertToScalableVector(DAG, ContainerDstVT.changeTypeToInteger(), Val);
     Val = DAG.getNode(Opcode, DL, ContainerDstVT, Pg, Val,
-                      DAG.getUNDEF(ContainerDstVT));
+                      DAG.getPOISON(ContainerDstVT));
     return convertFromScalableVector(DAG, VT, Val);
   } else {
     EVT CvtVT = ContainerSrcVT.changeVectorElementType(
@@ -31404,7 +31403,7 @@ AArch64TargetLowering::LowerFixedLengthIntToFPToSVE(SDValue Op,
     SDValue Pg = getPredicateForFixedLengthVector(DAG, DL, SrcVT);
 
     Val = convertToScalableVector(DAG, ContainerSrcVT, Val);
-    Val = DAG.getNode(Opcode, DL, CvtVT, Pg, Val, DAG.getUNDEF(CvtVT));
+    Val = DAG.getNode(Opcode, DL, CvtVT, Pg, Val, DAG.getPOISON(CvtVT));
     Val = getSVESafeBitCast(ContainerSrcVT, Val, DAG);
     Val = convertFromScalableVector(DAG, SrcVT, Val);
 
@@ -31767,7 +31766,7 @@ AArch64TargetLowering::LowerFixedLengthFPToIntToSVE(SDValue Op,
     Val = convertToScalableVector(DAG, ContainerDstVT, Val);
     Val = getSVESafeBitCast(CvtVT, Val, DAG);
     Val = DAG.getNode(Opcode, DL, ContainerDstVT, Pg, Val,
-                      DAG.getUNDEF(ContainerDstVT));
+                      DAG.getPOISON(ContainerDstVT));
     return convertFromScalableVector(DAG, VT, Val);
   } else {
     EVT CvtVT = ContainerSrcVT.changeTypeToInteger();
@@ -31776,7 +31775,7 @@ AArch64TargetLowering::LowerFixedLengthFPToIntToSVE(SDValue Op,
     // Safe to use a larger than specified result since an fp_to_int where the
     // result doesn't fit into the destination is undefined.
     Val = convertToScalableVector(DAG, ContainerSrcVT, Val);
-    Val = DAG.getNode(Opcode, DL, CvtVT, Pg, Val, DAG.getUNDEF(CvtVT));
+    Val = DAG.getNode(Opcode, DL, CvtVT, Pg, Val, DAG.getPOISON(CvtVT));
     Val = convertFromScalableVector(DAG, SrcVT.changeTypeToInteger(), Val);
 
     return DAG.getNode(ISD::TRUNCATE, DL, VT, Val);
@@ -31955,7 +31954,7 @@ SDValue AArch64TargetLowering::LowerFixedLengthVECTOR_SHUFFLEToSVE(
       SDValue Pg = getPredicateForVector(DAG, DL, BlockedVT);
       SDValue BlockedOp1 = DAG.getNode(ISD::BITCAST, DL, BlockedVT, Op1);
       SDValue BlockedRev = DAG.getNode(RevOp, DL, BlockedVT, Pg, BlockedOp1,
-                                       DAG.getUNDEF(BlockedVT));
+                                       DAG.getPOISON(BlockedVT));
       SDValue Container =
           DAG.getNode(ISD::BITCAST, DL, ContainerVT, BlockedRev);
       return convertFromScalableVector(DAG, VT, Container);
@@ -31966,7 +31965,7 @@ SDValue AArch64TargetLowering::LowerFixedLengthVECTOR_SHUFFLEToSVE(
       isREVMask(ShuffleMask, EltSize, VT.getVectorNumElements(), 128)) {
     SDValue Pg = getPredicateForVector(DAG, DL, VT);
     SDValue Revd = DAG.getNode(AArch64ISD::REVD_MERGE_PASSTHRU, DL, ContainerVT,
-                               Pg, Op1, DAG.getUNDEF(ContainerVT));
+                               Pg, Op1, DAG.getPOISON(ContainerVT));
     return convertFromScalableVector(DAG, VT, Revd);
   }
 

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-frame-offests.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-frame-offests.ll
@@ -12,12 +12,12 @@ define void @foo(ptr %a) #0 {
 ; CHECK:       SelectionDAG has 13 nodes:
 ; CHECK-NEXT:    t0: ch,glue = EntryToken
 ; CHECK-NEXT:    t2: i64,ch = CopyFromReg t0, Register:i64 %0
-; CHECK-NEXT:    t21: nxv2i64,ch = LDR_ZXI<Mem:(volatile load (<vscale x 1 x s128>) from %ir.a, align 64)> t2, TargetConstant:i64<0>, t0
+; CHECK-NEXT:    t22: nxv2i64,ch = LDR_ZXI<Mem:(volatile load (<vscale x 1 x s128>) from %ir.a, align 64)> t2, TargetConstant:i64<0>, t0
 ; CHECK-NEXT:    t8: i64 = ADDXri TargetFrameIndex:i64<1>, TargetConstant:i32<0>, TargetConstant:i32<0>
 ; CHECK-NEXT:    t6: i64 = ADDXri TargetFrameIndex:i64<0>, TargetConstant:i32<0>, TargetConstant:i32<0>
-; CHECK-NEXT:    t22: ch = STR_ZXI<Mem:(volatile store (<vscale x 1 x s128>) into %ir.r0, align 64)> t21, t6, TargetConstant:i64<0>, t21:1
-; CHECK-NEXT:    t23: ch = STR_ZXI<Mem:(volatile store (<vscale x 1 x s128>) into %ir.r1, align 64)> t21, t8, TargetConstant:i64<0>, t22
-; CHECK-NEXT:    t10: ch = RET_ReallyLR t23
+; CHECK-NEXT:    t23: ch = STR_ZXI<Mem:(volatile store (<vscale x 1 x s128>) into %ir.r0, align 64)> t22, t6, TargetConstant:i64<0>, t22:1
+; CHECK-NEXT:    t24: ch = STR_ZXI<Mem:(volatile store (<vscale x 1 x s128>) into %ir.r1, align 64)> t22, t8, TargetConstant:i64<0>, t23
+; CHECK-NEXT:    t10: ch = RET_ReallyLR t24
 ; CHECK-EMPTY:
 entry:
   %r0 = alloca <8 x i64>

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-masked-gather.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-masked-gather.ll
@@ -1194,15 +1194,11 @@ define void @masked_gather_passthru(ptr %a, ptr %b, ptr %c) vscale_range(16,0) #
 ; CHECK-NEXT:    ptrue p0.s, vl32
 ; CHECK-NEXT:    ptrue p2.d, vl32
 ; CHECK-NEXT:    ld1w { z0.s }, p0/z, [x0]
+; CHECK-NEXT:    ld1w { z1.s }, p0/z, [x2]
 ; CHECK-NEXT:    fcmeq p1.s, p0/z, z0.s, #0.0
 ; CHECK-NEXT:    ld1d { z0.d }, p2/z, [x1]
 ; CHECK-NEXT:    punpklo p2.h, p1.b
-; CHECK-NEXT:    mov z1.s, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    ptrue p1.s
 ; CHECK-NEXT:    ld1w { z0.d }, p2/z, [z0.d]
-; CHECK-NEXT:    and z1.s, z1.s, #0x1
-; CHECK-NEXT:    cmpne p1.s, p1/z, z1.s, #0
-; CHECK-NEXT:    ld1w { z1.s }, p0/z, [x2]
 ; CHECK-NEXT:    uzp1 z0.s, z0.s, z0.s
 ; CHECK-NEXT:    sel z0.s, p1, z0.s, z1.s
 ; CHECK-NEXT:    st1w { z0.s }, p0, [x0]


### PR DESCRIPTION
Convert many, but not all contexts creating new undefs
to use poison instead.