### PR TITLE
[lldb][test] Add SBExpressionOptions parameter to expect_expr

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2593,7 +2593,6 @@ FileCheck output:
         )
 
         frame = self.frame()
-        options = lldb.SBExpressionOptions()
 
         if not options:
             options = lldb.SBExpressionOptions()

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2575,6 +2575,7 @@ FileCheck output:
         result_value=None,
         result_type=None,
         result_children=None,
+        options=None,
     ):
         """
         Evaluates the given expression and verifies the result.
@@ -2584,6 +2585,7 @@ FileCheck output:
         :param result_type: The type that the expression result should have. None if the type should not be checked.
         :param result_children: The expected children of the expression result
                                 as a list of ValueChecks. None if the children shouldn't be checked.
+        :param options: Expression evaluation options. None if a default set of options should be used.
         """
         self.assertTrue(
             expr.strip() == expr,
@@ -2593,11 +2595,14 @@ FileCheck output:
         frame = self.frame()
         options = lldb.SBExpressionOptions()
 
-        # Disable fix-its that tests don't pass by accident.
-        options.SetAutoApplyFixIts(False)
+        if not options:
+            options = lldb.SBExpressionOptions()
 
-        # Set the usual default options for normal expressions.
-        options.SetIgnoreBreakpoints(True)
+            # Disable fix-its that tests don't pass by accident.
+            options.SetAutoApplyFixIts(False)
+
+            # Set the usual default options for normal expressions.
+            options.SetIgnoreBreakpoints(True)
 
         if self.frame().IsValid():
             options.SetLanguage(frame.GuessLanguage())


### PR DESCRIPTION
Allows API tests to pass `SBExpressionOptions` when testing a successful expression evaluation with `expect_expr`. Currently one would have to use `SBFrame::EvaluateExpression` or pass the option as an argument to the raw command (via `expect()` or `HandleCommand()`).

Chose not to do the `SetIgnoreBreakpoints`/`SetAutoApplyFixIts` with the assumption that most expression evaluation tests don't actually need to care about these. If the options are passed explicitly, lets use them as-is. Otherwise default to the old options.

First usage of this new parameter would be in https://github.com/llvm/llvm-project/pull/177926