### PR TITLE
[Clang] Invert emptiness check for correctness

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -13825,7 +13825,7 @@ void Sema::DiagnoseUniqueObjectDuplication(const VarDecl *VD) {
 
 void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
   llvm::scope_exit ResetDeclForInitializer([this]() {
-    if (this->ExprEvalContexts.empty())
+    if (!this->ExprEvalContexts.empty())
       this->ExprEvalContexts.back().DeclForInitializer = nullptr;
   });
 


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/163885 landed, @zwuis [ pointed out a bug](https://github.com/llvm/llvm-project/pull/163885#discussion_r2726301659) in a deferred call which was supposed to clear the DeclForInitializer field but was doing so incorrectly because the emptiness check is wrong.

Invert the check since the current check is wrong and an access to `.back()` is undefined behavior when the container is empty.

It is hard to add a test specifically for this change. It seems rather difficult to achieve the right circumstances to trigger this cleanup function with any valid source input. This check is more of a defensive check to make sure we aren't calling `back()` on an empty thing.

cc @zwuis  