### PR TITLE
Modify llvm-gsymutil to work around invalid DW_AT_LLVM_stmt_sequence attributes.

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -335,35 +335,48 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
 
   if (!CUI.LineTable->lookupAddressRange(SecAddress, RangeSize, RowVector,
                                          StmtSeqOffset)) {
-    // If we have a DW_TAG_subprogram but no line entries, fall back to using
-    // the DW_AT_decl_file an d DW_AT_decl_line if we have both attributes.
-    std::string FilePath = Die.getDeclFile(
-        DILineInfoSpecifier::FileLineInfoKind::AbsoluteFilePath);
-    if (FilePath.empty()) {
-      // If we had a DW_AT_decl_file, but got no file then we need to emit a
-      // warning.
-      const uint64_t DwarfFileIdx = dwarf::toUnsigned(
-          Die.findRecursively(dwarf::DW_AT_decl_file), UINT32_MAX);
-      // Check if there is no DW_AT_decl_line attribute, and don't report an
-      // error if it isn't there.
-      if (DwarfFileIdx == UINT32_MAX)
+    // if StmtSeqOffset had a value and the lookup succceeds, then we had an
+    // invalid value in DW_AT_LLVM_stmt_sequence, but we did find some line
+    // entries without using it.
+    if (StmtSeqOffset && CUI.LineTable->lookupAddressRange(SecAddress, RangeSize, RowVector)) {
+        Out.Report("Invalid DW_AT_LLVM_stmt_sequence value", [&](raw_ostream &OS) {
+          OS << "error: function DIE at " << HEX32(Die.getOffset())
+              << " has a DW_AT_LLVM_stmt_sequence value "
+              << HEX32(*StmtSeqOffset) << " which doesn't match any line table "
+              << "sequence offset but there are " << RowVector.size()
+              <<" matching line entries in other sequences.\n";
+        });
+    } else {
+      // If we have a DW_TAG_subprogram but no line entries, fall back to using
+      // the DW_AT_decl_file an d DW_AT_decl_line if we have both attributes.
+      std::string FilePath = Die.getDeclFile(
+          DILineInfoSpecifier::FileLineInfoKind::AbsoluteFilePath);
+      if (FilePath.empty()) {
+        // If we had a DW_AT_decl_file, but got no file then we need to emit a
+        // warning.
+        const uint64_t DwarfFileIdx = dwarf::toUnsigned(
+            Die.findRecursively(dwarf::DW_AT_decl_file), UINT32_MAX);
+        // Check if there is no DW_AT_decl_line attribute, and don't report an
+        // error if it isn't there.
+        if (DwarfFileIdx == UINT32_MAX)
+          return;
+        Out.Report("Invalid file index in DW_AT_decl_file", [&](raw_ostream &OS) {
+          OS << "error: function DIE at " << HEX32(Die.getOffset())
+              << " has an invalid file index " << DwarfFileIdx
+              << " in its DW_AT_decl_file attribute, unable to create a single "
+              << "line entry from the DW_AT_decl_file/DW_AT_decl_line "
+              << "attributes.\n";
+        });
         return;
-      Out.Report("Invalid file index in DW_AT_decl_file", [&](raw_ostream &OS) {
-        OS << "error: function DIE at " << HEX32(Die.getOffset())
-           << " has an invalid file index " << DwarfFileIdx
-           << " in its DW_AT_decl_file attribute, unable to create a single "
-           << "line entry from the DW_AT_decl_file/DW_AT_decl_line "
-           << "attributes.\n";
-      });
+      }
+      if (auto Line =
+              dwarf::toUnsigned(Die.findRecursively({dwarf::DW_AT_decl_line}))) {
+        LineEntry LE(StartAddress, Gsym.insertFile(FilePath), *Line);
+        FI.OptLineTable = LineTable();
+        FI.OptLineTable->push(LE);
+      }
       return;
     }
-    if (auto Line =
-            dwarf::toUnsigned(Die.findRecursively({dwarf::DW_AT_decl_line}))) {
-      LineEntry LE(StartAddress, Gsym.insertFile(FilePath), *Line);
-      FI.OptLineTable = LineTable();
-      FI.OptLineTable->push(LE);
-    }
-    return;
   }
 
   FI.OptLineTable = LineTable();

--- a/llvm/test/tools/llvm-gsymutil/X86/elf-invalid-llvm-stmt-sequence.yaml
+++ b/llvm/test/tools/llvm-gsymutil/X86/elf-invalid-llvm-stmt-sequence.yaml
@@ -1,0 +1,119 @@
+## Test that if we have a DW_AT_LLVM_stmt_sequence attribute on a function DIE
+## in DWARF that has an invalid sequence offset, we can successfully convert
+## it to gsym with all valid line entries. When a sequence offset is invalid,
+## llvm-gsymutil should emit an error but still convert the valid line entries.
+
+# RUN: yaml2obj %s -o %t
+# RUN: llvm-gsymutil --convert %t -o %t.gsym  2>&1 | FileCheck %s --check-prefix=CONVERT
+# RUN: llvm-gsymutil %t.gsym 2>&1 | FileCheck %s --check-prefix=DUMP
+
+# Make sure we get an error when parsing due to an invalid
+# DW_AT_LLVM_stmt_sequence.
+# CONVERT: error: function DIE at 0x00000015 has a DW_AT_LLVM_stmt_sequence value 0x0000002a which doesn't match any line table sequence offset but there are 2 matching line entries in other sequences.
+# CONVERT: Loaded 1 functions from DWARF.
+
+# Check that the line table got converted correctly for the function with
+# a valid DW_AT_LLVM_stmt_sequence.
+# DUMP:      FunctionInfo @ 0x0000005c: [0x0000000000001000 - 0x0000000000001100) "bar"
+# DUMP-NEXT: LineTable:
+# DUMP-NEXT:   0x0000000000001000 main.cpp:10
+# DUMP-NEXT:   0x0000000000001010 main.cpp:11
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+  Entry:           0x00000000004003E0
+DWARF:
+  debug_str:
+    - ''
+    - main.cpp
+    - bar
+  debug_abbrev:
+    - ID:              0
+      Table:
+        - Code:            0x1
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_language
+              Form:            DW_FORM_udata
+            - Attribute:       DW_AT_stmt_list
+              Form:            DW_FORM_sec_offset
+        - Code:            0x2
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_LLVM_stmt_sequence
+              Form:            DW_FORM_sec_offset
+  debug_info:
+    - Length:          0x2B
+      Version:         4
+      AbbrevTableID:   0
+      AbbrOffset:      0x0
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x1
+          Values:
+            - Value:           0x1
+            - Value:           0x4
+            - Value:           0x0
+        - AbbrCode:        0x2
+          Values:
+            - Value:           0xA
+            - Value:           0x1000
+            - Value:           0x1100
+            - Value:           0x2A
+        - AbbrCode:        0x0
+  debug_line:
+    - Length:          64
+      Version:         2
+      PrologueLength:  31
+      MinInstLength:   1
+      DefaultIsStmt:   1
+      LineBase:        251
+      LineRange:       14
+      OpcodeBase:      13
+      StandardOpcodeLengths: [ 0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1 ]
+      Files:
+        - Name:            main.cpp
+          DirIdx:          0
+          ModTime:         0
+          Length:          0
+      Opcodes:
+        - Opcode:          DW_LNS_extended_op
+          ExtLen:          9
+          SubOpcode:       DW_LNE_set_address
+          Data:            4096
+        - Opcode:          DW_LNS_advance_line
+          SData:           9
+          Data:            0
+        - Opcode:          DW_LNS_copy
+          Data:            0
+        - Opcode:          DW_LNS_advance_pc
+          Data:            16
+        - Opcode:          DW_LNS_advance_line
+          SData:           1
+          Data:            0
+        - Opcode:          DW_LNS_copy
+          Data:            0
+        - Opcode:          DW_LNS_advance_pc
+          Data:            240
+        - Opcode:          DW_LNS_advance_line
+          SData:           2
+          Data:            0
+        - Opcode:          DW_LNS_extended_op
+          ExtLen:          1
+          SubOpcode:       DW_LNE_end_sequence
+          Data:            0
+...

--- a/llvm/test/tools/llvm-gsymutil/X86/elf-llvm-stmt-sequence.yaml
+++ b/llvm/test/tools/llvm-gsymutil/X86/elf-llvm-stmt-sequence.yaml
@@ -1,0 +1,118 @@
+## Test that if we have a DW_AT_LLVM_stmt_sequence attribute on a function DIE
+## in DWARF that has a valid sequence offset, we can successfully convert
+## it to gsym with all valid line entries.
+
+# RUN: yaml2obj %s -o %t
+# RUN: llvm-gsymutil --convert %t -o %t.gsym  2>&1 | FileCheck %s --check-prefix=CONVERT
+# RUN: llvm-gsymutil %t.gsym 2>&1 | FileCheck %s --check-prefix=DUMP
+
+# Make sure there were no errors when parsing due to the
+# DW_AT_LLVM_stmt_sequence.
+# CONVERT-NOT: error:
+# CONVERT: Loaded 1 functions from DWARF.
+
+# Check that the line table got converted correctly for the function with
+# a valid DW_AT_LLVM_stmt_sequence.
+# DUMP:      FunctionInfo @ 0x0000005c: [0x0000000000001000 - 0x0000000000001100) "bar"
+# DUMP-NEXT: LineTable:
+# DUMP-NEXT:   0x0000000000001000 main.cpp:10
+# DUMP-NEXT:   0x0000000000001010 main.cpp:11
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+  Entry:           0x00000000004003E0
+DWARF:
+  debug_str:
+    - ''
+    - main.cpp
+    - bar
+  debug_abbrev:
+    - ID:              0
+      Table:
+        - Code:            0x1
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_language
+              Form:            DW_FORM_udata
+            - Attribute:       DW_AT_stmt_list
+              Form:            DW_FORM_sec_offset
+        - Code:            0x2
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_LLVM_stmt_sequence
+              Form:            DW_FORM_sec_offset
+  debug_info:
+    - Length:          0x2B
+      Version:         4
+      AbbrevTableID:   0
+      AbbrOffset:      0x0
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x1
+          Values:
+            - Value:           0x1
+            - Value:           0x4
+            - Value:           0x0
+        - AbbrCode:        0x2
+          Values:
+            - Value:           0xA
+            - Value:           0x1000
+            - Value:           0x1100
+            - Value:           0x29
+        - AbbrCode:        0x0
+  debug_line:
+    - Length:          64
+      Version:         2
+      PrologueLength:  31
+      MinInstLength:   1
+      DefaultIsStmt:   1
+      LineBase:        251
+      LineRange:       14
+      OpcodeBase:      13
+      StandardOpcodeLengths: [ 0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1 ]
+      Files:
+        - Name:            main.cpp
+          DirIdx:          0
+          ModTime:         0
+          Length:          0
+      Opcodes:
+        - Opcode:          DW_LNS_extended_op
+          ExtLen:          9
+          SubOpcode:       DW_LNE_set_address
+          Data:            4096
+        - Opcode:          DW_LNS_advance_line
+          SData:           9
+          Data:            0
+        - Opcode:          DW_LNS_copy
+          Data:            0
+        - Opcode:          DW_LNS_advance_pc
+          Data:            16
+        - Opcode:          DW_LNS_advance_line
+          SData:           1
+          Data:            0
+        - Opcode:          DW_LNS_copy
+          Data:            0
+        - Opcode:          DW_LNS_advance_pc
+          Data:            240
+        - Opcode:          DW_LNS_advance_line
+          SData:           2
+          Data:            0
+        - Opcode:          DW_LNS_extended_op
+          ExtLen:          1
+          SubOpcode:       DW_LNE_end_sequence
+          Data:            0
+...


### PR DESCRIPTION
The DW_AT_LLVM_stmt_sequence attribute is an attribute that can be added to a DW_TAG_subprogram DIE to uniquely identify the exact line tables entries for a given function. This helps when we merge functions in the same compile unit and end up with multiple sequences in the line table that describe the same address range. Having this attribute on a function allows us to select the right line table entries for a function. This also helps us convert to GSYM and always get the line tables right.

We have seen a large amount of errors when binaries have DW_AT_LLVM_stmt_sequence attributes on functions but their values have invalid .debug_line sequence offsets. When this would happen, the conversion to GSYM would not emit any line table entries for that function. This patch tries to use the DW_AT_LLVM_stmt_sequence attribute when finding all line entries for a function, but it will fall back to not using and requiring it to be correct. This ensures we always get the most information in the GSYM even when DW_AT_LLVM_stmt_sequence values are not valid. Others are working on fixing the compiler or LTO/Bolt issues that cause invalid DW_AT_LLVM_stmt_sequence values to be in a final executable, but this patch will help track and mitigate the issue.