### PR TITLE
[llvm][AIX][unit] skip AIXTargetVersionDetect when target env in effect

### DIFF
--- a/llvm/unittests/TargetParser/Host.cpp
+++ b/llvm/unittests/TargetParser/Host.cpp
@@ -605,7 +605,7 @@ TEST(HostTest, AIXTargetVersionDetect) {
   if (ConfiguredTargetTriple.getOSMajorVersion())
     GTEST_SKIP(); // The version was configured explicitly; skip.
 
-#if defined(LLVM_TARGET_TRIPLE_ENV)
+#ifdef LLVM_TARGET_TRIPLE_ENV
   if (const char *EnvTriple = std::getenv(LLVM_TARGET_TRIPLE_ENV))
     GTEST_SKIP(); // The target was configured by env; skip.
 #endif

--- a/llvm/unittests/TargetParser/Host.cpp
+++ b/llvm/unittests/TargetParser/Host.cpp
@@ -605,6 +605,9 @@ TEST(HostTest, AIXTargetVersionDetect) {
   if (ConfiguredTargetTriple.getOSMajorVersion())
     GTEST_SKIP(); // The version was configured explicitly; skip.
 
+  if (const char *EnvTriple = std::getenv(LLVM_TARGET_TRIPLE_ENV))
+    GTEST_SKIP(); // The target was configured by env; skip.
+
   VersionTuple SystemVersion;
   getAIXSystemVersion(SystemVersion);
   VersionTuple TargetVersion = TargetTriple.getOSVersion();

--- a/llvm/unittests/TargetParser/Host.cpp
+++ b/llvm/unittests/TargetParser/Host.cpp
@@ -605,8 +605,10 @@ TEST(HostTest, AIXTargetVersionDetect) {
   if (ConfiguredTargetTriple.getOSMajorVersion())
     GTEST_SKIP(); // The version was configured explicitly; skip.
 
+#if defined(LLVM_TARGET_TRIPLE_ENV)
   if (const char *EnvTriple = std::getenv(LLVM_TARGET_TRIPLE_ENV))
     GTEST_SKIP(); // The target was configured by env; skip.
+#endif
 
   VersionTuple SystemVersion;
   getAIXSystemVersion(SystemVersion);


### PR DESCRIPTION
The unit tests expects OS levels in the default triple to match the host, but if we are overriding the compiled in default with an environment setting that may not be the case.