### PR TITLE
[AMDGPU][SILoadStoreOptimizer] Fix unused variable warning

### DIFF
--- a/llvm/lib/Target/AMDGPU/SILoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/AMDGPU/SILoadStoreOptimizer.cpp
@@ -2282,8 +2282,6 @@ bool SILoadStoreOptimizer::processBaseWithConstOffset64(
   }
 
   // Now extract the base register (which should be a 64-bit VGPR).
-  assert(MRI->getVRegDef(BaseOp->getReg()) &&
-         "Expected definition for base register");
   Addr.Base.LoReg = BaseOp->getReg();
   Addr.Base.UseV64Pattern = true;
   return true;

--- a/llvm/lib/Target/AMDGPU/SILoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/AMDGPU/SILoadStoreOptimizer.cpp
@@ -2282,8 +2282,8 @@ bool SILoadStoreOptimizer::processBaseWithConstOffset64(
   }
 
   // Now extract the base register (which should be a 64-bit VGPR).
-  MachineInstr *BaseDef = MRI->getVRegDef(BaseOp->getReg());
-  assert(BaseDef && "Expected definition for base register");
+  assert(MRI->getVRegDef(BaseOp->getReg()) &&
+         "Expected definition for base register");
   Addr.Base.LoReg = BaseOp->getReg();
   Addr.Base.UseV64Pattern = true;
   return true;


### PR DESCRIPTION
Fix unused variable warning that fires in SILoadStoreOptimizer.cpp when assertions are disabled.  On review, we can just delete the whole assert, since it isn't querying the def anymore.  Fixes #176816 (13b20e7aeab83e82368be9ffd22ce02cb9b831ae).