### PR TITLE
[lldb][Expression] Add --c++-ignore-context-qualifiers expression evaluation option

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -308,8 +308,7 @@ private:
 
 class EvaluateExpressionOptions {
 public:
-  EvaluateExpressionOptions()
-      : m_language_options_sp(std::make_shared<StructuredData::Dictionary>()) {}
+  EvaluateExpressionOptions();
 
 // MSVC has a bug here that reports C4268: 'const' static/global data
 // initialized with compiler generated default constructor fills the object
@@ -493,6 +492,10 @@ public:
   /// Otherwise returns the boolean value of the option.
   llvm::Expected<bool>
   GetBooleanLanguageOption(llvm::StringRef option_name) const;
+
+  void SetCppIgnoreContextQualifiers(bool value);
+
+  bool GetCppIgnoreContextQualifiers() const;
 
 private:
   const StructuredData::Dictionary &GetLanguageOptions() const;

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -542,14 +542,6 @@ private:
   /// used for symbol/function lookup before any other context (except for
   /// the module corresponding to the current frame).
   SymbolContextList m_preferred_lookup_contexts;
-
-  /// If true, evaluates the expression without taking into account the
-  /// CV-qualifiers of the scope. E.g., this would permit calling a
-  /// non-const C++ method when stopped in a const-method (which would be
-  /// disallowed by C++ language rules).
-  ///
-  /// FIXME: move this to a language-specific dictionary of options.
-  bool m_cpp_ignore_context_qualifiers = false;
 };
 
 // Target

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -546,7 +546,7 @@ private:
   /// disallowed by C++ language rules).
   ///
   /// FIXME: move this to a language-specific dictionary of options.
-  bool m_cpp_ignore_context_qualifierss = false;
+  bool m_cpp_ignore_context_qualifiers = false;
 };
 
 // Target

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -544,7 +544,9 @@ private:
   /// CV-qualifiers of the scope. E.g., this would permit calling a
   /// non-const C++ method when stopped in a const-method (which would be
   /// disallowed by C++ language rules).
-  bool m_ignore_context_qualifierss = false;
+  ///
+  /// FIXME: move this to a language-specific dictionary of options.
+  bool m_cpp_ignore_context_qualifierss = false;
 };
 
 // Target

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -539,6 +539,12 @@ private:
   /// used for symbol/function lookup before any other context (except for
   /// the module corresponding to the current frame).
   SymbolContextList m_preferred_lookup_contexts;
+
+  /// If true, evaluates the expression without taking into account the
+  /// CV-qualifiers of the scope. E.g., this would permit calling a
+  /// non-const C++ method when stopped in a const-method (which would be
+  /// disallowed by C++ language rules).
+  bool m_ignore_context_qualifierss = false;
 };
 
 // Target

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -44,6 +44,9 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
   const int short_option = GetDefinitions()[option_idx].short_option;
 
   switch (short_option) {
+  case 'Q':
+    ignore_context_qualifiers = true;
+    break;
   case 'l':
     language = Language::GetLanguageTypeFromString(option_arg);
     if (language == eLanguageTypeUnknown) {
@@ -191,6 +194,7 @@ void CommandObjectExpression::CommandOptions::OptionParsingStarting(
   top_level = false;
   allow_jit = true;
   suppress_persistent_result = eLazyBoolCalculate;
+  ignore_context_qualifiers = false;
 }
 
 llvm::ArrayRef<OptionDefinition>
@@ -213,6 +217,7 @@ CommandObjectExpression::CommandOptions::GetEvaluateExpressionOptions(
   options.SetExecutionPolicy(
       allow_jit ? EvaluateExpressionOptions::default_execution_policy
                 : lldb_private::eExecutionPolicyNever);
+  options.SetIgnoreContextQualifiers(ignore_context_qualifiers);
 
   bool auto_apply_fixits;
   if (this->auto_apply_fixits == eLazyBoolCalculate)

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -45,7 +45,7 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
 
   switch (short_option) {
   case 'Q':
-    ignore_context_qualifiers = true;
+    cpp_ignore_context_qualifiers = true;
     break;
   case 'l':
     language = Language::GetLanguageTypeFromString(option_arg);
@@ -194,7 +194,7 @@ void CommandObjectExpression::CommandOptions::OptionParsingStarting(
   top_level = false;
   allow_jit = true;
   suppress_persistent_result = eLazyBoolCalculate;
-  ignore_context_qualifiers = false;
+  cpp_ignore_context_qualifiers = false;
 }
 
 llvm::ArrayRef<OptionDefinition>
@@ -217,7 +217,7 @@ CommandObjectExpression::CommandOptions::GetEvaluateExpressionOptions(
   options.SetExecutionPolicy(
       allow_jit ? EvaluateExpressionOptions::default_execution_policy
                 : lldb_private::eExecutionPolicyNever);
-  options.SetIgnoreContextQualifiers(ignore_context_qualifiers);
+  options.SetCppIgnoreContextQualifiers(cpp_ignore_context_qualifiers);
 
   bool auto_apply_fixits;
   if (this->auto_apply_fixits == eLazyBoolCalculate)

--- a/lldb/source/Commands/CommandObjectExpression.h
+++ b/lldb/source/Commands/CommandObjectExpression.h
@@ -57,7 +57,7 @@ public:
     LanguageRuntimeDescriptionDisplayVerbosity m_verbosity;
     LazyBool auto_apply_fixits;
     LazyBool suppress_persistent_result;
-    bool ignore_context_qualifiers;
+    bool cpp_ignore_context_qualifiers;
   };
 
   CommandObjectExpression(CommandInterpreter &interpreter);

--- a/lldb/source/Commands/CommandObjectExpression.h
+++ b/lldb/source/Commands/CommandObjectExpression.h
@@ -57,6 +57,7 @@ public:
     LanguageRuntimeDescriptionDisplayVerbosity m_verbosity;
     LazyBool auto_apply_fixits;
     LazyBool suppress_persistent_result;
+    bool ignore_context_qualifiers;
   };
 
   CommandObjectExpression(CommandInterpreter &interpreter);

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -779,7 +779,7 @@ let Command = "expression" in {
              "Expression results will be labeled with $-prefixed variables, "
              "e.g. $0, $1, etc.">;
   def ignore_context_qualifiers
-      : Option<"cpp-ignore-context-qualifiers", "Q">,
+      : Option<"c++-ignore-context-qualifiers", "Q">,
         Groups<[1, 2]>,
         Desc<"When specified, evaluates the expression without taking into "
              "account the type ${Q}ualifiers of the scope. In C++, this would "

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -778,6 +778,14 @@ let Command = "expression" in {
         Desc<"Persist expression result in a variable for subsequent use. "
              "Expression results will be labeled with $-prefixed variables, "
              "e.g. $0, $1, etc.">;
+  def ignore_context_qualifiers
+      : Option<"ignore-context-qualifiers", "Q">,
+        Groups<[1, 2]>,
+        Desc<"When specified, evaluates the expression without taking into "
+             "account the type ${Q}ualifiers of the scope. E.g., this would "
+             "permit "
+             "calling a non-const C++ method when stopped in a const-method "
+             "(which would be disallowed by C++ language rules).">;
 }
 
 let Command = "frame diag" in {

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -779,13 +779,12 @@ let Command = "expression" in {
              "Expression results will be labeled with $-prefixed variables, "
              "e.g. $0, $1, etc.">;
   def ignore_context_qualifiers
-      : Option<"ignore-context-qualifiers", "Q">,
+      : Option<"cpp-ignore-context-qualifiers", "Q">,
         Groups<[1, 2]>,
         Desc<"When specified, evaluates the expression without taking into "
-             "account the type ${Q}ualifiers of the scope. E.g., this would "
-             "permit "
-             "calling a non-const C++ method when stopped in a const-method "
-             "(which would be disallowed by C++ language rules).">;
+             "account the type ${Q}ualifiers of the scope. In C++, this would "
+             "permit calling a non-const method when stopped in a const-method "
+             "(which would be disallowed by language rules).">;
 }
 
 let Command = "frame diag" in {

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -88,10 +88,12 @@ ClangExpressionDeclMap::ClangExpressionDeclMap(
     bool keep_result_in_memory,
     Materializer::PersistentVariableDelegate *result_delegate,
     const lldb::TargetSP &target,
-    const std::shared_ptr<ClangASTImporter> &importer, ValueObject *ctx_obj)
+    const std::shared_ptr<ClangASTImporter> &importer, ValueObject *ctx_obj,
+    bool ignore_context_qualifiers)
     : ClangASTSource(target, importer), m_found_entities(), m_struct_members(),
       m_keep_result_in_memory(keep_result_in_memory),
-      m_result_delegate(result_delegate), m_ctx_obj(ctx_obj), m_parser_vars(),
+      m_result_delegate(result_delegate), m_ctx_obj(ctx_obj),
+      m_ignore_context_qualifiers(ignore_context_qualifiers), m_parser_vars(),
       m_struct_vars() {
   EnableStructVars();
 }
@@ -1997,7 +1999,8 @@ void ClangExpressionDeclMap::AddContextClassType(NameSearchContext &context,
     std::array<CompilerType, 1> args{void_clang_type.GetPointerType()};
 
     CompilerType method_type = m_clang_ast_context->CreateFunctionType(
-        void_clang_type, args, false, ut.GetTypeQualifiers());
+        void_clang_type, args, false,
+        m_ignore_context_qualifiers ? 0 : ut.GetTypeQualifiers());
 
     const bool is_virtual = false;
     const bool is_static = false;

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
@@ -78,11 +78,18 @@ public:
   /// \param[in] ctx_obj
   ///     If not empty, then expression is evaluated in context of this object.
   ///     See the comment to `UserExpression::Evaluate` for details.
+  ///
+  /// \param[in] ignore_context_qualifiers
+  ///     If \c true, evaluates the expression without taking into account the
+  ///     CV-qualifiers of the scope. E.g., this would permit calling a
+  ///     non-const C++ method when stopped in a const-method (which would be
+  ///     disallowed by C++ language rules).
   ClangExpressionDeclMap(
       bool keep_result_in_memory,
       Materializer::PersistentVariableDelegate *result_delegate,
       const lldb::TargetSP &target,
-      const std::shared_ptr<ClangASTImporter> &importer, ValueObject *ctx_obj);
+      const std::shared_ptr<ClangASTImporter> &importer, ValueObject *ctx_obj,
+      bool ignore_context_qualifiers);
 
   /// Destructor
   ~ClangExpressionDeclMap() override;
@@ -305,6 +312,12 @@ private:
                           ///evaluated in context of this object.
                           ///For details see the comment to
                           ///`UserExpression::Evaluate`.
+
+  /// If \c true, evaluates the expression without taking into account the
+  /// CV-qualifiers of the scope. E.g., this would permit calling a
+  /// non-const C++ method when stopped in a const-method (which would be
+  /// disallowed by C++ language rules).
+  bool m_ignore_context_qualifiers = false;
 
   /// The following values should not live beyond parsing
   class ParserVars {

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionSourceCode.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionSourceCode.h
@@ -63,8 +63,8 @@ public:
   ///
   /// \return true iff the source code was successfully generated.
   bool GetText(std::string &text, ExecutionContext &exe_ctx, bool add_locals,
-               bool force_add_all_locals,
-               llvm::ArrayRef<std::string> modules) const;
+               bool force_add_all_locals, llvm::ArrayRef<std::string> modules,
+               bool ignore_context_qualifiers) const;
 
   // Given a string returned by GetText, find the beginning and end of the body
   // passed to CreateWrapped. Return true if the bounds could be found.  This

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -417,7 +417,7 @@ void ClangUserExpression::CreateSourceCode(
 
     if (!m_source_code->GetText(m_transformed_text, exe_ctx, !m_ctx_obj,
                                 for_completion, modules_to_import,
-                                m_options.GetIgnoreContextQualifiers())) {
+                                m_options.GetCppIgnoreContextQualifiers())) {
       diagnostic_manager.PutString(lldb::eSeverityError,
                                    "couldn't construct expression body");
       return;

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -416,7 +416,8 @@ void ClangUserExpression::CreateSourceCode(
         m_filename, prefix, m_expr_text, GetWrapKind()));
 
     if (!m_source_code->GetText(m_transformed_text, exe_ctx, !m_ctx_obj,
-                                for_completion, modules_to_import)) {
+                                for_completion, modules_to_import,
+                                m_options.GetIgnoreContextQualifiers())) {
       diagnostic_manager.PutString(lldb::eSeverityError,
                                    "couldn't construct expression body");
       return;
@@ -950,8 +951,8 @@ char ClangUserExpression::ClangUserExpressionHelper::ID;
 void ClangUserExpression::ClangUserExpressionHelper::ResetDeclMap(
     ExecutionContext &exe_ctx,
     Materializer::PersistentVariableDelegate &delegate,
-    bool keep_result_in_memory,
-    ValueObject *ctx_obj) {
+    bool keep_result_in_memory, ValueObject *ctx_obj,
+    bool ignore_context_qualifiers) {
   std::shared_ptr<ClangASTImporter> ast_importer;
   auto *state = exe_ctx.GetTargetSP()->GetPersistentExpressionStateForLanguage(
       lldb::eLanguageTypeC);
@@ -961,7 +962,7 @@ void ClangUserExpression::ClangUserExpressionHelper::ResetDeclMap(
   }
   m_expr_decl_map_up = std::make_unique<ClangExpressionDeclMap>(
       keep_result_in_memory, &delegate, exe_ctx.GetTargetSP(), ast_importer,
-      ctx_obj);
+      ctx_obj, ignore_context_qualifiers);
 }
 
 clang::ASTConsumer *

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
@@ -166,9 +166,9 @@ public:
   void ResetDeclMap(ExecutionContext &exe_ctx,
                     Materializer::PersistentVariableDelegate &result_delegate,
                     bool keep_result_in_memory) {
-    m_type_system_helper.ResetDeclMap(exe_ctx, result_delegate,
-                                      keep_result_in_memory, m_ctx_obj,
-                                      m_options.GetIgnoreContextQualifiers());
+    m_type_system_helper.ResetDeclMap(
+        exe_ctx, result_delegate, keep_result_in_memory, m_ctx_obj,
+        m_options.GetCppIgnoreContextQualifiers());
   }
 
   lldb::ExpressionVariableSP

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
@@ -71,8 +71,8 @@ public:
 
     void ResetDeclMap(ExecutionContext &exe_ctx,
                       Materializer::PersistentVariableDelegate &result_delegate,
-                      bool keep_result_in_memory,
-                      ValueObject *ctx_obj);
+                      bool keep_result_in_memory, ValueObject *ctx_obj,
+                      bool ignore_context_qualifiers);
 
     /// Return the object that the parser should allow to access ASTs. May be
     /// NULL if the ASTs do not need to be transformed.
@@ -167,8 +167,8 @@ public:
                     Materializer::PersistentVariableDelegate &result_delegate,
                     bool keep_result_in_memory) {
     m_type_system_helper.ResetDeclMap(exe_ctx, result_delegate,
-                                      keep_result_in_memory,
-                                      m_ctx_obj);
+                                      keep_result_in_memory, m_ctx_obj,
+                                      m_options.GetIgnoreContextQualifiers());
   }
 
   lldb::ExpressionVariableSP

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUtilityFunction.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUtilityFunction.cpp
@@ -187,5 +187,5 @@ void ClangUtilityFunction::ClangUtilityFunctionHelper::ResetDeclMap(
   }
   m_expr_decl_map_up = std::make_unique<ClangExpressionDeclMap>(
       keep_result_in_memory, nullptr, exe_ctx.GetTargetSP(), ast_importer,
-      nullptr);
+      nullptr, /*ignore_context_qualifiers=*/false);
 }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -5413,7 +5413,7 @@ StructuredData::Dictionary &EvaluateExpressionOptions::GetLanguageOptions() {
 // FIXME: this option is C++ plugin specific and should be registered by it,
 // instead of hard-coding it here.
 constexpr llvm::StringLiteral s_cpp_ignore_context_qualifiers_option =
-    "cpp-ignore-context-qualifiers";
+    "c++-ignore-context-qualifiers";
 
 EvaluateExpressionOptions::EvaluateExpressionOptions()
     : m_language_options_sp(std::make_shared<StructuredData::Dictionary>()) {

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -5409,3 +5409,23 @@ StructuredData::Dictionary &EvaluateExpressionOptions::GetLanguageOptions() {
 
   return *m_language_options_sp;
 }
+
+// FIXME: this option is C++ plugin specific and should be registered by it,
+// instead of hard-coding it here.
+constexpr llvm::StringLiteral s_cpp_ignore_context_qualifiers_option =
+    "cpp-ignore-context-qualifiers";
+
+EvaluateExpressionOptions::EvaluateExpressionOptions()
+    : m_language_options_sp(std::make_shared<StructuredData::Dictionary>()) {
+  SetCppIgnoreContextQualifiers(false);
+}
+
+void EvaluateExpressionOptions::SetCppIgnoreContextQualifiers(bool value) {
+  llvm::cantFail(
+      SetBooleanLanguageOption(s_cpp_ignore_context_qualifiers_option, value));
+}
+
+bool EvaluateExpressionOptions::GetCppIgnoreContextQualifiers() const {
+  return llvm::cantFail(
+      GetBooleanLanguageOption(s_cpp_ignore_context_qualifiers_option));
+}

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
@@ -29,9 +29,9 @@ class TestCase(TestBase):
         )
         self.expect_expr("m_mem", result_value="-2")
 
-        # Test short and long --cpp-ignore-context-qualifiers option.
+        # Test short and long --c++-ignore-context-qualifiers option.
         self.expect(
-            "expression --cpp-ignore-context-qualifiers -- m_mem = 3.0",
+            "expression --c++-ignore-context-qualifiers -- m_mem = 3.0",
             error=False,
         )
         self.expect_expr("m_mem", result_value="3")
@@ -42,9 +42,9 @@ class TestCase(TestBase):
         )
         self.expect_expr("m_mem", result_value="4")
 
-        # Test --cpp-ignore-context-qualifiers via SBExpressionOptions.
+        # Test --c++-ignore-context-qualifiers via SBExpressionOptions.
         options = lldb.SBExpressionOptions()
-        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers", True)
+        options.SetBooleanLanguageOption("c++-ignore-context-qualifiers", True)
         self.expect_expr("m_mem = -2.0; m_mem", options=options, result_value="-2")
 
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
@@ -29,9 +29,9 @@ class TestCase(TestBase):
         )
         self.expect_expr("m_mem", result_value="-2")
 
-        # Test short and long --ignore-context-qualifiers option.
+        # Test short and long --cpp-ignore-context-qualifiers option.
         self.expect(
-            "expression --ignore-context-qualifiers -- m_mem = 3.0",
+            "expression --cpp-ignore-context-qualifiers -- m_mem = 3.0",
             error=False,
         )
         self.expect_expr("m_mem", result_value="3")
@@ -42,7 +42,7 @@ class TestCase(TestBase):
         )
         self.expect_expr("m_mem", result_value="4")
 
-        # Test --ignore-context-qualifiers via SBExpressionOptions.
+        # Test --cpp-ignore-context-qualifiers via SBExpressionOptions.
         options = lldb.SBExpressionOptions()
         options.SetIgnoreContextQualifiers()
         self.expect_expr("m_mem = -2.0; m_mem", options=options, result_value="-2")

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
@@ -44,7 +44,7 @@ class TestCase(TestBase):
 
         # Test --cpp-ignore-context-qualifiers via SBExpressionOptions.
         options = lldb.SBExpressionOptions()
-        options.SetIgnoreContextQualifiers()
+        options.SetCppIgnoreContextQualifiers()
         self.expect_expr("m_mem = -2.0; m_mem", options=options, result_value="-2")
 
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
@@ -44,7 +44,7 @@ class TestCase(TestBase):
 
         # Test --cpp-ignore-context-qualifiers via SBExpressionOptions.
         options = lldb.SBExpressionOptions()
-        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers")
+        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers", True)
         self.expect_expr("m_mem = -2.0; m_mem", options=options, result_value="-2")
 
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
@@ -44,7 +44,7 @@ class TestCase(TestBase):
 
         # Test --cpp-ignore-context-qualifiers via SBExpressionOptions.
         options = lldb.SBExpressionOptions()
-        options.SetCppIgnoreContextQualifiers()
+        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers")
         self.expect_expr("m_mem = -2.0; m_mem", options=options, result_value="-2")
 
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
@@ -27,6 +27,26 @@ class TestCase(TestBase):
                 "cannot assign to non-static data member within const member function"
             ],
         )
+        self.expect_expr("m_mem", result_value="-2")
+
+        # Test short and long --ignore-context-qualifiers option.
+        self.expect(
+            "expression --ignore-context-qualifiers -- m_mem = 3.0",
+            error=False,
+        )
+        self.expect_expr("m_mem", result_value="3")
+
+        self.expect(
+            "expression -Q -- m_mem = 4.0",
+            error=False,
+        )
+        self.expect_expr("m_mem", result_value="4")
+
+        # Test --ignore-context-qualifiers via SBExpressionOptions.
+        options = lldb.SBExpressionOptions()
+        options.SetIgnoreContextQualifiers()
+        self.expect_expr("m_mem = -2.0; m_mem", options=options, result_value="-2")
+
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")
 
         lldbutil.continue_to_source_breakpoint(
@@ -43,6 +63,9 @@ class TestCase(TestBase):
                 "cannot assign to non-static data member within const member function"
             ],
         )
+        self.expect_expr("x", result_value="2")
+
+        self.expect_expr("x = -5; x", options=options, result_value="-5")
 
         lldbutil.continue_to_source_breakpoint(
             self,
@@ -76,6 +99,9 @@ class TestCase(TestBase):
             ],
         )
         self.expect_expr("m_mem", result_value="-2")
+
+        self.expect_expr("m_mem = -1; m_mem", options=options, result_value="-1")
+
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")
 
         lldbutil.continue_to_source_breakpoint(
@@ -102,4 +128,6 @@ class TestCase(TestBase):
                 "cannot assign to non-static data member within const member function"
             ],
         )
-        self.expect_expr("m_mem", result_value="-2")
+        self.expect_expr("m_mem", result_value="-1")
+
+        self.expect_expr("m_mem = -2; m_mem", options=options, result_value="-2")

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
         )
 
         options = lldb.SBExpressionOptions()
-        options.SetCppIgnoreContextQualifiers()
+        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers")
         options.SetIgnoreBreakpoints(True)
         self.expect_expr("volatile_method()", options=options)
         self.expect(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
         )
 
         options = lldb.SBExpressionOptions()
-        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers")
+        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers", True)
         options.SetIgnoreBreakpoints(True)
         self.expect_expr("volatile_method()", options=options)
         self.expect(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
@@ -20,6 +20,16 @@ class TestCase(TestBase):
             substrs=["has type 'const Foo'", "but function is not marked const"],
         )
 
+        options = lldb.SBExpressionOptions()
+        options.SetIgnoreContextQualifiers()
+        options.SetIgnoreBreakpoints(True)
+        self.expect_expr("volatile_method()", options=options)
+        self.expect(
+            "expression --ignore-context-qualifiers -- bar()",
+            error=True,
+            substrs=["call to member function 'bar' is ambiguous"],
+        )
+
         lldbutil.continue_to_source_breakpoint(
             self, process, "Break here: volatile", lldb.SBFileSpec("main.cpp")
         )
@@ -34,6 +44,13 @@ class TestCase(TestBase):
             substrs=["has type 'volatile Foo'", "but function is not marked volatile"],
         )
         self.expect_expr("volatile_method()")
+
+        self.expect_expr("const_method()", options=options)
+        self.expect(
+            "expression --ignore-context-qualifiers -- bar()",
+            error=True,
+            substrs=["call to member function 'bar' is ambiguous"],
+        )
 
         lldbutil.continue_to_source_breakpoint(
             self, process, "Break here: const volatile", lldb.SBFileSpec("main.cpp")
@@ -57,4 +74,12 @@ class TestCase(TestBase):
                 "has type 'const volatile Foo'",
                 "but function is not marked const or volatile",
             ],
+        )
+
+        self.expect_expr("const_method()", options=options)
+        self.expect_expr("volatile_method()", options=options)
+        self.expect(
+            "expression --ignore-context-qualifiers -- bar()",
+            error=True,
+            substrs=["call to member function 'bar' is ambiguous"],
         )

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
@@ -21,11 +21,11 @@ class TestCase(TestBase):
         )
 
         options = lldb.SBExpressionOptions()
-        options.SetIgnoreContextQualifiers()
+        options.SetCppIgnoreContextQualifiers()
         options.SetIgnoreBreakpoints(True)
         self.expect_expr("volatile_method()", options=options)
         self.expect(
-            "expression --ignore-context-qualifiers -- bar()",
+            "expression --cpp-ignore-context-qualifiers -- bar()",
             error=True,
             substrs=["call to member function 'bar' is ambiguous"],
         )
@@ -47,7 +47,7 @@ class TestCase(TestBase):
 
         self.expect_expr("const_method()", options=options)
         self.expect(
-            "expression --ignore-context-qualifiers -- bar()",
+            "expression --cpp-ignore-context-qualifiers -- bar()",
             error=True,
             substrs=["call to member function 'bar' is ambiguous"],
         )
@@ -79,7 +79,7 @@ class TestCase(TestBase):
         self.expect_expr("const_method()", options=options)
         self.expect_expr("volatile_method()", options=options)
         self.expect(
-            "expression --ignore-context-qualifiers -- bar()",
+            "expression --cpp-ignore-context-qualifiers -- bar()",
             error=True,
             substrs=["call to member function 'bar' is ambiguous"],
         )

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
@@ -21,11 +21,11 @@ class TestCase(TestBase):
         )
 
         options = lldb.SBExpressionOptions()
-        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers", True)
+        options.SetBooleanLanguageOption("c++-ignore-context-qualifiers", True)
         options.SetIgnoreBreakpoints(True)
         self.expect_expr("volatile_method()", options=options)
         self.expect(
-            "expression --cpp-ignore-context-qualifiers -- bar()",
+            "expression --c++-ignore-context-qualifiers -- bar()",
             error=True,
             substrs=["call to member function 'bar' is ambiguous"],
         )
@@ -47,7 +47,7 @@ class TestCase(TestBase):
 
         self.expect_expr("const_method()", options=options)
         self.expect(
-            "expression --cpp-ignore-context-qualifiers -- bar()",
+            "expression --c++-ignore-context-qualifiers -- bar()",
             error=True,
             substrs=["call to member function 'bar' is ambiguous"],
         )
@@ -79,7 +79,7 @@ class TestCase(TestBase):
         self.expect_expr("const_method()", options=options)
         self.expect_expr("volatile_method()", options=options)
         self.expect(
-            "expression --cpp-ignore-context-qualifiers -- bar()",
+            "expression --c++-ignore-context-qualifiers -- bar()",
             error=True,
             substrs=["call to member function 'bar' is ambiguous"],
         )

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
@@ -37,7 +37,7 @@ class TestCase(TestBase):
         )
 
         options = lldb.SBExpressionOptions()
-        options.SetCppIgnoreContextQualifiers()
+        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers")
         self.expect_expr("x = 6.0; x", options=options, result_value="6")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
@@ -37,7 +37,7 @@ class TestCase(TestBase):
         )
 
         options = lldb.SBExpressionOptions()
-        options.SetIgnoreContextQualifiers()
+        options.SetCppIgnoreContextQualifiers()
         self.expect_expr("x = 6.0; x", options=options, result_value="6")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
@@ -37,7 +37,7 @@ class TestCase(TestBase):
         )
 
         options = lldb.SBExpressionOptions()
-        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers")
+        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers", True)
         self.expect_expr("x = 6.0; x", options=options, result_value="6")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
@@ -36,6 +36,10 @@ class TestCase(TestBase):
             ],
         )
 
+        options = lldb.SBExpressionOptions()
+        options.SetIgnoreContextQualifiers()
+        self.expect_expr("x = 6.0; x", options=options, result_value="6")
+
         lldbutil.continue_to_source_breakpoint(
             self,
             process,

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
@@ -37,7 +37,7 @@ class TestCase(TestBase):
         )
 
         options = lldb.SBExpressionOptions()
-        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers", True)
+        options.SetBooleanLanguageOption("c++-ignore-context-qualifiers", True)
         self.expect_expr("x = 6.0; x", options=options, result_value="6")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
@@ -30,7 +30,7 @@ class TestCase(TestBase):
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")
 
         options = lldb.SBExpressionOptions()
-        options.SetCppIgnoreContextQualifiers()
+        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers")
         self.expect_expr("m_mem = -2.0; m_mem", options=options, result_value="-2")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
@@ -30,7 +30,7 @@ class TestCase(TestBase):
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")
 
         options = lldb.SBExpressionOptions()
-        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers", True)
+        options.SetBooleanLanguageOption("c++-ignore-context-qualifiers", True)
         self.expect_expr("m_mem = -2.0; m_mem", options=options, result_value="-2")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
@@ -30,7 +30,7 @@ class TestCase(TestBase):
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")
 
         options = lldb.SBExpressionOptions()
-        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers")
+        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers", True)
         self.expect_expr("m_mem = -2.0; m_mem", options=options, result_value="-2")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
@@ -29,6 +29,10 @@ class TestCase(TestBase):
         )
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")
 
+        options = lldb.SBExpressionOptions()
+        options.SetIgnoreContextQualifiers()
+        self.expect_expr("m_mem = -2.0; m_mem", options=options, result_value="-2")
+
         lldbutil.continue_to_source_breakpoint(
             self,
             process,
@@ -43,6 +47,7 @@ class TestCase(TestBase):
                 "cannot assign to non-static data member within const member function"
             ],
         )
+        self.expect_expr("x = -7.0; x", options=options, result_value="-7")
 
         lldbutil.continue_to_source_breakpoint(
             self,
@@ -77,6 +82,7 @@ class TestCase(TestBase):
         )
         self.expect_expr("m_mem", result_value="-2")
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")
+        self.expect_expr("m_mem = -8.0; m_mem", options=options, result_value="-8")
 
         lldbutil.continue_to_source_breakpoint(
             self,
@@ -102,4 +108,4 @@ class TestCase(TestBase):
                 "cannot assign to non-static data member within const member function"
             ],
         )
-        self.expect_expr("m_mem", result_value="-2")
+        self.expect_expr("m_mem = -11.0; m_mem", options=options, result_value="-11")

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
@@ -30,7 +30,7 @@ class TestCase(TestBase):
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")
 
         options = lldb.SBExpressionOptions()
-        options.SetIgnoreContextQualifiers()
+        options.SetCppIgnoreContextQualifiers()
         self.expect_expr("m_mem = -2.0; m_mem", options=options, result_value="-2")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
@@ -37,7 +37,7 @@ class TestCase(TestBase):
         )
 
         options = lldb.SBExpressionOptions()
-        options.SetCppIgnoreContextQualifiers()
+        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers")
         self.expect_expr("x = 6.0; x", options=options, result_value="6")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
@@ -37,7 +37,7 @@ class TestCase(TestBase):
         )
 
         options = lldb.SBExpressionOptions()
-        options.SetIgnoreContextQualifiers()
+        options.SetCppIgnoreContextQualifiers()
         self.expect_expr("x = 6.0; x", options=options, result_value="6")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
@@ -37,7 +37,7 @@ class TestCase(TestBase):
         )
 
         options = lldb.SBExpressionOptions()
-        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers")
+        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers", True)
         self.expect_expr("x = 6.0; x", options=options, result_value="6")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
@@ -36,6 +36,10 @@ class TestCase(TestBase):
             ],
         )
 
+        options = lldb.SBExpressionOptions()
+        options.SetIgnoreContextQualifiers()
+        self.expect_expr("x = 6.0; x", options=options, result_value="6")
+
         lldbutil.continue_to_source_breakpoint(
             self,
             process,

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
@@ -37,7 +37,7 @@ class TestCase(TestBase):
         )
 
         options = lldb.SBExpressionOptions()
-        options.SetBooleanLanguageOption("cpp-ignore-context-qualifiers", True)
+        options.SetBooleanLanguageOption("c++-ignore-context-qualifiers", True)
         self.expect_expr("x = 6.0; x", options=options, result_value="6")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/this/TestCPPThis.py
+++ b/lldb/test/API/lang/cpp/this/TestCPPThis.py
@@ -48,7 +48,7 @@ class CPPThisTestCase(TestBase):
 
         self.expect("expression -- (int)getpid(); m_a", startstr="(const int) $1 = 3")
         self.expect(
-            "expression --cpp-ignore-context-qualifiers -- m_a = 2",
+            "expression --c++-ignore-context-qualifiers -- m_a = 2",
             startstr="(int) $2 = 2",
         )
 

--- a/lldb/test/API/lang/cpp/this/TestCPPThis.py
+++ b/lldb/test/API/lang/cpp/this/TestCPPThis.py
@@ -48,7 +48,8 @@ class CPPThisTestCase(TestBase):
 
         self.expect("expression -- (int)getpid(); m_a", startstr="(const int) $1 = 3")
         self.expect(
-            "expression --cpp-ignore-context-qualifiers -- m_a = 2", startstr="(int) $2 = 2"
+            "expression --cpp-ignore-context-qualifiers -- m_a = 2",
+            startstr="(int) $2 = 2",
         )
 
         self.runCmd("process continue")

--- a/lldb/test/API/lang/cpp/this/TestCPPThis.py
+++ b/lldb/test/API/lang/cpp/this/TestCPPThis.py
@@ -47,14 +47,17 @@ class CPPThisTestCase(TestBase):
         )
 
         self.expect("expression -- (int)getpid(); m_a", startstr="(const int) $1 = 3")
+        self.expect(
+            "expression --ignore-context-qualifiers -- m_a = 2", startstr="(int) $2 = 2"
+        )
 
         self.runCmd("process continue")
 
-        self.expect("expression -- s_a", startstr="(int) $2 = 5")
+        self.expect("expression -- s_a", startstr="(int) $3 = 5")
 
         self.runCmd("process continue")
 
-        self.expect("expression -- m_a", startstr="(int) $3 = 3")
+        self.expect("expression -- m_a", startstr="(int) $4 = 2")
 
     def set_breakpoint(self, line):
         lldbutil.run_break_set_by_file_and_line(

--- a/lldb/test/API/lang/cpp/this/TestCPPThis.py
+++ b/lldb/test/API/lang/cpp/this/TestCPPThis.py
@@ -48,7 +48,7 @@ class CPPThisTestCase(TestBase):
 
         self.expect("expression -- (int)getpid(); m_a", startstr="(const int) $1 = 3")
         self.expect(
-            "expression --ignore-context-qualifiers -- m_a = 2", startstr="(int) $2 = 2"
+            "expression --cpp-ignore-context-qualifiers -- m_a = 2", startstr="(int) $2 = 2"
         )
 
         self.runCmd("process continue")

--- a/lldb/unittests/Expression/ClangExpressionDeclMapTest.cpp
+++ b/lldb/unittests/Expression/ClangExpressionDeclMapTest.cpp
@@ -23,7 +23,7 @@ namespace {
 struct FakeClangExpressionDeclMap : public ClangExpressionDeclMap {
   FakeClangExpressionDeclMap(const std::shared_ptr<ClangASTImporter> &importer)
       : ClangExpressionDeclMap(false, nullptr, lldb::TargetSP(), importer,
-                               nullptr) {
+                               nullptr, /*ignore_context_qualifiers=*/false) {
     m_holder = std::make_unique<clang_utils::TypeSystemClangHolder>("ast");
     m_scratch_context = m_holder->GetAST();
   }


### PR DESCRIPTION
Depends on:
* https://github.com/llvm/llvm-project/pull/177920
* https://github.com/llvm/llvm-project/pull/177922
* https://github.com/llvm/llvm-project/pull/179208

(only commit d8676d0ed9286777e1a1e9f625389540cc42c231 and later are relevant for this review)

In https://github.com/llvm/llvm-project/pull/177922 we make expressions run in C++ member functions honor the function qualifiers of the current stop context. E.g., this means we can no longer run non-const member functions when stopped in a const-member function.

To ensure users can still do this if they really need/want to, we provide an option to not honor the qualifiers at all, leaving the `__lldb_expr` minimally qualified, allowing it to call any function/mutate any members.