### PR TITLE
[NFC][SPIR-V] Avoid null pointer dereference

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
@@ -368,6 +368,7 @@ SPIRVCombinerHelper::getDotProductVectorType(Register ResReg, uint32_t K,
     assert(ScalarResType->isIntegerTy() || ScalarResType->isFloatingPointTy());
     break;
   }
+  assert(ScalarResType && "Could not determine scalar result type");
   Type *VecType =
       (K > 1 ? FixedVectorType::get(ScalarResType, K) : ScalarResType);
   return GR->getOrCreateSPIRVType(VecType, Builder,

--- a/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
@@ -369,7 +369,7 @@ SPIRVCombinerHelper::getDotProductVectorType(Register ResReg, uint32_t K,
     break;
   }
   if (!ScalarResType)
-      llvm_unreachable("Could not determine scalar result type");
+    llvm_unreachable("Could not determine scalar result type");
   Type *VecType =
       (K > 1 ? FixedVectorType::get(ScalarResType, K) : ScalarResType);
   return GR->getOrCreateSPIRVType(VecType, Builder,

--- a/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
@@ -368,7 +368,8 @@ SPIRVCombinerHelper::getDotProductVectorType(Register ResReg, uint32_t K,
     assert(ScalarResType->isIntegerTy() || ScalarResType->isFloatingPointTy());
     break;
   }
-  assert(ScalarResType && "Could not determine scalar result type");
+  if (!ScalarResType)
+      llvm_unreachable("Could not determine scalar result type");
   Type *VecType =
       (K > 1 ? FixedVectorType::get(ScalarResType, K) : ScalarResType);
   return GR->getOrCreateSPIRVType(VecType, Builder,


### PR DESCRIPTION
The issue is found by static code analysis tool.

We expect scalar result type is determined in `getDotProductVectorType`. Per discussion:
https://github.com/llvm/llvm-project/pull/172050#pullrequestreview-3692008084