### PR TITLE
[Driver][Darwin] Pass stack usage file for LTO

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -660,6 +660,15 @@ void darwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(Args.MakeArgString("-lto-stats-file=" + StatsFile.str()));
   }
 
+  // Set up stack usage file path.
+  if (Args.hasArg(options::OPT_fstack_usage)) {
+    SmallString<128> StackUsageFile(Output.getFilename());
+    llvm::sys::path::replace_extension(StackUsageFile, "su");
+    CmdArgs.push_back("-mllvm");
+    CmdArgs.push_back(
+        Args.MakeArgString("-stack-usage-file=" + StackUsageFile));
+  }
+
   // It seems that the 'e' option is completely ignored for dynamic executables
   // (the default), and with static executables, the last one wins, as expected.
   Args.addAllArgs(CmdArgs, {options::OPT_d_Flag, options::OPT_s, options::OPT_t,

--- a/clang/test/Driver/darwin-ld-lto.c
+++ b/clang/test/Driver/darwin-ld-lto.c
@@ -46,3 +46,8 @@
 // RUN:   FileCheck --check-prefix=KEXT %s
 // KEXT: {{ld(.exe)?"}}
 // KEXT: "-mllvm" "-disable-atexit-based-global-dtor-lowering"
+
+// Check that we select a filename for -fstack-usage.
+// RUN: %clang --target=arm64-apple-darwin %s -flto -fstack-usage -o foo \
+// RUN:   -### 2>&1 | FileCheck --check-prefix=STACKUSAGE %s
+// STACKUSAGE: "-mllvm" "-stack-usage-file=foo.su"


### PR DESCRIPTION
Add a .su extension to the main output's filename and pass this down to the LLVM layer.

rdar://143089305