### PR TITLE
[SystemZ][asan] Improve error handling for pragma export as a statement

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1336,8 +1336,6 @@ def warn_pragma_init_seg_unsupported_target : Warning<
 def err_pragma_file_or_compound_scope : Error<
   "'#pragma %0' can only appear at file scope or at the start of a "
   "compound statement">;
-def err_pragma_file_scope : Error<
-  "'#pragma %0' can only appear at file scope">;
 // - #pragma stdc unknown
 def ext_stdc_pragma_ignored : ExtWarn<"unknown pragma in STDC namespace">,
    InGroup<UnknownPragmas>;

--- a/clang/lib/Parse/ParsePragma.cpp
+++ b/clang/lib/Parse/ParsePragma.cpp
@@ -1409,10 +1409,11 @@ void Parser::zOSHandlePragmaHelper(tok::TokenKind PragmaKind) {
   StringRef PragmaName = "export";
 
   using namespace clang::charinfo;
-  auto *TheTokens =
-      (std::pair<std::unique_ptr<Token[]>, size_t> *)Tok.getAnnotationValue();
+  auto *TheTokens = static_cast<std::pair<std::unique_ptr<Token[]>, size_t> *>(
+      Tok.getAnnotationValue());
   PP.EnterTokenStream(std::move(TheTokens->first), TheTokens->second, true,
                       /*IsReinject=*/true);
+  Tok.setAnnotationValue(nullptr);
   ConsumeAnnotationToken();
 
   llvm::scope_exit OnReturn([this]() {

--- a/clang/lib/Parse/ParsePragma.cpp
+++ b/clang/lib/Parse/ParsePragma.cpp
@@ -1412,7 +1412,7 @@ void Parser::zOSHandlePragmaHelper(tok::TokenKind PragmaKind) {
   auto *TheTokens =
       (std::pair<std::unique_ptr<Token[]>, size_t> *)Tok.getAnnotationValue();
   PP.EnterTokenStream(std::move(TheTokens->first), TheTokens->second, true,
-                      false);
+                      /*IsReinject=*/true);
   ConsumeAnnotationToken();
 
   llvm::scope_exit OnReturn([this]() {

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -506,8 +506,7 @@ Retry:
   case tok::annot_pragma_export:
     ProhibitAttributes(CXX11Attrs);
     ProhibitAttributes(GNUAttrs);
-    Diag(Tok, diag::err_pragma_file_scope) << "export";
-    ConsumeAnnotationToken();
+    HandlePragmaExport();
     return StmtEmpty();
   }
 
@@ -1039,8 +1038,7 @@ void Parser::ParseCompoundStatementLeadingPragmas() {
       HandlePragmaDump();
       break;
     case tok::annot_pragma_export:
-      Diag(Tok, diag::err_pragma_file_scope) << "export";
-      ConsumeAnnotationToken();
+      HandlePragmaExport();
       break;
     default:
       checkForPragmas = false;

--- a/clang/lib/Sema/SemaAttr.cpp
+++ b/clang/lib/Sema/SemaAttr.cpp
@@ -1346,6 +1346,11 @@ NamedDecl *Sema::lookupExternCFunctionOrVariable(IdentifierInfo *IdentId,
 
 void Sema::ActOnPragmaExport(IdentifierInfo *IdentId, SourceLocation NameLoc,
                              Scope *curScope) {
+  if (!CurContext->getRedeclContext()->isFileContext()) {
+    Diag(NameLoc, diag::err_pragma_expected_file_scope) << "export";
+    return;
+  }
+
   PendingPragmaInfo Info;
   Info.NameLoc = NameLoc;
   Info.Used = false;


### PR DESCRIPTION
The changes in https://github.com/llvm/llvm-project/pull/141671 had a failure in some asan bots.  The code for parsing pragma export is the same as for the MS pragmas.  I did noticed that the MS pragma handling code says the tokens are reinjected when calling EnterTokenStream().  Do the same for pragma export.

The tokens on the MS pragma  and pragma export are handled by:
1. PragmaMSPragma::HandlePragma
   - collect the tokens into an array
   - an annotated token is created with the pragma token & array of tokens
   - calls EnterToken() adds the annotated token
2. Parser::HandlePragmaMSPragma()
    - takes the array of tokens off the annotated token can adds them to the stream using EnterTokenStream()
    - this call says the tokens are reinjected.