### PR TITLE
[regalloc][basic] Fix non-deterministic codegen in basic register allocator

### DIFF
--- a/llvm/lib/CodeGen/RegAllocBasic.h
+++ b/llvm/lib/CodeGen/RegAllocBasic.h
@@ -28,8 +28,8 @@ struct CompSpillWeight {
   bool operator()(const LiveInterval *A, const LiveInterval *B) const {
     // Compare by weight first, then use register number as a stable tie-breaker
     // to ensure deterministic ordering when the weights are equal.
-    return std::make_tuple(A->weight(), A->reg()) <
-           std::make_tuple(B->weight(), B->reg());
+    return std::tuple(A->weight(), A->reg()) <
+           std::tuple(B->weight(), B->reg());
   }
 };
 

--- a/llvm/lib/CodeGen/RegAllocBasic.h
+++ b/llvm/lib/CodeGen/RegAllocBasic.h
@@ -20,12 +20,16 @@
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/Spiller.h"
 #include <queue>
+#include <tuple>
 
 namespace llvm {
 
 struct CompSpillWeight {
   bool operator()(const LiveInterval *A, const LiveInterval *B) const {
-    return A->weight() < B->weight();
+    // Compare by weight first, then use register number as a stable tie-breaker
+    // to ensure deterministic ordering when the weights are equal.
+    return std::make_tuple(A->weight(), A->reg()) <
+           std::make_tuple(B->weight(), B->reg());
   }
 };
 

--- a/llvm/test/CodeGen/AMDGPU/register-killed-error-after-alloc-failure0.mir
+++ b/llvm/test/CodeGen/AMDGPU/register-killed-error-after-alloc-failure0.mir
@@ -23,15 +23,16 @@
 # GREEDY: S_NOP 0, implicit killed renamable $vgpr20_vgpr21
 
 
-# BASIC: SI_SPILL_V128_SAVE undef $vgpr0_vgpr1_vgpr2_vgpr3
+# BASIC: SI_SPILL_V512_SAVE killed $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15
 # BASIC: SI_SPILL_V256_SAVE killed $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23
-# BASIC: SI_SPILL_V512_SAVE killed $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, %stack.0, $sgpr32, 0, implicit $exec :: (store (s512) into %stack.0, align 4, addrspace 5)
-# BASIC: SI_SPILL_V64_SAVE killed $vgpr0_vgpr1, %stack.{{[0-9]+}}, $sgpr32, 0, implicit $exec :: (store (s64) into %stack.{{[0-9]+}}, align 4, addrspace 5)
-# BASIC: $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15 = SI_SPILL_V512_RESTORE %stack.0, $sgpr32, 0, implicit $exec :: (load (s512) from %stack.0, align 4, addrspace 5)
-# BASIC: $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23 = SI_SPILL_V256_RESTORE
-# BASIC: $vgpr0_vgpr1_vgpr2_vgpr3 = SI_SPILL_V128_RESTORE
-# BASIC: S_NOP 0, implicit killed renamable $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, implicit killed renamable $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, implicit undef $vgpr0_vgpr1_vgpr2_vgpr3
-# BASIC: $vgpr0_vgpr1 = SI_SPILL_V64_RESTORE
+# BASIC: SI_SPILL_V128_SAVE undef $vgpr0_vgpr1_vgpr2_vgpr3
+# BASIC: SI_SPILL_V64_SAVE killed $vgpr0_vgpr1
+# BASIC: renamable $vgpr0_vgpr1_vgpr2_vgpr3 = SI_SPILL_V128_RESTORE
+# BASIC: renamable $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23 = SI_SPILL_V256_RESTORE
+# BASIC: $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15 = SI_SPILL_V512_RESTORE
+# BASIC: S_NOP 0, implicit undef $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7_vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, implicit killed renamable $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, implicit killed renamable $vgpr0_vgpr1_vgpr2_vgpr3
+# BASIC: renamable $vgpr0_vgpr1 = SI_SPILL_V64_RESTORE
+# BASIC: S_NOP 0, implicit killed renamable $vgpr0_vgpr1
 
 --- |
   define void @killed_reg_after_regalloc_failure() #0 {

--- a/llvm/unittests/CodeGen/CMakeLists.txt
+++ b/llvm/unittests/CodeGen/CMakeLists.txt
@@ -38,6 +38,7 @@ add_llvm_unittest(CodeGenTests
   MachineInstrTest.cpp
   MachineOperandTest.cpp
   MIR2VecTest.cpp
+  RegAllocBasicTest.cpp
   RegAllocScoreTest.cpp
   RegisterTest.cpp
   PassManagerTest.cpp

--- a/llvm/unittests/CodeGen/RegAllocBasicTest.cpp
+++ b/llvm/unittests/CodeGen/RegAllocBasicTest.cpp
@@ -1,0 +1,94 @@
+//===- RegAllocBasicTest.cpp - Tests for basic register allocator --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../../lib/CodeGen/RegAllocBasic.h"
+#include "llvm/CodeGen/LiveInterval.h"
+#include "gtest/gtest.h"
+#include <queue>
+
+using namespace llvm;
+
+namespace {
+
+TEST(RegAllocBasicTest, CompSpillWeightDeterminism) {
+  // Test that CompSpillWeight provides deterministic ordering by testing
+  // all valid combinations of weight and register number comparisons.
+  //
+  // This is a regression test for non-deterministic behavior that occurred
+  // when ASAN changed memory layout, causing different heap configurations
+  // for LiveIntervals with identical spill weights.
+  //
+  // Comparison has two components: (weight, register number)
+  // Each can be <, =, or > resulting in 9 total combinations, but the case
+  // where register is equal and weight is different is impossible because each
+  // virtual register has exactly one LiveInterval with one weight.
+
+  // Create 3 LiveIntervals to test all 7 valid comparison combinations.
+  // Layout: W{weight}R{register}
+  LiveInterval W1R10(Register::index2VirtReg(10), 1.0f);
+  LiveInterval W1R30(Register::index2VirtReg(30), 1.0f);
+  LiveInterval W2R20(Register::index2VirtReg(20), 2.0f);
+
+  CompSpillWeight IsLessThan;
+
+  // Test all meaningful combinations of (weight comparison, register
+  // comparison). IsLessThan(A, B) returns true if A has lower priority than B
+  // (A < B in max-heap)
+
+  // Case 1: weight <, reg < : A has lower priority (weight dominates)
+  EXPECT_TRUE(IsLessThan(&W1R10, &W2R20));
+  EXPECT_FALSE(IsLessThan(&W2R20, &W1R10));
+
+  // Case 2: weight <, reg > : A has lower priority (weight dominates)
+  EXPECT_TRUE(IsLessThan(&W1R30, &W2R20));
+  EXPECT_FALSE(IsLessThan(&W2R20, &W1R30));
+
+  // Case 3: weight =, reg < : A has lower priority (register breaks tie)
+  EXPECT_TRUE(IsLessThan(&W1R10, &W1R30));
+  EXPECT_FALSE(IsLessThan(&W1R30, &W1R10));
+
+  // Case 4: weight =, reg = : equal (both comparisons return false)
+  EXPECT_FALSE(IsLessThan(&W1R10, &W1R10));
+
+  // Case 5: weight =, reg > : A has higher priority (register breaks tie)
+  EXPECT_FALSE(IsLessThan(&W1R30, &W1R10));
+  EXPECT_TRUE(IsLessThan(&W1R10, &W1R30));
+
+  // Case 6: weight >, reg < : A has higher priority (weight dominates)
+  EXPECT_FALSE(IsLessThan(&W2R20, &W1R30));
+  EXPECT_TRUE(IsLessThan(&W1R30, &W2R20));
+
+  // Case 7: weight >, reg > : A has higher priority (weight dominates)
+  EXPECT_FALSE(IsLessThan(&W2R20, &W1R10));
+  EXPECT_TRUE(IsLessThan(&W1R10, &W2R20));
+
+  // Test priority_queue ordering with all intervals
+  std::priority_queue<const LiveInterval *, std::vector<const LiveInterval *>,
+                      CompSpillWeight>
+      PQ;
+
+  // Insert all intervals in arbitrary order
+  PQ.push(&W1R30);
+  PQ.push(&W2R20);
+  PQ.push(&W1R10);
+
+  // Expected order: highest weight first, then descending register within ties
+  // Weight 2.0: R20
+  EXPECT_EQ(PQ.top()->reg(), Register::index2VirtReg(20));
+  EXPECT_EQ(PQ.top()->weight(), 2.0f);
+  PQ.pop();
+
+  // Weight 1.0: R30, R10 (descending register order)
+  EXPECT_EQ(PQ.top()->reg(), Register::index2VirtReg(30));
+  EXPECT_EQ(PQ.top()->weight(), 1.0f);
+  PQ.pop();
+  EXPECT_EQ(PQ.top()->reg(), Register::index2VirtReg(10));
+  EXPECT_EQ(PQ.top()->weight(), 1.0f);
+}
+
+} // anonymous namespace


### PR DESCRIPTION
The basic register allocator's priority queue exhibited non-deterministic behavior when multiple LiveIntervals had identical spill weights. This caused different register allocation decisions between ASAN and non-ASAN builds, leading to spurious test failures on some internal tests.

Root Cause:
The CompSpillWeight comparator only compared spill weights:
```
  return A->weight() < B->weight();
```

When two LiveIntervals had equal weights, the comparator returned false for both comp(A,B) and comp(B,A), making them equivalent in the heap ordering. The C++ standard does not specify the relative order of equivalent elements in a heap. In practice, the heap's internal structure for equivalent elements depends on implementation details and memory layout. ASAN changes memory layout, leading to different valid heap configurations and thus different dequeue order.

Fix:
Add an explicit stable tie-breaker using virtual register numbers:
```
  return std::tuple(A->weight(), A->reg()) <
         std::tuple(B->weight(), B->reg());
```

Register numbers are stable integers independent of memory layout, ensuring deterministic behavior across all build configurations. When spill weights are equal, higher-numbered virtual registers are allocated first, which is equally valid and deterministic.

Test Updates:
Updated test expectations in
CodeGen/AMDGPU/register-killed-error-after-alloc-failure0.mir to reflect the new deterministic allocation order. When LiveIntervals have equal spill weights, the allocator now consistently processes them in register number order rather than in an implementation-defined order.