### PR TITLE
[RISCV] Update P extension to 019.

### DIFF
--- a/clang/test/Driver/print-supported-extensions-riscv.c
+++ b/clang/test/Driver/print-supported-extensions-riscv.c
@@ -240,7 +240,7 @@
 // CHECK-NEXT:     xwchc                2.2       'Xwchc' (WCH/QingKe additional compressed opcodes)
 // CHECK-EMPTY:
 // CHECK-NEXT: Experimental extensions
-// CHECK-NEXT:     p                    0.18      'P' ('Base P' (Packed SIMD))
+// CHECK-NEXT:     p                    0.19      'P' ('Base P' (Packed SIMD))
 // CHECK-NEXT:     y                    0.96      'Y' ('Base Y' (CHERI))
 // CHECK-NEXT:     zibi                 0.1       'Zibi' (Branch with Immediate)
 // CHECK-NEXT:     zicfilp              1.0       'Zicfilp' (Landing pad)

--- a/llvm/docs/RISCVUsage.rst
+++ b/llvm/docs/RISCVUsage.rst
@@ -336,7 +336,7 @@ LLVM supports (to various degrees) a number of experimental extensions.  All exp
 The primary goal of experimental support is to assist in the process of ratification by providing an existence proof of an implementation, and simplifying efforts to validate the value of a proposed extension against large code bases.  Experimental extensions are expected to either transition to ratified status, or be eventually removed.  The decision on whether to accept an experimental extension is currently done on an entirely case by case basis; if you want to propose one, attending the bi-weekly RISC-V sync-up call is strongly advised.
 
 ``experimental-p``
-  LLVM implements the `018 draft specification <https://www.jhauser.us/RISCV/ext-P/>`__.
+  LLVM implements the `019 draft specification <https://www.jhauser.us/RISCV/ext-P/>`__.
 
 ``experimental-zibi``
   LLVM implements the `0.1 release specification <https://github.com/riscv/zibi/releases/tag/v0.1.0>`__.

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -122,7 +122,7 @@ Changes to the RISC-V Backend
 
 * `llvm-objdump` now has support for `--symbolize-operands` with RISC-V.
 * `-mcpu=spacemit-x100` was added.
-* Change P extension version to match the 019 draft specificatio$n. Encoded in `-march` as `0p19`.
+* Change P extension version to match the 019 draft specification. Encoded in `-march` as `0p19`.
 
 Changes to the WebAssembly Backend
 ----------------------------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -122,6 +122,7 @@ Changes to the RISC-V Backend
 
 * `llvm-objdump` now has support for `--symbolize-operands` with RISC-V.
 * `-mcpu=spacemit-x100` was added.
+* Change P extension version to match the 019 draft specificatio$n. Encoded in `-march` as `0p19`.
 
 Changes to the WebAssembly Backend
 ----------------------------------

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -1111,7 +1111,7 @@ def HasStdExtSmctrOrSsctr : Predicate<"Subtarget->hasStdExtSmctrOrSsctr()">,
 
 // Packed SIMD Extensions
 def FeatureStdExtP
-    : RISCVExperimentalExtension<0, 18,
+    : RISCVExperimentalExtension<0, 19,
                                  "'Base P' (Packed SIMD)">;
 def HasStdExtP : Predicate<"Subtarget->hasStdExtP()">,
                  AssemblerPredicate<(all_of FeatureStdExtP),

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1237,9 +1237,9 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PM2WADDASU_H : RVPWideningTernary_rrr<0b1101, 0b11, "pm2waddasu.h">;
 
   def PMQWACC_H    : RVPWideningTernary_rrr<0b1111, 0b00, "pmqwacc.h">;
-  def PMQWACC      : RVPWideningTernary_rrr<0b1111, 0b01, "pmqwacc">;
+  def MQWACC       : RVPWideningTernary_rrr<0b1111, 0b01, "mqwacc">;
   def PMQRWACC_H   : RVPWideningTernary_rrr<0b1111, 0b10, "pmqrwacc.h">;
-  def PMQRWACC     : RVPWideningTernary_rrr<0b1111, 0b11, "pmqrwacc">;
+  def MQRWACC      : RVPWideningTernary_rrr<0b1111, 0b11, "mqrwacc">;
 
   def PREDSUM_DHS  : RVPNarrowingBinary_rr<0b001, 0b00, "predsum.dhs">;
   def PREDSUM_DBS  : RVPNarrowingBinary_rr<0b001, 0b10, "predsum.dbs">;

--- a/llvm/test/CodeGen/RISCV/attributes.ll
+++ b/llvm/test/CodeGen/RISCV/attributes.ll
@@ -618,7 +618,7 @@
 ; RV64SSCTR: .attribute 5, "rv64i2p1_sscsrind1p0_ssctr1p0"
 ; RV64SDEXT: .attribute 5, "rv64i2p1_sdext1p0"
 ; RV64SDTRIG: .attribute 5, "rv64i2p1_sdtrig1p0"
-; RV64P: .attribute 5, "rv64i2p1_p0p18"
+; RV64P: .attribute 5, "rv64i2p1_p0p19"
 ; RV64Y: .attribute 5, "rv64i2p1_y0p96"
 ; RV64ZIBI: .attribute 5, "rv64i2p1_zibi0p1"
 

--- a/llvm/test/MC/RISCV/attribute-arch.s
+++ b/llvm/test/MC/RISCV/attribute-arch.s
@@ -507,8 +507,8 @@
 .attribute arch, "rv32i_sdtrig1p0"
 # CHECK: attribute      5, "rv32i2p1_sdtrig1p0"
 
-.attribute arch, "rv32i_p0p18"
-# CHECK: attribute      5, "rv32i2p1_p0p18"
+.attribute arch, "rv32i_p0p19"
+# CHECK: attribute      5, "rv32i2p1_p0p19"
 
-.attribute arch, "rv64i_p0p18"
-# CHECK: attribute      5, "rv64i2p1_p0p18"
+.attribute arch, "rv64i_p0p19"
+# CHECK: attribute      5, "rv64i2p1_p0p19"

--- a/llvm/test/MC/RISCV/rv32p-valid.s
+++ b/llvm/test/MC/RISCV/rv32p-valid.s
@@ -849,15 +849,15 @@ pm2waddasu.h t3, t5, a0
 # CHECK-ASM-AND-OBJ: pmqwacc.h t5, t5, a2
 # CHECK-ASM: encoding: [0x9b,0x2f,0xcf,0x78]
 pmqwacc.h t5, t5, a2
-# CHECK-ASM-AND-OBJ: pmqwacc s2, a4, a2
+# CHECK-ASM-AND-OBJ: mqwacc s2, a4, a2
 # CHECK-ASM: encoding: [0x9b,0x29,0xc7,0x7a]
-pmqwacc s2, a4, a2
+mqwacc s2, a4, a2
 # CHECK-ASM-AND-OBJ: pmqrwacc.h a4, t3, a4
 # CHECK-ASM: encoding: [0x9b,0x27,0xee,0x7c]
 pmqrwacc.h a4, t3, a4
-# CHECK-ASM-AND-OBJ: pmqrwacc s0, s2, t5
+# CHECK-ASM-AND-OBJ: mqrwacc s0, s2, t5
 # CHECK-ASM: encoding: [0x9b,0x24,0xe9,0x7f]
-pmqrwacc s0, s2, t5
+mqrwacc s0, s2, t5
 # CHECK-ASM-AND-OBJ: predsum.dhs s0, t3, a0
 # CHECK-ASM: encoding: [0x1b,0x44,0xae,0x18]
 predsum.dhs s0, t3, a0

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -1392,7 +1392,7 @@ R"(All available -march extensions for RISC-V
     xwchc                2.2
 
 Experimental extensions
-    p                    0.18
+    p                    0.19
     y                    0.96
     zibi                 0.1
     zicfilp              1.0       This is a long dummy description


### PR DESCRIPTION
This renames two scalar instructions to not start with P. P means "packed".