### PR TITLE
[X86] combineConcatVectorOps - concat(scalar_to_vector(extractelt(x,0)),scalar_to_vector(extractelt(y,0))) -> concat(x,y)

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -59615,7 +59615,7 @@ static SDValue combineConcatVectorOps(const SDLoc &DL, MVT VT,
       if (!IsSplat &&
           (VT.is256BitVector() ||
            (VT.is512BitVector() && Subtarget.useAVX512Regs())) &&
-          llvm::all_of(Ops, [Op0, VT](SDValue Op) {
+          llvm::all_of(Ops, [Op0](SDValue Op) {
             return Op.getOperand(0).getOpcode() == ISD::EXTRACT_VECTOR_ELT &&
                    Op.getOperand(0).getOperand(0).getValueType() ==
                        Op0.getValueType() &&

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -59611,6 +59611,25 @@ static SDValue combineConcatVectorOps(const SDLoc &DL, MVT VT,
       }
       break;
     }
+    case ISD::SCALAR_TO_VECTOR: {
+      if (!IsSplat &&
+          (VT.is256BitVector() ||
+           (VT.is512BitVector() && Subtarget.useAVX512Regs())) &&
+          llvm::all_of(Ops, [Op0, VT](SDValue Op) {
+            return Op.getOperand(0).getOpcode() == ISD::EXTRACT_VECTOR_ELT &&
+                   Op.getOperand(0).getOperand(0).getValueType() ==
+                       Op0.getValueType() &&
+                   isNullConstant(Op.getOperand(0).getOperand(1));
+          })) {
+        SmallVector<SDValue, 4> Subs;
+        for (SDValue SubOp : Ops)
+          Subs.push_back(SubOp.getOperand(0).getOperand(0));
+        if (SDValue R =
+                combineConcatVectorOps(DL, VT, Subs, DAG, Subtarget, Depth + 1))
+          return R;
+      }
+      break;
+    }
     case ISD::VECTOR_SHUFFLE: {
       // TODO: Generalize NumOps support.
       if (!IsSplat && NumOps == 2 &&

--- a/llvm/test/CodeGen/X86/pclmulqdq.ll
+++ b/llvm/test/CodeGen/X86/pclmulqdq.ll
@@ -159,19 +159,7 @@ define <8 x i64> @pclmul512_lo_hi(<8 x i64> %v0, <8 x i64> %v1) {
 ;
 ; AVX512-VPCLMULQDQ-LABEL: pclmul512_lo_hi:
 ; AVX512-VPCLMULQDQ:       # %bb.0:
-; AVX512-VPCLMULQDQ-NEXT:    vextracti128 $1, %ymm0, %xmm2
-; AVX512-VPCLMULQDQ-NEXT:    vextracti128 $1, %ymm1, %xmm3
-; AVX512-VPCLMULQDQ-NEXT:    vpclmulqdq $16, %xmm3, %xmm2, %xmm2
-; AVX512-VPCLMULQDQ-NEXT:    vextracti32x4 $2, %zmm0, %xmm3
-; AVX512-VPCLMULQDQ-NEXT:    vextracti32x4 $2, %zmm1, %xmm4
-; AVX512-VPCLMULQDQ-NEXT:    vpclmulqdq $16, %xmm4, %xmm3, %xmm3
-; AVX512-VPCLMULQDQ-NEXT:    vextracti32x4 $3, %zmm0, %xmm4
-; AVX512-VPCLMULQDQ-NEXT:    vextracti32x4 $3, %zmm1, %xmm5
-; AVX512-VPCLMULQDQ-NEXT:    vpclmulqdq $16, %xmm5, %xmm4, %xmm4
-; AVX512-VPCLMULQDQ-NEXT:    vpclmulqdq $16, %xmm1, %xmm0, %xmm0
-; AVX512-VPCLMULQDQ-NEXT:    vinserti128 $1, %xmm4, %ymm3, %ymm1
-; AVX512-VPCLMULQDQ-NEXT:    vinserti128 $1, %xmm2, %ymm0, %ymm0
-; AVX512-VPCLMULQDQ-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
+; AVX512-VPCLMULQDQ-NEXT:    vpclmulqdq $16, %zmm1, %zmm0, %zmm0
 ; AVX512-VPCLMULQDQ-NEXT:    retq
   %i0 = zext i1 0 to i64 ; constant time lo/hi select
   %i1 = zext i1 1 to i64 ; constant time lo/hi select
@@ -242,19 +230,7 @@ define <8 x i64> @pclmul512_hi_lo(<8 x i64> %v0, <8 x i64> %v1) {
 ;
 ; AVX512-VPCLMULQDQ-LABEL: pclmul512_hi_lo:
 ; AVX512-VPCLMULQDQ:       # %bb.0:
-; AVX512-VPCLMULQDQ-NEXT:    vextracti128 $1, %ymm0, %xmm2
-; AVX512-VPCLMULQDQ-NEXT:    vextracti128 $1, %ymm1, %xmm3
-; AVX512-VPCLMULQDQ-NEXT:    vpclmulqdq $1, %xmm3, %xmm2, %xmm2
-; AVX512-VPCLMULQDQ-NEXT:    vextracti32x4 $2, %zmm0, %xmm3
-; AVX512-VPCLMULQDQ-NEXT:    vextracti32x4 $2, %zmm1, %xmm4
-; AVX512-VPCLMULQDQ-NEXT:    vpclmulqdq $1, %xmm4, %xmm3, %xmm3
-; AVX512-VPCLMULQDQ-NEXT:    vextracti32x4 $3, %zmm0, %xmm4
-; AVX512-VPCLMULQDQ-NEXT:    vextracti32x4 $3, %zmm1, %xmm5
-; AVX512-VPCLMULQDQ-NEXT:    vpclmulqdq $1, %xmm5, %xmm4, %xmm4
-; AVX512-VPCLMULQDQ-NEXT:    vpclmulqdq $1, %xmm1, %xmm0, %xmm0
-; AVX512-VPCLMULQDQ-NEXT:    vinserti128 $1, %xmm4, %ymm3, %ymm1
-; AVX512-VPCLMULQDQ-NEXT:    vinserti128 $1, %xmm2, %ymm0, %ymm0
-; AVX512-VPCLMULQDQ-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
+; AVX512-VPCLMULQDQ-NEXT:    vpclmulqdq $1, %zmm1, %zmm0, %zmm0
 ; AVX512-VPCLMULQDQ-NEXT:    retq
   %i0 = zext i1 1 to i64 ; constant time lo/hi select
   %i1 = zext i1 0 to i64 ; constant time lo/hi select


### PR DESCRIPTION
Peek through free scalar_to_vector/extract_vector_elt pairs (of the same vector width) that might still persist (ideally a better topological sorting would have removed these already....)