### PR TITLE
[lldb] Fix UbSan decorator

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -12,6 +12,7 @@ import os
 
 
 # Third-party modules
+from typing import Optional
 import unittest
 
 # LLDB Modules
@@ -60,6 +61,9 @@ settings = []
 
 # Path to the FileCheck testing tool. Not optional.
 filecheck = None
+
+# Path to the nm tool.
+nm: Optional[str] = None
 
 # Path to the yaml2obj tool. Not optional.
 yaml2obj = None
@@ -169,6 +173,14 @@ def get_filecheck_path():
     """
     if filecheck and os.path.lexists(filecheck):
         return filecheck
+
+
+def get_nm_path():
+    """
+    Get the path to the nm tool.
+    """
+    if nm and os.path.lexists(nm):
+        return nm
 
 
 def get_yaml2obj_path():

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1046,36 +1046,18 @@ def skipUnlessUndefinedBehaviorSanitizer(func):
                 outputf,
             ):
                 return "Compiler cannot compile with -fsanitize=undefined"
+            if not outputf.path:
+                return "Cannot create Temp file path."
+
+            nm_bin = configuration.get_nm_path()
+            if not nm_bin:
+                return "No llvm-nm or nm binary."
 
             # Check that we actually see ubsan instrumentation in the binary.
-            cmd = "nm %s" % outputf.path
-            with os.popen(cmd) as nm_output:
-                if "___ubsan_handle_divrem_overflow" not in nm_output.read():
-                    return "Division by zero instrumentation is missing"
+            nm_output = subprocess.check_output([nm_bin, outputf.path], text=True)
+            if "__ubsan_handle_divrem_overflow" not in nm_output:
+                return "Division by zero instrumentation is missing"
 
-        # Find the ubsan dylib.
-        # FIXME: This check should go away once compiler-rt gains support for __ubsan_on_report.
-        cmd = (
-            "%s -fsanitize=undefined -x c - -o - -### 2>&1"
-            % lldbplatformutil.getCompiler()
-        )
-        with os.popen(cmd) as cc_output:
-            driver_jobs = cc_output.read()
-            m = re.search(r'"([^"]+libclang_rt.ubsan_osx_dynamic.dylib)"', driver_jobs)
-            if not m:
-                return "Could not find the ubsan dylib used by the driver"
-            ubsan_dylib = m.group(1)
-
-        # Check that the ubsan dylib has special monitor hooks.
-        cmd = "nm -gU %s" % ubsan_dylib
-        with os.popen(cmd) as nm_output:
-            syms = nm_output.read()
-            if "___ubsan_on_report" not in syms:
-                return "Missing ___ubsan_on_report"
-            if "___ubsan_get_current_report_data" not in syms:
-                return "Missing ___ubsan_get_current_report_data"
-
-        # OK, this dylib + compiler works for us.
         return None
 
     return skipTestIfFn(is_compiler_clang_with_ubsan)(func)

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -280,6 +280,9 @@ def parseOptionsAndInitTestdirs():
         configuration.llvm_tools_dir = args.llvm_tools_dir
         configuration.filecheck = shutil.which("FileCheck", path=args.llvm_tools_dir)
         configuration.yaml2obj = shutil.which("yaml2obj", path=args.llvm_tools_dir)
+        configuration.nm = shutil.which(
+            "llvm-nm", path=args.llvm_tools_dir
+        ) or shutil.which("nm", path=args.llvm_tools_dir)
 
     if not configuration.get_filecheck_path():
         logging.warning("No valid FileCheck executable; some tests may fail...")

--- a/lldb/source/Target/InstrumentationRuntimeStopInfo.cpp
+++ b/lldb/source/Target/InstrumentationRuntimeStopInfo.cpp
@@ -53,7 +53,8 @@ InstrumentationRuntimeStopInfo::GetSuggestedStackFrameIndex(
   // case we somehow ended up looking at an infinite recursion.
   constexpr size_t max_stack_depth = 128;
 
-  size_t stack_idx = 0;
+  // Start at parent frame.
+  size_t stack_idx = 1;
   StackFrameSP most_relevant_frame_sp =
       thread_sp->GetStackFrameAtIndex(stack_idx);
 

--- a/lldb/source/Target/InstrumentationRuntimeStopInfo.cpp
+++ b/lldb/source/Target/InstrumentationRuntimeStopInfo.cpp
@@ -53,8 +53,7 @@ InstrumentationRuntimeStopInfo::GetSuggestedStackFrameIndex(
   // case we somehow ended up looking at an infinite recursion.
   constexpr size_t max_stack_depth = 128;
 
-  // Start at parent frame.
-  size_t stack_idx = 1;
+  size_t stack_idx = 0;
   StackFrameSP most_relevant_frame_sp =
       thread_sp->GetStackFrameAtIndex(stack_idx);
 

--- a/lldb/test/API/functionalities/ubsan/basic/TestUbsanBasic.py
+++ b/lldb/test/API/functionalities/ubsan/basic/TestUbsanBasic.py
@@ -13,7 +13,6 @@ import json
 class UbsanBasicTestCase(TestBase):
     @skipUnlessUndefinedBehaviorSanitizer
     @no_debug_info_test
-    @skipUnlessDarwin  # FIXME: update this test to work on other platforms
     def test(self):
         self.build()
         self.ubsan_tests()
@@ -53,11 +52,11 @@ class UbsanBasicTestCase(TestBase):
             substrs=["1 match found"],
         )
 
+        # FIXME: Check on non macOS platform we land don't
+        # stop on __ubsan_on_report instead we stop on main.
         if self.platformIsDarwin():
             # We should not be stopped in the sanitizer library.
             self.assertIn("main", frame.GetFunctionName())
-        else:
-            self.assertIn("__ubsan_on_report", frame.GetFunctionName())
 
         # The stopped thread backtrace should contain either 'align line'
         found = False

--- a/lldb/test/API/functionalities/ubsan/basic/TestUbsanBasic.py
+++ b/lldb/test/API/functionalities/ubsan/basic/TestUbsanBasic.py
@@ -13,6 +13,7 @@ import json
 class UbsanBasicTestCase(TestBase):
     @skipUnlessUndefinedBehaviorSanitizer
     @no_debug_info_test
+    @skipUnlessDarwin  # FIXME: update this test to work on other platforms
     def test(self):
         self.build()
         self.ubsan_tests()


### PR DESCRIPTION
the ubsan decorator previously assumes the platform is macOS.

macOS has an extra underscore in symbols names match two or more.
uses the llvm-nm that is built instead of the system's nm. 

