### PR TITLE
[mlir][scf] Interpret trip counts as unsigned integers  

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/Utils/Utils.h
+++ b/mlir/include/mlir/Dialect/SCF/Utils/Utils.h
@@ -251,6 +251,7 @@ FailureOr<scf::ParallelOp> parallelLoopUnrollByFactors(
 /// Get constant trip counts for each of the induction variables of the given
 /// loop operation. If any of the loop's trip counts is not constant, return an
 /// empty vector.
+/// TODO(#178506): Should return SmallVector<uint64_t> for correct signedness.
 llvm::SmallVector<int64_t>
 getConstLoopTripCounts(mlir::LoopLikeOpInterface loopOp);
 

--- a/mlir/include/mlir/Dialect/Utils/StaticValueUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/StaticValueUtils.h
@@ -212,10 +212,11 @@ foldDynamicOffsetSizeList(SmallVectorImpl<OpFoldResult> &offsetsOrSizes);
 LogicalResult foldDynamicStrideList(SmallVectorImpl<OpFoldResult> &strides);
 
 /// Return the number of iterations for a loop with a lower bound `lb`, upper
-/// bound `ub` and step `step`. The `isSigned` flag indicates whether the loop
-/// comparison between lb and ub is signed or unsigned. A negative step or a
-/// lower bound greater than the upper bound are considered invalid and will
-/// yield a zero trip count.
+/// bound `ub` and step `step`, as an unsigned integer. The `isSigned` flag
+/// indicates whether the loop comparison between lb and ub is signed or
+/// unsigned. (The result of this function must be interpreted as an unsigned
+/// integer.) A lower bound greater than the upper bound is considered invalid
+/// and will yield a zero trip count.
 /// The `computeUbMinusLb` callback is invoked to compute the difference between
 /// the upper and lower bound when not constant. It can be used by the client
 /// to compute a static difference when the bounds are not constant.
@@ -228,9 +229,6 @@ LogicalResult foldDynamicStrideList(SmallVectorImpl<OpFoldResult> &strides);
 /// where %ub is computed as a static offset from %lb.
 /// Note: the matched addition should be nsw/nuw (matching the loop comparison)
 /// to avoid overflow, otherwise an overflow would imply a zero trip count.
-///
-/// For unsigned narrow types, the result is zero-extended to 64 bits to avoid
-/// misinterpretation when callers use getSExtValue().
 std::optional<APInt> constantTripCount(
     OpFoldResult lb, OpFoldResult ub, OpFoldResult step, bool isSigned,
     llvm::function_ref<std::optional<llvm::APSInt>(Value, Value, bool)>

--- a/mlir/include/mlir/Dialect/Utils/StaticValueUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/StaticValueUtils.h
@@ -228,6 +228,9 @@ LogicalResult foldDynamicStrideList(SmallVectorImpl<OpFoldResult> &strides);
 /// where %ub is computed as a static offset from %lb.
 /// Note: the matched addition should be nsw/nuw (matching the loop comparison)
 /// to avoid overflow, otherwise an overflow would imply a zero trip count.
+///
+/// For unsigned narrow types, the result is zero-extended to 64 bits to avoid
+/// misinterpretation when callers use getSExtValue().
 std::optional<APInt> constantTripCount(
     OpFoldResult lb, OpFoldResult ub, OpFoldResult step, bool isSigned,
     llvm::function_ref<std::optional<llvm::APSInt>(Value, Value, bool)>

--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -443,7 +443,7 @@ LogicalResult ForOp::promoteIfSingleIteration(RewriterBase &rewriter) {
   LDBG() << "promoteIfSingleIteration tripCount is " << tripCount
          << " for loop "
          << OpWithFlags(getOperation(), OpPrintingFlags().skipRegions());
-  if (!tripCount.has_value() || tripCount->getSExtValue() > 1)
+  if (!tripCount.has_value() || tripCount->getZExtValue() > 1)
     return failure();
 
   if (*tripCount == 0) {

--- a/mlir/lib/Dialect/SCF/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/SCF/Utils/Utils.cpp
@@ -397,8 +397,8 @@ FailureOr<UnrolledLoopInfo> mlir::loopUnrollByFactor(
     }
 
     int64_t tripCountEvenMultiple =
-        constTripCount->getSExtValue() -
-        (constTripCount->getSExtValue() % unrollFactor);
+        constTripCount->getZExtValue() -
+        (constTripCount->getZExtValue() % unrollFactor);
     int64_t upperBoundUnrolledCst = lbCst + tripCountEvenMultiple * stepCst;
     int64_t stepUnrolledCst = stepCst * unrollFactor;
 
@@ -500,9 +500,9 @@ LogicalResult mlir::loopUnrollFull(scf::ForOp forOp) {
   const APInt &tripCount = *mayBeConstantTripCount;
   if (tripCount.isZero())
     return success();
-  if (tripCount.getSExtValue() == 1)
+  if (tripCount.getZExtValue() == 1)
     return forOp.promoteIfSingleIteration(rewriter);
-  return loopUnrollByFactor(forOp, tripCount.getSExtValue());
+  return loopUnrollByFactor(forOp, tripCount.getZExtValue());
 }
 
 /// Check if bounds of all inner loops are defined outside of `forOp`
@@ -1572,7 +1572,7 @@ mlir::getConstLoopTripCounts(mlir::LoopLikeOpInterface loopOp) {
         lb, ub, step, /*isSigned=*/true, scf::computeUbMinusLb);
     if (!numIter)
       return {};
-    tripCounts.push_back(numIter->getSExtValue());
+    tripCounts.push_back(numIter->getZExtValue());
   }
   return tripCounts;
 }

--- a/mlir/lib/Dialect/SCF/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/SCF/Utils/Utils.cpp
@@ -396,7 +396,8 @@ FailureOr<UnrolledLoopInfo> mlir::loopUnrollByFactor(
       return UnrolledLoopInfo{forOp, std::nullopt};
     }
 
-    // TODO(#178506): This may overflow for large trip counts. Should use uint64_t.
+    // TODO(#178506): This may overflow for large trip counts. Should use
+    // uint64_t.
     int64_t tripCountEvenMultiple =
         constTripCount->getZExtValue() -
         (constTripCount->getZExtValue() % unrollFactor);
@@ -1568,7 +1569,8 @@ mlir::getConstLoopTripCounts(mlir::LoopLikeOpInterface loopOp) {
   std::optional<SmallVector<OpFoldResult>> steps = loopOp.getLoopSteps();
   if (!loBnds || !upBnds || !steps)
     return {};
-  // TODO(#178506): The result should be SmallVector<uint64_t> and use uint64_t for trip counts.
+  // TODO(#178506): The result should be SmallVector<uint64_t> and use uint64_t
+  // for trip counts.
   llvm::SmallVector<int64_t> tripCounts;
   for (auto [lb, ub, step] : llvm::zip(*loBnds, *upBnds, *steps)) {
     // TODO(#178506): Signedness is not handled correctly here.

--- a/mlir/lib/Dialect/Utils/StaticValueUtils.cpp
+++ b/mlir/lib/Dialect/Utils/StaticValueUtils.cpp
@@ -403,9 +403,9 @@ std::optional<APInt> constantTripCount(
     tripCount = tripCount + 1;
   LDBG() << "constantTripCount found: " << tripCount;
 
-  // For unsigned narrow types, zero-extend to 64 bits to avoid misinterpretation
-  // when callers use getSExtValue(). This ensures values like 255 (0xFF in 8-bit)
-  // are treated as positive when sign-extended.
+  // For unsigned narrow types, zero-extend to 64 bits to avoid
+  // misinterpretation when callers use getSExtValue(). This ensures values like
+  // 255 (0xFF in 8-bit) are treated as positive when sign-extended.
   APInt result = tripCount;
   if (!isSigned && bitwidth < 64)
     result = result.zext(64);

--- a/mlir/test/Dialect/SCF/trip_count.mlir
+++ b/mlir/test/Dialect/SCF/trip_count.mlir
@@ -709,11 +709,10 @@ func.func @trip_count_i8_unsigned_full_range(%a : i32, %b : i32) -> i32 {
   %c255 = arith.constant 255 : i8
   %c1 = arith.constant 1 : i8
 
-  // This is the bug case: unsigned i8 from 0 to 255
-  // Before fix: 0xFF in 8-bit was interpreted as -1 with getSExtValue()
-  // After fix: Narrow unsigned types are zero-extended to 64-bit
-  // Result: 255 as i64
-  // CHECK: "test.trip-count" = 255 : i64
+  // Unsigned i8 from 0 to 255: trip count is 255
+  // Trip counts are returned in their natural bitwidth and printed as signed.
+  // 255 in i8 is represented as -1 when printed in signed format.
+  // CHECK: "test.trip-count" = -1 : i8
   %r = scf.for unsigned %i = %c0 to %c255 step %c1 iter_args(%0 = %a) -> i32 : i8 {
     scf.yield %b : i32
   }
@@ -728,10 +727,9 @@ func.func @trip_count_i8_unsigned_partial_range(%a : i32, %b : i32) -> i32 {
   %c200 = arith.constant 200 : i8
   %c1 = arith.constant 1 : i8
 
-  // Unsigned i8 from 0 to 200, should work correctly
-  // After fix: Narrow unsigned types are zero-extended to 64-bit
-  // Result: 200 as i64
-  // CHECK: "test.trip-count" = 200 : i64
+  // Unsigned i8 from 0 to 200: trip count is 200
+  // 200 in i8 is represented as -56 when printed in signed format.
+  // CHECK: "test.trip-count" = -56 : i8
   %r = scf.for unsigned %i = %c0 to %c200 step %c1 iter_args(%0 = %a) -> i32 : i8 {
     scf.yield %b : i32
   }
@@ -746,9 +744,8 @@ func.func @trip_count_i8_unsigned_high_range(%a : i32, %b : i32) -> i32 {
   %c255 = arith.constant 255 : i8
   %c1 = arith.constant 1 : i8
 
-  // Unsigned i8 from 200 to 255
-  // After fix: Narrow unsigned types are zero-extended to 64-bit
-  // CHECK: "test.trip-count" = 55 : i64
+  // Unsigned i8 from 200 to 255: trip count is 55
+  // CHECK: "test.trip-count" = 55 : i8
   %r = scf.for unsigned %i = %c200 to %c255 step %c1 iter_args(%0 = %a) -> i32 : i8 {
     scf.yield %b : i32
   }
@@ -779,10 +776,9 @@ func.func @trip_count_i16_unsigned_full_range(%a : i32, %b : i32) -> i32 {
   %c65535 = arith.constant 65535 : i16
   %c1 = arith.constant 1 : i16
 
-  // Unsigned i16 from 0 to 65535, should be 65535
-  // After fix: Narrow unsigned types are zero-extended to 64-bit
-  // Result: 65535 as i64
-  // CHECK: "test.trip-count" = 65535 : i64
+  // Unsigned i16 from 0 to 65535: trip count is 65535
+  // 65535 in i16 is represented as -1 when printed in signed format.
+  // CHECK: "test.trip-count" = -1 : i16
   %r = scf.for unsigned %i = %c0 to %c65535 step %c1 iter_args(%0 = %a) -> i32 : i16 {
     scf.yield %b : i32
   }
@@ -797,10 +793,9 @@ func.func @trip_count_i8_unsigned_step_2(%a : i32, %b : i32) -> i32 {
   %c255 = arith.constant 255 : i8
   %c2 = arith.constant 2 : i8
 
-  // Unsigned i8 from 0 to 255 step 2, should be 128 (255/2 rounded up)
-  // After fix: Narrow unsigned types are zero-extended to 64-bit
-  // Result: 128 as i64
-  // CHECK: "test.trip-count" = 128 : i64
+  // Unsigned i8 from 0 to 255 step 2: trip count is 128 (255/2 rounded up)
+  // 128 in i8 is represented as -128 when printed in signed format.
+  // CHECK: "test.trip-count" = -128 : i8
   %r = scf.for unsigned %i = %c0 to %c255 step %c2 iter_args(%0 = %a) -> i32 : i8 {
     scf.yield %b : i32
   }

--- a/mlir/test/lib/Dialect/SCF/TestSCFUtils.cpp
+++ b/mlir/test/lib/Dialect/SCF/TestSCFUtils.cpp
@@ -50,7 +50,7 @@ struct TestSCFForUtilsPass
             "test.trip-count",
             IntegerAttr::get(IntegerType::get(&getContext(),
                                               tripCount.value().getBitWidth()),
-                             tripCount.value().getSExtValue()));
+                             tripCount.value().getZExtValue()));
       else
         loopOp->setDiscardableAttr("test.trip-count",
                                    StringAttr::get(&getContext(), "none"));


### PR DESCRIPTION
  Trip counts represent iteration counts and are always non-negative. This PR fixes all call sites to correctly use `getZExtValue()` instead of `getSExtValue()` when  extracting trip count values from `APInt`.  Also documents to clarify results are unsigned.