### PR TITLE
InstCombine: Try SimplifyDemandedBits on copysign signs

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3046,6 +3046,19 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     if (match(Mag, m_FAbs(m_Value(X))) || match(Mag, m_FNeg(m_Value(X))))
       return replaceOperand(*II, 0, X);
 
+    Type *SignEltTy = Sign->getType()->getScalarType();
+
+    Value *CastSrc;
+    if (match(Sign, m_ElementWiseBitCast(m_OneUse(m_Value(CastSrc)))) &&
+        CastSrc->getType()->isIntOrIntVectorTy() &&
+        APFloat::hasSignBitInMSB(SignEltTy->getFltSemantics())) {
+      KnownBits Known(SignEltTy->getPrimitiveSizeInBits());
+      if (SimplifyDemandedBits(cast<Instruction>(Sign), 0,
+                               APInt::getSignMask(Known.getBitWidth()), Known,
+                               SQ))
+        return II;
+    }
+
     break;
   }
   case Intrinsic::fabs: {


### PR DESCRIPTION
Some of the math library function implementations have a sequence
of logic operations to compute the sign bit which could be folded
out.

The DAG version already does this. The DAG version is also more
permissive and permits directly calling this on float typed values.
The IR version is not, so apply this transformation to the source of
a bitcast from integer.

Fixes #177932