### PR TITLE
[Driver][SYCL] Add tests for -Xarch_<arch> option forwarding to SYCL JIT compilation.

### DIFF
--- a/clang/test/Driver/sycl-offload-jit-xarch.cpp
+++ b/clang/test/Driver/sycl-offload-jit-xarch.cpp
@@ -1,0 +1,13 @@
+// Test passing of -Xarch_<arch> <option> to SYCL offload compilations.
+
+// Verify that -Xarch_spirv64 forwards options to the SYCL device compilation
+// and clang-linker-wrapper call.
+// RUN: %clang -fsycl -Xarch_spirv64 -O3 -### %s 2>&1 \
+// RUN: | FileCheck -check-prefixes=SYCL-DEVICE-O3,CLW-O3 %s
+// SYCL-DEVICE-O3: "-triple" "spirv64-unknown-unknown" "-O3"{{.*}} "-fsycl-is-device"
+// CLW-O3: {{"[^"]*clang-linker-wrapper[^"]*".* "--device-compiler=spirv64-unknown-unknown=-O3"}}
+
+// Verify that `-Xarch_spirv64` forwards libraries to the device linker.
+// RUN: %clang -fsycl -Xarch_spirv64 -Wl,-lfoo -### %s 2>&1 \
+// RUN: | FileCheck -check-prefix=DEVICE-LINKER %s
+// DEVICE-LINKER: {{"[^"]*clang-linker-wrapper[^"]*".* "--device-linker=spirv64-unknown-unknown=-lfoo"}}

--- a/clang/test/Driver/sycl-offload-jit-xarch.cpp
+++ b/clang/test/Driver/sycl-offload-jit-xarch.cpp
@@ -3,9 +3,9 @@
 // Verify that -Xarch_spirv64 forwards options to the SYCL device compilation
 // and clang-linker-wrapper call.
 // RUN: %clang -fsycl -Xarch_spirv64 -O3 -### %s 2>&1 \
-// RUN: | FileCheck -check-prefixes=SYCL-DEVICE-O3,CLW-O3 %s
+// RUN: | FileCheck -check-prefix=SYCL-DEVICE-O3 %s
 // SYCL-DEVICE-O3: "-triple" "spirv64-unknown-unknown" "-O3"{{.*}} "-fsycl-is-device"
-// CLW-O3: {{"[^"]*clang-linker-wrapper[^"]*".* "--device-compiler=spirv64-unknown-unknown=-O3"}}
+// SYCL-DEVICE-O3: {{"[^"]*clang-linker-wrapper[^"]*".* "--device-compiler=spirv64-unknown-unknown=-O3"}}
 
 // Verify that `-Xarch_spirv64` forwards libraries to the device linker.
 // RUN: %clang -fsycl -Xarch_spirv64 -Wl,-lfoo -### %s 2>&1 \

--- a/clang/test/Driver/sycl-offload-jit-xarch.cpp
+++ b/clang/test/Driver/sycl-offload-jit-xarch.cpp
@@ -2,12 +2,12 @@
 
 // Verify that -Xarch_spirv64 forwards options to the SYCL device compilation
 // and clang-linker-wrapper call.
-// RUN: %clang -fsycl -Xarch_spirv64 -O3 -### %s 2>&1 \
+// RUN: %clang -fsycl --offload-targets=spirv64-unknown-unknown -Xarch_spirv64 -O3 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefix=SYCL-DEVICE-O3 %s
 // SYCL-DEVICE-O3: "-triple" "spirv64-unknown-unknown" "-O3"{{.*}} "-fsycl-is-device"
 // SYCL-DEVICE-O3: {{"[^"]*clang-linker-wrapper[^"]*".* "--device-compiler=spirv64-unknown-unknown=-O3"}}
 
 // Verify that `-Xarch_spirv64` forwards libraries to the device linker.
-// RUN: %clang -fsycl -Xarch_spirv64 -Wl,-lfoo -### %s 2>&1 \
+// RUN: %clang -fsycl --offload-targets=spirv64-unknown-unknown -Xarch_spirv64 -Wl,-lfoo -### %s 2>&1 \
 // RUN: | FileCheck -check-prefix=DEVICE-LINKER %s
 // DEVICE-LINKER: {{"[^"]*clang-linker-wrapper[^"]*".* "--device-linker=spirv64-unknown-unknown=-lfoo"}}


### PR DESCRIPTION
This change adds test coverage to verify that options passed via `-Xarch_<arch> <option>` are correctly forwarded to SYCL JIT compilations.