### PR TITLE
[lit] add %{readenv:<var>} to internal and external shells

### DIFF
--- a/llvm/docs/CommandGuide/lit.rst
+++ b/llvm/docs/CommandGuide/lit.rst
@@ -663,6 +663,7 @@ TestRunner.py:
  %:t                     On Windows, %/t but a ``:`` is removed if its the second character.
                          Otherwise, %t but with a single leading ``/`` removed.
  %{readfile:<filename>}  Reads the file specified.
+ %{readenv:<var>}        Reads the environment variable specified.
  ======================= ==============
 
 Other substitutions are provided that are variations on this base set and

--- a/llvm/utils/lit/lit/ShCommands.py
+++ b/llvm/utils/lit/lit/ShCommands.py
@@ -23,7 +23,7 @@ class Command:
             file.write(quoted)
 
             # For debugging / validation.
-            import ShUtil
+            import lit.ShUtil as ShUtil
 
             dequoted = list(ShUtil.ShLexer(quoted).lex())
             if dequoted != [arg]:

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -87,8 +87,7 @@ class ShellEnvironment(object):
 
     """Mutable shell environment containing things like CWD and env vars.
 
-    Environment variables are not implemented, but cwd tracking is. In addition,
-    we maintain a dir stack for pushd/popd.
+    In addition to env vars and cwd we maintain a dir stack for pushd/popd.
     """
 
     def __init__(self, cwd, env, umask=-1, ulimit=None):

--- a/llvm/utils/lit/tests/Inputs/shtest-readenv/command-from-env.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-readenv/command-from-env.txt
@@ -1,0 +1,2 @@
+# RUN: export CMD="echo"
+# RUN: %{readenv:CMD} SUCCESS

--- a/llvm/utils/lit/tests/Inputs/shtest-readenv/empty-string.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-readenv/empty-string.txt
@@ -1,0 +1,3 @@
+# RUN: export ASDF=""
+# RUN: echo PRE %{readenv:ASDF} POST
+

--- a/llvm/utils/lit/tests/Inputs/shtest-readenv/env.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-readenv/env.txt
@@ -1,0 +1,7 @@
+# This checks that env var expansion is done before the start of the pipeline
+# and that "env" does not leak out to the next line.
+
+# RUN: export FOO=foo
+# Internal "env" cannot be combined with "echo", so call external echo.
+# RUN: env FOO=bar %{external-echo} PRE1 %{readenv:FOO} POST1
+# RUN: echo PRE2 %{readenv:FOO} POST2

--- a/llvm/utils/lit/tests/Inputs/shtest-readenv/export.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-readenv/export.txt
@@ -1,0 +1,2 @@
+# RUN: export VAR="VAR CONTENT"
+# RUN: echo PRE %{readenv:VAR} POST

--- a/llvm/utils/lit/tests/Inputs/shtest-readenv/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-readenv/lit.cfg
@@ -1,0 +1,19 @@
+import os
+
+import lit.formats
+import lit.util
+
+config.name = "shtest-readenv"
+config.suffixes = [".txt"]
+lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
+use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
+config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
+config.test_source_root = None
+config.test_exec_root = None
+
+# The internal env command cannot invoke the internal echo command.
+# Pass along the external echo to test that we handle "env" correctly.
+import shutil
+echo = shutil.which("echo")
+if echo:
+    config.substitutions.append(("%{external-echo}", echo))

--- a/llvm/utils/lit/tests/Inputs/shtest-readenv/pipeline.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-readenv/pipeline.txt
@@ -1,0 +1,4 @@
+# Test that env vars are expanded for the entire pipeline at the start
+# RUN: export A=INIT
+# RUN: export A=FIRST && echo PRE1 %{readenv:A} POST1 ; export A=SECOND ; echo PRE2 %{readenv:A} POST2
+# RUN: echo PRE3 %{readenv:A} POST3

--- a/llvm/utils/lit/tests/Inputs/shtest-readenv/reexport.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-readenv/reexport.txt
@@ -1,0 +1,4 @@
+# RUN: export VAR="FIRST"
+# RUN: export VAR="%{readenv:VAR}:SECOND"
+# RUN: echo PRE %{readenv:VAR} POST
+

--- a/llvm/utils/lit/tests/Inputs/shtest-readenv/unset.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-readenv/unset.txt
@@ -1,0 +1,1 @@
+# RUN: echo PRE %{readenv:SOME_UNSET_ENV_VAR} POST

--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -128,6 +128,8 @@ if not llvm_config:
     if platform.system() == "AIX":
         config.available_features.add("system-aix")
 
+# config.substitutions.append(("%{system-path}", config.environment.get("PATH", "")))
+
 # For each of lit's internal shell commands ('env', 'cd', 'diff', etc.), put
 # a fake command that always fails at the start of PATH.  This helps us check
 # that we always use lit's internal version rather than some external version

--- a/llvm/utils/lit/tests/shtest-readenv-external.py
+++ b/llvm/utils/lit/tests/shtest-readenv-external.py
@@ -87,6 +87,5 @@
 # CHECK-NEXT: PRE Environment variable specified in readenv subsitution is not set: SOME_UNSET_ENV_VAR POST
 # CHECK: Command Output (stderr):
 # CHECK-NEXT: --
-# CHECK-NEXT: echo PRE ${SOME_UNSET_ENV_VAR-'Environment variable specified in readenv subsitution is not set: SOME_UNSET_ENV_VAR'} POST # {{R}}UN: at line 1 
+# CHECK-NEXT: echo PRE ${SOME_UNSET_ENV_VAR-'Environment variable specified in readenv subsitution is not set: SOME_UNSET_ENV_VAR'} POST # {{R}}UN: at line 1
 # CHECK-NEXT: + echo PRE 'Environment variable specified in readenv subsitution is not set: SOME_UNSET_ENV_VAR' POST
-

--- a/llvm/utils/lit/tests/shtest-readenv-external.py
+++ b/llvm/utils/lit/tests/shtest-readenv-external.py
@@ -1,0 +1,92 @@
+## Tests the readenv substitution.
+
+# UNSUPPORTED: system-windows
+
+# RUN: env LIT_USE_INTERNAL_SHELL=0 PATH=%{system-path} %{lit} -a %{inputs}/shtest-readenv | FileCheck -match-full-lines %s
+
+# CHECK: -- Testing: 7 tests{{.*}}
+
+# CHECK-LABEL: PASS: shtest-readenv :: command-from-env.txt ({{[^)]*}})
+# CHECK: Command Output (stdout):
+# CHECK: SUCCESS
+# CHECK: Command Output (stderr):
+# CHECK: export CMD="echo" # {{R}}UN: at line 1
+# CHECK: + export CMD=echo
+# CHECK: + CMD=echo
+# CHECK: ${CMD-'Environment variable specified in readenv subsitution is not set: CMD'} SUCCESS # {{R}}UN: at line 2
+# CHECK: + echo SUCCESS
+
+# CHECK-LABEL: PASS: shtest-readenv :: empty-string.txt ({{[^)]*}})
+# CHECK: Command Output (stdout):
+# CHECK: PRE POST
+# CHECK: Command Output (stderr):
+# CHECK: export ASDF="" # {{R}}UN: at line 1
+# CHECK: + export ASDF=
+# CHECK: + ASDF=
+# CHECK: echo PRE ${ASDF-'Environment variable specified in readenv subsitution is not set: ASDF'} POST # {{R}}UN: at line 2
+# CHECK: + echo PRE POST
+
+# CHECK-LABEL: PASS: shtest-readenv :: env.txt ({{[^)]*}})
+# CHECK: Command Output (stdout):
+# CHECK: PRE1 foo POST1
+# CHECK: PRE2 foo POST2
+# CHECK: Command Output (stderr):
+# CHECK: export FOO=foo # {{R}}UN: at line 4
+# CHECK: + export FOO=foo
+# CHECK: + FOO=foo
+# CHECK: env FOO=bar [[ECHO:.*]] PRE1 ${FOO-'Environment variable specified in readenv subsitution is not set: FOO'} POST1 # {{R}}UN: at line 6
+# CHECK: + env FOO=bar [[ECHO]] PRE1 foo POST1
+# CHECK: echo PRE2 ${FOO-'Environment variable specified in readenv subsitution is not set: FOO'} POST2 # {{R}}UN: at line 7
+# CHECK: + echo PRE2 foo POST2
+
+# CHECK-LABEL: PASS: shtest-readenv :: export.txt ({{[^)]*}})
+# CHECK: Command Output (stdout):
+# CHECK: PRE VAR CONTENT POST
+# CHECK: Command Output (stderr):
+# CHECK: export VAR="VAR CONTENT" # {{R}}UN: at line 1
+# CHECK: + export 'VAR=VAR CONTENT'
+# CHECK: + VAR='VAR CONTENT'
+# CHECK: echo PRE ${VAR-'Environment variable specified in readenv subsitution is not set: VAR'} POST # {{R}}UN: at line 2
+# CHECK: + echo PRE VAR CONTENT POST
+
+# CHECK-LABEL: PASS: shtest-readenv :: pipeline.txt ({{[^)]*}})
+# CHECK: Command Output (stdout):
+# CHECK: PRE1 FIRST POST1
+# CHECK: PRE2 SECOND POST2
+# CHECK: PRE3 SECOND POST3
+# CHECK: Command Output (stderr):
+# CHECK: export A=INIT # {{R}}UN: at line 2
+# CHECK: + export A=INIT
+# CHECK: + A=INIT
+# CHECK: export A=FIRST && echo PRE1 ${A-'Environment variable specified in readenv subsitution is not set: A'} POST1 ; export A=SECOND ; echo PRE2 ${A-'Environment variable specified in readenv subsitution is not set: A'} POST2 # {{R}}UN: at line 3
+# CHECK: + export A=FIRST
+# CHECK: + A=FIRST
+# CHECK: + echo PRE1 FIRST POST1
+# CHECK: + export A=SECOND
+# CHECK: + A=SECOND
+# CHECK: + echo PRE2 SECOND POST2
+# CHECK: echo PRE3 ${A-'Environment variable specified in readenv subsitution is not set: A'} POST3 # {{R}}UN: at line 4
+# CHECK: + echo PRE3 SECOND POST3
+
+# CHECK-LABEL: PASS: shtest-readenv :: reexport.txt ({{[^)]*}})
+# CHECK: Command Output (stdout):
+# CHECK: PRE FIRST:SECOND POST
+# CHECK: Command Output (stderr):
+# CHECK: export VAR="FIRST" # {{R}}UN: at line 1
+# CHECK: + export VAR=FIRST
+# CHECK: + VAR=FIRST
+# CHECK: export VAR="${VAR-'Environment variable specified in readenv subsitution is not set: VAR'}:SECOND" # {{R}}UN: at line 2
+# CHECK: + export VAR=FIRST:SECOND
+# CHECK: + VAR=FIRST:SECOND
+# CHECK: echo PRE ${VAR-'Environment variable specified in readenv subsitution is not set: VAR'} POST # {{R}}UN: at line 3
+# CHECK: + echo PRE FIRST:SECOND POST
+
+# CHECK-LABEL: PASS: shtest-readenv :: unset.txt ({{[^)]*}})
+# CHECK: Command Output (stdout):
+# CHECK-NEXT: --
+# CHECK-NEXT: PRE Environment variable specified in readenv subsitution is not set: SOME_UNSET_ENV_VAR POST
+# CHECK: Command Output (stderr):
+# CHECK-NEXT: --
+# CHECK-NEXT: echo PRE ${SOME_UNSET_ENV_VAR-'Environment variable specified in readenv subsitution is not set: SOME_UNSET_ENV_VAR'} POST # {{R}}UN: at line 1 
+# CHECK-NEXT: + echo PRE 'Environment variable specified in readenv subsitution is not set: SOME_UNSET_ENV_VAR' POST
+

--- a/llvm/utils/lit/tests/shtest-readenv.py
+++ b/llvm/utils/lit/tests/shtest-readenv.py
@@ -1,0 +1,65 @@
+## Tests the readenv substitution.
+
+# RUN: env LIT_USE_INTERNAL_SHELL=1 not %{lit} -a %{inputs}/shtest-readenv | FileCheck -match-full-lines %s
+
+# CHECK: -- Testing: 7 tests{{.*}}
+
+# CHECK-LABEL: PASS: shtest-readenv :: command-from-env.txt ({{[^)]*}})
+# CHECK: export CMD="echo"
+# CHECK: # executed command: export CMD=echo
+# CHECK: $CMD SUCCESS
+# CHECK: # executed command: '%{readenv:CMD}' SUCCESS
+# CHECK: # | SUCCESS
+
+# CHECK-LABEL: PASS: shtest-readenv :: empty-string.txt ({{[^)]*}})
+# CHECK: export ASDF=""
+# CHECK: # executed command: export ASDF=
+# CHECK: echo PRE $ASDF POST
+# CHECK: # executed command: echo PRE '%{readenv:ASDF}' POST
+# CHECK: # | PRE POST
+
+# CHECK-LABEL: PASS: shtest-readenv :: env.txt ({{[^)]*}})
+# CHECK: export FOO=foo
+# CHECK: # executed command: export FOO=foo
+# CHECK: env FOO=bar [[ECHO:.*]] PRE1 $FOO POST1
+# CHECK: # executed command: env FOO=bar [[ECHO]] PRE1 '%{readenv:FOO}' POST1
+# CHECK: # | PRE1 foo POST1
+# CHECK: echo PRE2 $FOO POST2
+# CHECK: # executed command: echo PRE2 '%{readenv:FOO}' POST2
+# CHECK: # | PRE2 foo POST2
+
+# CHECK-LABEL: PASS: shtest-readenv :: export.txt ({{[^)]*}})
+# CHECK: export VAR="VAR CONTENT"
+# CHECK: # executed command: export 'VAR=VAR CONTENT'
+# CHECK: echo PRE $VAR POST
+# CHECK: # executed command: echo PRE '%{readenv:VAR}' POST
+# CHECK: # | PRE VAR CONTENT POST
+
+# CHECK-LABEL: PASS: shtest-readenv :: pipeline.txt ({{[^)]*}})
+# CHECK: export A=INIT
+# CHECK: # executed command: export A=INIT
+# CHECK: export A=FIRST && echo PRE1 $A POST1 ; export A=SECOND ; echo PRE2 $A POST2
+# CHECK: # executed command: export A=FIRST
+# CHECK: # executed command: echo PRE1 '%{readenv:A}' POST1
+# CHECK: # | PRE1 FIRST POST1
+# CHECK: # executed command: export A=SECOND
+# CHECK: # executed command: echo PRE2 '%{readenv:A}' POST2
+# CHECK: # | PRE2 SECOND POST2
+# CHECK: echo PRE3 $A POST3
+# CHECK: # executed command: echo PRE3 '%{readenv:A}' POST3
+# CHECK: # | PRE3 SECOND POST3
+
+# CHECK-LABEL: PASS: shtest-readenv :: reexport.txt ({{[^)]*}})
+# CHECK: export VAR="FIRST"
+# CHECK: # executed command: export VAR=FIRST
+# CHECK: export VAR="$VAR:SECOND"
+# CHECK: # executed command: export 'VAR=%{readenv:VAR}:SECOND'
+# CHECK: echo PRE $VAR POST
+# CHECK: # executed command: echo PRE '%{readenv:VAR}' POST
+# CHECK: # | PRE FIRST:SECOND POST
+
+# CHECK-LABEL: FAIL: shtest-readenv :: unset.txt ({{[^)]*}})
+# CHECK: echo PRE $SOME_UNSET_ENV_VAR POST
+# CHECK: # executed command: echo PRE '%{readenv:SOME_UNSET_ENV_VAR}' POST 
+# CHECK: # | Environment variable specified in readenv subsitution is not set: SOME_UNSET_ENV_VAR
+

--- a/llvm/utils/lit/tests/shtest-readenv.py
+++ b/llvm/utils/lit/tests/shtest-readenv.py
@@ -60,6 +60,5 @@
 
 # CHECK-LABEL: FAIL: shtest-readenv :: unset.txt ({{[^)]*}})
 # CHECK: echo PRE $SOME_UNSET_ENV_VAR POST
-# CHECK: # executed command: echo PRE '%{readenv:SOME_UNSET_ENV_VAR}' POST 
+# CHECK: # executed command: echo PRE '%{readenv:SOME_UNSET_ENV_VAR}' POST
 # CHECK: # | Environment variable specified in readenv subsitution is not set: SOME_UNSET_ENV_VAR
-


### PR DESCRIPTION
This adds the readenv substitution to lit. It provides an alternative to
readfile, for when creating a file for the contents is too much ceremony.
One example would be when setting an environment variable at the start
of the test with contents that should be passed to multiple RUN lines,
while also wanting to keep that content local to the file, instead of
e.g. creating a substitution in lit.local.cfg.

In the external shell it expands to `$FOO`, providing a smooth
transition for test cases currently using that pattern - with the caveat
that we deliberately provide a default value for unset variables,
intended to cause errors instead of silently failing. This matches the
internal shell behaviour as closely as possible, since the internal
shell will instantly fail the test when trying to read an unset
variable.

In the internal shell it's evaluated at the start of each command:
before `env`, but after the previous command in the pipeline has
executed. This makes sure that variable expansion is the same
between the internal and external shells.
