### PR TITLE
[lldb][UserExpression] Delay deletion of failed user expression

### DIFF
--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -290,34 +290,29 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
 
   // If there is a fixed expression, try to parse it:
   if (!parse_success) {
-    // Delete the expression that failed to parse before attempting to parse
-    // the next expression.
-    user_expression_sp.reset();
-
     execution_results = lldb::eExpressionParseError;
     if (!fixed_expression->empty() && options.GetAutoApplyFixIts()) {
       const uint64_t max_fix_retries = options.GetRetriesWithFixIts();
       for (uint64_t i = 0; i < max_fix_retries; ++i) {
         // Try parsing the fixed expression.
-        lldb::UserExpressionSP fixed_expression_sp(
-            target->GetUserExpressionForLanguage(
-                fixed_expression->c_str(), full_prefix, language, desired_type,
-                options, ctx_obj, error));
-        if (!fixed_expression_sp)
+        user_expression_sp.reset(target->GetUserExpressionForLanguage(
+            fixed_expression->c_str(), full_prefix, language, desired_type,
+            options, ctx_obj, error));
+        if (!user_expression_sp)
           break;
+
         DiagnosticManager fixed_diagnostic_manager;
-        parse_success = fixed_expression_sp->Parse(
+        parse_success = user_expression_sp->Parse(
             fixed_diagnostic_manager, exe_ctx, execution_policy,
             keep_expression_in_memory, generate_debug_info);
         if (parse_success) {
           diagnostic_manager.Clear();
-          user_expression_sp = fixed_expression_sp;
           break;
         }
         // The fixed expression also didn't parse. Let's check for any new
         // fixits we could try.
-        if (!fixed_expression_sp->GetFixedText().empty()) {
-          *fixed_expression = fixed_expression_sp->GetFixedText().str();
+        if (!user_expression_sp->GetFixedText().empty()) {
+          *fixed_expression = user_expression_sp->GetFixedText().str();
         } else {
           // Fixed expression didn't compile without a fixit, don't retry and
           // don't tell the user about it.


### PR DESCRIPTION
Instead of creating a new `UserExpressionSP` for the fix-it expression, just re-use the existing `user_expression_sp`. We used to always reset it when an expression failed, even if no fix-it was available. An upcoming patch will need the `user_expression_sp` to be alive at the point where we set up the diagnostic errors. So this patch removes the unconditional `reset()` on `!parse_success` in favour of resetting it to the new fixed expression, if one is available.