### PR TITLE
[flang] Document experimental support for multi-image features

### DIFF
--- a/flang/docs/FortranStandardsSupport.md
+++ b/flang/docs/FortranStandardsSupport.md
@@ -67,25 +67,24 @@ the multi-image execution. The table entries are based on the document [The new 
 | Feature                                                    | Status | Comments                                                |
 |------------------------------------------------------------|--------|---------------------------------------------------------|
 | Asynchronous communication                                 | P      | Syntax is accepted |
-| Teams                                                      | N      | Multi-image/Coarray feature |
-| Image failure                                              | P      | Multi-image/Coarray feature. stat_failed_image is added |
-| Form team statement                                        | N      | Multi-image/Coarray feature |
-| Change team construct                                      | N      | Multi-image/Coarray feature |
+| Collective subroutines                                     | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md), missing co_reduce |
+| Teams                                                      | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Form team statement                                        | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Change team construct                                      | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Sync team construct                                        | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Intrinsic functions get_team and team_number               | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Intrinsic function image_index                             | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Intrinsic function num_images                              | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Intrinsic function this_image                              | P      | Experimental support via [PRIF](ParallelMultiImageFortranRuntime.md) |
+| Image failure and stat= specifiers                         | P      | Multi-image/Coarray feature. stat_failed_image is added |
 | Coarrays allocated in teams                                | N      | Multi-image/Coarray feature |
 | Critical construct                                         | N      | Multi-image/Coarray feature |
 | Lock and unlock statements                                 | N      | Multi-image/Coarray feature |
 | Events                                                     | N      | Multi-image/Coarray feature |
-| Sync team construct                                        | N      | Multi-image/Coarray feature |
 | Image selectors                                            | N      | Multi-image/Coarray feature |
-| Intrinsic functions get_team 	and team_number              | N      | Multi-image/Coarray feature |
-| Intrinsic function image_index                             | N      | Multi-image/Coarray feature |
-| Intrinsic function num_images                              | N      | Multi-image/Coarray feature |
-| Intrinsic function this_image                              | N      | Multi-image/Coarray feature |
 | Intrinsic move_alloc extensions                            | P      | Multi-image/Coarray feature |
 | Detecting failed and stopped images                        | N      | Multi-image/Coarray feature |
-| Collective subroutines                                     | N      | Multi-image/Coarray feature |
 | New and enhanced atomic subroutines                        | N      | Multi-image/Coarray feature |
-| Failed images and stat= specifiers                         | N      | Multi-image/Coarray feature |
 | Intrinsic function coshape                                 | N      | Multi-image/Coarray feature |
 
 ## Fortran 2008

--- a/flang/docs/ParallelMultiImageFortranRuntime.md
+++ b/flang/docs/ParallelMultiImageFortranRuntime.md
@@ -15,3 +15,8 @@ Fortran's multi-image parallel features.
 
 The current revision of the PRIF specification is here:
 <https://doi.org/10.25344/S46S3W>
+
+Library implementations of PRIF include:
+
+* [Caffeine](https://go.lbl.gov/caffeine) - portable open-source implementation targeting shared- and distributed-memory systems running Linux or macOS
+


### PR DESCRIPTION
This PR updates flang's Fortran standard conformance documentation to reflect the recent addition of experimental support for multi-image features.

PRs implementing that support include:
* #151675
* #154081
* #154770
* #154166
* #165573
