### PR TITLE
[lldb] Fix Python stderr redirection in test

### DIFF
--- a/lldb/test/API/python_api/file_handle/TestFileHandle.py
+++ b/lldb/test/API/python_api/file_handle/TestFileHandle.py
@@ -684,7 +684,13 @@ class FileHandleTestCase(lldbtest.TestBase):
         """Ensure when we read stdin from a file, outputs from python goes to the right I/O stream."""
         with open(self.in_filename, "w") as f:
             f.write(
-                "script --language python --\nvalue = 250 + 5\nprint(value)\nprint(vel)"
+                """script --language python --
+import sys
+variable = 250 + 5
+print(variable)
+print("wrote to", "stderr", file=sys.stderr)
+quit
+"""
             )
 
         with open(self.out_filename, "w") as outf, open(
@@ -712,7 +718,7 @@ class FileHandleTestCase(lldbtest.TestBase):
             )
             self.dbg.GetOutputFile().Flush()
         expected_out_text = "255"
-        expected_err_text = "NameError"
+        expected_err_text = "wrote to stderr"
         # check stdout
         with open(self.out_filename, "r") as f:
             out_text = f.read()

--- a/lldb/test/Shell/ScriptInterpreter/Python/io.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/io.test
@@ -5,10 +5,11 @@
 # RUN: cat %t.stdout | FileCheck %s --check-prefix STDOUT
 # RUN: cat %t.stderr | FileCheck %s --check-prefix STDERR
 script
-variable = 300
+import sys
+variable = 250 + 5
 print(variable)
-print(not_value)
+print("wrote to", "stderr", file=sys.stderr)
 quit
 
-# STDOUT: 300
-# STDERR: NameError{{.*}}is not defined
+# STDOUT: 255
+# STDERR: wrote to stderr


### PR DESCRIPTION
Python's internal stderr may differ from sys.stderr. 
When Python writes errors, it uses its internal stderr rather than the overwritten sys.stderr.
This may not be the same file/handle

Fix the test to explicitly write to the specified stderr.