### PR TITLE
[lldb][Expression] Emit hint to use --c++-ignore-context-qualifiers

### DIFF
--- a/lldb/include/lldb/Expression/UserExpression.h
+++ b/lldb/include/lldb/Expression/UserExpression.h
@@ -313,6 +313,16 @@ protected:
                            lldb::ProcessSP &process_sp,
                            lldb::StackFrameSP &frame_sp);
 
+  /// Called by expression evaluator when a parse error occurs. Gives this
+  /// UserExpression object a chance to inspect and adjust the error diagnostics
+  /// contained in the specified \c diagnostic_manager.
+  ///
+  /// \param[in,out] diagnostic_manager DiagnosticManager manager holding the
+  /// parse error diagnostics. This function may mutate the diagnostics.
+  ///
+  virtual void
+  FixupParseErrorDiagnostics(DiagnosticManager &diagnostic_manager) const {}
+
   /// The address the process is stopped in.
   Address m_address;
   /// The text of the expression, as typed by the user.

--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -323,6 +323,9 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
     }
 
     if (!parse_success) {
+      if (user_expression_sp)
+        user_expression_sp->FixupParseErrorDiagnostics(diagnostic_manager);
+
       if (target->GetEnableNotifyAboutFixIts() && fixed_expression &&
           !fixed_expression->empty()) {
         std::string fixit =

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -980,11 +980,12 @@ void ClangUserExpression::FixupParseErrorDiagnostics(
     return;
   }
 
-  diagnostic_manager.AddDiagnostic(
+  diagnostic_manager.Printf(
+      lldb::eSeverityInfo,
       "Possibly trying to mutate object in a const context. Try "
       "running the expression with: expression --c++-ignore-context-qualifiers "
-      "-- <your expression>",
-      lldb::eSeverityInfo, eDiagnosticOriginLLDB);
+      "-- %s",
+      !m_fixed_text.empty() ? m_fixed_text.c_str() : m_expr_text.c_str());
 }
 
 char ClangUserExpression::ClangUserExpressionHelper::ID;

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -972,17 +972,17 @@ void ClangUserExpression::FixupParseErrorDiagnostics(
 
   // If the user already tried ignoring function qualifiers but
   // the expression still failed, we don't want to suggest the hint again.
-  if (m_options.GetIgnoreContextQualifiers()) {
+  if (m_options.GetCppIgnoreContextQualifiers()) {
     // Hard to prove that we don't get here so don't emit a diagnostic n
     // non-asserts builds. But we do want a signal in asserts builds.
     assert(false &&
-           "IgnoreContextQualifiers didn't resolve compiler diagnostic.");
+           "CppIgnoreContextQualifiers didn't resolve compiler diagnostic.");
     return;
   }
 
   diagnostic_manager.AddDiagnostic(
       "Possibly trying to mutate object in a const context. Try "
-      "running the expression with: expression --ignore-context-qualifiers "
+      "running the expression with: expression --cpp-ignore-context-qualifiers "
       "-- <your expression>",
       lldb::eSeverityInfo, eDiagnosticOriginLLDB);
 }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -982,7 +982,7 @@ void ClangUserExpression::FixupParseErrorDiagnostics(
 
   diagnostic_manager.AddDiagnostic(
       "Possibly trying to mutate object in a const context. Try "
-      "running the expression with: expression --cpp-ignore-context-qualifiers "
+      "running the expression with: expression --c++-ignore-context-qualifiers "
       "-- <your expression>",
       lldb::eSeverityInfo, eDiagnosticOriginLLDB);
 }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
@@ -179,6 +179,10 @@ public:
 
   llvm::StringRef GetFilename() const { return m_filename; }
 
+protected:
+  void FixupParseErrorDiagnostics(
+      DiagnosticManager &diagnostic_manager) const override;
+
 private:
   /// Populate m_in_cplusplus_method and m_in_objectivec_method based on the
   /// environment.

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_method/TestExprInConstMethod.py
@@ -16,15 +16,16 @@ class TestCase(TestBase):
             "expression m_const_mem = 2.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member",
-                "with const-qualified type",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
+            matching=False,
         )
         self.expect(
             "expression m_mem = 2.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member within const member function"
+                "cannot assign to non-static data member within const member function",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
         self.expect_expr("m_mem", result_value="-2")
@@ -60,7 +61,8 @@ class TestCase(TestBase):
             "expression x = 7.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member within const member function"
+                "cannot assign to non-static data member within const member function",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
         self.expect_expr("x", result_value="2")
@@ -87,15 +89,16 @@ class TestCase(TestBase):
             "expression m_const_mem = 2.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member",
-                "with const-qualified type",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
+            matching=False,
         )
         self.expect(
             "expression m_mem = 2.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member within const member function"
+                "cannot assign to non-static data member within const member function",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
         self.expect_expr("m_mem", result_value="-2")
@@ -117,15 +120,16 @@ class TestCase(TestBase):
             "expression m_const_mem = 2.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member",
-                "with const-qualified type",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
+            matching=False,
         )
         self.expect(
             "expression m_mem = 2.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member within const member function"
+                "cannot assign to non-static data member within const member function",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
         self.expect_expr("m_mem", result_value="-1")

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/const_volatile_method/TestExprInConstVolatileMethod.py
@@ -17,7 +17,11 @@ class TestCase(TestBase):
         self.expect(
             "expression volatile_method()",
             error=True,
-            substrs=["has type 'const Foo'", "but function is not marked const"],
+            substrs=[
+                "has type 'const Foo'",
+                "but function is not marked const",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
+            ],
         )
 
         options = lldb.SBExpressionOptions()
@@ -41,7 +45,11 @@ class TestCase(TestBase):
         self.expect(
             "expression const_method()",
             error=True,
-            substrs=["has type 'volatile Foo'", "but function is not marked volatile"],
+            substrs=[
+                "has type 'volatile Foo'",
+                "but function is not marked volatile",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
+            ],
         )
         self.expect_expr("volatile_method()")
 
@@ -65,6 +73,7 @@ class TestCase(TestBase):
             substrs=[
                 "has type 'const volatile Foo'",
                 "but function is not marked const or volatile",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
         self.expect(
@@ -73,6 +82,7 @@ class TestCase(TestBase):
             substrs=[
                 "has type 'const volatile Foo'",
                 "but function is not marked const or volatile",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
 

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/fixit/TestExprInConstMethodWithFixit.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/fixit/TestExprInConstMethodWithFixit.py
@@ -18,6 +18,7 @@ class TestCase(TestBase):
                 "member reference type 'const Bar' is not a pointer",
                 "but function is not marked const",
                 "Possibly trying to mutate object in a const context. Try running the expression with",
+                "expression --c++-ignore-context-qualifiers -- m_bar.method()",
             ],
         )
 
@@ -54,11 +55,12 @@ class TestCase(TestBase):
                 "member reference type 'const Bar' is not a pointer",
                 "but function is not marked const",
                 "Possibly trying to mutate object in a const context. Try running the expression with",
+                "expression --c++-ignore-context-qualifiers -- m_bar.method() + blah",
             ],
         )
 
         self.expect(
-            "expression -K -- m_bar->method() + blah",
+            "expression -Q -- m_bar->method() + blah",
             error=True,
             substrs=[
                 "Possibly trying to mutate object in a const context. Try running the expression with",

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/fixit/TestExprInConstMethodWithFixit.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/fixit/TestExprInConstMethodWithFixit.py
@@ -17,10 +17,11 @@ class TestCase(TestBase):
             substrs=[
                 "member reference type 'const Bar' is not a pointer",
                 "but function is not marked const",
+                "Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
 
-        # Two fix-its
+        # Two fix-its...
         self.expect(
             "expression -- m_bar->method() + m_bar->method()",
             error=True,
@@ -32,11 +33,35 @@ class TestCase(TestBase):
             ],
         )
 
+        # ...only emit a single hint.
+        self.assertEqual(
+            self.res.GetError().count(
+                "Possibly trying to mutate object in a const context."
+            ),
+            1,
+        )
+
+        self.expect(
+            "expression -Q -- m_bar->method()",
+            error=True,
+            substrs=["Evaluated this expression after applying Fix-It(s):"],
+        )
+
         self.expect(
             "expression m_bar->method() + blah",
             error=True,
             substrs=[
                 "member reference type 'const Bar' is not a pointer",
                 "but function is not marked const",
+                "Possibly trying to mutate object in a const context. Try running the expression with",
             ],
+        )
+
+        self.expect(
+            "expression -K -- m_bar->method() + blah",
+            error=True,
+            substrs=[
+                "Possibly trying to mutate object in a const context. Try running the expression with",
+            ],
+            matching=False,
         )

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/non_const_method/TestExprInNonConstMethod.py
@@ -32,7 +32,8 @@ class TestCase(TestBase):
             "expression x = 7.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member within const member function"
+                "cannot assign to non-static data member within const member function",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
 

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_const_method/TestExprInTemplateConstMethod.py
@@ -24,7 +24,8 @@ class TestCase(TestBase):
             "expression m_mem = 2.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member within const member function"
+                "cannot assign to non-static data member within const member function",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
         self.expect_expr("((Foo*)this)->bar()", result_type="double", result_value="5")
@@ -44,7 +45,8 @@ class TestCase(TestBase):
             "expression x = 7.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member within const member function"
+                "cannot assign to non-static data member within const member function",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
         self.expect_expr("x = -7.0; x", options=options, result_value="-7")
@@ -77,7 +79,8 @@ class TestCase(TestBase):
             "expression m_mem = 2.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member within const member function"
+                "cannot assign to non-static data member within const member function",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
         self.expect_expr("m_mem", result_value="-2")
@@ -105,7 +108,8 @@ class TestCase(TestBase):
             "expression m_mem = 2.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member within const member function"
+                "cannot assign to non-static data member within const member function",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
         self.expect_expr("m_mem = -11.0; m_mem", options=options, result_value="-11")

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
@@ -32,7 +32,8 @@ class TestCase(TestBase):
             "expression x = 7.0",
             error=True,
             substrs=[
-                "cannot assign to non-static data member within const member function"
+                "cannot assign to non-static data member within const member function",
+                "note: Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
 

--- a/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
+++ b/lldb/test/API/lang/cpp/expression-context-qualifiers/template_non_const_method/TestExprInTemplateNonConstMethod.py
@@ -34,6 +34,7 @@ class TestCase(TestBase):
             substrs=[
                 "cannot assign to non-static data member within const member function",
                 "note: Possibly trying to mutate object in a const context. Try running the expression with",
+                "expression --c++-ignore-context-qualifiers -- x = 7.0",
             ],
         )
 

--- a/lldb/test/API/lang/cpp/this/TestCPPThis.py
+++ b/lldb/test/API/lang/cpp/this/TestCPPThis.py
@@ -43,7 +43,7 @@ class CPPThisTestCase(TestBase):
             error=True,
             substrs=[
                 "cannot assign to non-static data member within const member function",
-                "Possibly trying to mutate object in a const context. Try running the expression with",
+                "Possibly trying to mutate object in a const context. Try running the expression with: expression --c++-ignore-context-qualifiers -- m_a = 2",
             ],
         )
 

--- a/lldb/test/API/lang/cpp/this/TestCPPThis.py
+++ b/lldb/test/API/lang/cpp/this/TestCPPThis.py
@@ -42,7 +42,8 @@ class CPPThisTestCase(TestBase):
             "expression -- m_a = 2",
             error=True,
             substrs=[
-                "cannot assign to non-static data member within const member function"
+                "cannot assign to non-static data member within const member function",
+                "Possibly trying to mutate object in a const context. Try running the expression with",
             ],
         )
 


### PR DESCRIPTION
Depends on:
* https://github.com/llvm/llvm-project/pull/177921
* https://github.com/llvm/llvm-project/pull/177926

(only last commit is relevant for this review)

This patch emits a workaround suggestion (in the form of a `note:` diagnostic) when an expression fails due to trying to mutate state/call functions with CV-qualifiers that are disallowed by C++ language rules based on the context the expression is evaluated in. The note looks as follows:
```
(lldb) expr next.method()
            ˄
            ╰─ error: 'this' argument to member function 'method' has type 'const Bar', but function is not marked const
note: Ran expression as 'C++14'.
note: note: 'method' declared here
note: Possibly trying to mutate object in a const context. Try running the expression with: expression --c++-ignore-context-qualifiers -- <your expression>
```