### PR TITLE
[RISCV] Rename vd->rd in the MC layer for vfirst.m/vcpop.m/vmv.x.s/vfmv.f.s.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrFormatsV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormatsV.td
@@ -148,6 +148,25 @@ class RVInstVUnary<bits<6> funct6, bits<5> vs1, RISCVVFormat opv, dag outs,
   let Inst{19-15} = vs1;
 }
 
+class RVInstVUnaryRd<bits<6> funct6, bits<5> vs1, RISCVVFormat opv, dag outs,
+                     dag ins, string opcodestr, string argstr>
+    : RVInst<outs, ins, opcodestr, argstr, [], InstFormatR> {
+  bits<5> rd;
+  bit vm;
+  bits<5> vs2;
+
+  let Inst{31-26} = funct6;
+  let Inst{25} = vm;
+  let Inst{24-20} = vs2;
+  let Inst{19-15} = vs1;
+  let Inst{14-12} = opv.Value;
+  let Inst{11-7} = rd;
+  let Inst{6-0} = OPC_OP_V.Value;
+
+  let Uses = [VL, VTYPE];
+  let RVVConstraint = NoConstraint;
+}
+
 class RVInstVLU<bits<3> nf, bit mew, RISCVLSUMOP lumop,
                 bits<3> width, dag outs, dag ins, string opcodestr,
                 string argstr>

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
@@ -1638,18 +1638,18 @@ def : MnemonicAlias<"vmandnot.mm", "vmandn.mm">;
 def : MnemonicAlias<"vmornot.mm", "vmorn.mm">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0,
-    RVVConstraint = NoConstraint, ElementsDependOn = EltDepsVLMask in {
+    ElementsDependOn = EltDepsVLMask in {
 
 // Vector mask population count vcpop
-def VCPOP_M : RVInstVUnary<0b010000, 0b10000, OPMVV, (outs GPR:$vd),
-                           (ins VR:$vs2, VMaskOp:$vm),
-                           "vcpop.m", "$vd, $vs2$vm">,
+def VCPOP_M : RVInstVUnaryRd<0b010000, 0b10000, OPMVV, (outs GPR:$rd),
+                             (ins VR:$vs2, VMaskOp:$vm),
+                             "vcpop.m", "$rd, $vs2$vm">,
               SchedUnaryMC<"WriteVMPopV", "ReadVMPopV">;
 
 // vfirst find-first-set mask bit
-def VFIRST_M : RVInstVUnary<0b010000, 0b10001, OPMVV, (outs GPR:$vd),
-                            (ins VR:$vs2, VMaskOp:$vm),
-                            "vfirst.m", "$vd, $vs2$vm">,
+def VFIRST_M : RVInstVUnaryRd<0b010000, 0b10001, OPMVV, (outs GPR:$rd),
+                              (ins VR:$vs2, VMaskOp:$vm),
+                              "vfirst.m", "$rd, $vs2$vm">,
               SchedUnaryMC<"WriteVMFFSV", "ReadVMFFSV">;
 
 } // hasSideEffects = 0, mayLoad = 0, mayStore = 0, RVVConstraint = NoConstraint, ElementsDependOn = EltDepsVLMask
@@ -1680,11 +1680,11 @@ def VID_V : RVInstVUnary<0b010100, 0b10001, OPMVV, (outs VR:$vd),
             SchedNullaryMC<"WriteVIdxV">;
 
 // Integer Scalar Move Instructions
-let vm = 1, RVVConstraint = NoConstraint in {
-def VMV_X_S : RVInstVUnary<0b010000, 0b00000, OPMVV, (outs GPR:$vd),
-                           (ins VR:$vs2), "vmv.x.s", "$vd, $vs2">,
+let vm = 1 in {
+def VMV_X_S : RVInstVUnaryRd<0b010000, 0b00000, OPMVV, (outs GPR:$rd),
+                             (ins VR:$vs2), "vmv.x.s", "$rd, $vs2">,
               Sched<[WriteVMovXS, ReadVMovXS]>;
-let Constraints = "$vd = $vd_wb" in
+let RVVConstraint = NoConstraint, Constraints = "$vd = $vd_wb" in
 def VMV_S_X : RVInstV2<0b010000, 0b00000, OPMVX, (outs VR:$vd_wb),
                       (ins VR:$vd, GPR:$rs1), "vmv.s.x", "$vd, $rs1">,
               Sched<[WriteVMovSX, ReadVMovSX_V, ReadVMovSX_X]>;
@@ -1696,13 +1696,12 @@ def VMV_S_X : RVInstV2<0b010000, 0b00000, OPMVX, (outs VR:$vd_wb),
 
 let Predicates = [HasVInstructionsAnyF] in {
 
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0, vm = 1,
-    RVVConstraint = NoConstraint  in {
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0, vm = 1 in {
 // Floating-Point Scalar Move Instructions
-def VFMV_F_S : RVInstVUnary<0b010000, 0b00000, OPFVV, (outs FPR32:$vd),
-                            (ins VR:$vs2), "vfmv.f.s", "$vd, $vs2">,
+def VFMV_F_S : RVInstVUnaryRd<0b010000, 0b00000, OPFVV, (outs FPR32:$rd),
+                              (ins VR:$vs2), "vfmv.f.s", "$rd, $vs2">,
                Sched<[WriteVMovFS, ReadVMovFS]>;
-let Constraints = "$vd = $vd_wb" in
+let RVVConstraint = NoConstraint, Constraints = "$vd = $vd_wb" in
 def VFMV_S_F : RVInstV2<0b010000, 0b00000, OPFVF, (outs VR:$vd_wb),
                        (ins VR:$vd, FPR32:$rs1), "vfmv.s.f", "$vd, $rs1">,
                Sched<[WriteVMovSF, ReadVMovSF_V, ReadVMovSF_F]>;


### PR DESCRIPTION
Add a new class for instructions that write GPR/FPR. Sink RVVConstraint=NoConstraint into this class.