### PR TITLE
[llvm][.gitignore] macOS case-sensitive update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,7 @@
 # vim swap files
 .*.sw?
 .sw?
-#OS X specific files.
-.DS_store
-#macOS case-sensitive version of above
+#macOS specific
 .DS_Store
 
 # Ignore the user specified CMake presets in subproject directories.

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@
 .sw?
 #OS X specific files.
 .DS_store
+#macOS case-sensitive version of above
+.DS_Store
 
 # Ignore the user specified CMake presets in subproject directories.
 /*/CMakeUserPresets.json


### PR DESCRIPTION
If you run macOS on a case-sensitive file system,
.DS_store and .DS_Store are different files and the existing lowercase-s version doesn't match. Fix that.