### PR TITLE
[CIR] Move BrOp block merging to canonicalize method

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1409,6 +1409,8 @@ def CIR_BrOp : CIR_Op<"br",[
   let assemblyFormat = [{
     $dest (`(` $destOperands^ `:` type($destOperands) `)`)? attr-dict
   }];
+
+  let hasCanonicalizeMethod = 1;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Move the redundant branch removal pattern from CIRCanonicalize pass
to BrOp::canonicalize. This follows  MLIR's convention where
canonicalization logic lives with the operation definition.

Changes:
- Add hasCanonicalizeMethod to BrOp in CIROps.td
- Implement BrOp::canonicalize in CIRDialect.cpp
- Auto-collect canonicalization patterns from all registered ops
  in CIRCanonicalizePass (matching MLIR's Canonicalizer approach)
- Remove the standalone RemoveRedundantBranches pattern class