### PR TITLE
[lldb-dap] Fix assertion on the recv thread.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -429,7 +429,7 @@ class DebugCommunication(object):
             otherwise None.
         """
         assert (
-            threading.current_thread != self._recv_thread
+            threading.current_thread() != self._recv_thread
         ), "Must not be called from the _recv_thread"
 
         def process_until_match():


### PR DESCRIPTION
threading.current_thread is a function