### PR TITLE
[flang][Lower] Fix UB in location handling

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -1117,7 +1117,7 @@ public:
                                                       fir::LocationKind::Base));
 
         // Gather include location information if any.
-        Fortran::parser::ProvenanceRange *prov = &*provenance;
+        std::optional<Fortran::parser::ProvenanceRange> prov = provenance;
         while (prov) {
           if (std::optional<Fortran::parser::ProvenanceRange> include =
                   cooked->allSources().GetInclusionInfo(*prov)) {
@@ -1127,9 +1127,9 @@ public:
               locAttrs.push_back(fir::LocationKindAttr::get(
                   &getMLIRContext(), fir::LocationKind::Inclusion));
             }
-            prov = &*include;
+            prov = include;
           } else {
-            prov = nullptr;
+            prov.reset();
           }
         }
         if (locs.size() > 1) {


### PR DESCRIPTION
Previously `prov` received the address of a variable allocated in stack memory (the contents of `include`). `prov` would then access that memory outside of the lifetime of that stack allocation: leading to UB.

This only manifested on thinLTO builds. No added test because flang/test/Lower/location.f90 covers it (when thinLTO is enabled) and there are bots guarding the thin-lto configuration.

Fixes #156629
Fixes #176404