### PR TITLE
[libclc] Use native reciprocal in float trig and rootn paths

### DIFF
--- a/libclc/clc/lib/generic/math/clc_atan.cl
+++ b/libclc/clc/lib/generic/math/clc_atan.cl
@@ -12,6 +12,7 @@
 #include <clc/math/clc_fabs.h>
 #include <clc/math/clc_fma.h>
 #include <clc/math/clc_mad.h>
+#include <clc/math/clc_native_recip.h>
 #include <clc/math/math.h>
 #include <clc/relational/clc_isnan.h>
 

--- a/libclc/clc/lib/generic/math/clc_atan.inc
+++ b/libclc/clc/lib/generic/math/clc_atan.inc
@@ -28,7 +28,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atan(__CLC_GENTYPE x) {
   // Reduce arguments 2^-19 <= |x| < 2^26
 
   // 39/16 <= x < 2^26
-  x = -MATH_RECIP(v);
+  x = -__clc_native_recip(v);
   __CLC_GENTYPE c = 1.57079632679489655800f; // atan(infinity)
 
   // 19/16 <= x < 39/16

--- a/libclc/clc/lib/generic/math/clc_atan2.cl
+++ b/libclc/clc/lib/generic/math/clc_atan2.cl
@@ -14,6 +14,7 @@
 #include <clc/math/clc_fma.h>
 #include <clc/math/clc_ldexp.h>
 #include <clc/math/clc_mad.h>
+#include <clc/math/clc_native_recip.h>
 #include <clc/math/math.h>
 #include <clc/math/tables.h>
 #include <clc/relational/clc_isinf.h>

--- a/libclc/clc/lib/generic/math/clc_atan2.inc
+++ b/libclc/clc/lib/generic/math/clc_atan2.inc
@@ -47,7 +47,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atan2(__CLC_GENTYPE y,
 #endif
 
   // Octant 0 result
-  __CLC_GENTYPE a = __clc_mad(p, MATH_RECIP(q), vbyu);
+  __CLC_GENTYPE a = __clc_mad(p, __clc_native_recip(q), vbyu);
 
   // Fix up 3 other octants
   __CLC_GENTYPE at = piby2 - a;

--- a/libclc/clc/lib/generic/math/clc_atan2pi.cl
+++ b/libclc/clc/lib/generic/math/clc_atan2pi.cl
@@ -14,6 +14,7 @@
 #include <clc/math/clc_fma.h>
 #include <clc/math/clc_ldexp.h>
 #include <clc/math/clc_mad.h>
+#include <clc/math/clc_native_recip.h>
 #include <clc/math/math.h>
 #include <clc/math/tables.h>
 #include <clc/relational/clc_isinf.h>

--- a/libclc/clc/lib/generic/math/clc_atan2pi.inc
+++ b/libclc/clc/lib/generic/math/clc_atan2pi.inc
@@ -31,7 +31,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atan2pi(__CLC_GENTYPE y,
       __clc_mad(vbyu2, __clc_mad(vbyu2, 0x1.1a714cp-2f, 0x1.287c56p+0f), 1.0f);
 
   // Octant 0 result
-  __CLC_GENTYPE a = MATH_DIVIDE(__clc_mad(p, MATH_RECIP(q), vbyu), pi);
+  __CLC_GENTYPE a = MATH_DIVIDE(__clc_mad(p, __clc_native_recip(q), vbyu), pi);
 
   // Fix up 3 other octants
   __CLC_GENTYPE at = 0.5f - a;

--- a/libclc/clc/lib/generic/math/clc_atanpi.cl
+++ b/libclc/clc/lib/generic/math/clc_atanpi.cl
@@ -12,6 +12,7 @@
 #include <clc/math/clc_fabs.h>
 #include <clc/math/clc_fma.h>
 #include <clc/math/clc_mad.h>
+#include <clc/math/clc_native_recip.h>
 #include <clc/math/math.h>
 #include <clc/relational/clc_isnan.h>
 

--- a/libclc/clc/lib/generic/math/clc_atanpi.inc
+++ b/libclc/clc/lib/generic/math/clc_atanpi.inc
@@ -30,7 +30,7 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_atanpi(__CLC_GENTYPE x) {
   // Reduce arguments 2^-19 <= |x| < 2^26
 
   // 39/16 <= x < 2^26
-  x = -MATH_RECIP(v);
+  x = -__clc_native_recip(v);
   __CLC_GENTYPE c = 1.57079632679489655800f; // atan(infinity)
 
   // 19/16 <= x < 39/16

--- a/libclc/clc/lib/generic/math/clc_rootn.cl
+++ b/libclc/clc/lib/generic/math/clc_rootn.cl
@@ -13,6 +13,7 @@
 #include <clc/math/clc_fma.h>
 #include <clc/math/clc_ldexp.h>
 #include <clc/math/clc_mad.h>
+#include <clc/math/clc_native_recip.h>
 #include <clc/math/clc_subnormal_config.h>
 #include <clc/math/math.h>
 #include <clc/math/tables.h>

--- a/libclc/clc/lib/generic/math/clc_rootn.inc
+++ b/libclc/clc/lib/generic/math/clc_rootn.inc
@@ -54,7 +54,7 @@
 
 _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_rootn(__CLC_GENTYPE x,
                                                  __CLC_INTN ny) {
-  __CLC_GENTYPE y = MATH_RECIP(__CLC_CONVERT_GENTYPE(ny));
+  __CLC_GENTYPE y = __clc_native_recip(__CLC_CONVERT_GENTYPE(ny));
 
   __CLC_INTN ix = __CLC_AS_INTN(x);
   __CLC_INTN ax = ix & EXSIGNBIT_SP32;

--- a/libclc/clc/lib/generic/math/clc_sincos_helpers.cl
+++ b/libclc/clc/lib/generic/math/clc_sincos_helpers.cl
@@ -13,6 +13,7 @@
 #include <clc/math/clc_fma.h>
 #include <clc/math/clc_mad.h>
 #include <clc/math/clc_native_divide.h>
+#include <clc/math/clc_native_recip.h>
 #include <clc/math/clc_trunc.h>
 #include <clc/math/math.h>
 

--- a/libclc/clc/lib/generic/math/clc_sincos_helpers.inc
+++ b/libclc/clc/lib/generic/math/clc_sincos_helpers.inc
@@ -125,7 +125,7 @@ _CLC_DEF _CLC_OVERLOAD __CLC_FLOATN __clc_tanf_piby4(__CLC_FLOATN x,
       1.15588821434688393452299f);
 
   __CLC_FLOATN t = __clc_mad(x * r, __clc_native_divide(a, b), x);
-  __CLC_FLOATN tr = -MATH_RECIP(t);
+  __CLC_FLOATN tr = -__clc_native_recip(t);
 
   return (regn & 1) != 0 ? tr : t;
 }


### PR DESCRIPTION
MATH_RECIP expands to 1.0f / x, which is not a reciprocal. Replace it with __clc_native_recip in atan/atanpi/atan2/atan2pi/cos/ cospi/sin/sinpi/rootn/tan float builtins.
Change to bitcode:
  %27 = fdiv float 1.000000e+00, %26, !fpmath !23
->
  %27 = fdiv arcp afn float 1.000000e+00, %26, !fpmath !23

The new code still passes OpenCL CTS math_brute_force on intel gpu.