### PR TITLE
[AArch64][llvm] Gate some `tlbip` insns with +tlbid or +d128

### DIFF
--- a/clang/test/Driver/print-supported-extensions-aarch64.c
+++ b/clang/test/Driver/print-supported-extensions-aarch64.c
@@ -16,7 +16,7 @@
 // CHECK-NEXT:     crc                 FEAT_CRC32                                             Enable Armv8.0-A CRC-32 checksum instructions
 // CHECK-NEXT:     crypto              FEAT_Crypto                                            Enable cryptographic instructions
 // CHECK-NEXT:     cssc                FEAT_CSSC                                              Enable Common Short Sequence Compression (CSSC) instructions
-// CHECK-NEXT:     d128                FEAT_D128, FEAT_LVA3, FEAT_SYSREG128, FEAT_SYSINSTR128 Enable Armv9.4-A 128-bit Page Table Descriptors, System Registers and instructions
+// CHECK-NEXT:     d128                FEAT_D128, FEAT_LVA3, FEAT_SYSREG128                   Enable Armv9.4-A 128-bit Page Table Descriptors, System Registers and instructions
 // CHECK-NEXT:     dit                 FEAT_DIT                                               Enable Armv8.4-A Data Independent Timing instructions
 // CHECK-NEXT:     dotprod             FEAT_DotProd                                           Enable dot product support
 // CHECK-NEXT:     f16f32dot           FEAT_F16F32DOT                                         Enable Armv9.7-A Advanced SIMD half-precision dot product accumulate to single-precision
@@ -115,6 +115,7 @@
 // CHECK-NEXT:     sve2p1              FEAT_SVE2p1                                            Enable Scalable Vector Extension 2.1 instructions
 // CHECK-NEXT:     sve2p2              FEAT_SVE2p2                                            Enable Armv9.6-A Scalable Vector Extension 2.2 instructions
 // CHECK-NEXT:     sve2p3              FEAT_SVE2p3                                            Enable Armv9.7-A Scalable Vector Extension 2.3 instructions
+// CHECK-NEXT:     sys128              FEAT_SYSINSTR128                                       Enable Armv9.4-A 128bit system instruction aliases
 // CHECK-NEXT:     tev                 FEAT_TEV                                               Enable TIndex Exception-like Vector instructions
 // CHECK-NEXT:     the                 FEAT_THE                                               Enable Armv8.9-A Translation Hardening Extension
 // CHECK-NEXT:     tlbid               FEAT_TLBID                                             Enable Armv9.7-A TLBI Domains extension

--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -459,17 +459,20 @@ def FeatureGCS : ExtensionWithMArch<"gcs", "GCS", "FEAT_GCS",
 def FeatureITE : ExtensionWithMArch<"ite", "ITE", "FEAT_ITE",
   "Enable Armv9.4-A Instrumentation Extension", [FeatureETE, FeatureTRBE]>;
 
+def FeatureSYS128 : ExtensionWithMArch<"sys128", "SYS128", "FEAT_SYSINSTR128",
+  "Enable Armv9.4-A 128bit system instruction aliases">;
+
 def FeatureLSE128 : ExtensionWithMArch<"lse128", "LSE128", "FEAT_LSE128",
   "Enable Armv9.4-A 128-bit Atomic instructions",
   [FeatureLSE]>;
 
-// FEAT_D128, FEAT_LVA3, FEAT_SYSREG128, and FEAT_SYSINSTR128 are mutually implicit.
+// FEAT_D128, FEAT_LVA3 and FEAT_SYSREG128 are mutually implicit.
 // Therefore group them all under a single feature flag, d128:
 def FeatureD128 : ExtensionWithMArch<"d128", "D128",
-  "FEAT_D128, FEAT_LVA3, FEAT_SYSREG128, FEAT_SYSINSTR128",
+  "FEAT_D128, FEAT_LVA3, FEAT_SYSREG128",
   "Enable Armv9.4-A 128-bit Page Table Descriptors, System Registers "
   "and instructions",
-  [FeatureLSE128]>;
+  [FeatureLSE128, FeatureSYS128]>;
 
 //===----------------------------------------------------------------------===//
 //  Armv9.5 Architecture Extensions
@@ -593,7 +596,7 @@ def FeatureLSCP : ExtensionWithMArch<"lscp", "LSCP", "FEAT_LSCP",
   "Enable Armv9.7-A Load-acquire and store-release pair extension">;
 
 def FeatureTLBID: ExtensionWithMArch<"tlbid", "TLBID", "FEAT_TLBID",
-  "Enable Armv9.7-A TLBI Domains extension">;
+  "Enable Armv9.7-A TLBI Domains extension", [FeatureSYS128]>;
 
 def FeatureMPAMv2: ExtensionWithMArch<"mpamv2", "MPAMv2", "FEAT_MPAMv2",
   "Enable Armv9.7-A MPAMv2 Lookaside Buffer Invalidate instructions">;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -391,6 +391,8 @@ def HasLSE128        : Predicate<"Subtarget->hasLSE128()">,
                                  AssemblerPredicateWithAll<(all_of FeatureLSE128), "lse128">;
 def HasD128          : Predicate<"Subtarget->hasD128()">,
                                  AssemblerPredicateWithAll<(all_of FeatureD128), "d128">;
+def HasSYS128        : Predicate<"Subtarget->hasSYS128()">,
+                                 AssemblerPredicateWithAll<(all_of FeatureSYS128), "sys128">;
 def HasCHK           : Predicate<"Subtarget->hasCHK()">,
                                  AssemblerPredicateWithAll<(all_of FeatureCHK), "chk">;
 def HasGCS           : Predicate<"Subtarget->hasGCS()">,
@@ -11264,7 +11266,7 @@ let Predicates = [HasRCPC3, HasNEON] in {
 //===----------------------------------------------------------------------===//
 // 128-bit System Instructions (FEAT_SYSINSTR128)
 //===----------------------------------------------------------------------===//
-let Predicates = [HasD128] in {
+let Predicates = [HasSYS128] in {
   def SYSPxt  : SystemPXtI<0, "sysp">;
 
   def SYSPxt_XZR

--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -897,16 +897,27 @@ defm TLBIP : TLBITableBase;
 
 multiclass TLBI<string name, bit hasTLBIP, bits<3> op1, bits<4> crn, bits<4> crm,
              bits<3> op2, bit needsreg = 1, bit optionalreg = 0> {
+  defvar HasE1IS = !ne(!find(name, "E1IS"), -1);
+  defvar HasE1OS = !ne(!find(name, "E1OS"), -1);
+  defvar HasE2IS = !ne(!find(name, "E2IS"), -1);
+  defvar HasE2OS = !ne(!find(name, "E2OS"), -1);
+  defvar allowTLBID = !or(!or(HasE1IS, HasE1OS), !or(HasE2IS, HasE2OS));
+  defvar TLBIPRequires = !if(allowTLBID,
+                             ["AArch64::FeatureD128", "AArch64::FeatureTLBID"],
+                             ["AArch64::FeatureD128"]);
+  defvar TLBIPRequiresNXS = !listconcat(TLBIPRequires, ["AArch64::FeatureXS"]);
   def : TLBIEntry<name, op1, crn, crm, op2, needsreg, optionalreg>;
   def : TLBIEntry<!strconcat(name, "nXS"), op1, crn, crm, op2, needsreg, optionalreg> {
     let Encoding{7} = 1;
     let ExtraRequires = ["AArch64::FeatureXS"];
   }
   if !eq(hasTLBIP, true) then {
-    def : TLBIPEntry<name, op1, crn, crm, op2, needsreg, optionalreg>;
+    def : TLBIPEntry<name, op1, crn, crm, op2, needsreg, optionalreg> {
+      let ExtraRequires = TLBIPRequires;
+    }
     def : TLBIPEntry<!strconcat(name, "nXS"), op1, crn, crm, op2, needsreg, optionalreg> {
       let Encoding{7} = 1;
-      let ExtraRequires = ["AArch64::FeatureXS"];
+      let ExtraRequires = TLBIPRequiresNXS;
     }
   }
 }

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -3883,6 +3883,7 @@ static const struct Extension {
     {"mec", {AArch64::FeatureMEC}},
     {"the", {AArch64::FeatureTHE}},
     {"d128", {AArch64::FeatureD128}},
+    {"sys128", {AArch64::FeatureSYS128}},
     {"lse128", {AArch64::FeatureLSE128}},
     {"ite", {AArch64::FeatureITE}},
     {"cssc", {AArch64::FeatureCSSC}},
@@ -4276,10 +4277,23 @@ bool AArch64AsmParser::parseSyspAlias(StringRef Name, SMLoc NameLoc,
             ? TLBIPorig->FeaturesRequired | FeatureBitset({AArch64::FeatureXS})
             : TLBIPorig->FeaturesRequired);
     if (!TLBIP.haveFeatures(getSTI().getFeatureBits())) {
-      std::string Name =
-          std::string(TLBIP.Name) + (HasnXSQualifier ? "nXS" : "");
-      std::string Str("TLBIP " + Name + " requires: ");
-      setRequiredFeatureString(TLBIP.getRequiredFeatures(), Str);
+      FeatureBitset Active = getSTI().getFeatureBits();
+      FeatureBitset Missing = TLBIP.getRequiredFeatures() & ~Active;
+      if (TLBIP.allowTLBID()) {
+        FeatureBitset BaseReq = TLBIP.getRequiredFeatures();
+        BaseReq.reset(AArch64::FeatureD128);
+        BaseReq.reset(AArch64::FeatureTLBID);
+        FeatureBitset BaseMissing = BaseReq & ~Active;
+        Missing = BaseMissing;
+        if (!Active[AArch64::FeatureD128] && !Active[AArch64::FeatureTLBID]) {
+          if (BaseMissing.none())
+            return TokError("instruction requires: tlbid or d128");
+          Missing.set(AArch64::FeatureD128);
+          Missing.set(AArch64::FeatureTLBID);
+        }
+      }
+      std::string Str("instruction requires: ");
+      setRequiredFeatureString(Missing, Str);
       return TokError(Str);
     }
     createSysAlias(TLBIP.Encoding, Operands, S);

--- a/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
+++ b/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
@@ -824,6 +824,27 @@ struct TLBI : SysAliasOptionalReg {
 namespace AArch64TLBIP {
 struct TLBIP : SysAliasOptionalReg {
   using SysAliasOptionalReg::SysAliasOptionalReg;
+
+  bool allowTLBID() const {
+    return FeaturesRequired[llvm::AArch64::FeatureTLBID];
+  }
+
+  bool haveFeatures(FeatureBitset ActiveFeatures) const {
+    if (ActiveFeatures[llvm::AArch64::FeatureAll])
+      return true;
+
+    if (!allowTLBID())
+      return (FeaturesRequired & ActiveFeatures) == FeaturesRequired;
+
+    FeatureBitset BaseReq = FeaturesRequired;
+    BaseReq.reset(llvm::AArch64::FeatureD128);
+    BaseReq.reset(llvm::AArch64::FeatureTLBID);
+    if ((BaseReq & ActiveFeatures) != BaseReq)
+      return false;
+
+    return ActiveFeatures[llvm::AArch64::FeatureD128] ||
+           ActiveFeatures[llvm::AArch64::FeatureTLBID];
+  }
 };
 #define GET_TLBIPTable_DECL
 #include "AArch64GenSystemOperands.inc"

--- a/llvm/test/MC/AArch64/armv9a-sysp.s
+++ b/llvm/test/MC/AArch64/armv9a-sysp.s
@@ -1,15 +1,15 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+d128,+tlb-rmi,+xs < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sys128,+d128,+tlb-rmi,+xs < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+tlb-rmi,+xs < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+d128,+tlb-rmi,+xs < %s \
-// RUN:        | llvm-objdump -d --mattr=+d128,+tlb-rmi,+xs --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+d128,+tlb-rmi,+xs < %s \
-// RUN:   | llvm-objdump -d --mattr=-d128,+tlb-rmi,+xs --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sys128,+d128,+tlb-rmi,+xs < %s \
+// RUN:        | llvm-objdump -d --mattr=+sys128,+d128,+tlb-rmi,+xs --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sys128,+d128,+tlb-rmi,+xs < %s \
+// RUN:   | llvm-objdump -d --mattr=-sys128,-d128,+tlb-rmi,+xs --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+d128,+tlb-rmi,+xs < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sys128,+d128,+tlb-rmi,+xs < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+d128,+tlb-rmi,+xs -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sys128,+d128,+tlb-rmi,+xs -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 
@@ -23,49 +23,49 @@
 sysp #0, c2, c0, #0, x0, x1// TTBR0_EL1     3  0  2  0  0
 // CHECK-INST: sysp #0, c2, c0, #0, x0, x1
 // CHECK-ENCODING: encoding: [0x00,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482000      <unknown>
 
 sysp #0, c2, c0, #1, x0, x1// TTBR1_EL1     3  0  2  0  1
 // CHECK-INST: sysp #0, c2, c0, #1, x0, x1
 // CHECK-ENCODING: encoding: [0x20,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482020      <unknown>
 
 sysp #0, c7, c4, #0, x0, x1// PAR_EL1       3  0  7  4  0
 // CHECK-INST: sysp #0, c7, c4, #0, x0, x1
 // CHECK-ENCODING: encoding: [0x00,0x74,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5487400      <unknown>
 
 sysp #0, c13, c0, #3, x0, x1         // RCWSMASK_EL1  3  0 13  0  3
 // CHECK-INST: sysp #0, c13, c0, #3, x0, x1
 // CHECK-ENCODING: encoding: [0x60,0xd0,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548d060      <unknown>
 
 sysp #0, c13, c0, #6, x0, x1         // RCWMASK_EL1   3  0 13  0  6
 // CHECK-INST: sysp #0, c13, c0, #6, x0, x1
 // CHECK-ENCODING: encoding: [0xc0,0xd0,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548d0c0      <unknown>
 
 sysp #4, c2, c0, #0, x0, x1// TTBR0_EL2     3  4  2  0  0
 // CHECK-INST: sysp #4, c2, c0, #0, x0, x1
 // CHECK-ENCODING: encoding: [0x00,0x20,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d54c2000      <unknown>
 
 sysp #4, c2, c0, #1, x0, x1// TTBR1_EL2     3  4  2  0  1
 // CHECK-INST: sysp #4, c2, c0, #1, x0, x1
 // CHECK-ENCODING: encoding: [0x20,0x20,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d54c2020      <unknown>
 
 sysp #4, c2, c1, #0, x0, x1// VTTBR_EL2     3  4  2  1  0
 // CHECK-INST: sysp #4, c2, c1, #0, x0, x1
 // CHECK-ENCODING: encoding: [0x00,0x21,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d54c2100      <unknown>
 
 
@@ -73,176 +73,176 @@ sysp #4, c2, c1, #0, x0, x1// VTTBR_EL2     3  4  2  1  0
 sysp #0, c2, c0, #0, x0, x1
 // CHECK-INST: sysp #0, c2, c0, #0, x0, x1
 // CHECK-ENCODING: encoding: [0x00,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482000      <unknown>
 
 sysp #0, c2, c0, #1, x0, x1
 // CHECK-INST: sysp #0, c2, c0, #1, x0, x1
 // CHECK-ENCODING: encoding: [0x20,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482020      <unknown>
 
 sysp #0, c7, c4, #0, x0, x1
 // CHECK-INST: sysp #0, c7, c4, #0, x0, x1
 // CHECK-ENCODING: encoding: [0x00,0x74,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5487400      <unknown>
 
 sysp #0, c13, c0, #3, x0, x1
 // CHECK-INST: sysp #0, c13, c0, #3, x0, x1
 // CHECK-ENCODING: encoding: [0x60,0xd0,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548d060      <unknown>
 
 sysp #0, c13, c0, #6, x0, x1
 // CHECK-INST: sysp #0, c13, c0, #6, x0, x1
 // CHECK-ENCODING: encoding: [0xc0,0xd0,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548d0c0      <unknown>
 
 sysp #4, c2, c0, #0, x0, x1
 // CHECK-INST: sysp #4, c2, c0, #0, x0, x1
 // CHECK-ENCODING: encoding: [0x00,0x20,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d54c2000      <unknown>
 
 sysp #4, c2, c0, #1, x0, x1
 // CHECK-INST: sysp #4, c2, c0, #1, x0, x1
 // CHECK-ENCODING: encoding: [0x20,0x20,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d54c2020      <unknown>
 
 sysp #4, c2, c1, #0, x0, x1
 // CHECK-INST: sysp #4, c2, c1, #0, x0, x1
 // CHECK-ENCODING: encoding: [0x00,0x21,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d54c2100      <unknown>
 
 sysp #0, c2, c0, #0, x0, x1
 // CHECK-INST: sysp #0, c2, c0, #0, x0, x1
 // CHECK-ENCODING: encoding: [0x00,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482000      <unknown>
 
 sysp #0, c2, c0, #0, x2, x3
 // CHECK-INST: sysp #0, c2, c0, #0, x2, x3
 // CHECK-ENCODING: encoding: [0x02,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482002      <unknown>
 
 sysp #0, c2, c0, #0, x4, x5
 // CHECK-INST: sysp #0, c2, c0, #0, x4, x5
 // CHECK-ENCODING: encoding: [0x04,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482004      <unknown>
 
 sysp #0, c2, c0, #0, x6, x7
 // CHECK-INST: sysp #0, c2, c0, #0, x6, x7
 // CHECK-ENCODING: encoding: [0x06,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482006      <unknown>
 
 sysp #0, c2, c0, #0, x8, x9
 // CHECK-INST: sysp #0, c2, c0, #0, x8, x9
 // CHECK-ENCODING: encoding: [0x08,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482008      <unknown>
 
 sysp #0, c2, c0, #0, x10, x11
 // CHECK-INST: sysp #0, c2, c0, #0, x10, x11
 // CHECK-ENCODING: encoding: [0x0a,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548200a      <unknown>
 
 sysp #0, c2, c0, #0, x12, x13
 // CHECK-INST: sysp #0, c2, c0, #0, x12, x13
 // CHECK-ENCODING: encoding: [0x0c,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548200c      <unknown>
 
 sysp #0, c2, c0, #0, x14, x15
 // CHECK-INST: sysp #0, c2, c0, #0, x14, x15
 // CHECK-ENCODING: encoding: [0x0e,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548200e      <unknown>
 
 sysp #0, c2, c0, #0, x16, x17
 // CHECK-INST: sysp #0, c2, c0, #0, x16, x17
 // CHECK-ENCODING: encoding: [0x10,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482010      <unknown>
 
 sysp #0, c2, c0, #0, x18, x19
 // CHECK-INST: sysp #0, c2, c0, #0, x18, x19
 // CHECK-ENCODING: encoding: [0x12,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482012      <unknown>
 
 sysp #0, c2, c0, #0, x20, x21
 // CHECK-INST: sysp #0, c2, c0, #0, x20, x21
 // CHECK-ENCODING: encoding: [0x14,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482014      <unknown>
 
 sysp #0, c2, c0, #0, x22, x23
 // CHECK-INST: sysp #0, c2, c0, #0, x22, x23
 // CHECK-ENCODING: encoding: [0x16,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482016      <unknown>
 
 sysp #0, c2, c0, #0, x24, x25
 // CHECK-INST: sysp #0, c2, c0, #0, x24, x25
 // CHECK-ENCODING: encoding: [0x18,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d5482018      <unknown>
 
 sysp #0, c2, c0, #0, x26, x27
 // CHECK-INST: sysp #0, c2, c0, #0, x26, x27
 // CHECK-ENCODING: encoding: [0x1a,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548201a      <unknown>
 
 sysp #0, c2, c0, #0, x28, x29
 // CHECK-INST: sysp #0, c2, c0, #0, x28, x29
 // CHECK-ENCODING: encoding: [0x1c,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548201c      <unknown>
 
 sysp #0, c2, c0, #0, x30, x31
 // CHECK-INST: sysp #0, c2, c0, #0, x30, xzr
 // CHECK-ENCODING: encoding: [0x1e,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548201e      <unknown>
 
 
 sysp #0, c2, c0, #0, x31, x31
 // CHECK-INST: sysp #0, c2, c0, #0
 // CHECK-ENCODING: encoding: [0x1f,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548201f      <unknown>
 
 sysp #0, c2, c0, #0, xzr, xzr
 // CHECK-INST: sysp #0, c2, c0, #0
 // CHECK-ENCODING: encoding: [0x1f,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548201f      <unknown>
 
 sysp #0, c2, c0, #0, x31, xzr
 // CHECK-INST: sysp #0, c2, c0, #0
 // CHECK-ENCODING: encoding: [0x1f,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548201f      <unknown>
 
 sysp #0, c2, c0, #0, xzr, x31
 // CHECK-INST: sysp #0, c2, c0, #0
 // CHECK-ENCODING: encoding: [0x1f,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548201f      <unknown>
 
 sysp #0, c2, c0, #0
 // CHECK-INST: sysp #0, c2, c0, #0
 // CHECK-ENCODING: encoding: [0x1f,0x20,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: sys128
 // CHECK-UNKNOWN:  d548201f      <unknown>
 
 tlbip IPAS2E1, x4, x5
@@ -260,25 +260,25 @@ tlbip IPAS2E1NXS, x4, x5
 tlbip IPAS2E1IS, x4, x5
 // CHECK-INST: tlbip ipas2e1is, x4, x5
 // CHECK-ENCODING: encoding: [0x24,0x80,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c8024      <unknown>
 
 tlbip IPAS2E1ISNXS, x4, x5
 // CHECK-INST: tlbip ipas2e1isnxs, x4, x5
 // CHECK-ENCODING: encoding: [0x24,0x90,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c9024      <unknown>
 
 tlbip IPAS2E1OS, x4, x5
 // CHECK-INST: tlbip ipas2e1os, x4, x5
 // CHECK-ENCODING: encoding: [0x04,0x84,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c8404      <unknown>
 
 tlbip IPAS2E1OSNXS, x4, x5
 // CHECK-INST: tlbip ipas2e1osnxs, x4, x5
 // CHECK-ENCODING: encoding: [0x04,0x94,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c9404      <unknown>
 
 tlbip IPAS2LE1, x4, x5
@@ -296,25 +296,25 @@ tlbip IPAS2LE1NXS, x4, x5
 tlbip IPAS2LE1IS, x4, x5
 // CHECK-INST: tlbip ipas2le1is, x4, x5
 // CHECK-ENCODING: encoding: [0xa4,0x80,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c80a4      <unknown>
 
 tlbip IPAS2LE1ISNXS, x4, x5
 // CHECK-INST: tlbip ipas2le1isnxs, x4, x5
 // CHECK-ENCODING: encoding: [0xa4,0x90,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c90a4      <unknown>
 
 tlbip IPAS2LE1OS, x4, x5
 // CHECK-INST: tlbip ipas2le1os, x4, x5
 // CHECK-ENCODING: encoding: [0x84,0x84,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c8484      <unknown>
 
 tlbip IPAS2LE1OSNXS, x4, x5
 // CHECK-INST: tlbip ipas2le1osnxs, x4, x5
 // CHECK-ENCODING: encoding: [0x84,0x94,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c9484      <unknown>
 
 tlbip VAE1, x8, x9
@@ -332,25 +332,25 @@ tlbip VAE1NXS, x8, x9
 tlbip VAE1IS, x8, x9
 // CHECK-INST: tlbip vae1is, x8, x9
 // CHECK-ENCODING: encoding: [0x28,0x83,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5488328      <unknown>
 
 tlbip VAE1ISNXS, x8, x9
 // CHECK-INST: tlbip vae1isnxs, x8, x9
 // CHECK-ENCODING: encoding: [0x28,0x93,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5489328      <unknown>
 
 tlbip VAE1OS, x8, x9
 // CHECK-INST: tlbip vae1os, x8, x9
 // CHECK-ENCODING: encoding: [0x28,0x81,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5488128      <unknown>
 
 tlbip VAE1OSNXS, x8, x9
 // CHECK-INST: tlbip vae1osnxs, x8, x9
 // CHECK-ENCODING: encoding: [0x28,0x91,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5489128      <unknown>
 
 tlbip VALE1, x8, x9
@@ -368,25 +368,25 @@ tlbip VALE1NXS, x8, x9
 tlbip VALE1IS, x8, x9
 // CHECK-INST: tlbip vale1is, x8, x9
 // CHECK-ENCODING: encoding: [0xa8,0x83,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54883a8      <unknown>
 
 tlbip VALE1ISNXS, x8, x9
 // CHECK-INST: tlbip vale1isnxs, x8, x9
 // CHECK-ENCODING: encoding: [0xa8,0x93,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54893a8      <unknown>
 
 tlbip VALE1OS, x8, x9
 // CHECK-INST: tlbip vale1os, x8, x9
 // CHECK-ENCODING: encoding: [0xa8,0x81,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54881a8      <unknown>
 
 tlbip VALE1OSNXS, x8, x9
 // CHECK-INST: tlbip vale1osnxs, x8, x9
 // CHECK-ENCODING: encoding: [0xa8,0x91,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54891a8      <unknown>
 
 tlbip VAAE1, x8, x9
@@ -404,25 +404,25 @@ tlbip VAAE1NXS, x8, x9
 tlbip VAAE1IS, x8, x9
 // CHECK-INST: tlbip vaae1is, x8, x9
 // CHECK-ENCODING: encoding: [0x68,0x83,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5488368      <unknown>
 
 tlbip VAAE1ISNXS, x8, x9
 // CHECK-INST: tlbip vaae1isnxs, x8, x9
 // CHECK-ENCODING: encoding: [0x68,0x93,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5489368      <unknown>
 
 tlbip VAAE1OS, x8, x9
 // CHECK-INST: tlbip vaae1os, x8, x9
 // CHECK-ENCODING: encoding: [0x68,0x81,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5488168      <unknown>
 
 tlbip VAAE1OSNXS, x8, x9
 // CHECK-INST: tlbip vaae1osnxs, x8, x9
 // CHECK-ENCODING: encoding: [0x68,0x91,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5489168      <unknown>
 
 tlbip VAALE1, x8, x9
@@ -440,25 +440,25 @@ tlbip VAALE1NXS, x8, x9
 tlbip VAALE1IS, x8, x9
 // CHECK-INST: tlbip vaale1is, x8, x9
 // CHECK-ENCODING: encoding: [0xe8,0x83,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54883e8      <unknown>
 
 tlbip VAALE1ISNXS, x8, x9
 // CHECK-INST: tlbip vaale1isnxs, x8, x9
 // CHECK-ENCODING: encoding: [0xe8,0x93,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54893e8      <unknown>
 
 tlbip VAALE1OS, x8, x9
 // CHECK-INST: tlbip vaale1os, x8, x9
 // CHECK-ENCODING: encoding: [0xe8,0x81,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54881e8      <unknown>
 
 tlbip VAALE1OSNXS, x8, x9
 // CHECK-INST: tlbip vaale1osnxs, x8, x9
 // CHECK-ENCODING: encoding: [0xe8,0x91,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54891e8      <unknown>
 
 tlbip VAE2, x14, x15
@@ -476,25 +476,25 @@ tlbip VAE2NXS, x14, x15
 tlbip VAE2IS, x14, x15
 // CHECK-INST: tlbip vae2is, x14, x15
 // CHECK-ENCODING: encoding: [0x2e,0x83,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c832e      <unknown>
 
 tlbip VAE2ISNXS, x14, x15
 // CHECK-INST: tlbip vae2isnxs, x14, x15
 // CHECK-ENCODING: encoding: [0x2e,0x93,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c932e      <unknown>
 
 tlbip VAE2OS, x14, x15
 // CHECK-INST: tlbip vae2os, x14, x15
 // CHECK-ENCODING: encoding: [0x2e,0x81,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c812e      <unknown>
 
 tlbip VAE2OSNXS, x14, x15
 // CHECK-INST: tlbip vae2osnxs, x14, x15
 // CHECK-ENCODING: encoding: [0x2e,0x91,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c912e      <unknown>
 
 tlbip VALE2, x14, x15
@@ -512,25 +512,25 @@ tlbip VALE2NXS, x14, x15
 tlbip VALE2IS, x14, x15
 // CHECK-INST: tlbip vale2is, x14, x15
 // CHECK-ENCODING: encoding: [0xae,0x83,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c83ae      <unknown>
 
 tlbip VALE2ISNXS, x14, x15
 // CHECK-INST: tlbip vale2isnxs, x14, x15
 // CHECK-ENCODING: encoding: [0xae,0x93,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c93ae      <unknown>
 
 tlbip VALE2OS, x14, x15
 // CHECK-INST: tlbip vale2os, x14, x15
 // CHECK-ENCODING: encoding: [0xae,0x81,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c81ae      <unknown>
 
 tlbip VALE2OSNXS, x14, x15
 // CHECK-INST: tlbip vale2osnxs, x14, x15
 // CHECK-ENCODING: encoding: [0xae,0x91,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c91ae      <unknown>
 
 tlbip VAE3, x24, x25
@@ -620,25 +620,25 @@ tlbip RVAE1NXS, x18, x19
 tlbip RVAE1IS, x18, x19
 // CHECK-INST: tlbip rvae1is, x18, x19
 // CHECK-ENCODING: encoding: [0x32,0x82,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5488232      <unknown>
 
 tlbip RVAE1ISNXS, x18, x19
 // CHECK-INST: tlbip rvae1isnxs, x18, x19
 // CHECK-ENCODING: encoding: [0x32,0x92,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5489232      <unknown>
 
 tlbip RVAE1OS, x18, x19
 // CHECK-INST: tlbip rvae1os, x18, x19
 // CHECK-ENCODING: encoding: [0x32,0x85,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5488532      <unknown>
 
 tlbip RVAE1OSNXS, x18, x19
 // CHECK-INST: tlbip rvae1osnxs, x18, x19
 // CHECK-ENCODING: encoding: [0x32,0x95,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5489532      <unknown>
 
 tlbip RVAAE1, x18, x19
@@ -656,25 +656,25 @@ tlbip RVAAE1NXS, x18, x19
 tlbip RVAAE1IS, x18, x19
 // CHECK-INST: tlbip rvaae1is, x18, x19
 // CHECK-ENCODING: encoding: [0x72,0x82,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5488272      <unknown>
 
 tlbip RVAAE1ISNXS, x18, x19
 // CHECK-INST: tlbip rvaae1isnxs, x18, x19
 // CHECK-ENCODING: encoding: [0x72,0x92,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5489272      <unknown>
 
 tlbip RVAAE1OS, x18, x19
 // CHECK-INST: tlbip rvaae1os, x18, x19
 // CHECK-ENCODING: encoding: [0x72,0x85,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5488572      <unknown>
 
 tlbip RVAAE1OSNXS, x18, x19
 // CHECK-INST: tlbip rvaae1osnxs, x18, x19
 // CHECK-ENCODING: encoding: [0x72,0x95,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d5489572      <unknown>
 
 tlbip RVALE1, x18, x19
@@ -692,25 +692,25 @@ tlbip RVALE1NXS, x18, x19
 tlbip RVALE1IS, x18, x19
 // CHECK-INST: tlbip rvale1is, x18, x19
 // CHECK-ENCODING: encoding: [0xb2,0x82,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54882b2      <unknown>
 
 tlbip RVALE1ISNXS, x18, x19
 // CHECK-INST: tlbip rvale1isnxs, x18, x19
 // CHECK-ENCODING: encoding: [0xb2,0x92,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54892b2      <unknown>
 
 tlbip RVALE1OS, x18, x19
 // CHECK-INST: tlbip rvale1os, x18, x19
 // CHECK-ENCODING: encoding: [0xb2,0x85,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54885b2      <unknown>
 
 tlbip RVALE1OSNXS, x18, x19
 // CHECK-INST: tlbip rvale1osnxs, x18, x19
 // CHECK-ENCODING: encoding: [0xb2,0x95,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54895b2      <unknown>
 
 tlbip RVAALE1, x18, x19
@@ -728,25 +728,25 @@ tlbip RVAALE1NXS, x18, x19
 tlbip RVAALE1IS, x18, x19
 // CHECK-INST: tlbip rvaale1is, x18, x19
 // CHECK-ENCODING: encoding: [0xf2,0x82,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54882f2      <unknown>
 
 tlbip RVAALE1ISNXS, x18, x19
 // CHECK-INST: tlbip rvaale1isnxs, x18, x19
 // CHECK-ENCODING: encoding: [0xf2,0x92,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54892f2      <unknown>
 
 tlbip RVAALE1OS, x18, x19
 // CHECK-INST: tlbip rvaale1os, x18, x19
 // CHECK-ENCODING: encoding: [0xf2,0x85,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54885f2      <unknown>
 
 tlbip RVAALE1OSNXS, x18, x19
 // CHECK-INST: tlbip rvaale1osnxs, x18, x19
 // CHECK-ENCODING: encoding: [0xf2,0x95,0x48,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54895f2      <unknown>
 
 tlbip RVAE2, x28, x29
@@ -764,25 +764,25 @@ tlbip RVAE2NXS, x28, x29
 tlbip RVAE2IS, x28, x29
 // CHECK-INST: tlbip rvae2is, x28, x29
 // CHECK-ENCODING: encoding: [0x3c,0x82,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c823c      <unknown>
 
 tlbip RVAE2ISNXS, x28, x29
 // CHECK-INST: tlbip rvae2isnxs, x28, x29
 // CHECK-ENCODING: encoding: [0x3c,0x92,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c923c      <unknown>
 
 tlbip RVAE2OS, x28, x29
 // CHECK-INST: tlbip rvae2os, x28, x29
 // CHECK-ENCODING: encoding: [0x3c,0x85,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c853c      <unknown>
 
 tlbip RVAE2OSNXS, x28, x29
 // CHECK-INST: tlbip rvae2osnxs, x28, x29
 // CHECK-ENCODING: encoding: [0x3c,0x95,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c953c      <unknown>
 
 tlbip RVALE2, x28, x29
@@ -800,25 +800,25 @@ tlbip RVALE2NXS, x28, x29
 tlbip RVALE2IS, x28, x29
 // CHECK-INST: tlbip rvale2is, x28, x29
 // CHECK-ENCODING: encoding: [0xbc,0x82,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c82bc      <unknown>
 
 tlbip RVALE2ISNXS, x28, x29
 // CHECK-INST: tlbip rvale2isnxs, x28, x29
 // CHECK-ENCODING: encoding: [0xbc,0x92,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c92bc      <unknown>
 
 tlbip RVALE2OS, x28, x29
 // CHECK-INST: tlbip rvale2os, x28, x29
 // CHECK-ENCODING: encoding: [0xbc,0x85,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c85bc      <unknown>
 
 tlbip RVALE2OSNXS, x28, x29
 // CHECK-INST: tlbip rvale2osnxs, x28, x29
 // CHECK-ENCODING: encoding: [0xbc,0x95,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c95bc      <unknown>
 
 tlbip RVAE3, x10, x11
@@ -908,25 +908,25 @@ tlbip RIPAS2E1NXS, x20, x21
 tlbip RIPAS2E1IS, x20, x21
 // CHECK-INST: tlbip ripas2e1is, x20, x21
 // CHECK-ENCODING: encoding: [0x54,0x80,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c8054      <unknown>
 
 tlbip RIPAS2E1ISNXS, x20, x21
 // CHECK-INST: tlbip ripas2e1isnxs, x20, x21
 // CHECK-ENCODING: encoding: [0x54,0x90,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c9054      <unknown>
 
 tlbip RIPAS2E1OS, x20, x21
 // CHECK-INST: tlbip ripas2e1os, x20, x21
 // CHECK-ENCODING: encoding: [0x74,0x84,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c8474      <unknown>
 
 tlbip RIPAS2E1OSNXS, x20, x21
 // CHECK-INST: tlbip ripas2e1osnxs, x20, x21
 // CHECK-ENCODING: encoding: [0x74,0x94,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c9474      <unknown>
 
 tlbip RIPAS2LE1, x20, x21
@@ -944,35 +944,35 @@ tlbip RIPAS2LE1NXS, x20, x21
 tlbip RIPAS2LE1IS, x20, x21
 // CHECK-INST: tlbip ripas2le1is, x20, x21
 // CHECK-ENCODING: encoding: [0xd4,0x80,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c80d4      <unknown>
 
 tlbip RIPAS2LE1ISNXS, x20, x21
 // CHECK-INST: tlbip ripas2le1isnxs, x20, x21
 // CHECK-ENCODING: encoding: [0xd4,0x90,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c90d4      <unknown>
 
 tlbip RIPAS2LE1OS, x20, x21
 // CHECK-INST: tlbip ripas2le1os, x20, x21
 // CHECK-ENCODING: encoding: [0xf4,0x84,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c84f4      <unknown>
 
 tlbip RIPAS2LE1OSNXS, x20, x21
 // CHECK-INST: tlbip ripas2le1osnxs, x20, x21
 // CHECK-ENCODING: encoding: [0xf4,0x94,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c94f4      <unknown>
 
 tlbip RIPAS2LE1OS, xzr, xzr
 // CHECK-INST: tlbip ripas2le1os, xzr, xzr
 // CHECK-ENCODING: encoding: [0xff,0x84,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c84ff      <unknown>
 
 tlbip RIPAS2LE1OSNXS, xzr, xzr
 // CHECK-INST: tlbip ripas2le1osnxs, xzr, xzr
 // CHECK-ENCODING: encoding: [0xff,0x94,0x4c,0xd5]
-// CHECK-ERROR: error: instruction requires: d128
+// CHECK-ERROR: error: instruction requires: tlbid or d128
 // CHECK-UNKNOWN:  d54c94ff      <unknown>

--- a/llvm/test/MC/AArch64/directive-arch_extension-negative.s
+++ b/llvm/test/MC/AArch64/directive-arch_extension-negative.s
@@ -1,6 +1,6 @@
 // RUN: not llvm-mc -triple aarch64 \
 // RUN: -mattr=+crc,+sm4,+sha3,+sha2,+aes,+fp,+neon,+ras,+lse,+predres,+ccdp,+mte,+tlb-rmi,+pan-rwv,+ccpp,+rcpc,+ls64,+flagm,+hbc,+mops \
-// RUN: -mattr=+rcpc3,+lse128,+d128,+the,+rasv2,+ite,+cssc,+specres2,+gcs,+cmpbr \
+// RUN: -mattr=+rcpc3,+lse128,+sys128,+d128,+the,+rasv2,+ite,+cssc,+specres2,+gcs,+cmpbr \
 // RUN: -filetype asm -o - %s 2>&1 | FileCheck %s
 
 .arch_extension axp64
@@ -177,18 +177,20 @@ cpyfp [x0]!, [x1]!, x2!
 // CHECK: [[@LINE-1]]:1: error: instruction requires: mops
 // CHECK-NEXT: cpyfp [x0]!, [x1]!, x2!
 
-// nolse128 implied nod128, so reinstate it
+// nolse128 implied nod128 and nosys128, so reinstate them
+.arch_extension sys128
 .arch_extension d128
 // This needs to come before `.arch_extension nothe` as it uses an instruction
 // that requires both the and d128
 sysp #0, c2, c0, #0, x0, x1
 rcwcasp   x0, x1, x6, x7, [x4]
+// CHECK-NOT: [[@LINE-2]]:1: error: instruction requires: sys128
 // CHECK-NOT: [[@LINE-2]]:1: error: instruction requires: d128
-// CHECK-NOT: [[@LINE-2]]:1: error: instruction requires: d128
+.arch_extension nosys128
 .arch_extension nod128
 sysp #0, c2, c0, #0, x0, x1
 rcwcasp   x0, x1, x6, x7, [x4]
-// CHECK: [[@LINE-2]]:1: error: instruction requires: d128
+// CHECK: [[@LINE-2]]:1: error: instruction requires: sys128
 // CHECK-NEXT: sysp #0, c2, c0, #0, x0, x1
 // CHECK: [[@LINE-3]]:1: error: instruction requires: d128
 // CHECK-NEXT: rcwcasp   x0, x1, x6, x7, [x4]

--- a/llvm/test/MC/AArch64/tlbip-tlbid-or-d128.s
+++ b/llvm/test/MC/AArch64/tlbip-tlbid-or-d128.s
@@ -1,0 +1,259 @@
+// NOTE: These TLBIP forms are valid with either +tlbid or +d128.
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+tlbid,+tlb-rmi,+xs < %s | FileCheck %s --check-prefix=TLBID
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+d128,+tlb-rmi,+xs < %s | FileCheck %s --check-prefix=D128
+
+tlbip VAE1OS, x0, x1
+// TLBID: tlbip vae1os, x0, x1
+// D128: tlbip vae1os, x0, x1
+
+tlbip VAAE1OS, x0, x1
+// TLBID: tlbip vaae1os, x0, x1
+// D128: tlbip vaae1os, x0, x1
+
+tlbip VALE1OS, x0, x1
+// TLBID: tlbip vale1os, x0, x1
+// D128: tlbip vale1os, x0, x1
+
+tlbip VAALE1OS, x0, x1
+// TLBID: tlbip vaale1os, x0, x1
+// D128: tlbip vaale1os, x0, x1
+
+tlbip RVAE1IS, x0, x1
+// TLBID: tlbip rvae1is, x0, x1
+// D128: tlbip rvae1is, x0, x1
+
+tlbip RVAAE1IS, x0, x1
+// TLBID: tlbip rvaae1is, x0, x1
+// D128: tlbip rvaae1is, x0, x1
+
+tlbip RVALE1IS, x0, x1
+// TLBID: tlbip rvale1is, x0, x1
+// D128: tlbip rvale1is, x0, x1
+
+tlbip RVAALE1IS, x0, x1
+// TLBID: tlbip rvaale1is, x0, x1
+// D128: tlbip rvaale1is, x0, x1
+
+tlbip VAE1IS, x0, x1
+// TLBID: tlbip vae1is, x0, x1
+// D128: tlbip vae1is, x0, x1
+
+tlbip VAAE1IS, x0, x1
+// TLBID: tlbip vaae1is, x0, x1
+// D128: tlbip vaae1is, x0, x1
+
+tlbip VALE1IS, x0, x1
+// TLBID: tlbip vale1is, x0, x1
+// D128: tlbip vale1is, x0, x1
+
+tlbip VAALE1IS, x0, x1
+// TLBID: tlbip vaale1is, x0, x1
+// D128: tlbip vaale1is, x0, x1
+
+tlbip RVAE1OS, x0, x1
+// TLBID: tlbip rvae1os, x0, x1
+// D128: tlbip rvae1os, x0, x1
+
+tlbip RVAAE1OS, x0, x1
+// TLBID: tlbip rvaae1os, x0, x1
+// D128: tlbip rvaae1os, x0, x1
+
+tlbip RVALE1OS, x0, x1
+// TLBID: tlbip rvale1os, x0, x1
+// D128: tlbip rvale1os, x0, x1
+
+tlbip RVAALE1OS, x0, x1
+// TLBID: tlbip rvaale1os, x0, x1
+// D128: tlbip rvaale1os, x0, x1
+
+tlbip VAE1OSNXS, x0, x1
+// TLBID: tlbip vae1osnxs, x0, x1
+// D128: tlbip vae1osnxs, x0, x1
+
+tlbip VAAE1OSNXS, x0, x1
+// TLBID: tlbip vaae1osnxs, x0, x1
+// D128: tlbip vaae1osnxs, x0, x1
+
+tlbip VALE1OSNXS, x0, x1
+// TLBID: tlbip vale1osnxs, x0, x1
+// D128: tlbip vale1osnxs, x0, x1
+
+tlbip VAALE1OSNXS, x0, x1
+// TLBID: tlbip vaale1osnxs, x0, x1
+// D128: tlbip vaale1osnxs, x0, x1
+
+tlbip RVAE1ISNXS, x0, x1
+// TLBID: tlbip rvae1isnxs, x0, x1
+// D128: tlbip rvae1isnxs, x0, x1
+
+tlbip RVAAE1ISNXS, x0, x1
+// TLBID: tlbip rvaae1isnxs, x0, x1
+// D128: tlbip rvaae1isnxs, x0, x1
+
+tlbip RVALE1ISNXS, x0, x1
+// TLBID: tlbip rvale1isnxs, x0, x1
+// D128: tlbip rvale1isnxs, x0, x1
+
+tlbip RVAALE1ISNXS, x0, x1
+// TLBID: tlbip rvaale1isnxs, x0, x1
+// D128: tlbip rvaale1isnxs, x0, x1
+
+tlbip VAE1ISNXS, x0, x1
+// TLBID: tlbip vae1isnxs, x0, x1
+// D128: tlbip vae1isnxs, x0, x1
+
+tlbip VAAE1ISNXS, x0, x1
+// TLBID: tlbip vaae1isnxs, x0, x1
+// D128: tlbip vaae1isnxs, x0, x1
+
+tlbip VALE1ISNXS, x0, x1
+// TLBID: tlbip vale1isnxs, x0, x1
+// D128: tlbip vale1isnxs, x0, x1
+
+tlbip VAALE1ISNXS, x0, x1
+// TLBID: tlbip vaale1isnxs, x0, x1
+// D128: tlbip vaale1isnxs, x0, x1
+
+tlbip RVAE1OSNXS, x0, x1
+// TLBID: tlbip rvae1osnxs, x0, x1
+// D128: tlbip rvae1osnxs, x0, x1
+
+tlbip RVAAE1OSNXS, x0, x1
+// TLBID: tlbip rvaae1osnxs, x0, x1
+// D128: tlbip rvaae1osnxs, x0, x1
+
+tlbip RVALE1OSNXS, x0, x1
+// TLBID: tlbip rvale1osnxs, x0, x1
+// D128: tlbip rvale1osnxs, x0, x1
+
+tlbip RVAALE1OSNXS, x0, x1
+// TLBID: tlbip rvaale1osnxs, x0, x1
+// D128: tlbip rvaale1osnxs, x0, x1
+
+tlbip IPAS2E1IS, x0, x1
+// TLBID: tlbip ipas2e1is, x0, x1
+// D128: tlbip ipas2e1is, x0, x1
+
+tlbip RIPAS2E1IS, x0, x1
+// TLBID: tlbip ripas2e1is, x0, x1
+// D128: tlbip ripas2e1is, x0, x1
+
+tlbip IPAS2LE1IS, x0, x1
+// TLBID: tlbip ipas2le1is, x0, x1
+// D128: tlbip ipas2le1is, x0, x1
+
+tlbip RIPAS2LE1IS, x0, x1
+// TLBID: tlbip ripas2le1is, x0, x1
+// D128: tlbip ripas2le1is, x0, x1
+
+tlbip VAE2OS, x0, x1
+// TLBID: tlbip vae2os, x0, x1
+// D128: tlbip vae2os, x0, x1
+
+tlbip VALE2OS, x0, x1
+// TLBID: tlbip vale2os, x0, x1
+// D128: tlbip vale2os, x0, x1
+
+tlbip RVAE2IS, x0, x1
+// TLBID: tlbip rvae2is, x0, x1
+// D128: tlbip rvae2is, x0, x1
+
+tlbip RVALE2IS, x0, x1
+// TLBID: tlbip rvale2is, x0, x1
+// D128: tlbip rvale2is, x0, x1
+
+tlbip VAE2IS, x0, x1
+// TLBID: tlbip vae2is, x0, x1
+// D128: tlbip vae2is, x0, x1
+
+tlbip VALE2IS, x0, x1
+// TLBID: tlbip vale2is, x0, x1
+// D128: tlbip vale2is, x0, x1
+
+tlbip IPAS2E1OS, x0, x1
+// TLBID: tlbip ipas2e1os, x0, x1
+// D128: tlbip ipas2e1os, x0, x1
+
+tlbip RIPAS2E1OS, x0, x1
+// TLBID: tlbip ripas2e1os, x0, x1
+// D128: tlbip ripas2e1os, x0, x1
+
+tlbip IPAS2LE1OS, x0, x1
+// TLBID: tlbip ipas2le1os, x0, x1
+// D128: tlbip ipas2le1os, x0, x1
+
+tlbip RIPAS2LE1OS, x0, x1
+// TLBID: tlbip ripas2le1os, x0, x1
+// D128: tlbip ripas2le1os, x0, x1
+
+tlbip RVAE2OS, x0, x1
+// TLBID: tlbip rvae2os, x0, x1
+// D128: tlbip rvae2os, x0, x1
+
+tlbip RVALE2OS, x0, x1
+// TLBID: tlbip rvale2os, x0, x1
+// D128: tlbip rvale2os, x0, x1
+
+tlbip IPAS2E1ISNXS, x0, x1
+// TLBID: tlbip ipas2e1isnxs, x0, x1
+// D128: tlbip ipas2e1isnxs, x0, x1
+
+tlbip RIPAS2E1ISNXS, x0, x1
+// TLBID: tlbip ripas2e1isnxs, x0, x1
+// D128: tlbip ripas2e1isnxs, x0, x1
+
+tlbip IPAS2LE1ISNXS, x0, x1
+// TLBID: tlbip ipas2le1isnxs, x0, x1
+// D128: tlbip ipas2le1isnxs, x0, x1
+
+tlbip RIPAS2LE1ISNXS, x0, x1
+// TLBID: tlbip ripas2le1isnxs, x0, x1
+// D128: tlbip ripas2le1isnxs, x0, x1
+
+tlbip VAE2OSNXS, x0, x1
+// TLBID: tlbip vae2osnxs, x0, x1
+// D128: tlbip vae2osnxs, x0, x1
+
+tlbip VALE2OSNXS, x0, x1
+// TLBID: tlbip vale2osnxs, x0, x1
+// D128: tlbip vale2osnxs, x0, x1
+
+tlbip RVAE2ISNXS, x0, x1
+// TLBID: tlbip rvae2isnxs, x0, x1
+// D128: tlbip rvae2isnxs, x0, x1
+
+tlbip RVALE2ISNXS, x0, x1
+// TLBID: tlbip rvale2isnxs, x0, x1
+// D128: tlbip rvale2isnxs, x0, x1
+
+tlbip VAE2ISNXS, x0, x1
+// TLBID: tlbip vae2isnxs, x0, x1
+// D128: tlbip vae2isnxs, x0, x1
+
+tlbip VALE2ISNXS, x0, x1
+// TLBID: tlbip vale2isnxs, x0, x1
+// D128: tlbip vale2isnxs, x0, x1
+
+tlbip IPAS2E1OSNXS, x0, x1
+// TLBID: tlbip ipas2e1osnxs, x0, x1
+// D128: tlbip ipas2e1osnxs, x0, x1
+
+tlbip RIPAS2E1OSNXS, x0, x1
+// TLBID: tlbip ripas2e1osnxs, x0, x1
+// D128: tlbip ripas2e1osnxs, x0, x1
+
+tlbip IPAS2LE1OSNXS, x0, x1
+// TLBID: tlbip ipas2le1osnxs, x0, x1
+// D128: tlbip ipas2le1osnxs, x0, x1
+
+tlbip RIPAS2LE1OSNXS, x0, x1
+// TLBID: tlbip ripas2le1osnxs, x0, x1
+// D128: tlbip ripas2le1osnxs, x0, x1
+
+tlbip RVAE2OSNXS, x0, x1
+// TLBID: tlbip rvae2osnxs, x0, x1
+// D128: tlbip rvae2osnxs, x0, x1
+
+tlbip RVALE2OSNXS, x0, x1
+// TLBID: tlbip rvale2osnxs, x0, x1
+// D128: tlbip rvale2osnxs, x0, x1

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2203,6 +2203,16 @@ AArch64ExtensionDependenciesBaseArchTestParams
          {},
          {"fp8", "ssve-fp8dot2"}},
 
+        // d128 -> { lse128, sys128 }
+        {AArch64::ARMV9_7A, {"nolse128", "d128"}, {"d128", "lse128"}, {}},
+        {AArch64::ARMV9_7A, {"d128", "nolse128"}, {}, {"d128", "lse128"}},
+        {AArch64::ARMV9_7A, {"nosys128", "d128"}, {"d128", "sys128"}, {}},
+        {AArch64::ARMV9_7A, {"d128", "nosys128"}, {}, {"d128", "sys128"}},
+
+        // tlbid -> sys128
+        {AArch64::ARMV9_7A, {"nosys128", "tlbid"}, {"tlbid", "sys128"}, {}},
+        {AArch64::ARMV9_7A, {"tlbid", "nosys128"}, {}, {"tlbid", "sys128"}},
+
         // lse -> lse128
         {AArch64::ARMV8A, {"nolse", "lse128"}, {"lse", "lse128"}, {}},
         {AArch64::ARMV8A, {"lse128", "nolse"}, {}, {"lse", "lse128"}},


### PR DESCRIPTION
Change the gating of `tlbip` instructions containing `*E1IS*`, `*E1OS*`,
`*E2IS*` or `*E2OS*` to be used with either `+tlbid` or `+d128`. This is
because the 2025 Armv9.7-A MemSys specification says:

```
All TLBIP *E1IS*, TLBIP *E1OS*, TLBIP *E2IS* and TLBIP *E2OS* instructions
that are currently dependent on FEAT_D128 are updated to be dependent
on FEAT_D128 or FEAT_TLBID
```