### PR TITLE
[asan] Disable strict init checking on AIX

### DIFF
--- a/compiler-rt/lib/asan/asan_flags.cpp
+++ b/compiler-rt/lib/asan/asan_flags.cpp
@@ -160,7 +160,12 @@ static void ProcessFlags() {
   // Make "strict_init_order" imply "check_initialization_order".
   // TODO(samsonov): Use a single runtime flag for an init-order checker.
   if (f->strict_init_order) {
+#ifdef SANITIZER_AIX
+    Report("WARNING: strict_init_order is not supported on AIX.\n");
+    f->strict_init_order = false;
+#else
     f->check_initialization_order = true;
+#endif
   }
   CHECK_LE((uptr)common_flags()->malloc_context_size, kStackTraceMax);
   CHECK_LE(f->min_uar_stack_size_log, f->max_uar_stack_size_log);

--- a/compiler-rt/test/asan/TestCases/AIX/lit.local.cfg.py
+++ b/compiler-rt/test/asan/TestCases/AIX/lit.local.cfg.py
@@ -3,6 +3,7 @@ def getRoot(config):
         return config
     return getRoot(config.parent)
 
+
 root = getRoot(config)
 
 if root.target_os not in ["AIX"]:

--- a/compiler-rt/test/asan/TestCases/AIX/lit.local.cfg.py
+++ b/compiler-rt/test/asan/TestCases/AIX/lit.local.cfg.py
@@ -1,0 +1,9 @@
+def getRoot(config):
+    if not config.parent:
+        return config
+    return getRoot(config.parent)
+
+root = getRoot(config)
+
+if root.target_os not in ["AIX"]:
+    config.unsupported = True

--- a/compiler-rt/test/asan/TestCases/AIX/strict-init-order-warning.cpp
+++ b/compiler-rt/test/asan/TestCases/AIX/strict-init-order-warning.cpp
@@ -1,0 +1,8 @@
+// RUN: %clangxx_asan %s -o %t
+// RUN: %env_asan_opts=strict_init_order=true %run %t 2>&1 | FileCheck %s
+
+// CHECK: WARNING: strict_init_order is not supported on AIX.
+
+int main() {
+  return 0;
+}

--- a/compiler-rt/test/asan/TestCases/AIX/strict-init-order-warning.cpp
+++ b/compiler-rt/test/asan/TestCases/AIX/strict-init-order-warning.cpp
@@ -3,6 +3,4 @@
 
 // CHECK: WARNING: strict_init_order is not supported on AIX.
 
-int main() {
-  return 0;
-}
+int main() { return 0; }

--- a/compiler-rt/test/asan/TestCases/initialization-bug-no-global.cpp
+++ b/compiler-rt/test/asan/TestCases/initialization-bug-no-global.cpp
@@ -9,6 +9,9 @@
 // Fails on some Darwin bots, probably iOS.
 // XFAIL: ios
 
+// Strict init order checking is not supported on AIX
+// UNSUPPORTED: target={{.*aix.*}}
+
 #include <stdio.h>
 
 extern int y;


### PR DESCRIPTION
The `__cxa_atexit` interceptor is disabled for `SANITIZER_AIX` because Clang on AIX neither uses `__cxa_atexit` nor links against a library with such. This interceptor calls `StopInitOrderChecking()`, which is needed to prevent false positives for the `initialization-order-fiasco` error observed in the asan test `init-order-atexit.cpp` that uses the `strict_init_order` flag. For now, we'll disable the `strict_init_order` flag, but we'll look to support it in the future by implementing an `exit` interceptor or some other alternative. With the flag disabled, we won't update `init-order-atexit.cpp`  to ensure it continues to pass and the false positive doesn't show up.  