### PR TITLE
[libc][math] Refactor sinf16 implementation to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -88,6 +88,7 @@
 #include "math/rsqrtf16.h"
 #include "math/sin.h"
 #include "math/sinf.h"
+#include "math/sinf16.h"
 #include "math/sinhf.h"
 #include "math/sinhf16.h"
 #include "math/tan.h"

--- a/libc/shared/math/sinf16.h
+++ b/libc/shared/math/sinf16.h
@@ -1,4 +1,4 @@
-//===-- Half-precision sin(x) function ------------------------------------===//
+//===-- Shared sinf16 function ----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/sinf16.h"
+#ifndef LLVM_LIBC_SHARED_MATH_SINF16_H
+#define LLVM_LIBC_SHARED_MATH_SINF16_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/sinf16.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(float16, sinf16, (float16 x)) { return math::sinf16(x); }
+using math::sinf16;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_SINF16_H

--- a/libc/shared/math/sinf16.h
+++ b/libc/shared/math/sinf16.h
@@ -9,6 +9,10 @@
 #ifndef LLVM_LIBC_SHARED_MATH_SINF16_H
 #define LLVM_LIBC_SHARED_MATH_SINF16_H
 
+#include "include/llvm-libc-macros/float16-macros.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+
 #include "shared/libc_common.h"
 #include "src/__support/math/sinf16.h"
 
@@ -19,5 +23,7 @@ using math::sinf16;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT16
 
 #endif // LLVM_LIBC_SHARED_MATH_SINF16_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1126,6 +1126,23 @@ add_header_library(
 )
 
 add_header_library(
+  sinf16
+  HDRS
+    sinf16.h
+  DEPENDS
+    .sincosf16_utils
+    libc.hdr.errno_macros
+    libc.hdr.fenv_macros
+    libc.src.__support.FPUtil.cast
+    libc.src.__support.FPUtil.except_value_utils
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.multiply_add
+    libc.src.__support.macros.optimization
+    libc.src.__support.macros.properties.types
+)
+
+add_header_library(
   sinhfcoshf_utils
   HDRS
     sinhfcoshf_utils.h

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1126,23 +1126,6 @@ add_header_library(
 )
 
 add_header_library(
-  sinf16
-  HDRS
-    sinf16.h
-  DEPENDS
-    .sincosf16_utils
-    libc.hdr.errno_macros
-    libc.hdr.fenv_macros
-    libc.src.__support.FPUtil.cast
-    libc.src.__support.FPUtil.except_value_utils
-    libc.src.__support.FPUtil.fenv_impl
-    libc.src.__support.FPUtil.fp_bits
-    libc.src.__support.FPUtil.multiply_add
-    libc.src.__support.macros.optimization
-    libc.src.__support.macros.properties.types
-)
-
-add_header_library(
   sinhfcoshf_utils
   HDRS
     sinhfcoshf_utils.h
@@ -1301,6 +1284,23 @@ add_header_library(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
+)
+
+add_header_library(
+  sinf16
+  HDRS
+    sinf16.h
+  DEPENDS
+    .sincosf16_utils
+    libc.hdr.errno_macros
+    libc.hdr.fenv_macros
+    libc.src.__support.FPUtil.cast
+    libc.src.__support.FPUtil.except_value_utils
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.multiply_add
+    libc.src.__support.macros.optimization
+    libc.src.__support.macros.properties.types
 )
 
 add_header_library(

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -1294,6 +1294,7 @@ add_header_library(
     .sincosf16_utils
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
+    libc.include.llvm-libc-macros.float16_macros
     libc.src.__support.FPUtil.cast
     libc.src.__support.FPUtil.except_value_utils
     libc.src.__support.FPUtil.fenv_impl

--- a/libc/src/__support/math/sinf16.h
+++ b/libc/src/__support/math/sinf16.h
@@ -1,0 +1,131 @@
+//===-- Half-precision sin(x) function ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_SINF16_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_SINF16_H
+
+
+#include "hdr/errno_macros.h"
+#include "hdr/fenv_macros.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/cast.h"
+#include "src/__support/FPUtil/except_value_utils.h"
+#include "src/__support/FPUtil/multiply_add.h"
+#include "src/__support/macros/optimization.h"
+#include "sincosf16_utils.h"
+
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+namespace sinf16_internal {
+
+#ifndef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
+LIBC_INLINE_VAR constexpr size_t N_EXCEPTS = 4;
+
+LIBC_INLINE_VAR constexpr fputil::ExceptValues<float16, N_EXCEPTS> SINF16_EXCEPTS{{
+    // (input, RZ output, RU offset, RD offset, RN offset)
+    {0x2b45, 0x2b43, 1, 0, 1},
+    {0x585c, 0x3ba3, 1, 0, 1},
+    {0x5cb0, 0xbbff, 0, 1, 0},
+    {0x51f5, 0xb80f, 0, 1, 0},
+}};
+#endif // !LIBC_MATH_HAS_SKIP_ACCURATE_PASS
+
+} // namespace sinf16_internal
+
+LIBC_INLINE static float16 sinf16(float16 x) {
+  using namespace sinf16_internal;
+  using namespace sincosf16_internal;
+  using FPBits = fputil::FPBits<float16>;
+  FPBits xbits(x);
+
+  uint16_t x_u = xbits.uintval();
+  uint16_t x_abs = x_u & 0x7fff;
+  float xf = x;
+
+  // Range reduction:
+  // For |x| > pi/32, we perform range reduction as follows:
+  // Find k and y such that:
+  //   x = (k + y) * pi/32
+  //   k is an integer, |y| < 0.5
+  //
+  // This is done by performing:
+  //   k = round(x * 32/pi)
+  //   y = x * 32/pi - k
+  //
+  // Once k and y are computed, we then deduce the answer by the sine of sum
+  // formula:
+  //   sin(x) = sin((k + y) * pi/32)
+  //   	      = sin(k * pi/32) * cos(y * pi/32) +
+  //   	        sin(y * pi/32) * cos(k * pi/32)
+
+#ifndef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
+  // Handle exceptional values
+  bool x_sign = x_u >> 15;
+
+  if (auto r = SINF16_EXCEPTS.lookup_odd(x_abs, x_sign);
+      LIBC_UNLIKELY(r.has_value()))
+    return r.value();
+#endif // !LIBC_MATH_HAS_SKIP_ACCURATE_PASS
+
+  int rounding = fputil::quick_get_round();
+
+  // Exhaustive tests show that for |x| <= 0x1.f4p-11, 1ULP rounding errors
+  // occur. To fix this, the following apply:
+  if (LIBC_UNLIKELY(x_abs <= 0x13d0)) {
+    // sin(+/-0) = +/-0
+    if (LIBC_UNLIKELY(x_abs == 0U))
+      return x;
+
+    // When x > 0, and rounding upward, sin(x) == x.
+    // When x < 0, and rounding downward, sin(x) == x.
+    if ((rounding == FE_UPWARD && xbits.is_pos()) ||
+        (rounding == FE_DOWNWARD && xbits.is_neg()))
+      return x;
+
+    // When x < 0, and rounding upward, sin(x) == (x - 1ULP)
+    if (rounding == FE_UPWARD && xbits.is_neg()) {
+      x_u--;
+      return FPBits(x_u).get_val();
+    }
+  }
+
+  if (xbits.is_inf_or_nan()) {
+    if (xbits.is_signaling_nan()) {
+      fputil::raise_except_if_required(FE_INVALID);
+      return FPBits::quiet_nan().get_val();
+    }
+
+    if (xbits.is_inf()) {
+      fputil::set_errno_if_required(EDOM);
+      fputil::raise_except_if_required(FE_INVALID);
+    }
+
+    return x + FPBits::quiet_nan().get_val();
+  }
+
+  float sin_k, cos_k, sin_y, cosm1_y;
+  sincosf16_eval(xf, sin_k, cos_k, sin_y, cosm1_y);
+
+  if (LIBC_UNLIKELY(sin_y == 0 && sin_k == 0))
+    return FPBits::zero(xbits.sign()).get_val();
+
+  // Since, cosm1_y = cos_y - 1, therefore:
+  //   sin(x) = cos_k * sin_y + sin_k + (cosm1_y * sin_k)
+  return fputil::cast<float16>(fputil::multiply_add(
+      sin_y, cos_k, fputil::multiply_add(cosm1_y, sin_k, sin_k)));
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_SINF16_H

--- a/libc/src/__support/math/sinf16.h
+++ b/libc/src/__support/math/sinf16.h
@@ -9,6 +9,10 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_SINF16_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_SINF16_H
 
+#include "include/llvm-libc-macros/float16-macros.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+
 #include "hdr/errno_macros.h"
 #include "hdr/fenv_macros.h"
 #include "sincosf16_utils.h"
@@ -126,5 +130,7 @@ LIBC_INLINE static float16 sinf16(float16 x) {
 } // namespace math
 
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT16
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MATH_SINF16_H

--- a/libc/src/__support/math/sinf16.h
+++ b/libc/src/__support/math/sinf16.h
@@ -9,17 +9,15 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MATH_SINF16_H
 #define LLVM_LIBC_SRC___SUPPORT_MATH_SINF16_H
 
-
 #include "hdr/errno_macros.h"
 #include "hdr/fenv_macros.h"
+#include "sincosf16_utils.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/cast.h"
 #include "src/__support/FPUtil/except_value_utils.h"
 #include "src/__support/FPUtil/multiply_add.h"
 #include "src/__support/macros/optimization.h"
-#include "sincosf16_utils.h"
-
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -30,13 +28,14 @@ namespace sinf16_internal {
 #ifndef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
 LIBC_INLINE_VAR constexpr size_t N_EXCEPTS = 4;
 
-LIBC_INLINE_VAR constexpr fputil::ExceptValues<float16, N_EXCEPTS> SINF16_EXCEPTS{{
-    // (input, RZ output, RU offset, RD offset, RN offset)
-    {0x2b45, 0x2b43, 1, 0, 1},
-    {0x585c, 0x3ba3, 1, 0, 1},
-    {0x5cb0, 0xbbff, 0, 1, 0},
-    {0x51f5, 0xb80f, 0, 1, 0},
-}};
+LIBC_INLINE_VAR constexpr fputil::ExceptValues<float16, N_EXCEPTS>
+    SINF16_EXCEPTS{{
+        // (input, RZ output, RU offset, RD offset, RN offset)
+        {0x2b45, 0x2b43, 1, 0, 1},
+        {0x585c, 0x3ba3, 1, 0, 1},
+        {0x5cb0, 0xbbff, 0, 1, 0},
+        {0x51f5, 0xb80f, 0, 1, 0},
+    }};
 #endif // !LIBC_MATH_HAS_SKIP_ACCURATE_PASS
 
 } // namespace sinf16_internal

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -384,6 +384,8 @@ add_entrypoint_object(
     ../sinf16.h
   DEPENDS
     libc.src.__support.math.sinf16
+  COMPILE_OPTIONS
+    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -383,18 +383,7 @@ add_entrypoint_object(
   HDRS
     ../sinf16.h
   DEPENDS
-    libc.hdr.errno_macros
-    libc.hdr.fenv_macros
-    libc.src.__support.FPUtil.cast
-    libc.src.__support.FPUtil.fenv_impl
-    libc.src.__support.FPUtil.fp_bits
-    libc.src.__support.FPUtil.except_value_utils
-    libc.src.__support.FPUtil.multiply_add
-    libc.src.__support.macros.optimization
-    libc.src.__support.macros.properties.types
-    libc.src.__support.math.sincosf16_utils
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
+    libc.src.__support.math.sinf16
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -85,6 +85,7 @@ add_fp_unittest(
     libc.src.__support.math.rsqrtf16
     libc.src.__support.math.sin
     libc.src.__support.math.sinf
+    libc.src.__support.math.sinf16
     libc.src.__support.math.sinhf
     libc.src.__support.math.sinhf16
     libc.src.__support.math.tan

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -52,6 +52,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat16) {
 
   EXPECT_FP_EQ(0x1.921fb6p+0f16, LIBC_NAMESPACE::shared::acosf16(0.0f16));
   EXPECT_FP_EQ(0x1p+0f16, LIBC_NAMESPACE::shared::f16sqrtl(1.0L));
+  EXPECT_FP_EQ(0.0f16, LIBC_NAMESPACE::shared::sinf16(0.0f16));
 }
 
 #endif // LIBC_TYPES_HAS_FLOAT16

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3508,6 +3508,16 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_sinf16",
+    hdrs = ["src/__support/math/sinf16.h"],
+    deps = [
+        ":__support_fputil_nearest_integer",
+        ":__support_fputil_polyeval",
+        ":__support_math_sincosf16_utils",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_sinhf16",
     hdrs = ["src/__support/math/sinhf16.h"],
     deps = [
@@ -5148,9 +5158,7 @@ libc_math_function(
 libc_math_function(
     name = "sinf16",
     additional_deps = [
-        ":__support_fputil_nearest_integer",
-        ":__support_fputil_polyeval",
-        ":__support_math_sincosf16_utils",
+        ":__support_math_sinf16",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -5159,6 +5159,7 @@ libc_math_function(
     name = "sinf16",
     additional_deps = [
         ":__support_math_sinf16",
+        ":errno",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3514,6 +3514,7 @@ libc_support_library(
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_math_sincosf16_utils",
+        ":llvm_libc_macros_float16_macros",
     ],
 )
 


### PR DESCRIPTION
Part of #147386
    
in preparation for:
https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450