### PR TITLE
[TLI] Add isLegalNTStore/Load hook

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -363,17 +363,11 @@ public:
   }
 
   virtual bool isLegalNTStore(Type *DataType, Align Alignment) const {
-    // By default, assume nontemporal memory stores are available for stores
-    // that are aligned and have a size that is a power of 2.
-    unsigned DataSize = DL.getTypeStoreSize(DataType);
-    return Alignment >= DataSize && isPowerOf2_32(DataSize);
+    return false;
   }
 
   virtual bool isLegalNTLoad(Type *DataType, Align Alignment) const {
-    // By default, assume nontemporal memory loads are available for loads that
-    // are aligned and have a size that is a power of 2.
-    unsigned DataSize = DL.getTypeStoreSize(DataType);
-    return Alignment >= DataSize && isPowerOf2_32(DataSize);
+    return false;
   }
 
   virtual bool isLegalBroadcastLoad(Type *ElementTy,

--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -477,6 +477,16 @@ public:
     return getTLI()->isLegalAddressingMode(DL, AM, Ty, AddrSpace, I);
   }
 
+  bool isLegalNTStore(Type *DataType, Align Alignment) const override {
+    const DataLayout &DL = this->getDataLayout();
+    return getTLI()->isLegalNTStore(DataType, Alignment, DL);
+  }
+
+  bool isLegalNTLoad(Type *DataType, Align Alignment) const override {
+    const DataLayout &DL = this->getDataLayout();
+    return getTLI()->isLegalNTLoad(DataType, Alignment, DL);
+  }
+
   int64_t getPreferredLargeGEPBaseOffset(int64_t MinOffset, int64_t MaxOffset) {
     return getTLI()->getPreferredLargeGEPBaseOffset(MinOffset, MaxOffset);
   }

--- a/llvm/include/llvm/CodeGen/TargetLowering.h
+++ b/llvm/include/llvm/CodeGen/TargetLowering.h
@@ -2988,6 +2988,24 @@ public:
     return Value == 0;
   }
 
+  /// Return true if the target supports nontemporal store.
+  virtual bool isLegalNTStore(Type *DataType, Align Alignment,
+                              const DataLayout &DL) const {
+    // By default, assume nontemporal memory stores are available for stores
+    // that are aligned and have a size that is a power of 2.
+    unsigned DataSize = DL.getTypeStoreSize(DataType);
+    return Alignment >= DataSize && isPowerOf2_32(DataSize);
+  }
+
+  /// Return true if the target supports nontemporal load.
+  virtual bool isLegalNTLoad(Type *DataType, Align Alignment,
+                             const DataLayout &DL) const {
+    // By default, assume nontemporal memory loads are available for loads that
+    // are aligned and have a size that is a power of 2.
+    unsigned DataSize = DL.getTypeStoreSize(DataType);
+    return Alignment >= DataSize && isPowerOf2_32(DataSize);
+  }
+
   /// Given a shuffle vector SVI representing a vector splat, return a new
   /// scalar type of size equal to SVI's scalar type if the new type is more
   /// profitable. Returns nullptr otherwise. For example under MVE float splats

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -29607,7 +29607,7 @@ void AArch64TargetLowering::ReplaceNodeResults(
     //
     // Coordinated with LDNP constraints in
     // `llvm/lib/Target/AArch64/AArch64InstrInfo.td`
-    // and `AArch64TTIImpl::isLegalNTLoad`.
+    // and `AArch64TargetLowering::isLegalNTLoad`.
     if (LoadNode->isNonTemporal() && Subtarget->isLittleEndian() &&
         MemVT.getSizeInBits() == 256u &&
         (MemVT.getScalarSizeInBits() == 8u ||

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -3794,7 +3794,7 @@ def : Pat<(AArch64ldp (am_indexed7s64 GPR64sp:$Rn, simm7s8:$offset)),
 // Currently we only support NT loads lowering for little-endian targets.
 //
 // Coordinated with LDNP constraints in `AArch64TargetLowering::ReplaceNodeResults`
-// and `AArch64TTIImpl::isLegalNTLoad`.
+// and `AArch64TargetLowering::isLegalNTLoad`.
 let Predicates = [IsLE] in {
   def : Pat<(AArch64ldnp(am_indexed7s128 GPR64sp:$Rn, simm7s16:$offset)),
             (LDNPQi GPR64sp:$Rn, simm7s16:$offset)>;
@@ -10753,8 +10753,8 @@ def : Pat<(i64 (int_aarch64_neon_urshl (i64 FPR64:$Rn), (i64 FPR64:$Rm))),
 //
 // Currently we only support NT stores lowering for little-endian targets.
 //
-// Coordinated with STNP constraints in `AArch64TargetLowering::LowerNTStore`
-// and `AArch64TTIImpl::isLegalNTStore`.
+// Coordinated with STNP constraints in `LowerNTStore`
+// and `AArch64TargetLowering::isLegalNTStore`.
 //
 // Currently, STNP lowering can only either keep or increase code size, thus
 // we predicate it to not apply when optimizing for code size.

--- a/llvm/lib/Target/X86/X86ISelLowering.h
+++ b/llvm/lib/Target/X86/X86ISelLowering.h
@@ -1456,6 +1456,11 @@ namespace llvm {
 
     bool isLegalStoreImmediate(int64_t Imm) const override;
 
+    bool isLegalNTLoad(Type *DataType, Align Alignment,
+                       const DataLayout &DL) const override;
+    bool isLegalNTStore(Type *DataType, Align Alignment,
+                        const DataLayout &DL) const override;
+
     /// Add x86-specific opcodes to the default list.
     bool isBinOp(unsigned Opcode) const override;
 

--- a/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
+++ b/llvm/lib/Target/X86/X86TargetTransformInfo.cpp
@@ -6374,41 +6374,6 @@ bool X86TTIImpl::isLegalMaskedStore(Type *DataTy, Align Alignment,
   return isLegalMaskedLoadStore(ScalarTy, ST);
 }
 
-bool X86TTIImpl::isLegalNTLoad(Type *DataType, Align Alignment) const {
-  unsigned DataSize = DL.getTypeStoreSize(DataType);
-  // The only supported nontemporal loads are for aligned vectors of 16 or 32
-  // bytes.  Note that 32-byte nontemporal vector loads are supported by AVX2
-  // (the equivalent stores only require AVX).
-  if (Alignment >= DataSize && (DataSize == 16 || DataSize == 32))
-    return DataSize == 16 ?  ST->hasSSE1() : ST->hasAVX2();
-
-  return false;
-}
-
-bool X86TTIImpl::isLegalNTStore(Type *DataType, Align Alignment) const {
-  unsigned DataSize = DL.getTypeStoreSize(DataType);
-
-  // SSE4A supports nontemporal stores of float and double at arbitrary
-  // alignment.
-  if (ST->hasSSE4A() && (DataType->isFloatTy() || DataType->isDoubleTy()))
-    return true;
-
-  // Besides the SSE4A subtarget exception above, only aligned stores are
-  // available nontemporaly on any other subtarget.  And only stores with a size
-  // of 4..32 bytes (powers of 2, only) are permitted.
-  if (Alignment < DataSize || DataSize < 4 || DataSize > 32 ||
-      !isPowerOf2_32(DataSize))
-    return false;
-
-  // 32-byte vector nontemporal stores are supported by AVX (the equivalent
-  // loads require AVX2).
-  if (DataSize == 32)
-    return ST->hasAVX();
-  if (DataSize == 16)
-    return ST->hasSSE1();
-  return true;
-}
-
 bool X86TTIImpl::isLegalBroadcastLoad(Type *ElementTy,
                                       ElementCount NumElements) const {
   // movddup

--- a/llvm/lib/Target/X86/X86TargetTransformInfo.h
+++ b/llvm/lib/Target/X86/X86TargetTransformInfo.h
@@ -278,8 +278,6 @@ public:
   isLegalMaskedStore(Type *DataType, Align Alignment, unsigned AddressSpace,
                      TTI::MaskKind MaskKind =
                          TTI::MaskKind::VariableOrConstantMask) const override;
-  bool isLegalNTLoad(Type *DataType, Align Alignment) const override;
-  bool isLegalNTStore(Type *DataType, Align Alignment) const override;
   bool isLegalBroadcastLoad(Type *ElementTy,
                             ElementCount NumElements) const override;
   bool forceScalarizeMaskedGather(VectorType *VTy,

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -1045,7 +1045,8 @@ bool LoopVectorizationLegality::canVectorizeInstr(Instruction &I) {
     // For nontemporal stores, check that a nontemporal vector version is
     // supported on the target.
     if (ST->getMetadata(LLVMContext::MD_nontemporal)) {
-      // Arbitrarily try a vector of 2 elements.
+      // Check a 2-element vector type, which implictly covers any power-of-2
+      // sized vector type by logically splitting to pairs
       auto *VecTy = FixedVectorType::get(T, /*NumElts=*/2);
       assert(VecTy && "did not find vectorized version of stored type");
       if (!TTI->isLegalNTStore(VecTy, ST->getAlign())) {
@@ -1057,9 +1058,11 @@ bool LoopVectorizationLegality::canVectorizeInstr(Instruction &I) {
     }
 
   } else if (auto *LD = dyn_cast<LoadInst>(&I)) {
+    // For nontemporal loads, check that a nontemporal vector version is
+    // supported on the target.
     if (LD->getMetadata(LLVMContext::MD_nontemporal)) {
-      // For nontemporal loads, check that a nontemporal vector version is
-      // supported on the target (arbitrarily try a vector of 2 elements).
+      // Check a 2-element vector type, which implictly covers any power-of-2
+      // sized vector type by logically splitting to pairs
       auto *VecTy = FixedVectorType::get(I.getType(), /*NumElts=*/2);
       assert(VecTy && "did not find vectorized version of load type");
       if (!TTI->isLegalNTLoad(VecTy, LD->getAlign())) {


### PR DESCRIPTION
The issue this patch tries to solve is to differentiate between is an NT store/load directly legal on the target, and should an NT store/load be considered for vectorization early before we know the final vectorized store type. The differentiation is necessary for later passes in the pipeline to check legality without being over-permissive.

It adds 2 new TLI hooks with the same name, so that they can be easily called from the backend. I intend to submit a followup patch to introduce a new user of the TLI hook: https://github.com/llvm/llvm-project/pull/177938, but I think this semantic differentiation deserves a patch of its own - this is effectively a NFC.

The default implementation of the TTI hooks has not functionally changed, but they delegate to TLI now checks.

Note: this patch removes the AArch64 TTI override for `isLegalNTStore` as its currently not used anymore, only to re-introduce it in a followup patch with a fixed implementation based on what the target actually supports, and a new user.
