### PR TITLE
[MTE][Darwin] This patch extends support for the stack frame history buffer to  Darwin.

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/MemoryTaggingSupport.h
+++ b/llvm/include/llvm/Transforms/Utils/MemoryTaggingSupport.h
@@ -92,10 +92,11 @@ Value *readRegister(IRBuilder<> &IRB, StringRef Name);
 Value *getFP(IRBuilder<> &IRB);
 Value *getPC(const Triple &TargetTriple, IRBuilder<> &IRB);
 Value *getAndroidSlotPtr(IRBuilder<> &IRB, int Slot);
+Value *getDarwinSlotPtr(IRBuilder<> &IRB, int Slot);
 
 void annotateDebugRecords(AllocaInfo &Info, unsigned int Tag);
 Value *incrementThreadLong(IRBuilder<> &IRB, Value *ThreadLong,
-                           unsigned int Inc);
+                           unsigned int Inc, bool IsMemtagDarwin = false);
 
 } // namespace memtag
 } // namespace llvm

--- a/llvm/lib/Target/AArch64/AArch64StackTagging.cpp
+++ b/llvm/lib/Target/AArch64/AArch64StackTagging.cpp
@@ -472,14 +472,24 @@ Instruction *AArch64StackTagging::insertBaseTaggedPointer(
   // This ABI will make it into Android API level 35.
   // The ThreadLong format is the same as with HWASan, but the entries for
   // stack MTE take two slots (16 bytes).
-  if (ClRecordStackHistory == instr && TargetTriple.isAndroid() &&
-      TargetTriple.isAArch64() && !TargetTriple.isAndroidVersionLT(35) &&
-      !AllocasToInstrument.empty()) {
-    constexpr int StackMteSlot = -3;
+  //
+  // Stack history is recorded by default on Darwin.
+  if (ClRecordStackHistory == instr ||
+      (!ClRecordStackHistory.getNumOccurrences() &&
+       TargetTriple.isOSDarwin())) {
     constexpr uint64_t TagMask = 0xFULL << 56;
+    Value *SlotPtr = nullptr;
+    if (TargetTriple.isAndroid() && TargetTriple.isAArch64() &&
+        !TargetTriple.isAndroidVersionLT(35) && !AllocasToInstrument.empty()) {
+      SlotPtr = memtag::getAndroidSlotPtr(IRB, -3);
+    } else if (TargetTriple.isOSDarwin() && TargetTriple.isAArch64() &&
+               !TargetTriple.isSimulatorEnvironment()) {
+      SlotPtr = memtag::getDarwinSlotPtr(IRB, 231);
+    } else {
+      return Base;
+    }
 
     auto *IntptrTy = IRB.getIntPtrTy(M.getDataLayout());
-    Value *SlotPtr = memtag::getAndroidSlotPtr(IRB, StackMteSlot);
     auto *ThreadLong = IRB.CreateLoad(IntptrTy, SlotPtr);
     Value *FP = memtag::getFP(IRB);
     Value *Tag = IRB.CreateAnd(IRB.CreatePtrToInt(Base, IntptrTy), TagMask);
@@ -489,7 +499,9 @@ Instruction *AArch64StackTagging::insertBaseTaggedPointer(
     IRB.CreateStore(PC, RecordPtr);
     IRB.CreateStore(TaggedFP, IRB.CreateConstGEP1_64(IntptrTy, RecordPtr, 1));
 
-    IRB.CreateStore(memtag::incrementThreadLong(IRB, ThreadLong, 16), SlotPtr);
+    IRB.CreateStore(memtag::incrementThreadLong(IRB, ThreadLong, 16,
+                                                TargetTriple.isOSDarwin()),
+                    SlotPtr);
   }
   return Base;
 }

--- a/llvm/lib/Transforms/Utils/MemoryTaggingSupport.cpp
+++ b/llvm/lib/Transforms/Utils/MemoryTaggingSupport.cpp
@@ -261,6 +261,25 @@ Value *getFP(IRBuilder<> &IRB) {
       IRB.getIntPtrTy(M->getDataLayout()));
 }
 
+Value *getDarwinSlotPtr(IRBuilder<> &IRB, int Slot) {
+  Module *M = IRB.GetInsertBlock()->getParent()->getParent();
+  // FIXME: This should use the thread_pointer intrinsic. However, the
+  // intrinsic is not currently implemented on Darwin correctly. The
+  // TPIDRRO_EL0 register became part of the ABI to access TSD on recent
+  // versions of OS and so it is safe to use here
+  // Darwin provides a fixed slot for sanitizers at offset 231.
+  MDNode *MD = MDNode::get(M->getContext(),
+                           {MDString::get(M->getContext(), "TPIDRRO_EL0")});
+  Value *Args[] = {MetadataAsValue::get(M->getContext(), MD)};
+  return IRB.CreateConstGEP1_32(
+      IRB.getInt8Ty(),
+      IRB.CreateIntToPtr(
+          IRB.CreateIntrinsic(Intrinsic::read_register,
+                              {IRB.getIntPtrTy(M->getDataLayout())}, Args),
+          IRB.getPtrTy()),
+      8 * Slot);
+}
+
 Value *getAndroidSlotPtr(IRBuilder<> &IRB, int Slot) {
   Module *M = IRB.GetInsertBlock()->getParent()->getParent();
   // Android provides a fixed TLS slot for sanitizers. See TLS_SLOT_SANITIZER
@@ -297,7 +316,7 @@ void annotateDebugRecords(AllocaInfo &Info, unsigned int Tag) {
 }
 
 Value *incrementThreadLong(IRBuilder<> &IRB, Value *ThreadLong,
-                           unsigned int Inc) {
+                           unsigned int Inc, bool IsMemtagDarwin) {
   // Update the ring buffer. Top byte of ThreadLong defines the size of the
   // buffer in pages, it must be a power of two, and the start of the buffer
   // must be aligned by twice that much. Therefore wrap around of the ring
@@ -321,9 +340,16 @@ Value *incrementThreadLong(IRBuilder<> &IRB, Value *ThreadLong,
   //            0x01AAAAAAAAAAA000
   //
   // Then the WrapMask will be a no-op until the next wrap case.
+  //
+  // Darwin relies on bit 60-62 to store the size of the buffer in pages. This
+  // limits N to [0,2] while the rest of the proof remains unchanged. Bits
+  // 56-59 are avoided in order to prevent MTE Canonical Tag Faults while
+  // accessing the ring buffer. Bit 63 is avoided to prevent unintentional
+  // signed extension by AShr.
   assert((4096 % Inc) == 0);
   Value *WrapMask = IRB.CreateXor(
-      IRB.CreateShl(IRB.CreateAShr(ThreadLong, 56), 12, "", true, true),
+      IRB.CreateShl(IRB.CreateAShr(ThreadLong, IsMemtagDarwin ? 60 : 56), 12,
+                    "", true, true),
       ConstantInt::get(ThreadLong->getType(), (uint64_t)-1));
   return IRB.CreateAnd(
       IRB.CreateAdd(ThreadLong, ConstantInt::get(ThreadLong->getType(), Inc)),

--- a/llvm/test/CodeGen/AArch64/stack-tagging-prologue.ll
+++ b/llvm/test/CodeGen/AArch64/stack-tagging-prologue.ll
@@ -1,10 +1,12 @@
-; RUN: opt < %s -aarch64-stack-tagging -stack-tagging-use-stack-safety=0 -S -o - | FileCheck %s --check-prefixes=CHECK
-; RUN: opt < %s -aarch64-stack-tagging -stack-tagging-use-stack-safety=0 -S -stack-tagging-record-stack-history=instr -o - | FileCheck %s --check-prefixes=INSTR
-; RUN llc -mattr=+mte -stack-tagging-use-stack-safety=0 -stack-tagging-record-stack-history=instr %s -o - | FileCheck %s --check-prefixes=ASMINSTR
+; RUN: opt < %s -aarch64-stack-tagging -stack-tagging-use-stack-safety=0 -S -mtriple="aarch64" -o - | FileCheck %s --check-prefixes=CHECK
+; RUN: opt < %s -aarch64-stack-tagging -stack-tagging-use-stack-safety=0 -S -stack-tagging-record-stack-history=instr -mtriple="aarch64--linux-android35" -o - | FileCheck %s --check-prefixes=INSTR,ANDROID_INSTR
+; RUN: opt < %s -aarch64-stack-tagging -stack-tagging-use-stack-safety=0 -S -stack-tagging-record-stack-history=instr -mtriple="aarch64-darwin" -o - | FileCheck %s --check-prefixes=INSTR,DARWIN_INSTR
+; RUN: llc -mattr=+mte -stack-tagging-use-stack-safety=0 -stack-tagging-record-stack-history=instr %s -o - -mtriple="aarch64--linux-android35" | FileCheck %s --check-prefixes=ASMINSTR,ANDROID_ASMINSTR
+; RUN: llc -mattr=+mte -stack-tagging-use-stack-safety=0 -stack-tagging-record-stack-history=instr %s -o - -mtriple="aarch64-darwin" | FileCheck %s --check-prefixes=ASMINSTR,DARWIN_ASMINSTR
+; RUN: llc -mattr=+mte -stack-tagging-use-stack-safety=0 %s -o - -mtriple="aarch64-darwin" | FileCheck %s --check-prefixes=ASMINSTR,DARWIN_ASMINSTR
 
 
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
-target triple = "aarch64--linux-android35"
 
 declare void @use32(ptr)
 
@@ -23,20 +25,24 @@ entry:
 
 ; INSTR-LABEL: define void @OneVar(
 ; INSTR:  [[BASE:%.*]] = call ptr @llvm.aarch64.irg.sp(i64 0)
-; INSTR:  [[TLS:%.*]] = call ptr @llvm.thread.pointer.p0()
-; INSTR:  [[TLS_SLOT:%.*]] = getelementptr i8, ptr [[TLS]], i32 -24
+; ANDROID_INSTR:  [[TLS:%.*]] = call ptr @llvm.thread.pointer.p0()
+; ANDROID_INSTR:  [[TLS_SLOT:%.*]] = getelementptr i8, ptr [[TLS]], i32 -24
+; DARWIN_INSTR:  [[TLS_INT:%.*]] = call i64 @llvm.read_register.i64(metadata [[TPIDRRO_REG:!.*]])
+; DARWIN_INSTR: [[TLS:%.*]] = inttoptr i64 [[TLS_INT]] to ptr
+; DARWIN_INSTR: [[TLS_SLOT:%.*]] = getelementptr i8, ptr [[TLS]], i32 1848
 ; INSTR:  [[TLS_VALUE:%.*]] = load i64, ptr [[TLS_SLOT]], align 8
 ; INSTR:  [[FP:%.*]] = call ptr @llvm.frameaddress.p0(i32 0)
 ; INSTR:  [[FP_INT:%.*]] = ptrtoint ptr [[FP]] to i64
 ; INSTR:  [[BASE_INT:%.*]] = ptrtoint ptr [[BASE]] to i64
 ; INSTR:  [[BASE_TAG:%.*]] = and i64 [[BASE_INT]], 1080863910568919040
 ; INSTR:  [[TAGGED_FP:%.*]] = or i64 [[FP_INT]], [[BASE_TAG]]
-; INSTR:  [[PC:%.*]] = call i64 @llvm.read_register.i64(metadata !0)
+; INSTR:  [[PC:%.*]] = call i64 @llvm.read_register.i64(metadata [[PC_REG:!.*]])
 ; INSTR:  [[TLS_VALUE_PTR:%.*]] = inttoptr i64 [[TLS_VALUE]] to ptr
 ; INSTR:  store i64 [[PC]], ptr [[TLS_VALUE_PTR]], align 8
 ; INSTR:  [[SECOND_SLOT:%.*]] = getelementptr i64, ptr [[TLS_VALUE_PTR]], i64 1
 ; INSTR:  store i64 [[TAGGED_FP]], ptr [[SECOND_SLOT]], align 8
-; INSTR:  [[SIZE_IN_PAGES:%.*]] = ashr i64 [[TLS_VALUE]], 56
+; ANDROID_INSTR:  [[SIZE_IN_PAGES:%.*]] = ashr i64 [[TLS_VALUE]], 56
+; DARWIN_INSTR:  [[SIZE_IN_PAGES:%.*]] = ashr i64 [[TLS_VALUE]], 60
 ; INSTR:  [[WRAP_MASK_INTERMEDIARY:%.*]] = shl nuw nsw i64 [[SIZE_IN_PAGES]], 12
 ; INSTR:  [[WRAP_MASK:%.*]] = xor i64 [[WRAP_MASK_INTERMEDIARY]], -1
 ; INSTR:  [[NEXT_TLS_VALUE_BEFORE_WRAP:%.*]] = add i64 [[TLS_VALUE]], 16
@@ -44,18 +50,23 @@ entry:
 ; INSTR:  store i64 [[NEXT_TLS_VALUE]], ptr [[TLS_SLOT]], align 8
 ; INSTR:  [[X:%.*]] = alloca { i32, [12 x i8] }, align 16
 ; INSTR:  [[TX:%.*]] = call ptr @llvm.aarch64.tagp.{{.*}}(ptr [[X]], ptr [[BASE]], i64 0)
-; INSTR:  [[PC:!.*]] = !{!"pc"}
+; DARWIN_INSTR: [[TPIDRRO_REG]] = !{!"TPIDRRO_EL0"}
+; INSTR:  [[PC_REG:!.*]] = !{!"pc"}
 
 ; ASMINSTR-LABEL: OneVar:
-; ASMINSTR:  mrs	[[TLS:x.*]], TPIDR_EL0
+; ANDROID_ASMINSTR:  mrs	[[TLS:x.*]], TPIDR_EL0
 ; ASMINSTR:  irg	[[BASE:x.*]], sp
+; DARWIN_ASMINSTR: mrs [[TLS:x.*]], TPIDRRO_EL0
 ; ASMINSTR:  adr	[[PC:x.*]], #0
-; ASMINSTR:  ldur	[[TLS_SLOT:x.*]], [[[TLS]], #-24]
+; ANDROID_ASMINSTR:  ldur	[[TLS_SLOT:x.*]], [[[TLS]], #-24]
+; DARWIN_ASMINSTR:   ldr	[[TLS_SLOT:x.*]], [[[TLS]], #1848]
 ; ASMINSTR:  and	[[SP_TAG:x.*]], [[BASE]], #0xf00000000000000
-; ASMINSTR:  orr	[[TAGGED_FP]], x29, [[SP_TAG]]
-; ASMINSTR:  asr	[[TLS_SIZE:x.*]], [[TLS_SLOT]], #56
+; ASMINSTR:  orr	[[TAGGED_FP:x.*]], x29, [[SP_TAG]]
+; ANDROID_ASMINSTR:  asr	[[TLS_SIZE:x.*]], [[TLS_SLOT]], #56
+; DARWIN_ASMINSTR:  asr	[[TLS_SIZE:x.*]], [[TLS_SLOT]], #60
 ; ASMINSTR:  add	[[NEXT_TLS_VALUE_BEFORE_WRAP:x.*]], [[TLS_SLOT]], #16
 ; ASMINSTR:  stp	[[PC]], [[TAGGED_FP]], [[[TLS_SLOT]]]
 ; ASMINSTR:  bic	[[NEXT_TLS_VALUE:x.*]], [[NEXT_TLS_VALUE_BEFORE_WRAP]], [[TLS_SIZE]], lsl #12
-; ASMINSTR:  stur	[[NEXT_TLS_VALUE]], [[[TLS]], #-24]
+; ANDROID_ASMINSTR:  stur	[[NEXT_TLS_VALUE]], [[[TLS]], #-24]
+; DARWIN_ASMINSTR:   str [[NEXT_TLS_VALUE]], [[[TLS]], #1848]
 ; ASMINSTR:  stg	[[BASE]], [[[BASE]]]


### PR DESCRIPTION
Darwin reserves slot 231 for storing a pointer to the history ring buffer. It also uses bits 60-62 to store the size of the ring buffer

rdar://168176496