### PR TITLE
[WebAssembly] Zero and NaN checks for min/max

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -190,7 +190,7 @@ WebAssemblyTargetLowering::WebAssemblyTargetLowering(
   if (Subtarget->hasRelaxedSIMD()) {
     setOperationAction(
         {ISD::FMINNUM, ISD::FMINIMUMNUM, ISD::FMAXNUM, ISD::FMAXIMUMNUM},
-        {MVT::v4f32, MVT::v2f64}, Legal);
+        {MVT::v4f32, MVT::v2f64}, Custom);
   }
   // SIMD-specific configuration
   if (Subtarget->hasSIMD128()) {
@@ -1747,6 +1747,12 @@ SDValue WebAssemblyTargetLowering::LowerOperation(SDValue Op,
   case ISD::FP_TO_SINT_SAT:
   case ISD::FP_TO_UINT_SAT:
     return LowerFP_TO_INT_SAT(Op, DAG);
+  case ISD::FMINNUM:
+  case ISD::FMINIMUMNUM:
+    return LowerFMINIMUMNUM(Op, DAG);
+  case ISD::FMAXNUM:
+  case ISD::FMAXIMUMNUM:
+    return LowerFMAXIMUMNUM(Op, DAG);
   case ISD::LOAD:
     return LowerLoad(Op, DAG);
   case ISD::STORE:
@@ -2855,6 +2861,33 @@ SDValue WebAssemblyTargetLowering::LowerFP_TO_INT_SAT(SDValue Op,
   if (ResT == MVT::v8i16 && SatVT == MVT::i16)
     return Op;
 
+  return SDValue();
+}
+
+static bool HasNoSignedZerosOrNaNs(SDValue Op, SelectionDAG &DAG) {
+  return (Op->getFlags().hasNoNaNs() ||
+          (DAG.isKnownNeverNaN(Op->getOperand(0)) &&
+           DAG.isKnownNeverNaN(Op->getOperand(1)))) &&
+         (Op->getFlags().hasNoSignedZeros() ||
+          DAG.isKnownNeverZeroFloat(Op->getOperand(0)) ||
+          DAG.isKnownNeverZeroFloat(Op->getOperand(1)));
+}
+
+SDValue WebAssemblyTargetLowering::LowerFMINIMUMNUM(SDValue Op,
+                                                    SelectionDAG &DAG) const {
+  if (Subtarget->hasRelaxedSIMD() && HasNoSignedZerosOrNaNs(Op, DAG)) {
+    return DAG.getNode(WebAssemblyISD::RELAXED_FMIN, SDLoc(Op),
+                       Op.getValueType(), Op.getOperand(0), Op.getOperand(1));
+  }
+  return SDValue();
+}
+
+SDValue WebAssemblyTargetLowering::LowerFMAXIMUMNUM(SDValue Op,
+                                                    SelectionDAG &DAG) const {
+  if (Subtarget->hasRelaxedSIMD() && HasNoSignedZerosOrNaNs(Op, DAG)) {
+    return DAG.getNode(WebAssemblyISD::RELAXED_FMAX, SDLoc(Op),
+                       Op.getValueType(), Op.getOperand(0), Op.getOperand(1));
+  }
   return SDValue();
 }
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -1749,10 +1749,10 @@ SDValue WebAssemblyTargetLowering::LowerOperation(SDValue Op,
     return LowerFP_TO_INT_SAT(Op, DAG);
   case ISD::FMINNUM:
   case ISD::FMINIMUMNUM:
-    return LowerFMINIMUMNUM(Op, DAG);
+    return LowerFMIN(Op, DAG);
   case ISD::FMAXNUM:
   case ISD::FMAXIMUMNUM:
-    return LowerFMAXIMUMNUM(Op, DAG);
+    return LowerFMAX(Op, DAG);
   case ISD::LOAD:
     return LowerLoad(Op, DAG);
   case ISD::STORE:
@@ -2873,8 +2873,8 @@ static bool HasNoSignedZerosOrNaNs(SDValue Op, SelectionDAG &DAG) {
           DAG.isKnownNeverZeroFloat(Op->getOperand(1)));
 }
 
-SDValue WebAssemblyTargetLowering::LowerFMINIMUMNUM(SDValue Op,
-                                                    SelectionDAG &DAG) const {
+SDValue WebAssemblyTargetLowering::LowerFMIN(SDValue Op,
+                                             SelectionDAG &DAG) const {
   if (Subtarget->hasRelaxedSIMD() && HasNoSignedZerosOrNaNs(Op, DAG)) {
     return DAG.getNode(WebAssemblyISD::RELAXED_FMIN, SDLoc(Op),
                        Op.getValueType(), Op.getOperand(0), Op.getOperand(1));
@@ -2882,8 +2882,8 @@ SDValue WebAssemblyTargetLowering::LowerFMINIMUMNUM(SDValue Op,
   return SDValue();
 }
 
-SDValue WebAssemblyTargetLowering::LowerFMAXIMUMNUM(SDValue Op,
-                                                    SelectionDAG &DAG) const {
+SDValue WebAssemblyTargetLowering::LowerFMAX(SDValue Op,
+                                             SelectionDAG &DAG) const {
   if (Subtarget->hasRelaxedSIMD() && HasNoSignedZerosOrNaNs(Op, DAG)) {
     return DAG.getNode(WebAssemblyISD::RELAXED_FMAX, SDLoc(Op),
                        Op.getValueType(), Op.getOperand(0), Op.getOperand(1));

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.h
@@ -119,8 +119,8 @@ private:
   SDValue LowerAccessVectorElement(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerShift(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFP_TO_INT_SAT(SDValue Op, SelectionDAG &DAG) const;
-  SDValue LowerFMINIMUMNUM(SDValue Op, SelectionDAG &DAG) const;
-  SDValue LowerFMAXIMUMNUM(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerFMIN(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerFMAX(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerLoad(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerStore(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerMUL_LOHI(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.h
@@ -119,6 +119,8 @@ private:
   SDValue LowerAccessVectorElement(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerShift(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFP_TO_INT_SAT(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerFMINIMUMNUM(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerFMAXIMUMNUM(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerLoad(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerStore(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerMUL_LOHI(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
@@ -1776,8 +1776,8 @@ defm SIMD_RELAXED_FMIN :
 defm SIMD_RELAXED_FMAX :
    RelaxedBinary<F64x2, int_wasm_relaxed_max, "relaxed_max", 0x110>;
 
-def relaxed_fminimumnum : SDNode<"WebAssemblyISD::RELAXED_FMIN", SDTFPBinOp>;
-def relaxed_fmaximumnum : SDNode<"WebAssemblyISD::RELAXED_FMAX", SDTFPBinOp>;
+def relaxed_fmin : SDNode<"WebAssemblyISD::RELAXED_FMIN", SDTFPBinOp>;
+def relaxed_fmax : SDNode<"WebAssemblyISD::RELAXED_FMAX", SDTFPBinOp>;
 
 def relaxed_pmin :
   PatFrag<(ops node:$lhs, node:$rhs), (pmin $lhs, $rhs), [{
@@ -1804,10 +1804,9 @@ let Predicates = [HasRelaxedSIMD] in {
     defvar relaxed_min = !cast<NI>("SIMD_RELAXED_FMIN_"#vec);
     defvar relaxed_max = !cast<NI>("SIMD_RELAXED_FMAX_"#vec);
 
-    // Transform standard fminimum/fmaximum to relaxed versions
-    def : Pat<(vec.vt (relaxed_fminimumnum (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
+    def : Pat<(vec.vt (relaxed_fmin (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
               (relaxed_min V128:$lhs, V128:$rhs)>;
-    def : Pat<(vec.vt (relaxed_fmaximumnum (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
+    def : Pat<(vec.vt (relaxed_fmax (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
               (relaxed_max V128:$lhs, V128:$rhs)>;
 
     // Transform pmin/max-supposed patterns to relaxed min max

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrSIMD.td
@@ -1776,26 +1776,45 @@ defm SIMD_RELAXED_FMIN :
 defm SIMD_RELAXED_FMAX :
    RelaxedBinary<F64x2, int_wasm_relaxed_max, "relaxed_max", 0x110>;
 
+def relaxed_fminimumnum : SDNode<"WebAssemblyISD::RELAXED_FMIN", SDTFPBinOp>;
+def relaxed_fmaximumnum : SDNode<"WebAssemblyISD::RELAXED_FMAX", SDTFPBinOp>;
+
+def relaxed_pmin :
+  PatFrag<(ops node:$lhs, node:$rhs), (pmin $lhs, $rhs), [{
+  return (N->getFlags().hasNoNaNs() ||
+          (CurDAG->isKnownNeverNaN(N->getOperand(0)) &&
+           CurDAG->isKnownNeverNaN(N->getOperand(1)))) &&
+         (N->getFlags().hasNoSignedZeros() ||
+          CurDAG->isKnownNeverZeroFloat(N->getOperand(0)) ||
+          CurDAG->isKnownNeverZeroFloat(N->getOperand(1)));
+}]>;
+
+def relaxed_pmax :
+  PatFrag<(ops node:$lhs, node:$rhs), (pmax $lhs, $rhs), [{
+  return (N->getFlags().hasNoNaNs() ||
+          (CurDAG->isKnownNeverNaN(N->getOperand(0)) &&
+           CurDAG->isKnownNeverNaN(N->getOperand(1)))) &&
+         (N->getFlags().hasNoSignedZeros() ||
+          CurDAG->isKnownNeverZeroFloat(N->getOperand(0)) ||
+          CurDAG->isKnownNeverZeroFloat(N->getOperand(1)));
+}]>;
+
 let Predicates = [HasRelaxedSIMD] in {
   foreach vec = [F32x4, F64x2] in {
     defvar relaxed_min = !cast<NI>("SIMD_RELAXED_FMIN_"#vec);
     defvar relaxed_max = !cast<NI>("SIMD_RELAXED_FMAX_"#vec);
 
     // Transform standard fminimum/fmaximum to relaxed versions
-    def : Pat<(vec.vt (fminnum (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
+    def : Pat<(vec.vt (relaxed_fminimumnum (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
               (relaxed_min V128:$lhs, V128:$rhs)>;
-    def : Pat<(vec.vt (fminimumnum (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
-              (relaxed_min V128:$lhs, V128:$rhs)>;
-    def : Pat<(vec.vt (fmaxnum (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
-              (relaxed_max V128:$lhs, V128:$rhs)>;
-    def : Pat<(vec.vt (fmaximumnum (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
+    def : Pat<(vec.vt (relaxed_fmaximumnum (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
               (relaxed_max V128:$lhs, V128:$rhs)>;
 
     // Transform pmin/max-supposed patterns to relaxed min max
     let AddedComplexity = 1 in {
-      def : Pat<(vec.vt (pmin (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
+      def : Pat<(vec.vt (relaxed_pmin (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
                 (relaxed_min $lhs, $rhs)>;
-      def : Pat<(vec.vt (pmax (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
+      def : Pat<(vec.vt (relaxed_pmax (vec.vt V128:$lhs), (vec.vt V128:$rhs))),
                 (relaxed_max $lhs, $rhs)>;
       defm : PMinMaxInt<vec, relaxed_min, relaxed_max>;
     }

--- a/llvm/test/CodeGen/WebAssembly/simd-relaxed-fmax.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-relaxed-fmax.ll
@@ -11,22 +11,176 @@ define <4 x float> @test_maxnum_f32x4(<4 x float> %a, <4 x float> %b) {
 ; CHECK:         .functype test_maxnum_f32x4 (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    # fallthrough-return
+  %result = call <4 x float> @llvm.maxnum.v4f32(<4 x float> %a, <4 x float> %b)
+  ret <4 x float> %result
+}
+
+define <4 x float> @test_maxnum_f32x4_nnan_nsz(<4 x float> %a, <4 x float> %b) {
+; CHECK-LABEL: test_maxnum_f32x4_nnan_nsz:
+; CHECK:         .functype test_maxnum_f32x4_nnan_nsz (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    f32x4.relaxed_max
 ; CHECK-NEXT:    # fallthrough-return
-  %result = call <4 x float> @llvm.maxnum.v4f32(<4 x float> %a, <4 x float> %b)
+  %result = call nsz nnan <4 x float> @llvm.maxnum.v4f32(<4 x float> %a, <4 x float> %b)
   ret <4 x float> %result
 }
 
 define <4 x float> @test_maximumnum_f32x4(<4 x float> %a, <4 x float> %b) {
 ; CHECK-LABEL: test_maximumnum_f32x4:
 ; CHECK:         .functype test_maximumnum_f32x4 (v128, v128) -> (v128)
+; CHECK-NEXT:    .local f32, f32, f32, f32, f32, f32, f32, f32
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    local.tee 3
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 3
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.tee 4
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.tee 5
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 5
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.tee 6
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.tee 7
+; CHECK-NEXT:    local.get 7
+; CHECK-NEXT:    local.get 7
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 7
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.tee 8
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.tee 9
+; CHECK-NEXT:    local.get 9
+; CHECK-NEXT:    local.get 9
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 9
+; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    local.tee 0
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f32.gt
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 4
+; CHECK-NEXT:    local.get 4
+; CHECK-NEXT:    local.get 4
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f32.gt
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 7
+; CHECK-NEXT:    local.get 7
+; CHECK-NEXT:    local.get 6
+; CHECK-NEXT:    local.get 6
+; CHECK-NEXT:    local.get 6
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 7
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f32.gt
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 9
+; CHECK-NEXT:    local.get 9
+; CHECK-NEXT:    local.get 8
+; CHECK-NEXT:    local.get 8
+; CHECK-NEXT:    local.get 8
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 9
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f32.gt
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    local.tee 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    v128.const 0, 0, 0, 0
+; CHECK-NEXT:    i32x4.eq
+; CHECK-NEXT:    v128.bitselect
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    v128.const 0x0p0, 0x0p0, 0x0p0, 0x0p0
+; CHECK-NEXT:    f32x4.eq
+; CHECK-NEXT:    v128.bitselect
+; CHECK-NEXT:    # fallthrough-return
+  %result = call <4 x float> @llvm.maximumnum.v4f32(<4 x float> %a, <4 x float> %b)
+  ret <4 x float> %result
+}
+
+define <4 x float> @test_maximumnum_f32x4_nsz_nnan(<4 x float> %a, <4 x float> %b) {
+; CHECK-LABEL: test_maximumnum_f32x4_nsz_nnan:
+; CHECK:         .functype test_maximumnum_f32x4_nsz_nnan (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    f32x4.relaxed_max
 ; CHECK-NEXT:    # fallthrough-return
-  %result = call <4 x float> @llvm.maximumnum.v4f32(<4 x float> %a, <4 x float> %b)
+  %result = call nsz nnan <4 x float> @llvm.maximumnum.v4f32(<4 x float> %a, <4 x float> %b)
   ret <4 x float> %result
 }
 
@@ -35,22 +189,115 @@ define <2 x double> @test_maxnum_f64x2(<2 x double> %a, <2 x double> %b) {
 ; CHECK:         .functype test_maxnum_f64x2 (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    call fmax
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    call fmax
+; CHECK-NEXT:    f64x2.replace_lane 1
 ; CHECK-NEXT:    # fallthrough-return
   %result = call <2 x double> @llvm.maxnum.v2f64(<2 x double> %a, <2 x double> %b)
   ret <2 x double> %result
 }
 
-define <2 x double> @test_minimumnum_f64x2(<2 x double> %a, <2 x double> %b) {
-; CHECK-LABEL: test_minimumnum_f64x2:
-; CHECK:         .functype test_minimumnum_f64x2 (v128, v128) -> (v128)
+define <2 x double> @test_maxnum_f64x2_nsz_nnan(<2 x double> %a, <2 x double> %b) {
+; CHECK-LABEL: test_maxnum_f64x2_nsz_nnan:
+; CHECK:         .functype test_maxnum_f64x2_nsz_nnan (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    f64x2.relaxed_max
 ; CHECK-NEXT:    # fallthrough-return
+  %result = call nsz nnan <2 x double> @llvm.maxnum.v2f64(<2 x double> %a, <2 x double> %b)
+  ret <2 x double> %result
+}
+
+
+define <2 x double> @test_maximumnum_f64x2(<2 x double> %a, <2 x double> %b) {
+; CHECK-LABEL: test_maximumnum_f64x2:
+; CHECK:         .functype test_maximumnum_f64x2 (v128, v128) -> (v128)
+; CHECK-NEXT:    .local f64, f64, f64, f64
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    local.tee 3
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    f64.ne
+; CHECK-NEXT:    f64.select
+; CHECK-NEXT:    local.tee 3
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.tee 4
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.tee 5
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    f64.ne
+; CHECK-NEXT:    f64.select
+; CHECK-NEXT:    local.tee 5
+; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    local.tee 0
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f64.ne
+; CHECK-NEXT:    f64.select
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f64.gt
+; CHECK-NEXT:    f64.select
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 4
+; CHECK-NEXT:    local.get 4
+; CHECK-NEXT:    local.get 4
+; CHECK-NEXT:    f64.ne
+; CHECK-NEXT:    f64.select
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f64.gt
+; CHECK-NEXT:    f64.select
+; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    local.tee 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    v128.const 0, 0
+; CHECK-NEXT:    i64x2.eq
+; CHECK-NEXT:    v128.bitselect
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    v128.const 0x0p0, 0x0p0
+; CHECK-NEXT:    f64x2.eq
+; CHECK-NEXT:    v128.bitselect
+; CHECK-NEXT:    # fallthrough-return
   %result = call <2 x double> @llvm.maximumnum.v2f64(<2 x double> %a, <2 x double> %b)
+  ret <2 x double> %result
+}
+
+define <2 x double> @test_maximumnum_f64x2_nsz_nnan(<2 x double> %a, <2 x double> %b) {
+; CHECK-LABEL: test_maximumnum_f64x2_nsz_nnan:
+; CHECK:         .functype test_maximumnum_f64x2_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %result = call nsz nnan <2 x double> @llvm.maximumnum.v2f64(<2 x double> %a, <2 x double> %b)
   ret <2 x double> %result
 }
 
@@ -60,7 +307,7 @@ define <4 x float> @test_pmax_v4f32_olt(<4 x float> %x, <4 x float> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    f32x4.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp olt <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -73,7 +320,7 @@ define <4 x float> @test_pmax_v4f32_ole(<4 x float> %x, <4 x float> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    f32x4.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ole <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -86,7 +333,7 @@ define <4 x float> @test_pmax_v4f32_ogt(<4 x float> %x, <4 x float> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    f32x4.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ogt <4 x float> %y, %x
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -99,7 +346,7 @@ define <4 x float> @test_pmax_v4f32_oge(<4 x float> %x, <4 x float> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    f32x4.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp oge <4 x float> %y, %x
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -112,8 +359,29 @@ define <4 x float> @pmax_v4f32_fast_olt(<4 x float> %x, <4 x float> %y) {
 ; CHECK:         .functype pmax_v4f32_fast_olt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 3
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast olt <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -127,7 +395,7 @@ define <4 x float> @test_pmax_v4f32_fast_ole(<4 x float> %x, <4 x float> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    f32x4.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ole <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -140,8 +408,29 @@ define <4 x float> @test_pmax_v4f32_fast_ogt(<4 x float> %x, <4 x float> %y) {
 ; CHECK:         .functype test_pmax_v4f32_fast_ogt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 3
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ogt <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %x, <4 x float> %y
@@ -155,16 +444,16 @@ define <4 x float> @test_pmax_v4f32_fast_oge(<4 x float> %x, <4 x float> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    f32x4.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast oge <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %x, <4 x float> %y
   ret <4 x float> %a
 }
 
-define <4 x i32> @test_pmax_int_v4f32(<4 x i32> %x, <4 x i32> %y) {
-; CHECK-LABEL: test_pmax_int_v4f32:
-; CHECK:         .functype test_pmax_int_v4f32 (v128, v128) -> (v128)
+define <4 x i32> @test_pmax_int_v4f32_olt(<4 x i32> %x, <4 x i32> %y) {
+; CHECK-LABEL: test_pmax_int_v4f32_olt:
+; CHECK:         .functype test_pmax_int_v4f32_olt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    local.get 0
@@ -183,7 +472,7 @@ define <2 x double> @test_pmax_v2f64_olt(<2 x double> %x, <2 x double> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    f64x2.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp olt <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -196,7 +485,7 @@ define <2 x double> @test_pmax_v2f64_ole(<2 x double> %x, <2 x double> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    f64x2.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ole <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -209,7 +498,7 @@ define <2 x double> @test_pmax_v2f64_ogt(<2 x double> %x, <2 x double> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    f64x2.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ogt <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %x, <2 x double> %y
@@ -221,7 +510,7 @@ define <2 x double> @test_pmax_v2f64_oge(<2 x double> %x, <2 x double> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    f64x2.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp oge <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %x, <2 x double> %y
@@ -234,8 +523,17 @@ define <2 x double> @pmax_v2f64_fast_olt(<2 x double> %x, <2 x double> %y) {
 ; CHECK:         .functype pmax_v2f64_fast_olt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    call fmax
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    call fmax
+; CHECK-NEXT:    f64x2.replace_lane 1
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast olt <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -249,7 +547,7 @@ define <2 x double> @test_pmax_v2f64_fast_ole(<2 x double> %x, <2 x double> %y) 
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    f64x2.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ole <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -261,8 +559,17 @@ define <2 x double> @test_pmax_v2f64_fast_ogt(<2 x double> %x, <2 x double> %y) 
 ; CHECK:         .functype test_pmax_v2f64_fast_ogt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    call fmax
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    call fmax
+; CHECK-NEXT:    f64x2.replace_lane 1
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ogt <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %x, <2 x double> %y
@@ -276,16 +583,16 @@ define <2 x double> @test_pmax_v2f64_fast_oge(<2 x double> %x, <2 x double> %y) 
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    f64x2.pmax
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast oge <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %x, <2 x double> %y
   ret <2 x double> %a
 }
 
-define <2 x i64> @test_pmax_int_v2f64(<2 x i64> %x, <2 x i64> %y) {
-; CHECK-LABEL: test_pmax_int_v2f64:
-; CHECK:         .functype test_pmax_int_v2f64 (v128, v128) -> (v128)
+define <2 x i64> @test_pmax_int_v2f64_olt(<2 x i64> %x, <2 x i64> %y) {
+; CHECK-LABEL: test_pmax_int_v2f64_olt:
+; CHECK:         .functype test_pmax_int_v2f64_olt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    local.get 0
@@ -296,6 +603,643 @@ define <2 x i64> @test_pmax_int_v2f64(<2 x i64> %x, <2 x i64> %y) {
   %c = fcmp olt <2 x double> %fy, %fx
   %a = select <2 x i1> %c, <2 x i64> %x, <2 x i64> %y
   ret <2 x i64> %a
+}
+
+define <4 x float> @test_pmax_v4f32_ult(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_ult:
+; CHECK:         .functype test_pmax_v4f32_ult (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ult <4 x float> %x, %y
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmax_v4f32_ule(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_ule:
+; CHECK:         .functype test_pmax_v4f32_ule (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ule <4 x float> %x, %y
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmax_v4f32_ugt(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_ugt:
+; CHECK:         .functype test_pmax_v4f32_ugt (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ugt <4 x float> %y, %x
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmax_v4f32_uge(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_uge:
+; CHECK:         .functype test_pmax_v4f32_uge (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp uge <4 x float> %y, %x
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setlt
+define <4 x float> @pmax_v4f32_fast_ult(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: pmax_v4f32_fast_ult:
+; CHECK:         .functype pmax_v4f32_fast_ult (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ult <4 x float> %x, %y
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setle
+define <4 x float> @test_pmax_v4f32_fast_ule(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_fast_ule:
+; CHECK:         .functype test_pmax_v4f32_fast_ule (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ule <4 x float> %x, %y
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setgt
+define <4 x float> @test_pmax_v4f32_fast_ugt(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_fast_ugt:
+; CHECK:         .functype test_pmax_v4f32_fast_ugt (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    call fmaxf
+; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ugt <4 x float> %x, %y
+  %a = select <4 x i1> %c, <4 x float> %x, <4 x float> %y
+  ret <4 x float> %a
+}
+
+; For setge
+define <4 x float> @test_pmax_v4f32_fast_uge(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_fast_uge:
+; CHECK:         .functype test_pmax_v4f32_fast_uge (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast uge <4 x float> %x, %y
+  %a = select <4 x i1> %c, <4 x float> %x, <4 x float> %y
+  ret <4 x float> %a
+}
+
+define <4 x i32> @test_pmax_int_v4f32_ult(<4 x i32> %x, <4 x i32> %y) {
+; CHECK-LABEL: test_pmax_int_v4f32_ult:
+; CHECK:         .functype test_pmax_int_v4f32_ult (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.ge
+; CHECK-NEXT:    v128.bitselect
+; CHECK-NEXT:    # fallthrough-return
+  %fx = bitcast <4 x i32> %x to <4 x float>
+  %fy = bitcast <4 x i32> %y to <4 x float>
+  %c = fcmp ult <4 x float> %fy, %fx
+  %a = select <4 x i1> %c, <4 x i32> %x, <4 x i32> %y
+  ret <4 x i32> %a
+}
+
+define <2 x double> @test_pmax_v2f64_ult(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_ult:
+; CHECK:         .functype test_pmax_v2f64_ult (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ult <2 x double> %x, %y
+  %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+define <2 x double> @test_pmax_v2f64_ule(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_ule:
+; CHECK:         .functype test_pmax_v2f64_ule (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ule <2 x double> %x, %y
+  %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+define <2 x double> @test_pmax_v2f64_ugt(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_ugt:
+; CHECK:         .functype test_pmax_v2f64_ugt (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ugt <2 x double> %x, %y
+  %a = select <2 x i1> %c, <2 x double> %x, <2 x double> %y
+  ret <2 x double> %a
+}
+
+define <2 x double> @test_pmax_v2f64_uge(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_uge:
+; CHECK:         .functype test_pmax_v2f64_uge (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp uge <2 x double> %x, %y
+  %a = select <2 x i1> %c, <2 x double> %x, <2 x double> %y
+  ret <2 x double> %a
+}
+
+; For setlt
+define <2 x double> @pmax_v2f64_fast_ult(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: pmax_v2f64_fast_ult:
+; CHECK:         .functype pmax_v2f64_fast_ult (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    call fmax
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    call fmax
+; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ult <2 x double> %x, %y
+  %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+; For setle
+define <2 x double> @test_pmax_v2f64_fast_ule(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_fast_ule:
+; CHECK:         .functype test_pmax_v2f64_fast_ule (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ule <2 x double> %x, %y
+  %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+; For setgt
+define <2 x double> @test_pmax_v2f64_fast_ugt(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_fast_ugt:
+; CHECK:         .functype test_pmax_v2f64_fast_ugt (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    call fmax
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    call fmax
+; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ugt <2 x double> %x, %y
+  %a = select <2 x i1> %c, <2 x double> %x, <2 x double> %y
+  ret <2 x double> %a
+}
+
+; For setge
+define <2 x double> @test_pmax_v2f64_fast_uge(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_fast_uge:
+; CHECK:         .functype test_pmax_v2f64_fast_uge (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.pmax
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast uge <2 x double> %x, %y
+  %a = select <2 x i1> %c, <2 x double> %x, <2 x double> %y
+  ret <2 x double> %a
+}
+
+define <2 x i64> @test_pmax_int_v2f64_ult(<2 x i64> %x, <2 x i64> %y) {
+; CHECK-LABEL: test_pmax_int_v2f64_ult:
+; CHECK:         .functype test_pmax_int_v2f64_ult (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.ge
+; CHECK-NEXT:    v128.bitselect
+; CHECK-NEXT:    # fallthrough-return
+  %fx = bitcast <2 x i64> %x to <2 x double>
+  %fy = bitcast <2 x i64> %y to <2 x double>
+  %c = fcmp ult <2 x double> %fy, %fx
+  %a = select <2 x i1> %c, <2 x i64> %x, <2 x i64> %y
+  ret <2 x i64> %a
+}
+
+define <4 x float> @test_pmax_v4f32_olt_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_olt_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_olt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp olt <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmax_v4f32_ole_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_ole_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_ole_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ole <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmax_v4f32_ogt_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_ogt_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_ogt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ogt <4 x float> %y, %x
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmax_v4f32_oge_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_oge_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_oge_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp oge <4 x float> %y, %x
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setlt
+define <4 x float> @pmax_v4f32_fast_olt_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: pmax_v4f32_fast_olt_nsz_nnan:
+; CHECK:         .functype pmax_v4f32_fast_olt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast olt <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setle
+define <4 x float> @test_pmax_v4f32_fast_ole_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_fast_ole_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_fast_ole_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ole <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setgt
+define <4 x float> @test_pmax_v4f32_fast_ogt_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_fast_ogt_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_fast_ogt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ogt <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %x, <4 x float> %y
+  ret <4 x float> %a
+}
+
+; For setge
+define <4 x float> @test_pmax_v4f32_fast_oge_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_fast_oge_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_fast_oge_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast oge <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %x, <4 x float> %y
+  ret <4 x float> %a
+}
+
+; For setlt
+define <2 x double> @pmax_v2f64_fast_olt_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: pmax_v2f64_fast_olt_nsz_nnan:
+; CHECK:         .functype pmax_v2f64_fast_olt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast olt <2 x double> %x, %y
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+; For setle
+define <2 x double> @test_pmax_v2f64_fast_ole_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_fast_ole_nsz_nnan:
+; CHECK:         .functype test_pmax_v2f64_fast_ole_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ole <2 x double> %x, %y
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+; For setgt
+define <2 x double> @test_pmax_v2f64_fast_ogt_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_fast_ogt_nsz_nnan:
+; CHECK:         .functype test_pmax_v2f64_fast_ogt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ogt <2 x double> %x, %y
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %x, <2 x double> %y
+  ret <2 x double> %a
+}
+
+; For setge
+define <2 x double> @test_pmax_v2f64_fast_oge_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_fast_oge_nsz_nnan:
+; CHECK:         .functype test_pmax_v2f64_fast_oge_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast oge <2 x double> %x, %y
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %x, <2 x double> %y
+  ret <2 x double> %a
+}
+
+define <4 x float> @test_pmax_v4f32_ult_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_ult_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_ult_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ult <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmax_v4f32_ule_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_ule_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_ule_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ule <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmax_v4f32_ugt_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_ugt_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_ugt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ugt <4 x float> %y, %x
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmax_v4f32_uge_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_uge_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_uge_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp uge <4 x float> %y, %x
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setlt
+define <4 x float> @pmax_v4f32_fast_ult_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: pmax_v4f32_fast_ult_nsz_nnan:
+; CHECK:         .functype pmax_v4f32_fast_ult_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ult <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setle
+define <4 x float> @test_pmax_v4f32_fast_ule_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_fast_ule_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_fast_ule_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ule <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setgt
+define <4 x float> @test_pmax_v4f32_fast_ugt_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_fast_ugt_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_fast_ugt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ugt <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %x, <4 x float> %y
+  ret <4 x float> %a
+}
+
+; For setge
+define <4 x float> @test_pmax_v4f32_fast_uge_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmax_v4f32_fast_uge_nsz_nnan:
+; CHECK:         .functype test_pmax_v4f32_fast_uge_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast uge <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %x, <4 x float> %y
+  ret <4 x float> %a
+}
+
+; For setlt
+define <2 x double> @pmax_v2f64_fast_ult_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: pmax_v2f64_fast_ult_nsz_nnan:
+; CHECK:         .functype pmax_v2f64_fast_ult_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ult <2 x double> %x, %y
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+; For setle
+define <2 x double> @test_pmax_v2f64_fast_ule_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_fast_ule_nsz_nnan:
+; CHECK:         .functype test_pmax_v2f64_fast_ule_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ule <2 x double> %x, %y
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+; For setgt
+define <2 x double> @test_pmax_v2f64_fast_ugt_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_fast_ugt_nsz_nnan:
+; CHECK:         .functype test_pmax_v2f64_fast_ugt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ugt <2 x double> %x, %y
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %x, <2 x double> %y
+  ret <2 x double> %a
+}
+
+; For setge
+define <2 x double> @test_pmax_v2f64_fast_uge_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmax_v2f64_fast_uge_nsz_nnan:
+; CHECK:         .functype test_pmax_v2f64_fast_uge_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_max
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast uge <2 x double> %x, %y
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %x, <2 x double> %y
+  ret <2 x double> %a
 }
 
 declare <4 x float> @llvm.maxnum.v4f32(<4 x float>, <4 x float>)

--- a/llvm/test/CodeGen/WebAssembly/simd-relaxed-fmin.ll
+++ b/llvm/test/CodeGen/WebAssembly/simd-relaxed-fmin.ll
@@ -10,22 +10,175 @@ define <4 x float> @test_minnum_f32x4(<4 x float> %a, <4 x float> %b) {
 ; CHECK:         .functype test_minnum_f32x4 (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 3
 ; CHECK-NEXT:    # fallthrough-return
   %result = call <4 x float> @llvm.minnum.v4f32(<4 x float> %a, <4 x float> %b)
   ret <4 x float> %result
 }
 
-define <4 x float> @test_minimumnum_f32x4(<4 x float> %a, <4 x float> %b) {
-; CHECK-LABEL: test_minimumnum_f32x4:
-; CHECK:         .functype test_minimumnum_f32x4 (v128, v128) -> (v128)
+define <4 x float> @test_minnum_f32x4_nsz_nnan(<4 x float> %a, <4 x float> %b) {
+; CHECK-LABEL: test_minnum_f32x4_nsz_nnan:
+; CHECK:         .functype test_minnum_f32x4_nsz_nnan (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    f32x4.relaxed_min
 ; CHECK-NEXT:    # fallthrough-return
+  %result = call nsz nnan <4 x float> @llvm.minnum.v4f32(<4 x float> %a, <4 x float> %b)
+  ret <4 x float> %result
+}
+define <4 x float> @test_minimumnum_f32x4(<4 x float> %a, <4 x float> %b) {
+; CHECK-LABEL: test_minimumnum_f32x4:
+; CHECK:         .functype test_minimumnum_f32x4 (v128, v128) -> (v128)
+; CHECK-NEXT:    .local f32, f32, f32, f32, f32, f32, f32, f32
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    local.tee 3
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 3
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.tee 4
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.tee 5
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 5
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.tee 6
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.tee 7
+; CHECK-NEXT:    local.get 7
+; CHECK-NEXT:    local.get 7
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 7
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.tee 8
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.tee 9
+; CHECK-NEXT:    local.get 9
+; CHECK-NEXT:    local.get 9
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 9
+; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    local.tee 0
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f32.lt
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 4
+; CHECK-NEXT:    local.get 4
+; CHECK-NEXT:    local.get 4
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f32.lt
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 7
+; CHECK-NEXT:    local.get 7
+; CHECK-NEXT:    local.get 6
+; CHECK-NEXT:    local.get 6
+; CHECK-NEXT:    local.get 6
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 7
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f32.lt
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 9
+; CHECK-NEXT:    local.get 9
+; CHECK-NEXT:    local.get 8
+; CHECK-NEXT:    local.get 8
+; CHECK-NEXT:    local.get 8
+; CHECK-NEXT:    f32.ne
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 9
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f32.lt
+; CHECK-NEXT:    f32.select
+; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    local.tee 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    v128.const -2147483648, -2147483648, -2147483648, -2147483648
+; CHECK-NEXT:    i32x4.eq
+; CHECK-NEXT:    v128.bitselect
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    v128.const 0x0p0, 0x0p0, 0x0p0, 0x0p0
+; CHECK-NEXT:    f32x4.eq
+; CHECK-NEXT:    v128.bitselect
+; CHECK-NEXT:    # fallthrough-return
   %result = call <4 x float> @llvm.minimumnum.v4f32(<4 x float> %a, <4 x float> %b)
+  ret <4 x float> %result
+}
+
+define <4 x float> @test_minimumnum_f32x4_nsz_nnan(<4 x float> %a, <4 x float> %b) {
+; CHECK-LABEL: test_minimumnum_f32x4_nsz_nnan:
+; CHECK:         .functype test_minimumnum_f32x4_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %result = call nsz nnan <4 x float> @llvm.minimumnum.v4f32(<4 x float> %a, <4 x float> %b)
   ret <4 x float> %result
 }
 
@@ -34,22 +187,114 @@ define <2 x double> @test_minnum_f64x2(<2 x double> %a, <2 x double> %b) {
 ; CHECK:         .functype test_minnum_f64x2 (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    call fmin
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    call fmin
+; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    # fallthrough-return
+  %result = call <2 x double> @llvm.minnum.v2f64(<2 x double> %a, <2 x double> %b)
+  ret <2 x double> %result
+}
+
+define <2 x double> @test_minnum_f64x2_nsz_nnan(<2 x double> %a, <2 x double> %b) {
+; CHECK-LABEL: test_minnum_f64x2_nsz_nnan:
+; CHECK:         .functype test_minnum_f64x2_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    f64x2.relaxed_min
 ; CHECK-NEXT:    # fallthrough-return
-  %result = call <2 x double> @llvm.minnum.v2f64(<2 x double> %a, <2 x double> %b)
+  %result = call nsz nnan <2 x double> @llvm.minnum.v2f64(<2 x double> %a, <2 x double> %b)
   ret <2 x double> %result
 }
 
 define <2 x double> @test_minimumnum_f64x2(<2 x double> %a, <2 x double> %b) {
 ; CHECK-LABEL: test_minimumnum_f64x2:
 ; CHECK:         .functype test_minimumnum_f64x2 (v128, v128) -> (v128)
+; CHECK-NEXT:    .local f64, f64, f64, f64
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    local.tee 3
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    f64.ne
+; CHECK-NEXT:    f64.select
+; CHECK-NEXT:    local.tee 3
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.tee 4
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.tee 5
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    f64.ne
+; CHECK-NEXT:    f64.select
+; CHECK-NEXT:    local.tee 5
+; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    local.tee 0
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f64.ne
+; CHECK-NEXT:    f64.select
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 3
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f64.lt
+; CHECK-NEXT:    f64.select
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 4
+; CHECK-NEXT:    local.get 4
+; CHECK-NEXT:    local.get 4
+; CHECK-NEXT:    f64.ne
+; CHECK-NEXT:    f64.select
+; CHECK-NEXT:    local.tee 2
+; CHECK-NEXT:    local.get 5
+; CHECK-NEXT:    local.get 2
+; CHECK-NEXT:    f64.lt
+; CHECK-NEXT:    f64.select
+; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    local.tee 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    v128.const -9223372036854775808, -9223372036854775808
+; CHECK-NEXT:    i64x2.eq
+; CHECK-NEXT:    v128.bitselect
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    v128.const 0x0p0, 0x0p0
+; CHECK-NEXT:    f64x2.eq
+; CHECK-NEXT:    v128.bitselect
+; CHECK-NEXT:    # fallthrough-return
+  %result = call <2 x double> @llvm.minimumnum.v2f64(<2 x double> %a, <2 x double> %b)
+  ret <2 x double> %result
+}
+
+define <2 x double> @test_minimumnum_f64x2_nsz_nnan(<2 x double> %a, <2 x double> %b) {
+; CHECK-LABEL: test_minimumnum_f64x2_nsz_nnan:
+; CHECK:         .functype test_minimumnum_f64x2_nsz_nnan (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    f64x2.relaxed_min
 ; CHECK-NEXT:    # fallthrough-return
-  %result = call <2 x double> @llvm.minimumnum.v2f64(<2 x double> %a, <2 x double> %b)
+  %result = call nsz nnan <2 x double> @llvm.minimumnum.v2f64(<2 x double> %a, <2 x double> %b)
   ret <2 x double> %result
 }
 
@@ -59,7 +304,7 @@ define <4 x float> @test_pmin_v4f32_olt(<4 x float> %x, <4 x float> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    f32x4.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp olt <4 x float> %y, %x
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -72,7 +317,7 @@ define <4 x float> @test_pmin_v4f32_ole(<4 x float> %x, <4 x float> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    f32x4.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ole <4 x float> %y, %x
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -85,7 +330,7 @@ define <4 x float> @test_pmin_v4f32_ogt(<4 x float> %x, <4 x float> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    f32x4.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ogt <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -98,7 +343,7 @@ define <4 x float> @test_pmin_v4f32_oge(<4 x float> %x, <4 x float> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    f32x4.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp oge <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -111,8 +356,29 @@ define <4 x float> @pmin_v4f32_fast_olt(<4 x float> %x, <4 x float> %y) {
 ; CHECK:         .functype pmin_v4f32_fast_olt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 3
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast olt <4 x float> %y, %x
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -126,7 +392,7 @@ define <4 x float> @test_pmin_v4f32_fast_ole(<4 x float> %x, <4 x float> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    f32x4.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ole <4 x float> %y, %x
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -139,8 +405,29 @@ define <4 x float> @test_pmin_v4f32_fast_ogt(<4 x float> %x, <4 x float> %y) {
 ; CHECK:         .functype test_pmin_v4f32_fast_ogt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 3
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ogt <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -154,7 +441,7 @@ define <4 x float> @test_pmin_v4f32_fast_oge(<4 x float> %x, <4 x float> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    f32x4.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast oge <4 x float> %x, %y
   %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
@@ -182,7 +469,7 @@ define <2 x double> @test_pmin_v2f64_olt(<2 x double> %x, <2 x double> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    f64x2.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp olt <2 x double> %y, %x
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -195,7 +482,7 @@ define <2 x double> @test_pmin_v2f64_ole(<2 x double> %x, <2 x double> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    f64x2.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ole <2 x double> %y, %x
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -208,7 +495,7 @@ define <2 x double> @test_pmin_v2f64_ogt(<2 x double> %x, <2 x double> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    f64x2.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp ogt <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -221,7 +508,7 @@ define <2 x double> @test_pmin_v2f64_oge(<2 x double> %x, <2 x double> %y) {
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    f64x2.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp oge <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -234,8 +521,17 @@ define <2 x double> @pmin_v2f64_fast_olt(<2 x double> %x, <2 x double> %y) {
 ; CHECK:         .functype pmin_v2f64_fast_olt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    call fmin
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    call fmin
+; CHECK-NEXT:    f64x2.replace_lane 1
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast olt <2 x double> %y, %x
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -249,7 +545,7 @@ define <2 x double> @test_pmin_v2f64_fast_ole(<2 x double> %x, <2 x double> %y) 
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 1
 ; CHECK-NEXT:    local.get 0
-; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    f64x2.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ole <2 x double> %y, %x
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -262,8 +558,17 @@ define <2 x double> @test_pmin_v2f64_fast_ogt(<2 x double> %x, <2 x double> %y) 
 ; CHECK:         .functype test_pmin_v2f64_fast_ogt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    call fmin
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    call fmin
+; CHECK-NEXT:    f64x2.replace_lane 1
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast ogt <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
@@ -277,16 +582,16 @@ define <2 x double> @test_pmin_v2f64_fast_oge(<2 x double> %x, <2 x double> %y) 
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
-; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    f64x2.pmin
 ; CHECK-NEXT:    # fallthrough-return
   %c = fcmp fast oge <2 x double> %x, %y
   %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
   ret <2 x double> %a
 }
 
-define <2 x i64> @test_pmin_int_v2f64(<2 x i64> %x, <2 x i64> %y) {
-; CHECK-LABEL: test_pmin_int_v2f64:
-; CHECK:         .functype test_pmin_int_v2f64 (v128, v128) -> (v128)
+define <2 x i64> @test_pmin_int_v2f64_olt(<2 x i64> %x, <2 x i64> %y) {
+; CHECK-LABEL: test_pmin_int_v2f64_olt:
+; CHECK:         .functype test_pmin_int_v2f64_olt (v128, v128) -> (v128)
 ; CHECK-NEXT:  # %bb.0:
 ; CHECK-NEXT:    local.get 0
 ; CHECK-NEXT:    local.get 1
@@ -297,6 +602,534 @@ define <2 x i64> @test_pmin_int_v2f64(<2 x i64> %x, <2 x i64> %y) {
   %c = fcmp olt <2 x double> %fy, %fx
   %a = select <2 x i1> %c, <2 x i64> %y, <2 x i64> %x
   ret <2 x i64> %a
+}
+
+define <4 x float> @test_pmin_v4f32_ult(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_ult:
+; CHECK:         .functype test_pmin_v4f32_ult (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ult <4 x float> %y, %x
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmin_v4f32_ule(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_ule:
+; CHECK:         .functype test_pmin_v4f32_ule (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ule <4 x float> %y, %x
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmin_v4f32_ugt(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_ugt:
+; CHECK:         .functype test_pmin_v4f32_ugt (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ugt <4 x float> %x, %y
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmin_v4f32_uge(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_uge:
+; CHECK:         .functype test_pmin_v4f32_uge (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp uge <4 x float> %x, %y
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setlt
+define <4 x float> @pmin_v4f32_fast_ult(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: pmin_v4f32_fast_ult:
+; CHECK:         .functype pmin_v4f32_fast_ult (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ult <4 x float> %y, %x
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setle
+define <4 x float> @test_pmin_v4f32_fast_ule(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_fast_ule:
+; CHECK:         .functype test_pmin_v4f32_fast_ule (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ule <4 x float> %y, %x
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setgt
+define <4 x float> @test_pmin_v4f32_fast_ugt(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_fast_ugt:
+; CHECK:         .functype test_pmin_v4f32_fast_ugt (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 0
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 1
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 2
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 2
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.extract_lane 3
+; CHECK-NEXT:    call fminf
+; CHECK-NEXT:    f32x4.replace_lane 3
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ugt <4 x float> %x, %y
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setge
+define <4 x float> @test_pmin_v4f32_fast_uge(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_fast_uge:
+; CHECK:         .functype test_pmin_v4f32_fast_uge (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast uge <4 x float> %x, %y
+  %a = select <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x i32> @test_pmin_int_v4f32_ult(<4 x i32> %x, <4 x i32> %y) {
+; CHECK-LABEL: test_pmin_int_v4f32_ult:
+; CHECK:         .functype test_pmin_int_v4f32_ult (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.ge
+; CHECK-NEXT:    v128.bitselect
+; CHECK-NEXT:    # fallthrough-return
+  %fx = bitcast <4 x i32> %x to <4 x float>
+  %fy = bitcast <4 x i32> %y to <4 x float>
+  %c = fcmp ult <4 x float> %fy, %fx
+  %a = select <4 x i1> %c, <4 x i32> %y, <4 x i32> %x
+  ret <4 x i32> %a
+}
+
+define <2 x double> @test_pmin_v2f64_ult(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_ult:
+; CHECK:         .functype test_pmin_v2f64_ult (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ult <2 x double> %y, %x
+  %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+define <2 x double> @test_pmin_v2f64_ule(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_ule:
+; CHECK:         .functype test_pmin_v2f64_ule (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ule <2 x double> %y, %x
+  %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+define <2 x double> @test_pmin_v2f64_ugt(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_ugt:
+; CHECK:         .functype test_pmin_v2f64_ugt (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ugt <2 x double> %x, %y
+  %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+define <2 x double> @test_pmin_v2f64_uge(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_uge:
+; CHECK:         .functype test_pmin_v2f64_uge (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp uge <2 x double> %x, %y
+  %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+; For setlt
+define <2 x double> @pmin_v2f64_fast_ult(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: pmin_v2f64_fast_ult:
+; CHECK:         .functype pmin_v2f64_fast_ult (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    call fmin
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    call fmin
+; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ult <2 x double> %y, %x
+  %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+; For setle
+define <2 x double> @test_pmin_v2f64_fast_ule(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_fast_ule:
+; CHECK:         .functype test_pmin_v2f64_fast_ule (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ule <2 x double> %y, %x
+  %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+; For setgt
+define <2 x double> @test_pmin_v2f64_fast_ugt(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_fast_ugt:
+; CHECK:         .functype test_pmin_v2f64_fast_ugt (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 0
+; CHECK-NEXT:    call fmin
+; CHECK-NEXT:    f64x2.splat
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.extract_lane 1
+; CHECK-NEXT:    call fmin
+; CHECK-NEXT:    f64x2.replace_lane 1
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ugt <2 x double> %x, %y
+  %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+; For setge
+define <2 x double> @test_pmin_v2f64_fast_uge(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_fast_uge:
+; CHECK:         .functype test_pmin_v2f64_fast_uge (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.pmin
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast uge <2 x double> %x, %y
+  %a = select <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+define <2 x i64> @test_pmin_int_v2f64(<2 x i64> %x, <2 x i64> %y) {
+; CHECK-LABEL: test_pmin_int_v2f64:
+; CHECK:         .functype test_pmin_int_v2f64 (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.ge
+; CHECK-NEXT:    v128.bitselect
+; CHECK-NEXT:    # fallthrough-return
+  %fx = bitcast <2 x i64> %x to <2 x double>
+  %fy = bitcast <2 x i64> %y to <2 x double>
+  %c = fcmp ult <2 x double> %fy, %fx
+  %a = select <2 x i1> %c, <2 x i64> %y, <2 x i64> %x
+  ret <2 x i64> %a
+}
+
+define <4 x float> @test_pmin_v4f32_ult_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_ult_nsz_nnan:
+; CHECK:         .functype test_pmin_v4f32_ult_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ult <4 x float> %y, %x
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmin_v4f32_ule_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_ule_nsz_nnan:
+; CHECK:         .functype test_pmin_v4f32_ule_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ule <4 x float> %y, %x
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmin_v4f32_ugt_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_ugt_nsz_nnan:
+; CHECK:         .functype test_pmin_v4f32_ugt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ugt <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <4 x float> @test_pmin_v4f32_uge_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_uge_nsz_nnan:
+; CHECK:         .functype test_pmin_v4f32_uge_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp uge <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setlt
+define <4 x float> @pmin_v4f32_fast_ult_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: pmin_v4f32_fast_ult_nsz_nnan:
+; CHECK:         .functype pmin_v4f32_fast_ult_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ult <4 x float> %y, %x
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setle
+define <4 x float> @test_pmin_v4f32_fast_ule_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_fast_ule_nsz_nnan:
+; CHECK:         .functype test_pmin_v4f32_fast_ule_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ule <4 x float> %y, %x
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setgt
+define <4 x float> @test_pmin_v4f32_fast_ugt_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_fast_ugt_nsz_nnan:
+; CHECK:         .functype test_pmin_v4f32_fast_ugt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ugt <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+; For setge
+define <4 x float> @test_pmin_v4f32_fast_uge_nsz_nnan(<4 x float> %x, <4 x float> %y) {
+; CHECK-LABEL: test_pmin_v4f32_fast_uge_nsz_nnan:
+; CHECK:         .functype test_pmin_v4f32_fast_uge_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f32x4.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast uge <4 x float> %x, %y
+  %a = select nsz nnan <4 x i1> %c, <4 x float> %y, <4 x float> %x
+  ret <4 x float> %a
+}
+
+define <2 x double> @test_pmin_v2f64_ult_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_ult_nsz_nnan:
+; CHECK:         .functype test_pmin_v2f64_ult_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ult <2 x double> %y, %x
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+define <2 x double> @test_pmin_v2f64_ule_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_ule_nsz_nnan:
+; CHECK:         .functype test_pmin_v2f64_ule_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ule <2 x double> %y, %x
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+define <2 x double> @test_pmin_v2f64_ugt_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_ugt_nsz_nnan:
+; CHECK:         .functype test_pmin_v2f64_ugt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp ugt <2 x double> %x, %y
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+define <2 x double> @test_pmin_v2f64_uge_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_uge_nsz_nnan:
+; CHECK:         .functype test_pmin_v2f64_uge_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp uge <2 x double> %x, %y
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+; For setlt
+define <2 x double> @pmin_v2f64_fast_ult_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: pmin_v2f64_fast_ult_nsz_nnan:
+; CHECK:         .functype pmin_v2f64_fast_ult_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ult <2 x double> %y, %x
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+; For setle
+define <2 x double> @test_pmin_v2f64_fast_ule_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_fast_ule_nsz_nnan:
+; CHECK:         .functype test_pmin_v2f64_fast_ule_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ule <2 x double> %y, %x
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+; For setgt
+define <2 x double> @test_pmin_v2f64_fast_ugt_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_fast_ugt_nsz_nnan:
+; CHECK:         .functype test_pmin_v2f64_fast_ugt_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast ugt <2 x double> %x, %y
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
+}
+
+; For setge
+define <2 x double> @test_pmin_v2f64_fast_uge_nsz_nnan(<2 x double> %x, <2 x double> %y) {
+; CHECK-LABEL: test_pmin_v2f64_fast_uge_nsz_nnan:
+; CHECK:         .functype test_pmin_v2f64_fast_uge_nsz_nnan (v128, v128) -> (v128)
+; CHECK-NEXT:  # %bb.0:
+; CHECK-NEXT:    local.get 0
+; CHECK-NEXT:    local.get 1
+; CHECK-NEXT:    f64x2.relaxed_min
+; CHECK-NEXT:    # fallthrough-return
+  %c = fcmp fast uge <2 x double> %x, %y
+  %a = select nsz nnan <2 x i1> %c, <2 x double> %y, <2 x double> %x
+  ret <2 x double> %a
 }
 
 declare <4 x float> @llvm.minnum.v4f32(<4 x float>, <4 x float>)


### PR DESCRIPTION
Custom lower FMINNUM, FMINIMUMNUM, FMAXNUM and FMAXIMUMNUM to generate relaxed_min and relaxed_max when the inputs cannot be NaN or signed zero.

Tablegen patterns have also been modified to check the above conditions when trying to match relaxed min/max using the pmin/pmax pattern.

This is my suggested alternative to #177814.