### PR TITLE
[mlir][Linalg] implement bufferization for `linalg.pack`

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -205,11 +205,10 @@ struct PackOpInterface
                           const BufferizationOptions &options,
                           BufferizationState &state) const {
     auto packOp = cast<linalg::PackOp>(op);
-    if (packOp.hasPureBufferSemantics())
-      return success();
+    assert(!packOp.hasPureBufferSemantics() && "expected op with tensors");
     if (!packOp.hasPureTensorSemantics())
-      return packOp.emitError() << "op does not have pure tensor semantics";
-
+      return packOp.emitError()
+             << "mixed tensor/buffer semantic op not supported yet";
     FailureOr<Value> sourceBuffer =
         getBuffer(rewriter, packOp.getSource(), options, state);
     if (failed(sourceBuffer))

--- a/mlir/lib/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -191,6 +191,47 @@ struct SoftmaxOpInterface
     return success();
   }
 };
+
+struct PackOpInterface
+    : public DstBufferizableOpInterfaceExternalModel<PackOpInterface,
+                                                     linalg::PackOp> {
+  bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                              const AnalysisState &state) const {
+    auto packOp = cast<linalg::PackOp>(op);
+    return !packOp.isDpsInit(&opOperand);
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options,
+                          BufferizationState &state) const {
+    auto packOp = cast<linalg::PackOp>(op);
+    if (packOp.hasPureBufferSemantics())
+      return success();
+    if (!packOp.hasPureTensorSemantics())
+      return packOp.emitError() << "op does not have pure tensor semantics";
+
+    FailureOr<Value> sourceBuffer =
+        getBuffer(rewriter, packOp.getSource(), options, state);
+    if (failed(sourceBuffer))
+      return failure();
+    FailureOr<Value> destBuffer =
+        getBuffer(rewriter, packOp.getDest(), options, state);
+    if (failed(destBuffer))
+      return failure();
+
+    SmallVector<Value> operands;
+    operands.push_back(*sourceBuffer);
+    operands.push_back(*destBuffer);
+    if (auto val = packOp.getPaddingValue())
+      operands.push_back(val);
+    llvm::append_range(operands, packOp.getInnerTiles());
+
+    linalg::PackOp::create(rewriter, packOp.getLoc(), TypeRange{}, operands,
+                           op->getAttrs());
+    replaceOpWithBufferizedValues(rewriter, op, *destBuffer);
+    return success();
+  }
+};
 } // namespace
 
 void mlir::linalg::registerBufferizableOpInterfaceExternalModels(
@@ -206,5 +247,6 @@ void mlir::linalg::registerBufferizableOpInterfaceExternalModels(
         >::registerOpInterface(ctx);
 
     SoftmaxOp::attachInterface<SoftmaxOpInterface>(*ctx);
+    PackOp::attachInterface<PackOpInterface>(*ctx);
   });
 }


### PR DESCRIPTION
Add a BufferizableOpInterface implementation for linalg.pack now that pack supports memref semantics https://github.com/llvm/llvm-project/commit/4b066c7fff3455dc547fabb676583391febe41e9. This completes the op’s bufferization path and avoids copy-before-write for destination operands.