### PR TITLE
Fix Fortran Debug Build

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Support/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/Support/CMakeLists.txt
@@ -24,6 +24,8 @@ add_flang_library(FIROpenACCSupport
   FIRDialect
   FIRDialectSupport
   FIRSupport
+  FortranEvaluate
+  FortranSupport
   HLFIRDialect
 
   MLIR_DEPS


### PR DESCRIPTION
Fortran build is broken for -DCMAKE_BUILD_TYPE=Debug.  Reason is linker errors due to undefined symbols defined in FortranEvaluate and FortranSupport, which are not linked to FIROpenACCSupport.  This fixes by linking those libraries to FIROpenACCSupport.
