### PR TITLE
[flang] Remove `AmbiguousStructureConstructor` warnings

### DIFF
--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -53,10 +53,10 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     PolymorphicActualAllocatableOrPointerToMonomorphicDummy, RelaxedPureDummy,
     UndefinableAsynchronousOrVolatileActual, AutomaticInMainProgram, PrintCptr,
     SavedLocalInSpecExpr, PrintNamelist, AssumedRankPassedToNonAssumedRank,
-    IgnoreIrrelevantAttributes, Unsigned, AmbiguousStructureConstructor,
-    ContiguousOkForSeqAssociation, ForwardRefExplicitTypeDummy,
-    InaccessibleDeferredOverride, CudaWarpMatchFunction, DoConcurrentOffload,
-    TransferBOZ, Coarray, PointerPassObject, MultipleIdenticalDATA)
+    IgnoreIrrelevantAttributes, Unsigned, ContiguousOkForSeqAssociation,
+    ForwardRefExplicitTypeDummy, InaccessibleDeferredOverride,
+    CudaWarpMatchFunction, DoConcurrentOffload, TransferBOZ, Coarray,
+    PointerPassObject, MultipleIdenticalDATA)
 
 // Portability and suspicious usage warnings
 ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3061,11 +3061,6 @@ auto ExpressionAnalyzer::ResolveGeneric(const Symbol &symbol,
         Warn(common::LanguageFeature::AmbiguousStructureConstructor,
             "Reference to the intrinsic function '%s' is ambiguous with a structure constructor of the same name"_port_en_US,
             symbol.name());
-      } else {
-        Warn(common::LanguageFeature::AmbiguousStructureConstructor,
-            "Reference to generic function '%s' (resolving to specific '%s') is ambiguous with a structure constructor of the same name"_port_en_US,
-            symbol.name(),
-            nonElemental ? nonElemental->name() : elemental->name());
       }
     }
   }

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3017,53 +3017,7 @@ auto ExpressionAnalyzer::ResolveGeneric(const Symbol &symbol,
       }
     }
   }
-  // F'2023 C7108 checking.  No Fortran compiler actually enforces this
-  // constraint, so it's just a portability warning here.
-  if (derivedType && (explicitIntrinsic || nonElemental || elemental) &&
-      context_.ShouldWarn(
-          common::LanguageFeature::AmbiguousStructureConstructor)) {
-    // See whethr there's ambiguity with a structure constructor.
-    bool possiblyAmbiguous{true};
-    if (const semantics::Scope * dtScope{derivedType->scope()}) {
-      parser::Messages buffer;
-      auto restorer{GetContextualMessages().SetMessages(buffer)};
-      std::list<ComponentSpec> componentSpecs;
-      for (const auto &actual : actuals) {
-        if (actual) {
-          ComponentSpec compSpec;
-          if (const Expr<SomeType> *expr{actual->UnwrapExpr()}) {
-            compSpec.expr = *expr;
-          } else {
-            possiblyAmbiguous = false;
-          }
-          if (auto loc{actual->sourceLocation()}) {
-            compSpec.source = compSpec.exprSource = *loc;
-          }
-          if (auto kw{actual->keyword()}) {
-            compSpec.hasKeyword = true;
-            compSpec.keywordSymbol = dtScope->FindComponent(*kw);
-          }
-          componentSpecs.emplace_back(std::move(compSpec));
-        } else {
-          possiblyAmbiguous = false;
-        }
-      }
-      semantics::DerivedTypeSpec dtSpec{derivedType->name(), *derivedType};
-      dtSpec.set_scope(*dtScope);
-      possiblyAmbiguous = possiblyAmbiguous &&
-          CheckStructureConstructor(
-              derivedType->name(), dtSpec, std::move(componentSpecs))
-              .has_value() &&
-          !buffer.AnyFatalError();
-    }
-    if (possiblyAmbiguous) {
-      if (explicitIntrinsic) {
-        Warn(common::LanguageFeature::AmbiguousStructureConstructor,
-            "Reference to the intrinsic function '%s' is ambiguous with a structure constructor of the same name"_port_en_US,
-            symbol.name());
-      }
-    }
-  }
+
   // Return the right resolution, if there is one.  Explicit intrinsics
   // are preferred, then non-elements specifics, then elementals, and
   // lastly structure constructors.

--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -103,7 +103,6 @@ LanguageFeatureControl::LanguageFeatureControl() {
   warnLanguage_.set(LanguageFeature::HollerithPolymorphic);
   warnLanguage_.set(LanguageFeature::ListDirectedSize);
   warnLanguage_.set(LanguageFeature::IgnoreIrrelevantAttributes);
-  warnLanguage_.set(LanguageFeature::AmbiguousStructureConstructor);
   warnLanguage_.set(LanguageFeature::TransferBOZ);
   warnUsage_.set(UsageWarning::ShortArrayActual);
   warnUsage_.set(UsageWarning::FoldingException);

--- a/flang/test/Semantics/c7108.f90
+++ b/flang/test/Semantics/c7108.f90
@@ -33,9 +33,7 @@ program p
   use m
   type(foo) x
   x = foo(); print *, x       ! ok, not ambiguous
-  !PORTABILITY: Reference to generic function 'foo' (resolving to specific 'bar0') is ambiguous with a structure constructor of the same name [-Wambiguous-structure-constructor]
-  x = foo(2); print *, x      ! ambigous
-  !PORTABILITY: Reference to generic function 'foo' (resolving to specific 'bar2') is ambiguous with a structure constructor of the same name [-Wambiguous-structure-constructor]
-  x = foo(3.); print *, x     ! ambiguous due to data conversion
+  x = foo(2); print *, x      ! According to F23 C7108, not ambiguous
+  x = foo(3.); print *, x     ! According to F23 C7108, not ambiguous
   x = foo(.true.); print *, x ! ok, not ambigous
 end

--- a/flang/test/Semantics/generic09.f90
+++ b/flang/test/Semantics/generic09.f90
@@ -33,9 +33,6 @@ module m3
   end
 end
 
-!CHECK: portability: Reference to generic function 'foo' (resolving to specific 'f1') is ambiguous with a structure constructor of the same name
-!CHECK: portability: Reference to generic function 'foo' (resolving to specific 'f2') is ambiguous with a structure constructor of the same name
-
 program main
   use m3
   type(foo) x

--- a/flang/test/Semantics/resolve11.f90
+++ b/flang/test/Semantics/resolve11.f90
@@ -66,8 +66,7 @@ subroutine s4
   !ERROR: 'fun' is PRIVATE in 'm4'
   use m4, only: foo, fun
   type(foo) x ! ok
-  !PORTABILITY: Reference to generic function 'foo' (resolving to specific 'fun') is ambiguous with a structure constructor of the same name [-Wambiguous-structure-constructor]
-  print *, foo()
+  print *, foo() ! According to F23 C7108, not ambiguous
 end
 
 module m5

--- a/flang/test/Semantics/resolve17.f90
+++ b/flang/test/Semantics/resolve17.f90
@@ -290,8 +290,7 @@ module m14d
  contains
   subroutine test
     real :: y
-    !PORTABILITY: Reference to generic function 'foo' (resolving to specific 'bar') is ambiguous with a structure constructor of the same name [-Wambiguous-structure-constructor]
-    y = foo(1.0)
+    y = foo(1.0) ! According to F23 C7108, not ambiguous
     x = foo(2)
   end subroutine
 end module
@@ -302,8 +301,7 @@ module m14e
  contains
   subroutine test
     real :: y
-    !PORTABILITY: Reference to generic function 'foo' (resolving to specific 'bar') is ambiguous with a structure constructor of the same name [-Wambiguous-structure-constructor]
-    y = foo(1.0)
+    y = foo(1.0) ! According to F23 C7108, not ambiguous
     x = foo(2)
   end subroutine
 end module

--- a/flang/test/Semantics/resolve18.f90
+++ b/flang/test/Semantics/resolve18.f90
@@ -348,7 +348,8 @@ subroutine s_21_23
   use m21
   use m23
   type(foo) x ! Intel and NAG error
-  !PORTABILITY: Reference to generic function 'foo' (resolving to specific 'f1') is ambiguous with a structure constructor of the same name [-Wambiguous-structure-constructor]
+
+  ! According to F23 C7108, not ambiguous
   print *, foo(1.) ! Intel error
   print *, foo(1.,2.,3.) ! Intel error
   call ext(foo) ! GNU and Intel error

--- a/flang/unittests/Common/FortranFeaturesTest.cpp
+++ b/flang/unittests/Common/FortranFeaturesTest.cpp
@@ -364,9 +364,6 @@ TEST(FortranFeaturesTest, CamelCaseToLowerCaseHyphenated) {
       CamelCaseToLowerCaseHyphenated(EnumToString(LanguageFeature::Unsigned)),
       "unsigned");
   EXPECT_EQ(CamelCaseToLowerCaseHyphenated(
-                EnumToString(LanguageFeature::AmbiguousStructureConstructor)),
-      "ambiguous-structure-constructor");
-  EXPECT_EQ(CamelCaseToLowerCaseHyphenated(
                 EnumToString(LanguageFeature::ContiguousOkForSeqAssociation)),
       "contiguous-ok-for-seq-association");
   EXPECT_EQ(CamelCaseToLowerCaseHyphenated(


### PR DESCRIPTION
Remove `AmbiguousStructureConstructor` warnings, which includes a warning about standards-conforming generic function references, which are never ambiguous with structure constructors, as discussed in a conversation in the following [issue](https://github.com/j3-fortran/fortran_proposals/issues/348#issuecomment-3694937658).