### PR TITLE
[lldb-dap][NFC] Use a lambda instead of std::bind.

### DIFF
--- a/lldb/include/lldb/Host/JSONTransport.h
+++ b/lldb/include/lldb/Host/JSONTransport.h
@@ -199,9 +199,7 @@ public:
   RegisterMessageHandler(MainLoop &loop, MessageHandler &handler) override {
     Status status;
     MainLoop::ReadHandleUP read_handle = loop.RegisterReadObject(
-        m_in,
-        std::bind(&IOTransport::OnRead, this, std::placeholders::_1,
-                  std::ref(handler)),
+        m_in, [this, &handler](MainLoopBase &base) { OnRead(base, handler); },
         status);
     if (status.Fail()) {
       return status.takeError();

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -1065,7 +1065,7 @@ llvm::Error DAP::Loop() {
     m_disconnecting = false;
   }
 
-  auto thread = std::thread(std::bind(&DAP::TransportHandler, this));
+  auto thread = std::thread([this] { TransportHandler(); });
 
   llvm::scope_exit cleanup([this]() {
     // FIXME: Merge these into the MainLoop handler.


### PR DESCRIPTION
I find it easier to read what is happening, especially for member functions.