### PR TITLE
[flang] Disallow implied-DO indices in initial data target subscripts

### DIFF
--- a/flang/lib/Evaluate/check-expression.cpp
+++ b/flang/lib/Evaluate/check-expression.cpp
@@ -299,8 +299,10 @@ public:
     return common::visit(common::visitors{
                              [&](const Triplet &t) { return (*this)(t); },
                              [&](const auto &y) {
-                               return y.value().Rank() == 0 &&
-                                   IsConstantExpr(y.value());
+                               const auto &v = y.value();
+                               return v.Rank() == 0 &&
+                                   !ContainsAnyImpliedDoIndex(v) &&
+                                   IsConstantExpr(v);
                              },
                          },
         x.u);

--- a/flang/test/Semantics/bug79850.f90
+++ b/flang/test/Semantics/bug79850.f90
@@ -1,0 +1,19 @@
+! RUN: %flang_fc1 -emit-fir -o /dev/null %s 2>&1 | FileCheck %s --allow-empty
+! CHECK-NOT: error
+! CHECK-NOT: ac-do-variable has no binding
+!
+! Regression test for https://github.com/llvm/llvm-project/issues/79850
+! Ensure flang does not crash when compiling code that uses pointer components
+! in structure constructors.
+
+program p
+  type child
+    integer, pointer :: id
+  end type
+
+  integer, target :: t1(10)
+  type(child) :: t2(10)
+
+  t1 = 0
+  t2 = (/ ( child(t1(i)), i=1,10 ) /)
+end program


### PR DESCRIPTION
Since implied-DO indices are dynamic and depend on runtime iteration variables, it should not be considered for initial data targets. Only constant, scalar subscripts without implied-DO indices should be considered.

Fixes: #79850 