### PR TITLE
[libm] Update include guards in libc/src/__support/math

### DIFF
--- a/libc/src/__support/math/atan2f_float.h
+++ b/libc/src/__support/math/atan2f_float.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SRC___SUPPORT_MATH_ATAN2F_FLOAT_H
-#define LIBC_SRC___SUPPORT_MATH_ATAN2F_FLOAT_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ATAN2F_FLOAT_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_ATAN2F_FLOAT_H
 
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/double_double.h"
@@ -242,4 +242,4 @@ LIBC_INLINE static constexpr float atan2f(float y, float x) {
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SRC___SUPPORT_MATH_ATAN2F_FLOAT_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_ATAN2F_FLOAT_H

--- a/libc/src/__support/math/atanf_float.h
+++ b/libc/src/__support/math/atanf_float.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SRC___SUPPORT_MATH_ATANF_FLOAT_H
-#define LIBC_SRC___SUPPORT_MATH_ATANF_FLOAT_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ATANF_FLOAT_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_ATANF_FLOAT_H
 
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/FPBits.h"
@@ -165,4 +165,4 @@ LIBC_INLINE static float atanf(float x) {
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SRC___SUPPORT_MATH_ATANF_FLOAT_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_ATANF_FLOAT_H

--- a/libc/src/__support/math/cbrt.h
+++ b/libc/src/__support/math/cbrt.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SRC___SUPPORT_MATH_CBRT_H
-#define LIBC_SRC___SUPPORT_MATH_CBRT_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_CBRT_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_CBRT_H
 
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/FPBits.h"
@@ -347,4 +347,4 @@ LIBC_INLINE static constexpr double cbrt(double x) {
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SRC___SUPPORT_MATH_CBRT_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_CBRT_H

--- a/libc/src/__support/math/cbrtf.h
+++ b/libc/src/__support/math/cbrtf.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SRC___SUPPORT_MATH_CBRTF_H
-#define LIBC_SRC___SUPPORT_MATH_CBRTF_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_CBRTF_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_CBRTF_H
 
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/FPBits.h"
@@ -158,4 +158,4 @@ LIBC_INLINE static constexpr float cbrtf(float x) {
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SRC___SUPPORT_MATH_CBRTF_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_CBRTF_H

--- a/libc/src/__support/math/cos.h
+++ b/libc/src/__support/math/cos.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SRC___SUPPORT_MATH_COS_H
-#define LIBC_SRC___SUPPORT_MATH_COS_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_COS_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_COS_H
 
 #include "range_reduction_double_common.h"
 #include "sincos_eval.h"
@@ -170,4 +170,4 @@ LIBC_INLINE static constexpr double cos(double x) {
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SRC___SUPPORT_MATH_COS_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_COS_H

--- a/libc/src/__support/math/cosf.h
+++ b/libc/src/__support/math/cosf.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SRC___SUPPORT_MATH_COSF_H
-#define LIBC_SRC___SUPPORT_MATH_COSF_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_COSF_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_COSF_H
 
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/FPBits.h"
@@ -169,6 +169,6 @@ LIBC_INLINE static constexpr float cosf(float x) {
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SRC___SUPPORT_MATH_COSF_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_COSF_H
 
 #endif // LIBC_MATH_HAS_INTERMEDIATE_COMP_IN_FLOAT

--- a/libc/src/__support/math/range_reduction.h
+++ b/libc/src/__support/math/range_reduction.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SRC___SUPPORT_MATH_RANGE_REDUCTION_H
-#define LIBC_SRC___SUPPORT_MATH_RANGE_REDUCTION_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_RANGE_REDUCTION_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_RANGE_REDUCTION_H
 
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/multiply_add.h"
@@ -87,4 +87,4 @@ LIBC_INLINE int64_t large_range_reduction(double x, int x_exp, double &y) {
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SRC___SUPPORT_MATH_RANGE_REDUCTION_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_RANGE_REDUCTION_H

--- a/libc/src/__support/math/range_reduction_fma.h
+++ b/libc/src/__support/math/range_reduction_fma.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SRC___SUPPORT_MATH_RANGE_REDUCTION_FMA_H
-#define LIBC_SRC___SUPPORT_MATH_RANGE_REDUCTION_FMA_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_RANGE_REDUCTION_FMA_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_RANGE_REDUCTION_FMA_H
 
 #include "src/__support/FPUtil/FMA.h"
 #include "src/__support/FPUtil/FPBits.h"
@@ -89,4 +89,4 @@ LIBC_INLINE int64_t large_range_reduction(double x, int x_exp, double &y) {
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SRC___SUPPORT_MATH_RANGE_REDUCTION_FMA_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_RANGE_REDUCTION_FMA_H

--- a/libc/src/__support/math/sin.h
+++ b/libc/src/__support/math/sin.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SRC___SUPPORT_MATH_SIN_H
-#define LIBC_SRC___SUPPORT_MATH_SIN_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_SIN_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_SIN_H
 
 #include "range_reduction_double_common.h"
 #include "sincos_eval.h"
@@ -178,4 +178,4 @@ LIBC_INLINE static constexpr double sin(double x) {
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SRC___SUPPORT_MATH_SIN_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_SIN_H

--- a/libc/src/__support/math/sincosf_utils.h
+++ b/libc/src/__support/math/sincosf_utils.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SRC___SUPPORT_MATH_SINCOSF_UTILS_H
-#define LIBC_SRC___SUPPORT_MATH_SINCOSF_UTILS_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_SINCOSF_UTILS_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_SINCOSF_UTILS_H
 
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/PolyEval.h"
@@ -122,4 +122,4 @@ LIBC_INLINE void sincospif_eval(double xd, double &sin_k, double &cos_k,
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SRC___SUPPORT_MATH_SINCOSF_UTILS_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_SINCOSF_UTILS_H

--- a/libc/src/__support/math/tan.h
+++ b/libc/src/__support/math/tan.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SRC___SUPPORT_MATH_TAN_H
-#define LIBC_SRC___SUPPORT_MATH_TAN_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_TAN_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_TAN_H
 
 #include "hdr/errno_macros.h"
 #include "range_reduction_double_common.h"
@@ -302,4 +302,4 @@ LIBC_INLINE static double tan(double x) {
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SRC___SUPPORT_MATH_TAN_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_TAN_H

--- a/libc/src/__support/math/tanf.h
+++ b/libc/src/__support/math/tanf.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBC_SRC___SUPPORT_MATH_TANF_H
-#define LIBC_SRC___SUPPORT_MATH_TANF_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_TANF_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_TANF_H
 
 #include "sincosf_utils.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
@@ -161,4 +161,4 @@ LIBC_INLINE static float tanf(float x) {
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LIBC_SRC___SUPPORT_MATH_TANF_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_TANF_H


### PR DESCRIPTION
...due to the feedback on #177963.

Patch generated by running

    rg -l '\bLIBC_SRC' libc/src/__support/math | \
      xargs sed -i '' -e \
      's/LIBC_SRC___SUPPORT_MATH_\([A-Z0-9_]*\)/LLVM_LIBC_SRC___SUPPORT_MATH_\1/'