### PR TITLE
[GlobalISel] Add integer_reassoc_combines from SelectionDAG

### DIFF
--- a/llvm/include/llvm/Target/GlobalISel/Combine.td
+++ b/llvm/include/llvm/Target/GlobalISel/Combine.td
@@ -1799,7 +1799,7 @@ shl_of_vscale,
 sub_of_vscale,
 ]>;
 
-// fold ((A+(B-C))-B) -> A-C
+// fold ((A + (B - C)) - B) -> A-C
 def APlusBMinusCMinusB : GICombineRule<
    (defs root:$root),
    (match (G_SUB $sub1, $B, $C),
@@ -1807,7 +1807,7 @@ def APlusBMinusCMinusB : GICombineRule<
           (G_SUB $root, $add1, $B)),
    (apply (G_SUB $root, $A, $C))>;
 
-// fold ((A-(B-C))-C) -> A-B
+// fold ((A - (B - C)) - C) -> A-B
 def AMinusBMinusCMinusC : GICombineRule<
     (defs root:$root),
     (match (G_SUB $sub1, $B, $C),

--- a/llvm/include/llvm/Target/GlobalISel/Combine.td
+++ b/llvm/include/llvm/Target/GlobalISel/Combine.td
@@ -1799,6 +1799,21 @@ shl_of_vscale,
 sub_of_vscale,
 ]>;
 
+// fold ((A+(B-C))-B) -> A-C
+def APlusBMinusCMinusB : GICombineRule<
+   (defs root:$root),
+   (match (G_SUB $sub1, $B, $C),
+          (G_ADD $add1, $A, $sub1),
+          (G_SUB $root, $add1, $B)),
+   (apply (G_SUB $root, $A, $C))>;
+
+// fold ((A-(B-C))-C) -> A-B
+def AMinusBMinusCMinusC : GICombineRule<
+    (defs root:$root),
+    (match (G_SUB $sub1, $B, $C),
+            (G_SUB $sub2, $A, $sub1),
+            (G_SUB $root, $sub2, $C)),
+    (apply (G_SUB $root, $A, $B))>;
 
 // fold ((0-A) + B) -> B-A
 def ZeroMinusAPlusB : GICombineRule<
@@ -1911,6 +1926,8 @@ def AMinusC1PlusC2: GICombineRule<
    (apply [{ Helper.applyBuildFn(*${root}, ${matchinfo}); }])>;
 
 def integer_reassoc_combines: GICombineGroup<[
+  APlusBMinusCMinusB,
+  AMinusBMinusCMinusC,
   ZeroMinusAPlusB,
   APlusZeroMinusB,
   APlusBMinusB,

--- a/llvm/include/llvm/Target/GlobalISel/Combine.td
+++ b/llvm/include/llvm/Target/GlobalISel/Combine.td
@@ -1799,7 +1799,7 @@ shl_of_vscale,
 sub_of_vscale,
 ]>;
 
-// fold ((A + (B - C)) - B) -> A-C
+// fold ((A+(B-C))-B) -> A-C
 def APlusBMinusCMinusB : GICombineRule<
    (defs root:$root),
    (match (G_SUB $sub1, $B, $C),
@@ -1807,7 +1807,7 @@ def APlusBMinusCMinusB : GICombineRule<
           (G_SUB $root, $add1, $B)),
    (apply (G_SUB $root, $A, $C))>;
 
-// fold ((A - (B - C)) - C) -> A-B
+// fold ((A-(B-C))-C) -> A-B
 def AMinusBMinusCMinusC : GICombineRule<
     (defs root:$root),
     (match (G_SUB $sub1, $B, $C),

--- a/llvm/test/CodeGen/AArch64/GlobalISel/combine-integer.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/combine-integer.mir
@@ -3,6 +3,52 @@
 
 
 ---
+name:   APlusBMinusCMinusB
+body:             |
+  bb.0:
+    liveins: $x0, $x1, $x2
+    ; CHECK-LABEL: name: APlusBMinusCMinusB
+    ; CHECK: liveins: $x0, $x1, $x2
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %a:_(s64) = COPY $x0
+    ; CHECK-NEXT: %c:_(s64) = COPY $x2
+    ; CHECK-NEXT: %sub:_(s64) = G_SUB %a, %c
+    ; CHECK-NEXT: $x0 = COPY %sub(s64)
+    ; CHECK-NEXT: RET_ReallyLR implicit $x0
+    %a:_(s64) = COPY $x0
+    %b:_(s64) = COPY $x1
+    %c:_(s64) = COPY $x2
+    %sub1:_(s64) = G_SUB %b, %c
+    %add1:_(s64) = G_ADD %a, %sub1
+    %sub:_(s64) = G_SUB %add1, %b
+    $x0 = COPY %sub
+    RET_ReallyLR implicit $x0
+
+...
+---
+name:   AMinusBMinusCMinusC
+body:             |
+  bb.0:
+    liveins: $x0, $x1, $x2
+    ; CHECK-LABEL: name: AMinusBMinusCMinusC
+    ; CHECK: liveins: $x0, $x1, $x2
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: %a:_(s64) = COPY $x0
+    ; CHECK-NEXT: %b:_(s64) = COPY $x1
+    ; CHECK-NEXT: %sub:_(s64) = G_SUB %a, %b
+    ; CHECK-NEXT: $x0 = COPY %sub(s64)
+    ; CHECK-NEXT: RET_ReallyLR implicit $x0
+    %a:_(s64) = COPY $x0
+    %b:_(s64) = COPY $x1
+    %c:_(s64) = COPY $x2
+    %sub1:_(s64) = G_SUB %b, %c
+    %sub2:_(s64) = G_SUB %a, %sub1
+    %sub:_(s64) = G_SUB %sub2, %c
+    $x0 = COPY %sub
+    RET_ReallyLR implicit $x0
+
+...
+---
 name:   ZeroMinusAPlusB
 body:             |
   bb.0:


### PR DESCRIPTION
This PR converts two DAGCombiner fold patterns to GlobalISel MIR patterns:
- `((A + (B - C)) - B) -> A - C`
- `((A - (B - C)) - C) -> A - B`

Original patterns: https://github.com/llvm/llvm-project/blob/5b4811eddb28264ef1ccacc93c0f7d8cb0da31c8/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L4359

The patterns do not include hasOneUse checks since the instruction count remains the same even when both intermediate results have other uses (3 ops → 3 ops).