### PR TITLE
[InstCombine] Fold select of intrinsic into intrinsic of select

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -805,6 +805,7 @@ public:
   Instruction *foldSelectExtConst(SelectInst &Sel);
   Instruction *foldSelectEqualityTest(SelectInst &SI);
   Instruction *foldSelectOpOp(SelectInst &SI, Instruction *TI, Instruction *FI);
+  Instruction *foldSelectIntrinsic(SelectInst &SI);
   Instruction *foldSelectIntoOp(SelectInst &SI, Value *, Value *);
   Instruction *foldSPFofSPF(Instruction *Inner, SelectPatternFlavor SPF1,
                             Value *A, Value *B, Instruction &Outer,

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -501,7 +501,7 @@ static Instruction *foldSelectIntrinsicUnary(SelectInst &SI,
 
   if (match(TrueV, m_Intrinsic<ID>(m_Value(TV))) &&
       match(FalseV, m_Intrinsic<ID>(m_Value(FV)))) {
-    Value *NewSel = Builder.CreateSelect(SI.getCondition(), TV, FV);
+    Value *NewSel = Builder.CreateSelect(SI.getCondition(), TV, FV, "", &SI);
     Instruction *NewCall =
         Builder.CreateIntrinsic(ID, {NewSel->getType()}, {NewSel});
     return NewCall;
@@ -520,7 +520,7 @@ foldSelectIntrinsicBinary(SelectInst &SI, InstCombiner::BuilderTy &Builder) {
   if (match(TrueV, m_Intrinsic<ID>(m_Value(TV), m_ConstantInt(TZ))) &&
       match(FalseV, m_Intrinsic<ID>(m_Value(FV), m_ConstantInt(FZ))) &&
       TZ == FZ) {
-    Value *NewSel = Builder.CreateSelect(SI.getCondition(), TV, FV);
+    Value *NewSel = Builder.CreateSelect(SI.getCondition(), TV, FV, "", &SI);
     Instruction *NewCall =
         Builder.CreateIntrinsic(ID, {NewSel->getType()}, {NewSel, TZ});
     return NewCall;

--- a/llvm/test/Transforms/InstCombine/intrinsic-select.ll
+++ b/llvm/test/Transforms/InstCombine/intrinsic-select.ll
@@ -611,13 +611,25 @@ define i32 @select_of_ctlz(i1 %cond, i32 %x, i32 %y) {
   ret i32 %sel
 }
 
-define i32 @select_of_ctlz_zero_poison(i1 %cond, i32 %x, i32 %y) {
-; CHECK-LABEL: @select_of_ctlz_zero_poison(
+define i32 @select_of_ctlz_zero_poison_false(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_ctlz_zero_poison_false(
 ; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[COND:%.*]], i32 [[X:%.*]], i32 [[Y:%.*]]
 ; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[TMP1]], i1 false)
 ; CHECK-NEXT:    ret i32 [[SEL]]
 ;
   %ctlz1 = call i32 @llvm.ctlz.i32(i32 %x, i1 false)
+  %ctlz2 = call i32 @llvm.ctlz.i32(i32 %y, i1 true)
+  %sel = select i1 %cond, i32 %ctlz1, i32 %ctlz2
+  ret i32 %sel
+}
+
+define i32 @select_of_ctlz_zero_poison_true(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_ctlz_zero_poison_true(
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[COND:%.*]], i32 [[X:%.*]], i32 [[Y:%.*]]
+; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[TMP1]], i1 true)
+; CHECK-NEXT:    ret i32 [[SEL]]
+;
+  %ctlz1 = call i32 @llvm.ctlz.i32(i32 %x, i1 true)
   %ctlz2 = call i32 @llvm.ctlz.i32(i32 %y, i1 true)
   %sel = select i1 %cond, i32 %ctlz1, i32 %ctlz2
   ret i32 %sel

--- a/llvm/test/Transforms/InstCombine/intrinsic-select.ll
+++ b/llvm/test/Transforms/InstCombine/intrinsic-select.ll
@@ -535,10 +535,9 @@ define <2 x i8> @test_select_rotate_right_non_splat(i1 %0) {
 
 define i32 @select_of_ctpop(i1 %cond, i32 %x, i32 %y) {
 ; CHECK-LABEL: @select_of_ctpop(
-; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[TMP1:%.*]])
-; CHECK-NEXT:    [[CTPOP2:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[Y:%.*]])
-; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL]], i32 [[CTPOP2]]
-; CHECK-NEXT:    ret i32 [[SEL1]]
+; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL:%.*]], i32 [[CTPOP2:%.*]]
+; CHECK-NEXT:    [[SEL2:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[SEL1]])
+; CHECK-NEXT:    ret i32 [[SEL2]]
 ;
   %ctpop1 = call i32 @llvm.ctpop.i32(i32 %x)
   %ctpop2 = call i32 @llvm.ctpop.i32(i32 %y)
@@ -576,8 +575,8 @@ define i32 @select_of_ctpop_multi_use(i1 %cond, i32 %x, i32 %y) {
 ; CHECK-LABEL: @select_of_ctpop_multi_use(
 ; CHECK-NEXT:    [[CTPOP1:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[X:%.*]])
 ; CHECK-NEXT:    call void @use(i32 [[CTPOP1]])
-; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[TMP1:%.*]])
-; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[CTPOP1]], i32 [[SEL]]
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[COND:%.*]], i32 [[X]], i32 [[Y:%.*]]
+; CHECK-NEXT:    [[SEL1:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[TMP1]])
 ; CHECK-NEXT:    ret i32 [[SEL1]]
 ;
   %ctpop1 = call i32 @llvm.ctpop.i32(i32 %x)
@@ -589,10 +588,9 @@ define i32 @select_of_ctpop_multi_use(i1 %cond, i32 %x, i32 %y) {
 
 define <4 x i32> @select_of_ctpop_vec(<4 x i1> %cond, <4 x i32> %x, <4 x i32> %y) {
 ; CHECK-LABEL: @select_of_ctpop_vec(
-; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) <4 x i32> @llvm.ctpop.v4i32(<4 x i32> [[TMP1:%.*]])
-; CHECK-NEXT:    [[CTPOP2:%.*]] = call range(i32 0, 33) <4 x i32> @llvm.ctpop.v4i32(<4 x i32> [[Y:%.*]])
-; CHECK-NEXT:    [[SEL1:%.*]] = select <4 x i1> [[COND:%.*]], <4 x i32> [[SEL]], <4 x i32> [[CTPOP2]]
-; CHECK-NEXT:    ret <4 x i32> [[SEL1]]
+; CHECK-NEXT:    [[SEL1:%.*]] = select <4 x i1> [[COND:%.*]], <4 x i32> [[SEL:%.*]], <4 x i32> [[CTPOP2:%.*]]
+; CHECK-NEXT:    [[SEL2:%.*]] = call range(i32 0, 33) <4 x i32> @llvm.ctpop.v4i32(<4 x i32> [[SEL1]])
+; CHECK-NEXT:    ret <4 x i32> [[SEL2]]
 ;
   %ctpop1 = call <4 x i32> @llvm.ctpop.v4i32(<4 x i32> %x)
   %ctpop2 = call <4 x i32> @llvm.ctpop.v4i32(<4 x i32> %y)
@@ -602,10 +600,9 @@ define <4 x i32> @select_of_ctpop_vec(<4 x i1> %cond, <4 x i32> %x, <4 x i32> %y
 
 define i32 @select_of_ctlz(i1 %cond, i32 %x, i32 %y) {
 ; CHECK-LABEL: @select_of_ctlz(
-; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[TMP1:%.*]], i1 false)
-; CHECK-NEXT:    [[CTLZ2:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[Y:%.*]], i1 false)
-; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL]], i32 [[CTLZ2]]
-; CHECK-NEXT:    ret i32 [[SEL1]]
+; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL:%.*]], i32 [[CTLZ2:%.*]]
+; CHECK-NEXT:    [[SEL2:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[SEL1]], i1 false)
+; CHECK-NEXT:    ret i32 [[SEL2]]
 ;
   %ctlz1 = call i32 @llvm.ctlz.i32(i32 %x, i1 false)
   %ctlz2 = call i32 @llvm.ctlz.i32(i32 %y, i1 false)
@@ -631,8 +628,8 @@ define i32 @select_of_ctlz_multi_use(i1 %cond, i32 %x, i32 %y) {
 ; CHECK-LABEL: @select_of_ctlz_multi_use(
 ; CHECK-NEXT:    [[CTLZ1:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[X:%.*]], i1 false)
 ; CHECK-NEXT:    call void @use(i32 [[CTLZ1]])
-; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[TMP1:%.*]], i1 false)
-; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[CTLZ1]], i32 [[SEL]]
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[COND:%.*]], i32 [[X]], i32 [[Y:%.*]]
+; CHECK-NEXT:    [[SEL1:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[TMP1]], i1 false)
 ; CHECK-NEXT:    ret i32 [[SEL1]]
 ;
   %ctlz1 = call i32 @llvm.ctlz.i32(i32 %x, i1 false)
@@ -655,10 +652,9 @@ define <4 x i32> @select_of_ctlz_vec(<4 x i1> %cond, <4 x i32> %x, <4 x i32> %y)
 
 define i32 @select_of_cttz(i1 %cond, i32 %x, i32 %y) {
 ; CHECK-LABEL: @select_of_cttz(
-; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.cttz.i32(i32 [[TMP1:%.*]], i1 false)
-; CHECK-NEXT:    [[CTTZ2:%.*]] = call range(i32 0, 33) i32 @llvm.cttz.i32(i32 [[Y:%.*]], i1 false)
-; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL]], i32 [[CTTZ2]]
-; CHECK-NEXT:    ret i32 [[SEL1]]
+; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL:%.*]], i32 [[CTTZ2:%.*]]
+; CHECK-NEXT:    [[SEL2:%.*]] = call range(i32 0, 33) i32 @llvm.cttz.i32(i32 [[SEL1]], i1 false)
+; CHECK-NEXT:    ret i32 [[SEL2]]
 ;
   %cttz1 = call i32 @llvm.cttz.i32(i32 %x, i1 false)
   %cttz2 = call i32 @llvm.cttz.i32(i32 %y, i1 false)
@@ -668,10 +664,9 @@ define i32 @select_of_cttz(i1 %cond, i32 %x, i32 %y) {
 
 define i32 @select_of_abs(i1 %cond, i32 %x, i32 %y) {
 ; CHECK-LABEL: @select_of_abs(
-; CHECK-NEXT:    [[SEL:%.*]] = call i32 @llvm.abs.i32(i32 [[TMP1:%.*]], i1 false)
-; CHECK-NEXT:    [[ABS2:%.*]] = call i32 @llvm.abs.i32(i32 [[Y:%.*]], i1 false)
-; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL]], i32 [[ABS2]]
-; CHECK-NEXT:    ret i32 [[SEL1]]
+; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL:%.*]], i32 [[ABS2:%.*]]
+; CHECK-NEXT:    [[SEL2:%.*]] = call i32 @llvm.abs.i32(i32 [[SEL1]], i1 false)
+; CHECK-NEXT:    ret i32 [[SEL2]]
 ;
   %abs1 = call i32 @llvm.abs.i32(i32 %x, i1 false)
   %abs2 = call i32 @llvm.abs.i32(i32 %y, i1 false)

--- a/llvm/test/Transforms/InstCombine/intrinsic-select.ll
+++ b/llvm/test/Transforms/InstCombine/intrinsic-select.ll
@@ -532,3 +532,149 @@ define <2 x i8> @test_select_rotate_right_non_splat(i1 %0) {
   %ret = call <2 x i8> @llvm.fshr.v2i8(<2 x i8> %s, <2 x i8> %s, <2 x i8> <i8 7, i8 7>)
   ret <2 x i8> %ret
 }
+
+define i32 @select_of_ctpop(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_ctpop(
+; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[TMP1:%.*]])
+; CHECK-NEXT:    [[CTPOP2:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[Y:%.*]])
+; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL]], i32 [[CTPOP2]]
+; CHECK-NEXT:    ret i32 [[SEL1]]
+;
+  %ctpop1 = call i32 @llvm.ctpop.i32(i32 %x)
+  %ctpop2 = call i32 @llvm.ctpop.i32(i32 %y)
+  %sel = select i1 %cond, i32 %ctpop1, i32 %ctpop2
+  ret i32 %sel
+}
+
+; Negative test: TV is not ctpop, should not transform
+define i32 @select_of_ctpop_negative_tv(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_ctpop_negative_tv(
+; CHECK-NEXT:    [[CTPOP2:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[Y:%.*]])
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND:%.*]], i32 [[X:%.*]], i32 [[CTPOP2]]
+; CHECK-NEXT:    ret i32 [[SEL]]
+;
+  %ctpop1 = add i32 %x, 0
+  %ctpop2 = call i32 @llvm.ctpop.i32(i32 %y)
+  %sel = select i1 %cond, i32 %ctpop1, i32 %ctpop2
+  ret i32 %sel
+}
+
+; Negative test: FV is not ctpop, should not transform
+define i32 @select_of_ctpop_negative_fv(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_ctpop_negative_fv(
+; CHECK-NEXT:    [[CTPOP1:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[Y:%.*]])
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND:%.*]], i32 [[CTPOP1]], i32 [[X:%.*]]
+; CHECK-NEXT:    ret i32 [[SEL]]
+;
+  %ctpop1 = call i32 @llvm.ctpop.i32(i32 %y)
+  %ctpop2 = add i32 %x, 0
+  %sel = select i1 %cond, i32 %ctpop1, i32 %ctpop2
+  ret i32 %sel
+}
+
+define i32 @select_of_ctpop_multi_use(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_ctpop_multi_use(
+; CHECK-NEXT:    [[CTPOP1:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[X:%.*]])
+; CHECK-NEXT:    call void @use(i32 [[CTPOP1]])
+; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[TMP1:%.*]])
+; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[CTPOP1]], i32 [[SEL]]
+; CHECK-NEXT:    ret i32 [[SEL1]]
+;
+  %ctpop1 = call i32 @llvm.ctpop.i32(i32 %x)
+  call void @use(i32 %ctpop1)
+  %ctpop2 = call i32 @llvm.ctpop.i32(i32 %y)
+  %sel = select i1 %cond, i32 %ctpop1, i32 %ctpop2
+  ret i32 %sel
+}
+
+define <4 x i32> @select_of_ctpop_vec(<4 x i1> %cond, <4 x i32> %x, <4 x i32> %y) {
+; CHECK-LABEL: @select_of_ctpop_vec(
+; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) <4 x i32> @llvm.ctpop.v4i32(<4 x i32> [[TMP1:%.*]])
+; CHECK-NEXT:    [[CTPOP2:%.*]] = call range(i32 0, 33) <4 x i32> @llvm.ctpop.v4i32(<4 x i32> [[Y:%.*]])
+; CHECK-NEXT:    [[SEL1:%.*]] = select <4 x i1> [[COND:%.*]], <4 x i32> [[SEL]], <4 x i32> [[CTPOP2]]
+; CHECK-NEXT:    ret <4 x i32> [[SEL1]]
+;
+  %ctpop1 = call <4 x i32> @llvm.ctpop.v4i32(<4 x i32> %x)
+  %ctpop2 = call <4 x i32> @llvm.ctpop.v4i32(<4 x i32> %y)
+  %sel = select <4 x i1> %cond, <4 x i32> %ctpop1, <4 x i32> %ctpop2
+  ret <4 x i32> %sel
+}
+
+define i32 @select_of_ctlz(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_ctlz(
+; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[TMP1:%.*]], i1 false)
+; CHECK-NEXT:    [[CTLZ2:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[Y:%.*]], i1 false)
+; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL]], i32 [[CTLZ2]]
+; CHECK-NEXT:    ret i32 [[SEL1]]
+;
+  %ctlz1 = call i32 @llvm.ctlz.i32(i32 %x, i1 false)
+  %ctlz2 = call i32 @llvm.ctlz.i32(i32 %y, i1 false)
+  %sel = select i1 %cond, i32 %ctlz1, i32 %ctlz2
+  ret i32 %sel
+}
+
+; Negative test: zero poison flags differ, don't transform
+define i32 @select_of_ctlz_negative_zero_poison(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_ctlz_negative_zero_poison(
+; CHECK-NEXT:    [[CTLZ1:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[X:%.*]], i1 false)
+; CHECK-NEXT:    [[CTLZ2:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[Y:%.*]], i1 true)
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND:%.*]], i32 [[CTLZ1]], i32 [[CTLZ2]]
+; CHECK-NEXT:    ret i32 [[SEL]]
+;
+  %ctlz1 = call i32 @llvm.ctlz.i32(i32 %x, i1 false)
+  %ctlz2 = call i32 @llvm.ctlz.i32(i32 %y, i1 true)
+  %sel = select i1 %cond, i32 %ctlz1, i32 %ctlz2
+  ret i32 %sel
+}
+
+define i32 @select_of_ctlz_multi_use(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_ctlz_multi_use(
+; CHECK-NEXT:    [[CTLZ1:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[X:%.*]], i1 false)
+; CHECK-NEXT:    call void @use(i32 [[CTLZ1]])
+; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[TMP1:%.*]], i1 false)
+; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[CTLZ1]], i32 [[SEL]]
+; CHECK-NEXT:    ret i32 [[SEL1]]
+;
+  %ctlz1 = call i32 @llvm.ctlz.i32(i32 %x, i1 false)
+  call void @use(i32 %ctlz1)
+  %ctlz2 = call i32 @llvm.ctlz.i32(i32 %y, i1 false)
+  %sel = select i1 %cond, i32 %ctlz1, i32 %ctlz2
+  ret i32 %sel
+}
+
+define <4 x i32> @select_of_ctlz_vec(<4 x i1> %cond, <4 x i32> %x, <4 x i32> %y) {
+; CHECK-LABEL: @select_of_ctlz_vec(
+; CHECK-NEXT:    [[CTLZ2:%.*]] = call range(i32 0, 33) <4 x i32> @llvm.ctlz.v4i32(<4 x i32> [[Y:%.*]], i1 false)
+; CHECK-NEXT:    ret <4 x i32> [[CTLZ2]]
+;
+  %ctlz1 = call <4 x i32> @llvm.ctlz.v4i32(<4 x i32> %x, i1 false)
+  %ctlz2 = call <4 x i32> @llvm.ctlz.v4i32(<4 x i32> %y, i1 false)
+  %sel = select <4 x i1> %cond, <4 x i32> %ctlz2, <4 x i32> %ctlz2
+  ret <4 x i32> %sel
+}
+
+define i32 @select_of_cttz(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_cttz(
+; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.cttz.i32(i32 [[TMP1:%.*]], i1 false)
+; CHECK-NEXT:    [[CTTZ2:%.*]] = call range(i32 0, 33) i32 @llvm.cttz.i32(i32 [[Y:%.*]], i1 false)
+; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL]], i32 [[CTTZ2]]
+; CHECK-NEXT:    ret i32 [[SEL1]]
+;
+  %cttz1 = call i32 @llvm.cttz.i32(i32 %x, i1 false)
+  %cttz2 = call i32 @llvm.cttz.i32(i32 %y, i1 false)
+  %sel = select i1 %cond, i32 %cttz1, i32 %cttz2
+  ret i32 %sel
+}
+
+define i32 @select_of_abs(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_abs(
+; CHECK-NEXT:    [[SEL:%.*]] = call i32 @llvm.abs.i32(i32 [[TMP1:%.*]], i1 false)
+; CHECK-NEXT:    [[ABS2:%.*]] = call i32 @llvm.abs.i32(i32 [[Y:%.*]], i1 false)
+; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL]], i32 [[ABS2]]
+; CHECK-NEXT:    ret i32 [[SEL1]]
+;
+  %abs1 = call i32 @llvm.abs.i32(i32 %x, i1 false)
+  %abs2 = call i32 @llvm.abs.i32(i32 %y, i1 false)
+  %sel = select i1 %cond, i32 %abs1, i32 %abs2
+  ret i32 %sel
+}

--- a/llvm/test/Transforms/InstCombine/intrinsic-select.ll
+++ b/llvm/test/Transforms/InstCombine/intrinsic-select.ll
@@ -535,9 +535,9 @@ define <2 x i8> @test_select_rotate_right_non_splat(i1 %0) {
 
 define i32 @select_of_ctpop(i1 %cond, i32 %x, i32 %y) {
 ; CHECK-LABEL: @select_of_ctpop(
-; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL:%.*]], i32 [[CTPOP2:%.*]]
-; CHECK-NEXT:    [[SEL2:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[SEL1]])
-; CHECK-NEXT:    ret i32 [[SEL2]]
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[COND:%.*]], i32 [[X:%.*]], i32 [[Y:%.*]]
+; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[TMP1]])
+; CHECK-NEXT:    ret i32 [[SEL]]
 ;
   %ctpop1 = call i32 @llvm.ctpop.i32(i32 %x)
   %ctpop2 = call i32 @llvm.ctpop.i32(i32 %y)
@@ -571,13 +571,14 @@ define i32 @select_of_ctpop_negative_fv(i1 %cond, i32 %x, i32 %y) {
   ret i32 %sel
 }
 
-define i32 @select_of_ctpop_multi_use(i1 %cond, i32 %x, i32 %y) {
-; CHECK-LABEL: @select_of_ctpop_multi_use(
+; Negative test: ctpop1 has multiple uses, don't transform
+define i32 @select_of_ctpop_negative_multi_use(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_ctpop_negative_multi_use(
 ; CHECK-NEXT:    [[CTPOP1:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[X:%.*]])
 ; CHECK-NEXT:    call void @use(i32 [[CTPOP1]])
-; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[COND:%.*]], i32 [[X]], i32 [[Y:%.*]]
-; CHECK-NEXT:    [[SEL1:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[TMP1]])
-; CHECK-NEXT:    ret i32 [[SEL1]]
+; CHECK-NEXT:    [[CTPOP2:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[Y:%.*]])
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND:%.*]], i32 [[CTPOP1]], i32 [[CTPOP2]]
+; CHECK-NEXT:    ret i32 [[SEL]]
 ;
   %ctpop1 = call i32 @llvm.ctpop.i32(i32 %x)
   call void @use(i32 %ctpop1)
@@ -588,9 +589,9 @@ define i32 @select_of_ctpop_multi_use(i1 %cond, i32 %x, i32 %y) {
 
 define <4 x i32> @select_of_ctpop_vec(<4 x i1> %cond, <4 x i32> %x, <4 x i32> %y) {
 ; CHECK-LABEL: @select_of_ctpop_vec(
-; CHECK-NEXT:    [[SEL1:%.*]] = select <4 x i1> [[COND:%.*]], <4 x i32> [[SEL:%.*]], <4 x i32> [[CTPOP2:%.*]]
-; CHECK-NEXT:    [[SEL2:%.*]] = call range(i32 0, 33) <4 x i32> @llvm.ctpop.v4i32(<4 x i32> [[SEL1]])
-; CHECK-NEXT:    ret <4 x i32> [[SEL2]]
+; CHECK-NEXT:    [[TMP1:%.*]] = select <4 x i1> [[COND:%.*]], <4 x i32> [[X:%.*]], <4 x i32> [[Y:%.*]]
+; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) <4 x i32> @llvm.ctpop.v4i32(<4 x i32> [[TMP1]])
+; CHECK-NEXT:    ret <4 x i32> [[SEL]]
 ;
   %ctpop1 = call <4 x i32> @llvm.ctpop.v4i32(<4 x i32> %x)
   %ctpop2 = call <4 x i32> @llvm.ctpop.v4i32(<4 x i32> %y)
@@ -600,9 +601,9 @@ define <4 x i32> @select_of_ctpop_vec(<4 x i1> %cond, <4 x i32> %x, <4 x i32> %y
 
 define i32 @select_of_ctlz(i1 %cond, i32 %x, i32 %y) {
 ; CHECK-LABEL: @select_of_ctlz(
-; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL:%.*]], i32 [[CTLZ2:%.*]]
-; CHECK-NEXT:    [[SEL2:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[SEL1]], i1 false)
-; CHECK-NEXT:    ret i32 [[SEL2]]
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[COND:%.*]], i32 [[X:%.*]], i32 [[Y:%.*]]
+; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[TMP1]], i1 false)
+; CHECK-NEXT:    ret i32 [[SEL]]
 ;
   %ctlz1 = call i32 @llvm.ctlz.i32(i32 %x, i1 false)
   %ctlz2 = call i32 @llvm.ctlz.i32(i32 %y, i1 false)
@@ -610,12 +611,10 @@ define i32 @select_of_ctlz(i1 %cond, i32 %x, i32 %y) {
   ret i32 %sel
 }
 
-; Negative test: zero poison flags differ, don't transform
-define i32 @select_of_ctlz_negative_zero_poison(i1 %cond, i32 %x, i32 %y) {
-; CHECK-LABEL: @select_of_ctlz_negative_zero_poison(
-; CHECK-NEXT:    [[CTLZ1:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[X:%.*]], i1 false)
-; CHECK-NEXT:    [[CTLZ2:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[Y:%.*]], i1 true)
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND:%.*]], i32 [[CTLZ1]], i32 [[CTLZ2]]
+define i32 @select_of_ctlz_zero_poison(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_ctlz_zero_poison(
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[COND:%.*]], i32 [[X:%.*]], i32 [[Y:%.*]]
+; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[TMP1]], i1 false)
 ; CHECK-NEXT:    ret i32 [[SEL]]
 ;
   %ctlz1 = call i32 @llvm.ctlz.i32(i32 %x, i1 false)
@@ -624,13 +623,14 @@ define i32 @select_of_ctlz_negative_zero_poison(i1 %cond, i32 %x, i32 %y) {
   ret i32 %sel
 }
 
-define i32 @select_of_ctlz_multi_use(i1 %cond, i32 %x, i32 %y) {
-; CHECK-LABEL: @select_of_ctlz_multi_use(
+; Negative test: ctlz1 has multiple uses, don't transform
+define i32 @select_of_ctlz_negative_multi_use(i1 %cond, i32 %x, i32 %y) {
+; CHECK-LABEL: @select_of_ctlz_negative_multi_use(
 ; CHECK-NEXT:    [[CTLZ1:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[X:%.*]], i1 false)
 ; CHECK-NEXT:    call void @use(i32 [[CTLZ1]])
-; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[COND:%.*]], i32 [[X]], i32 [[Y:%.*]]
-; CHECK-NEXT:    [[SEL1:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[TMP1]], i1 false)
-; CHECK-NEXT:    ret i32 [[SEL1]]
+; CHECK-NEXT:    [[CTLZ2:%.*]] = call range(i32 0, 33) i32 @llvm.ctlz.i32(i32 [[Y:%.*]], i1 false)
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[COND:%.*]], i32 [[CTLZ1]], i32 [[CTLZ2]]
+; CHECK-NEXT:    ret i32 [[SEL]]
 ;
   %ctlz1 = call i32 @llvm.ctlz.i32(i32 %x, i1 false)
   call void @use(i32 %ctlz1)
@@ -652,9 +652,9 @@ define <4 x i32> @select_of_ctlz_vec(<4 x i1> %cond, <4 x i32> %x, <4 x i32> %y)
 
 define i32 @select_of_cttz(i1 %cond, i32 %x, i32 %y) {
 ; CHECK-LABEL: @select_of_cttz(
-; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL:%.*]], i32 [[CTTZ2:%.*]]
-; CHECK-NEXT:    [[SEL2:%.*]] = call range(i32 0, 33) i32 @llvm.cttz.i32(i32 [[SEL1]], i1 false)
-; CHECK-NEXT:    ret i32 [[SEL2]]
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[COND:%.*]], i32 [[X:%.*]], i32 [[Y:%.*]]
+; CHECK-NEXT:    [[SEL:%.*]] = call range(i32 0, 33) i32 @llvm.cttz.i32(i32 [[TMP1]], i1 false)
+; CHECK-NEXT:    ret i32 [[SEL]]
 ;
   %cttz1 = call i32 @llvm.cttz.i32(i32 %x, i1 false)
   %cttz2 = call i32 @llvm.cttz.i32(i32 %y, i1 false)
@@ -664,9 +664,9 @@ define i32 @select_of_cttz(i1 %cond, i32 %x, i32 %y) {
 
 define i32 @select_of_abs(i1 %cond, i32 %x, i32 %y) {
 ; CHECK-LABEL: @select_of_abs(
-; CHECK-NEXT:    [[SEL1:%.*]] = select i1 [[COND:%.*]], i32 [[SEL:%.*]], i32 [[ABS2:%.*]]
-; CHECK-NEXT:    [[SEL2:%.*]] = call i32 @llvm.abs.i32(i32 [[SEL1]], i1 false)
-; CHECK-NEXT:    ret i32 [[SEL2]]
+; CHECK-NEXT:    [[TMP1:%.*]] = select i1 [[COND:%.*]], i32 [[X:%.*]], i32 [[Y:%.*]]
+; CHECK-NEXT:    [[SEL:%.*]] = call i32 @llvm.abs.i32(i32 [[TMP1]], i1 false)
+; CHECK-NEXT:    ret i32 [[SEL]]
 ;
   %abs1 = call i32 @llvm.abs.i32(i32 %x, i1 false)
   %abs2 = call i32 @llvm.abs.i32(i32 %y, i1 false)


### PR DESCRIPTION
Fix https://github.com/llvm/llvm-project/issues/140917

Transform:
`select cond, intrinsic(x, ...), intrinsic(y, ...)`
into:
`intrinsic(select cond, x, y, ...)`
for `ctpop/ctlz/cttz/abs`.

alive2 proof: https://alive2.llvm.org/ce/z/Zp55Dy